### PR TITLE
[FIX] hr: prevent error when archiving employee with detailed reason

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -127,7 +127,7 @@ class HrVersion(models.Model):
 
     departure_reason_id = fields.Many2one("hr.departure.reason", string="Departure Reason",
                                           groups="hr.group_hr_user", copy=False, ondelete='restrict', tracking=True)
-    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False, tracking=True)
+    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False)
     departure_date = fields.Date(string="Departure Date", groups="hr.group_hr_user", copy=False, tracking=True)
 
     resource_calendar_id = fields.Many2one('resource.calendar', inverse='_inverse_resource_calendar_id', check_company=True, string="Working Hours", tracking=True)

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -612,6 +612,7 @@ class TestHrVersion(TransactionCase):
             "currency_id",
             "date_end",
             "date_start",
+            "departure_description",
             "display_name",
             "id",
             "is_current",


### PR DESCRIPTION
When archiving an employee with a Detailed Reason, a traceback occurs.

Steps to reproduce the error:
- Open any employee record > Archive
- Set ``Detailed Reason`` > Apply

Traceback:
```py
NotImplementedError: Unsupported tracking on field departure_description (type html
```

https://github.com/odoo/odoo/blob/8002b82d5783744b88b75c1199c4c1f222a0f7d0/addons/hr/models/hr_version.py#L130
here, ``tracking=True`` was added for the ``departure_description`` html field by the commit [1].
but tracking is not supported for the html field.
So, it will lead to the above traceback.

Tracking for ``departure_description`` field is already handled via a chatter message in the write method by the commit [2]. https://github.com/odoo/odoo/blob/8002b82d5783744b88b75c1199c4c1f222a0f7d0/addons/hr/models/hr_employee.py#L1187-L1191

[1]: https://github.com/odoo/odoo/commit/aa4d13b89b4497d2e5b33faa49ad86e0788782a2

[2]: https://github.com/odoo/odoo/commit/9b723e2591224f2b563924d3b3dfe27ab909b7d0

sentry-6973440621

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
