### PR TITLE
18.0 l10n sa edi pos remove invoice creation on settling due order adns

### DIFF
--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -10,7 +10,13 @@ patch(PaymentScreen.prototype, {
         await super._finalizeValidation(...arguments);
         const order = this.currentOrder;
         // note: isSACompany guarantees order.is_to_invoice()
-        if (order.isSACompany && order.finalized && order.l10n_sa_invoice_edi_state !== "sent") {
+        // But if invoice is not mandatory, like in case of settlement, skip it
+        if (
+            order.isSACompany &&
+            order.finalized &&
+            order.l10n_sa_invoice_edi_state !== "sent" &&
+            order.isInvoiceMandatoryForSA
+        ) {
             const orderError = _t("%s by going to Backend > Orders > Invoice", order.pos_reference);
             const href = `/odoo/customer-invoices/${this.currentOrder?.raw?.account_move}`;
             const link = markup(

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/models.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/models.js
@@ -6,24 +6,43 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrder.prototype, {
     setup(_defaultObj, options) {
         super.setup(...arguments);
-        if (this.isSACompany) {
+        if (this.isInvoiceMandatoryForSA) {
             this.to_invoice = true;
         }
     },
     is_to_invoice() {
-        if (this.isSACompany) {
+        if (this.isInvoiceMandatoryForSA) {
             return true;
         }
         return super.is_to_invoice(...arguments);
     },
     set_to_invoice(to_invoice) {
-        if (this.isSACompany) {
+        if (this.isInvoiceMandatoryForSA) {
             this.assert_editable();
             this.to_invoice = true;
         } else {
             super.set_to_invoice(...arguments);
         }
     },
+
+    set_partner(partner) {
+        /*
+        The settlement dialog sets is_settling_account = true after creating the order
+        So making it default to false here as this is called after is_settling_account is set
+        is_settling_account is only applicable if enterprise:pos_settle_due module is installed
+        */
+        super.set_partner(partner);
+        if (this?.is_settling_account) {
+            this.set_to_invoice(false);
+        }
+    },
+
+    get isInvoiceMandatoryForSA() {
+        // Zatca enforces invoice, but for settlement due, invoices are not needed
+        // Only applicable if enterprise:pos_settle_due module is installed
+        return this.isSACompany && !this?.is_settling_account;
+    },
+
     get isSACompany() {
         return this.company.country_id?.code == "SA";
     },


### PR DESCRIPTION
## Dependent PR
https://github.com/odoo/enterprise/pull/98353

## Description of the issue/feature this PR addresses:
Users are blocked when trying to use the **Settle Due** feature in Point of Sale if the ZATCA (l10n_sa_edi_pos) integration is enabled.

## Current behavior before PR:
When a PoS order is created using a "Pay Later" payment method, an invoice is correctly generated and sent to ZATCA.

However, when the user later tries to settle that customer's due balance (using the **Settle Due** option), the l10n_sa_edi_pos module incorrectly forces the Invoice option to be enabled and makes the field read-only. This blocks the user because:

- Settlement orders do not contain any lines, so a new invoice cannot be generated.
- The original invoice was already sent to ZATCA, and the settlement payment should not be sent as a new e-invoice.

Thus, the user cannot proceed with the settlement.

## Desired behavior after PR is merged:
After this fix, the **Invoice** checkbox will no longer be forced or marked as read-only during **Settle Due** operations. The field will default to False, aligning with standard Odoo behavior for settlements and allowing the user to complete the payment.

task-5144679

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
