### PR TITLE
[IMP] account_{edi_ubl_cii,peppol}: partner improvements

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -211,6 +211,10 @@ class ResPartner(models.Model):
         for partner in self:
             partner.is_peppol_edi_format = partner.invoice_edi_format in self._get_peppol_formats()
 
+    def _get_peppol_endpoint_value(self, country_code, field):
+        self.ensure_one()
+        return field in self._fields and self[field]
+
     @api.depends(lambda self: self._peppol_eas_endpoint_depends() + ['peppol_eas'])
     def _compute_peppol_endpoint(self):
         """ If the EAS changes and a valid endpoint is available, set it. Otherwise, keep the existing value."""
@@ -219,11 +223,9 @@ class ResPartner(models.Model):
             country_code = partner._deduce_country_code()
             if country_code in EAS_MAPPING:
                 field = EAS_MAPPING[country_code].get(partner.peppol_eas)
-                if field \
-                        and field in partner._fields \
-                        and partner[field] \
-                        and not partner._build_error_peppol_endpoint(partner.peppol_eas, partner[field]):
-                    partner.peppol_endpoint = partner[field]
+                value = partner._get_peppol_endpoint_value(country_code, field)
+                if field and value and not partner._build_error_peppol_endpoint(partner.peppol_eas, value):
+                    partner.peppol_endpoint = value
 
     @api.depends(lambda self: self._peppol_eas_endpoint_depends())
     def _compute_peppol_eas(self):
@@ -240,8 +242,9 @@ class ResPartner(models.Model):
                     new_eas = next(iter(EAS_MAPPING[country_code].keys()))
                     # Iterate on the possible EAS until a valid one is found
                     for eas, field in eas_to_field.items():
-                        if field and field in partner._fields and partner[field]:
-                            if not partner._build_error_peppol_endpoint(eas, partner[field]):
+                        if field and field in partner._fields:
+                            value = partner._get_peppol_endpoint_value(country_code, field)
+                            if value and not partner._build_error_peppol_endpoint(eas, value):
                                 new_eas = eas
                                 break
                     partner.peppol_eas = new_eas

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -213,7 +213,19 @@ class ResPartner(models.Model):
 
     def _get_peppol_endpoint_value(self, country_code, field):
         self.ensure_one()
-        return field in self._fields and self[field]
+        value = field in self._fields and self[field]
+
+        if (
+            country_code == 'BE'
+            and field == 'company_registry'
+            and not value
+            and self.vat
+        ):
+            value = self.vat
+            if value.isalnum():
+                value = value.removeprefix(country_code)
+
+        return value
 
     @api.depends(lambda self: self._peppol_eas_endpoint_depends() + ['peppol_eas'])
     def _compute_peppol_endpoint(self):

--- a/addons/account_edi_ubl_cii/views/res_partner_views.xml
+++ b/addons/account_edi_ubl_cii/views/res_partner_views.xml
@@ -14,7 +14,7 @@
                        widget="filterable_selection"
                        options="{'whitelist_fname': 'available_peppol_eas'}"
                        class="o_field_peppol_eas_selection"/>
-                <field name="peppol_endpoint" nolabel="1" placeholder="Your endpoint"/>
+                <field name="peppol_endpoint" nolabel="1"/>
             </xpath>
         </field>
     </record>

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -28,14 +28,18 @@ class ResPartner(models.Model):
     available_peppol_edi_formats = fields.Json(compute='_compute_available_peppol_edi_formats')
     peppol_verification_state = fields.Selection(
         selection=[
-            ('not_verified', 'Not verified yet'),
-            ('not_valid', 'Not on Peppol'),  # does not exist on Peppol at all
-            ('not_valid_format', 'Cannot receive this format'),  # registered on Peppol but cannot receive the selected document type
-            ('valid', 'Valid'),
+            ('not_verified', 'Unchecked'),
+            ('not_valid', 'Partner is not on Peppol'),  # does not exist on Peppol at all
+            ('not_valid_format', 'Partner cannot receive format'),  # registered on Peppol but cannot receive the selected document type
+            ('valid', 'Partner is on Peppol'),
         ],
-        string='Peppol endpoint verification',
+        string='Peppol status',
         company_dependent=True,
     )
+
+    @api.onchange('invoice_edi_format', 'peppol_endpoint', 'peppol_eas')
+    def _onchange_verify_peppol_status(self):
+        self.button_account_peppol_check_partner_endpoint()
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -30,12 +30,8 @@
                 </xpath>
                 <xpath expr="//field[@name='peppol_endpoint']" position="after">
                     <field name="peppol_verification_state" invisible="1" force_save="1"/>
-                    <label for="peppol_verification_state"
-                           groups="base.group_no_one"
-                           invisible="not peppol_endpoint"/>
-                    <div class="row"
-                         groups="base.group_no_one"
-                         invisible="not peppol_endpoint">
+                    <label for="peppol_verification_state" invisible="not peppol_endpoint"/>
+                    <div class="row" invisible="not peppol_endpoint">
                         <div class="col-6">
                             <field name="peppol_verification_state" readonly="1"/>
                         </div>


### PR DESCRIPTION

This commit improves the UX by displaying more intuitive placeholders
for the peppol identifier. The peppol information is also automatically
verified when important data changes.

It also adds a special case for Belgium in which we try to use the vat
number as the peppol identifier with the company registry endpoint.

task: 5172378