### PR TITLE
[FIX] pos_blackbox_be: move hiding tip product logic inside bbox module

### DIFF
--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -26,7 +26,7 @@
                 </setting>
             </block>
             <div id="tip_product" position="after">
-                <div invisible="not pos_module_pos_restaurant or not pos_iface_tipproduct or country_code == 'BE'">
+                <div invisible="not pos_module_pos_restaurant or not pos_iface_tipproduct">
                     <field name="pos_set_tip_after_payment" class="oe_inline"/>
                     <label class="fw-normal" for="pos_set_tip_after_payment" string="Add tip after payment"/>
                 </div>


### PR DESCRIPTION
- Move logic of hiding `tip_product` field in `pos_config` form view when country is Belgium inside `pos_blackbox_be` module.

task-id: 5011427

enterprise PR: https://github.com/odoo/enterprise/pull/98145





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
