### PR TITLE
[FIX] account_peppol: broken requests dependency

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -117,7 +117,7 @@ class ResPartner(models.Model):
 
         try:
             decoded_response = response.json()
-        except requests.exceptions.JSONDecodeError:
+        except ValueError:
             _logger.error('invalid JSON response %s when querying peppol participant %s', response.status_code, edi_identification)
             return
 


### PR DESCRIPTION
JSONDecodeError was added in requests 2.28 and odoo 17 should be compatible with requests 2.22

see https://github.com/odoo/odoo/blob/17.0/requirements.txt#L76

no-task