### PR TITLE
[IMP] account_peppol: remove peppol_move_state from list view

### DIFF
--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -2,10 +2,10 @@
 
 {
     'name': "Peppol",
-    'summary': "This module is used to send/receive documents with PEPPOL",
+    'summary': "This module is used to send/receive documents with Peppol",
     'description': """
-- Register as a PEPPOL participant
-- Send and receive documents via PEPPOL network in Peppol BIS Billing 3.0 format
+- Register as a Peppol participant
+- Send and receive documents via Peppol network in Peppol BIS Billing 3.0 format
     """,
     'category': 'Accounting/Accounting',
     'version': '1.1',

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -8,7 +8,7 @@ from odoo.addons.account.models.company import PEPPOL_MAILING_COUNTRIES
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    peppol_message_uuid = fields.Char(string='PEPPOL message ID')
+    peppol_message_uuid = fields.Char(string='Peppol message ID')
     peppol_move_state = fields.Selection(
         selection=[
             ('ready', 'Ready to send'),
@@ -19,7 +19,7 @@ class AccountMove(models.Model):
             ('error', 'Error'),
         ],
         compute='_compute_peppol_move_state', store=True,
-        string='PEPPOL status',
+        string='Peppol status',
         copy=False,
     )
 
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
         # if the peppol_move_state is processing/done
         # then it means it has been already sent to peppol proxy and we can't cancel
         if any(move.peppol_move_state in {'processing', 'done'} for move in self):
-            raise UserError(_("Cannot cancel an entry that has already been sent to PEPPOL"))
+            raise UserError(_("Cannot cancel an entry that has already been sent to Peppol"))
         self.peppol_move_state = False
         self.sending_data = False
 

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -56,7 +56,7 @@ class AccountMoveSend(models.AbstractModel):
             'level': 'info',
             'action_text': _("Why should you use it ?"),
             'action': {
-                'name': _("Why should I use PEPPOL ?"),
+                'name': _("Why should I use Peppol ?"),
                 'type': 'ir.actions.client',
                 'tag': 'account_peppol.what_is_peppol',
                 'target': 'new',

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -74,7 +74,7 @@ class ResCompany(models.Model):
             ('receiver', 'Can send and receive'),
             ('rejected', 'Rejected'),
         ],
-        string='PEPPOL status', required=True, default='not_registered',
+        string='Peppol status', required=True, default='not_registered',
     )
     account_peppol_edi_user = fields.Many2one(
         comodel_name='account_edi_proxy_client.user',

--- a/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
+++ b/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
@@ -9,13 +9,13 @@
                     <li class="d-flex gap-4">
                         <div>
                             <h5 class="mb-0">The e-invoicing network</h5>
-                            PEPPOL is the secure standard for e-invoices used in EU and across the world.
+                            Peppol is the secure standard for e-invoices used in EU and across the world.
                         </div>
                     </li>
                     <li class="d-flex gap-4">
                         <div>
                             <h5 class="mb-0">Fully automated</h5>
-                            PEPPOL allows for complete automation of sending and receiving e-invoices.
+                            Peppol allows for complete automation of sending and receiving e-invoices.
                         </div>
                     </li>
                     <li class="d-flex gap-4">

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -10,7 +10,7 @@
                 <button name="action_cancel_peppol_documents"
                         type="object"
                         class="btn btn-secondary"
-                        string="Cancel PEPPOL"
+                        string="Cancel Peppol"
                         invisible="peppol_move_state != 'to_send' or state == 'draft'"/>
             </header>
             <sheet position="before">
@@ -27,7 +27,8 @@
         <field name="inherit_id" ref="account.view_out_invoice_tree"/>
         <field name="arch" type="xml">
             <field name="status_in_payment" position="before">
-                <field name="peppol_move_state" optional="hide"/>
+                <!-- TODO remove the view extension in master -->
+                <field name="peppol_move_state" column_invisible="1"/>
             </field>
         </field>
     </record>
@@ -38,7 +39,8 @@
         <field name="inherit_id" ref="account.view_out_credit_note_tree"/>
         <field name="arch" type="xml">
             <field name="status_in_payment" position="before">
-                <field name="peppol_move_state" optional="hide"/>
+                <!-- TODO remove the view extension in master -->
+                <field name="peppol_move_state" column_invisible="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
1. Align naming PEPPOL -> Peppol. This is the directive from OpenPeppol for few years already in all their communications.
2. Remove the PEPPOL status from the `account.move` list view.

task-none (FP feedback for point 2)
