### PR TITLE
[FIX] im_livechat: prevent breadcrumb flicker when navigating sessions

### DIFF
--- a/addons/im_livechat/static/src/views/livechat_form_controller.js
+++ b/addons/im_livechat/static/src/views/livechat_form_controller.js
@@ -1,0 +1,18 @@
+import { useService } from "@web/core/utils/hooks";
+import { FormController } from "@web/views/form/form_controller";
+
+export class LivechatSessionFormController extends FormController {
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+    }
+    get thread() {
+        return this.store.Thread.get({
+            model: "discuss.channel",
+            id: this.model.root.resId,
+        });
+    }
+    displayName() {
+        return this.thread?.displayName || super.displayName();
+    }
+}

--- a/addons/im_livechat/static/src/views/livechat_form_view.js
+++ b/addons/im_livechat/static/src/views/livechat_form_view.js
@@ -1,9 +1,11 @@
 import { registry } from "@web/core/registry";
 import { formView } from "@web/views/form/form_view";
+import { LivechatSessionFormController } from "./livechat_form_controller";
 import { LivechatSessionFormRenderer } from "./livechat_form_renderer";
 
 export const LivechatSesionFormView = {
     ...formView,
+    Controller: LivechatSessionFormController,
     Renderer: LivechatSessionFormRenderer,
     display: { controlPanel: false },
 };


### PR DESCRIPTION
Before this PR,
The breadcrumbs flickered when navigating between livechat sessions.
This occurred because the `FormController` ([@web/views/form/form_controller](https://github.com/odoo/odoo/blob/saas-18.3/addons/mail/static/src/core/web/discuss_patch.js#L16-L23)) 
updated the breadcrumb title inside the `onRendered` hook and set it to 
`this.model.root.data.display_name` which is `undefined`, the `Discuss` component 
also updated the breadcrumb title in a `useEffect` hook. ([@mail/code/web/discuss_patch.js](https://github.com/odoo/odoo/blob/saas-18.3/addons/mail/static/src/core/web/discuss_patch.js#L16-L23))
  
The two updates conflicted: the onRendered hook first set the title to 
“Unnamed,” and then the useEffect hook replaced it with the correct title, 
causing a brief flicker. Additionally, when navigating to another session with 
the same thread.displayName, the useEffect hook did not trigger (since its 
dependency did not change), but onRendered still ran, causing the breadcrumb 
to remain “Unnamed”.
    
This PR fixes the issue by introducing a `LivechatFormController` which
updates the breadcrumbs when channel is fetched in store.
    
task-4671251

Before:
![breadcrumbs-before](https://github.com/user-attachments/assets/ae8e6943-07ce-4b4a-a3e6-4c027afe32c3)

After:
![breadcrumbs-after](https://github.com/user-attachments/assets/f26e4d9e-66b0-4209-9ff2-938688c6042f)

task-4671251