### PR TITLE
[FIX] website_sale: hide products not related to current website

### DIFF
--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -305,6 +305,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             return (
                 should_show_product
                 and product_template._is_add_to_cart_possible(parent_combination)
+                and product_template.filtered_domain(request.website.website_domain())
             )
         return should_show_product
 

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -190,6 +190,28 @@ class TestWebsiteSaleProductConfigurator(
 
         self.assertTrue(show_configurator)
 
+    def test_optional_products_not_visible_on_other_websites(self):
+        """Optional products assigned to a different website should not be shown"""
+        second_website = self.env['website'].create({'name': 'second website'})
+        optional_product = self.env['product.template'].create({
+            'name': "Optional product",
+            'website_published': True,
+            'website_id': second_website.id
+        })
+
+        main_product = self.env['product.template'].create({
+            'name': "Main product",
+            'website_published': True,
+            'optional_product_ids': [Command.set(optional_product.ids)],
+        })
+
+        with MockRequest(self.env, website=self.website):
+            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
+                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
+            )
+
+        self.assertFalse(show_configurator)
+
     def test_product_configurator_single_variant(self):
         """ Test that the product configurator isn't shown if the product has a single variant. """
         attribute = self.env['product.attribute'].create({


### PR DESCRIPTION
Steps to reproduce:
===================
1- Create another website
2- Sales app > Products > Open any product's form
3- In the Optional Products field, select any other product in your database for this field
4- Open the product form of the optional product you selected 5- Set the Website field to only be one of your websites, rather than All
6- Navigate to the Website app > Select the non set website in the other Steps
7- Open your shop > Select your main product > Click the add to cart button
-> See the optional product  appear in the pop-up.

Cause:
======
_should_show_product function doesn't validate if a product is available on the website from which the request originates when handling multiple websites.

Solution:
=========
Update the function to take multiple websites into consideration

opw-5179894

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
