### PR TITLE
[FIX] account_peppol: remove dead views & unused selection value

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -21,9 +21,9 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
     * Official doc for EHF Billing 3.0 is the OpenPeppol BIS 3 doc +
       https://anskaffelser.dev/postaward/g3/spec/current/billing-3.0/norway/
 
-        "Based on work done in PEPPOL BIS Billing 3.0, Difi has included Norwegian rules in PEPPOL BIS Billing 3.0 and
+        "Based on work done in Peppol BIS Billing 3.0, Difi has included Norwegian rules in Peppol BIS Billing 3.0 and
         does not see a need to implement a different CIUS targeting the Norwegian market. Implementation of EHF Billing
-        3.0 is therefore done by implementing PEPPOL BIS Billing 3.0 without extensions or extra rules."
+        3.0 is therefore done by implementing Peppol BIS Billing 3.0 without extensions or extra rules."
 
     Thus, EHF 3 and Bis 3 are actually the same format. The specific rules for NO defined in Bis 3 are added in Bis 3.
 

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -2,10 +2,10 @@
 
 {
     'name': "Peppol",
-    'summary': "This module is used to send/receive documents with PEPPOL",
+    'summary': "This module is used to send/receive documents with Peppol",
     'description': """
-- Register as a PEPPOL participant
-- Send and receive documents via PEPPOL network in Peppol BIS Billing 3.0 format
+- Register as a Peppol participant
+- Send and receive documents via Peppol network in Peppol BIS Billing 3.0 format
     """,
     'category': 'Accounting/Accounting',
     'version': '1.1',

--- a/addons/account_peppol/data/cron.xml
+++ b/addons/account_peppol/data/cron.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_cron_peppol_get_new_documents" model="ir.cron">
-        <field name="name">PEPPOL: retrieve new documents</field>
+        <field name="name">Peppol: retrieve new documents</field>
         <field name="interval_number">4</field>
         <field name="interval_type">hours</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
@@ -10,7 +10,7 @@
     </record>
 
     <record id="ir_cron_peppol_get_message_status" model="ir.cron">
-        <field name="name">PEPPOL: update message status</field>
+        <field name="name">Peppol: update message status</field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
@@ -19,7 +19,7 @@
     </record>
 
     <record id="ir_cron_peppol_get_participant_status" model="ir.cron">
-        <field name="name">PEPPOL: update participant status</field>
+        <field name="name">Peppol: update participant status</field>
         <field name="interval_number">1</field>
         <field name="interval_type">weeks</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
@@ -28,7 +28,7 @@
     </record>
 
     <record id="ir_cron_peppol_webhook_keepalive" model="ir.cron">
-        <field name="name">PEPPOL: webhook keep alive</field>
+        <field name="name">Peppol: webhook keep alive</field>
         <field name="interval_number">2</field>
         <field name="interval_type">weeks</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -17,7 +17,7 @@ BATCH_SIZE = 50
 class Account_Edi_Proxy_ClientUser(models.Model):
     _inherit = 'account_edi_proxy_client.user'
 
-    proxy_type = fields.Selection(selection_add=[('peppol', 'PEPPOL')], ondelete={'peppol': 'cascade'})
+    proxy_type = fields.Selection(selection_add=[('peppol', 'Peppol')], ondelete={'peppol': 'cascade'})
 
     # -------------------------------------------------------------------------
     # HELPER METHODS

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -8,18 +8,17 @@ from odoo.addons.account.models.company import PEPPOL_MAILING_COUNTRIES
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    peppol_message_uuid = fields.Char(string='PEPPOL message ID')
+    peppol_message_uuid = fields.Char(string='Peppol message ID')
     peppol_move_state = fields.Selection(
         selection=[
             ('ready', 'Ready to send'),
             ('to_send', 'Queued'),
-            ('skipped', 'Skipped'),  # TODO remove this state in master, we now put a regular error.
             ('processing', 'Pending Reception'),
             ('done', 'Done'),
             ('error', 'Error'),
         ],
         compute='_compute_peppol_move_state', store=True,
-        string='PEPPOL status',
+        string='Peppol status',
         copy=False,
     )
 
@@ -32,7 +31,7 @@ class AccountMove(models.Model):
         # if the peppol_move_state is processing/done
         # then it means it has been already sent to peppol proxy and we can't cancel
         if any(move.peppol_move_state in {'processing', 'done'} for move in self):
-            raise UserError(_("Cannot cancel an entry that has already been sent to PEPPOL"))
+            raise UserError(_("Cannot cancel an entry that has already been sent to Peppol"))
         self.peppol_move_state = False
         self.sending_data = False
 

--- a/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
+++ b/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
@@ -9,13 +9,13 @@
                     <li class="d-flex gap-4">
                         <div>
                             <h5 class="mb-0">The e-invoicing network</h5>
-                            PEPPOL is the secure standard for e-invoices used in EU and across the world.
+                            Peppol is the secure standard for e-invoices used in EU and across the world.
                         </div>
                     </li>
                     <li class="d-flex gap-4">
                         <div>
                             <h5 class="mb-0">Fully automated</h5>
-                            PEPPOL allows for complete automation of sending and receiving e-invoices.
+                            Peppol allows for complete automation of sending and receiving e-invoices.
                         </div>
                     </li>
                     <li class="d-flex gap-4">

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -10,7 +10,7 @@
                 <button name="action_cancel_peppol_documents"
                         type="object"
                         class="btn btn-secondary"
-                        string="Cancel PEPPOL"
+                        string="Cancel Peppol"
                         invisible="peppol_move_state != 'to_send' or state == 'draft'"/>
             </header>
             <sheet position="before">

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -45,7 +45,7 @@
                                     class="btn btn-secondary"
                                     type="object"
                                     string="Verify"
-                                    help="Verify partner's PEPPOL endpoint"/>
+                                    help="Verify partner's Peppol endpoint"/>
                         </div>
                     </div>
                 </xpath>

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -139,7 +139,7 @@ class AccountEdiXmlUbl_Ro(models.AbstractModel):
         partner_vals = super()._import_retrieve_partner_vals(tree, role)
         if 'peppol_endpoint' in partner_vals:
             # ANAF allows for endpoints to be an address mail, since we don't want to create a new
-            # user with an address mail as a PEPPOL endpoint, we simply remove it in that case.
+            # user with an address mail as a Peppol endpoint, we simply remove it in that case.
             error = self.env['res.partner']._build_error_peppol_endpoint(False, partner_vals['peppol_endpoint'])
             if error:
                 partner_vals['peppol_endpoint'] = False


### PR DESCRIPTION
Align PEPPOL to Peppol as done by OpenPeppol in all their communication and visuals.

Cleanup the unused views and selection.
- 'Skipped' is not used for a few versions already, let's clean the selection.
- We no longer display the "PEPPOL status" in list view, let's cleanup the view extensions.

task-none
