### PR TITLE
[FIX] point_of_sale, pos_hr: prevent gaps in session names

### DIFF
--- a/addons/pos_hr/models/pos_session.py
+++ b/addons/pos_hr/models/pos_session.py
@@ -21,8 +21,8 @@ class PosSession(models.Model):
             data += ['hr.employee']
         return data
 
-    def set_opening_control(self, cashbox_value: int, notes: str):
-        super().set_opening_control(cashbox_value, notes)
+    def _set_opening_control_data(self, cashbox_value: int, notes: str):
+        super()._set_opening_control_data(cashbox_value, notes)
         if author_id := self._get_message_author():
             self.message_post(body=plaintext2html(_('Opened register')), author_id=author_id.id)
 

--- a/addons/pos_hr/tests/__init__.py
+++ b/addons/pos_hr/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_frontend
+from . import test_point_of_sale_flow

--- a/addons/pos_hr/tests/test_point_of_sale_flow.py
+++ b/addons/pos_hr/tests/test_point_of_sale_flow.py
@@ -1,0 +1,30 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+import odoo
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.exceptions import UserError
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPointOfSaleFlow(TestPointOfSaleCommon):
+    def test_pos_hr_session_name_gap(self):
+        self.pos_config.open_ui()
+        session = self.pos_config.current_session_id
+        session.set_opening_control(0, None)
+        current_session_name = session.name
+        session.action_pos_session_closing_control()
+
+        self.pos_config.open_ui()
+        session = self.pos_config.current_session_id
+
+        def _message_post_patch(*_args, **_kwargs):
+            raise UserError('Test Error')
+
+        with patch.object(self.env.registry.models['pos.session'], "message_post", _message_post_patch):
+            with self.assertRaises(UserError):
+                session.set_opening_control(0, None)
+
+        session.set_opening_control(0, None)
+        self.assertEqual(int(session.name.split('/')[1]), int(current_session_name.split('/')[1]) + 1)


### PR DESCRIPTION
Before this commit, if an issue occurred while posting the cash details, the session sequence would still increment even though the operation failed, leading to gaps in session names.

With this commit, the sequence only increments when the operation succeeds, ensuring continuous session naming without gaps.

related: https://github.com/odoo/enterprise/pull/98157
opw-5180712

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
