### PR TITLE
[FIX] mail: adjust condition to use proper model for user preferences

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -408,7 +408,9 @@ export class Store extends BaseStore {
                 // Prevent duplicate inbox push notifications since they're already handled by
                 // `mail.message/inbox` bus notifications, and the `modelsHandleByPush` heuristic
                 // in `out_of_focus_service.js` isn't reliable enough to detect these cases.
-                const isInbox = this.store.self.notification_preference === "inbox" && model !== "discuss.channel";
+                const isInbox =
+                    this.store.self.main_user_id?.notification_type === "inbox" &&
+                    model !== "discuss.channel";
                 if ((isTabFocused && thread?.isDisplayed) || isInbox) {
                     navigator.serviceWorker.controller?.postMessage({
                         type: "notification-display-response",


### PR DESCRIPTION
**Current behavior before PR:**

The `isInbox` condition was always evaluated as false because it incorrectly 
checked the user's notification preference in the wrong model. This caused 
users to receive two push notifications for the same message.

**Desired behavior after PR is merged:**

The `isInbox` condition now checks the user model for notification preferences, ensuring the correct behavior.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
