### PR TITLE
[FIX] mail: ensure warnings filter works as expected in search view

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -116,8 +116,6 @@ class MailActivityMixin(models.AbstractModel):
             record.activity_user_id = record.activity_ids[0].user_id if record.activity_ids else False
 
     def _search_activity_exception_decoration(self, operator, operand):
-        if Domain.is_negative_operator(operator):
-            return NotImplemented
         return [('activity_ids.activity_type_id.decoration_type', operator, operand)]
 
     @api.depends('activity_ids.state')


### PR DESCRIPTION
Issue Before This Commit:
=======================
Currently, when the `Warnings` filter was applied in search view of `mrp.production`, `purchase.order`, `stock.picking`, or `product.template` models, records without any warning were shown instead of those with a warning or danger status. As a result, users may overlook records requiring attention, since records marked with warning or danger were not visible when filtering leading to confusion and missed follow-ups.

Steps to Reproduce:
=======================
- Install the `MRP` module.
- Go to Manufacturing → Operations → Manufacturing Orders.
- Create 1–2 demo MOs. Apply the `Warnings` filter in the search view.
- Observe that records without warning or danger status are displayed.

Cause of the Issue:
=======================
In this [commit](https://github.com/odoo/odoo/commit/92301a5b300dec1ddfca44dc35318b83d67c56fa), the `_search_activity_exception_decoration` method was incorrectly modified to handle negative operators. When a negative operator (like `not in`) is used, the method tried to complete the search using the positive `in` operator, causing incorrect filtering and returning records without warning or danger status.

With This Commit:
=======================
The unnecessary condition handling negative operators has been removed. The method now correctly uses the operator provided in the search, ensuring that the warnings filter returns only records with a warning or danger status. This fix eliminates confusion caused by incorrect search results and reduces the risk of missing critical exceptions during processing.

TaskID-5154877