### PR TITLE
[FIX] web: search_panel, introduce missing border

### DIFF
--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -185,8 +185,8 @@
             t-att-class="isChildList ? env.isSmall ? '' : 'o_treeEntry' : 'ps-0'"
             >
             <header
-                class="list-group-item list-group-item-action d-flex align-items-center px-0 py-lg-0 border-0"
-                t-att-class="{'active text-900 fw-bold': state.active[section.id] === valueId}"
+                class="list-group-item list-group-item-action d-flex align-items-center px-0 py-lg-0"
+                t-attf-class="{{state.active[section.id] === valueId ? 'active text-900 fw-bold' : 'border-0'}}"
                 t-on-click="() => this.toggleCategory(section, value)"
                 >
                 <div


### PR DESCRIPTION
This commit introduces a missing border on active category items within the search panel.

task-5121027

Requires:
- https://github.com/odoo/enterprise/pull/95900

| Before | After |
|--------|--------|
| <img width="587" height="654" alt="Capture d’écran 2025-10-28 à 10 28 49" src="https://github.com/user-attachments/assets/4c9f9292-9a18-4470-863d-35b34a3fade6" /> | <img width="494" height="645" alt="Capture d’écran 2025-10-28 à 10 28 31" src="https://github.com/user-attachments/assets/d7994472-b7ae-4518-966a-d42def9e35d5" /> |





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
