### PR TITLE
[FIX] website: avoid triggering post link when opening a <select>

### DIFF
--- a/addons/website/static/src/interactions/post_link.js
+++ b/addons/website/static/src/interactions/post_link.js
@@ -5,12 +5,24 @@ import { sendRequest } from "@website/js/utils";
 
 export class PostLink extends Interaction {
     static selector = ".post_link";
+    dynamicSelectors = {
+        ...this.dynamicSelectors,
+        // Distinguish _root according to node type.
+        _select: () => this.el.matches("select") && this.el,
+        _nonSelect: () => !this.el.matches("select") && this.el,
+    };
     dynamicContent = {
         _root: {
-            "t-on-click.prevent": this.onClickPost,
             "t-att-class": () => ({
                 "o_post_link_js_loaded": true,
             }),
+        },
+        _nonSelect: {
+            "t-on-click.prevent": this.onClickPost,
+        },
+        _select: {
+            // In some browsers the click event is triggered when opening the select.
+            "t-on-change.prevent": this.onClickPost,
         },
     };
 

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -116,6 +116,7 @@
 <!-- ======   Template: Date Selector   ========================================
 ============================================================================ -->
 <template id="date_selector">
+    <!-- TODO: remove oninput in master -->
     <select name="archive" oninput="location = this.value;" class="form-select">
         <!-- TODO: remove in master -->
         <option t-if="False" t-att-value="blog_url(date_begin=False, date_end=False) if blog else '/blog'"


### PR DESCRIPTION
In some browsers, opening a `<select>` triggers a click event. Because of this when the blog's sidebar "Archive" dropdown is opened, it might reload the page before the selection is actually made.

This commit solves this by detecting a distinct event when PostLink is activated on `<select>` element.

Steps to reproduce:
- Using Firefox
- Install `website_blog`
- Edit the blogs page
- Activate the sidebar
- Save
- Open the "Archive" dropdown

=> The page was reloaded
