### PR TITLE
[FIX] website_event: deal with dead "s_speaker_bio" snippet

### DIFF
--- a/addons/website_event/views/event_snippets.xml
+++ b/addons/website_event/views/event_snippets.xml
@@ -2,6 +2,14 @@
 <odoo>
 
 <!-- Snippets and options -->
+
+<!--
+FIXME this template has no effect as the app already contains an earlier
+`website_event.snippets` view definition. It is kept in stable to be
+extra-careful (who knows...) and that snippet code will totally disappear in
+master (indeed, it is not really important and its structure does not seem
+perfect and nobody missed this for 4+ major versions).
+-->
 <template id="snippets" inherit_id="website.snippets">
     <xpath expr="//t[@id='event_speaker_bio_hook']" position="replace">
         <t t-snippet="website_event.s_speaker_bio" string="Speaker Bio" t-thumbnail="/website_event/static/src/img/snippets_thumbs/s_speaker_bio.svg"/>


### PR DESCRIPTION
Problem introduced at [1] (see [2]). In stable, this comments the code to explain the dead code presence. In master, that snippet will be removed, as nobody seemed to have missed him for 4+ major versions and its structure is not perfect (overflow hidden...). Thankfully it should not come with any compatibility issue as it was not associated with any JS/CSS). Maybe a new equivalent will be introduced in master later on.

[1]: https://github.com/odoo/odoo/commit/b5c87d86cad1aa2b44f805da0b2d6635aeb85b96
[2]: https://github.com/odoo/odoo/pull/68644#discussion_r903721785

task-4084801

