### PR TITLE
[FIX] website_sale{,_stock}: keep open cart unchanged on reorder

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1858,7 +1858,9 @@ class CustomerPortal(portal.CustomerPortal):
     @http.route('/my/orders/reorder_modal_content', type='json', auth='public', website=True)
     def _get_saleorder_reorder_content_modal(self, order_id, access_token):
         try:
-            sale_order = self._document_check_access('sale.order', order_id, access_token=access_token)
+            sale_order = self._document_check_access(
+                'sale.order', order_id, access_token=access_token,
+            ).with_user(request.env.user).sudo()
         except (AccessError, MissingError):
             return request.redirect('/my')
 

--- a/addons/website_sale_stock/tests/test_website_sale_stock_reorder_from_portal.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_reorder_from_portal.py
@@ -1,16 +1,23 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+from uuid import uuid4
+
+from odoo import Command
+from odoo.http import root
 from odoo.tests import tagged
-from odoo.tests.common import HttpCase
+
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleStockReorderFromPortal(HttpCase):
+class TestWebsiteSaleStockReorderFromPortal(HttpCaseWithUserPortal):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env['website'].get_current_website().enabled_portal_reorder_button = True
+        cls.website = cls.env['website'].get_current_website()
+        cls.website.enabled_portal_reorder_button = True
 
         cls.available_product = cls.env['product.product'].create({
             'name': 'available_product',
@@ -33,9 +40,8 @@ class TestWebsiteSaleStockReorderFromPortal(HttpCase):
             'sale_ok': True,
             'website_published': True,
         })
-        user_admin = cls.env.ref('base.user_admin')
-        order = cls.env['sale.order'].create({
-            'partner_id': user_admin.partner_id.id,
+        cls.order = cls.env['sale.order'].create({
+            'partner_id': cls.partner_portal.id,
             'state': 'sale',
             'order_line': [
                 (0, 0, {
@@ -52,7 +58,7 @@ class TestWebsiteSaleStockReorderFromPortal(HttpCase):
                 })
             ]
         })
-        order.message_subscribe(user_admin.partner_id.ids)
+        cls.order.message_subscribe(cls.partner_portal.ids)
 
         cls.env['stock.quant'].with_context(inventory_mode=True).create({
             'product_id': cls.available_product.id,
@@ -66,4 +72,42 @@ class TestWebsiteSaleStockReorderFromPortal(HttpCase):
         }).action_apply_inventory()
 
     def test_website_sale_stock_reorder_from_portal_stock(self):
-        self.start_tour("/", 'website_sale_stock_reorder_from_portal', login='admin')
+        self.start_tour(
+            "/", 'website_sale_stock_reorder_from_portal', login=self.user_portal.login,
+        )
+
+    def test_website_sale_stock_reorder_cart_change(self):
+        """Ensure cart remains unchanged when attempting a reorder."""
+        cart = self.env['sale.order'].create({
+            'partner_id': self.partner_portal.id,
+            'website_id': self.website.id,
+            'order_line': [Command.create({
+                'product_id': self.unavailable_product.id,
+                'product_uom_qty': 5.0,
+            })],
+        })
+        session = self.authenticate(self.user_portal.login, self.user_portal.login)
+        session['sale_order_id'] = cart.id
+        root.session_store.save(session)
+        rpc_request = {'jsonrpc': '2.0', 'method': 'call', 'id': str(uuid4()), 'params': {
+            'order_id': self.order.id,
+            'access_token': self.order._portal_ensure_token(),
+        }}
+        res = self.url_open(
+            '/my/orders/reorder_modal_content',
+            data=json.dumps(rpc_request).encode(),
+            headers={'Content-Type': 'application/json'},
+            timeout=None,
+        ).json().get('result', {})
+        combination_info = next(
+            product_info['combinationInfo'] for product_info in res['products']
+            if product_info['combinationInfo']['product_id'] == self.unavailable_product.id
+        )
+        self.assertEqual(
+            combination_info['cart_qty'], 5.0,
+            "Combination info retrieved via RPC should be correct.",
+        )
+        self.assertEqual(
+            cart.partner_id, self.partner_portal,
+            "Customer should remain unchanged on cart.",
+        )


### PR DESCRIPTION
Versions
--------
- 16.0
- 17.0
- 18.0

Steps
-----
1. Have a product that cannot be sold out of stock (but is in stock);
2. have a confirmed sales order for a portal user with said product;
3. as portal user, add the product to your cart;
4. go to My Account / Your Orders;
5. open the confirmed sales order;
6. click Order Again.

Issue
-----
The cart that was opened by the portal user now has OdooBot as Customer.

Cause
-----
The `_document_check_access` method returns a sale order record with `SUPERUSER_ID` in its env[^1]. Meanwhile, the `website.sale_get_order` method checks the current user's partner, and if it's different from the order's partner, it gets reassigned, assuming an address change[^2].

[^1]: https://github.com/odoo/odoo/blob/9eb0b12/addons/portal/controllers/portal.py#L439-L459
[^2]: https://github.com/odoo/odoo/blob/9eb0b12/addons/website_sale/models/website.py#L386-L404

Because `SUPERUSER_ID` is the user in the environment, the order's partner gets changed to OdooBot.

Solution
--------
After `_document_check_access`, add the request's user to the record's env.

opw-5097915