### PR TITLE
[IMP] web: sample data backpedaling

### DIFF
--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -332,7 +332,6 @@
 
 // Sample data
 @mixin o-sample-data-disabled {
-    opacity: 0.06;
     pointer-events: none;
     user-select: none;
 }

--- a/addons/web/static/src/views/action_helper.js
+++ b/addons/web/static/src/views/action_helper.js
@@ -13,8 +13,4 @@ export class ActionHelper extends Component {
     get showDefaultHelper() {
         return !this.props.noContentHelp;
     }
-
-    showWidgetSampleData() {
-        return this.props.showRibbon;
-    }
 }

--- a/addons/web/static/src/views/action_helper.xml
+++ b/addons/web/static/src/views/action_helper.xml
@@ -4,12 +4,6 @@
     <t t-name="web.ActionHelper">
         <div class="o_view_nocontent">
             <div class="o_nocontent_help">
-                <t t-if="showWidgetSampleData()">
-                    <RibbonWidget  t-props="{
-                        text: 'SAMPLE DATA',
-                        bgClass: 'text-bg-danger',
-                    }"/>
-                </t>
                 <t t-if="showDefaultHelper">
                     <p class="o_view_nocontent_empty_folder">
                         <t t-if="title" t-esc="title"/>

--- a/addons/web/static/src/views/view.scss
+++ b/addons/web/static/src/views/view.scss
@@ -18,6 +18,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    background-image:  radial-gradient(
+        at 50% 50%,
+        #{$o-view-background-color} 0px,
+        #{rgba($o-view-background-color, 0.5)} 100%
+    );
 
     .o_nocontent_help {
         @include o-nocontent-empty;

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -2292,8 +2292,6 @@ test("empty graph view with sample data", async () => {
 
     expect(".o_graph_view .o_content").toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent").toHaveCount(1);
-    expect(".ribbon").toHaveCount(1);
-    expect(".ribbon").toHaveText("SAMPLE DATA");
     expect(".o_graph_canvas_container canvas").toHaveCount(1);
 
     await toggleSearchBarMenu();
@@ -2301,7 +2299,6 @@ test("empty graph view with sample data", async () => {
 
     expect(".o_graph_view .o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent").toHaveCount(0);
-    expect(".ribbon").toHaveCount(0);
     expect(".o_graph_canvas_container canvas").toHaveCount(1);
 });
 
@@ -2326,7 +2323,6 @@ test("non empty graph view with sample data", async () => {
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent").toHaveCount(0);
     expect(".o_graph_canvas_container canvas").toHaveCount(1);
-    expect(".ribbon").toHaveCount(0);
 
     await toggleSearchBarMenu();
     await toggleMenuItem("False Domain");
@@ -2334,7 +2330,6 @@ test("non empty graph view with sample data", async () => {
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_graph_canvas_container canvas").toHaveCount(0);
     expect(".o_view_nocontent").toHaveCount(1);
-    expect(".ribbon").toHaveCount(0);
 });
 
 test("empty graph view without sample data after filter", async () => {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -7019,8 +7019,6 @@ test("empty kanban with sample data", async () => {
         message: "there should be 10 sample records",
     });
     expect(".o_view_nocontent").toHaveCount(1);
-    expect(".ribbon").toHaveCount(1);
-    expect(".ribbon").toHaveText("SAMPLE DATA");
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Match nothing");
@@ -7028,7 +7026,6 @@ test("empty kanban with sample data", async () => {
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(0);
     expect(".o_view_nocontent").toHaveCount(1);
-    expect(".ribbon").toHaveCount(0);
 });
 
 test("empty grouped kanban with sample data and many2many_tags", async () => {
@@ -7148,14 +7145,12 @@ test("non empty kanban with sample data", async () => {
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4);
     expect(".o_view_nocontent").toHaveCount(0);
-    expect(".ribbon").toHaveCount(0);
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Match nothing");
 
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(0);
-    expect(".ribbon").toHaveCount(0);
 });
 
 test("empty grouped kanban with sample data: add a column", async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7224,8 +7224,6 @@ test(`empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(10);
     expect(`.o_nocontent_help`).toHaveCount(1);
-    expect(".ribbon").toHaveCount(1);
-    expect(".ribbon").toHaveText("SAMPLE DATA");
 
     // Check list sample data
     expect(`.o_data_row .o_data_cell:eq(0)`).toHaveText("", {
@@ -7254,7 +7252,6 @@ test(`empty list with sample data`, async () => {
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_nocontent_help`).toHaveCount(1);
-    expect(".ribbon").toHaveCount(0);
 
     await toggleMenuItem("False Domain");
     await toggleMenuItem("True Domain");
@@ -7262,7 +7259,6 @@ test(`empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(4);
     expect(`.o_nocontent_help`).toHaveCount(0);
-    expect(".ribbon").toHaveCount(0);
 });
 
 test(`refresh empty list with sample data`, async () => {
@@ -7413,7 +7409,6 @@ test(`non empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(4);
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
-    expect(".ribbon").toHaveCount(0);
 
     await toggleSearchBarMenu();
     await toggleMenuItem("true_domain");
@@ -7421,7 +7416,6 @@ test(`non empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(0);
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
-    expect(".ribbon").toHaveCount(0);
 });
 
 test(`click on header in empty list with sample data`, async () => {

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -2799,12 +2799,9 @@ test("empty pivot view with sample data", async () => {
 
     expect(".o_pivot_view .o_content").toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(1);
-    expect(".ribbon").toHaveCount(1);
-    expect(".ribbon").toHaveText("SAMPLE DATA");
     await removeFacet();
     expect(".o_pivot_view .o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(0);
-    expect(".ribbon").toHaveCount(0);
     expect("table").toHaveCount(1);
 });
 
@@ -2828,13 +2825,11 @@ test("non empty pivot view with sample data", async () => {
 
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(0);
-    expect(".ribbon").toHaveCount(0);
     expect("table").toHaveCount(1);
     await toggleSearchBarMenu();
     await toggleMenuItem("Small Than 0");
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(1);
-    expect(".ribbon").toHaveCount(0);
     expect("table").toHaveCount(0);
 });
 


### PR DESCRIPTION
This commit removes the sample data ribbon introduced in #208864 and adds an opacity blur over sample data.

task-5207352
