### PR TITLE
[FIX] mrp: prevent error on splitting multiple manufacturing orders at once

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -39,7 +39,7 @@ class MrpProductionSplit(models.TransientModel):
     def _compute_num_splits(self):
         self.num_splits = 0
         for wizard in self:
-            if wizard.product_uom_id.compare(self.max_batch_size, 0) > 0:
+            if wizard.product_uom_id.compare(wizard.max_batch_size, 0) > 0:
                 wizard.num_splits = float_round(
                     wizard.product_qty / wizard.max_batch_size,
                     precision_digits=0,


### PR DESCRIPTION
Currently, an error occurs when trying to split multiple manufacturing orders at once from the list view.

**Steps to Reproduce:**
1. Install the MRP module with demo data.
2. Select multiple manufacturing orders from the list view.
3. Click on the "Split" option under the Action button.

**Error:**
`ValueError - Expected singleton: mrp.production.split(1, 2, 3, 4, 5, 6, 7, 8, 9)`

**Cause:**
The `_compute_num_splits` method referenced `self.max_batch_size` directly, which expects a single record. When multiple records were processed at once, this caused a singleton error.

**Fix:**
This commit handles multiple manufacturing order splits to prevent the error.

sentry-6951925545