### PR TITLE
[IMP] orm: get name instead of label by default for properties selection

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -45,7 +45,7 @@ def render_res_ids(model, res_ids, results):
     For falsy ids, use an empty recordset.
     """
     res_ids, falsy_ids = tools.partition(lambda id_: id_ or isinstance(id_, api.NewId), res_ids)
-    yield from model.browse(res_ids)
+    yield from model.browse(res_ids).with_context(property_selection_get_label=True)
     if not falsy_ids:
         return
     yield model.browse()

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -1979,7 +1979,8 @@ class PropertiesCase(TestPropertiesMixin):
             self.message_1['attributes']['state']
         with self.assertRaises(KeyError):
             self.message_2['attributes']['state']
-        self.assertEqual(self.message_3['attributes']['state'], 'Draft')
+        self.assertEqual(self.message_3['attributes']['state'], 'draft')
+        self.assertEqual(self.message_3.with_context(property_selection_get_label=True)['attributes']['state'], 'Draft')
 
         self.message_1.attributes = [{
             'name': 'tags',

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -642,7 +642,7 @@ class Properties(Field):
             raise ValueError(f"Missing property name for {self}")
 
         def get_property(record):
-            property_value = self.__get__(record.with_context(property_selection_get_key=True))
+            property_value = self.__get__(record)
             value = property_value.get(property_name)
             if value:
                 return value
@@ -828,9 +828,10 @@ class Property(abc.Mapping):
             return self.record.env[prop.get('comodel')].browse(prop.get('value'))
 
         if prop.get('type') == 'selection' and prop.get('value'):
-            if self.record.env.context.get('property_selection_get_key'):
-                return next((sel[0] for sel in prop.get('selection') if sel[0] == prop['value']), False)
-            return next((sel[1] for sel in prop.get('selection') if sel[0] == prop['value']), False)
+            option = next((sel for sel in prop.get('selection') if sel[0] == prop['value']), False)
+            if not option:
+                return option
+            return option[1] if self.record.env.context.get('property_selection_get_label') else option[0]
 
         if prop.get('type') == 'tags' and prop.get('value'):
             return ', '.join(tag[1] for tag in prop.get('tags') if tag[0] in prop['value'])


### PR DESCRIPTION
Purpose
=======
Followup of odoo/odoo/pull/232800 , when getting a property selection, we want to return the name by default instead of the label.