### PR TITLE
[FIX] sale_project: `qty_delivered_method` depndencies

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -105,7 +105,7 @@ class SaleOrderLine(models.Model):
             if line.product_id.type == 'service' and line.state == 'sale':
                 line.product_updatable = False
 
-    @api.depends('product_id')
+    @api.depends('product_id.type', 'product_id.service_type', 'is_expense')
     def _compute_qty_delivered_method(self):
         milestones_lines = self.filtered(lambda sol:
             not sol.is_expense

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1329,3 +1329,23 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         so.action_confirm()
         self.assertFalse(self.product_order_service2.project_id.task_ids)
         self.assertFalse(sol.task_id)
+
+    def test_sol_compute_qty_delivered_method(self):
+        """
+        This test checks that the qty_delivered_method is correctly computed
+        """
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+        })
+        so.action_confirm()
+        SaleOrderLine = self.env['sale.order.line'].with_context(default_order_id=so.id)
+
+        self.product_order_service1.service_type = 'manual'
+        sol = SaleOrderLine.create({
+            'product_id': self.product_order_service1.id,
+            'product_uom_qty': 10,
+        })
+        self.assertEqual(sol.qty_delivered_method, 'manual', "Service product with service_type 'manual' should have qty_delivered_method 'manual'.")
+
+        self.product_order_service1.service_type = 'milestones'
+        self.assertEqual(sol.qty_delivered_method, 'milestones', "Service product with service_type 'milestones' should have qty_delivered_method 'milestones'.")


### PR DESCRIPTION
To reproduce:
=============
- create SO with a product of service type 'manual'
- go to product and change its service type to 'milestones'
- go back to SO -> the field 'Delivered Quantity Method' is not updated

Problem:
========
`qty_delivered_method` is a computed field depending only on `product_id`. When changing the service type of the product, the field is not recomputed.

Solution:
=========
Add dependencies on `product_id.type` and `product_id.service_type`. 
P.S: also added `is_expense` as dependency as it is used in the computation.

opw-5096446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
