### PR TITLE
[FIX] web: stop interactions when selectorHas/selectorNotHas become

### DIFF
--- a/addons/web/static/src/public/interaction_service.js
+++ b/addons/web/static/src/public/interaction_service.js
@@ -165,7 +165,16 @@ class InteractionService {
     }
 
     shouldStop(el, interaction) {
-        return el === interaction.el || el.contains(interaction.el);
+        const { selectorNotHas, selectorHas } = interaction.interaction.constructor;
+        if (!interaction.el) {
+            return true;
+        }
+        return (
+            el === interaction.el ||
+            el.contains(interaction.el) ||
+            (selectorHas && !interaction.el.querySelector(selectorHas)) ||
+            (selectorNotHas && !!interaction.el.querySelector(selectorNotHas))
+        );
     }
 
     stopInteractions(el = this.el) {


### PR DESCRIPTION
invalid

Before this commit, the `selectorHas` and `selectorNotHas` conditions of interactions were ignored when calling `stopInteractions` on a sub-element of the interaction target.

For example, in edit mode, adding or removing a node could invalidate `selectorHas`/`selectorNotHas`, but the interaction would not be stopped as expected.

With this commit, when calling `shouldStop` on an interaction, we now check that `selectorHas` and `selectorNotHas` are still valid. If they are not, `shouldStop` returns true so the interaction is properly stopped.

How to reproduce:
- Edit a website page
- Add an Image Gallery snippet
- Remove all images → The `ImageGalleryEdit` interaction activates to display a placeholder allowing the user to add an image
- Perform an undo

Before this commit:
    The `ImageGalleryEdit` placeholder remained visible.

After this commit:
    The `ImageGalleryEdit` placeholder correctly disappears.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
