### PR TITLE
[FIX] mail: don't call old disconnected guests

### DIFF
--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -129,6 +129,9 @@ class ChatbotCase(chatbot_common.ChatbotCase):
             lambda m: m.partner_id == self.chatbot_script.operator_partner_id
         )
         guest_member = discuss_channel.channel_member_ids.filtered(lambda m: bool(m.guest_id))
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="guest_id", identity_value=guest_member.guest_id.id
+        )
         self_member._rtc_join_call()
         self.assertTrue(guest_member.rtc_inviting_session_id)
         self.assertFalse(bot_member.rtc_inviting_session_id)

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -436,10 +436,15 @@ class ChannelMember(models.Model):
         :param list member_ids: List of the partner ids to invite.
         """
         self.ensure_one()
+        recent_guest_ids = self.env["bus.presence"].sudo().search([
+            ("guest_id", "in", self.channel_id.channel_member_ids.guest_id.ids),
+            ("last_poll", ">", fields.Datetime.now() - timedelta(hours=12))
+        ]).guest_id
         domain = [
             ('channel_id', '=', self.channel_id.id),
             ('rtc_inviting_session_id', '=', False),
             ('rtc_session_ids', '=', False),
+            "|", ("guest_id", "=", False), ("guest_id", "in", recent_guest_ids.ids),
         ]
         if member_ids:
             domain = expression.AND([domain, [('id', 'in', member_ids)]])

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -235,6 +235,9 @@ class TestChannelRTC(MailCommon):
     def test_11_start_call_in_group_should_invite_all_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="guest_id", identity_value=test_guest.id
+        )
         channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
@@ -398,6 +401,9 @@ class TestChannelRTC(MailCommon):
     def test_20_join_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="guest_id", identity_value=test_guest.id
+        )
         channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
@@ -588,6 +594,9 @@ class TestChannelRTC(MailCommon):
     def test_21_leave_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="guest_id", identity_value=test_guest.id
+        )
         channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
@@ -700,6 +709,9 @@ class TestChannelRTC(MailCommon):
     def test_25_lone_call_participant_leaving_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="guest_id", identity_value=test_guest.id
+        )
         channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
@@ -812,6 +824,9 @@ class TestChannelRTC(MailCommon):
     def test_30_add_members_while_in_call_should_invite_new_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="guest_id", identity_value=test_guest.id
+        )
         channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda member: member.partner_id == self.user_employee.partner_id)
         now = fields.Datetime.now()


### PR DESCRIPTION
With this commit, guests who haven't been online in the last 12 hours will not be notified of a call starting.

task-5136330

backport of https://github.com/odoo/odoo/pull/230337