### PR TITLE
[IMP] im_livechat: manage expertises from info panel

### DIFF
--- a/addons/im_livechat/controllers/channel.py
+++ b/addons/im_livechat/controllers/channel.py
@@ -59,3 +59,18 @@ class LivechatChannelController(ChannelController):
                 },
                 subchannel="LOOKING_FOR_HELP",
             )
+
+    @route(
+        "/im_livechat/conversation/update_expertises", auth="user", methods=["POST"], type="jsonrpc"
+    )
+    def livechat_conversation_update_expertises(self, channel_id, expertise_ids, mode):
+        if not self.env.user.has_group("im_livechat.im_livechat_group_user"):
+            return
+        if channel := request.env["discuss.channel"].search(
+            [("id", "=", channel_id), ("channel_type", "=", "livechat")]
+        ):
+            # sudo: discuss.channel - live chat users can update the expertises of any live chat.
+            channel.sudo().livechat_expertise_ids = [
+                Command.link(expertise_id) if mode == "ADD" else Command.unlink(expertise_id)
+                for expertise_id in expertise_ids
+            ]

--- a/addons/im_livechat/models/im_livechat_expertise.py
+++ b/addons/im_livechat/models/im_livechat_expertise.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-from odoo import Command, fields, models
+from odoo import api, Command, fields, models
 
 
 class Im_LivechatExpertise(models.Model):
@@ -49,3 +49,9 @@ class Im_LivechatExpertise(models.Model):
         for expertise, users in users_by_expertise.items():
             users_by_expertise[expertise] = users.with_prefetch(user_settings.user_id.ids)
         return users_by_expertise
+
+    @api.model
+    def name_create(self, name):
+        if existing_tag := self.search([("name", "=", name.strip())]):
+            return existing_tag.id, existing_tag.display_name
+        return super().name_create(name)

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -146,3 +146,6 @@ class ResUsers(models.Model):
     def _init_store_data(self, store: Store):
         super()._init_store_data(store)
         store.add_global_values(has_access_livechat=self.env.user.has_access_livechat)
+        store.add_global_values(
+            is_livechat_manager=self.env.user.has_group("im_livechat.im_livechat_group_manager")
+        )

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -8,6 +8,7 @@ declare module "models" {
     export interface Store {
         goToOldestUnreadLivechatThread: () => boolean;
         has_access_livechat: boolean;
+        is_livechat_manager: boolean;
         livechatChannels: ReturnType<Store['makeCachedFetchData']>;
         livechatStatusButtons: Readonly<object[]>;
     }

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.js
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.js
@@ -1,0 +1,89 @@
+import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
+import { useTagNavigation } from "@web/core/record_selectors/tag_navigation_hook";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
+import { useService } from "@web/core/utils/hooks";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+
+/**
+ * @typedef {Object} Props
+ * @property {import("models").DiscussChannel} channel
+ * @extends {Component<Props, Env>}
+ */
+export class ExpertiseTagsAutocomplete extends Component {
+    static template = "im_livechat.ExpertiseTagsAutocomplete";
+    static props = ["channel"];
+    static components = { BadgeTag, Many2XAutocomplete };
+
+    setup() {
+        super.setup(...arguments);
+        this.orm = useService("orm");
+        this.store = useService("mail.store");
+        useTagNavigation("root", {
+            delete: (index) => {
+                const expertise = this.props.channel.livechat_expertise_ids[index];
+                if (expertise) {
+                    this.removeExpertise(expertise.id);
+                }
+            },
+        });
+    }
+
+    /**
+     * @param {number[]} expertiseIds
+     * @param {{mode: "ADD" | "REMOVE"}} param1.mode
+     */
+    updateExpertises(expertiseIds, { mode }) {
+        const idsToUpdate = expertiseIds.filter((id) =>
+            mode === "REMOVE" ? this.isSelected(id) : !this.isSelected(id)
+        );
+        if (idsToUpdate.length === 0) {
+            return;
+        }
+        rpc("/im_livechat/conversation/update_expertises", {
+            channel_id: this.props.channel.id,
+            expertise_ids: idsToUpdate,
+            mode,
+        });
+    }
+
+    /** @param {string} name */
+    async createOrLinkExpertise(name) {
+        if (
+            this.props.channel.livechat_expertise_ids.some((expertise) => expertise.name === name)
+        ) {
+            return;
+        }
+        const [expertiseId] = await this.orm.call("im_livechat.expertise", "name_create", [name]);
+        this.updateExpertises([expertiseId], { mode: "ADD" });
+    }
+
+    /** @param {number} expertiseId */
+    isSelected(expertiseId) {
+        return this.props.channel.livechat_expertise_ids.some(
+            (expertise) => expertise.id === expertiseId
+        );
+    }
+
+    /** @param {{id: number, display_name: string}} expertises */
+    onUpdate(expertises) {
+        this.updateExpertises(
+            expertises.map((expertise) => expertise.id),
+            { mode: "ADD" }
+        );
+    }
+
+    /** @param {number} expertiseId */
+    removeExpertise(expertiseId) {
+        this.updateExpertises([expertiseId], { mode: "REMOVE" });
+    }
+
+    get placeholder() {
+        if (this.props.channel.livechat_expertise_ids.length === 0) {
+            return _t("Add expertise");
+        }
+        return "";
+    }
+}

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.ExpertiseTagsAutocomplete">
+        <div
+            class="o-livechat-expertiseTags d-inline-flex o_tags_input o_input flex-wrap gap-1 mb-3"
+            t-ref="root"
+        >
+            <BadgeTag t-foreach="props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" onDelete="() => this.removeExpertise(expertise.id)"/>
+            <div class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
+                <Many2XAutocomplete
+                    placeholder="placeholder"
+                    resModel="'im_livechat.expertise'"
+                    activeActions="{'link': true}"
+                    isToMany="true"
+                    fieldString.translate="Expertise"
+                    update.bind="onUpdate"
+                    quickCreate="store.is_livechat_manager ? (name) => this.createOrLinkExpertise(name) : null"
+                    getDomain="() => []"
+                >
+                    <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                        <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record.id) }">
+                            <span t-out="autoCompleteItemScope.label"/>
+                        </span>
+                    </t>
+                </Many2XAutocomplete>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -1,4 +1,5 @@
 import { TranscriptSender } from "@im_livechat/core/common/transcript_sender";
+import { ExpertiseTagsAutocomplete } from "@im_livechat/core/web/expertise_tags_autocomplete";
 import { ConversationTagEdit } from "@im_livechat/core/web/livechat_conversation_tag_edit";
 
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
@@ -6,15 +7,15 @@ import { prettifyMessageContent } from "@mail/utils/common/format";
 
 import { Component, useEffect, useRef, useSubEnv } from "@odoo/owl";
 
+import { startUrl } from "@web/core/browser/router";
 import { rpc } from "@web/core/network/rpc";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
-import { startUrl } from "@web/core/browser/router";
-import { BadgeTag } from "@web/core/tags_list/badge_tag";
-import { usePopover } from "@web/core/popover/popover_hook";
 
 export class LivechatChannelInfoList extends Component {
-    static components = { ActionPanel, BadgeTag, TranscriptSender };
+    static components = { ActionPanel, BadgeTag, ExpertiseTagsAutocomplete, TranscriptSender };
     static template = "im_livechat.LivechatChannelInfoList";
     static props = ["thread"];
 
@@ -55,13 +56,6 @@ export class LivechatChannelInfoList extends Component {
         return this.props.thread.messages
             .filter((m) => m.chatbotStep?.expectAnswer)
             .map((m) => m.chatbotStep);
-    }
-
-    get expertiseTags() {
-        return this.props.thread.livechat_expertise_ids.map((expertise) => ({
-            id: expertise.id,
-            text: expertise.name,
-        }));
     }
 
     onBlurNote() {

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -45,13 +45,9 @@
                     </div>
                 </t>
             </div>
-            <div t-if="expertiseTags.length" class="d-flex flex-column bg-inherit gap-1">
+            <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Expertise</h6>
-                <div class="d-flex flex-wrap gap-1">
-                    <t t-foreach="expertiseTags" t-as="tag" t-key="tag.id">
-                        <BadgeTag cssClass="'me-1 mb-1'" text="tag.text"/>
-                    </t>
-                </div>
+                <ExpertiseTagsAutocomplete channel="props.thread.channel"/>
             </div>
             <t t-name="extra_infos"/>
             <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -10,6 +10,7 @@ const storePatch = {
         super.setup(...arguments);
         this.livechatChannels = this.makeCachedFetchData("im_livechat.channel");
         this.has_access_livechat = false;
+        this.is_livechat_manager = false;
     },
     /**
      * @override

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -6,7 +6,7 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, press, test } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
 
@@ -156,21 +156,18 @@ test("editing livechat status is synced between tabs", async () => {
     }); // Status should be synced with bus
 });
 
-test("Shows expertise", async () => {
+test("Manage expertises from channel info list", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], {
+        group_ids: pyEnv["res.groups"]
+            .search_read([["id", "=", serverState.groupLivechatManagerId]])
+            .map(({ id }) => id),
+    });
     const userId = pyEnv["res.users"].create({ name: "James" });
-    pyEnv["res.partner"].create({
-        name: "James",
-        user_ids: [userId],
-    });
+    pyEnv["res.partner"].create({ name: "James", user_ids: [userId] });
     const countryId = pyEnv["res.country"].create({ code: "be", name: "Belgium" });
-    const guestId = pyEnv["mail.guest"].create({
-        name: "Visitor #20",
-    });
-    const expertiseIds = pyEnv["im_livechat.expertise"].create([
-        { name: "pricing" },
-        { name: "events" },
-    ]);
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
+    const expertiseIds = pyEnv["im_livechat.expertise"].create([{ name: "pricing" }]);
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
@@ -184,5 +181,15 @@ test("Shows expertise", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-livechat-ChannelInfoList .o_tag", { text: "pricing" });
+    await insertText(".o-livechat-expertiseTags input", "events");
+    await click("a", { text: 'Create "events"' });
+    await contains(".o-livechat-ChannelInfoList .o_tag", { text: "events" });
+    await click(".o-livechat-expertiseTags input");
+    await press("Backspace");
+    await contains(".o-livechat-ChannelInfoList .o_tag", { text: "events", count: 0 });
+    await press("Backspace");
+    await contains(".o-livechat-ChannelInfoList .o_tag", { text: "pricing", count: 0 });
+    await contains(".o-livechat-expertiseTags input[placeholder='Add expertise']");
+    await click("a", { text: "events" });
     await contains(".o-livechat-ChannelInfoList .o_tag", { text: "events" });
 });

--- a/addons/im_livechat/static/tests/livechat_test_helpers.js
+++ b/addons/im_livechat/static/tests/livechat_test_helpers.js
@@ -36,6 +36,7 @@ export const livechatModels = {
 };
 
 serverState.groupLivechatId = 42;
+serverState.groupLivechatManagerId = 43;
 
 /**
  * Setup the server side of the livechat app.

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -3,7 +3,7 @@ import {
     parseRequestParams,
     registerRoute,
 } from "@mail/../tests/mock_server/mail_mock_server";
-import { makeKwArgs } from "@web/../tests/web_test_helpers";
+import { Command, makeKwArgs } from "@web/../tests/web_test_helpers";
 import { loadBundle } from "@web/core/assets";
 import { patch } from "@web/core/utils/patch";
 
@@ -63,7 +63,9 @@ async function get_session(request) {
         });
         return { store_data: store.get_result(), channel_id: -1 };
     }
-    const channelVals = LivechatChannel._get_livechat_discuss_channel_vals(channel_id, {'agent': agent});
+    const channelVals = LivechatChannel._get_livechat_discuss_channel_vals(channel_id, {
+        agent: agent,
+    });
     channelVals.country_id = country_id;
     const channelId = DiscussChannel.create(channelVals);
     const store = new mailDataHelpers.Store();
@@ -184,6 +186,26 @@ async function session_update_note(request) {
         livechat_note: note,
     });
     return true;
+}
+
+registerRoute(
+    "/im_livechat/conversation/update_expertises",
+    livechat_conversation_update_expertises
+);
+/** @type {RouteCallback} */
+async function livechat_conversation_update_expertises(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    const { channel_id, expertise_ids, mode } = await parseRequestParams(request);
+    const [channel] = DiscussChannel.search_read([["id", "=", channel_id]]);
+    if (!channel) {
+        return false;
+    }
+    DiscussChannel.write(channel_id, {
+        livechat_expertise_ids: expertise_ids.map((id) =>
+            mode === "ADD" ? Command.link(id) : Command.unlink(id)
+        ),
+    });
 }
 
 patch(mailDataHelpers, {

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_groups.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_groups.js
@@ -9,5 +9,10 @@ export class ResGroups extends mailModels.ResGroups {
             name: "Livechat User",
             privilege_id: false,
         },
+        {
+            id: serverState.groupLivechatManagerId,
+            name: "Livechat Manager",
+            privilege_id: false,
+        },
     ];
 }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_users.js
@@ -9,6 +9,9 @@ export class ResUsers extends mailModels.ResUsers {
         super._init_store_data(...arguments);
         store.add({
             has_access_livechat: this.env.user?.group_ids.includes(serverState.groupLivechatId),
+            is_livechat_manager: this.env.user?.group_ids.includes(
+                serverState.groupLivechatManagerId
+            ),
         });
     }
 }

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -441,6 +441,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "hasMessageTranslationFeature": False,
                 "has_access_create_lead": False,
                 "internalUserGroupId": self.env.ref("base.group_user").id,
+                "is_livechat_manager": False,
                 "mt_comment": self.env.ref("mail.mt_comment").id,
                 "mt_note": self.env.ref("mail.mt_note").id,
                 "odoobot": self.user_root.partner_id.id,


### PR DESCRIPTION
The live chat info panel shows expertises linked to the chat. However, it's not possible to assign expertises to the chat (only available from the chat bot script).

Expertises are useful to quickly identify which kind of help is needed on a chat, or to find conversations about the same topic.

This commit allows to add expertises from the channel info panel.

task-5190361

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
