### PR TITLE
[FIX] pos_sale: amount_unpaid wrong computation

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import math
 
 from odoo import api, fields, models, _
 
@@ -30,7 +31,12 @@ class SaleOrder(models.Model):
     @api.depends('order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
     def _compute_amount_unpaid(self):
         for sale_order in self:
-            total_invoice_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('invoice_lines').filtered(lambda l: l.parent_state != 'cancel').mapped('price_total'))
+            total_invoice_paid = sum(
+                sale_order.order_line.filtered(lambda l: not l.display_type)
+                .mapped('invoice_lines')
+                .filtered(lambda l: l.parent_state != 'cancel')
+                .mapped(lambda l: math.copysign(l.price_total, -l.balance))
+            )
             total_pos_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('pos_order_line_ids.price_subtotal_incl'))
             sale_order.amount_unpaid = sale_order.amount_total - (total_invoice_paid + total_pos_paid)
 


### PR DESCRIPTION
When having a down payment that is reversed by a credit note,
the amount unpaid is wrongly computed.

This is because we take the sum of invoice lines price total, regardless
they come from invoice or credit note. Therefore we end up with negative
value.

Steps:

- Have a SO for 500
- Make a downpayment for 300, confirm
- Make a credit note for the downpayment invoice, confirm
-> SO's amount unpaid is -100, it should be 500. If you now settle the SO,
the amount unpaid will be -300 instead of 0.

opw-5175562
