### PR TITLE
[FIX] web: Correctly calculate string length in fuzzy search

### DIFF
--- a/addons/web/static/src/core/utils/search.js
+++ b/addons/web/static/src/core/utils/search.js
@@ -36,11 +36,12 @@ function match(pattern, strs) {
 function _match(pattern, str) {
     let totalScore = 0;
     let currentScore = 0;
-    const len = str.length;
     let patternIndex = 0;
 
     pattern = unaccent(pattern, false);
     str = unaccent(str, false);
+
+    const len = str.length;
 
     for (let i = 0; i < len; i++) {
         if (str[i] === pattern[patternIndex]) {

--- a/addons/web/static/tests/core/utils/search_test.js
+++ b/addons/web/static/tests/core/utils/search_test.js
@@ -12,6 +12,7 @@ QUnit.module("utils", () => {
             { name: "Jane Yellow" },
             { name: "Brandon Green" },
             { name: "Jérémy Red" },
+            { name: "สมศรี จู่โจม" },
         ];
         assert.deepEqual(
             fuzzyLookup("ba", data, (d) => d.name),
@@ -40,6 +41,10 @@ QUnit.module("utils", () => {
         assert.deepEqual(
             fuzzyLookup("", data, (d) => d.name),
             []
+        );
+        assert.deepEqual(
+            fuzzyLookup("สมศ", data, (d) => d.name),
+            [{ name: "สมศรี จู่โจม" }]
         );
     });
 


### PR DESCRIPTION
The fuzzy search mechanism (specifically the _match utility) calculates the length of the string before normalizing it (e.g., with `unaccent`). However, `unaccent` can remove non-spacing marks (like Thai tone marks or vowels), which changes the length of the string.

This mismatch caused the search loop to iterate past the end of the normalized string, leading to incorrect behavior or potential errors.

This commit moves the length calculation to after the string has been unaccented, ensuring the loop has the correct bounds.

opw-5189276

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
