### PR TITLE
[IMP] web_tour: improvement of tour recorder

### DIFF
--- a/addons/web_tour/static/src/js/tour_recorder/tour_recorder.xml
+++ b/addons/web_tour/static/src/js/tour_recorder/tour_recorder.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 <t t-name="web_tour.TourRecorder">
-    <div class="d-flex position-fixed bottom-0 start-0 bg-primary o_tour_recorder">
-        <div t-ref="tour_recorder" class="d-flex">
-            <button class="o_button_record btn btn-primary rounded-0" t-on-click.prevent.stop="toggleRecording">
-                <span class="px-2 me-1 rounded-circle" t-att-class="state.recording ? 'bg-danger': 'bg-secondary'" role="status" aria-hidden="true"></span>
+    <div t-ref="tour_recorder" class="d-flex position-fixed ms-2 mb-2 p-1 rounded bg-primary shadow-sm o_tour_recorder" t-attf-style="left: {{state.position.x}}px; bottom: {{state.position.y}}px;">
+        <div class="d-flex align-items-center">
+            <div class="bg-primary text-secondary o_tour_recorder_handler px-1" style="cursor: grab;">
+                <span class="oi oi-draggable"/>
+            </div>
+            <button class="o_button_record btn btn-primary " t-on-click.prevent.stop="toggleRecording">
+                <span class="px-2 me-1 rounded-circle" t-att-class="state.recording ? 'bg-danger': 'bg-white'" role="status" aria-hidden="true"></span>
                 Record
                 <span class="fst-italic fw-lighter" t-if="state.editedElement"> (recording keyboard)</span>
             </button>
-            <Dropdown position="'top-end'">
-                <button class="o_button_steps btn btn-primary rounded-0">
-                    Steps <span class="badge rounded-pill bg-danger"><t t-esc="state.steps.length"/></span>
+            <Dropdown position="'bottom-end'" menuClass="'p-0'" state="dropdownState">
+                <button class="o_button_steps btn btn-primary mx-1" t-att-disabled="!state.steps.length">
+                    Steps <span class="bg-danger rounded py-1 px-2"><t t-esc="state.steps.length"/></span>
                 </button>
                 <t t-set-slot="content">
-                    <div class="o_tour_recorder p-2">
-                        <h4>Steps:</h4>
-                        <table class="table table-striped">
-                            <thead>
+                    <div class="o_tour_recorder" style="height: 400px; width: 500px">
+                        <table class="table">
+                            <thead class="fw-bold bg-secondary-subtle position-sticky top-0">
                                 <tr>
-                                    <td>n°</td>
-                                    <td>trigger</td>
-                                    <td></td>
+                                    <td>#</td>
+                                    <td style="width: 25rem">Trigger</td>
+                                    <td><button class="btn btn-link py-0" t-on-click="openResetStepsDialog">Clear</button></td>
                                 </tr>
                             </thead>
                             <tbody>
@@ -31,7 +33,7 @@
                                             <t t-esc="step.trigger"/>
                                             <span t-if="step.run and step.run != 'click'" class="fst-italic fw-lighter"><br/>(run: <t t-esc="step.run"/>) </span>
                                         </td>
-                                        <td><button class="o_button_delete_step btn btn-link text-danger fa fa-trash mx-1" t-on-click.prevent.stop="() => state.steps.splice(step_index, 1)"/></td>
+                                        <td><button class="o_button_delete_step btn btn-link text-danger fa fa-trash mx-1" t-on-click.prevent.stop="() => this.removeStep(step_index)"/></td>
                                     </tr>
                                 </t>
                             </tbody>
@@ -40,23 +42,40 @@
                 </t>
             </Dropdown>
             <Dropdown t-if="state.steps.length" position="'top-end'">
-                <button class="o_button_save btn btn-primary px-1 rounded-0">
-                    <i class="fa fa-floppy-o"></i>
+                <button class="o_button_save btn btn-primary px-2 rounded-0" data-tooltip="Save">
+                    <i class="fa fa-cloud-upload"></i>
                 </button>
                 <t t-set-slot="content">
-                    <div class="o_tour_recorder p-1" style="min-width: 30vw;">
-                        <form class="p-1" t-on-submit.prevent="saveTour">
-                            <label for="name" class="o_form_label my-1">Name:</label><br/>
-                            <input t-att-value="state.tourName" t-on-change="(ev) => state.tourName = ev.target.value" class="o_input" placeholder="name_of_the_tour" type="text" name="name"/>
-                            <label for="url" class="o_form_label my-1">Url:</label><br/>
-                            <input t-att-value="state.url" t-on-change="(ev) => state.url = ev.target.value" class="o_input" type="text" name="url"/>
-                            <button class="o_button_save_confirm btn btn-primary mt-3">Save</button>
+                    <div class="o_tour_recorder p-1" style="width: 400px;">
+                        <form t-on-submit.prevent="saveTour">
+                            <div class="container">
+                                <div class="row pt-1">
+                                    <div class="col-4">
+                                        <label for="tour_name" class="o_form_label fw-bold me-2">Name</label>
+                                    </div>
+                                    <div class="col-8 o_field_widget">
+                                        <input t-att-value="state.tourName" t-on-change="(ev) => state.tourName = ev.target.value" class="o_input" type="text" id="tour_name"/>
+                                    </div>
+                                </div>  
+                                <div class="row pt-3">
+                                    <div class="col-4">
+                                        <label for="url" class="o_form_label fw-bold">Starting URL</label>
+                                    </div>
+                                    <div class="col-8 o_field_widget">
+                                        <input t-att-value="state.url" t-on-change="(ev) => state.url = ev.target.value" class="o_input" type="text" id="url"/>
+                                    </div>
+                                </div>   
+                                <div class="row pt-2">
+                                    <div class="col">
+                                        <button class="o_button_save_confirm btn btn-primary">Save</button>
+                                    </div>
+                                </div>     
+                            </div>
                         </form>
                     </div>
                 </t>
             </Dropdown>
-            <button t-if="state.steps.length" class="btn btn-primary px-1" t-on-click="resetTourRecorderState"><i class="fa fa-undo"></i></button>
-            <button class="btn btn-primary position-absolute bottom-0 start-100 rounded-0 border-1 o_tour_recorder_close_button" t-on-click.prevent.stop="() => props.onClose()"><i class="fa fa-close"></i></button>
+            <button class="btn btn-primary o_tour_recorder_close_button" t-on-click.prevent.stop="openCloseRecorderDialog" data-tooltip="Close"><i class="fa fa-close"></i></button>
         </div>
     </div>
 </t>

--- a/addons/web_tour/static/tests/tour_recorder.test.js
+++ b/addons/web_tour/static/tests/tour_recorder.test.js
@@ -249,7 +249,7 @@ test("Remove step during recording", async () => {
     checkTourSteps([".o_child"]);
     await click(".o_button_steps");
     await animationFrame();
-    contains(".o_button_delete_step").click();
+    await contains(".o_button_delete_step").click();
     await click(".o_button_steps");
     await animationFrame();
     checkTourSteps([]);
@@ -305,7 +305,7 @@ test("Save custom tour", async () => {
 
     await click(".o_button_save");
     await animationFrame();
-    await contains("input[name='name']").click();
+    await contains("#tour_name").click();
     await edit("tour_name");
     await animationFrame();
     await click(".o_button_save_confirm");
@@ -459,6 +459,8 @@ test("Check Tour Recorder State", async () => {
     await click(".o_button_record");
     await animationFrame();
     await click(".o_tour_recorder_close_button");
+    await animationFrame();
+    await click(".modal-footer .btn-primary");
     await animationFrame();
     expect(tourRecorderState.getCurrentTourRecorder()).toEqual([]);
     expect(tourRecorderState.isRecording()).toBe("0");


### PR DESCRIPTION
The UX/UI of the tour recorder has been improve.
The behaviour too:
- Record shortcuts
- Record events done in command palette
- The notification contains link to view the new tour
- Tour recorder removed when a tour is starting
- Can enable tour recorder with the word "record" command palette
- Confirmation dialog before closing tour recorder

TASK-5113575


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
