### PR TITLE
[REF] mail: make ActionList class more maintainable 

### DIFF
--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -12,7 +12,6 @@ const actionListProps = [
     "fw?",
     "hasBtnBg?",
     "odooControlPanelSwitchStyle?",
-    "thread?",
 ];
 
 class Action extends Component {

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -43,38 +43,67 @@
 </t>
 
 <t t-name="mail.Action.main">
-    <t t-set="isComposerRoundedBtn" t-value="props.inline and env.inComposer"/>
-    <t t-set="isThreadRoundedBtn" t-value="props.inline and action.tags.includes('JOIN_LEAVE_CALL') and action.icon and !action.inlineName"/>
+    <t t-set="isInlineCircleButton" t-value="env.inComposer or (action.tags.includes('JOIN_LEAVE_CALL') and action.icon and !action.inlineName)"/>
+    <!-- core-->
     <t t-set="btnClass" t-value="attClassObjectToString({
-        [action.btnClass ?? '']: true,
-        [action.tagClassNames]: true,
-        'position-relative': true,
-        'active': action.isActive,
-        'o-mail-ActionList-button btn btn-secondary btn-group-item': true,
+        'o-mail-ActionList-button btn btn-secondary btn-group-item position-relative': true,
         'o-first': props.isFirstInGroup,
         'o-last': props.isLastInGroup,
+        'active': action.isActive,
         'o-odooControlPanelSwitchStyle': props.odooControlPanelSwitchStyle,
         'o-hasBtnBg': hasBtnBg,
-        'rounded-circle': isComposerRoundedBtn or isThreadRoundedBtn,
-        'rounded-start-3': !isComposerRoundedBtn and !isThreadRoundedBtn and !action.tags.includes('JOIN_LEAVE_CALL') and props.inline and props.isFirstInGroup,
-        'rounded-end-3': !isComposerRoundedBtn and !isThreadRoundedBtn and !action.tags.includes('JOIN_LEAVE_CALL') and props.inline and props.isLastInGroup,
-        'px-2 o-py-1_5': props.inline and env.inMeetingView and !env.inComposer,
-        'o-px-1_5 py-1': props.inline and (hasBtnBg and !action.tags.includes('JOIN_LEAVE_CALL') and !env.inMeetingView) or (!hasBtnBg and env.inComposer),
-        'd-flex align-items-center': props.inline and hasBtnBg and action.tags.includes('JOIN_LEAVE_CALL') and !env.inChatWindow,
-        'o-p-1_5': props.inline and hasBtnBg and action.tags.includes('JOIN_LEAVE_CALL') and !env.inChatWindow and !env.inMeetingView,
-        'p-1 d-flex align-items-center': props.inline and hasBtnBg and action.tags.includes('JOIN_LEAVE_CALL') and env.inChatWindow,
         'o-inline': props.inline,
-        'o-p-0_5': props.inline and !hasBtnBg and !env.inComposer,
-        'border-0': props.inline and !hasBtnBg and action.icon,
-        'border-2 o-px-0_5 o-mx-0_5': props.inline and !hasBtnBg and !action.icon,
-        'px-3 py-2': props.dropdown and ui.isSmall,
-        'py-1': props.dropdown and !ui.isSmall,
-        'text-start px-2': !props.inline and !ui.isSmall,
         'btn-danger': action.tags.includes('DANGER'),
         'btn-success': action.tags.includes('SUCCESS'),
+    })"/>
+    <!-- alignment -->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
+        'd-flex align-items-center': props.inline and isInlineCircleButton,
+        'text-start': props.dropdown and !ui.isSmall,
+    })"/>
+    <!-- border-->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
+        'border-0': props.inline and !hasBtnBg and action.icon,
+        'border-2': props.inline and !hasBtnBg and !action.icon,
+    })"/>
+    <!-- roundness -->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
+        'rounded-circle':  props.inline and  isInlineCircleButton,
+        'rounded-start-3': props.inline and !isInlineCircleButton and props.isFirstInGroup,
+        'rounded-end-3':   props.inline and !isInlineCircleButton and props.isLastInGroup,
+    })"/>
+    <!-- margin -->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
+        'o-mx-0_5': props.inline and !hasBtnBg and !action.icon,
+    })"/>
+    <!-- padding -->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
+        'px-2 o-py-1_5': props.inline   and   env.inMeetingView and !env.inComposer,
+        'o-px-1_5 py-1': props.inline   and  ((hasBtnBg and !isInlineCircleButton and !env.inMeetingView) or (!hasBtnBg and env.inComposer)),
+        'o-p-1_5':       props.inline   and  !env.inMeetingView and hasBtnBg and isInlineCircleButton and !env.inChatWindow,
+        'o-px-0_5':      props.inline   and  !env.inMeetingView and !hasBtnBg and !action.icon,
+        'p-1':           props.inline   and  hasBtnBg and isInlineCircleButton and env.inChatWindow,
+        'o-p-0_5':       props.inline   and  !hasBtnBg and !env.inComposer,
+        'px-3 py-2':     props.dropdown and   ui.isSmall,
+        'px-2 py-1':     props.dropdown and  !ui.isSmall,
+    })"/>
+    <!-- simulated dark theme -->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
         'o-text-white border-0 o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
         'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and !action.tags.includes('CALL_LAYOUT'),
         'bg-transparent': store.shouldSimulateDarkTheme(this) and action.tags.includes('CALL_LAYOUT'),
+    })"/>
+    <!-- dynamic classes-->
+    <t t-set="btnClass" t-value="attClassObjectToString({
+        [btnClass]: true,
+        [action.btnClass ?? '']: true,
+        [action.tagClassNames]: true,
     })"/>
     <t t-set="attrs" t-value="{ 'aria-label': action.name, 'disabled': action.disabledCondition, 'name': action.id, 'data-sequence': action.sequence, 'data-sequence-group': action.sequenceGroup, 'data-sequence-quick': action.sequenceQuick }"/>
     <t t-if="action.component and action.componentCondition" t-component="action.component" t-props="action.componentProps"/>

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -96,8 +96,8 @@
     <t t-set="btnClass" t-value="attClassObjectToString({
         [btnClass]: true,
         'o-text-white border-0 o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
-        'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and !action.tags.includes('CALL_LAYOUT'),
-        'bg-transparent': store.shouldSimulateDarkTheme(this) and action.tags.includes('CALL_LAYOUT'),
+        'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and hasBtnBg,
+        'bg-transparent': store.shouldSimulateDarkTheme(this) and !hasBtnBg,
     })"/>
     <!-- dynamic classes-->
     <t t-set="btnClass" t-value="attClassObjectToString({

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -28,7 +28,7 @@
                         <t t-set-slot="content">
                             <t t-if="props.chatWindow.exists()">
                                 <t t-set="quickActionsInDropdown" t-value="partitionedActions.quick.slice(ui.isSmall ? 2 : 4)"/>
-                                <ActionList actions="[quickActionsInDropdown, partitionedActions.other, ...partitionedActions.group]" dropdown="true" thread="channel.thread"/>
+                                <ActionList actions="[quickActionsInDropdown, partitionedActions.other, ...partitionedActions.group]" dropdown="true"/>
                             </t>
                         </t>
                     </Dropdown>
@@ -51,7 +51,7 @@
             </div>
             <div class="ms-1 flex-grow-1"/>
             <div class="d-flex flex-shrink-0 me-1">
-                <ActionList actions="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" inline="true" thread="channel.thread"/>
+                <ActionList actions="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" inline="true"/>
             </div>
             <t t-if="this.store.inPublicPage and !this.store.self_user">
                 <button class="btn ps-1" t-if="!state.editingGuestName">

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -44,7 +44,7 @@
                     </t>
                     <div class="ms-1 flex-grow-1"/>
                     <div class="pe-3">
-                        <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group.slice().reverse()]" inline="true" odooControlPanelSwitchStyle="true" thread="thread"/>
+                        <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group.slice().reverse()]" inline="true" odooControlPanelSwitchStyle="true"/>
                     </div>
                 </div>
                 <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">

--- a/addons/mail/static/src/discuss/call/common/meeting_side_actions.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_side_actions.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.MeetingSideActions">
         <t t-set="dummy" t-value="computeActions()"/>
         <div class="o-mail-MeetingSideActions d-flex">
-            <ActionList actions="actions" inline="true" hasBtnBg="true" thread="store.rtc.channel?.thread" odooControlPanelSwitchStyle="true"/>
+            <ActionList actions="actions" inline="true" hasBtnBg="true" odooControlPanelSwitchStyle="true"/>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel_actions.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel_actions.xml
@@ -2,6 +2,6 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarChannelActions">
         <t t-set="partitionedActions" t-value="threadActions.partition"/>
-        <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group]" dropdown="true" thread="thread"/>
+        <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group]" dropdown="true"/>
     </t>
 </templates>


### PR DESCRIPTION
The ActionList component is used by all discuss actions, one of the goals is consistent UI/UX for the most part.

The challenging part is tweaking the UI slightly in some contexts, which is poorly solved at the moment with complex conditions for classes to style the buttons.

The big `btnClass` object makes it hard to see at a glance what's the resulting style of an action in a given context, and thus makes it hard to know how to make the appropriate changes without impacting other contexts by mistake.

This commit doesn't change the architecture, which is planned at some point, but re-organizes the part in template to be more maintainable.

### [IMP] mail: remove unused ActionList.thread prop
This prop was passed but unused.

### [REF] mail: more generic rule for simulate dark theme bg color
Condition was based on tag of action, i.e. `CALL_LAYOUT` that were just icons while other buttons have background. The condition is now based on whether the button has a background, which matches the original semantics for explicit bg color in simulated dark theme or transparent bg for just showing of icon button.