### PR TITLE
[FIX] {mrp,stock}_account,mrp_landed_costs: computed landed cost from MO

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -14,16 +14,11 @@ class StockMove(models.Model):
         if self.production_id:
             valued_qty = self._get_valued_qty()
             return {
-                'value': self._get_value_from_production(valued_qty),
+                'value': self._get_value_from_production(valued_qty, at_date),
                 'quantity': valued_qty,
                 'description': _('From Production Order %(reference)s', reference=self.production_id.name),
             }
         return super()._get_value_data(forced_std_price, at_date, ignore_manual_update)
-
-    def _get_value_from_production(self, quantity):
-        # TODO: Maybe move _cal_price here
-        self.ensure_one()
-        return quantity * self.price_unit
 
     def _get_all_related_sm(self, product):
         moves = super()._get_all_related_sm(product)

--- a/addons/mrp_landed_costs/models/__init__.py
+++ b/addons/mrp_landed_costs/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import stock_landed_cost
+from . import stock_move

--- a/addons/mrp_landed_costs/models/stock_move.py
+++ b/addons/mrp_landed_costs/models/stock_move.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_value_from_production(self, quantity, at_date=None):
+        value = super()._get_value_from_production(quantity, at_date)
+        # Add landed costs value
+        lc = self._get_landed_cost(at_date=at_date)
+        extra_value = 0
+        if lc.get(self):
+            extra_value = sum(lc[self].mapped('additional_landed_cost'))
+        value += extra_value
+        return value

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -366,6 +366,11 @@ class StockMove(models.Model):
     def _get_value_from_quotation(self, quantity, at_date=None):
         return dict(VALUATION_DICT)
 
+    def _get_value_from_production(self, quantity, at_date=None):
+        # TODO: Maybe move _cal_price here
+        self.ensure_one()
+        return quantity * self.price_unit
+
     def _get_value_from_returns(self, quantity, at_date=None):
         if self.origin_returned_move_id and self.origin_returned_move_id.is_out:
             origin_move = self.origin_returned_move_id


### PR DESCRIPTION
**Problem:**
landed cost does not work with MO

**Steps to reproduce:**
- in settings, enable the landed cost setting
- create two storable product (the final prod and the comp)
- set a positive cost on both
- set an on hand quantity for the comp
- set the category of the final product as avco perpetual
- create a BOM for the final prod where the component is 
the comp product.
- create a third product (the landed cost)
- for the product type select service 
- in the purchase tab check 'is landed cost'
- create a manufacturing order for the final product
- confirm and produce all
- navigate to Inventory/reporting/stock, search for your product
and notice the unit cost.
- open landed costs and click on New
- select the manufacturing order and add the landed cost
- validate 
- navigate to Inventory/reporting/stock 

**Current behavior:**
the unit price of your product has not changed.
I you navigate to Inventory/reporting/move analysis and check the move
with the reference of the MO, the value of the move has not changed 
either.

**Expected behavior:**
Both these value should have been impacted by the landed cost
like they would have if we were adding the landed
cost to a picking.

**Cause of the issue:**
When calling _get_value_data on a move, 
- If there is no production_id, the return value is computed 
in the super method.
There, when _get_value_from_account_move is called, 
https://github.com/odoo/odoo/blob/385d8473952eeaa9dcc7740bacfc2c9cbdc2d1e2/addons/stock_account/models/stock_move.py#L299
the override in sotck_landed_costs adds the landed costs to 'value'
https://github.com/odoo/odoo/blob/385d8473952eeaa9dcc7740bacfc2c9cbdc2d1e2/addons/stock_landed_costs/models/stock_move.py#L18-L22
- But if the move has 
a production_id the return is computed in the mrp_account 
override.
https://github.com/odoo/odoo/blob/385d8473952eeaa9dcc7740bacfc2c9cbdc2d1e2/addons/mrp_account/models/stock_move.py#L14-L19
But there is no mechanism to take into account the landed cost.


opw-5170554