### PR TITLE
[IMP] sms: flag marketing sms

### DIFF
--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -237,6 +237,7 @@ class MailingMailing(models.Model):
             'mass_force_send': self.sms_force_send,
             'mass_sms_allow_unsubscribe': self.sms_allow_unsubscribe,
             'use_exclusion_list': self.use_exclusion_list,
+            'sms_type': 'marketing',
         }
 
     def _action_send_mail(self, res_ids=None):

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -179,6 +179,7 @@ class MailThread(models.AbstractModel):
             'body': body,
             'mail_message_id': message.id,
             'state': 'outgoing',
+            'sms_type': kwargs.get('sms_type'),
         }
 
         # notify from computed recipients_data (followers, specific recipients)
@@ -234,7 +235,7 @@ class MailThread(models.AbstractModel):
 
     def _get_notify_valid_parameters(self):
         return super()._get_notify_valid_parameters() | {
-            'put_in_queue', 'sms_numbers', 'sms_pid_to_number', 'sms_content',
+            'put_in_queue', 'sms_numbers', 'sms_pid_to_number', 'sms_content', 'sms_type',
         }
 
     @api.model

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -68,6 +68,10 @@ class SmsSms(models.Model):
         'Marked for deletion', default=False,
         help='Will automatically be deleted, while notifications will not be deleted in any case.'
     )
+    sms_type = fields.Selection([
+        ('marketing', 'Marketing'),
+        ('alert', 'Alert'),
+    ])
 
     _uuid_unique = models.Constraint(
         'unique(uuid)',
@@ -190,6 +194,7 @@ class SmsSms(models.Model):
         messages = [{
             'content': body,
             'numbers': [{'number': sms.number, 'uuid': sms.uuid} for sms in body_sms_records],
+            'sms_type': 'marketing' if 'marketing' in body_sms_records.mapped('sms_type') else 'alert',
         } for body, body_sms_records in self.grouped('body').items()]
 
         delivery_reports_url = url_join(self[0].get_base_url(), '/sms/status')

--- a/addons/sms/tools/sms_api.py
+++ b/addons/sms/tools/sms_api.py
@@ -104,7 +104,7 @@ class SmsApi(SmsApiBase):  # TODO RIGR in master: rename SmsApi to SmsApiIAP, an
         return self._contact_iap('/api/sms/3/send', {
             'messages': messages,
             'webhook_url': delivery_reports_url,
-            'dbuuid': self.env['ir.config_parameter'].sudo().get_str('database.uuid')
+            'dbuuid': self.env['ir.config_parameter'].sudo().get_str('database.uuid'),
         })
 
     def _get_sms_api_error_messages(self):

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -50,6 +50,10 @@ class SmsComposer(models.TransientModel):
     use_exclusion_list = fields.Boolean(
         'Use Exclusion List', default=True, copy=False,
         help='Prevent sending messages to blacklisted contacts. Disable only when absolutely necessary.')
+    sms_type = fields.Selection([
+        ('marketing', 'Marketing'),
+        ('alert', 'Alert'),
+    ])
     # recipients
     recipient_valid_count = fields.Integer('# Valid recipients', compute='_compute_recipients', compute_sudo=False)
     recipient_invalid_count = fields.Integer('# Invalid recipients', compute='_compute_recipients', compute_sudo=False)
@@ -244,7 +248,9 @@ class SmsComposer(models.TransientModel):
                 all_bodies[record.id],
                 subtype_id=subtype_id,
                 number_field=self.number_field_name,
-                sms_numbers=self.sanitized_numbers.split(',') if self.sanitized_numbers else None)
+                sms_numbers=self.sanitized_numbers.split(',') if self.sanitized_numbers else None,
+                sms_type=self.sms_type,
+            )
         return messages
 
     def _action_send_sms_mass(self, records=None):
@@ -348,6 +354,7 @@ class SmsComposer(models.TransientModel):
                 'partner_id': recipients['partner'].id,
                 'state': state,
                 'uuid': uuid4().hex,
+                'sms_type': self.sms_type,
             }
         return result
 


### PR DESCRIPTION
This commit add a new flag on sms, marketing. Currently, we are sending all our
sms with flag 'alert', but marketing sms have some rules. We can't
send marketing sms all the day. It's only allowed from 8am to 8pm, and
not on sundays.

SmsFactor, our sms provider, allow us to flag sms as 'marketing', so they
will deal with the condition on their side.

task-5167944