### PR TITLE
[FIX] purchase: direct portal user to correct website

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -379,16 +379,17 @@ class PurchaseOrder(models.Model):
             pass
         else:
             access_opt = customer_portal_group[2].setdefault('button_access', {})
+            base_url = self.get_base_url()
             if self.env.context.get('is_reminder'):
                 access_opt['title'] = _('View')
                 actions = customer_portal_group[2].setdefault('actions', list())
                 actions.extend([
-                    {'url': self.get_confirm_url(confirm_type='reminder'), 'title': _('Accept')},
-                    {'url': self.get_update_url(), 'title': _('Update Dates')},
+                    {'url': base_url + self.get_confirm_url(confirm_type='reminder'), 'title': _('Accept')},
+                    {'url': base_url + self.get_update_url(), 'title': _('Update Dates')},
                 ])
             else:
                 access_opt['title'] = _('Confirm')
-                access_opt['url'] = self.get_confirm_url(confirm_type='reception')
+                access_opt['url'] = base_url + self.get_confirm_url(confirm_type='reception')
 
         return groups
 


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Host a server with demo data on localhost;
2. create & switch to a second company;
3. have a website linked to the second company;
4. set the website's domain to http://2.localhost:8069;
5. create a purchase order;
6. send order via email;
8. open mail via Settings / Technical / Email / Emails.

Issue
-----
The "View Quotation" button links to the default URL instead of the second company's website.

Cause
-----
The button added via `_notify_get_recipients_groups` only adds a relative URL, which then defaults to the database's base url when sent.

Solution
--------
Use an absolute URL, using the order's `get_base_url` method.

opw-5035391