### PR TITLE
[IMP] point_of_sale: Add reversal moves at pos journal entries overview

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1635,8 +1635,9 @@ class PosSession(models.Model):
         stock_account_moves = pickings.move_ids.account_move_id
         cash_moves = self.statement_line_ids.mapped('move_id')
         bank_payment_moves = self.bank_payment_ids.mapped('move_id')
+        reversal_moves = self.mapped('order_ids.reversed_move_ids')
         other_related_moves = self._get_other_related_moves()
-        return invoices | invoice_payments | self.move_id | stock_account_moves | cash_moves | bank_payment_moves | other_related_moves
+        return invoices | invoice_payments | self.move_id | stock_account_moves | cash_moves | bank_payment_moves | reversal_moves | other_related_moves
 
     def _get_receivable_account(self, payment_method):
         """Returns the default pos receivable account if no receivable_account_id is set on the payment method."""


### PR DESCRIPTION
When an invoice is created for a PoS order of an already closed session a reversal entry is created to revert the entries created when the session was closed. This reversals weren't shown on the journal entries list view when clicking on the smart button at the Session form view, having to manually look for them if you knew about them.

This commit adds this entries into the `_get_related_account_moves` call to be shown on the entries overview

target: master
task-4856009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
