### PR TITLE
[FIX] website_sale_wishlist: fix tour random fail

### DIFF
--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -26,6 +26,9 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: "click",
         },
         {
+            trigger: ":not(:has(.my_wish_quantity:visible))",
+        },
+        {
             content: "go back to the store",
             trigger: "a[href='/shop']",
             run: "click",


### PR DESCRIPTION
Add a step to make sure the wishlist is empty before continuing the tour

runbot-229616