### PR TITLE
[FIX] tools: Increase bytes passed to mimetype guesser

### DIFF
--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -8,7 +8,7 @@ from odoo.exceptions import MissingError, UserError
 from odoo.http import Stream, request
 from odoo.tools import file_open, replace_exceptions
 from odoo.tools.image import image_process, image_guess_size_from_field_name
-from odoo.tools.mimetypes import guess_mimetype, get_extension
+from odoo.tools.mimetypes import MIMETYPE_HEAD_SIZE, guess_mimetype, get_extension
 
 
 DEFAULT_PLACEHOLDER_PATH = 'web/static/img/placeholder.png'
@@ -130,10 +130,10 @@ class IrBinary(models.AbstractModel):
                 stream.mimetype = mimetype
             elif not stream.mimetype:
                 if stream.type == 'data':
-                    head = stream.data[:1024]
+                    head = stream.data[:MIMETYPE_HEAD_SIZE]
                 else:
                     with open(stream.path, 'rb') as file:
-                        head = file.read(1024)
+                        head = file.read(MIMETYPE_HEAD_SIZE)
                 stream.mimetype = guess_mimetype(head, default=default_mimetype)
 
             if filename:

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -15,6 +15,7 @@ import zipfile
 __all__ = ['guess_mimetype']
 
 _logger = logging.getLogger(__name__)
+MIMETYPE_HEAD_SIZE = 2048
 
 # We define our own guess_mimetype implementation and if magic is available we
 # use it instead.
@@ -188,7 +189,7 @@ if magic:
         _guesser = ms.buffer
 
     def guess_mimetype(bin_data, default=None):
-        mimetype = _guesser(bin_data[:1024])
+        mimetype = _guesser(bin_data[:MIMETYPE_HEAD_SIZE])
         # upgrade incorrect mimetype to official one, fixed upstream
         # https://github.com/file/file/commit/1a08bb5c235700ba623ffa6f3c95938fe295b262
         if mimetype == 'image/svg':


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

The current number of bytes (1024) sent to the mimetype guesser function is not enough for a correct guess on big .docx files (maybe other open office files too) whenever `python-magic` is installed.

If `python-magic` is not installed, it falls back to a [simpler implementation (by odoo)](https://github.com/odoo/odoo/pull/233266/files#diff-706296f6593337a9ff88c0e33e0e090eec75f63a22f9825dd31833ba17922840R145) that actually works correctly.

But in odoo.SH it seems that `python-magic` is always installed and in that case, it returns the mimetype "application/zip" for big .docx files.
The issue is not reproducible in runbot, so I'm assuming `python-magic` is not present in that environment.

I've tested it with double the amount of bytes and it seems to work correctly.

Please check the [following ticket](https://www.odoo.com/odoo/project.task/5125592) for more details.

### Current behavior before PR:
<img width="1141" height="674" alt="image" src="https://github.com/user-attachments/assets/a3d28757-c55a-4b0f-9ee5-042777943635" />


### Desired behavior after PR is merged:
The uploaded file's mimetype is correctly identified for big (>40mb) open office files.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
