### PR TITLE
[FIX] point_of_sale: Auto-trigger IndexedDB upgrade for missing tables

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -13,7 +13,6 @@ import { _t } from "@web/core/l10n/translation";
 import { logPosMessage } from "../utils/pretty_console_log";
 
 const { DateTime } = luxon;
-const INDEXED_DB_VERSION = 1;
 const CONSOLE_COLOR = "#28ffeb";
 
 export class PosData extends Reactive {
@@ -148,7 +147,7 @@ export class PosData extends Reactive {
         });
 
         return new Promise((resolve) => {
-            this.indexedDB = new IndexedDB(this.databaseName, INDEXED_DB_VERSION, models, resolve);
+            this.indexedDB = new IndexedDB(this.databaseName, false, models, resolve);
         });
     }
 


### PR DESCRIPTION
Currently, new IndexedDB object stores are only created during the 'onupgradeneeded' event. This event only fires if the database version is manually incremented in the code.

If a new module (e.g., restaurant) adds a new object store to the PoS database schema but the `dbVersion` is not bumped, the store is never created. This causes the PoS session to fail when it tries to access the missing store.

This commit modifies the `databaseEventListener` to add a check inside the `onsuccess` handler. After the database opens, it compares the list of required stores (`this.dbStores`) with the list of existing stores (`this.db.objectStoreNames`).

If a mismatch is detected:
1. The current database connection is closed.
2. The `dbVersion` is incremented.
3. The database connection process is re-run.

This forces the `onupgradeneeded` event to trigger, which then correctly creates the missing object stores, ensuring the database schema is always up-to-date.

opw-5166049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
