### PR TITLE
[FIX] mrp_account: allow for inventory valuation when no valuation account in set

### DIFF
--- a/addons/mrp_account/report/stock_valuation_report.py
+++ b/addons/mrp_account/report/stock_valuation_report.py
@@ -24,8 +24,9 @@ class StockValuationReport(models.AbstractModel):
         })
         for vals in production_locations_valuation_vals:
             account = self.env['account.account'].browse(vals['account_id'])
-            account_vals = account.read(['name', 'code', 'display_name'])[0]
-            report_data['accounts_by_id'][account.id] = account_vals
+            if account:
+                account_vals = account.read(['name', 'code', 'display_name'])[0]
+                report_data['accounts_by_id'][account.id] = account_vals
             cost_of_production['value'] -= vals['debit']
             lines_by_account_id[account.id]['debit'] += vals['debit']
             lines_by_account_id[account.id]['credit'] += vals['credit']


### PR DESCRIPTION
****Behavior:****
**Current:**
When generating the inventory valuation report, if the default stock valuation account is removed in the company settings, the system assumes that there will be an account linked to the debit/credit and will attempt to access it without any other check which will lead to an IndexError.

**Expected:**
We want to avoid blocking users as much as we can, so we will allow users to generate the report without the account and later fallback to stopping them with a warning if they try to generate an accounting entry from the valuation. Since we are now checking that there is an account before trying to access it, it doesn't matter if it is empty.

**Steps to reproduce:**

- Enable warehouse locations
- Make sure the Production location has a 'Cost of Production' account.
- Create two products with costs and prices
- Create a bom and manufacture one of the products.
- Go to Settings/Inventory Valuation and remove the Valuation Account
- When trying to generate the Inventory Valuation, you should get an error

opw-5184300
