### PR TITLE
[18.0] [FIX] web: export property fields with computed definition_record

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -316,7 +316,7 @@ class Export(http.Controller):
             target_model = Model.env[Model._fields[definition_record].comodel_name]
             domain_definition = [(definition_record_field, '!=', False)]
             # Depends of the records selected to avoid showing useless Properties
-            if domain:
+            if domain and Model._fields[definition_record].store:
                 self_subquery = Model.with_context(active_test=False)._search(domain)
                 field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
                 domain_definition.append(('id', 'in', self_subquery.subselect(field_to_get)))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Setup a model with a computed definition record field, like so:

```py
    properties_company_id = fields.Many2one(
        compute="_compute_properties_company_id",
        comodel_name="res.company",
    )

    @api.depends("company_id")
    @api.depends_context("company")
    def _compute_properties_company_id(self):
        for item in self:
            item.properties_company_id = item.company_id or self.env.company
```

Use this in a `Properties` definition:

```py
    properties = fields.Properties(
        definition="properties_company_id.properties_definition",
    )
```

Then simply try to export the model.

**Current behavior before PR:**

```python-traceback
Traceback (most recent call last):
  File "/odoo/src/odoo/odoo/http.py", line 2166, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/service/model.py", line 156, in retrying
    result = func()
             ^^^^^^
  File "/odoo/src/odoo/odoo/http.py", line 2133, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/http.py", line 2381, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/addons/web/controllers/export.py", line 400, in get_fields
    exportable_fields.update(self._get_property_fields(fields, model, domain=domain))
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/addons/web/controllers/export.py", line 321, in _get_property_fields
    field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 2973, in _field_to_sql
    return model._field_to_sql(alias, field.name, query)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 2976, in _field_to_sql
    raise ValueError(f"Cannot convert {field} to SQL because it is not stored")
```

**Desired behavior after PR is merged:**
Should not fail.


With this commit, the code fallbacks to export all properties defined, even those that are not used among the exported records.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
