### PR TITLE
[FIX] tools: prevent error when uploading invalid pdf file

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -217,8 +217,11 @@ def rotate_pdf(pdf):
         return _buffer.getvalue()
 
 
-def to_pdf_stream(attachment) -> io.BytesIO:
+def to_pdf_stream(attachment) -> io.BytesIO | None:
     """Get the byte stream of the attachment as a PDF."""
+    if not attachment.raw:
+        _logger.warning("%s has no raw data.", attachment)
+        return None
     stream = io.BytesIO(attachment.raw)
     if attachment.mimetype == 'application/pdf':
         return stream
@@ -227,6 +230,7 @@ def to_pdf_stream(attachment) -> io.BytesIO:
         Image.open(stream).convert("RGB").save(output_stream, format="pdf")
         return output_stream
     _logger.warning("mimetype (%s) not recognized for %s", attachment.mimetype, attachment)
+    return None
 
 
 def extract_page(attachment, num_page=0) -> io.BytesIO | None:


### PR DESCRIPTION
Currently, an error occurs when trying to preview the first page of a PDF 
attachment in Discuss if the PDF has no raw data.

**Steps to produce:**
- Install the `mail` module.
- Open `Discuss` and attach the PDF file without raw data [1].

**Error:**
`TypeError: a bytes-like object is required, not 'bool'`

**Root cause:**
At [2], `to_pdf_stream` directly calls `io.BytesIO()`, when the attachment has no 
`raw data`, Python raises an `error`.

**Fix:**
This commit prevents errors when a user attaches a PDF file that has no raw data.

[1]:
https://drive.google.com/file/d/1onJYlCL_k51UwqKhc0kFaYFJynKuk4fT/view?usp=sharing

[2]:
https://github.com/odoo/odoo/blob/d42102cac8fff3967cb605a897bbb0e8690464ed/odoo/tools/pdf/__init__.py#L222

sentry-6963775400