### PR TITLE
[FIX] pos_imin: iMin cashbox not working

### DIFF
--- a/addons/pos_imin/static/src/app/utils/imin_printer.js
+++ b/addons/pos_imin/static/src/app/utils/imin_printer.js
@@ -114,7 +114,7 @@ export class IminPrinterAdapter extends BasePrinter {
      * @override
      */
     openCashbox() {
-        if (!this.connected) {
+        if (!this.isConnected) {
             return;
         }
         try {


### PR DESCRIPTION
Explanation:

openCashbox() is calling this.connected to check if iMin is connected. However the variable is changed to isConnected in the previous PR. Therefore it will always return null.
