### PR TITLE
[FIX] spreadsheet: no update on re-selecting same date filter

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.xml
@@ -10,7 +10,7 @@
 
                 <div class="o-date-option-label" t-esc="option.label"/>
                 <t t-if="option.type === 'range'">
-                    <div class="d-flex flex-row">
+                    <div class="d-flex flex-row" t-on-click.stop="">
                         <DateTimeInput type="'date'" value="dateFrom()" onChange="(dateFrom) => this.setDateFrom(dateFrom)" />
                         <span class="d-flex align-items-center">to</span>
                         <DateTimeInput type="'date'" value="dateTo()" onChange="(dateTo) => this.setDateTo(dateTo)" />

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
@@ -25,6 +25,7 @@ import { OdooCoreViewPlugin } from "@spreadsheet/plugins";
 import { getItemId } from "../../helpers/model";
 import { serializeDate } from "@web/core/l10n/dates";
 import { getFilterCellValue, getFilterValueDomain } from "../helpers";
+import { deepEqual } from "@web/core/utils/objects";
 
 const { DateTime } = luxon;
 
@@ -61,6 +62,11 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
                 }
                 if (!checkFilterValueIsValid(filter, cmd.value)) {
                     return CommandResult.InvalidValueTypeCombination;
+                }
+
+                const currentFilterValue = this.getters.getGlobalFilterValue(cmd.id);
+                if (deepEqual(currentFilterValue, cmd.value)) {
+                    return CommandResult.NoChanges;
                 }
                 break;
             }

--- a/addons/spreadsheet/static/tests/global_filters/date_filter_value.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/date_filter_value.test.js
@@ -182,6 +182,23 @@ test("All the options should be displayed", async function () {
     expect(options[13].textContent).toBe("Custom Range");
 });
 
+test("Opening the custom range calendar does not trigger update", async function () {
+    const env = await makeMockEnv();
+    await mountDateFilterValue(env, {
+        value: { type: "range", from: "2023-01-01", to: "2023-01-31" },
+        update: () => {
+            expect.step("update");
+        },
+    });
+
+    expect.verifySteps([]);
+    await contains("input").click();
+    expect.verifySteps([]);
+    await contains("input.o_datetime_input:first").click();
+    expect(".o_datetime_picker").toHaveCount(1);
+    expect.verifySteps([]);
+});
+
 test("Can select a relative period", async function () {
     const env = await makeMockEnv();
     await mountDateFilterValue(env, {
@@ -436,24 +453,17 @@ test("Can open date time picker to select a range", async function () {
 });
 
 test("Choosing a from after the to will re-order dates", async function () {
-    let firstCall = true;
     const env = await makeMockEnv();
     await mountDateFilterValue(env, {
         value: { type: "range", from: "2023-01-30", to: "2023-01-31" },
         update: (value) => {
-            if (firstCall) {
-                // Bypass the first call as it is just the initial value
-                // (activate when clicking on the input)
-                firstCall = false;
-                return;
-            }
             expect(value).toEqual({ type: "range", from: "2023-01-01", to: "2023-01-30" });
             expect.step("update");
         },
     });
     await contains("input").click();
     await contains("input.o_datetime_input:last").click();
-    // Select 1th of January 2023
+    // Select 1st of January 2023
     await contains(".o_date_item_cell.o_datetime_button:first").click();
     expect.verifySteps(["update"]);
 });

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
@@ -37,11 +37,6 @@ test("Value of text filter", () => {
 
     result = setGlobalFilterValueWithoutReload(model, {
         id: "1",
-    });
-    expect(result.isSuccessful).toBe(true);
-
-    result = setGlobalFilterValueWithoutReload(model, {
-        id: "1",
         value: { operator: "ilike", strings: 5 },
     });
     expect(result.isSuccessful).toBe(false);
@@ -86,11 +81,6 @@ test("Value of selection filter", () => {
         resModel: "res.currency",
         selectionField: "position",
         defaultValue: { operator: "in", selectionValues: ["default value"] },
-    });
-    expect(result.isSuccessful).toBe(true);
-
-    result = setGlobalFilterValueWithoutReload(model, {
-        id: "1",
     });
     expect(result.isSuccessful).toBe(true);
 

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -310,6 +310,28 @@ test("Can save a value to an existing global filter", async function () {
     expect(listDomain.length).toBe(3);
 });
 
+test("Command rejected when setting the same date filter value", async () => {
+    const { model } = await createSpreadsheetWithPivotAndList();
+    await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER, {
+        pivot: DEFAULT_FIELD_MATCHINGS,
+        list: DEFAULT_LIST_FIELD_MATCHINGS,
+    });
+    const gf = model.getters.getGlobalFilters()[0];
+    const year = DateTime.local().year;
+
+    let result = await setGlobalFilterValue(model, {
+        id: gf.id,
+        value: { type: "month", month: 2, year },
+    });
+    expect(result).toBe(DispatchResult.Success);
+
+    result = await setGlobalFilterValue(model, {
+        id: gf.id,
+        value: { type: "month", month: 2, year },
+    });
+    expect(result.reasons).toEqual([CommandResult.NoChanges]);
+});
+
 test("Domain of simple date filter", async function () {
     mockDate("2022-07-14 00:00:00");
     const { model } = await createSpreadsheetWithPivotAndList();


### PR DESCRIPTION
## Description

- Re-clicking the current date filter (relative/month/quarter/year/range) triggered redundant RPCs and chart re-animations. In Custom Range, clicks inside inputs also bubbled to the dropdown item, causing unwanted updates.

##### This PR:

- Stop event bubbling inside Custom Range inputs to avoid spurious updates.

- In GlobalFiltersCoreViewPlugin.allowDispatch(), return NoChanges when the incoming value equals the current filter value (currentFilterValue).


Task: [5187275](https://www.odoo.com/odoo/project/2328/tasks/5187275)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
