### PR TITLE
[FIX] website, html_editor: refresh gallery thumbnails

### DIFF
--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -261,6 +261,7 @@ export class ImagePostProcessPlugin extends Plugin {
                 delete el.dataset[key];
             }
         }
+        this.dispatchTo("on_image_updated_handlers", { imageEl: el });
     }
 }
 

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -384,6 +384,7 @@ export class MediaPlugin extends Plugin {
         } else {
             el.setAttribute("src", newAttachmentSrc);
         }
+        this.dispatchTo("on_image_saved_handlers", { imageEl: el });
     }
 
     /**

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -9,6 +9,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
 import { uniqueId } from "@web/core/utils/functions";
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { forwardToThumbnail } from "@html_builder/utils/utils_css";
 
 export class ImageGalleryImagesOption extends BaseOptionComponent {
     static template = "website.ImageGalleryImagesOption";
@@ -44,6 +45,9 @@ class ImageGalleryOption extends Plugin {
         reorder_items_handlers: this.reorderGalleryItems.bind(this),
         on_will_remove_handlers: this.onWillRemove.bind(this),
         on_removed_handlers: this.onRemoved.bind(this),
+        on_replaced_media_handlers: ({ newMediaEl }) => this.updateCarouselThumbnail(newMediaEl),
+        on_image_updated_handlers: ({ imageEl }) => this.updateCarouselThumbnail(imageEl),
+        on_image_saved_handlers: ({ imageEl }) => this.updateCarouselThumbnail(imageEl),
         on_snippet_dropped_handlers: ({ snippetEl }) => {
             const carousels = snippetEl.querySelectorAll(".s_image_gallery .carousel");
             this.addCarouselListener(carousels);
@@ -420,6 +424,12 @@ class ImageGalleryOption extends Plugin {
             const images = this.getImages(this.imageRemovedGalleryElement);
             this.setImages(this.imageRemovedGalleryElement, mode, images);
             this.imageRemovedGalleryElement = undefined;
+        }
+    }
+
+    updateCarouselThumbnail(mediaEl) {
+        if (mediaEl.matches(".s_image_gallery img")) {
+            forwardToThumbnail(mediaEl);
         }
     }
 }

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -6,6 +6,7 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
     changeOptionInPopover,
+    clickOnEditAndWaitEditMode,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour('snippet_image_gallery', {
@@ -137,6 +138,7 @@ registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
         id: "s_image_gallery",
         name: "Image Gallery",
     }),
+    ...changeOptionInPopover("Image Gallery", "Indicators", "Squared Miniatures"),
     changeOption("Image Gallery", "addImage"),
 {
     content: "Click on the default image",
@@ -146,8 +148,48 @@ registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
     addMedia(),
 {
     content: "Check that the new image has been added",
-    trigger: ":iframe .s_image_gallery:has(img[data-index='3'])",
+    trigger: ":iframe .s_image_gallery_indicators_squared:has(img[data-index='3'])",
 }, {
     content: "Check that the thumbnail of the first image has not been changed",
     trigger: ":iframe .s_image_gallery div.carousel-indicators button:first-child[style='background-image: url(/web/image/website.library_image_08)']",
+},
+    ...clickOnSave(),
+    ...clickOnEditAndWaitEditMode(),
+{
+    content: "Check that the thumbnail of the new image is displayed",
+    trigger: ":iframe .s_image_gallery div.carousel-indicators button:nth-child(4)[style*='s_default_image']",
+}, {
+    content: "Select the first image in the gallery",
+    trigger: ":iframe .s_image_gallery .carousel-item:first-child img",
+    run: "click",
+}, {
+    content: "Open the replace media dialog",
+    trigger: "[data-action-id='replaceMedia']",
+    run: "click",
+}, {
+    content: "Pick another image to replace the first one",
+    trigger: ".o_select_media_dialog img[title='s_default_image_2.jpg']",
+    run: "click",
+},
+    ...clickOnSave(),
+    ...clickOnEditAndWaitEditMode(),
+{
+    content: "Check that the first image has been replaced",
+    trigger: ":iframe .s_image_gallery .carousel-item:first-child img[src*='s_default_image_2']",
+}, {
+    content: "Check that the thumbnail of the first image is updated",
+    trigger: ":iframe .s_image_gallery div.carousel-indicators button:first-child[style*='s_default_image_2']",
+}, {
+    content: "Select the second image in the gallery",
+    trigger: ":iframe .s_image_gallery .carousel-control-next-icon",
+    run: "click",
+},
+    changeOption("Image", "[data-label='Shape'] .dropdown-toggle"),
+{
+    content: "Click on the first image shape",
+    trigger: "[data-action-id='setImageShape']",
+    run: "click",
+}, {
+    content: "Check that the thumbnail of the second image is an SVG",
+    trigger: ":iframe .s_image_gallery div.carousel-indicators button:nth-child(2)[style*='data:image/svg+xml']",
 }]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -125,6 +125,7 @@ class TestSnippets(HttpCase):
 
     def test_snippet_image_gallery_thumbnail_update(self):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_default_image.jpg')
+        create_image_attachment(self.env, '/web/image/website.s_banner_default_image_2', 's_default_image_2.jpg')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery_thumbnail_update', login='admin')
 
     def test_dropdowns_and_header_hide_on_scroll(self):


### PR DESCRIPTION
Steps to reproduce:

- Drag and drop an "Image Gallery" snippet onto the page.
- Set the indicators to "Squared Miniatures".
- Replace an image using the media dialog.
- Look at the carousel indicators. They didn’t update.
- Same issue if you change any other image options (filter, etc.)

Before this commit, the edited image was updated but the small thumbnails under the gallery still showed the old picture.

After this commit, the gallery listens to media updates and the thumbnails now refresh to match the edited image.

task-5189020