### PR TITLE
[FIX] account, l10n_in: CoA loading don't raise if ref not found

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -73,7 +73,7 @@ class ResCompany(models.Model):
         for company in companies_need_update_fp:
             ChartTemplate = self.env['account.chart.template'].with_company(company)
             fiscal_position_data = ChartTemplate._get_in_account_fiscal_position()
-            ChartTemplate._load_data({'account.fiscal.position': fiscal_position_data})
+            ChartTemplate.with_context(raise_if_not_found_ref=False)._load_data({'account.fiscal.position': fiscal_position_data})
 
     @api.constrains('l10n_in_pan')
     def _check_l10n_in_pan(self):


### PR DESCRIPTION
If new taxes are introduced in stable (for legal reasons), and for Indian localisation we create new fiscals position for branch In such that case the new taxes will be not updated for the current company in such that case it will be lead to traceback with External ID not found for taxes.

In this commit we add a new context `raise_if_not_found_ref`, through which if the tax doesn't exists the error is not raised




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
