### PR TITLE
[FIX] product: prevent error on pricelist items when removing value

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -270,7 +270,7 @@ class ProductPricelistItem(models.Model):
         base_selection_vals = dict(self._fields['base']._description_selection(self.env))
         self.rule_tip = False
         for item in self:
-            if item.compute_price != 'formula':
+            if item.compute_price != 'formula' or not item.base:
                 continue
             base_amount = 100
             discount = item.price_discount if item.base != 'standard_price' else -item.price_markup


### PR DESCRIPTION
Currently, an error occurs when user removes value from `Based On` field and saving.

Steps to replicate:
- Install `website_sale` with demo and enable pricelists from settings.
- Open pricelists and Open any Pricelist.
- Under the pricelist rules, make sure `Price Type` is selected as Formula.
- Remove value from `Based Price` and click elsewhere.

Error:
`KeyError: False`

Cause:
- As the `base` field was changed the compute was called and `item.base` was passed on as 'False' at line [1] and caused the Keyerror.

Solution:
- The code skips execution when `item.base` is False, as there is no point in making the `item.rule_tip` [2] if we dont have all the values.

[1]: https://github.com/odoo/odoo/blob/257537584bedc1ab7db1bdc700f89145a3bb6095/addons/product/models/product_pricelist_item.py#L287

[2]: https://github.com/odoo/odoo/blob/257537584bedc1ab7db1bdc700f89145a3bb6095/addons/product/models/product_pricelist_item.py#L284-L296

sentry-6948941509

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
