### PR TITLE
[FIX] mail: minor fixes in polls

### DIFF
--- a/addons/mail/static/src/core/common/poll.js
+++ b/addons/mail/static/src/core/common/poll.js
@@ -6,7 +6,7 @@ const { DateTime } = luxon;
 
 /**
  * @typedef {Object} Props
- * @property {import("models").Poll} poll
+ * @property {import("models").MailPollModel} poll
  * @extends {Component<Props, Env>}
  */
 export class Poll extends Component {

--- a/addons/mail/static/src/core/common/poll.xml
+++ b/addons/mail/static/src/core/common/poll.xml
@@ -5,7 +5,7 @@
             <div class="card-body d-flex flex-column gap-1 p-3">
                 <p class="card-title text-start fw-bold mb-0" t-esc="props.poll.poll_question"/>
                 <p class="card-subtitle mb-2 text-muted smaller">
-                    <t t-if="props.allow_multiple_options">Select one or more options</t>
+                    <t t-if="props.poll.allow_multiple_options">Select one or more options</t>
                     <t t-else="">Select one option</t>
                 </p>
                 <div class="o-mail-PollOption rounded" t-foreach="props.poll.option_ids" t-as="option" t-key="option.id" t-att-style="percentageAttStyle(option)" t-att-class="{'o-selected': state.selectedOptionIds.has(option.id), 'o-winningOption': option.eq(props.poll.winning_option_id), 'o-hasVotes': option.number_of_votes > 0 }">
@@ -19,7 +19,7 @@
                     </div>
                     <label t-else="" class="d-flex justify-content-between p-2 cursor-pointer">
                         <span class="fw-bold me-1 text-truncate" t-esc="option.option_label"/>
-                        <input class="form-check-input" t-att-disabled="state.voting" t-att-checked="state.selectedOptionIds.has(option.id)" t-on-change="(ev) => this.onOptionCheckboxToggle(option.id, ev.target.checked)" type="checkbox"/>
+                        <input class="form-check-input" t-att-disabled="state.voting" t-att-checked="state.selectedOptionIds.has(option.id)" t-on-change="(ev) => this.onOptionCheckboxToggle(option.id, ev.target.checked)" t-att-type="props.poll.allow_multiple_options ? 'checkbox' : 'radio'"/>
                     </label>
                 </div>
                 <div class="d-flex align-items-center mt-2">


### PR DESCRIPTION
**Description of the issue this PR addresses:**

Minor fixes in polls.

**Current behavior before PR:**
- The text always displayed `Select one option` even when multiple options were 
allowed.
- The JSDoc type hint for the poll model was incorrect.
- The input type always appeared as a checkbox, even for single-selection polls, 
which could mislead users into thinking multiple options could be selected.

**Desired behavior after PR is merged:**

- The correct text `Select one or more options` is shown when multiple options 
are allowed.
- The JSDoc type hint is updated from `Poll` to `MailPollModel` for accuracy.
- The input type dynamically switches between `checkbox` and `radio` depending 
on whether multiple options are allowed or not.

Before: [**Single / Multiple Selection**] 
<img width="605" height="459" alt="image" src="https://github.com/user-attachments/assets/dd09901b-3836-406b-a192-754d0f6aca6e" />

After: [**Single / Multiple Selection**]
<img width="605" height="459" alt="image" src="https://github.com/user-attachments/assets/9b4fa71e-02b0-43b2-b0a9-cf319397c324" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
