### PR TITLE
[FIX] pos_pine_labs: avoid key error for `plutusTransactionReferenceID`

### DIFF
--- a/addons/pos_pine_labs/static/src/app/utils/payment/payment_pine_labs.js
+++ b/addons/pos_pine_labs/static/src/app/utils/payment/payment_pine_labs.js
@@ -193,7 +193,11 @@ export class PaymentPineLabs extends PaymentInterface {
      */
     async _waitForPaymentToConfirm() {
         const paymentLine = this.pos.getOrder().getSelectedPaymentline();
-        if (!paymentLine || paymentLine.payment_status == "retry") {
+        if (
+            !paymentLine ||
+            paymentLine.payment_status == "retry" ||
+            !paymentLine.pine_labs_plutus_transaction_ref
+        ) {
             return false;
         }
         const data = {


### PR DESCRIPTION
Steps:
----------
- Install pos_pine_labs and l10n_in module.
- Create a payment method for the Pine Labs terminal in an indian company.
- Configure the config with the Pine Labs payment method.
- Open pos session process order till payment screen.
- Go offline and try to add a Pine Labs payment method.
- Go back online and create a second order using the plus (+) button in the navbar.
- Switch back to the first order.

Issue:
----------
- A pop-up error appears due to a missing `plutusTransactionReferenceID` key when switching back to the first order and trying to get Pinelabs' transaction status.

Fix:
----------
- Ensure the payment status is fetched only when the `plutusTransactionReferenceID` key is available in the payment line.

opw-5176160
