### PR TITLE
[FIX] point_of_sale: Fix recursion error while updating config

### DIFF
--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -29,3 +29,4 @@ from . import pos_payment_method
 from . import pos_bill
 from . import report_sale_details
 from . import pos_printer
+from . import account_fiscal_position

--- a/addons/point_of_sale/models/account_fiscal_position.py
+++ b/addons/point_of_sale/models/account_fiscal_position.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = 'account.fiscal.position'
+
+    def action_archive(self):
+        configs = self.env['pos.config'].search([('default_fiscal_position_id', 'in', self.ids)])
+        configs.default_fiscal_position_id = False
+        return super().action_archive()


### PR DESCRIPTION
**Steps To Reproduce:-**

1. Install point_of_sale in 17.0
2. Activate flexible taxes setting
3. set default fiscal position  and after that archived that fiscal position.
4. try edit and save the POS config any operation below mentioned recursion error will come.

**Issue :-**

Due to archived record of fiscal postion is keep updating due to not satisfying this condition [config.default_fiscal_position_id.id not in config.fiscal_position_ids.ids](https://github.com/odoo/odoo/blob/62652ba3a7a90699e7aa8ff98e2d4980f1b43694/addons/point_of_sale/models/pos_config.py#L529) here ``config.fiscal_position_ids`` on this active filter is applying and it coming empty and going to update many2many field this process goes infinite due to archive fiscal position record

**FIX:-**
       adding the check of active record fiscal position

```
 File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 442, in _set_fiscal_position
    config.fiscal_position_ids = [(4, config.default_fiscal_position_id.id)]
  File "/data/build/odoo/odoo/fields.py", line 1337, in __set__
    records.write({self.name: write_value})
  File "/data/build/odoo/addons/pos_restaurant/models/pos_config.py", line 52, in write
    return super(PosConfig, self).write(vals)
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 420, in write
    self.sudo()._set_fiscal_position()
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 442, in _set_fiscal_position
    config.fiscal_position_ids = [(4, config.default_fiscal_position_id.id)]
  File "/data/build/odoo/odoo/fields.py", line 1337, in __set__
    records.write({self.name: write_value})
  File "/data/build/odoo/addons/pos_restaurant/models/pos_config.py", line 52, in write
    return super(PosConfig, self).write(vals)
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 420, in write
    self.sudo()._set_fiscal_position()
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 442, in _set_fiscal_position
    config.fiscal_position_ids = [(4, config.default_fiscal_position_id.id)]
  File "/data/build/odoo/odoo/fields.py", line 1337, in __set__
    records.write({self.name: write_value})
  File "/data/build/odoo/addons/pos_restaurant/models/pos_config.py", line 52, in write
    return super(PosConfig, self).write(vals)
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 420, in write
    self.sudo()._set_fiscal_position()
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 442, in _set_fiscal_position
    config.fiscal_position_ids = [(4, config.default_fiscal_position_id.id)]
  File "/data/build/odoo/odoo/fields.py", line 1337, in __set__
    records.write({self.name: write_value})
  File "/data/build/odoo/addons/pos_restaurant/models/pos_config.py", line 52, in write
    return super(PosConfig, self).write(vals)
  File "/data/build/odoo/addons/point_of_sale/models/pos_config.py", line 418, in write
    result = super(PosConfig, self).write(vals)
  File "/data/build/odoo/odoo/models.py", line 3820, in write
    field.write(self, value)
  File "/data/build/odoo/odoo/fields.py", line 4287, in write
    return self.write_batch([(records, value)])
  File "/data/build/odoo/odoo/fields.py", line 4308, in write_batch
    return self.write_real(records_commands_list, create)
  File "/data/build/odoo/odoo/fields.py", line 4835, in write_real
    old_relation = {record.id: set(record[self.name]._ids) for record in records}
  File "/data/build/odoo/odoo/fields.py", line 4835, in <dictcomp>
    old_relation = {record.id: set(record[self.name]._ids) for record in records}
  File "/data/build/odoo/odoo/models.py", line 6007, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/data/build/odoo/odoo/fields.py", line 2824, in __get__
    return super().__get__(records, owner)
  File "/data/build/odoo/odoo/fields.py", line 1270, in __get__
    return self.convert_to_record(value, record)
  File "/data/build/odoo/odoo/fields.py", line 4199, in convert_to_record
    corecords = corecords.filtered(Comodel._active_name).with_prefetch(prefetch_ids)
  File "/data/build/odoo/odoo/models.py", line 5496, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
  File "/data/build/odoo/odoo/models.py", line 5496, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
  File "/data/build/odoo/odoo/models.py", line 5493, in <lambda>
    func = lambda rec: any(rec.mapped(name))
  File "/data/build/odoo/odoo/models.py", line 5470, in mapped
    recs = recs._fields[name].mapped(recs)
  File "/data/build/odoo/odoo/fields.py", line 1299, in mapped
    return self.convert_to_record_multi(vals, records)
  File "/data/build/odoo/odoo/fields.py", line 942, in convert_to_record_multi
    return [convert(value, record) for value, record in zip(values, records)]
  File "/data/build/odoo/odoo/fields.py", line 942, in <listcomp>
    return [convert(value, record) for value, record in zip(values, records)]
  File "/data/build/odoo/odoo/models.py", line 5844, in __iter__
    yield self.__class__(self.env, (id_,), self._prefetch_ids)
RecursionError: maximum recursion depth exceeded
```

**OPW** - 5208462
**UPG** - 3248441


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
