### PR TITLE
[FIX] l10n_tw_edi_ecpay: correct JSON data handling for downpayment invoices

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -471,23 +471,24 @@ class AccountMove(models.Model):
 
             twd_excluded_amount = base_line['tax_details']['raw_total_excluded']
             twd_included_amount = base_line['tax_details']['raw_total_included']
+            quantity = abs(line.quantity)
 
             if self.l10n_tw_edi_is_b2b:
-                item_price = float_round(twd_excluded_amount / line.quantity, precision_rounding=0.01)
+                item_price = float_round(twd_excluded_amount / quantity, precision_rounding=0.01)
                 item_amount = float_round(twd_excluded_amount, precision_rounding=0.01)
             else:
                 if not is_allowance and line.tax_ids and not line.tax_ids[0].price_include:
-                    item_price = float_round(twd_excluded_amount / line.quantity, precision_rounding=0.01)
+                    item_price = float_round(twd_excluded_amount / quantity, precision_rounding=0.01)
                     item_amount = float_round(twd_excluded_amount, precision_rounding=0.01)
                 else:
-                    item_price = float_round(twd_included_amount / line.quantity, precision_rounding=0.01)
+                    item_price = float_round(twd_included_amount / quantity, precision_rounding=0.01)
                     item_amount = float_round(twd_included_amount, precision_rounding=0.01)
 
                 item_amount_taxed = float_round(twd_included_amount, precision_rounding=0.01)
 
             # For special tax, we use twd_included_amount
             if tax_type == "4":
-                item_price = float_round(twd_included_amount / line.quantity, precision_rounding=0.01)
+                item_price = float_round(twd_included_amount / quantity, precision_rounding=0.01)
                 item_amount = float_round(twd_included_amount, precision_rounding=0.01)
 
             # Set item sequence for each invoice line, the sequence cannot start from 0
@@ -500,7 +501,7 @@ class AccountMove(models.Model):
                     "OriginalInvoiceDate": self.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d"),
                     "OriginalSequenceNumber": line.l10n_tw_edi_ecpay_item_sequence,
                     "ItemName": line.name[:100],
-                    "ItemCount": line.quantity,
+                    "ItemCount": quantity,
                     "ItemPrice": item_price,
                     "ItemAmount": item_amount,
                 })
@@ -508,7 +509,7 @@ class AccountMove(models.Model):
                 item_list.append({
                     "ItemSeq": line.l10n_tw_edi_ecpay_item_sequence,
                     "ItemName": line.name[:100],
-                    "ItemCount": line.quantity,
+                    "ItemCount": quantity,
                     "ItemWord": line.product_uom_id.name[:6] if line.product_uom_id else False,
                     "ItemPrice": item_price,
                     "ItemTaxType": line.tax_ids[0].l10n_tw_edi_tax_type if tax_type != "4" and line.tax_ids else "",


### PR DESCRIPTION
When an invoice is created from a sale order with a downpayment, the invoice line for the downpayment typically has a negative quantity and a positive unit price. However, ECPay does not accept negative quantities, and this also leads to incorrect price values being sent in the JSON payload.

To address this, when an invoice line has a negative quantity, it is inverted to ensure the data sent to ECPay is valid and consistent.

**task**-5211264
