### PR TITLE
[FIX] hr_attendance: access right issues

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -78,7 +78,7 @@ class HrAttendanceOvertimeLine(models.Model):
                 has_manager_right or
                 (
                     has_officer_right
-                    and overtime.employee_id.attendance_maneger_id == self.env.user
+                    and overtime.employee_id.attendance_manager_id == self.env.user
                 )
             )
 

--- a/addons/hr_attendance/security/ir.model.access.csv
+++ b/addons/hr_attendance/security/ir.model.access.csv
@@ -5,5 +5,6 @@ access_hr_attendance_officer,hr.attendance.officer,model_hr_attendance,group_hr_
 access_hr_attendance_own_reader,hr.attendance.own.reader,model_hr_attendance,group_hr_attendance_own_reader,1,0,0,0
 access_hr_attendance_overtime_rule_admin,hr.attendance.admin.overtime.rule,model_hr_attendance_overtime_rule,group_hr_attendance_manager,1,1,1,1
 access_hr_attendance_overtime_ruleset_admin,hr.attendance.admin.overtime.ruleset,model_hr_attendance_overtime_ruleset,group_hr_attendance_manager,1,1,1,1
-access_hr_attendance_overtime_rule_user,hr.attendance.admin.overtime.rule,model_hr_attendance_overtime_rule,base.group_user,1,0,0,0
+access_hr_attendance_overtime_rule_user,hr.attendance.admin.overtime.rule,model_hr_attendance_overtime_rule,hr.group_hr_manager,1,0,0,0
 access_hr_attendance_overtime_line_officer,hr.attendance.officer.overtime.line,model_hr_attendance_overtime_line,group_hr_attendance_officer,1,1,1,1
+access_hr_attendance_overtime_ruleset_hr_manager,hr.attendance.admin.overtime.ruleset,model_hr_attendance_overtime_ruleset,hr.group_hr_manager,1,0,0,0


### PR DESCRIPTION
Problem
----------
Ruleset can't be read if the user is not an attendance manager. The ruleset_id on employee have the group `group_hr_manager`but it doesn't imply attendance manager. Wrong computation of `is_manager` on overtime line if the user has only attendance officer rights and the employee with overtime has this user as attendance manager.

Solution
----------
Make the ruleset readonly for hr manager.
Fix the is_manager compute

task-5180810
