### PR TITLE
[FIX] sale_project: Retain context for "Tasks" smart button on SO

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -148,7 +148,9 @@ class SaleOrder(models.Model):
             action['context'] = {}
         else:
             # Load top bar if all the tasks linked to the SO belong to the same project
-            action = self.env['ir.actions.actions'].with_context({'active_id': project_ids.id})._for_xml_id('project.act_project_project_2_project_task_all')
+            action = self.env['ir.actions.actions'].with_context(
+                active_id=project_ids.id,
+            )._for_xml_id('project.act_project_project_2_project_task_all')
             action['context'] = {
                 'active_id': project_ids.id,
                 'search_default_sale_order_id': self.id,


### PR DESCRIPTION
Repro:
- Activate any language different than english
- Create a service product with create Project & Task
- Create a sales order with the product
- Navigate with smart buttons Project > Tasks > Activate Top Menu
- All good
- Now navigate directly to Tasks from the sales order
- Top Menu is in English 

Issue:
- The issue here is the context language being lost due to context overriding in the code.

Fix:
- In this commit, I have updated the method from `with_context({'active_id': self.id})` to
`with_context(active_id=self.id)`. This fix ensures that the previous context is retained.

opw-5160373

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
