### PR TITLE
[FIX] website_sale_product_feed: fix _post_init_hook

### DIFF
--- a/addons/website_sale_product_feed/__init__.py
+++ b/addons/website_sale_product_feed/__init__.py
@@ -11,4 +11,4 @@ def _post_init_hook(env):
     if enable_gmc:
         env.ref('base.group_user')._apply_group(env.ref('website_sale_product_feed.group_product_feed'))
         websites.enabled_gmc_src = enable_gmc
-    websites[:1]._populate_product_feeds()
+        websites[:1]._populate_product_feeds()

--- a/addons/website_sale_product_feed/models/product_feed.py
+++ b/addons/website_sale_product_feed/models/product_feed.py
@@ -220,15 +220,20 @@ class ProductFeed(models.Model):
         }
 
     def _get_feed_product_domain(self):
-        product_domain = Domain.AND([
-            Domain('is_published', '=', True),
-            Domain('type', 'in', ('consu', 'combo')),
-            self.website_id.website_domain(),
-        ])
+        product_domain = self._get_website_product_domain(self.website_id)
+
         if self.product_category_ids:
             product_domain &= Domain('public_categ_ids', 'child_of', self.product_category_ids.ids)
 
         return product_domain
+
+    @api.model
+    def _get_website_product_domain(self, website):
+        return Domain.AND([
+            Domain('is_published', '=', True),
+            Domain('type', 'in', ('consu', 'combo')),
+            website.website_domain(),
+        ])
 
     def _get_feed_products(self):
         product_domain = self._get_feed_product_domain()

--- a/addons/website_sale_product_feed/models/website.py
+++ b/addons/website_sale_product_feed/models/website.py
@@ -2,6 +2,8 @@
 
 from odoo import fields, models
 
+from odoo.addons.website_sale_product_feed import const
+
 
 class Website(models.Model):
     _inherit = 'website'
@@ -18,6 +20,12 @@ class Website(models.Model):
     def _populate_product_feeds(self):
         """Populate product feeds for the website with default values."""
         for website in self:
+            website_product_domain = self.env['product.feed']._get_website_product_domain(website)
+            if (
+                self.env['product.product'].search_count(website_product_domain)
+                > const.PRODUCT_FEED_SOFT_LIMIT
+            ):
+                continue
             website.env['product.feed'].create({
                 'name': website.env._("GMC 1"),
                 'website_id': website.id,


### PR DESCRIPTION
```
  File /home/odoo/src/odoo/saas-18.4/addons/website_sale_product_feed/models/product_feed.py, line 105, in _check_product_limit
    raise ValidationError(feed.env._(
odoo.exceptions.ValidationError: A single feed cannot contain more than 5,000 products. Please separate products with Categories.
```
```
(Pdb) feed.env['product.product'].search_count(feed._get_feed_product_domain())
12433
```
During migration I am getting the traceback mentioned above, which is occurring because [here](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale_product_feed/__init__.py#L14) we have populated feed records in _post_init_hook which will create feed records without any [category ID](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale_product_feed/models/website.py#L21) because of which, [here](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale_product_feed/models/product_feed.py#L101) we get all records without a category, which is of course higher than our soft limit of 5000, and a validation error occurs: the customer database does not have GMC enabled. Still, it calls _populate_product_feeds, which is why I have moved it to a condition.

opw-5180407

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
