### PR TITLE
[FIX] project_timesheet_holidays: replace employee with user in AAL perations

### DIFF
--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -205,11 +205,11 @@ class TestTimesheetHolidays(TestCommonTimesheet):
 
         # should not able to update timeoff timesheets
         with self.assertRaises(UserError):
-            timesheets.with_user(self.empl_employee).write({'task_id': 4})
+            timesheets.with_user(self.user_employee).write({'task_id': 4})
 
         # should not able to create timesheet in timeoff task
         with self.assertRaises(UserError):
-            self.env['account.analytic.line'].with_user(self.empl_employee).create({
+            self.env['account.analytic.line'].with_user(self.user_employee).create({
                 'name': "my timesheet",
                 'project_id': self.internal_project.id,
                 'task_id': self.internal_task_leaves.id,


### PR DESCRIPTION

In the 'test_timesheet_time_off_including_public_holiday' test case, 'employee' was mistakenly passed to 'with_user'. This commit replaces 'employee' with 'user' for consistency.

task-4809916
