### PR TITLE
[IMP] pos_loyalty: show loyalty points on customer display

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -102,7 +102,7 @@
                     </div>
                 </div>
 
-                <div t-if="order.amount and !order.finalized" class="py-3 px-4 bg-view border-top">
+                <div t-if="order.amount and !order.finalized" class="o_customer_display_total py-3 px-4 bg-view border-top">
                     <div class="d-flex flex-column justify-content-center gap-1 w-100 w-sm-50 ms-auto">
                         <div class="row fs-2 fw-bolder">
                             <div class="col text-end">Total</div>

--- a/addons/pos_loyalty/__manifest__.py
+++ b/addons/pos_loyalty/__manifest__.py
@@ -31,6 +31,13 @@
         'point_of_sale._assets_pos': [
             'pos_loyalty/static/src/**/*',
             ('remove', 'pos_loyalty/static/src/portal/*'),
+            ('remove', 'pos_loyalty/static/src/overrides/customer_display_overrides/customer_display.xml'),
+        ],
+        'point_of_sale.customer_display_assets': [
+            'pos_loyalty/static/src/overrides/customer_display_overrides/customer_display.xml',
+        ],
+        'point_of_sale.customer_display_assets_test': [
+            'pos_loyalty/static/tests/tours/customer_display_tour.js',
         ],
         'web.assets_tests': [
             'pos_loyalty/static/tests/tours/**/*',

--- a/addons/pos_loyalty/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/pos_loyalty/static/src/app/customer_display/customer_display_adapter.js
@@ -1,0 +1,9 @@
+import { patch } from "@web/core/utils/patch";
+import { CustomerDisplayPosAdapter } from "@point_of_sale/app/customer_display/customer_display_adapter";
+
+patch(CustomerDisplayPosAdapter.prototype, {
+    formatOrderData(order) {
+        super.formatOrderData(order);
+        this.data.loyaltyData = order?.getLoyaltyPoints() || [];
+    },
+});

--- a/addons/pos_loyalty/static/src/overrides/customer_display_overrides/customer_display.xml
+++ b/addons/pos_loyalty/static/src/overrides/customer_display_overrides/customer_display.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_loyalty.CustomerDisplay" t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_customer_display_total')]" position="after">
+            <t t-if="order and order.amount and !order.finalized and order.loyaltyData">
+                <div class="border-top px-4 py-2 bg-white">
+                    <t t-foreach="order.loyaltyData or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
+                        <div
+                            t-if="_loyaltyStat.points.won or _loyaltyStat.points.spent"
+                            class="d-flex justify-content-between align-items-center py-1 flex-wrap"
+                        >
+                            <div class="loyalty-points-title fs-4 fw-semibold" t-out="_loyaltyStat.points.name"/>
+
+                            <div class="d-flex align-items-center gap-1 fw-bold fs-4 flex-nowrap text-end">
+                                <span t-if="_loyaltyStat.points.balance" class="loyalty-points-balance" t-out="_loyaltyStat.points.balance"/>
+                                <span t-if="_loyaltyStat.points.won" class="loyalty-points-won text-success">
+                                    + <t t-out="_loyaltyStat.points.won"/>
+                                </span>
+                                <span t-if="_loyaltyStat.points.spent" class="loyalty-points-spent text-danger">
+                                    - <t t-out="_loyaltyStat.points.spent"/>
+                                </span>
+                                <span class="text-muted mx-1">=</span>
+                                <span class="loyalty-points-total fw-bolder" t-out="_loyaltyStat.points.total"/>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_loyalty/static/tests/tours/customer_display_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/customer_display_tour.js
@@ -1,0 +1,48 @@
+import { registry } from "@web/core/registry";
+import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
+import * as CustomerDisplay from "@point_of_sale/../tests/customer_display/customer_display_utils";
+
+const ADD_PRODUCT = JSON.stringify({
+    ...JSON.parse(CustomerDisplay.ADD_PRODUCT),
+    loyaltyData: [
+        {
+            couponId: 101,
+            points: {
+                won: 25,
+                spent: 10,
+                total: 65,
+                balance: 50,
+                name: "Loyalty Points",
+            },
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("test_customer_display_loyalty_points", {
+    steps: () =>
+        [
+            CustomerDisplay.addProduct(ADD_PRODUCT, "add product"),
+            Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
+            CustomerDisplay.amountIs("Total", "2,972.75"),
+            {
+                content: "Check that the title should be Loyalty Points",
+                trigger: ".loyalty-points-title:contains(Loyalty Points)",
+            },
+            {
+                content: "Check loyalty balance points are displayed correctly",
+                trigger: ".loyalty-points-balance:contains(50)",
+            },
+            {
+                content: "Check loyalty won points are displayed correctly in green",
+                trigger: ".loyalty-points-won.text-success:contains(+ 25)",
+            },
+            {
+                content: "Check loyalty spent points are displayed correctly in red",
+                trigger: ".loyalty-points-spent.text-danger:contains(- 10)",
+            },
+            {
+                content: "Check loyalty total points are displayed correctly",
+                trigger: ".loyalty-points-total.fw-bolder:contains(65)",
+            },
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3435,3 +3435,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="pos_user",
         )
         self.assertEqual(loyalty_card.points, 90)
+
+    def test_customer_display_loyalty_points(self):
+        self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'test_customer_display_loyalty_points', login="pos_user")


### PR DESCRIPTION
Before this commit:
=================
- The customer display did not show any information about loyalty points.
- Customers couldn’t see their earned or redeemed points during checkout.

After this commit:
=================
- Loyalty points are now displayed on the customer display screen.
- The display now shows the customer’s total balance, earned (won), and spent points during checkout.

Task - 5184627
