### PR TITLE
[FIX] sale,web: adapt section on report and portal

### DIFF
--- a/addons/sale/static/src/scss/sale_portal.scss
+++ b/addons/sale/static/src/scss/sale_portal.scss
@@ -26,6 +26,10 @@
     width: 100% !important;
 }
 
+.sale_tbody tr:has(+ .o_line_section) {
+    border-bottom: $border-width solid $dark;
+}
+
 .o_portal .sale_tbody .js_quantity_container {
 
     .js_quantity {

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -772,7 +772,7 @@
                                     <tr
                                         t-if="is_section or is_subsection"
                                         name="tr_section"
-                                        t-attf-class="border-dark {{'fw-bold o_line_section bg-200' if is_section else 'fw-medium o_line_subsection bg-100'}}"
+                                        t-attf-class="{{'fw-bold o_line_section bg-200' if is_section else 'fw-medium o_line_subsection border-dark bg-100'}}"
                                     >
                                         <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
                                         <t

--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -11,7 +11,11 @@ table.table {
         vertical-align: middle;
     }
 
-    .o_line_section, .o_line_subsection {
+    .o_line_section {
+        border-top: $border-width solid $o-gray-400;
+    }
+
+    .o_line_subsection {
         border-bottom: $border-width solid $o-gray-400;
     }
 


### PR DESCRIPTION
In commit[1] [2] the sections and subsections were adapted on reports and
portal. However in commit[3] we slightly changed the design, thus the
change needs to be replicated on reports and portal.

task-5216018
Followup of  task-5125867

[1]: https://github.com/odoo/odoo/commit/4e81bb2e2f99ef6e038534de05a4dbe48080c49e
[2]: https://github.com/odoo/odoo/commit/21384e5c5ac2161e28ca13844675a507b50fcb54
[3]: https://github.com/odoo/odoo/commit/1952f2e95a6050c7beb5e8120301c712c6e0a58
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
