### PR TITLE
mobile view scrollbar

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -524,23 +524,10 @@ export class WebsitePreview extends Component {
         const websiteDoc = this.iframe.el?.contentDocument;
         const fallbackDoc = this.iframefallback.el?.contentDocument;
         if (!this.websiteContext.edition && websiteDoc && fallbackDoc) {
-            if (websiteDoc.head) {
-                fallbackDoc.head
-                    .querySelectorAll("link[rel='stylesheet'], style")
-                    .forEach((el) => el.remove());
-                for (const el of websiteDoc.head.querySelectorAll(
-                    "link[rel='stylesheet'], style"
-                )) {
-                    fallbackDoc.head.appendChild(el.cloneNode(true));
-                }
-            }
-            if (websiteDoc.body) {
-                fallbackDoc.body.replaceWith(websiteDoc.body.cloneNode(true));
-                this.iframefallback.el.classList.remove("d-none");
-                getScrollingElement(fallbackDoc).scrollTop =
-                    getScrollingElement(websiteDoc).scrollTop;
-                this._cleanIframeFallback();
-            }
+            fallbackDoc.documentElement.replaceWith(websiteDoc.documentElement.cloneNode(true));
+            this.iframefallback.el.classList.remove("d-none");
+            getScrollingElement(fallbackDoc).scrollTop = getScrollingElement(websiteDoc).scrollTop;
+            this._cleanIframeFallback();
         }
     }
     _onPageHide() {

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -492,6 +492,7 @@ export class WebsitePreview extends Component {
         this.iframe.el.contentDocument.addEventListener('keyup', ev => {
             this.iframe.el.dispatchEvent(new KeyboardEvent('keyup', ev));
         });
+        this.iframefallback.el?.contentDocument.documentElement.replaceChildren();
     }
 
     /**


### PR DESCRIPTION
### [FIX] website: copy the whole document to fallback iframe

Since da85d7f8f39f43bd21603b40f357dfc572036d27, the style in head and
the body of the website preview are copied to the fallback iframe's
document. This did not copied the attributes on the `html` node, which
somtimes impacted the appearance.

With this commit, the whole document is copied to the fallback iframe.

Steps to reproduce:
- Activate "Mobile preview" when viewing the website
- Go to a page that is long enough for a scrollbar to appear
- Navigate to another page
- Bug: During the transition, the fallback is shown, and its scrollbar
  is wider than the one of the page that was shown just before

task-5212287

### [FIX] website: remove content of fallback iframe after load

Since commit 7b19831e1c624b483008feb526ba773ec8b23009, an fallback
iframe is shown behind the website preview to avoid flicker on
navigation. Since commit 3036c7dc4720a88f2717b96a29d45d923eb6ec75, the
preview for mobile has some transparency on its scrollbar. Thus the part
of the fallback iframe behind the scrollbar when previewing mobile was
slightly visible.

This commit fixes it by removing the fallback iframe's content after the
website has loaded (and the fallback is not needed anymore).

Steps to reproduce:
- On website, activate "Mobile preview"
- Navigate to a page long enough to have a scrollbar
- Navigate to another page long enough to have a scrollbar
- Scroll a bit
- Bug: The scrollbar of the fallback is slightly visible

task-5212287

