### PR TITLE
[FIX] l10n_jo: po is broken with module

### DIFF
--- a/addons/l10n_jo/i18n_extra/l10n_jo.pot
+++ b/addons/l10n_jo/i18n_extra/l10n_jo.pot
@@ -130,6 +130,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
+#. module: l10n_jo
 #. odoo-python
 #: code:addons/l10n_jo/models/template_jo_standard.py:0
 msgid "Cash"


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/74109a1b1a5d31fa55b08257f6a9365b0c1758f0 broke the po by not putting the module the term comes from.

This resulting in a traceback when installing the language. 
It also breaks existing database with Arabic and l10n_jo already set.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
