### PR TITLE
[IMP] crm, crm_livechat: ignore leads capacity and opt-out on operator forward

### DIFF
--- a/addons/crm/data/crm_team_demo.xml
+++ b/addons/crm/data/crm_team_demo.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="sales_team.team_sales_department" model="crm.team" forcecreate="False">
-            <field name="assignment_domain">[['probability', '>=', 20]]</field>
-        </record>
-
         <record id="sales_team.crm_team_1" model="crm.team">
             <field name="use_leads">True</field>
             <field name="assignment_domain">[['phone', '!=', False]]</field>

--- a/addons/crm/data/crm_team_member_demo.xml
+++ b/addons/crm/data/crm_team_member_demo.xml
@@ -3,11 +3,9 @@
 
     <record id="sales_team.crm_team_member_admin_sales" model="crm.team.member">
         <field name="assignment_max">30</field>
-        <field name="assignment_domain">[['probability', '>=', 20]]</field>
     </record>
     <record id="sales_team.crm_team_member_demo_team_1" model="crm.team.member">
         <field name="assignment_max">45</field>
-        <field name="assignment_domain">[['probability', '>=', 5]]</field>
     </record>
 
 </data></odoo>

--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -91,8 +91,7 @@ class ChatbotScriptStep(models.Model):
                 ),
             )
             teams = possible_teams.filtered(
-                lambda team: team.assignment_max
-                and lead.filtered_domain(literal_eval(team.assignment_domain or "[]"))
+                lambda team: lead.filtered_domain(literal_eval(team.assignment_domain or "[]"))
             )
         if self.env.user.partner_id.company_id:
             teams = teams.filtered(
@@ -102,9 +101,7 @@ class ChatbotScriptStep(models.Model):
         assignable_user_ids = [
             member.user_id.id
             for member in teams.crm_team_member_ids
-            if not member.assignment_optout
-            and member._get_assignment_quota() > 0
-            and lead.filtered_domain(literal_eval(member.assignment_domain or "[]"))
+            if lead.filtered_domain(literal_eval(member.assignment_domain or "[]"))
         ]
         previous_operator = discuss_channel.livechat_operator_id
         users = self.env["res.users"]

--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -38,19 +38,6 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         assigned_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
         self.assertEqual(assigned_lead.user_id, self.user_employee)
         self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
-        # sales team member quota is reached (lead already assigned before)
-        discuss_channel = self._play_session_with_lead()
-        quota_reached_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(quota_reached_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        assigned_lead.unlink()
-        # sales team member opt out
-        self.sale_team.crm_team_member_ids.assignment_optout = True
-        discuss_channel = self._play_session_with_lead()
-        optout_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(optout_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        self.sale_team.crm_team_member_ids.assignment_optout = False
         # sales team member invalid domain (probability of lead is 5.39)
         self.sale_team.crm_team_member_ids.assignment_domain = "[('probability', '>=', 20)]"
         discuss_channel = self._play_session_with_lead()
@@ -66,13 +53,6 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         self.assertEqual(auto_team_lead.team_id, self.sale_team)
         self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
         auto_team_lead.unlink()
-        # sales team opt out
-        self.sale_team.assignment_optout = True
-        discuss_channel = self._play_session_with_lead()
-        team_optout_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(team_optout_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        self.sale_team.assignment_optout = False
         # sales team invalid domain (probability of lead is 5.39)
         self.sale_team.assignment_domain = "[('probability', '>=', 20)]"
         discuss_channel = self._play_session_with_lead()


### PR DESCRIPTION
Before this commit, when choosing an operator in the "create lead & forward" chatbot step, we would check the lead assignment rules when choosing which sales team member (operator) to forward to.

This causes some confusion as it is not clearly presented that fields like lead assignment capacity or lead assignment filter would impact the live chat.

With this commit, the rules for leads assignment are not considered when choosing the operator to forward to.

task-5137022
