### PR TITLE
[FIX] website: reset shape when mouse leaves preview

### DIFF
--- a/addons/website/static/src/interactions/image_shape_hover_effect.edit.js
+++ b/addons/website/static/src/interactions/image_shape_hover_effect.edit.js
@@ -1,0 +1,81 @@
+import { registry } from "@web/core/registry";
+import { ImageShapeHoverEffect } from "./image_shape_hover_effect";
+
+const ImageShapeHoverEffectEdit = (I) =>
+    class extends I {
+        destroy() {
+            // The originalImgSrc might not yet be updated by sourceObserver
+            // if the interaction stops in the same tick as the mutation
+            // happens. Only restore the src if it still matches the last
+            // hovering src.
+            if (this.el.src === this.hoveringImgSrc) {
+                this.el.src = this.originalImgSrc;
+            }
+            this.disconnectSourceObserver();
+        }
+
+        // Copy of the mouseLeave of the original interaction. The only
+        // difference is that it restores the original image source after the
+        // animation is over, since in edit mode the image source might change
+        // before the end of the animation (for example while previewing shapes
+        // image filters or something else).
+        mouseLeave() {
+            this.lastMouseEvent = this.lastMouseEvent.then(
+                () =>
+                    new Promise((resolve) => {
+                        if (!this.originalImgSrc || !this.svgInEl || !this.el.dataset.hoverEffect) {
+                            resolve();
+                            return;
+                        }
+                        if (!this.svgOutEl) {
+                            // Reverse animations.
+                            this.svgOutEl = this.svgInEl.cloneNode(true);
+                            const animateTransformEls = this.svgOutEl.querySelectorAll(
+                                "#hoverEffects animateTransform, #hoverEffects animate"
+                            );
+                            animateTransformEls.forEach((animateTransformEl) => {
+                                let valuesValue = animateTransformEl.getAttribute("values");
+                                valuesValue = valuesValue.split(";").reverse().join(";");
+                                animateTransformEl.setAttribute("values", valuesValue);
+                            });
+                        }
+                        this.setImgSrc(this.svgOutEl, () => {
+                            // After the animation, restore original src
+                            setTimeout(() => {
+                                if (this.isDestroyed) {
+                                    resolve();
+                                    return;
+                                }
+                                this.disconnectSourceObserver();
+                                this.el.src = this.originalImgSrc;
+                                this.connectSourceObserver();
+                                this.el.onload = () => {
+                                    resolve();
+                                };
+                            }, this.getAnimationMaxDuration(this.svgOutEl));
+                        });
+                    })
+            );
+        }
+
+        // returns the time after which the animation should be over
+        getAnimationMaxDuration(svg) {
+            let maxDuration = 0;
+            const animateEls = svg.querySelectorAll(
+                "#hoverEffects animateTransform, #hoverEffects animate"
+            );
+            animateEls.forEach((animateEl) => {
+                const dur = animateEl.getAttribute("dur");
+                if (dur) {
+                    const duration = parseFloat(dur) * (dur.endsWith("ms") ? 1 : 1000);
+                    maxDuration = Math.max(maxDuration, duration);
+                }
+            });
+            return maxDuration;
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.image_shape_hover_effect", {
+    Interaction: ImageShapeHoverEffect,
+    mixin: ImageShapeHoverEffectEdit,
+});

--- a/addons/website/static/src/interactions/image_shape_hover_effect.js
+++ b/addons/website/static/src/interactions/image_shape_hover_effect.js
@@ -124,7 +124,7 @@ export class ImageShapeHoverEffect extends Interaction {
                 return;
             }
             this.adjustImageSourceFrom(preloadedImg);
-            this.lastImgSrc = preloadedImg.getAttribute("src");
+            this.hoveringImgSrc = preloadedImg.getAttribute("src");
             this.el.onload = () => {
                 resolve();
             };
@@ -150,9 +150,3 @@ export class ImageShapeHoverEffect extends Interaction {
 registry
     .category("public.interactions")
     .add("website.image_shape_hover_effect", ImageShapeHoverEffect);
-
-registry
-    .category("public.interactions.edit")
-    .add("website.image_shape_hover_effect", {
-        Interaction: ImageShapeHoverEffect,
-    });


### PR DESCRIPTION
After hover effect has been added back in this [commit], we could see an issue when we had a hover effect and tried to preview a shape.

Steps to see the issue:
- Open website and start editing
- Drop a text-image snippet onto the page.
- Then add a hover effect to the snippet image.
- Open the image shape selector and hover over the shapes.

=> Bug: the preview is broken; when the mouse leaves a shape, the original shape is not reset.
Same issue with other options when there is a hover effect on an image (e.g. "image Filter").

Current flow is:
We are previewing shape -> img src is changed -> `originalImgSrc` in `ImageShapeHoverEffect` interaction is changed -> we revert preview -> img src is reverted, but MutationObserver doesn't change `originalImgSrc` immediately, and when reverting a step, we stop the interaction -> destroy is called and image source is set to `originalImgSrc`, but it is the old one with a shape. We want to update the `src` only if it is currently the one that we set as hovering.

[commit]: https://github.com/odoo/odoo/commit/80b5db99a3c26c3dd4fb5c55e04b8813dddb5b8d

task-5207382