### PR TITLE
[FIX] account: invoice edi format (part 1)

### DIFF
--- a/addons/account/static/src/components/account_move_form/account_move_form.js
+++ b/addons/account/static/src/components/account_move_form/account_move_form.js
@@ -26,7 +26,7 @@ export class AccountMoveFormController extends FormController {
     }
 
     async loadExtraPrintItems() {
-        if (!this.model.root.isNew) {
+        if (this.model.root.isNew) {
             return []
         }
         return this.orm.call("account.move", "get_extra_print_items", [this.model.root.resId]);

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -17,8 +17,8 @@ class ResPartner(models.Model):
             ('ubl_bis3', "EU Standard (Peppol Bis 3.0)"),
             ('xrechnung', "Germany (XRechnung)"),
             ('nlcius', "Netherlands (NLCIUS)"),
-            ('ubl_a_nz', "Australia BIS Billing 3.0 A-NZ"),
-            ('ubl_sg', "Singapore BIS Billing 3.0 SG"),
+            ('ubl_a_nz', "Australia (BIS Billing 3.0 A-NZ)"),
+            ('ubl_sg', "Singapore (BIS Billing 3.0 SG)"),
         ],
     )
     is_ubl_format = fields.Boolean(compute='_compute_is_ubl_format')

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -115,6 +115,9 @@ class ResConfigSettings(models.TransientModel):
             self.account_peppol_edi_user._peppol_deregister_participant()
         return True
 
+    # Note: Deprecated; the button is permanently invisible.
+    # Disabling services can lead to complicance issues and is not necessary
+    # since all existing services should just work.
     def button_account_peppol_configure_services(self):
         wizard = self.env['account_peppol.service.wizard'].create({
             'edi_user_id': self.account_peppol_edi_user.id,

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -62,11 +62,15 @@
 
                         <!-- All action buttons -->
                         <div invisible="account_peppol_proxy_state != 'receiver' or account_peppol_edi_mode == 'demo'">
+                            <!-- Note: Deprecated; the button is permanently invisible. -->
+                            <!-- Disabling services can lead to complicance issues and is not necessary -->
+                            <!-- since all existing services should just work. -->
                             <button string="Configure Peppol Services"
                                     name="button_account_peppol_configure_services"
                                     type="object"
                                     class="btn-link mt-3 mb-3"
-                                    icon="oi-arrow-right"/>
+                                    icon="oi-arrow-right"
+                                    invisible="1"/>
                         </div>
 
                         <div class="d-flex gap-1 action_buttons" colspan="3">

--- a/addons/account_peppol/wizard/service_wizard.xml
+++ b/addons/account_peppol/wizard/service_wizard.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <!-- DEPRECATED -->
         <record model="ir.ui.view" id="peppol_service_configuration">
             <field name="name">account.peppol.service.configuration.form</field>
             <field name="model">account_peppol.service.wizard</field>
@@ -17,7 +18,7 @@
                                     <field name="wizard_id" column_invisible="1"/>
                                     <field name="document_name" readonly="1"/>
                                     <field name="document_identifier" groups="base.group_no_one" readonly="1"/>
-                                    <field name="enabled" widget="boolean_toggle"/>
+                                    <field name="enabled" widget="boolean_toggle" readonly="enabled"/>
                                 </list>
                             </field>
                         </div>


### PR DESCRIPTION
#### [FIX] account_peppol: disallow disabling services
Currently it is possible to disallow any services in the configuration.
This can lead to complicance issues; i.e. if someone disables "BIS Billing 3.0".

1. Ensure Peppol is activated (test mode or production; not demo)
2. Settings -> Accounting -> PEPPOL Electronic Invoicing -> Configure Peppol Services
3. Any service can be disabled.

This commit hides the button to open the service wizard.
(Also in the wizard it is now not possible to disable services anymore.)

#### [FIX] account: generation of print-related entries in cog menu
Before this commit:
The dynamic generation of the print related entries in the cog menu
does not work correctly.

Problem / Solutions:
There is a check in the javascript that does not work as intended.
Thus the entries are not added to the cog menu in all cases.
The check was intended to only block it for "new" records (not saved yet);
to avoid issues in case the move has no id yet.
After this commit we just check the id directly.

#### [FIX] account_edi_ubl_cii: missing parenthesis in invoice_edi_format
Follow-up to commit 860c0974f9b541be63f4079ef52366f91c1994ce .
There we improved the eInvoice format labels for clarity.
But 2 label were formatted differently than the others.
This commit fixes that.

#### References
task-4737164