### PR TITLE
[FIX][17.0] sale: prevent error in "Generate Pricelist Report" when no pricelist defined (#180247)

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -173,8 +173,12 @@
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">
-ctx = env.context
-ctx.update({'default_pricelist': env['product.pricelist'].search([], limit=1).id})
+pricelist = env['product.pricelist'].search([], limit=1)
+if not pricelist:
+    raise UserError("No pricelist found. Please create a pricelist first.")
+
+ctx = dict(env.context)
+ctx.update({'default_pricelist': pricelist.id})
 action = {
     'name': 'Pricelist Report',
     'type': 'ir.actions.client',

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -531,8 +531,12 @@
         <field name="binding_model_id" ref="product.model_product_product"/>
         <field name="state">code</field>
         <field name="code">
-ctx = env.context
-ctx.update({'default_pricelist': env['product.pricelist'].search([], limit=1).id})
+pricelist = env['product.pricelist'].search([], limit=1)
+if not pricelist:
+    raise UserError("No pricelist found. Please create a pricelist first.")
+
+ctx = dict(env.context)
+ctx.update({'default_pricelist': pricelist.id})
 action = {
     'name': 'Pricelist Report',
     'type': 'ir.actions.client',

--- a/doc/cla/individual/devsijariya.md
+++ b/doc/cla/individual/devsijariya.md
@@ -1,0 +1,12 @@
+India, 2025-10-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Dev Sijariya sanskarsijariya80@gmail.com https://github.com/DevSijariya
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When triggering the “Generate Pricelist Report” server action, an OwlError occurred if no pricelist record was defined in the database.
This happened because the code attempted to access ctx.selectedPricelist.id while the pricelist context was undefined.

Current behavior before PR:
The system raises an OwlError when clicking “Generate Pricelist Report” if no pricelist exists.
The user cannot open the report without manually creating a pricelist first.

Desired behavior after PR is merged:
A check ensures that a valid pricelist exists before generating the report.
If no pricelist is found, a user-friendly error message is shown instead of a crash.
Prevents the undefined context error on the client side.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
