### PR TITLE
[FIX] Fix oauth provider reference to handle not found case

### DIFF
--- a/addons/auth_oauth/models/ir_config_parameter.py
+++ b/addons/auth_oauth/models/ir_config_parameter.py
@@ -10,7 +10,7 @@ class IrConfigParameter(models.Model):
     def init(self, force=False):
         super(IrConfigParameter, self).init(force=force)
         if force:
-            oauth_oe = self.env.ref('auth_oauth.provider_openerp')
+            oauth_oe = self.env.ref('auth_oauth.provider_openerp', raise_if_not_found=False)
             if not oauth_oe:
                 return
             dbuuid = self.sudo().get_param('database.uuid')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When a user has deleted the Odoo Oauth provider, an error occurs when restoring the database. 

**Current behavior before PR:**

You'll get this error:

```
odoo.service.db.restore_db(dbname, backup, copy, **extra_kwargs)
File "<decorator-gen-27>", line 2, in restore_db
File "/opt/ou/odoo/odoo/service/db.py", line 44, in if_db_mgt_enabled
return method(self, *args, **kwargs)
File "/opt/ou/odoo/odoo/service/db.py", line 360, in restore_db
env['ir.config_parameter'].init(force=True)
File "/opt/ou/odoo/addons/auth_oauth/models/ir_config_parameter.py", line 13, in init
oauth_oe = self.env.ref('auth_oauth.provider_openerp')
File "/opt/ou/odoo/odoo/api.py", line 611, in ref
res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
File "/opt/ou/odoo/odoo/addons/base/models/ir_model.py", line 2059, in _xmlid_to_res_model_res_id
return self._xmlid_lookup(xmlid)[1:3]
File "<decorator-gen-43>", line 2, in _xmlid_lookup
File "/opt/ou/odoo/odoo/tools/cache.py", line 90, in lookup
value = d[key] = self.method(*args, **kwargs)
File "/opt/ou/odoo/odoo/addons/base/models/ir_model.py", line 2052, in _xmlid_lookup
raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: auth_oauth.provider_openerp
Error: External ID not found in the system: auth_oauth.provider_openerp

```

**Desired behavior after PR is merged:**

No error will occur

The afflicted versions are AFAIK, **16.0**, **17.0**, **18.0**, and **19.0**


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
