### PR TITLE
[FIX] debian: support installing pypdf with Trixie packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Depends:
  python3-psutil,
  python3-psycopg2,
  python3-openssl,
- python3-pypdf2,
+ python3-pypdf2 | python3-pypdf,
  python3-rjsmin,
  python3-qrcode,
  python3-renderpm,

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@ psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel packag
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
 pyopenssl==24.1.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
-PyPDF2==2.12.1 ; python_version > '3.10'
+PyPDF2==2.12.1 ; python_version > '3.10' and python_version < '3.13' # (Noble and below)
+PyPDF==5.4.0 ; python_version >= '3.13' # (Trixie)
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.5
 python-dateutil==2.8.2 ; python_version >= '3.11'


### PR DESCRIPTION
Since Debian 13 (Trixie), the package `python3-pypdf2` isn't anymore in the repository, and is superseded by `python3-pypdf` (which actually follows the upstream's updates)).

Note: Ubuntu has also removed this package in 25.10, and therefore in the next LTS (26.04).
