### PR TITLE
[IMP] mail, *: do not display the Invite people action for channel and group

### DIFF
--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -50,6 +50,7 @@ test("Can invite a partner to a livechat channel", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await click("button[title='Members']");
     await click("button[title='Invite People']");
     await click("input", {
         parent: [".o-discuss-ChannelInvitation-selectable", { text: "James" }],
@@ -62,7 +63,6 @@ test("Can invite a partner to a livechat channel", async () => {
         text: "Mitch (FR) invited James to the channel1:00 PM",
     });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("button[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "James" });
 });
 
@@ -91,6 +91,7 @@ test("Available operators come first", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await click("button[title='Members']");
     await click("button[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
     await contains(":nth-child(1 of .o-discuss-ChannelInvitation-selectable)", { text: "Ron" });
@@ -147,9 +148,11 @@ test("Partners invited most frequently by the current user come first", async ()
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #1" });
+    await click("button[title='Members']");
     await click("button[title='Invite People']");
     await click("input", { parent: [".o-discuss-ChannelInvitation-selectable", { text: "John" }] });
     await click("button:enabled", { text: "Invite" });
+    await contains(".o-discuss-ChannelMember", { text: "John" });
     await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #2" });
     await click("button[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
@@ -189,6 +192,7 @@ test("shows operators are in call", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await click("button[title='Members']");
     await click("[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation-selectable:contains('bob in a call')");
     await contains(".o-discuss-ChannelInvitation-selectable:contains('john')");
@@ -225,6 +229,7 @@ test("Operator invite shows livechat_username", async () => {
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #1" });
+    await click("button[title='Members']");
     await click("button[title='Invite People']");
     await contains("input", {
         parent: [".o-discuss-ChannelInvitation-selectable", { text: "Johnny" }],

--- a/addons/im_livechat/static/tests/discuss_app_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_app_patch.test.js
@@ -75,7 +75,8 @@ test("invite button should be present on livechat", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Discuss button[title='Invite People']");
+    await click("button[title='Members']");
+    await contains("button[title='Invite People']");
 });
 
 test("livechats are sorted by last activity time in the sidebar: most recent at the top", async () => {

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -36,13 +36,13 @@ test("Thread name unchanged when inviting new users", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-DiscussContent-threadName[title='Visitor #20']");
+    await click("button[title='Members']");
     await click("button[title='Invite People']");
     await click("input", {
         parent: [".o-discuss-ChannelInvitation-selectable", { text: "James" }],
     });
     await click("button:enabled", { text: "Invite" });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("button[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "James" });
     await contains(".o-mail-DiscussContent-threadName[title='Visitor #20']");
 });

--- a/addons/mail/static/src/discuss/core/common/channel_action_dialog.js
+++ b/addons/mail/static/src/discuss/core/common/channel_action_dialog.js
@@ -1,0 +1,13 @@
+import { Component, xml } from "@odoo/owl";
+
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class ChannelActionDialog extends Component {
+    static components = { Dialog };
+    static props = ["title", "contentComponent", "contentProps", "close?", "contentClass?"];
+    static template = xml`
+        <Dialog size="'md'" title="props.title" footer="false" contentClass="'o-bg-body '+ props.contentClass" bodyClass="'p-1'">
+            <t t-component="props.contentComponent" t-props="props.contentProps"/>
+        </Dialog>
+    `;
+}

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -1,5 +1,7 @@
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { ChannelMember } from "@mail/discuss/core/common/channel_member";
+import { ChannelActionDialog } from "@mail/discuss/core/common/channel_action_dialog";
+import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
 
 import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
@@ -7,13 +9,14 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 export class ChannelMemberList extends Component {
-    static components = { ActionPanel, ChannelMember };
+    static components = { ActionPanel, ChannelActionDialog, ChannelMember };
     static props = ["channel", "openChannelInvitePanel", "className?"];
     static template = "discuss.ChannelMemberList";
 
     setup() {
         super.setup();
         this.store = useService("mail.store");
+        this.dialogService = useService("dialog");
         onWillStart(() => {
             if (this.props.channel.fetchMembersState === "not_fetched") {
                 this.props.channel.fetchChannelMembers();
@@ -35,6 +38,18 @@ export class ChannelMemberList extends Component {
     get offlineSectionText() {
         return _t("Offline - %(offline_count)s", {
             offline_count: this.props.channel.offlineMembers.length,
+        });
+    }
+
+    openInviteDialog() {
+        this.dialogService.add(ChannelActionDialog, {
+            contentClass: "o-discuss-ChannelInvitation",
+            contentComponent: ChannelInvitation,
+            contentProps: {
+                channel: this.props.channel,
+                close: () => this.store.env.services.dialog.closeAll(),
+            },
+            title: "",
         });
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
-            <button name="inviteButton" t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3"><i class="oi oi-user-plus"/><span>Invite a User</span></button>
+            <button name="inviteButton" t-on-click="() => this.openInviteDialog()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite a User</span></button>
             <t t-if="props.channel.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -805,10 +805,10 @@ test("should also invite to the call when inviting to the channel", async () => 
     await openDiscuss(channelId);
     await click("[title='Start Call']");
     await contains(".o-discuss-Call");
-    await click(".o-mail-DiscussContent-header button[title='Invite People']");
-    await contains(".o-discuss-ChannelInvitation");
+    await click("button[title='Invite People']");
+    await contains(".o-discuss-ChannelInvitation:has(:text('Invite people'))");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner'))");
-    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
+    await click("button[title='Invite']:enabled");
     await contains(".o-discuss-CallParticipantCard.o-isInvitation");
 });
 

--- a/addons/mail/static/tests/discuss/core/bus_subscription.test.js
+++ b/addons/mail/static/tests/discuss/core/bus_subscription.test.js
@@ -67,6 +67,7 @@ test("bus subscription updated when joining locally pinned thread", async () => 
     await start();
     await openDiscuss(channelId);
     await waitForChannels([`discuss.channel_${channelId}`]);
+    await click("button[title='Members']");
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Mitchell Admin'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -15,7 +15,7 @@ import { Command, getService, serverState, withUser } from "@web/../tests/web_te
 describe.current.tags("desktop");
 defineMailModels();
 
-test("should display the channel invitation form after clicking on the invite button of a chat", async () => {
+test("Can invite people from member panel", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -32,8 +32,8 @@ test("should display the channel invitation form after clicking on the invite bu
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-DiscussContent-header button[title='Invite People']");
-    await contains(".o-discuss-ChannelInvitation");
+    await click("button[title='Invite People']");
+    await contains(".o-mail-ActionPanel-header:text('Invite people')");
 });
 
 test("can invite users in channel from chat window", async () => {
@@ -85,7 +85,7 @@ test("should be able to search for a new user to invite from an existing chat", 
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-DiscussContent-header button[title='Invite People']");
+    await click("button[title='Invite People']");
     await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
     await contains(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner2'))");
 });
@@ -107,7 +107,7 @@ test("Invitation form should display channel group restriction", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-DiscussContent-header button[title='Invite People']");
+    await click("button[title='Invite People']");
     await contains(
         ".o-discuss-ChannelInvitation div:text('Access restricted to group \"testGroup\"')",
         {

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -162,7 +162,6 @@ test("Channel member count update after user joined", async () => {
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Harry'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList h6:text('Offline - 2')");
 });
 

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -24,7 +24,6 @@ test("Add member to channel", async () => {
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Harry'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember:text('Harry')");
 });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -770,11 +770,10 @@ test("basic top bar rendering", async () => {
     await contains(".o-mail-DiscussContent-threadName", { value: "Starred messages" });
     await click(".o-mail-DiscussSidebarChannel-itemName:text('General')");
     await contains(".o-mail-DiscussContent-threadName", { value: "General" });
-    await contains(".o-mail-DiscussContent-header button", { count: 9 });
+    await contains(".o-mail-DiscussContent-header button", { count: 8 });
     await contains(".o-mail-DiscussContent-header button[title='Start Video Call']");
     await contains(".o-mail-DiscussContent-header button[title='Start Call']");
     await contains(".o-mail-DiscussContent-header button[title='Notification Settings']");
-    await contains(".o-mail-DiscussContent-header button[title='Invite People']");
     await contains(".o-mail-DiscussContent-header button[title='Search Messages']");
     await contains(".o-mail-DiscussContent-header button[title='Threads']");
     await contains(".o-mail-DiscussContent-header button[title='Attachments']");
@@ -1703,17 +1702,6 @@ test("should auto-pin chat when receiving a new DM", async () => {
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Demo')");
 });
 
-test("'Invite People' button should be displayed in the topbar of channels", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({
-        name: "general",
-        channel_type: "channel",
-    });
-    await start();
-    await openDiscuss(channelId);
-    await contains("button[title='Invite People']");
-});
-
 test("'Invite People' button should be displayed in the topbar of chats", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Marc Demo" });
@@ -1723,21 +1711,6 @@ test("'Invite People' button should be displayed in the topbar of chats", async 
             Command.create({ partner_id: partnerId }),
         ],
         channel_type: "chat",
-    });
-    await start();
-    await openDiscuss(channelId);
-    await contains("button[title='Invite People']");
-});
-
-test("'Invite People' button should be displayed in the topbar of groups", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: partnerId }),
-        ],
-        channel_type: "group",
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -3,6 +3,10 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("discuss.invite_by_email", {
     steps: () => [
         {
+            trigger: "button[title='Members']",
+            run: "click",
+        },
+        {
             trigger: "button[title='Invite People']",
             run: "click",
         },
@@ -39,9 +43,6 @@ registry.category("web_tour.tours").add("discuss.invite_by_email", {
         {
             trigger: "button:contains(Invite to Group Chat)",
             run: "click",
-        },
-        {
-            trigger: "body:not(:has(.o-mail-ActionPanel))",
         },
     ],
 });


### PR DESCRIPTION
*=im_livechat

Previously, channels with `memberList` had two ways to invite new users — one through the header action button and another via the member list panel. This caused redundancy since both performed the same action.

This commit removes the header invite button for channel types that already have a member list and keeps only the invite option inside the member list panel. The behavior for chat-type channels remains unchanged.
In addition, the invite button in the member list panel now opens a proper dialog instead of a popover.
Invite buttons in other areas, such as the sidebar and chat window actions, remains unchanged for ease of access

enterprise: https://github.com/odoo/enterprise/pull/98457
Task-5406953
