### PR TITLE
[FIX] debian: underscore.js not used anymore

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Depends:
  fonts-font-awesome,
  fonts-roboto-unhinted,
  gsfonts,
- libjs-underscore,
  lsb-base,
  postgresql-client,
  python3-asn1crypto,

--- a/debian/copyright
+++ b/debian/copyright
@@ -294,10 +294,6 @@ Files: addons/web/static/lib/qweb/*
 Copyright: 2013 Fabien Meghazi
 License: MIT
 
-Files: addons/web/static/lib/underscore.string/*
-Copyright: Esa-Matti Suuronen, Alexandru Marasteanu
-License: MIT
-
 Files: addons/web/static/src/css/reset.min.css
 Copyright: 2011 736 Computing Services Limited
 License: MIT

--- a/debian/copyright
+++ b/debian/copyright
@@ -286,7 +286,7 @@ Files: addons/web/static/lib/qweb/*
 Copyright: 2013 Fabien Meghazi
 License: MIT
 
-Files: addons/web/static/src/css/reset.min.css
+Files: addons/web/static/src/webclient/actions/reports/reset.min.css
 Copyright: 2011 736 Computing Services Limited
 License: MIT
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -221,10 +221,6 @@ Files: addons/web/static/lib/bootstrap/scss/_custom-forms.scss
 Copyright: 2014 Waybury
 License: MIT
 
-Files: addons/web/static/lib/es6-promise/*
-Copyright: 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
-License: MIT
-
 Files: addons/web/static/lib/fullcalendar/*
 Copyright: 2019 Adam Shaw, Microsoft Corporation
 License: MIT

--- a/debian/copyright
+++ b/debian/copyright
@@ -225,10 +225,6 @@ Files: addons/web/static/lib/fullcalendar/*
 Copyright: 2019 Adam Shaw, Microsoft Corporation
 License: MIT
 
-Files: addons/web/static/lib/fuzzy-master/*
-Copyright: 2012 Matt York
-License: MIT
-
 Files: addons/web/static/lib/signature_pad/signature_pad.umd.js
 Copyright: 2023 Szymon Nowak
 License: MIT

--- a/debian/copyright
+++ b/debian/copyright
@@ -233,8 +233,8 @@ Files: addons/web/static/lib/jquery/*
 Copyright: JS Foundation and other contributors; jQuery Foundation and other contributors
 License: MIT
 
-Files: addons/web/static/lib/moment/*
-Copyright: Tim Wood, Iskren Chernev, Moment.js contributors
+Files: addons/web/static/lib/luxon/*
+Copyright: 2019 JS Foundation and other contributors
 License: MIT
 
 Files: addons/web/static/lib/pdfjs/build/*

--- a/debian/odoo.links
+++ b/debian/odoo.links
@@ -4,7 +4,6 @@ usr/share/fonts-font-awesome/fonts/fontawesome-webfont.ttf usr/lib/python3/dist-
 usr/share/fonts-font-awesome/fonts/fontawesome-webfont.ttf usr/lib/python3/dist-packages/odoo/addons/web/static/lib/fontawesome/fonts/fontawesome-webfont.eot
 usr/share/fonts-font-awesome/fonts/fontawesome-webfont.woff usr/lib/python3/dist-packages/odoo/addons/web/static/lib/fontawesome/fonts/fontawesome-webfont.woff2
 usr/share/fonts-font-awesome/fonts/fontawesome-webfont.woff2 usr/lib/python3/dist-packages/odoo/addons/web/static/lib/fontawesome/fonts/fontawesome-webfont.woff
-usr/share/javascript/underscore/underscore.js usr/lib/python3/dist-packages/odoo/addons/web/static/lib/underscore/underscore.js
 usr/share/fonts/truetype/roboto/unhinted/RobotoTTF/Roboto-Black.ttf usr/lib/python3/dist-packages/odoo/addons/web/static/fonts/google/Roboto/Roboto-Black.ttf
 usr/share/fonts/truetype/roboto/unhinted/RobotoTTF/Roboto-BlackItalic.ttf usr/lib/python3/dist-packages/odoo/addons/web/static/fonts/google/Roboto/Roboto-BlackItalic.ttf
 usr/share/fonts/truetype/roboto/unhinted/RobotoTTF/Roboto-Bold.ttf usr/lib/python3/dist-packages/odoo/addons/web/static/fonts/google/Roboto/Roboto-Bold.ttf


### PR DESCRIPTION
As we don't use the Underscore.js library anymore, there is no point to depend and/or reference it in the Debian packaging.
