### PR TITLE
[IMP] im_livechat: manage expertises from info panel

### DIFF
--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -146,3 +146,11 @@ class ResUsers(models.Model):
     def _init_store_data(self, store: Store):
         super()._init_store_data(store)
         store.add_global_values(has_access_livechat=self.env.user.has_access_livechat)
+        if not self.env.user._is_public():
+            store.add(
+                self.env.user,
+                Store.Attr(
+                    "is_livechat_manager",
+                    lambda u: u.has_group("im_livechat.im_livechat_group_manager"),
+                ),
+            )

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -32,6 +32,9 @@ declare module "models" {
         livechat_expertise: String[];
         livechat_languages: String[];
     }
+    export interface ResUsers {
+        is_livechat_manager: boolean;
+    }
     export interface Store {
         Chatbot: StaticMailRecord<Chatbot, typeof ChatbotClass>;
         "chatbot.script": StaticMailRecord<ChatbotScript, typeof ChatbotScriptClass>;

--- a/addons/im_livechat/static/src/core/common/res_users_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/res_users_model_patch.js
@@ -1,0 +1,12 @@
+import { ResUsers } from "@mail/core/common/res_users_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").ResUsers} */
+const resUsersPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.is_livechat_manager = false;
+    },
+};
+patch(ResUsers.prototype, resUsersPatch);

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.js
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.js
@@ -1,0 +1,85 @@
+import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
+import { x2ManyCommands } from "@web/core/orm_service";
+import { useTagNavigation } from "@web/core/record_selectors/tag_navigation_hook";
+import { TagsList } from "@web/core/tags_list/tags_list";
+import { useService } from "@web/core/utils/hooks";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+
+/**
+ * @typedef {Object} Props
+ * @property {import("models").Thread} channel
+ * @extends {Component<Props, Env>}
+ */
+export class ExpertiseTagsAutocomplete extends Component {
+    static template = "im_livechat.ExpertiseTagsAutocomplete";
+    static props = ["channel"];
+    static components = { TagsList, Many2XAutocomplete };
+
+    setup() {
+        super.setup(...arguments);
+        this.orm = useService("orm");
+        this.store = useService("mail.store");
+        useTagNavigation("root", {
+            delete: (index) => {
+                const expertise = this.props.channel.livechat_expertise_ids[index];
+                if (expertise) {
+                    this.writeExpertises([x2ManyCommands.unlink(expertise.id)]);
+                }
+            },
+        });
+    }
+
+    /** @param {(ReturnType<typeof x2ManyCommands.link>|ReturnType<typeof x2ManyCommands.unlink>)[]} ormCommands */
+    writeExpertises(ormCommands) {
+        rpc("/im_livechat/conversation/write_expertises", {
+            channel_id: this.props.channel.id,
+            orm_commands: ormCommands,
+        });
+    }
+
+    /** @param {string} name */
+    createAndLinkExpertise(name) {
+        if (
+            this.props.channel.livechat_expertise_ids.some(
+                (expertise) => expertise.name === name.trim()
+            )
+        ) {
+            return;
+        }
+        rpc("/im_livechat/conversation/create_and_link_expertise", {
+            channel_id: this.props.channel.id,
+            expertise_name: name,
+        });
+    }
+
+    /** @param {{id: number, display_name: string}} expertises */
+    addExpertises(expertises) {
+        const toAdd = expertises.filter((expertise) => !this.isSelected(expertise.id));
+        if (!toAdd.length) {
+            return;
+        }
+        this.writeExpertises(toAdd.map((expertise) => x2ManyCommands.link(expertise.id)));
+    }
+
+    get placeholder() {
+        if (this.props.channel.livechat_expertise_ids.length === 0) {
+            return _t("Add expertise");
+        }
+        return "";
+    }
+
+    get tags() {
+        return this.props.channel.livechat_expertise_ids.map((expertise) => ({
+            id: expertise.id,
+            onDelete: () => this.writeExpertises([x2ManyCommands.unlink(expertise.id)]),
+            text: expertise.name,
+        }));
+    }
+
+    isSelected(expertiseId) {
+        return this.props.channel.livechat_expertise_ids.some((e) => e.id === expertiseId);
+    }
+}

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.ExpertiseTagsAutocomplete">
+        <div
+            class="o-livechat-ExpertiseTagsAutocomplete d-inline-flex o_tags_input o_input flex-wrap gap-1 mb-3"
+            t-ref="root"
+        >
+            <TagsList displayText="true" tags="tags"/>
+            <div class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
+                <Many2XAutocomplete
+                    placeholder="placeholder"
+                    resModel="'im_livechat.expertise'"
+                    activeActions="{'link': true}"
+                    isToMany="true"
+                    fieldString.translate="Expertise"
+                    update.bind="addExpertises"
+                    quickCreate="store.self_partner?.main_user_id?.is_livechat_manager ? (name) => this.createAndLinkExpertise(name) : null"
+                    getDomain="() => []"
+                >
+                    <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                        <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record.id) }">
+                            <span t-out="autoCompleteItemScope.label"/>
+                        </span>
+                    </t>
+                </Many2XAutocomplete>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -1,4 +1,5 @@
 import { TranscriptSender } from "@im_livechat/core/common/transcript_sender";
+import { ExpertiseTagsAutocomplete } from "@im_livechat/core/web/expertise_tags_autocomplete";
 import { ConversationTagEdit } from "@im_livechat/core/web/livechat_conversation_tag_edit";
 
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
@@ -6,15 +7,15 @@ import { prettifyMessageContent } from "@mail/utils/common/format";
 
 import { Component, useEffect, useRef, useSubEnv } from "@odoo/owl";
 
+import { startUrl } from "@web/core/browser/router";
 import { rpc } from "@web/core/network/rpc";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
-import { startUrl } from "@web/core/browser/router";
 import { TagsList } from "@web/core/tags_list/tags_list";
-import { usePopover } from "@web/core/popover/popover_hook";
 
 export class LivechatChannelInfoList extends Component {
-    static components = { ActionPanel, TagsList, TranscriptSender };
+    static components = { ActionPanel, TagsList, ExpertiseTagsAutocomplete, TranscriptSender };
     static template = "im_livechat.LivechatChannelInfoList";
     static props = ["thread"];
 
@@ -58,6 +59,7 @@ export class LivechatChannelInfoList extends Component {
             .map((m) => m.chatbotStep);
     }
 
+    /** @deprecated */
     get expertiseTags() {
         return this.props.thread.livechat_expertise_ids.map((expertise) => ({
             id: expertise.id,

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -43,11 +43,9 @@
                     </div>
                 </t>
             </div>
-            <div t-if="expertiseTags.length" class="d-flex flex-column bg-inherit gap-1">
+            <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Expertise</h6>
-                <div class="d-flex flex-wrap gap-1">
-                    <TagsList displayText="true" tags="expertiseTags"/>
-                </div>
+                <ExpertiseTagsAutocomplete channel="props.thread"/>
             </div>
             <t t-name="extra_infos"/>
             <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">

--- a/addons/im_livechat/static/tests/livechat_test_helpers.js
+++ b/addons/im_livechat/static/tests/livechat_test_helpers.js
@@ -36,6 +36,7 @@ export const livechatModels = {
 };
 
 serverState.groupLivechatId = 42;
+serverState.groupLivechatManagerId = 43;
 
 /**
  * Setup the server side of the livechat app.

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_groups.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_groups.js
@@ -9,5 +9,10 @@ export class ResGroups extends mailModels.ResGroups {
             name: "Livechat User",
             privilege_id: false,
         },
+        {
+            id: serverState.groupLivechatManagerId,
+            name: "Livechat Manager",
+            privilege_id: false,
+        },
     ];
 }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_users.js
@@ -10,5 +10,10 @@ export class ResUsers extends mailModels.ResUsers {
         store.add({
             has_access_livechat: this.env.user?.group_ids.includes(serverState.groupLivechatId),
         });
+        store.add(this.browse(this.env.uid), {
+            is_livechat_manager: this.env.user?.group_ids.includes(
+                serverState.groupLivechatManagerId
+            ),
+        });
     }
 }

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -168,6 +168,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 {
                     "id": test_user.id,
                     "is_admin": False,
+                    "is_livechat_manager": False,
                     "notification_type": "email",
                     "signature": ["markup", str(test_user.signature)],
                     "share": False,
@@ -288,6 +289,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 {
                     "id": operator.id,
                     "is_admin": False,
+                    "is_livechat_manager": False,
                     "notification_type": "email",
                     "share": False,
                     "signature": ["markup", str(operator.signature)],

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -425,6 +425,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 {
                     "id": self.users[0].id,
                     "is_admin": False,
+                    "is_livechat_manager": False,
                     "notification_type": "inbox",
                     "share": False,
                     "signature": ["markup", str(self.users[0].signature)],


### PR DESCRIPTION
The live chat info panel shows expertises linked to the chat. However, it's not possible to assign expertises to the chat (only available from the chat bot script).

Expertises are useful to quickly identify which kind of help is needed on a chat, or to find conversations about the same topic.

This commit allows to add expertises from the channel info panel.

task-5190361

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
