### PR TITLE
[IMP] mail: refactor message previewText

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -25,27 +25,10 @@
             <div class="text-truncate base-fs fw-bolder mb-0 mx-2 px-1" t-esc="props.chatWindow.channel.displayName"/>
             <t t-set="message" t-value="channel.newestPersistentOfAllMessage" />
             <div t-if="previewText" class="text-truncate small mx-2 px-1 text-muted">
-                <t t-call="mail.message_preview_prefix">
-                    <t t-set="message" t-value="message"/>
-                </t>
                 <MessageSeenIndicator t-if="message.showSeenIndicator(channel.thread)" message="message" thread="channel.thread" />
-                <t t-if="message.hasOnlyAttachments">
-                    <i class="fa me-1" t-att-class="message.previewIcon"/>
-                    <t t-out="message.previewText" />
-                </t>
-                <t t-else="" t-out="previewText" />
+                <t t-out="message.previewText" />
             </div>
         </div>
-    </t>
-
-    <!-- @type {import("models").Message} message -->
-    <t t-name="mail.message_preview_prefix">
-        <t t-if="message.isSelfAuthored">
-            <i class="fa fa-mail-reply me-1 opacity-75"/>You:
-        </t>
-        <t t-elif="!message.author?.eq(channel?.correspondent?.persona)">
-            <t t-esc="message.authorName"/>:
-        </t>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -37,7 +37,6 @@
                     </t>
                     <t t-set-slot="body">
                         <t t-if="message?.hasOnlyAttachments">
-                            <i class="fa me-1" t-att-class="message.previewIcon"/>
                             <t t-out="message.previewText" />
                         </t>
                         <span t-else="" t-out="message?.previewText" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
@@ -45,12 +44,6 @@
                     <t t-set-slot="icon">
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (thread.correspondent.isTyping ? 'ms-n2' : 'ms-n1')"/>
                         <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border shadow-sm'"/>
-                    </t>
-                    <t t-if="message" t-set-slot="body-icon">
-                        <t t-call="mail.message_preview_prefix">
-                            <t t-set="message" t-value="message"/>
-                            <t t-set="channel" t-value="thread.channel"/>
-                        </t>
                     </t>
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
@@ -10,10 +10,7 @@
                     <span t-if="message" class="text-muted smaller flex-shrink-0" t-esc="dateText(message)"/>
                 </div>
                 <div class="o-mail-SubChannelPreview-lastMessage text-start text-muted fw-normal smaller overflow-hidden ms-2">
-                    <t t-if="message" t-call="mail.message_preview_prefix">
-                        <t t-set="message" t-value="message"/>
-                    </t>
-                    <t t-out="message?.inlineBody"/>
+                    <t t-out="message?.previewText"/>
                 </div>
             </div>
             <i t-if="env.inMessage" class="oi oi-chevron-right ms-2 opacity-50"/>


### PR DESCRIPTION
Before this commit, message preview prefix was a subtemplate of
ChatBubble. Since this template is reused, being a subtemplate isn't
very practical.
This commit refactor previewText to include the prefix.
