### PR TITLE
[FIX] mrp: correct typo in API endpoint (#233410)

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -37,9 +37,9 @@ class MrpProductionSplit(models.TransientModel):
 
     @api.depends('max_batch_size')
     def _compute_num_splits(self):
-        self.num_splits = 0
         for wizard in self:
-            if wizard.product_uom_id.compare(self.max_batch_size, 0) > 0:
+            wizard.num_splits = 0
+            if wizard.product_uom_id.compare(wizard.max_batch_size, 0) > 0:
                 wizard.num_splits = float_round(
                     wizard.product_qty / wizard.max_batch_size,
                     precision_digits=0,
@@ -65,8 +65,8 @@ class MrpProductionSplit(models.TransientModel):
 
     @api.depends('production_detailed_vals_ids')
     def _compute_valid_details(self):
-        self.valid_details = False
         for wizard in self:
+            wizard.valid_details = False
             if wizard.production_detailed_vals_ids:
                 wizard.valid_details = wizard.product_uom_id.compare(wizard.product_qty, sum(wizard.production_detailed_vals_ids.mapped('quantity'))) == 0
 

--- a/doc/cla/individual/MrRana-Odoo.md
+++ b/doc/cla/individual/MrRana-Odoo.md
@@ -1,0 +1,15 @@
+India, 2025-10-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mr.Rana ranakrishna0715@zohomail.in https://github.com/MrRana-Odoo
+
+List of contributors:
+
+Mr.Rana ranakrishna0715@zohomail.in https://github.com/MrRana-Odoo


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Issue Mentioned on #233410 

Current behavior before PR:
Issue Mentioned on #233410 

Desired behavior after PR is merged:

The split wizard completes successfully.

<img width="1920" height="903" alt="mrp_split_wizard_solved" src="https://github.com/user-attachments/assets/9a693ecd-f84f-4d71-b861-902d46276258" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
