### PR TITLE
 [FIX] sale: Prevent Pricelist Report crash when no pricelist is defined

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -212,16 +212,16 @@
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">
-            pricelist = env['product.pricelist'].search([], limit=1)
-            if not pricelist:
-                raise UserError(_("Please configure at least one Pricelist before generating the report."))
-                
-            action = {
-                'name': 'Pricelist Report',
-                'type': 'ir.actions.client',
-                'tag': 'generate_pricelist_report',
-                'context': env.context,
-            }
+pricelist = env['product.pricelist'].search([], limit=1)
+if not pricelist:
+    raise UserError(("Please configure at least one Pricelist before generating the report."))
+
+action = {
+    'name': 'Pricelist Report',
+    'type': 'ir.actions.client',
+    'tag': 'generate_pricelist_report',
+    'context': env.context,
+}
         </field>
     </record>
 

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -212,12 +212,16 @@
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">
-action = {
-    'name': 'Pricelist Report',
-    'type': 'ir.actions.client',
-    'tag': 'generate_pricelist_report',
-    'context': env.context,
-}
+            pricelist = env['product.pricelist'].search([], limit=1)
+            if not pricelist:
+                raise UserError(_("Please configure at least one Pricelist before generating the report."))
+                
+            action = {
+                'name': 'Pricelist Report',
+                'type': 'ir.actions.client',
+                'tag': 'generate_pricelist_report',
+                'context': env.context,
+            }
         </field>
     </record>
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -643,12 +643,16 @@
         <field name="binding_model_id" ref="product.model_product_product"/>
         <field name="state">code</field>
         <field name="code">
-action = {
-    'name': 'Pricelist Report',
-    'type': 'ir.actions.client',
-    'tag': 'generate_pricelist_report',
-    'context': env.context,
-}
+            pricelist = env['product.pricelist'].search([], limit=1)
+            if not pricelist:
+                raise UserError(_("Please configure at least one Pricelist before generating the report."))
+                
+            action = {
+                'name': 'Pricelist Report',
+                'type': 'ir.actions.client',
+                'tag': 'generate_pricelist_report',
+                'context': env.context,
+            }
         </field>
     </record>
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -643,16 +643,16 @@
         <field name="binding_model_id" ref="product.model_product_product"/>
         <field name="state">code</field>
         <field name="code">
-            pricelist = env['product.pricelist'].search([], limit=1)
-            if not pricelist:
-                raise UserError(_("Please configure at least one Pricelist before generating the report."))
-                
-            action = {
-                'name': 'Pricelist Report',
-                'type': 'ir.actions.client',
-                'tag': 'generate_pricelist_report',
-                'context': env.context,
-            }
+pricelist = env['product.pricelist'].search([], limit=1)
+if not pricelist:
+    raise UserError(("Please configure at least one Pricelist before generating the report."))
+
+action = {
+    'name': 'Pricelist Report',
+    'type': 'ir.actions.client',
+    'tag': 'generate_pricelist_report',
+    'context': env.context,
+}
         </field>
     </record>
 


### PR DESCRIPTION
Current behavior before PR:
Generating the Pricelist Report raises a JavaScript error —
Cannot read properties of undefined (reading 'id') —
when there is no pricelist in the database.

Desired behavior after PR is merged:
Instead of crashing, the system now validates the presence of at least one pricelist.
If none is found, it raises a clear UserError message:
“Please configure at least one Pricelist before generating the report.”

This prevents the crash and guides the user to properly configure pricelists before running the report.

Issue : https://github.com/odoo/odoo/issues/233393


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
