### PR TITLE
[IMP] tools: Remove a lie from --test-tags description

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -287,7 +287,7 @@ class configmanager:
                          "A filter spec has the format: [-][tag][/module][:class][.method][[params]] "
                          "The '-' specifies if we want to include or exclude tests matching this spec. "
                          "The tag will match tags added on a class with a @tagged decorator "
-                         "(all Test classes have 'standard' and 'at_install' tags "
+                         "(all Test classes have 'standard' and 'post_install' tags "
                          "until explicitly removed, see the decorator documentation). "
                          "'*' will match all tags. "
                          "If tag is omitted on include mode, its value is 'standard'. "


### PR DESCRIPTION
all tests are post_install by default not at_install. see: https://github.com/odoo/odoo/pull/231001

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
