### PR TITLE
[FIX] sale_stock_margin: prevent division by zero for `purchase_price`

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -17,10 +17,12 @@ class SaleOrderLine(models.Model):
             elif line.product_id and line.product_id.categ_id and line.product_id.categ_id.property_cost_method != 'standard':
                 # don't overwrite any existing value unless non-standard cost method
                 qty_from_delivery = line.qty_delivered
-                price_unit_from_delivery = line.move_ids.filtered(lambda m: m.state == 'done')._get_price_unit() if qty_from_delivery else 0
-                qty_from_std_price = max(line.product_uom_qty - qty_from_delivery, 0)
-
-                purch_price = (qty_from_delivery * price_unit_from_delivery + qty_from_std_price * product.standard_price) / (qty_from_delivery + qty_from_std_price)
+                price_unit_from_delivery = line.move_ids.filtered(lambda m: m.state == 'done')._get_price_unit() if qty_from_delivery > 0 else 0
+                if qty_from_delivery <= 0:
+                    purch_price = product.standard_price
+                else:
+                    qty_from_std_price = max(line.product_uom_qty - qty_from_delivery, 0)
+                    purch_price = (qty_from_delivery * price_unit_from_delivery + qty_from_std_price * product.standard_price) / (qty_from_delivery + qty_from_std_price)
                 line.purchase_price = line._convert_to_sol_currency(
                     purch_price,
                     product.cost_currency_id,


### PR DESCRIPTION
Steps to reproduce:
- Install 'sale_stock_margin' module
- Create SO > Create product with category -> 'Costing Method' : 'FIFO'
- 'Confirm' SO > Change product 'Quantity' to zero

Traceback:
ZeroDivisionError: float division by zero

At [1], this error occurs because both 'product_uom_qty' and 'qty_delivered'
are '0', resulting in a denominator of zero, which is not allowed.

[1]: https://github.com/odoo/odoo/blob/a884794ebfc8145c61bb34908093f00246f224ff/addons/sale_stock_margin/models/sale_order_line.py#L23

Issue also occurs when 'product_uom_qty' = 0 and 'qty_delivery' < 0
since `qty_from_delivery + qty_from_std_price` = 0 in this case.

Expected result:
- If both `product_uom_qty` = `qty_delivered` = 0 => fallback on
  standard_price (default behavior when only `sale_margin` installed)
- If `qty_delivery <= 0` => fallback on `standard_price` to avoid
  inconsistent values for return moves, i.e. value would vary depending
  on whether or not the return is linked to a delivery (i.e.
  `price_unit_from_delivery`) whereas a return not linked to a delivery
  will default to `standard_price`

sentry-6978885438

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
