### PR TITLE
[FIX] mail: fix sub-channel search tour

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
@@ -34,7 +34,7 @@ export class SubChannelList extends Component {
         this.searchRef = useRef("search");
         this.sequential = useSequential();
         useAutofocus({ refName: "search" });
-        useVisible("load-more", (isVisible) => {
+        this.loadMoreState = useVisible("load-more", (isVisible) => {
             if (isVisible) {
                 this.props.thread.loadMoreSubChannels({
                     searchTerm: this.state.searching ? this.state.searchTerm : undefined,


### PR DESCRIPTION
The `test_discuss_sub_channel_search` tour ensures that
lazy loading of threads works correctly with the search
feature.

Technically, the component uses the `useVisible` hook
which waits for a trigger to be visible before loading
more threads.

However, under high CPU load, the `IntersectionObserver`
might not detect the change. For example, clearing the
search input will make the element disappear, but scrolling
afterward may make it reappear. As a result, the component
might not detect that it should load more threads. In
practice, this should never happen. The test now waits
for the state to update before scrolling.

fixes runbot-181951