### PR TITLE
[FIX] web: don't fold group when edit in list

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -221,7 +221,7 @@
                         <t t-foreach="groupByButtons[group.groupByField.name]" t-as="button" t-key="button.id">
                             <t t-if="!evalInvisible(button.invisible, group.record)">
                                 <t t-if="button.clickParams.type === 'edit'">
-                                    <button t-att-title="button.title" class="btn" t-on-click="() => this.editGroupRecord(group)" tabindex="-1">
+                                    <button t-att-title="button.title" class="btn" t-on-click.stop="() => this.editGroupRecord(group)" tabindex="-1">
                                         <i t-attf-class="fa fa-fw {{button.icon}} o_button_icon"/>
                                     </button>
                                 </t>

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7870,6 +7870,40 @@ test(`groupby node with edit button`, async () => {
     expect.verifySteps(["doAction"]);
 });
 
+test(`edit button does not trigger fold group`, async () => {
+    mockService("action", {
+        doAction(action) {
+            expect.step("doAction");
+            expect(action).toEqual({
+                context: { create: false },
+                res_id: 1,
+                res_model: "res.currency",
+                type: "ir.actions.act_window",
+                views: [[false, "form"]],
+            });
+        },
+    });
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <groupby name="currency_id">
+                    <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
+                </groupby>
+            </list>
+        `,
+        groupBy: ['currency_id']
+    });
+    expect(`.o_group_open`).toHaveCount(0);
+    await contains(`.o_group_header:eq(0)`).click();
+    expect(`.o_group_open`).toHaveCount(1);
+    await contains(`.o_group_header .o_group_buttons button:eq(0)`).click();
+    expect(`.o_group_open`).toHaveCount(1);
+    expect.verifySteps(["doAction"]);
+});
+
 test(`groupby node with subfields, and onchange`, async () => {
     Foo._onChanges = {
         foo() {},


### PR DESCRIPTION
This commit prevents the fa-edit button from folding/unfolding groups on click in list view.
This fixes an issue where following breadcrumbs would unfold previously folded groups.

task-5213733
