### PR TITLE
[FIX] {website_,}hr_recruitment: fix job page button visibility

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -119,7 +119,7 @@
                                         <div t-if="record.company_id.raw_value" class="col align-content-center" groups="base.group_multi_company">
                                             <i class="fa fa-building-o" role="img" aria-label="Company" title="Company"></i> <field name="company_id"/>
                                         </div>
-                                        <div class="col align-content-center">
+                                        <div name="large_screen_job_page_div" class="col align-content-center" invisible="1">
                                             <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
                                                 Job Page
                                             </button>
@@ -148,7 +148,7 @@
                                         </div>
                                     </div>
                                     <div class="d-flex">
-                                        <div class="col-6 d-flex align-items-center justify-content-center">
+                                        <div name="mobile_job_page_div" class="col-6 d-flex align-items-center justify-content-center" invisible="1">
                                             <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
                                                 Job Page
                                             </button>

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -17,6 +17,18 @@
                     Job Page
                 </a>
             </xpath>
+            <xpath expr="//div[@name='large_screen_job_page_div']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath expr="//div[@name='mobile_job_page_div']/button[@name='%(hr_recruitment.action_hr_job_applications)d']"
+                position="replace">
+                <a type="object" name="open_website_url" class="btn btn-primary" role="button">
+                    Job Page
+                </a>
+            </xpath>
+            <xpath expr="//div[@name='mobile_job_page_div']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This commit fixes the visibility of the "Job Page" button on the job kanban view. The job page button is now invisible when the `Online Posting` setting is disabled and visible when it is enabled, and directs to the job link.

task-5153230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
