### PR TITLE
[REM] project,sale_timesheet: remove milestones section from the side panel

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -40,45 +40,6 @@
                 </div>
             </ProjectRightSidePanelSection>
             <ProjectRightSidePanelSection
-                name="'milestones'"
-                show="!!state.data.milestones &amp;&amp; !!state.data.milestones.data"
-            >
-                <t t-set-slot="header">
-                    <t t-if="state.data.milestones.data.length !== 0">
-                        <span class="btn btn-secondary">
-                            <div class="o_view_tasks">
-                                <a t-on-click="viewTasks">
-                                    Tasks
-                                </a>
-                            </div>
-                        </span>
-                    </t>
-                    <span class="btn btn-secondary">
-                        <div class="o_add_milestone">
-                            <a t-on-click="viewMilestones">
-                                <t t-if="state.data.milestones.data.length === 0">
-                                    Add Milestones
-                                </t>
-                                <t t-else="">
-                                    Edit Milestones
-                                </t>
-                            </a>
-                        </div>
-                    </span>
-                </t>
-                <t t-set-slot="title">
-                    Milestones
-                </t>
-                <div t-foreach="state.data.milestones.data" t-as="milestone" t-key="milestone.id" class="o_rightpanel_data_row">
-                    <ProjectMilestone context="context" milestone="milestone"/>
-                </div>
-                <div t-if="state.data.milestones.data.length === 0" class="px-3 pb-3">
-                    <span class="text-muted fst-italic">
-                        Track major progress points that must be reached to achieve success.
-                    </span>
-                </div>
-            </ProjectRightSidePanelSection>
-            <ProjectRightSidePanelSection
                 name="'profitability'"
                 show="state.data.show_project_profitability_helper"
                 headerClassName="'border-top pt-0 pt-md-3'"

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -144,46 +144,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     content: "Open Dashboard",
     run: "click",
 }, {
-    trigger: ".o_add_milestone a",
-    content: "Add a first milestone",
-    run: "click",
-}, {
-    trigger: ".o_list_button_add",
-    content: "Create new milestone",
-    run: "click",
-}, {
-    trigger: "div.o_field_widget[name=name] input",
-    run: "edit New milestone",
-}, {
-    trigger: "input[data-field=deadline]",
-    run: "edit 12/12/2099",
-}, {
-    trigger: ".o_list_button_save",
-    run: "click",
-}, {
-    trigger: ".o_list_button_add",
-    content: "Make sure the milestone is saved before continuing",
-}, {
-    trigger: "td[data-tooltip='New milestone'] + td",
-    run: "click",
-}, {
-    trigger: "input[data-field=deadline]",
-    run: "edit 12/12/2100 && click body"
-},  {
-    trigger: ".o_list_button_add",
-    content: "Create new milestone",
-    run: "click",
-}, {
-    trigger: "div.o_field_widget[name=name] input",
-    run: "edit Second milestone",
-}, {
-    trigger: "input[data-field=deadline]",
-    run: "edit 12/12/2022 && click body",
-}, {
-    trigger: ".breadcrumb-item.o_back_button",
-    run: "click",
-}, {
-    trigger: ".o-kanban-button-new",
+    trigger: ".o_project_update_kanban_view .o-kanban-button-new",
     content: "Create a new update",
     run: "click",
 }, {
@@ -192,16 +153,6 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".o_form_button_save",
     run: "click",
-}, {
-    trigger: ".o_field_widget[name='description'] h1:contains('Activities')",
-}, {
-    trigger: ".o_field_widget[name='description'] h3:contains('Milestones')",
-}, {
-    trigger: ".o_field_widget[name='description'] div[name='milestone'] ul li:contains('(12/12/2099 => 12/12/2100)')",
-}, {
-    trigger: ".o_field_widget[name='description'] div[name='milestone'] ul li:contains('(due 12/12/2022)')",
-}, {
-    trigger: ".o_field_widget[name='description'] div[name='milestone'] ul li:contains('(due 12/12/2100)')",
 }, {
     trigger: '.o_back_button',
     content: 'Go back to the kanban view the project',

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -322,32 +322,6 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: ".o_rightpanel_section[name='profitability'] .o_rightpanel_data > div > .o_rightpanel_subsection:eq(2) > table > thead > tr > th:eq(0):contains('Total')",
     content: 'Check the user sees Profitability subsection row',
 }, {
-    trigger: ".o_rightpanel_section[name='milestones'] .o_rightpanel_title:contains('Milestones')",
-    content: 'Check the user sees Milestones section',
-    run: "click",
-}, {
-    trigger: ".o_add_milestone a",
-    content: "Add a first milestone",
-    run: "click",
-}, {
-    trigger: ".o_list_button_add",
-    content: "Add a first milestone",
-    run: "click",
-}, {
-    trigger: "div.o_field_widget[name=name] input",
-    run: "edit New milestone",
-}, {
-    trigger: "input[data-field=deadline]",
-    content: "Edit new Milestone",
-    run: "edit 12/12/2099",
-}, {
-    trigger: ".o_list_button_save",
-    content: "Save new Milestone",
-    run: "click",
-}, {
-    trigger: ".breadcrumb-item.o_back_button",
-    run: "click",
-}, {
     trigger: ".o-kanban-button-new",
     content: "Create new Project Update",
     run: "click",
@@ -358,9 +332,6 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
 }, {
     trigger: ".o_field_widget[name=description] h3:contains('Profitability')",
     content: "Profitability title must be in description",
-}, {
-    trigger: ".o_field_widget[name=description] h3:contains('Milestones')",
-    content: "Milestones title must be in description",
 },
 // Those steps are currently needed in order to prevent the following issue:
 // "Form views in edition mode are automatically saved when the page is closed, which leads to stray network requests and inconsistencies."


### PR DESCRIPTION

This commit removes the "Milestones" section from the right-side
panel of the project dashboard.

The related tour tests in `project` and `sale_timesheet`
that verified this feature have also been removed.

task-5164128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
