### PR TITLE
[IMP] hw_drivers: remove crypt library usage

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -44,7 +44,7 @@ class DisplayDriver(Driver):
         self.rendered_html = ''
         if self.device_identifier != 'distant_display':
             # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
-            self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= 24.10 else 'firefox'
+            self.browser = 'chromium-browser' if float(helpers.get_version()[1:8]) >= 24.10 else 'firefox'
             self.browser_process_name = 'chromium' if self.browser == 'chromium-browser' else self.browser
             self._x_screen = device.get('x_screen', '0')
             self.load_url()

--- a/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
@@ -13,6 +13,8 @@ fi
 echo "addons/point_of_sale/tools/posbox/overwrite_after_init/home/pi/odoo" >> .git/info/sparse-checkout
 echo "addons/iot_base" >> .git/info/sparse-checkout
 echo "addons/iot_drivers" >> .git/info/sparse-checkout
+echo "addons/iot_box_image/configuration" >> .git/info/sparse-checkout
+echo "setup/iot_box_builder/configuration" >> .git/info/sparse-checkout
 
 git fetch "${localremote}" "${localbranch}" --depth=1
 git reset "${localremote}"/"${localbranch}" --hard
@@ -32,6 +34,23 @@ fi
 if [ -d /home/pi/odoo/addons/iot_drivers ]; then
   # TODO: remove this when v18.0 is deprecated (hw_drivers/,hw_posbox_homepage/ -> iot_drivers/)
   sed -i 's|hw_drivers.*hw_posbox_homepage|iot_drivers|g' /home/pi/odoo.conf
+fi
+
+# we create a symlinks in case the image uses hardcoded paths (ramdisks.service for example)
+if [ -d /home/pi/odoo/addons/iot_box_image ]; then
+  # if we have the iot_box_image module, it means configuration files are not in point_of_sale anymore
+  mkdir -p /home/pi/odoo/addons/point_of_sale/tools/posbox
+  ln -sf /home/pi/odoo/addons/iot_box_image/configuration /home/pi/odoo/addons/point_of_sale/tools/posbox
+fi
+
+if [ -d /home/pi/odoo/setup/iot_box_builder ]; then
+  # if we have the iot_box_builder module, it means configuration files are not in point_of_sale anymore
+  # in case ramdisks.service points to point_of_sale, we create a symlink
+  mkdir -p /home/pi/odoo/addons/point_of_sale/tools/posbox
+  ln -sf /home/pi/odoo/setup/iot_box_builder/configuration /home/pi/odoo/addons/point_of_sale/tools/posbox
+  # in case ramdisks.service points to iot_box_image, we create a symlink
+  mkdir -p /home/pi/odoo/addons/iot_box_image
+  ln -sf /home/pi/odoo/setup/iot_box_builder/configuration /home/pi/odoo/addons/iot_box_image
 fi
 
 sudo service led-status start


### PR DESCRIPTION
To ensure compatibility with python 3.13+, we updated the method to generate the rpi's password to avoid using the removed `crypt` lib.

We also ensure that files moved between `point_of_sale/tools/posbox/`, `addons/iot_box_image/` and `setup/iot_box_builder` can still be found by system processes using symlinks.