### PR TITLE
[FIX] web: correct PM/AM display for Arabic datetime fields

### DIFF
--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -359,7 +359,11 @@ export function formatDateTime(value, options = {}) {
     let format = options.format;
     if (!format) {
         if (options.showSeconds === false) {
-            format = `${localization.dateFormat} ${localization.shortTimeFormat}`;
+            let timeFormat = localization.shortTimeFormat;
+            if (/hh?/.test(timeFormat) && !/a/i.test(timeFormat)) {
+                timeFormat += ' a';
+            }
+            format = `${localization.dateFormat} ${timeFormat}`;
         } else {
             format = localization.dateTimeFormat;
         }


### PR DESCRIPTION
When the database language is set to Arabic, all datetime fields across the system incorrectly displayed PM (afternoon/evening) times without the Arabic meridiem marker (م), causing times to appear ambiguous and be parsed incorrectly as AM times when re-read from the input.

Issue:
------
- Switch to Arabic Language
- Enter 11:00 PM in any datetime field (attendance, calendar, etc.)
- System correctly stores it as 23:00 (hour 23 in 24-hour format)
- When displaying back to the user, the formatter uses shortTimeFormat which is configured as "hh:mm" (without the 'a' meridiem token)
- Display shows: "١١:٠٠" (11:00 with no م marker)
- When the field loses focus, parseDateTime tries to parse using format "hh:mm:ss a" (expects meridiem marker)
- Since no marker is present, Luxon defaults to AM
- Time gets changed from 23:00 (11 PM) to 11:00 (11 AM)

Root Cause:
-----------
The formatDateTime function uses different time formats depending on whether seconds should be displayed:

- When showSeconds = false: uses localization.shortTimeFormat ("hh:mm")
- When showSeconds = true: uses localization.dateTimeFormat (...hh:mm:ss a)

The shortTimeFormat is missing the 'a' token for meridiem marker, but the parser always expects it when timeFormat includes 'a'. This creates a mismatch between formatting and parsing.

Solution:
---------
Modified formatDateTime() to detect when shortTimeFormat uses 12-hour format (h/hh tokens) but is missing the meridiem marker ('a' token). In such cases, append ' a' to the format string before formatting.

This ensures 12-hour times include the meridiem marker which Luxon correctly outputs for each locale (م for PM in Arabic, PM in English), making times unambiguous and allowing them to be parsed correctly.

The fix only affects 12-hour formats missing the meridiem marker, and does not modify 24-hour formats (H/HH tokens), preserving existing behavior for formats that intentionally use 24-hour display.

opw-5137828
