### PR TITLE
[FIX] payment_mercado_pago: fix the super call

### DIFF
--- a/addons/payment_mercado_pago/static/src/interactions/payment_form.js
+++ b/addons/payment_mercado_pago/static/src/interactions/payment_form.js
@@ -116,14 +116,13 @@ patch(PaymentForm.prototype, {
         }
 
         // Trigger form validation.
-        const _super = super.bind(this);
         this.mercadoPagoFormData = await this.waitFor(this.lastMercadoPagoBrick.getFormData());
         if (!this.mercadoPagoFormData){
             this._displayErrorDialog(_t("Incorrect payment details"));
             this._enableButton();  // The submit button is disabled at this point, enable it.
             return;
         }
-        return await _super._initiatePaymentFlow(...arguments);
+        await super._initiatePaymentFlow(...arguments);
     },
 
     /**


### PR DESCRIPTION
'_super' is removed, since the binding of 'this' is no longer needed and since 'super' is not a function it caused an error and prevented the payment.
