### PR TITLE
[IMP] mail: store the email used to contact the recipient

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3452,6 +3452,7 @@ class MailThread(models.AbstractModel):
             )
             recipients_emails = recipients_group['recipients_emails']
             recipients_ids = recipients_group['recipients_ids']
+            recipients_to_emails = {r['id']: r['email_normalized'] for r in recipients_group['recipients_data']}
 
             # create MailMail for partners
             for recipients_ids_chunk in split_every(gen_batch_size, recipients_ids):
@@ -3466,6 +3467,7 @@ class MailThread(models.AbstractModel):
                     notif_create_values += [{
                         'mail_mail_id': new_email.id,
                         'res_partner_id': recipient_id,
+                        'mail_email_address': recipients_to_emails.get(recipient_id),
                         **base_notification_values,
                     } for recipient_id in recipients_ids_chunk]
                 emails += new_email

--- a/addons/mail/static/src/core/common/message_notification_popover.xml
+++ b/addons/mail/static/src/core/common/message_notification_popover.xml
@@ -6,12 +6,13 @@
             <t t-set="otherNotifications" t-value="this.props.message.notification_ids.filter((notif) => !notif._proxy.isFollowerNotification)"/>
             <t t-set="followerNotifications" t-value="this.props.message.notification_ids.filter((notif) => notif._proxy.isFollowerNotification)"/>
             <div t-foreach="otherNotifications" t-as="notification" t-key="notification.id">
+                <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id.email"/>
                 <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
                 <span t-if="notification.res_partner_id">
                     <t t-esc="props.message.getPersonaName(notification.res_partner_id)"/>
-                    <t t-if="notification.res_partner_id.email and !notification.isFailure"> (<t t-out="notification.res_partner_id.email"/>)</t>
+                    <t t-if="email_to and !notification.isFailure"> (<t t-out="email_to"/>)</t>
                 </span>
-                <span t-elif="notification.mail_email_address" t-out="notification.mail_email_address"/>
+                <span t-elif="email_to" t-out="email_to"/>
                 <span class="ms-1 text-muted" t-if="notification.isFailure">(<t t-esc="notification.failureMessage"/>)</span>
             </div>
             <div t-if="props.message.incoming_email_cc or props.message.incoming_email_to" t-foreach="(props.message.incoming_email_cc || []).concat(props.message.incoming_email_to || [])" t-as="incomingEmail" t-key="incomingEmail_index">
@@ -20,12 +21,13 @@
                 <span t-if="incomingEmail[1]" t-out="incomingEmail[1]" class="ps-1"/>
             </div>
             <div t-foreach="followerNotifications" t-as="notification" t-key="notification.id">
+                <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id.email"/>
                 <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
                 <span t-if="notification.res_partner_id">
                     <t t-esc="props.message.getPersonaName(notification.res_partner_id)"/>
-                    <t t-if="notification.res_partner_id.email and !notification.isFailure"> (<t t-out="notification.res_partner_id.email"/>)</t>
+                    <t t-if="email_to and !notification.isFailure"> (<t t-out="email_to"/>)</t>
                 </span>
-                <span t-elif="notification.mail_email_address" t-out="notification.mail_email_address"/>
+                <span t-elif="email_to" t-out="email_to"/>
                 <span class="ms-1 text-muted" t-if="notification.isFailure">(<t t-esc="notification.failureMessage"/>)</span>
             </div>
         </div>

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1571,7 +1571,7 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
                 # find notification
                 notif = notifications.filtered(
                     lambda n: n.mail_message_id == message
-                    and ((partner and n.res_partner_id == partner) or n.mail_email_address in email_to_lst)
+                    and ((partner and n.res_partner_id == partner) or (not n.res_partner_id and n.mail_email_address in email_to_lst))
                     and n.notification_type == ntype
                 )
                 self.assertEqual(len(notif), 1,

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -263,6 +263,9 @@ class TestMailComposerRendering(TestMailComposer):
             'We must preserve (mso) comments in email html'
         )
 
+        notification = self.env["mail.notification"].search(
+            [('mail_email_address', '=', self.partner_employee.email)])
+        self.assertEqual(len(notification), 1)
 
 @tagged("mail_composer")
 class TestMailComposerUI(MailCommon, HttpCase):

--- a/addons/mail/views/mail_notification_views.xml
+++ b/addons/mail/views/mail_notification_views.xml
@@ -29,6 +29,7 @@
                             <field name="notification_type"/>
                             <field name="mail_mail_id"/>
                             <field name="res_partner_id"/>
+                            <field name="mail_email_address"/>
                         </group>
                         <group string="Status">
                             <field name="is_read"/>

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -868,7 +868,9 @@ class MailComposeMessage(models.TransientModel):
             if not mail.recipient_ids and not emails:
                 create_vals_all.append(notif_base_values)
             else:
-                create_vals_all.extend(notif_base_values | {'res_partner_id': partner.id} for partner in mail.recipient_ids)
+                create_vals_all.extend(notif_base_values
+                    | {'res_partner_id': partner.id, 'mail_email_address': partner.email}
+                    for partner in mail.recipient_ids)
                 create_vals_all.extend(notif_base_values | {'mail_email_address': email} for email in emails)
         return create_vals_all
 

--- a/addons/sms/views/mail_notification_views.xml
+++ b/addons/sms/views/mail_notification_views.xml
@@ -16,7 +16,7 @@
         <field name="model">mail.notification</field>
         <field name="inherit_id" ref="mail.mail_notification_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='res_partner_id']" position="after">
+            <xpath expr="//field[@name='mail_email_address']" position="after">
                 <field name="sms_number"/>
             </xpath>
             <xpath expr="//field[@name='mail_mail_id']" position="after">

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1218,8 +1218,10 @@ class TestMailgateway(MailGatewayCommon):
         self.assertEqual(self.test_record.message_bounce, 0)
 
         notification = self.env['mail.notification'].create({
+            'notification_type': 'email',
             'mail_message_id': self.fake_email.id,
             'res_partner_id': self.partner_1.id,
+            'mail_email_address': self.partner_1.email_normalized,
         })
 
         bounce_email_to = f'{self.alias_bounce}@{self.alias_domain}'


### PR DESCRIPTION
Purpose
=======
When we send an email to a partner, we don't store the email used.
So if we change the email of the partner, then the email shown in the
mail notification won't be accurate anymore.

Now, we store that email in `mail_email_address`.

Task-5215602