### PR TITLE
[FIX] web: loadState: fix test failing randomly

### DIFF
--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -1869,7 +1869,9 @@ describe(`new urls`, () => {
 
         await mountWebClient();
         await getService("action").doAction(100);
+        await runAllTimers(); // wait for the router to be updated
         await contains(".o_data_cell").click();
+        await runAllTimers(); // wait for the router to be updated
         await getService("action").doAction(200);
         expect.verifySteps(["/web/action/load", "/web/action/load"]);
 


### PR DESCRIPTION
Before this commit, the test sometimes failed because the resulting url was `/odoo/action-100/1/action-200/1` whereas it should have been `/odoo/action-100/1/action-200`. The issue occurs because the `pushState` method of the router by default batches its calls to the next tick (setTimeout(0)). As a consequence, in the test, the actions were sometimes executed too quickly s.t. the state of the different actions were mixed.

First, this is an obvious issue of the way the state of the router is updated by the action service, which is highlighted by the test. Second, this issue is very unlikely (not to say impossible) to be reproduced in practice, as it would require the user to click to quickly that more than one action could be executed in the same tick.

For those reasons, in 19, we decided to simply strenghten the test such that it no longer fails. In master, we will use the `sync` option of pushState to push the state directly when the controller is mounted. That change being a bit tricky and prone to unexpected effets, we prefered not to do it in stable.

runbot error~233361

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
