### PR TITLE
[FIX] web: action service: push state directly when mounted

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1022,7 +1022,7 @@ export function makeActionManager(env, router = _router) {
                     };
 
                     controllerStack = nextStack; // the controller is mounted, commit the new stack
-                    pushState();
+                    pushState(controllerStack, { sync: true });
                     this.titleService.setParts({ action: controller.displayName });
                     browser.sessionStorage.setItem(
                         "current_action",
@@ -1844,7 +1844,7 @@ export function makeActionManager(env, router = _router) {
         return Object.assign(newState, pick(newState.actionStack.at(-1), ...stateKeys));
     }
 
-    function pushState(cStack = controllerStack) {
+    function pushState(cStack = controllerStack, options) {
         if (!cStack.length) {
             return;
         }
@@ -1853,7 +1853,7 @@ export function makeActionManager(env, router = _router) {
         browser.sessionStorage.setItem("current_state", JSON.stringify(newState));
 
         cStack.at(-1).state = newState;
-        router.pushState(newState, { replace: true });
+        router.pushState(newState, Object.assign({ replace: true }, options));
     }
     return {
         doAction,

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -795,7 +795,6 @@ describe(`new urls`, () => {
         redirect("/odoo/action-3/2");
         logHistoryInteractions();
 
-        onRpc("unity_read", ({ kwargs }) => expect.step(`unity_read ${kwargs.method}`));
         stepAllNetworkCalls();
 
         await mountWebClient();
@@ -821,11 +820,12 @@ describe(`new urls`, () => {
         await contains(`.o_control_panel .breadcrumb a`).click();
         expect(`.o_list_view`).toHaveCount(1);
         expect(`.o_form_view`).toHaveCount(0);
-        expect.verifySteps(["web_search_read", "has_group"]);
-
-        await animationFrame(); // pushState is debounced
+        expect.verifySteps([
+            "web_search_read",
+            "has_group",
+            "pushState http://example.com/odoo/action-3",
+        ]);
         expect(browser.location.href).toBe("http://example.com/odoo/action-3");
-        expect.verifySteps(["pushState http://example.com/odoo/action-3"]);
     });
 
     test(`go back with breadcrumbs after doAction`, async () => {
@@ -1587,17 +1587,17 @@ describe(`new urls`, () => {
             "get current_state-null",
             "get current_action-null",
             'set current_state-{"actionStack":[{"displayName":"Partners","action":9001,"view_type":"list"}],"action":9001}',
+            "pushState http://example.com/odoo/action-9001",
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
             "set current_lang-en",
-            "pushState http://example.com/odoo/action-9001",
             "get menu_id-100", // F5 reload checks stored menu
             "get current_lang-en",
             'get current_state-{"actionStack":[{"displayName":"Partners","action":9001,"view_type":"list"}],"action":9001}',
             'get current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
             'set current_state-{"actionStack":[{"displayName":"Partners","action":9001,"view_type":"list"}],"action":9001}',
+            "Update the state without updating URL, nextState: actionStack,action",
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
             "set current_lang-en",
-            "Update the state without updating URL, nextState: actionStack,action",
         ]);
     });
 
@@ -2105,9 +2105,6 @@ describe(`legacy urls`, () => {
     test(`lazy load multi record view if mono record one is requested`, async () => {
         redirect("/web#action=3&id=2&view_type=form");
         stepAllNetworkCalls();
-        onRpc("unity_read", ({ kwargs }) => {
-            expect.step(`unity_read ${kwargs.method}`);
-        });
 
         await mountWebClient();
         expect(`.o_list_view`).toHaveCount(0);

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -185,8 +185,7 @@ test(`basic action as App`, async () => {
 
     await contains(`.o_navbar_apps_menu button`).click();
     await contains(`.o-dropdown-item:eq(2)`).click();
-    await animationFrame();
-    await animationFrame();
+    await animationFrame(); // one render for the blank component, one for the client action
     expect(router.current.action).toBe(1002);
     expect(browser.location.href).toBe("http://example.com/odoo/action-1002");
     expect(`.test_client_action`).toHaveText("ClientAction_Id 2");
@@ -200,15 +199,13 @@ test(`do action keeps menu in url`, async () => {
 
     await contains(`.o_navbar_apps_menu button`).click();
     await contains(`.o-dropdown-item:eq(2)`).click();
-    await animationFrame();
-    await animationFrame();
+    await animationFrame(); // one render for the blank component, one for the client action
     expect(browser.location.href).toBe("http://example.com/odoo/action-1002");
     expect(router.current.action).toBe(1002);
     expect(`.test_client_action`).toHaveText("ClientAction_Id 2");
     expect(`.o_menu_brand`).toHaveText("App2");
 
     await getService("action").doAction(1001, { clearBreadcrumbs: true });
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-1001");
     expect(router.current.action).toBe(1001);
     expect(`.test_client_action`).toHaveText("ClientAction_Id 1");
@@ -236,14 +233,12 @@ test(`actions can push state`, async () => {
     expect(router.current).toEqual({});
 
     await getService("action").doAction("client_action_pushes");
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/client_action_pushes");
     expect(browser.history.length).toBe(2);
     expect(router.current.action).toBe("client_action_pushes");
     expect(router.current.menu_id).toBe(undefined);
 
     await contains(`.test_client_action`).click();
-    await animationFrame();
     expect(browser.location.href).toBe(
         "http://example.com/odoo/client_action_pushes?arbitrary=actionPushed"
     );
@@ -273,9 +268,7 @@ test(`actions override previous state`, async () => {
     expect(router.current).toEqual({});
 
     await getService("action").doAction("client_action_pushes");
-    await animationFrame(); // wait for pushState because it's unrealistic to click before it
     await contains(`.test_client_action`).click();
-    await animationFrame();
     expect(browser.location.href).toBe(
         "http://example.com/odoo/client_action_pushes?arbitrary=actionPushed"
     );
@@ -284,7 +277,6 @@ test(`actions override previous state`, async () => {
     expect(router.current.arbitrary).toBe("actionPushed");
 
     await getService("action").doAction(1001);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-1001", {
         message: "client_action_pushes removed from url because action 1001 is in target main",
     });
@@ -316,8 +308,7 @@ test(`actions override previous state from menu click`, async () => {
     await contains(`.test_client_action`).click();
     await contains(`.o_navbar_apps_menu button`).click();
     await contains(`.o-dropdown-item:eq(2)`).click();
-    await animationFrame();
-    await animationFrame();
+    await animationFrame(); // one render for the blank component, one for the client action
     expect(browser.location.href).toBe("http://example.com/odoo/action-1002");
     expect(router.current.action).toBe(1002);
 });
@@ -346,7 +337,6 @@ test(`action in target new do not push state`, async () => {
     await getService("action").doAction(2001);
     expect(`.modal .test_client_action`).toHaveCount(1);
 
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo", {
         message: "url did not change",
     });
@@ -360,7 +350,6 @@ test(`properly push state`, async () => {
     expect(browser.history.length).toBe(1);
 
     await getService("action").doAction(4);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-4");
     expect(browser.history.length).toBe(2);
     expect(router.current).toEqual({
@@ -375,7 +364,6 @@ test(`properly push state`, async () => {
     });
 
     await getService("action").doAction(8);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-4/action-8");
     expect(browser.history.length).toBe(3);
     expect(router.current).toEqual({
@@ -395,7 +383,6 @@ test(`properly push state`, async () => {
     });
 
     await contains(`tr .o_data_cell:first`).click();
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-4/action-8/4");
     expect(browser.history.length).toBe(4);
     expect(router.current).toEqual({
@@ -431,15 +418,12 @@ test(`push state after action is loaded, not before`, async () => {
     expect(browser.history.length).toBe(1);
 
     getService("action").doAction(4);
-    await animationFrame();
-    await animationFrame();
 
     expect(browser.location.href).toBe("http://example.com/odoo");
     expect(browser.history.length).toBe(1);
     expect(router.current).toEqual({});
 
     def.resolve();
-    await animationFrame();
     await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-4");
     expect(browser.history.length).toBe(2);
@@ -463,7 +447,6 @@ test(`do not push state when action fails`, async () => {
     expect(browser.history.length).toBe(1);
 
     await getService("action").doAction(8);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-8");
     expect(browser.history.length).toBe(2);
     expect(router.current).toEqual({
@@ -483,7 +466,6 @@ test(`do not push state when action fails`, async () => {
         message: "there should still be a list view in dom",
     });
 
-    await animationFrame(); // wait for possible debounced pushState
     expect(browser.location.href).toBe("http://example.com/odoo/action-8");
     expect(browser.history.length).toBe(2);
     expect(router.current).toEqual({
@@ -504,7 +486,6 @@ test(`view_type is in url when not the default one`, async () => {
     expect(browser.history.length).toBe(1);
 
     await getService("action").doAction(3);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-3");
     expect(browser.history.length).toBe(2);
     expect(router.current).toEqual({
@@ -520,7 +501,6 @@ test(`view_type is in url when not the default one`, async () => {
     expect(`.breadcrumb`).toHaveCount(0);
 
     await getService("action").doAction(3, { viewType: "kanban" });
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-3?view_type=kanban");
     expect(browser.history.length).toBe(3, { message: "created a history entry" });
     expect(`.breadcrumb`).toHaveCount(1, {
@@ -550,7 +530,6 @@ test(`switchView pushes the stat but doesn't add to the breadcrumbs`, async () =
     expect(browser.history.length).toBe(1);
 
     await getService("action").doAction(3);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-3");
     expect(browser.history.length).toBe(2);
     expect(router.current).toEqual({
@@ -566,7 +545,6 @@ test(`switchView pushes the stat but doesn't add to the breadcrumbs`, async () =
     expect(`.breadcrumb`).toHaveCount(0);
 
     await getService("action").switchView("kanban");
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-3?view_type=kanban");
     expect(browser.history.length).toBe(3, { message: "created a history entry" });
     expect(`.breadcrumb`).toHaveCount(0, { message: "didn't create a breadcrumb entry" });
@@ -589,7 +567,6 @@ test(`properly push globalState`, async () => {
     expect(browser.history.length).toBe(1);
 
     await getService("action").doAction(4);
-    await animationFrame();
     expect(browser.location.href).toBe("http://example.com/odoo/action-4");
     expect(browser.history.length).toBe(2);
     expect(router.current).toEqual({
@@ -610,24 +587,6 @@ test(`properly push globalState`, async () => {
 
     //open record
     await contains(".o_kanban_record").click();
-
-    // Add the globalState on the state before leaving the kanban
-    expect(router.current).toEqual({
-        action: 4,
-        actionStack: [
-            {
-                action: 4,
-                displayName: "Partners Action 4",
-                view_type: "kanban",
-            },
-        ],
-        globalState: {
-            searchModel: `{"nextGroupId":2,"nextGroupNumber":1,"nextId":2,"query":[{"searchItemId":1,"autocompleteValue":{"label":"blip","operator":"ilike","value":"blip"}}],"searchItems":{"1":{"type":"field","fieldName":"foo","fieldType":"char","description":"Foo","groupId":1,"id":1}},"searchPanelInfo":{"className":"","viewTypes":["kanban","list"],"loaded":false,"shouldReload":true},"sections":[]}`,
-        },
-    });
-
-    // pushState is defered
-    await animationFrame();
     expect(".o_form_view").toHaveCount(1);
     expect(browser.location.href).toBe("http://example.com/odoo/action-4/2");
     expect(router.current).toEqual({
@@ -655,19 +614,4 @@ test(`properly push globalState`, async () => {
     // The search Model should be restored
     expect(queryAllTexts(".o_facet_value")).toEqual(["blip"]);
     expect(browser.location.href).toBe("http://example.com/odoo/action-4");
-
-    // The global state is restored on the state
-    expect(router.current).toEqual({
-        action: 4,
-        actionStack: [
-            {
-                action: 4,
-                displayName: "Partners Action 4",
-                view_type: "kanban",
-            },
-        ],
-        globalState: {
-            searchModel: `{"nextGroupId":2,"nextGroupNumber":1,"nextId":2,"query":[{"searchItemId":1,"autocompleteValue":{"label":"blip","operator":"ilike","value":"blip"}}],"searchItems":{"1":{"type":"field","fieldName":"foo","fieldType":"char","description":"Foo","groupId":1,"id":1}},"searchPanelInfo":{"className":"","viewTypes":["kanban","list"],"loaded":false,"shouldReload":true},"sections":[]}`,
-        },
-    });
 });


### PR DESCRIPTION
By default, router.pushState batches the calls to the next tick, such that multiple consecutive calls do not create several entries in the history. In the action service, when a ControllerComponent is mounted (i.e. when the action, e.g. the kanban view, has been mounted into the DOM), we call pushState to update the router with the new current action.

Before this commit, the router state was thus updated a tick after the action was mounted into the DOM, and a test was randomly failing because of that. The test highlighted the fact that the state of several, different actions could be mixed if those actions were run in the same tick, which could hardly occur in practice, but which is not that unlikely in a testing environment.

This commit fixes that issue by using the `sync` option of pushState. When the ControllerComponent is mounted, it is safe to assume that its sub-components have already pushed their own state (mounted being called bottom-up). So calling pushState with `sync` true acts as "committing" the state of the new current action, thus ensuring that it can't be mixed with the state of another action.

runbot error~233361

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
