### PR TITLE
[FIX] project_todo: reset context to avoid adding additional todo vals

### DIFF
--- a/addons/project_todo/models/res_users.py
+++ b/addons/project_todo/models/res_users.py
@@ -104,4 +104,4 @@ class ResUsers(models.Model):
                 "name": title,
             })
         if create_vals:
-            self.env["project.task"].with_user(SUPERUSER_ID).with_context(mail_auto_subscribe_no_notify=True).create(create_vals)
+            self.env["project.task"].with_user(SUPERUSER_ID).with_context({'mail_auto_subscribe_no_notify': True}).create(create_vals)

--- a/addons/project_todo/tests/test_todo_onboarding_for_users.py
+++ b/addons/project_todo/tests/test_todo_onboarding_for_users.py
@@ -16,6 +16,7 @@ class TestTodoOnboardingUsers(TransactionCase):
         onboarding_tasks = ProjectTaskSudo.search([('user_ids', 'in', internal_user.ids)])
 
         self.assertEqual(len(onboarding_tasks), 1, "Exactly 1 onboarding task should be created for internal users upon creation.")
+        self.assertFalse(onboarding_tasks.project_id, "Onboarding task should not be linked to any project.")
         portal_user = new_test_user(
             self.env,
             login="portal_user",
@@ -31,3 +32,14 @@ class TestTodoOnboardingUsers(TransactionCase):
         )
         onboarding_tasks = ProjectTaskSudo.search([('user_ids', 'in', public_user.ids)])
         self.assertEqual(len(onboarding_tasks), 0, "Public users should not receive onboarding tasks upon creation.")
+
+        project = self.env['project.project'].create({'name': 'Test Project'})
+        other_internal_user = new_test_user(
+            self.env,
+            login="other_internal_user",
+            groups="base.group_user",
+            context={'default_project_id': project.id},
+        )
+        onboarding_tasks = ProjectTaskSudo.search([('user_ids', 'in', other_internal_user.ids)])
+        self.assertEqual(len(onboarding_tasks), 1, "Exactly 1 onboarding task should be created for internal users upon creation.")
+        self.assertFalse(onboarding_tasks.project_id, "Onboarding task should not be linked to any project.")


### PR DESCRIPTION
Before this commit, when the user creates a new user from the user_ids field of a task, an onboarding todo will be created with the context given by Framework JS, which means, if the context contains `default_project_id` the onboarding todo will become a task inside the project instead of being a real todo (task with no project set).

This commit makes sure the context is reset before creating the onboarding todo.

task-5217306
