### PR TITLE
[FIX] account: Make context resModel dependant

### DIFF
--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
@@ -21,6 +21,9 @@ class X2ManyButtons extends Component {
     async openTreeAndDiscard() {
         const ids = this.currentField.currentIds;
         await this.props.record.discard();
+        const context = this.currentField.resModel === "account.move"
+            ? { list_view_ref: "account.view_duplicated_moves_tree_js" }
+            : {};
         this.action.doAction({
             name: this.props.treeLabel,
             type: "ir.actions.act_window",
@@ -30,9 +33,7 @@ class X2ManyButtons extends Component {
                 [false, "form"],
             ],
             domain: [["id", "in", ids]],
-            context: {
-                form_view_ref: "account.view_duplicated_moves_tree_js",
-            },
+            context: context,
         });
     }
 

--- a/addons/account/static/tests/legacy/x2many_buttons_tests.js
+++ b/addons/account/static/tests/legacy/x2many_buttons_tests.js
@@ -160,7 +160,7 @@ QUnit.module("Fields", (hooks) => {
                         [false, "form"],
                     ],
                     context: {
-                        form_view_ref: "account.view_duplicated_moves_tree_js",
+                        list_view_ref: "account.view_duplicated_moves_tree_js",
                     }
                 });
             }


### PR DESCRIPTION
Repro:
- Create DDM for a client
- Create 4+ invoices for him
- Pay with SEPA
- Go to batch payment set it with SEPA
- Add all the invoices and set the  date to any date <5 days from today.
- A yellow line will appear along with (View All).. / click it
- From the view click on any payment.
- Exception arises saying made_sequence_gap not found in account.payment

Issue:
  made_sequence_gap belongs to 'account.move' incompatible with 'account.payment' causing the exception.

Solution:
  Here the view_duplicated_moves_tree_js view is intended for account.move elements not for account.payment ones, So I included it only when the resModel is account.move.

opw-5149260