### PR TITLE
[FIX] website_sale: find single-value no-variant-attribute product line

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -440,7 +440,12 @@ class SaleOrder(models.Model):
         if not filtered_sol:
             return self.env['sale.order.line']
 
-        if product.product_tmpl_id._has_no_variant_attributes():
+        has_configurable_no_variant_attributes = any(
+            len(line.value_ids) > 1 or line.attribute_id.display_type == 'multi'
+            for line in product.attribute_line_ids
+            if line.attribute_id.create_variant == 'no_variant'
+        )
+        if has_configurable_no_variant_attributes:
             filtered_sol = filtered_sol.filtered(
                 lambda sol:
                     sol.product_no_variant_attribute_value_ids.ids == no_variant_attribute_value_ids

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime
+from functools import partial
 from unittest.mock import patch
 
 from odoo.exceptions import UserError, ValidationError
@@ -312,20 +313,36 @@ class TestWebsiteSaleCart(BaseUsersCommon, ProductAttributesCommon, WebsiteSaleC
             ]
         })
         no_variant_ptavs = product_no_variants.attribute_line_ids.product_template_value_ids
+        no_variant_ptav = no_variant_ptavs[0]
+        add_one = partial(
+            self.empty_cart._cart_update,
+            product_id=product_no_variants.product_variant_id.id,
+            add_qty=1,
+        )
         self.assertEqual(len(self.empty_cart.order_line), 0)
-        self.empty_cart._cart_update(
-            product_id=product_no_variants.product_variant_id.id,
-            add_qty=1,
-            no_variant_attribute_value_ids=no_variant_ptavs[0].ids,
-        )
+
+        add_one(no_variant_attribute_value_ids=no_variant_ptav.ids)
         self.assertEqual(len(self.empty_cart.order_line), 1)
-        self.empty_cart._cart_update(
-            product_id=product_no_variants.product_variant_id.id,
-            add_qty=1,
-            no_variant_attribute_value_ids=no_variant_ptavs[0].ids,
-        )
+
+        add_one(no_variant_attribute_value_ids=no_variant_ptav.ids)
         self.assertEqual(len(self.empty_cart.order_line), 1)
         self.assertEqual(self.empty_cart.order_line.product_uom_qty, 2)
+
+        # Providing `no_variant_attribute_value_ids` should be optional if there's only 1 value...
+        product_no_variants.attribute_line_ids.value_ids = self.no_variant_attribute.value_ids[0]
+        add_one(no_variant_attribute_value_ids=[])
+        self.assertEqual(len(self.empty_cart.order_line), 1)
+        self.assertEqual(self.empty_cart.order_line.product_uom_qty, 3)
+
+        # ...except if it's a multi-checkbox attribute, making the value optional
+        self.no_variant_attribute.display_type = 'multi'
+        add_one(no_variant_attribute_value_ids=[])
+        self.assertEqual(len(self.empty_cart.order_line), 2)
+        self.assertEqual(self.empty_cart.order_line.mapped('product_uom_qty'), [3, 1])
+
+        add_one(no_variant_attribute_value_ids=no_variant_ptav.ids)
+        self.assertEqual(len(self.empty_cart.order_line), 2)
+        self.assertEqual(self.empty_cart.order_line.mapped('product_uom_qty'), [4, 1])
 
     def test_cart_new_pricelist_from_geoip(self):
         """Check that, when adding a new partner to a website order, the partner's GeoIP


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a product attribute with variant creation set to never;
2. have product using only this attribute, with only a single value;
3. open website editor on /shop;
4. enable add-to-cart button & save;
5. use button on the aforementioned product at least twice.

Issue
-----
Each time the product gets added, a new line is created.

Cause
-----
Because there's only a single value, the product configurator doesn't pop up by default when adding the product to the cart. Without the configurator pop-up, the `_cart_update` method doesn't receive any `no_variant_attribute_value_ids`, which are used find a matching line if the product template has any `no_variant` attribute.

Solution
--------
Instead of checking `product.product_tmpl._has_no_variant_attributes()`, to see if we should attempt to match `no_variant_attribute_value_ids`, check if the added product has any `no_variant` attributes that have more than one value or are optional (multi-checkbox). If not, a `no_variant` product behaves the same as a single-variant product.

opw-5093175
opw-5137351