### PR TITLE
[FIX] iot_drivers: checkout loop on service startup

### DIFF
--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -100,7 +100,7 @@ class ConnectionManager(Thread):
         # Send already detected devices and IoT Box info to the database
         manager._send_all_devices()
         # Switch git branch before restarting, this avoids restarting twice
-        upgrade.check_git_branch()
+        upgrade.check_git_branch(force=True)
         # Restart to get a certificate, load the IoT handlers...
         helpers.odoo_restart(2)
 

--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -149,7 +149,7 @@ class Manager(Thread):
         # Set scheduled actions
         schedule.every().day.at("00:00").do(certificate.ensure_validity)
         schedule.every().day.at("00:00").do(helpers.reset_log_level)
-        schedule.every().monday.at("00:00").do(upgrade.check_git_branch)
+        schedule.every().monday.at("00:00").do(upgrade.check_git_branch, force=True)
 
         # Set up the websocket connection
         ws_client = WebsocketClient()


### PR DESCRIPTION
As we were not checking if the version on the IoT Box was different from the database's one, we were getting stuck in a checkout loop: service starts -> check out -> restart -> check out -> ...