### PR TITLE
[IMP] hr_recruitment: fix spacing/double border in Kanban view

### DIFF
--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -58,10 +58,6 @@
             .o_hr_recruitment_kanban_card_large_screen {
                 display: none;    
             }
-
-            .o_kanban_record {
-                margin: 0 0 ($border-width * -1);
-            }
         }
 
         &.o_kanban_ungrouped {
@@ -79,7 +75,7 @@
     }
 }
 
-.o_hr_recruitment_kanban .o_content .o_kanban_record {
+.o_hr_recruitment_kanban .o_kanban_ungrouped .o_kanban_record {
     margin: 0px;
 }
 


### PR DESCRIPTION
This PR introduced an overly global selector for all kanban records that was supposed to be scoped to the recruitment application only.
https://github.com/odoo/odoo/commit/17af9256a7a9c5ca673057c7afce2bb3ac80bf95

We fixed the issue by rescoping a `margin: 0` override that was wrongly set to all kanban records (both grouped and ungrouped) inside the recruitment application to be able to safely remove the faulty negative margin rule that is already handled by default by the generic `.o_kanban_grouped` component anyway.

task-5214254


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
