### PR TITLE
[FIX] event_product: add ticket currency symbol

### DIFF
--- a/addons/event_product/views/event_ticket_views.xml
+++ b/addons/event_product/views/event_ticket_views.xml
@@ -61,6 +61,7 @@
                 />
             </field>
             <field name="description" position="after">
+                <field name="currency_id" column_invisible="True"/> <!-- Used to get the currency symbol on the ticket price. -->
                 <field name="price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
             </field>
         </field>


### PR DESCRIPTION
Add missing currency symbol next to the event ticket price in the event form view.

Task-5114075

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
