### PR TITLE
[IMP] mrp: split MO while updating qty

### DIFF
--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -19,3 +19,4 @@ from . import test_performance
 from . import test_consume_component
 from . import test_manual_consumption
 from . import test_workcenter
+from . import test_workorder

--- a/addons/mrp/tests/test_workorder.py
+++ b/addons/mrp/tests/test_workorder.py
@@ -19,3 +19,21 @@ class TestWorkorder(TestMrpCommon):
         })
         wiz.change_prod_qty()
         self.assertFalse(mo.workorder_ids[-1].move_raw_ids)
+
+    def test_workorder_in_progress_expected_duration(self):
+        """Test that in progress workorder duration are correctly adapted according to the
+        quantity to produce (`product_qty`).
+        """
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = self.bom_4
+        mo = mo_form.save()
+        mo.action_confirm()
+        wo = mo.workorder_ids[0]
+        initial_duration = wo.duration_expected
+        wo.button_start()
+        wiz = self.env['change.production.qty'].create({
+            'mo_id': mo.id,
+            'product_qty': 2
+        })
+        wiz.change_prod_qty()
+        self.assertEqual(wo.duration_expected, wiz.product_qty * initial_duration)

--- a/addons/mrp/tests/test_workorder.py
+++ b/addons/mrp/tests/test_workorder.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.mrp.tests.common import TestMrpCommon
+from odoo.tests import Form
+
+
+class TestWorkorder(TestMrpCommon):
+
+    def test_workorder_operation_assignment(self):
+        """Test that moves aren't automatically assigned to the last workorder
+        when the quantity to produce (`product_qty`) is changed.
+        """
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = self.bom_2
+        mo = mo_form.save()
+        mo.action_confirm()
+        wiz = self.env['change.production.qty'].create({
+            'mo_id': mo.id,
+            'product_qty': 5
+        })
+        wiz.change_prod_qty()
+        self.assertFalse(mo.workorder_ids[-1].move_raw_ids)

--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -81,13 +81,13 @@ class ChangeProductionQty(models.TransientModel):
                 production._set_qty_producing()
 
             for wo in production.workorder_ids:
-                wo.duration_expected = wo._get_duration_expected(ratio=new_production_qty / old_production_qty)
                 quantity = wo.qty_production - wo.qty_produced
                 if production.product_id.tracking == 'serial':
                     quantity = 1.0 if not float_is_zero(quantity, precision_digits=precision) else 0.0
                 else:
                     quantity = quantity if (quantity > 0 and not float_is_zero(quantity, precision_digits=precision)) else 0
                 wo._update_qty_producing(quantity)
+                wo.duration_expected = wo._get_duration_expected(ratio=new_production_qty / old_production_qty)
                 if wo.qty_produced < wo.qty_production and wo.state == 'done':
                     wo.state = 'progress'
                 if wo.qty_produced == wo.qty_production and wo.state == 'progress':

--- a/addons/mrp/wizard/change_production_qty_views.xml
+++ b/addons/mrp/wizard/change_production_qty_views.xml
@@ -16,11 +16,16 @@
                             </div>
                         </group>
                     </group>
-                    <span class="text-muted">Modifying the quantity to produce will also modify the quantities of components to consume for this manufacturing order.</span>
+                    <span class="text-muted">
+                        Modifying the quantity to produce will also modify the quantities of components to consume for this manufacturing order.
+                        <br/>
+                        Split the MO if you plan to produce the remaining quantity later.
+                    </span>
                     <field name="mo_id" invisible="1"/>
                     <footer>
                         <button name="change_prod_qty" string="Set Quantity" data-hotkey="q"
                             colspan="1" type="object" class="btn-primary"/>
+                        <button name="action_split_mo" string="Split" type="object" class="btn-secondary"/>
                         <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                     </footer>
                 </form>


### PR DESCRIPTION
This commit adds the possibility to split a MO
from the `Change Quantity to Produce` wizard
while updating the quantity to produce.

This offers more flexibility to the users as they
can split MO with more precise quantity (e.g.: to split an "in progress"
MO to mark a part as done and leaving the remaining quantity
to a second MO.). A MO can be split using any quantity in any state as
long as it's not marked as done and the split quantity is less than
the currenty quantity to produce and greater than 0.

The manufacturing order will not be set as done and remains open
after splitting.

Task: 5153835


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
