### PR TITLE
[FIX] mass_mailing: ensure MassMailingHtmlField works on Safari

### DIFF
--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -20,6 +20,7 @@ import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { closestScrollableY } from "@web/core/utils/scrolling";
 import { _t } from "@web/core/l10n/translation";
 import { localization } from "@web/core/l10n/localization";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
 
 const IFRAME_VALUE_SELECTOR = ".o_mass_mailing_value";
 const MASS_MAILING_IFRAME_ASSETS = [
@@ -196,7 +197,12 @@ export class MassMailingIframe extends Component {
         );
     }
 
+    get isBrowserSafari() {
+        return isBrowserSafari();
+    }
+
     async setupIframe() {
+        this.iframeRef.el?.contentDocument.head.appendChild(this.renderHeadContent());
         this.bundleControls = await this.loadIframeAssets();
         if (status(this) === "destroyed") {
             return;
@@ -208,7 +214,6 @@ export class MassMailingIframe extends Component {
         } else {
             this.iframeRef.el.contentDocument.body.classList.add("bg-white");
         }
-        this.iframeRef.el.contentDocument.head.appendChild(this.renderHeadContent());
         this.iframeRef.el.contentDocument.body.appendChild(this.renderBodyContent());
         htmlResizeObserver.observe(
             this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR)

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -9,7 +9,8 @@
                 <div class="flex-grow-1" t-att-class="{'align-self-center': this.state.isMobile}">
                     <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
                     <div t-att-class="{ 'o_is_mobile': this.state.isMobile, 'h-100': !this.state.isMobile }">
-                        <iframe sandbox="allow-same-origin" t-att-scrolling="this.state.isMobile ? '' : 'no'"
+                        <iframe t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"
+                            t-att-scrolling="this.state.isMobile ? '' : 'no'"
                             t-att-class="{ 'd-none': props.showThemeSelector or props.showCodeView }"
                             t-ref="iframeRef" t-on-blur="onBlur"/>
                     </div>
@@ -30,6 +31,7 @@
         </div>
     </t>
     <t t-name="mass_mailing.IframeHead">
+        <meta http-equiv="Content-Security-Policy" content="script-src 'none';"/>
         <meta charset="utf-8"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>


### PR DESCRIPTION
There is an issue with the MassMailingHtmlField on WebKit browsers such as
Safari where, once a "mail theme" is selected, the iframe stays blank and the
user is not able to edit the mailing.

Steps to reproduce:
  1. On Safari, got to Email Marketing app.
  2. Create a new email campaign.
  3. Select any of the pre-built templates (mail theme).

Cause:
There is an [issue] with the WebKit implementation of `iframe` `sandbox`:
- For an iframe with `src="about:blank"` (equivalent to no `src`) with
  `sandbox="allow-same-origin"`, if the parent document adds event listeners on
  elements inside the iframe contentDocument, they can not be executed without
  the flag `allow-scripts`, which defeats the purpose of the `sandbox` in our
  case.
Other JavaScript engines don't have this issue.

Resolution:
Event listeners set by the parent document currently are an essential feature of
the `HtmlBuilder` editor, and are also used to load scss bundles inside the
iframe. A major refactoring would be needed to not require them (the only
viable solution would be to make an editor endpoint, and enclose the whole
editor feature inside the iframe, and communicate with an Odoo view through
`postMessage`, sandbox would be set to "allow-scripts" only).

To alleviate the Odoo issue in the short term, `script-src`
Content-Security-Policy is set to none inside the iframe, and `allow-scripts`
flag is added to the sandbox attribute for browsers identifying as Safari. This
effectively allows event listeners set by the parent document to run, but still
prevents script execution inside the iframe.

[issue]: https://bugs.webkit.org/show_bug.cgi?id=218086

opw-5208425

Co-authored-by: Damien Abeloos <abd@odoo.com>
Co-authored-by: Maruan Aguerdouh <magm@odoo.com>