### PR TITLE
[FIX] mail: search panel in mailbox takes whole screen width in mobile

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -67,11 +67,11 @@
             <div class="o-mail-DiscussContent-core overflow-auto o-scrollbar-thin d-flex flex-grow-1 w-100" t-ref="core">
                 <t name="core-content">
                     <t t-if="thread">
-                        <div class="d-flex flex-column flex-grow-1 bg-inherit">
+                        <div t-if="!ui.isSmall or !threadActions.activeAction?.actionPanelComponentCondition" class="d-flex flex-column flex-grow-1 bg-inherit">
                             <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent"/></t>
                             <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                         </div>
-                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0">
+                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0" t-att-class="{ 'w-100': ui.isSmall }">
                             <t t-component="threadActions.activeAction.actionPanelComponent" thread="thread" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                         </div>
                     </t>

--- a/addons/mail/static/tests/discuss/search_messages_panel.test.js
+++ b/addons/mail/static/tests/discuss/search_messages_panel.test.js
@@ -5,21 +5,23 @@ import {
     insertText,
     onRpcBefore,
     openDiscuss,
+    patchUiSize,
     scroll,
+    SIZES,
     start,
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
+import { expect, mockTouch, mockUserAgent, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { serverState } from "@web/../tests/web_test_helpers";
 
 import { HIGHLIGHT_CLASS } from "@mail/core/common/message_search_hook";
 
-describe.current.tags("desktop");
 defineMailModels();
 
+test.tags("desktop");
 test("Should have a search button", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -28,6 +30,7 @@ test("Should have a search button", async () => {
     await contains("[title='Search Messages']");
 });
 
+test.tags("desktop");
 test("Should open the search panel when search button is clicked", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -39,6 +42,7 @@ test("Should open the search panel when search button is clicked", async () => {
     await contains(".o_searchview_input");
 });
 
+test.tags("desktop");
 test("Should open the search panel with hotkey 'f'", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -57,6 +61,7 @@ test("Should open the search panel with hotkey 'f'", async () => {
     await contains(".o-mail-SearchMessagesPanel");
 });
 
+test.tags("desktop");
 test("Search a message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -77,6 +82,7 @@ test("Search a message", async () => {
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
 });
 
+test.tags("desktop");
 test("Search should be hightlighted", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -97,6 +103,7 @@ test("Search should be hightlighted", async () => {
     await contains(`.o-mail-SearchMessagesPanel .o-mail-Message .${HIGHLIGHT_CLASS}`);
 });
 
+test.tags("desktop");
 test("Search a starred message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -118,6 +125,7 @@ test("Search a starred message", async () => {
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
 });
 
+test.tags("desktop");
 test("Search a message in inbox", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -139,7 +147,8 @@ test("Search a message in inbox", async () => {
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
 });
 
-test("Search a message in history", async () => {
+test.tags("desktop");
+test("Search a message in history (desktop)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const messageId = pyEnv["mail.message"].create({
@@ -166,6 +175,44 @@ test("Search a message in history", async () => {
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
 });
 
+test.tags("mobile");
+test("Search a message in history (mobile)", async () => {
+    mockTouch(true);
+    mockUserAgent("android");
+    patchUiSize({ size: SIZES.SM });
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const messageId = pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "This is a message",
+        attachment_ids: [],
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+        needaction: false,
+    });
+    pyEnv["mail.notification"].create({
+        is_read: true,
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss("mail.box_history");
+    await contains(".o-mail-Thread");
+    await click("[title='Search Messages']");
+    await contains(".o-mail-SearchMessagesPanel");
+    await contains(".o-mail-Thread", { count: 0 });
+    await insertText(".o_searchview_input", "message");
+    await triggerHotkey("Enter");
+    await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
+    await click(".o-mail-MessageCard-jump");
+    await contains(".o-mail-Thread");
+    await contains(".o-mail-SearchMessagesPanel", { count: 0 });
+});
+
+test.tags("desktop");
 test("Should close the search panel when search button is clicked again", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -176,6 +223,7 @@ test("Should close the search panel when search button is clicked again", async 
     await contains(".o-mail-SearchMessagesPanel");
 });
 
+test.tags("desktop");
 test("Search a message in 60 messages should return 30 message first", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -201,6 +249,7 @@ test("Search a message in 60 messages should return 30 message first", async () 
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message", { count: 30 });
 });
 
+test.tags("desktop");
 test("Scrolling to the bottom should load more searched message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -228,6 +277,7 @@ test("Scrolling to the bottom should load more searched message", async () => {
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message", { count: 60 });
 });
 
+test.tags("desktop");
 test("Editing the searched term should not edit the current searched term", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -256,6 +306,7 @@ test("Editing the searched term should not edit the current searched term", asyn
     await scroll(".o-mail-SearchMessagesPanel .o-mail-ActionPanel", "bottom");
 });
 
+test.tags("desktop");
 test("Search a message containing round brackets", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
@@ -276,6 +327,7 @@ test("Search a message containing round brackets", async () => {
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
 });
 
+test.tags("desktop");
 test("Search a message containing single quotes", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
Before this commit, the search panel in mailboxes (inbox, starred, history) took only part of the screen in mobile.

This happens because the template being used in mobile for mailbox is the same as desktop UI for discuss app. This component `DiscussContent` is used because mailboxes are not supported in chat windows, and full-screen conversations in discuss on mobile are actually chat windows. Reusing the `DiscussContent` component is almost the desired UX/UI. The side panel however was not designed for small screen, thus action panel is very narrow and is hard to use in mobile.

This commit fixes the issue by making the action panel mutually exclusive to message list in mobile, so that when search panel is open it takes the whole width of screen. We don't need to see message list in mobile, and thanks to chat window also using search panel that takes the whole screen, the search panel is already designed to auto-close itself and jump to a message.

Part of Task-4967066


Before / After

<img width="383" height="672" alt="Screenshot 2025-10-28 at 18 16 10" src="https://github.com/user-attachments/assets/f7a0bd0d-33ff-4e65-8b0e-0d3a0611b82c" />
<img width="382" height="673" alt="Screenshot 2025-10-28 at 18 15 52" src="https://github.com/user-attachments/assets/79f85cf1-e758-43fd-bc02-8e809e9795e3" />
