### PR TITLE
[IMP] stock: rename locations submenu for clarity

### DIFF
--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -225,7 +225,7 @@
     </record>
 
     <record model="ir.actions.act_window" id="stock_quant_action"> <!-- Used in dashboard -->
-        <field name="name">Locations</field>
+        <field name="name">Stock Locations</field>
         <field name="context">
         {
             'search_default_internal_loc': 1,
@@ -359,7 +359,7 @@ in this location. That leads to a negative stock.
     </record>
 
     <menuitem id="menu_action_inventory_tree" name="Physical Inventory" parent="menu_stock_adjustments" sequence="10" action="action_view_inventory_tree"/>
-    <menuitem id="menu_valuation" name="Locations"
+    <menuitem id="menu_valuation" name="Stock Locations"
               parent="stock.menu_warehouse_report" sequence="150"
               action="action_view_quants" groups="stock.group_stock_multi_locations,stock.group_tracking_owner,base.group_no_one"/>
 </odoo>


### PR DESCRIPTION
There were two submenus named _"Locations"_ - one under the `Configuration` menu
(visible only when `Storage Locations` is enabled) and one under the `Reporting`
menu, which could mislead users when searching through the global search
(e.g., using CTRL + K).

This commit improves usability and avoids confusion by renaming the submenu
under the `Reporting` menu from:
-  `Locations` to `Stock Locations`

Task - 5154204