### PR TITLE
[FIX] mail: prevent recursive dialog on LinkPreview deletion

### DIFF
--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -73,7 +73,7 @@
     </t>
 
     <t t-name="mail.LinkPreview.aside">
-        <div t-if="props.messageLinkPreview.message_id?.allowsEdition" class="position-absolute top-0 end-0 small">
+        <div t-if="props.messageLinkPreview.message_id?.allowsEdition and !env.inLinkPreviewConfirmDelete" class="position-absolute top-0 end-0 small">
             <button t-attf-class="{{ className }}" class="o-mail-LinkPreview-aside btn" aria-label="Remove" t-on-click="onClick">
                 <i class="fa fa-times"/>
             </button>

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.js
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
@@ -20,6 +20,7 @@ export class LinkPreviewConfirmDelete extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
+        useSubEnv({ inLinkPreviewConfirmDelete: true });
     }
 
     onClickOk() {

--- a/addons/mail/static/tests/message/link_preview.test.js
+++ b/addons/mail/static/tests/message/link_preview.test.js
@@ -179,6 +179,7 @@ test("Remove link preview Gif", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
+    await contains(".modal .o-mail-LinkPreviewImage button[aria-label='Remove']", { count: 0 });
     await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });
@@ -203,6 +204,7 @@ test("Remove link preview card", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-LinkPreviewCard button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
+    await contains(".modal .o-mail-LinkPreviewCard button[aria-label='Remove']", { count: 0 });
     await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewCard", { count: 0 });
 });
@@ -228,6 +230,7 @@ test("Remove link preview video", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-LinkPreviewVideo button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
+    await contains(".modal .o-mail-LinkPreviewVideo button[aria-label='Remove']", { count: 0 });
     await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewVideo", { count: 0 });
 });
@@ -251,6 +254,7 @@ test("Remove link preview image", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
+    await contains(".modal .o-mail-LinkPreviewImage button[aria-label='Remove']", { count: 0 });
     await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
[Current Behaviour](https://github.com/user-attachments/assets/57caaafa-be69-474e-83ac-b00923d6c5d7)


Before this PR, the delete button remained visible when the `LinkPreview` component was rendered within the `LinkPreviewConfirmDelete` dialog. Clicking on this button triggered recursive dialog spawning, creating an infinite loop of confirmation dialogs. 

This PR resolves the issue by conditionally rendering the delete button based on dialog context, preventing it from appearing when the `LinkPreview` is displayed within the confirmation dialog.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
