### PR TITLE
[FIX] mail: fail to send email through composer from contact list

### DIFF
--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -62,7 +62,11 @@
                                     <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                                 </group>
                                 <group>
-                                    <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
+                                    <field name="template_id"
+                                        domain="[('model', '=', model), '|', ('user_id', '=', False), ('user_id', '=', uid), '|', ('use_default_to', '=', True), '|', '|', ('email_to', '!=', False), ('partner_to', '!=', False), ('email_cc', '!=', False)]"
+                                        string="Load template"
+                                        options="{'no_create': True}"
+                                        class="w-50"
                                         context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
                                 </group>
                             </div>


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install the `Contacts` module and configure an outgoing mail server
2. Create a mail template with Auto Delete False and Applies to Contacts
3. Create a new contact with an email address
4. From the chatter, click Send Message, select the created mail template, and send it.
5. Go back to the Contacts list view and search for the newly created contact
6. Select the contact and from the Action menu, click Send Email
7. Again, select the same mail template and add a test email in the Reply-To Address field from the Settings page
8. Click Send

Observation:
-------------------------
1. The email sent from the chatter appears in Sent state.
2. The email sent from the wizard appears in Cancelled state.

Issue:
-------------------------
In the following code
https://github.com/odoo/odoo/blob/a85f268eab4647261b18b1106223c8e18dded085/addons/mail/wizard/mail_compose_message.py#L1037-L1044 there is no fallback for recipients when both `template_id` and `email_mode` are set. As a result, when `partner_ids` are missing in `mail_values_all`, the email fails to send.

Solution:
-------------------------
Added a condition to handle the case where both `template_id` and `email_mode` are present. If `partner_ids` are not defined in `mail_values_all`, the system now fetches `default_recipients` and adds them to `mail_values_all`.

opw-5143950