### PR TITLE
[FIX] web_editor: avoid inner table overflow of parent cell on resize

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2984,7 +2984,9 @@ export class OdooEditor extends EventTarget {
                 const sizeDelta = newSize - currentSize;
                 const currentNeighborSize = neighborRect[sizeProp];
                 const newNeighborSize = currentNeighborSize - sizeDelta;
-                const maxWidth = this.editable.clientWidth - pxToFloat(editableStyle.paddingLeft) - pxToFloat(editableStyle.paddingRight);
+                const enclosingCell = closestElement(table, "td, th");
+                const containerWidth = enclosingCell?.getBoundingClientRect().width || this.editable.clientWidth;
+                const maxWidth = containerWidth - pxToFloat(editableStyle.paddingLeft) - pxToFloat(editableStyle.paddingRight);
                 const tableRect = table.getBoundingClientRect();
                 if (newSize > MIN_SIZE &&
                         // prevent resizing horizontally beyond the bounds of


### PR DESCRIPTION
**Current behavior before PR:**

- When a table was created inside another table, resizing the inner table could cause it to overflow its parent cell, making it uneditable.

**Desired behavior after PR is merged:**

- The inner table no longer overflows its parent cell when resized, ensuring it remains editable.

task-5216916