### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: Rename to 'code de service'

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/i18n/fr.po
+++ b/addons/l10n_fr_facturx_chorus_pro/i18n/fr.po
@@ -34,15 +34,15 @@ msgstr "'Numéro de marché' dans Chorus PRO."
 #: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
 #: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
 #: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
-msgid "'Service Exécutant' in Chorus PRO."
-msgstr "'Service exécutant' dans Chorus PRO."
+msgid "'Code de Service' in Chorus PRO."
+msgstr "'Code de Service' dans Chorus PRO."
 
 #. module: l10n_fr_facturx_chorus_pro
 #: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
 #: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
 #: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
 msgid "Buyer Reference"
-msgstr "Service exécutant"
+msgstr "Code de Service"
 
 #. module: l10n_fr_facturx_chorus_pro
 #: model_terms:ir.ui.view,arch_db:l10n_fr_facturx_chorus_pro.view_move_form_inherit_chorus_pro

--- a/addons/l10n_fr_facturx_chorus_pro/i18n/l10n_fr_facturx_chorus_pro.pot
+++ b/addons/l10n_fr_facturx_chorus_pro/i18n/l10n_fr_facturx_chorus_pro.pot
@@ -33,7 +33,7 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
 #: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
 #: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
-msgid "'Service Exécutant' in Chorus PRO."
+msgid "'Code de Service' in Chorus PRO."
 msgstr ""
 
 #. module: l10n_fr_facturx_chorus_pro

--- a/addons/l10n_fr_facturx_chorus_pro/models/account_move.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_move.py
@@ -5,6 +5,6 @@ from odoo import fields, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    buyer_reference = fields.Char(help="'Service Exécutant' in Chorus PRO.")
+    buyer_reference = fields.Char(help="'Code de Service' in Chorus PRO.")
     contract_reference = fields.Char(help="'Numéro de Marché' in Chorus PRO.")
     purchase_order_reference = fields.Char(help="'Engagement Juridique' in Chorus PRO.")


### PR DESCRIPTION
Rename the field meant to input the "Code de Service" to match Chorus Pro's documentation more closely after client feedbacks.

Source: https://www.pagero.com/onboarding/aife/aife-fr#requirements

livechat-908691128
