### PR TITLE
[FIX] project: disable stage editing in project sharing kanban view

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -29,6 +29,7 @@
                 archivable="0"
                 import="0"
                 groups_draggable="0"
+                group_edit="0"
                 default_order="priority desc, sequence, state, date_deadline asc, id desc"
             >
                 <field name="state"/>


### PR DESCRIPTION
Steps to reproduce:
-
1. Install the Project module.
2. Create a new project and share it with a user.
3. Log in as that user.
4. Open the shared project Kanban view and try to edit a stage.
5. Try to search for more projects.

Issue:
-
A traceback occurs when clicking on 'Search More'.

Fix:
-
Prevent stage editing in shared project Kanban view.

task-5176630

