### PR TITLE
[FIX] mail: prevent re-ending already ended polls

### DIFF
--- a/addons/mail/models/mail_poll.py
+++ b/addons/mail/models/mail_poll.py
@@ -62,7 +62,10 @@ class MailPoll(models.Model):
 
     @api.model
     def _end_expired_polls(self):
-        self.env["mail.poll"].search_fetch([("poll_end_dt", "<=", "now")])._end_and_notify()
+        self.env["mail.poll"].search_fetch([
+            ("poll_end_dt", "<=", "now"),
+            ("end_message_id", "=", None),
+        ])._end_and_notify()
 
     @api.ondelete(at_uninstall=False)
     def _poll_on_delete(self):


### PR DESCRIPTION
Before this PR,
The cron job responsible for ending polls also included polls that were already ended.
As a result, every time a poll is ended, a new “poll ended” message was posted.
This happened because the query fetched all expired polls, regardless of whether they had already been closed.

This PR fixes the issue by updating the search domain to exclude ended polls.
It now only fetches polls whose poll_end_dt has passed and have no end_message_id, ensuring that only active (not yet ended) polls are processed.