### PR TITLE
[18.0] sales : [FIX] product: Prevent Pricelist Report crash when no pricelist is defined

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -180,6 +180,9 @@
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">
+pricelist = env['product.pricelist'].search([], limit=1)
+if not pricelist:
+    raise UserError(("Please configure at least one Pricelist before generating the report."))
 action = {
     'name': 'Pricelist Report',
     'type': 'ir.actions.client',

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -629,6 +629,9 @@
         <field name="binding_model_id" ref="product.model_product_product"/>
         <field name="state">code</field>
         <field name="code">
+pricelist = env['product.pricelist'].search([], limit=1)
+if not pricelist:
+    raise UserError(("Please configure at least one Pricelist before generating the report."))
 action = {
     'name': 'Pricelist Report',
     'type': 'ir.actions.client',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When generating a pricelist report, Odoo crashes if there are no configured pricelists.

Current behavior before PR:
The system raises an unhandled error when attempting to generate a report without any pricelist record.

Desired behavior after PR is merged:
If no pricelist exists, a user-friendly UserError message is shown instructing to configure at least one pricelist before generating the report.

This is a backport of PR #233429 (merged in 19.0) to 18.0.

Issue : https://github.com/odoo/odoo/issues/233393




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
