### PR TITLE
[FIX] mail: prevent traceback when adding emojis to a poll option

### DIFF
--- a/addons/mail/static/src/core/common/create_poll_option_dialog.js
+++ b/addons/mail/static/src/core/common/create_poll_option_dialog.js
@@ -33,7 +33,7 @@ export class CreatePollOptionDialog extends Component {
                 this.props.model.label = firstPart + str + secondPart;
                 this.selection.moveCursor((firstPart + str).length);
                 if (!this.ui.isSmall) {
-                    this.ref.el.focus();
+                    this.pickerRef.el.focus();
                 }
             },
         });

--- a/addons/mail/static/tests/poll/poll.test.js
+++ b/addons/mail/static/tests/poll/poll.test.js
@@ -1,0 +1,25 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    openDiscuss,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { describe, test } from "@odoo/hoot";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("can add emojis to a poll option", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Composer button[title='More Actions']");
+    await click(".o-dropdown-item:contains('Start a Poll')");
+    await contains(".modal-header", { text: "Create a poll" });
+    await click(".o-mail-CreatePollOptionDialog:first .fa-smile-o");
+    await click(".o-Emoji:contains('😀')");
+    await contains(".o-mail-CreatePollOptionDialog input:eq(0)", { value: "😀" });
+});


### PR DESCRIPTION
**Description of the issue this PR addresses:**

Fix the traceback that occurs when adding emojis to a poll.

**Steps to Reproduce:**
- Start a poll
- Try adding emojis to a poll option

**Current behavior before PR:**

Before this PR, the emoji picker element was correctly referenced in the 
component, but was not used properly inside the useEmojiPicker hook. 
As a result, the code attempted to access an undefined reference, causing an 
error when interacting with the picker.

**Desired behavior after PR is merged:**

This PR ensures that the correct reference is used within useEmojiPicker, 
resolving the issue.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
