### PR TITLE
[FIX] pos_loyalty: runbot errors 233434 and 233435

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -514,6 +514,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'limit_categories': True,
             'iface_available_categ_ids': [(6, 0, [pos_category.id])],
         })
+        self.whiteboard_pen.write({'pos_categ_ids': [(6, 0, [pos_category.id])]})
         self.main_pos_config.open_ui()
 
         self.pos_user.write({
@@ -537,7 +538,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         # Change the code to 044123456 so that we can use it in the next tour.
         # Make sure it starts with 044 because it's the prefix of the loyalty cards.
         gift_card_program.coupon_ids.code = '044123456'
-        self.whiteboard_pen.write({'pos_categ_ids': [(6, 0, [pos_category.id])]})
         # Run the tour to use the gift card
         self.start_pos_tour("GiftCardProgramTour2")
         # Check that gift cards are used (Whiteboard Pen price is 1.20)


### PR DESCRIPTION
Before this commit:
=======================
The `whiteboard_pen` product had no assigned category, while the main POS configuration was limited to specific categories.
As a result, `whiteboard_pen` was not displayed on the product screen. When no products were loaded, special products like gift cards and e-wallets also not shown,showing the `Load Sample` button instead of products. This caused tour tests expecting gift cards on the screen to fail.

After this commit:
======================
Assigned the same product category to whiteboard_pen as used in the POS configuration. This ensures that the product appears on the product screen and special products like gift cards also load properly, preventing the tour test from failing.

Runbot Error: 233434, 233435

