### PR TITLE
[FIX] website: restore header options in sidebar

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_box_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_box_option_plugin.js
@@ -11,42 +11,6 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { HeaderBoxOption } from "./header_box_option";
 import { HEADER_BOX } from "./header_option_plugin";
-import { BaseOptionComponent } from "@html_builder/core/utils";
-
-export class HeaderTemplateOption extends BaseOptionComponent {
-    static template = "website.headerTemplateOption";
-    static selector = "#wrapwrap > header";
-    static groups = ["website.group_website_designer"];
-    static editableOnly = false;
-}
-
-export class HeaderContentWidthOption extends BaseOptionComponent {
-    static template = "website.headerContentWidthOption";
-    static selector = "#wrapwrap > header";
-    static groups = ["website.group_website_designer"];
-    static editableOnly = false;
-}
-
-export class HeaderSidebarWidthOption extends BaseOptionComponent {
-    static template = "website.headerSidebarWidthOption";
-    static selector = "#wrapwrap > header";
-    static groups = ["website.group_website_designer"];
-    static editableOnly = false;
-}
-
-export class HeaderBackgroundOption extends BaseOptionComponent {
-    static template = "website.headerBackgroundOption";
-    static selector = "#wrapwrap > header";
-    static groups = ["website.group_website_designer"];
-    static editableOnly = false;
-}
-
-export class HeaderScrollEffectOption extends BaseOptionComponent {
-    static template = "website.headerScrollEffectOption";
-    static selector = "#wrapwrap > header";
-    static groups = ["website.group_website_designer"];
-    static editableOnly = false;
-}
 
 class HeaderBoxOptionPlugin extends Plugin {
     static id = "HeaderBoxOptionPlugin";

--- a/addons/website/static/src/builder/plugins/options/header/header_elements_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_elements_option.js
@@ -1,11 +1,9 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { basicHeaderOptionSettings } from "./basicHeaderOptionSettings";
 
 export class HeaderElementsOption extends BaseOptionComponent {
     static template = "website.HeaderElementsOption";
     static dependencies = ["customizeWebsite"];
-    static selector = "#wrapwrap > header";
-    static groups = ["website.group_website_designer"];
-    static editableOnly = false;
 
     setup() {
         super.setup();
@@ -24,3 +22,5 @@ export class HeaderElementsOption extends BaseOptionComponent {
         };
     }
 }
+
+Object.assign(HeaderElementsOption, basicHeaderOptionSettings);

--- a/addons/website/static/src/builder/plugins/options/header/header_font_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_font_option.js
@@ -3,7 +3,6 @@ import { basicHeaderOptionSettings } from "./basicHeaderOptionSettings";
 
 export class HeaderFontOption extends BaseOptionComponent {
     static template = "website.HeaderFontOption";
-    static editableOnly = basicHeaderOptionSettings.editableOnly;
-    static selector = basicHeaderOptionSettings.selector;
-    static groups = basicHeaderOptionSettings.groups;
 }
+
+Object.assign(HeaderFontOption, basicHeaderOptionSettings);

--- a/addons/website/static/src/builder/plugins/options/header/header_font_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_font_option.xml
@@ -27,7 +27,7 @@
         />
     </BuilderRow>
 
-    <BuilderRow label.translate="Format" tooltip.translate="Default Text Color">
+    <BuilderRow label.translate="Format" tooltip.translate="Default Text Size and Color">
         <BuilderNumberInput 
             action="'customizeWebsiteVariable'"
             actionParam="'header-font-size'" 

--- a/addons/website/static/src/builder/plugins/options/header/header_icon_background_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_icon_background_option.js
@@ -3,7 +3,6 @@ import { basicHeaderOptionSettings } from "./basicHeaderOptionSettings";
 
 export class HeaderIconBackgroundOption extends BaseOptionComponent {
     static template = "website.HeaderIconBackgroundOption";
-    static editableOnly = basicHeaderOptionSettings.editableOnly;
-    static selector = basicHeaderOptionSettings.selector;
-    static groups = basicHeaderOptionSettings.groups;
 }
+
+Object.assign(HeaderIconBackgroundOption, basicHeaderOptionSettings);

--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.js
@@ -49,4 +49,5 @@ export class HeaderNavigationOption extends BaseOptionComponent {
         return currentActiveViews;
     }
 }
+
 Object.assign(HeaderNavigationOption, basicHeaderOptionSettings);

--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option_plugin.js
@@ -1,13 +1,15 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { HeaderNavigationOption } from "./header_navigation_option";
+import { withSequence } from "@html_editor/utils/resource";
+import { HEADER_NAVIGATION } from "./header_option_plugin";
 
 class HeaderNavigationOptionPlugin extends Plugin {
     static id = "HeaderNavigationOptionPlugin";
     static dependencies = ["customizeWebsite"];
 
     resources = {
-        builder_options: [HeaderNavigationOption],
+        builder_options: [withSequence(HEADER_NAVIGATION, HeaderNavigationOption)],
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/options/header/header_template_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_template_option.js
@@ -3,11 +3,10 @@ import { basicHeaderOptionSettings } from "./basicHeaderOptionSettings";
 
 export class HeaderTemplateOption extends BaseOptionComponent {
     static template = "website.HeaderTemplateOption";
-    static editableOnly = basicHeaderOptionSettings.editableOnly;
-    static selector = basicHeaderOptionSettings.selector;
-    static groups = basicHeaderOptionSettings.groups;
 
     hasSomeOptions(opts) {
         return opts.some((opt) => this.isActiveItem(opt));
     }
 }
+
+Object.assign(HeaderTemplateOption, basicHeaderOptionSettings);


### PR DESCRIPTION
After PR[1] was merged, the header options were not displayed correctly in the sidebar.

In 19.0, there were many changes in the header options files (PR[2]) 
PR[1] was not adapted properly in the forward port, which led to duplicated classes and sequence issues.

This commit restores the options order.
It also fixes an incorrect tooltip.

-----------------------------------------------------------------------

PR[1]: https://github.com/odoo/odoo/pull/230283

PR[2]: https://github.com/odoo/odoo/pull/221703