### PR TITLE
[FIX] website_sale_collect: subtract the line qty only

### DIFF
--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -165,6 +165,27 @@ class TestSaleOrder(ClickAndCollectCommon):
         # only 4 units are available for the second order line instead of 5
         self.assertEqual(insufficient_stock_data[ol_unit], 4)
 
+    def test_product_in_stock_with_mixed_uom_order_lines_is_available(self):
+        """Test that if there is enough stock for all order lines the insufficient stock is
+        empty."""
+        pack_of_6_id = self.ref('uom.product_uom_pack_6')
+        # 1 pack of 6 + 4 units = 10 units in the cart
+        cart = self._create_in_store_delivery_order(order_line=[
+            Command.create({
+                'product_id': self.storable_product.id,
+                'product_uom_qty': 4.0,
+                'product_uom_id': self.storable_product.uom_id.id,
+            }),
+            Command.create({
+                'product_id': self.storable_product.id,
+                'product_uom_qty': 1.0,
+                'product_uom_id': pack_of_6_id,
+            }),
+        ])
+        # 10 units available, 10 requested
+        insufficient_stock_data = cart._get_insufficient_stock_data(self.warehouse.id)
+        self.assertFalse(insufficient_stock_data)
+
     def test_out_of_stock_product_is_unavailable(self):
         cart = self._create_in_store_delivery_order(
             order_line=[


### PR DESCRIPTION
Steps to reproduce:
1. Add a packaging to the storable product (ex. pack of 6)
2. Uncheck continue selling
3. Update qty of the product in the wh to 20
4. Add 4 units to the cart
5. Add 1 pack
6. Choose pickup in store and go to the checkout

The product is not in stock even though there is enough quantity.

