### PR TITLE
[IMP] html_builder, *: improve multi layer background support

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -153,6 +153,10 @@ export class BackgroundImageOptionPlugin extends Plugin {
             loadResult: "",
             params: { ...params, forceClean: true },
         });
+        // When background image with position "Repeat pattern" is removed,
+        // remove background size to avoid repeating gradient
+        editingElement.classList.remove("o_bg_img_opt_repeat");
+        editingElement.style.removeProperty("background-size");
         this.dispatchTo("on_bg_image_hide_handlers", editingElement);
     }
 }

--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -62,6 +62,13 @@ export class BackgroundImageOptionPlugin extends Plugin {
         // It is important to delete ".o_modified_image_to_save" from the old
         // target as its image source will be deleted.
         oldEditingEl.classList.remove("o_modified_image_to_save");
+        const computedStyles = getComputedStyle(oldEditingEl);
+        // Transfer only image layer(1st) size when multiple backgrounds exist
+        const oldBgSize = computedStyles.getPropertyValue("background-size").split(",")[0].trim();
+        const isOldEditingElRepeated = oldEditingEl.classList.contains("o_bg_img_opt_repeat");
+        // Clean the old editing element before applying on the new one
+        oldEditingEl.classList.remove("o_bg_img_opt_repeat");
+        oldEditingEl.style.removeProperty("background-size");
         const filterColorAction = this.dependencies.builderActions.getAction("selectFilterColor");
         const editingElement = this.getResource("get_target_element_providers")[0](oldEditingEl);
         const filter = filterColorAction.getValue({ editingElement });
@@ -75,6 +82,16 @@ export class BackgroundImageOptionPlugin extends Plugin {
         // Apply the changes on the new editing element
         if (oldBgURL) {
             this.setImageBackground(newEditingEl, oldBgURL);
+            if (isOldEditingElRepeated) {
+                newEditingEl.classList.add("o_bg_img_opt_repeat");
+            }
+            // If the new target contains a gradient background, append "cover"
+            // to the background-size so the gradient doesn’t repeat.
+            const hasGradient = getComputedStyle(newEditingEl)
+                .getPropertyValue("background-image")
+                .includes("gradient");
+            const newBgSize = hasGradient ? `${oldBgSize}, cover` : oldBgSize;
+            newEditingEl.style.setProperty("background-size", newBgSize);
             for (const [key, value] of filteredOldDataset) {
                 newEditingEl.dataset[key] = value;
             }

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -301,13 +301,16 @@ async function openBgPositionOverlay(editingElement, waitSidebarUpdated) {
     await waitFor(".o-overlay-container .o_we_overlay_dragger", { timeout: 2000 });
 }
 
-async function dragAndDropBgImage() {
-    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+async function dragAndDropBgImage(builderOptions = {}) {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `
         <section style="background-image: url('/web/image/123/transparent.png'); width: 500px; height:500px">
             <div class="o_we_shape o_html_builder_Connections_01">
                 AAAA
             </div>
-        </section>`);
+        </section>`,
+        builderOptions
+    );
     await openBgPositionOverlay(":iframe section", waitSidebarUpdated);
     const { startDrag, endDrag } = patchDragImage(
         ".o-overlay-container .o_we_overlay_dragger",
@@ -667,4 +670,20 @@ test("Previewed shape has the correct color and flip when a shape is applied", a
     ).backgroundImage;
     expect(shapePreviewStyle).toInclude(encodeURIComponent(HEX_BLUE));
     expect(shapePreviewStyle).toInclude("flip=xy");
+});
+
+test("Change the background position when multiple background layer is applied", async () => {
+    await dragAndDropBgImage({ loadIframeBundles: true });
+    const section = await waitFor(":iframe section");
+    await contains(section).click();
+    expect(section).not.toHaveClass("o_bg_img_opt_repeat");
+    expect(section).toHaveStyle("background-size: cover");
+    await contains("[data-label='Background'] .o_we_color_preview").click();
+    await contains(".o_font_color_selector .gradient-tab").click();
+    await contains(".o_colorpicker_sections .o_gradient_color_button").click();
+    await contains("[data-label='Position'] .dropdown-toggle").click();
+    await contains("[data-action-value='repeat-pattern']").click();
+    expect(section).toHaveClass("o_bg_img_opt_repeat");
+    expect(section).toHaveStyle("background-size: 100px, cover");
+    expect("[data-action-value='repeat-pattern']").toHaveClass("active");
 });

--- a/addons/website/static/tests/builder/website_builder/parallax_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/parallax_option.test.js
@@ -15,6 +15,23 @@ test("test parallax zoom", async () => {
     expect(":iframe section").not.toHaveStyle("background-image", { inline: true });
     expect("[data-label='Intensity'] input").toBeVisible();
 });
+
+test("add parallax keeps repeat pattern on background", async () => {
+    await setupWebsiteAndOpenParallaxOptions({}, { loadIframeBundles: true });
+    await contains("[data-label='Position'] .dropdown-toggle").click();
+    await contains("[data-action-value='repeat-pattern']").click();
+    expect(":iframe section").toHaveClass("o_bg_img_opt_repeat");
+    await contains("[data-label='Scroll Effect'] .dropdown-toggle").click();
+    await contains("[data-action-value='fixed']").click();
+    // Verify that the repeat pattern is still applied
+    expect(":iframe section").not.toHaveClass("o_bg_img_opt_repeat");
+    expect(":iframe section .s_parallax_bg").toHaveClass("o_bg_img_opt_repeat");
+    expect(":iframe section .s_parallax_bg").toHaveStyle("background-repeat: repeat");
+    // Check that the option is still selected in the dropdown
+    await contains("[data-label='Position'] .dropdown-toggle").click();
+    expect("[data-action-value='repeat-pattern']").toHaveClass("active");
+});
+
 test("add parallax changes editing element", async () => {
     await setupWebsiteAndOpenParallaxOptions({}, { loadIframeBundles: true });
     await contains("[data-action-value='fixed']").click();


### PR DESCRIPTION
*=website

**[IMP] html_builder: improve multi layer background support**
Previously, the website builder only supported single background layer, causing issues when both a gradient and an image were used together. 
Steps to Reproduce:
1. Drop any snippet.
2. Select a block and change the background color to the gradient.
3. Add transparent background image.
4. Change the image position from "Cover" to "Repeat Pattern."

Issues:
1. Switching background position to Repeat Pattern caused both the gradient and the image to repeat.(only image should repeat)
2. The “Position” option continued to display Cover instead of Repeat Pattern.
3. Removing the background image left the `o_bg_img_opt_repeat` class applied, making the gradient repeat incorrectly.

This commit fixes incorrect behavior with layered backgrounds by clearly separating image and gradient responsibilities. The image layer can now repeat or resize as expected, while the gradient layer is consistently kept at background-size: cover, preventing visual glitches when switching background types or options.

----------------------
**[FIX] html_builder: transfer background css when changing options**
Steps to Reproduce:

1. Drop any block.
2. Add background image.
3. Change the image position from "Cover" to "Repeat Pattern."
4. Add Parallax(Scroll Effect).
5. Switching to parallax removes the background position option.

Root Cause:
When parallax is enabled, the background image is moved from the section into a separate <span> (.s_parallax_bg). The options target changes from the section to the parallax element. However, its background-related CSS classes and styles are not transferred. As the new target lacks these, the previously set values are lost.

Fix:
In the `BackgroundImageOptionPlugin`, the `changeEditingEl` method is responsible for transferring CSS and dataset-related properties when the editing target changes. We now ensure that both `o_bg_img_opt_repeat`
class and the `background-size` property are correctly transferred from the previous target to the new one.

task-5049103