### PR TITLE
[FIX] base: prevent error on encoding declaration in xml editor

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -250,6 +250,7 @@ actual arch.
 
     def _inverse_arch(self):
         for view in self:
+            self._validate_xml_encoding(view.arch)
             data = dict(arch_db=view.arch)
             if 'install_filename' in self._context:
                 # we store the relative path to the resource instead of the absolute path, if found
@@ -276,6 +277,7 @@ actual arch.
 
     def _inverse_arch_base(self):
         for view, view_wo_lang in zip(self, self.with_context(lang=None)):
+            self._validate_xml_encoding(view.arch_base)
             view_wo_lang.arch = view.arch_base
 
     def reset_arch(self, mode='soft'):
@@ -491,8 +493,6 @@ actual arch.
                 # delete empty arch_db to avoid triggering _check_xml before _inverse_arch_base is called
                 del values['arch_db']
 
-            if values.get('arch_base'):
-                self._validate_xml_encoding(values['arch_base'])
             if not values.get('type'):
                 if values.get('inherit_id'):
                     values['type'] = self.browse(values['inherit_id']).type
@@ -509,7 +509,7 @@ actual arch.
                                 "Allowed types are: %(valid_types)s",
                                 view_type=values['type'], valid_types=', '.join(valid_types)
                             ))
-                    except LxmlError:
+                    except (etree.ParseError, ValueError):
                         # don't raise here, the constraint that runs `self._check_xml` will
                         # do the job properly.
                         pass
@@ -551,8 +551,6 @@ actual arch.
         if 'arch_db' in vals and not self.env.context.get('no_save_prev'):
             vals['arch_prev'] = self.arch_db
 
-        if vals.get('arch_base'):
-            self._validate_xml_encoding(vals['arch_base'])
         res = super(View, self).write(self._compute_defaults(vals))
 
         # Check the xml of the view if it gets re-activated.

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -14,7 +14,7 @@ from lxml.builder import E
 from psycopg2 import IntegrityError
 from psycopg2.extras import Json
 
-from odoo.exceptions import AccessError, ValidationError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tests import common, tagged
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.tools import mute_logger, view_validation, safe_eval
@@ -1953,6 +1953,25 @@ class TestViews(ViewCase):
                 'arch': '<template></template>',
                 'inherit_id': False,
             })
+
+    def test_xml_editor_rejects_encoding_declaration(self):
+        """Must raise a UserError when encoding declaration is included."""
+        with self.assertRaises(UserError):
+            self.View.create({
+                'name': 'encoding_declaration_view',
+                'arch_base': "<?xml version='1.0' encoding='utf-8'?>",
+                'inherit_id': False,
+            })
+
+        view = self.assertValid("<form string='Test'></form>", name="test_xml_encoding_view")
+        for field in ("arch", "arch_base"):
+            with self.subTest(field=field):
+                original_value = view[field]
+
+                with self.assertRaises(UserError):
+                    view.write({field: "<?xml version='1.0' encoding='utf-8'?><form/>"})
+
+                self.assertXMLEqual(view[field], original_value)
 
     def test_context_in_view(self):
         arch = """


### PR DESCRIPTION
Currently, an error occurs when a user includes an XML encoding declaration in the studio XML editor.

**Steps to produce:**

- Install the `web_studio` module and enable `developer mode`
- Open `Apps` > `studio` > `view` > `</> xml`
- Declare encoding as: `<?xml version='1.0' encoding='utf-8'?>` and click `save`

**Error:**
`ValueError: Unicode strings with encoding declaration are not supported. 
Please use bytes input or XML fragments without declaration.`

**Root cause:**
At [1], an error is raised when the XML declaration contains an `encoding`
attribute, as encoding declarations are invalid in Unicode strings.

**Fix:**
This commit ensures that a `UserError` is raised, improving the error message clarity.

A similar fix was applied in https://github.com/odoo/odoo/pull/205324.

[1]:
https://github.com/odoo/odoo/blob/8a22b6ca09e1da3ccba3540bc4851a5174e035cc/odoo/tools/translate.py#L316

sentry-6981234548