### PR TITLE
[FIX] website_sale: remove bad applyTo

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_list_page_option.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.js
@@ -5,7 +5,6 @@ import { products_sort_mapping } from "@website_sale/website_builder/shared";
 export class ProductsListPageOption extends BaseOptionComponent {
     static template = "website_sale.ProductsListPageOption";
     static selector = "#o_wsale_container";
-    static applyTo = "#o_wsale_container";
     static title = _t("Products Page");
     static groups = ["website.group_website_designer"];
     static editableOnly = false;


### PR DESCRIPTION
In PR https://github.com/odoo/odoo/pull/230283, an unnecessary applyTo was added to ProductsListPageOption Because of this, the option is never visible.
In this commit, we will therefore remove this applyT

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
