### PR TITLE
[FIX] website_sale: ProductsListPageOption should be always visible

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_list_page_option.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.js
@@ -4,7 +4,7 @@ import { products_sort_mapping } from "@website_sale/website_builder/shared";
 
 export class ProductsListPageOption extends BaseOptionComponent {
     static template = "website_sale.ProductsListPageOption";
-    static selector = "#o_wsale_container";
+    static selector = "main:has(#o_wsale_container)";
     static title = _t("Products Page");
     static groups = ["website.group_website_designer"];
     static editableOnly = false;


### PR DESCRIPTION
Before this PR, the ProductsListPageOption component only became
visible after clicking on the web page (By example, clicking on a product).
Now, by adapting the selector to target <main>, the page options remain
visible when navigating to the "Style" tab.