### PR TITLE
[FIX] website: keep gallery thumbnails background white

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -405,6 +405,17 @@
     }
 }
 
+// TODO adapt in Master. Override Bootstrap's dark indicators without
+// out-prioritizing user overrides in stable versions.
+:where(.s_image_gallery[data-vcss="002"].s_image_gallery_indicators_squared,
+    .s_image_gallery[data-vcss="002"].s_image_gallery_indicators_rounded) {
+    &, .carousel-dark {
+        .carousel-indicators [data-bs-target] {
+            background-color: white;
+        }
+    }
+}
+
 .s_gallery_lightbox {
     .modal-dialog {
         height: 100%;


### PR DESCRIPTION
Steps to reproduce:

- Go to Website and click Edit.
- Drag and drop an "Image Gallery" snippet onto the page.
- Enable the "Squared Miniatures" option.
- Add a PNG image with a transparent background to the gallery.

Before this commit, thumbnails had a black square background. After this commit, thumbnails have a white background.

task-5189020
