### PR TITLE
[FIX] html_editor: more robust history dialog

### DIFF
--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.js
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.js
@@ -45,7 +45,7 @@ export class HistoryDialog extends Component {
         revisionContent: null,
         revisionComparison: null,
         revisionId: null,
-        revisionLoading: false,
+        revisionLoading: true,
         cssMaxHeight: 400,
     });
 
@@ -208,8 +208,9 @@ export class HistoryDialog extends Component {
         if (!revision || !revision["create_date"]) {
             return "--";
         }
+        const userTZ = user.tz || "local";
         return formatDateTime(
-            DateTime.fromISO(revision["create_date"], { zone: "utc" }).setZone(user.tz),
+            DateTime.fromISO(revision["create_date"], { zone: "utc" }).setZone(userTZ),
             { showSeconds: false }
         );
     }


### PR DESCRIPTION
When the runbot CPU was running low or the network is slow, some history dialog related tours sometimes broke.

The `revisionLoading` state was false by default thus in those cases Owl was sometimes rendering the UI in a loaded state during init, which was messing with the tour steps.

Also use "local" timeZone if user.tz is false.

runbot-232648
runbot-233338



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
