### PR TITLE
[FIX] mail: add force_search_count to activity search

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -140,6 +140,10 @@
         <field name="name">Activity Overview</field>
         <field name="res_model">mail.activity</field>
         <field name="view_mode">list,form</field>
+        <!-- ensure pagination works even if _search removes records after fetching -->
+        <field name="context">{
+            'force_search_count': 1,
+        }</field>
     </record>
 
     <record id="mail_activity_view_form_popup" model="ir.ui.view">
@@ -436,7 +440,9 @@
         <field name="res_model">mail.activity</field>
         <field name="view_mode">list,kanban</field>
         <field name="search_view_id" ref="mail.mail_activity_view_search"/>
+        <!-- ensure pagination works even if _search removes records after fetching -->
         <field name="context">{
+            'force_search_count': 1,
             'search_default_filter_user_id_uid': 1,
             'search_default_filter_date_deadline_past': 1,
             'search_default_filter_date_deadline_today': 1,


### PR DESCRIPTION
**Steps to reproduce:**
- Create some activities which should not be accessible to a specific user (according to the `_search` filtering of `mail.activity`)
- Go to Activity Menu > View all activities as the given user
- Ensure that the limit (default: 80) is lower than the total number of activities which should be returned and that the new activities are in the returned elements
- On `web_search_read` some records are removed by the `_search` override
- The pagination navigation buttons are disabled as the returned number of records is lower than the limit
- This means that some activities are not accessible to the user (everything above the given limit)

**Issue:**
The issue comes from the `_search` override which checks the records available to the user. As it's done after fetching with the limit, the resulting number of records can be lower than expected and this breaks the `_format_web_search_read_results` which considers that we have all the possible records and doesn't try to fetch the total count of records.

**Fix:**
The main issue can't be directly fixed without modifying the way the access are checked in the `_search` override.

This could be mitigated by changing the search limit, making the search as superuser, or adding specific filtering but each has its own limitations.

Adding `force_search_count` should allow the user to navigate between pages anyway and see all the available activities. But the number displayed in the pagination will often be incorrect for the current and total count. (e.g. we can have 75 records but 1-80/150 is displayed out of 140 actually readable records)

opw-5046389

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
