### PR TITLE
[FIX] point_of_sale: exclude combo from total discount calculation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -669,7 +669,8 @@ export class PosOrder extends Base {
                     if (
                         orderLine.displayDiscountPolicy() === "without_discount" &&
                         !(orderLine.price_type === "manual") &&
-                        orderLine.discount == 0
+                        orderLine.discount == 0 &&
+                        !(orderLine.combo_parent_id || orderLine.combo_line_ids.length)
                     ) {
                         sum +=
                             (orderLine.getTaxedlstUnitPrice() -

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -485,7 +485,13 @@ export class PosOrderline extends Base {
         const baseLine = accountTaxHelpers.prepare_base_line_for_taxes_computation(
             this,
             this.prepareBaseLineForTaxesComputationExtraValues({
-                price_unit: this.getlstPrice(),
+                price_unit: this.product_id.getPrice(
+                    false,
+                    1,
+                    this.price_extra,
+                    false,
+                    this.product_id
+                ),
                 quantity: 1,
                 tax_ids: product.taxes_id,
             })

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -12,6 +12,7 @@ import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 import { run, negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
     steps: () =>
@@ -139,6 +140,7 @@ registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour"
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
             Order.hasLine({ price: "6.30" }),
+            ReceiptScreen.discountAmountIs("3.70"),
 
             ReceiptScreen.clickNextOrder(),
             ProductScreen.addOrderline("Test Product", "1"),
@@ -147,7 +149,22 @@ registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour"
                 Numpad.click("Price"),
                 Numpad.isActive("Price"),
                 Numpad.click("9"),
+                ...ProductScreen.selectedOrderlineHasDirect("Test Product", "1", "9.0"),
             ]),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.noDiscountAmount(),
+
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("10.0"),
+            ProductScreen.clickPriceList("special_pricelist"),
+            ProductScreen.totalAmountIs("9.0"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -191,6 +191,14 @@ export function noDiscountAmount() {
     ];
 }
 
+export function discountAmountIs(amount) {
+    return [
+        {
+            trigger: `span.label-discount:contains("Discounts") + span.pos-receipt-right-align:contains("${amount}")`,
+        },
+    ];
+}
+
 export function shippingDateExists() {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1038,6 +1038,10 @@ class TestUi(TestPointOfSaleHttpCommon):
             'percent_price': 10,
         })
 
+        setup_product_combo_items(self)
+        self.office_combo.write({'list_price': 10})
+        self.office_combo.combo_ids.combo_item_ids.product_id.taxes_id = False
+
         self.main_pos_config.write({
             'pricelist_id': base_pricelist.id,
             'available_pricelist_ids': [(6, 0, [base_pricelist.id, special_pricelist.id])],


### PR DESCRIPTION
Before this commit, if a pricelist with a discount was assigned to a PoS order, combo products that included free items would display an incorrect total discount on the receipt. The discount amount wrongly included the prices of the free products.

Since combo price calculations follow a different logic, this commit ensures that pricelist discounts are excluded from the total discount computation for combo products to avoid confusion.

opw-5046691

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
