### PR TITLE
[FIX] hr_expense: Allow overrides for auto-approve

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1119,11 +1119,16 @@ class HrExpense(models.Model):
                 raise UserError(_("You can not submit an expense without a category."))
             if not expense.manager_id:
                 expense.sudo().manager_id = expense._get_default_responsible_for_approval()
-        expenses_autovalidated = self.filtered(lambda expense: not expense.manager_id and not expense.employee_id.expense_manager_id)
+        expenses_autovalidated = self.filtered(lambda expense: expense._can_be_autovalidated())
         (self - expenses_autovalidated).approval_state = 'submitted'
         if expenses_autovalidated:  # Note, this will and should bypass the duplicate check. May be changed later
             expenses_autovalidated._do_approve(check=False)
         self.sudo().update_activities_and_mails()
+
+    def _can_be_autovalidated(self):
+        """ Check whether the given expenses can be auto-validated (no approver) """
+        self.ensure_one()
+        return (not self.manager_id and not self.employee_id.expense_manager_id) or self.manager_id == self.employee_id.user_id
 
     def action_approve(self):
         """ Approve an expense, pops a wizard if a duplicated expense is found to confirm they are all valid expenses """

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -222,7 +222,7 @@
                                 <field name="total_amount_currency" widget='monetary' options="{'currency_field': 'currency_id'}"
                                        readonly="not is_editable" class="oe_inline mw-50 me-0"/>
                                 <field name="currency_id" class="mw-25 ms-0" groups="base.group_multi_currency"
-                                       options="{'no_create': True}"
+                                       options="{'no_create': True, 'no_open': True}"
                                        readonly="not is_editable"/>
                                 <span class="d-flex" invisible="tax_amount == 0">(incl <field name="tax_amount" class="mx-1"/> tax)</span>
                             </div>


### PR DESCRIPTION
We need in the enterprise PR to change the autovalidation condition for stripe expense cards.

task-4860676

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
