### PR TITLE
[FIX] im_livechat: fix race condition

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
@@ -5,16 +5,11 @@ patch(ChatWindow.prototype, {
     _onClose(options = {}) {
         if (
             this.channel.channel_type === "livechat" &&
-            this.channel.livechatVisitorMember?.persona?.notEq(this.store.self)
+            this.channel.livechatVisitorMember?.persona?.notEq(this.store.self) &&
+            options.notifyState
         ) {
-            const channel = this.channel; // save ref before delete
-            super._onClose(...arguments);
-            this.delete();
-            if (options.notifyState) {
-                channel.leaveChannel({ force: true });
-            }
-        } else {
-            super._onClose(...arguments);
+            this.channel.leaveChannelRpc();
         }
+        super._onClose(...arguments);
     },
 });

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -69,12 +69,11 @@ patch(Thread.prototype, {
             this.store.discuss.activeTab = "livechat";
         }
     },
-    async leaveChannel({ force = false } = {}) {
+    async leaveChannel() {
         if (
             this.channel?.channel_type === "livechat" &&
             this.channel?.channel_member_ids.length <= 2 &&
-            !this.livechat_end_dt &&
-            !force
+            !this.livechat_end_dt
         ) {
             await this.askLeaveConfirmation(
                 _t("Leaving will end the live chat. Do you want to proceed?")

--- a/addons/mail/static/src/core/web/chat_window_model_patch.js
+++ b/addons/mail/static/src/core/web/chat_window_model_patch.js
@@ -3,7 +3,7 @@ import { ChatWindow } from "@mail/core/common/chat_window_model";
 import { patch } from "@web/core/utils/patch";
 
 patch(ChatWindow.prototype, {
-    async _onClose(options) {
+    _onClose(options) {
         if (
             this.store.env.services.ui.isSmall &&
             !this.store.discuss.isActive &&
@@ -14,9 +14,7 @@ patch(ChatWindow.prototype, {
             // case it should be re-opened to simulate it was always
             // there in the background.
             document.querySelector(".o_menu_systray i[aria-label='Messages']")?.click();
-            // ensure messaging menu is opened before chat window is closed
-            await Promise.resolve();
         }
-        await super._onClose(...arguments);
+        super._onClose(...arguments);
     },
 });

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -71,7 +71,7 @@ declare module "models" {
         lastInterestDt: import("luxon").DateTime;
         lastMessageSeenByAllId: undefined|number;
         lastSelfMessageSeenByEveryone: Message;
-        leaveChannel: (param0: { force: boolean }) => Promise<void>;
+        leaveChannel: () => Promise<void>;
         markAsFetched: () => Promise<void>;
         markedAsUnread: boolean;
         markingAsRead: boolean;

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -519,17 +519,13 @@ const threadPatch = {
             { description }
         );
     },
-    async leaveChannel({ force = false } = {}) {
-        if (
-            this.channel?.channel_type !== "group" &&
-            this.create_uid?.eq(this.store.self_user) &&
-            !force
-        ) {
+    async leaveChannel() {
+        if (this.channel?.channel_type !== "group" && this.create_uid?.eq(this.store.self_user)) {
             await this.askLeaveConfirmation(
                 _t("You are the administrator of this channel. Are you sure you want to leave?")
             );
         }
-        if (this.channel?.channel_type === "group" && !force) {
+        if (this.channel?.channel_type === "group") {
             await this.askLeaveConfirmation(
                 _t(
                     "You are about to leave this group conversation and will no longer have access to it unless you are invited again. Are you sure you want to continue?"
@@ -537,9 +533,10 @@ const threadPatch = {
             );
         }
         await this.closeChatWindow();
-        await this.store.env.services.orm.silent.call("discuss.channel", "action_unfollow", [
-            this.id,
-        ]);
+        this.leaveChannelRpc();
+    },
+    leaveChannelRpc() {
+        this.store.env.services.orm.silent.call("discuss.channel", "action_unfollow", [this.id]);
     },
     /** @param {string} name */
     async rename(name) {


### PR DESCRIPTION
Attempt to fix runbot error 233689 by refactoring `_onClose` across
patches.
The problem occurs because of the async nature and the many side effects
that occur.
`_onClose` is not supposed to be async.
The override in ai is deleting the channel via rpc, which creates a bus
even to delete the channel in the JS store. The following code will be executed
after that point (as we have await), with the bus sometimes being
received before, sometimes not

The fix is to ensure all the stack of onClose is executed
immediately (as it should have been), so the bus notif is always
received after.


This commit also simplifies leaveChannel.

PR enterprise: https://github.com/odoo/enterprise/pull/98368