### PR TITLE
[FIX] setup: fallback on pypdf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,7 +48,7 @@ Depends:
  python3-psycopg2,
  python3-pydot,
  python3-openssl,
- python3-pypdf2,
+ python3-pypdf2 | python3-pypdf,
  python3-qrcode,
  python3-renderpm,
  python3-reportlab,

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,8 @@ pydot==1.4.2
 pyopenssl==20.0.1; python_version < '3.12'
 pyopenssl==24.1.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
 PyPDF2==1.26.0 ; python_version <= '3.10'
-PyPDF2==2.12.1 ; python_version > '3.10'
+PyPDF2==2.12.1 ; python_version > '3.10' and python_version < '3.13' # (Noble and below)
+PyPDF==5.4.0 ; python_version >= '3.13' # (Trixie)
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.5
 python-dateutil==2.8.1


### PR DESCRIPTION
pypdf2 is not present anymore in debian/trixie
Fallback on pypdf if pypdf2 is not available
Note that it should mainly fix the deb_install but future fixes may be needed