### PR TITLE
[FIX] web,*: RPCCache: correctly handle rejected promises

### DIFF
--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -161,6 +161,12 @@ describe("field HTML", () => {
         // When those popovers are killed, OWL tries to reconcile its element List
         // in OverlayContainer, displaces the node that contains the iframe
         // and the editor subsequently crashes
+        const base64Img = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
+        onRpc("/html_editor/get_image_info", () => {
+            return {
+                original: { image_src: base64Img },
+            };
+        });
         class SomeModel extends models.Model {
             _name = "some.model"
             mailing_ids = fields.One2many({relation: "mailing.mailing"});


### PR DESCRIPTION
*mass_mailing

This commit fixes some issues in the RPC cache, when the fallback (i.e. the call to the server) failed. More specifically, if the same rpc was done multiple times before the first one returned, the returned promise might be pending forever:

1) if type="disk": only the promise of the first call was rejected,
    the promise of the other calls was left pending forever.
2) if type="ram": all calls got the same promise as response, which
    was left pending forever.

This commit fixes those issue and introduces new tests for the failing fallback scenario.

These issues have been highlighted when working on the offline UI, as in offline, rpcs always fail.

We also had to properly mock the route `/html_editor/get_image_info` in a mass_mailing test, as the call threw an "unimplemented route error" which was previously hidden by the issue 2) that this commit fixes.

task~5106517

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
