### PR TITLE
[FIX] spreadsheet(_dashboard): prevent crash on list sort

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_view_plugin.js
@@ -276,6 +276,9 @@ export class ListCoreViewPlugin extends OdooCoreViewPlugin {
             return undefined;
         }
         const cell = this.getters.getCell(position);
+        if (!cell?.isFormula) {
+            return undefined;
+        }
         const { functionName, args } = getFirstListFunction(cell.compiledFormula.tokens);
         const fieldArg = functionName === "ODOO.LIST.HEADER" ? args[1] : args[2];
         const dataSource = this.getters.getListDataSource(listId);
@@ -289,11 +292,11 @@ export class ListCoreViewPlugin extends OdooCoreViewPlugin {
     }
 
     getListSortDirection(position) {
-        const field = this.getters.getListFieldFromPosition(position);
         const listId = this.getters.getListIdFromPosition(position);
         if (!listId) {
             return "none";
         }
+        const field = this.getters.getListFieldFromPosition(position);
         const orderBy = this.getters.getListDefinition(listId).orderBy[0];
         if (!orderBy || !field || orderBy.name !== field.name) {
             return "none";
@@ -303,8 +306,11 @@ export class ListCoreViewPlugin extends OdooCoreViewPlugin {
 
     isSortableListHeader(position) {
         const listId = this.getters.getListIdFromPosition(position);
-        const cell = this.getters.getCell(position);
         if (!listId) {
+            return false;
+        }
+        const cell = this.getters.getCell(position);
+        if (!cell?.isFormula) {
             return false;
         }
         const { functionName } = getFirstListFunction(cell.compiledFormula.tokens);

--- a/addons/spreadsheet_dashboard/static/tests/clickable_cells/clickable_cells.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/clickable_cells/clickable_cells.test.js
@@ -166,3 +166,43 @@ test("list sort multiple fields", async () => {
     expect(model.getters.getListDefinition(1).orderBy).toEqual([]);
     await animationFrame();
 });
+
+test("Clickable ignores spill and empty cells for list sorting", async () => {
+    const data = {
+        sheets: [
+            {
+                cells: {
+                    A1: "foo",
+                    B1: "bar",
+                    // spill cells
+                    A2: "=ODOO.LIST.HEADER(1, A1:B1)",
+                    A3: '=ODOO.LIST(1, sequence(2), "foo")',
+                },
+            },
+        ],
+        lists: {
+            1: {
+                id: 1,
+                columns: [],
+                domain: [],
+                model: "partner",
+                orderBy: [],
+            },
+        },
+    };
+    const { model } = await createDashboardActionWithData(data);
+    expect(getCellIcons(model, "A2")).toHaveLength(0);
+    expect(".o-dashboard-clickable-cell .fa-sort").toHaveCount(0);
+
+    expect(getCellIcons(model, "B2")).toHaveLength(0);
+    expect(".o-dashboard-clickable-cell .fa-sort").toHaveCount(0);
+
+    expect(getCellIcons(model, "A3")).toHaveLength(0);
+    expect(".o-dashboard-clickable-cell .fa-sort").toHaveCount(0);
+
+    expect(getCellIcons(model, "A4")).toHaveLength(0);
+    expect(".o-dashboard-clickable-cell .fa-sort").toHaveCount(0);
+
+    expect(getCellIcons(model, "C10")).toHaveLength(0); // unrelated empty cell
+    expect(".o-dashboard-clickable-cell .fa-sort").toHaveCount(0);
+});


### PR DESCRIPTION
How to reproduce:
- Add a list to a dashboard
- edit the dashboard such that a spill formula involving the list appears `=ODOO.LIST(1, SEQUENCE(500), "name")` or `=odoo.list.header(1, C1:C2)` and C1: "name", C2:"name"

Save those changes and open the corresponding dashboad view

-> traceback

Task-5220385

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
