### PR TITLE
[FIX] im_livechat: fix operator not able to pin message in LC session

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -409,13 +409,13 @@ class DiscussChannel(models.Model):
         It's created only if the mail channel is linked to a chatbot step. We also need to save the
         user answer if the current step is a question selection.
         """
-        if self.chatbot_current_step_id:
+        if self.chatbot_current_step_id and not self.livechat_agent_history_ids:
             selected_answer = (
                 self.env["chatbot.script.answer"]
                 .browse(self.env.context.get("selected_answer_id"))
                 .exists()
             )
-            if selected_answer in self.chatbot_current_step_id.answer_ids:
+            if selected_answer and selected_answer in self.chatbot_current_step_id.answer_ids:
                 # sudo - chatbot.message: finding the question message to update the user answer is allowed.
                 question_msg = (
                     self.env["chatbot.message"]

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -33,9 +33,15 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
                         # so that the channel is unpinned
                         "unpin_dt": fields.Datetime.now(),
                         "last_interest_dt": fields.Datetime.now() - timedelta(seconds=30),
-                    }
+                        "livechat_member_type": "bot",
+                    },
                 ),
-                Command.create({"partner_id": request.env.user.partner_id.id}),
+                Command.create(
+                    {
+                        "partner_id": request.env.user.partner_id.id,
+                        "livechat_member_type": "visitor",
+                    },
+                ),
             ],
             'livechat_active': True,
             'livechat_operator_id': chatbot_script.operator_partner_id.id,


### PR DESCRIPTION
To reproduce (on runbot):

- S1: Connect as "admin", leave the "YourWebsite.com" then logout
- S1: Connect as "demo" user

- S2: As public user, go to /contactus and start a chat session
- S2: On the chatbot interaction, choose "I have a pricing question" (this will forward to the operator)
- S2: enter a message

- S1: On the livechat session, try to pin the last user message

Since 1ecddc3d79dd an `AccessError` is raised, as the "demo" user (which is only `LiveChat / User`) don't have access to the chatbot step anymore.

As we're not in the interacting with the chatbot when pinning a message, simplify skip that part if there is no "chatbotx answner" context to prevent the `AccessError`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
