### PR TITLE
[IMP] html_builder, web, website: add record management UI to BuilderList

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -4,6 +4,7 @@
 <t t-name="html_builder.BuilderList">
     <BuilderComponent>
         <div class="w-100 p-2 py-0">
+            <t t-set="isMany2X" t-value="this.allRecords and this.allRecords.length"/>
             <t t-if="state.value?.length > 2">
                 <div class="o_we_table_wrapper">
                     <table t-ref="table">
@@ -34,6 +35,7 @@
                                                     t-att-name="entry[0]"
                                                     t-att-value="item[entry[0]]"
                                                     t-att-data-id="item._id"
+                                                    t-att-disabled="isMany2X"
                                                     t-on-input="onInput"
                                                     t-on-change="onChange"
                                             />
@@ -53,41 +55,31 @@
                     </table>
                 </div>
             </t>
-            <div class="o-hb-select-wrapper" t-if="this.allRecords and this.allRecords.length" >
-                <t t-set="availableRecords" t-value="this.getAvailableRecords()"></t>
+            <div t-if="isMany2X" class="o-hb-select-wrapper">
+                <t t-set="excludedRecords" t-value="this.getExcludedRecords()"></t>
                 <div class="mt-1 ms-auto">
-                    <Dropdown state="this.dropdown" menuClass="'o-hb-select-dropdown mt-1'">
-                        <button class="bl-dropdown-toggle o-hb-select-toggle o-hb-btn btn btn-success text-start o-dropdown-caret w-100 mx-auto px-3"
-                            t-att-disabled="!availableRecords.length">
-                            <t t-set="noAvailableRecordLabel">You don't have any record to add</t>
-                            <span class=""
-                                t-att-title="!availableRecords.length ? noAvailableRecordLabel : ''"
-                                t-att-style="!availableRecords.length ? 'pointer-events: auto; display: inline-block;' : ''">
-                                <t t-out="props.addItemTitle" />
-                            </span>
-                        </button>
-                        <t t-set-slot="content">
-                            <t t-foreach="availableRecords" t-as="item" t-key="item.id">
-                                <t t-foreach="Object.entries(props.itemShape).filter(([key, value]) => !value.endsWith('boolean'))" t-as="entry" t-key="entry[0]">
-                                    <div class="o-hb-select-dropdown-item d-flex flex-column cursor-pointer o-dropdown-item dropdown-item o-navigable w-100 mx-auto"
-                                        style="max-height: 50vh;"
-                                        t-att-type="entry[1]"
-                                        t-att-name="entry[0]"
-                                        t-att-data-id="item.id"
-                                        t-on-click="addItem"
-                                    >
-                                        <t t-out="item[entry[0]]" />
-                                    </div>
-                                </t>
-                            </t>
-                        </t>
-                    </Dropdown>
+                    <div class="d-flex align-items-center gap-2">
+                        <div title="Add a record to the list">
+                            <SelectMenu
+                                choices="excludedRecords.map((record) => ({ value: record, label: record.display_name  }))"
+                                onSelect="(record) => this.addItem(record)"
+                                class="'o-hb-selectMany2X-wrapper min-w-0'"
+                                menuClass="'o-hb-select-dropdown o-hb-selectMany2X-dropdown'"
+                                togglerClass="'o-hb-selectMany2X-toggle btn-secondary'"
+                                disabled="!excludedRecords.length"
+                            >
+                                <t t-out="props.addItemTitle"/>
+                            </SelectMenu>
+                        </div>
+                        <button type="button" class="btn btn-lg btn-secondary fa fa-refresh" title="Update the list with all records and sort it alphabetically" t-on-click="updateRecords"/>
+                        <button type="button" class="btn btn-lg btn-secondary fa fa-gear" title="Open the record list manager" t-on-click="openRecordsDialog"/>
+                    </div>
                 </div>
             </div>
             <t t-else="">
                 <div class="text-end mt-1">
                     <button type="button" class="builder_list_add_item o-hb-btn btn btn-success px-3"
-                            t-on-click="addItem">
+                            t-on-click="() => this.addItem()">
                         <t t-out="props.addItemTitle"/>
                     </button>
                 </div>

--- a/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.js
@@ -1,0 +1,79 @@
+import { Component, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { fuzzyLookup } from "@web/core/utils/search";
+
+export class BuilderListDialog extends Component {
+    static template = "html_builder.BuilderListDialog";
+    static components = { Dialog };
+    static props = {
+        excludedRecords: { type: Array },
+        includedRecords: { type: Array },
+        close: { type: Function },
+        save: { type: Function },
+    };
+
+    setup() {
+        this.state = useState({
+            excludedRecords: [...this.props.excludedRecords].sort(this.sortByName),
+            includedRecords: [...this.props.includedRecords],
+            searchString: "",
+        });
+    }
+
+    save() {
+        this.props.save(this.state.includedRecords);
+        this.props.close();
+    }
+
+    get searchExcluded() {
+        if (!this.state.searchString) {
+            return this.state.excludedRecords;
+        }
+        return fuzzyLookup(
+            this.state.searchString,
+            this.state.excludedRecords,
+            (record) => record.display_name
+        );
+    }
+
+    get searchIncluded() {
+        if (!this.state.searchString) {
+            return this.state.includedRecords;
+        }
+        return fuzzyLookup(
+            this.state.searchString,
+            this.state.includedRecords,
+            (record) => record.display_name
+        );
+    }
+
+    onSearch(ev) {
+        this.state.searchString = ev.target.value;
+    }
+
+    include(record) {
+        const index = this.state.excludedRecords.indexOf(record);
+        this.state.includedRecords.push(...this.state.excludedRecords.splice(index, 1));
+    }
+
+    exclude(record) {
+        const index = this.state.includedRecords.indexOf(record);
+        this.state.excludedRecords.push(...this.state.includedRecords.splice(index, 1));
+        this.sortExcluded();
+    }
+
+    includeAll() {
+        this.state.includedRecords.push(...this.state.excludedRecords.splice(0));
+    }
+
+    excludeAll() {
+        this.state.excludedRecords.push(...this.state.includedRecords.splice(0));
+        this.sortExcluded();
+    }
+
+    sortExcluded() {
+        this.state.excludedRecords.sort((a, b) =>
+            (a.display_name || "").localeCompare(b.display_name || "")
+        );
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.scss
@@ -1,0 +1,11 @@
+.o_bl_dialog .modal-body {
+    .o_list_panel {
+        user-select: none;
+        height: 50vh;
+
+        .o_list_item:hover {
+            background: rgba($o-brand-odoo, .7);
+            color: white;
+        }
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xml:space="preserve">
+
+    <t t-name="html_builder.BuilderListDialog">
+        <Dialog contentClass="'o_bl_dialog'" title.translate="Manage Records" size="'lg'">
+            <input type="search" class="form-control" placeholder="Search" t-on-input="onSearch" />
+            <div class="row w-100">
+                <div class="o_left_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap">
+                    <div class="d-flex justify-content-between align-items-center mt-3">
+                        <h4 class="m-0">Excluded records</h4>
+                        <button class="btn btn-sm btn-link p-0" t-on-click="includeAll">
+                            <i class="fa fa-plus me-1" />Include all</button>
+                    </div>
+                    <div class="o_list_panel overflow-auto border mt-2">
+                        <h3 t-if="searchExcluded.length === 0" class="text-center text-muted my-2">No record.</h3>
+                        <t t-foreach="searchExcluded" t-as="record" t-key="record.id">
+                            <div class="o_list_item cursor-pointer position-relative ps-4"
+                                t-on-click="() => this.include(record)">
+                                <div class="d-flex align-items-center">
+                                    <span class="overflow-hidden w-100" t-esc="record.display_name" />
+                                    <span title="Include record" class="fa fa-plus float-end m-1 pe-2" />
+                                </div>
+                            </div>
+                        </t>
+                    </div>
+                </div>
+                <div class="o_right_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap mt-3 mt-md-0">
+                    <div class="d-flex justify-content-between align-items-center mt-3">
+                        <h4 class="m-0">Included records</h4>
+                        <button class="btn btn-sm btn-link p-0" t-on-click="excludeAll">
+                            <i class="fa fa-minus me-1" />Exclude all</button>
+                    </div>
+                    <div class="o_list_panel overflow-auto border mt-2">
+                        <h3 t-if="searchIncluded.length === 0" class="text-center text-muted my-2">No record.</h3>
+                        <t t-foreach="searchIncluded" t-as="record" t-key="record.id">
+                            <div class="o_list_item cursor-pointer position-relative ps-4"
+                                t-on-click="() => this.exclude(record)">
+                                <div class="d-flex align-items-center">
+                                    <span class="overflow-hidden w-100" t-esc="record.display_name" />
+                                    <span class="fa fa-minus m-1 pe-2 float-end" title="Exclude record" />
+                                </div>
+                            </div>
+                        </t>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="save" t-att-disabled="state.includedRecords.length === 0">Save</button>
+                <button class="btn btn-secondary" t-on-click="() => props.close()">Discard</button>
+            </t>
+        </Dialog>
+    </t>
+
+</template>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -287,10 +287,10 @@ test("do not lose id when adjusting 'selected'", async () => {
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
-    await contains(".we-bg-options-container .bl-dropdown-toggle").click();
-    await contains(".o_popover .o-hb-select-dropdown-item").click();
-    await contains(".we-bg-options-container .bl-dropdown-toggle").click();
-    await contains(".o_popover .o-hb-select-dropdown-item").click();
+    await contains(".we-bg-options-container .o-hb-selectMany2X-toggle").click();
+    await contains(".o_select_menu_menu .o-dropdown-item").click();
+    await contains(".we-bg-options-container .o-hb-selectMany2X-toggle").click();
+    await contains(".o_select_menu_menu .o-dropdown-item").click();
     expect(":iframe .test-options-target").toHaveAttribute(
         "data-list",
         JSON.stringify([
@@ -377,8 +377,8 @@ test("can add item with string and integer ids", async () => {
     await contains(":iframe .test-options-target").click();
 
     for (let i = 0; i < 2; i++) {
-        await contains(".we-bg-options-container .bl-dropdown-toggle").click();
-        await contains(".o_popover .o-hb-select-dropdown-item").click();
+        await contains(".we-bg-options-container .o-hb-selectMany2X-toggle").click();
+        await contains(".o_select_menu_menu .o-dropdown-item").click();
     }
-    expect(".we-bg-options-container .bl-dropdown-toggle").toHaveProperty("disabled");
+    expect(".we-bg-options-container .o-hb-selectMany2X-toggle").toHaveProperty("disabled");
 });

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -131,7 +131,7 @@ export class Popover extends Component {
         this.position = usePosition("ref", () => this.props.target, this.positioningOptions);
 
         const resizeObserver = new ResizeObserver(() => {
-            if (!this.props.fixedPosition && this.animationDone) {
+            if (!this.props.fixedPosition && (!this.props.animation || this.animationDone)) {
                 this.position.unlock();
             }
         });


### PR DESCRIPTION
__Current behavior before commit:__
The BuilderList component has limited functionality for managing
Many2one field options in forms. Users can only add records through a
simple dropdown menu, and there is no way to bulk manage, refresh, or
remove all records from the list.

__Description of the change:__
Enhance the BuilderList component with better record management UI.
It now contains 4 buttons:
- The dropwdown button is replaced by a SelectMany2X component to allow
record search.
- A button to open a new BuilderListDialog which is introduced for bulk
adding and removing records.
- An update button to refresh the list
- And a button to remove all items at once.

In addition, input fields are disabled for Many2X types to prevent
manual editing of record names.

task-4730998