### PR TITLE
[FIX] pos_restaurant_preparation_display: sync PDIS on table actions

### DIFF
--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -12,6 +12,9 @@ patch(PosOrder.prototype, {
     initState() {
         super.initState();
         this.uiState.selected_course_uuid = undefined;
+        if (this.config.module_pos_restaurant) {
+            this.uiState.mappingOrderlinesUuid = {};
+        }
     },
     getCustomerCount() {
         return this.customer_count;

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -187,6 +187,7 @@ patch(PosStore.prototype, {
                 destOrder.uiState.unmerge[uuid] = {
                     table_id: sourceOrder.table_id.id,
                     quantity: orphanLine.qty,
+                    formerUuid: orphanLine.uuid,
                 };
             }
 
@@ -272,6 +273,7 @@ patch(PosStore.prototype, {
                     acc.push({
                         quantity: details.quantity,
                         uuid: uuid,
+                        formerUuid: details.formerUuid,
                     });
                 }
                 return acc;
@@ -343,6 +345,9 @@ patch(PosStore.prototype, {
                 );
 
                 delete order.uiState.unmerge[line.uuid];
+                if (this.config.module_pos_restaurant) {
+                    newOrder.uiState.mappingOrderlinesUuid[detail.formerUuid] = newLine.uuid;
+                }
             }
 
             await this.syncAllOrders({ orders: [order, newOrder] });
@@ -809,7 +814,7 @@ patch(PosStore.prototype, {
 
         if (destinationTable) {
             if (!this.prepareOrderTransfer(sourceOrder, destinationTable)) {
-                await this.syncAllOrders({ orders: [sourceOrder] });
+                await this.handleFailToPrepareOrderTransfer([sourceOrder]);
                 return;
             }
             destinationOrder = this.getActiveOrdersOnTable(destinationTable.rootTable)[0];
@@ -823,13 +828,16 @@ patch(PosStore.prototype, {
         const sourceOrder = this.models["pos.order"].getBy("uuid", orderUuid);
 
         if (!this.prepareOrderTransfer(sourceOrder, destinationTable)) {
-            await this.syncAllOrders({ orders: [sourceOrder] });
+            await this.handleFailToPrepareOrderTransfer([sourceOrder]);
             return;
         }
 
         const destinationOrder = this.getActiveOrdersOnTable(destinationTable.rootTable)[0];
         await this.mergeOrders(sourceOrder, destinationOrder);
         await this.setTable(destinationTable);
+    },
+    async handleFailToPrepareOrderTransfer(orders) {
+        await this.syncAllOrders({ orders });
     },
     updateTables(...tables) {
         this.data.call("restaurant.table", "update_tables", [


### PR DESCRIPTION
Task: [#5005179](https://www.odoo.com/odoo/1737/tasks/5005179)

---

When executing table actions such as transfer, merge, link, or unlink, the related Preparation Displays (PDIS) were not being updated. This caused inconsistencies between the POS orders and the kitchen screens. Also, when merging or linking orders and cancelling some lines, a new `pdis_order` was created instead of reusing the existing one.

This fix ensures that PDIS are correctly synchronized and notified on any table actions.
