### PR TITLE
[IMP] iot_drivers: remove no longer required default parameter

### DIFF
--- a/addons/iot_drivers/__init__.py
+++ b/addons/iot_drivers/__init__.py
@@ -28,13 +28,12 @@ def set_default_options(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         headers = kwargs.pop('headers', None) or {}
-        verify = kwargs.pop('verify', False)
         headers['User-Agent'] = 'OdooIoTBox/1.0'
         server_url = tools.helpers.get_odoo_server_url()
         db_name = tools.helpers.get_conf('db_name')
         if server_url and db_name and args[0].startswith(server_url) and '/web/login?db=' not in args[0]:
             headers['X-Odoo-Database'] = db_name
-        return func(*args, headers=headers, verify=verify, **kwargs)
+        return func(*args, headers=headers, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
In #220920, a default `verify=False` option was added to requests calls to stop some requests failing before the system time was set from the network. This is no longer required as the Odoo service is booting later in the boot process now (after `rc.local` has finished executing) so the time is already correct.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
