### PR TITLE
[FIX] mail: replace `new meeting` icon with an SVG

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_search.xml
+++ b/addons/mail/static/src/core/public_web/discuss_search.xml
@@ -42,7 +42,11 @@
         'p-2': ui.isSmall,
         'o-px-1_5 py-2': !ui.isSmall and store.discuss.isSidebarCompact,
         'o-p-1_5': !ui.isSmall and !store.discuss.isSidebarCompact,
-    }"><i class="oi fa-fw oi-user-plus"/></button>
+    }">
+        <svg width="17" height="13" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M11 0a2 2 0 0 1 2 2v4l4-4v9l-4-3v3a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h9ZM6 6H3v1h3v3h1V7h3V6H7V3H6v3Z" fill="currentColor"/>
+        </svg>
+    </button>
 </t>
 
 </templates>


### PR DESCRIPTION
This commit replaces the `new meeting` icon (previously `oi-user-plus`) with an SVG depicting a video call. This aims to clarify the action performed when clicking the button, making its behavior more predictable.

| Master | This PR |
|--------|--------|
| <img width="297" height="54" alt="image" src="https://github.com/user-attachments/assets/06e5db74-dbcd-40d1-b992-ec27a3b37be9" /> | <img width="299" height="51" alt="image" src="https://github.com/user-attachments/assets/2339cf3f-89ac-4d3c-915e-c03863c88a75" /> | 

task-5216140

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
