### PR TITLE
[IMP] web: use odoomark for groups in kanban/list view

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -390,7 +390,7 @@ class Base(models.AbstractModel):
         # First level of grouping
         first_groupby = [groupby[0]]
         read_group_order = self._get_read_group_order(dict_order, first_groupby, aggregates)
-        groups, length = self._formatted_read_group_with_length(
+        groups, length = self.with_context(formatted_display_name=True)._formatted_read_group_with_length(
             domain, first_groupby, aggregates, offset=offset, limit=limit, order=read_group_order,
         )
 

--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -261,7 +261,7 @@ export function odoomark(text) {
                  * and the regex doesn't do anything crazy to unescape it.
                  */
                 tag = markup(tag);
-                return markup`<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">${tag}</span>`;
+                return markup`<span class="o_tag position-relative d-inline-flex align-items-center align-baseline mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">${tag}</span>`;
             },
         ],
     ];

--- a/addons/web/static/src/views/kanban/kanban_header.js
+++ b/addons/web/static/src/views/kanban/kanban_header.js
@@ -11,6 +11,7 @@ import { useDebounced } from "@web/core/utils/timing";
 import { ColumnProgress } from "@web/views/view_components/column_progress";
 import { GroupConfigMenu } from "@web/views/view_components/group_config_menu";
 import { QuickCreateState } from "./kanban_record_quick_create";
+import { odoomark } from "@web/core/utils/html";
 
 class KanbanHeaderTooltip extends Component {
     static template = "web.KanbanGroupTooltip";
@@ -42,6 +43,7 @@ export class KanbanHeader extends Component {
         this.rootRef = useRef("root");
         this.popover = usePopover(KanbanHeaderTooltip);
         this.onTitleMouseEnter = useDebounced(this.onTitleMouseEnter, 400);
+        this.odoomark = odoomark;
     }
 
     async onTitleMouseEnter(ev) {

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -6,14 +6,14 @@
             <div class="o_kanban_header_title position-relative d-flex lh-lg">
                 <div t-if="group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 opacity-100-hover flex-grow-1 gap-1"
                      t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave">
-                    <t t-esc="group.displayName"></t>
+                    <t t-out="odoomark(group.displayName)"></t>
                     <span t-if="group.count > 0 and !props.list.model.useSampleModel" t-esc="'(' + group.count + ')'"/>
                 </div>
                 <div t-if="!group.isFolded"
                     class="o_column_title flex-grow-1 min-w-0 mw-100 gap-1 d-flex fs-4 fw-bold align-top text-900"
                       t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave"
                 >
-                    <span class="text-truncate" t-esc="group.displayName"/>
+                    <span class="text-truncate" t-out="odoomark(group.displayName)"/>
                     <span t-if="!progressBar and !props.list.model.useSampleModel" t-esc="'(' + group.count + ')'"/>
                 </div>
                 <t t-if="env.isSmall or !group.isFolded">

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -46,6 +46,7 @@ import { MOVABLE_RECORD_TYPES } from "@web/model/relational_model/dynamic_group_
 import { ActionHelper } from "@web/views/action_helper";
 import { GroupConfigMenu } from "@web/views/view_components/group_config_menu";
 import { MultiCurrencyPopover } from "@web/views/view_components/multi_currency_popover";
+import { odoomark } from "@web/core/utils/html";
 
 /**
  * @typedef {import('@web/model/relational_model/dynamic_list').DynamicList} DynamicList
@@ -146,6 +147,7 @@ export class ListRenderer extends Component {
         this.groupByButtons = this.props.archInfo.groupBy.buttons;
         useExternalListener(window, "click", this.onGlobalClick.bind(this), { capture: true });
         this.tableRef = useRef("table");
+        this.odoomark = odoomark;
 
         this.longTouchTimer = null;
         this.touchStartMs = 0;

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -214,7 +214,9 @@
                 <div class="d-flex align-items-center">
                     <span t-attf-class="o_group_caret fa fa-fw {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }} me-1"
                         t-attf-style="--o-list-group-level: {{getGroupLevel(group)}}"/>
-                    <t t-esc="group.displayName"/> (<t t-esc="group.count"/>)
+                    <span>
+                        <t t-out="odoomark(group.displayName)"/> <span class="ms-1">(<t t-esc="group.count"/>)</span>
+                    </span>
                     <div t-if="(groupByButtons[group.groupByField.name] and !group.isFolded and group.record.resId)" class="o_group_buttons">
                         <t t-foreach="groupByButtons[group.groupByField.name]" t-as="button" t-key="button.id">
                             <t t-if="!evalInvisible(button.invisible, group.record)">

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1913,7 +1913,7 @@ export class Model extends Array {
                 if (relation && !Array.isArray(value)) {
                     const relatedRecord = this.env[relation].find(({ id }) => id === value);
                     if (relatedRecord) {
-                        group[groupbySpec] = [value, relatedRecord.display_name];
+                        group[groupbySpec] = [value, this._getFormattedDisplayName(relatedRecord)];
                         const _fold_name = this.env[relation]._fold_name;
                         if (_fold_name in this.env[relation]._fields) {
                             group.__fold = relatedRecord[_fold_name] || false;
@@ -1926,8 +1926,9 @@ export class Model extends Array {
                         group[groupbySpec] = false;
                     } else {
                         const relatedRecord = this.env[this._name].find(({ id }) => id === value);
-                        const displayName = relatedRecord?.display_name || "";
-                        group[groupbySpec] = [value, displayName];
+                        const formattedDisplayName =
+                            this._getFormattedDisplayName(relatedRecord) || "";
+                        group[groupbySpec] = [value, formattedDisplayName];
                     }
                 }
                 if (isDateField(type)) {
@@ -3134,6 +3135,10 @@ export class Model extends Array {
                 record.display_name = `${this._name},${record.id}`;
             }
         }
+    }
+
+    _getFormattedDisplayName(record) {
+        return record?.display_name;
     }
 
     /**

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -332,10 +332,10 @@ test("odoomark", () => {
         "<span class='text-muted'>test</span> something else <span class='text-muted'>test</span>"
     );
     expect(odoomark("`test`").toString()).toBe(
-        `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
+        `<span class="o_tag position-relative d-inline-flex align-items-center align-baseline mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
     );
     expect(odoomark("`test` something else `test`").toString()).toBe(
-        `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span> something else <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
+        `<span class="o_tag position-relative d-inline-flex align-items-center align-baseline mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span> something else <span class="o_tag position-relative d-inline-flex align-items-center align-baseline mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
     );
     expect(odoomark("test\ttest2").toString()).toBe(
         `test<span style="margin-left: 2em"></span>test2`

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -4017,7 +4017,7 @@ test("many2one search with formatted name", async () => {
     expect(
         ".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)"
     ).toHaveInnerHTML(
-        `Test: <b>Paul</b> <span class="text-muted">Eric</span> <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">good guy</span><br/><span style="margin-left: 2em"></span>More text`
+        `Test: <b>Paul</b> <span class="text-muted">Eric</span> <span class="o_tag position-relative d-inline-flex align-items-center align-baseline mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">good guy</span><br/><span style="margin-left: 2em"></span>More text`
     );
     await contains(
         ".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)"

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -9588,3 +9588,30 @@ test("limit is reset when restoring a view after ungrouping", async () => {
     await switchView("kanban");
     expect.verifySteps(["limit=40"]);
 });
+
+test(`groupby use odoomark`, async () => {
+    patchWithCleanup(Partner.prototype, {
+        _getFormattedDisplayName(record) {
+            return `**${record.name}** \`tag\``;
+        },
+    });
+
+    await mountView({
+        resModel: "partner",
+        type: "kanban",
+        arch: `
+            <kanban sample="1">
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                        <field name="product_id"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+
+    expect(`.o_kanban_group`).toHaveCount(2);
+    expect(`.o_kanban_group b`).toHaveCount(2);
+    expect(`.o_kanban_group span.o_badge`).toHaveCount(2);
+});

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2326,7 +2326,7 @@ test(`group a list view with the aggregable field 'value'`, async () => {
         groupBy: ["bar"],
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["No (1)\n 1", "Yes (3)\n 3"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No (1) 1", "Yes (3) 3"]);
 });
 
 test(`basic grouped list rendering with groupby m2m field`, async () => {
@@ -2343,7 +2343,7 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     });
     expect(`.o_group_header`).toHaveCount(4, { message: "should contain 4 open groups" });
     expect(`.o_group_open`).toHaveCount(0, { message: "no group is open" });
-    expect(queryAllTexts(`.o_group_header .o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_header .o_group_name`, { inline: true })).toEqual([
         "Value 1 (3)",
         "Value 2 (2)",
         "Value 3 (1)",
@@ -2356,16 +2356,16 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     await contains(`.o_group_name:eq(2)`).click();
     await contains(`.o_group_name:eq(3)`).click();
     expect(`.o_group_open`).toHaveCount(4, { message: "all groups are open" });
-    expect(queryAllTexts(`.o_list_view tbody > tr`)).toEqual([
+    expect(queryAllTexts(`.o_list_view tbody > tr`, { inline: true })).toEqual([
         "Value 1 (3)",
-        "yop \nValue 1\nValue 2",
-        "blip \nValue 1\nValue 2\nValue 3",
-        "blip \nValue 1",
+        "yop Value 1 Value 2",
+        "blip Value 1 Value 2 Value 3",
+        "blip Value 1",
         "Value 2 (2)",
-        "yop \nValue 1\nValue 2",
-        "blip \nValue 1\nValue 2\nValue 3",
+        "yop Value 1 Value 2",
+        "blip Value 1 Value 2 Value 3",
         "Value 3 (1)",
-        "blip \nValue 1\nValue 2\nValue 3",
+        "blip Value 1 Value 2 Value 3",
         "None (1)",
         "gnap",
     ]);
@@ -2387,10 +2387,10 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     expect(`.o_list_footer td > button`).toHaveCount(0, {
         message: "no quick create since no default groupby",
     });
-    expect(queryAllTexts(`tbody > tr`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
+    expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual(["Value 1 (3)", "Value 2 (1)"]);
 
     await contains(`th.o_group_name`).click();
-    expect(queryAllTexts(`tbody > tr`)).toEqual([
+    expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual([
         "Value 1 (3)",
         "Value 1 (2)",
         "Value 2 (1)",
@@ -2399,7 +2399,7 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     ]);
 
     await contains(`tbody th.o_group_name:eq(4)`).click();
-    expect(queryAllTexts(`.o_list_view tbody > tr`)).toEqual([
+    expect(queryAllTexts(`.o_list_view tbody > tr`, { inline: true })).toEqual([
         "Value 1 (3)",
         "Value 1 (2)",
         "Value 2 (1)",
@@ -2422,7 +2422,10 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
         arch: `<list default_group_by="m2o"><field name="foo"/></list>`,
     });
     expect(`.o_group_header:eq(0) th`).toHaveCount(2);
-    expect(queryAllTexts(".o_group_name")).toEqual(["Value 1 (3)", "Value 2 (1)"]);
+    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual([
+        "Value 1 (3)",
+        "Value 2 (1)",
+    ]);
     expect(`.o_list_footer td > button`).toHaveText("Add a M2o");
     await contains(`.o_list_footer td > button`).click();
     expect(`.o_list_footer td > button`).toHaveCount(0);
@@ -2430,7 +2433,11 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
     await contains(`.o_list_footer td input`).edit("New group", { confirm: false });
     await contains(`.o_list_footer .o_list_group_confirm`).click();
     expect.verifySteps(["name_create"]);
-    expect(queryAllTexts(".o_group_name")).toEqual(["Value 1 (3)", "Value 2 (1)", "New group (0)"]);
+    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual([
+        "Value 1 (3)",
+        "Value 2 (1)",
+        "New group (0)",
+    ]);
 });
 
 test(`grouped list rendering with groupby m2o field: group_create = false`, async () => {
@@ -2467,7 +2474,10 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
 
-    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 1 (3)",
+        "Value 2 (1)",
+    ]);
     expect(`.o_group_header:first th:last .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
@@ -2480,7 +2490,10 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await contains(`.o_dialog .o_form_button_save`).click();
     expect(`.o_dialog`).toHaveCount(0);
     expect.verifySteps(["web_save"]);
-    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value edit (3)", "Value 2 (1)"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value edit (3)",
+        "Value 2 (1)",
+    ]);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     if (getMockEnv().isSmall) {
         await contains(".o_bottom_sheet_backdrop").click();
@@ -2504,7 +2517,10 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
         groupBy: ["m2o"],
     });
 
-    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 1 (3)",
+        "Value 2 (1)",
+    ]);
     expect(`.o_group_header:first .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
@@ -2513,7 +2529,7 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
     expect(`.o_dialog .modal-body`).toHaveText("Are you sure you want to delete this column?");
     await contains(`.o_dialog footer button:contains(Delete)`).click();
     expect.verifySteps(["unlink"]);
-    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 2 (1)", "None (3)"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 2 (1)", "None (3)"]);
 });
 
 test(`grouped list rendering with groupby non m2o field`, async () => {
@@ -2573,7 +2589,7 @@ test(`list view with multiple groupbys`, async () => {
     });
     expect(`.o_view_nocontent`).toHaveCount(0);
     expect(`.o_group_has_content`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_has_content`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`.o_group_has_content`, { inline: true })).toEqual(["No (1)", "Yes (3)"]);
 });
 
 test(`enabling archive in list when groupby m2m field`, async () => {
@@ -2922,7 +2938,7 @@ test(`add record in list grouped by m2m`, async () => {
     });
 
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
         "Value 1 (3)",
         "Value 2 (2)",
         "Value 3 (1)",
@@ -4536,13 +4552,13 @@ test(`selection is kept on render without reload`, async () => {
     expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(0);
 
     // open blip grouping and check all lines
-    await contains(`.o_group_header:contains(blip (2))`).click();
+    await contains(`.o_group_header:contains(blip)`).click();
     await contains(`.o_data_row input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
     expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
 
     // open yop grouping and verify blip are still checked
-    await contains(`.o_group_header:contains(yop (1))`).click();
+    await contains(`.o_group_header:contains(yop)`).click();
     expect(`.o_data_row input:checked`).toHaveCount(1, {
         message: "opening a grouping does not uncheck others",
     });
@@ -4550,8 +4566,8 @@ test(`selection is kept on render without reload`, async () => {
     expect(`.o_control_panel_actions .o_selection_box`).toHaveCount(1);
 
     // close and open blip grouping and verify blip are unchecked
-    await contains(`.o_group_header:contains(blip (2))`).click();
-    await contains(`.o_group_header:contains(blip (2))`).click();
+    await contains(`.o_group_header:contains(blip)`).click();
+    await contains(`.o_group_header:contains(blip)`).click();
     expect(`.o_data_row input:checked`).toHaveCount(0, {
         message: "opening and closing a grouping uncheck its elements",
     });
@@ -4728,8 +4744,8 @@ test(`monetary aggregates in grouped list`, async () => {
     await contains(`.o_group_header:last`).click();
     // Don't handle currencies in aggregates for non monetary fields even with the widget:
     // it is bad practice and the server won't send the information anyway
-    expect(`.o_group_header:first`).toHaveText("USD (3)\n $ 800.00 19.00");
-    expect(`.o_group_header:last`).toHaveText("EUR (1)\n 1,200.00 € 0.40");
+    expect(`.o_group_header:first`).toHaveText("USD (3) $ 800.00 19.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("EUR (1) 1,200.00 € 0.40", { inline: true });
     expect(`.o_list_footer .o_list_number span:first`).toHaveText("$ 1,400.00?");
     await toggleMultiCurrencyPopover(".o_list_footer .o_list_number span:first sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
@@ -4752,8 +4768,8 @@ test(`monetary aggregates in grouped list (!= currencies in same group)`, async 
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("No (1)\n $ 0.00");
-    expect(`.o_group_header:last`).toHaveText("Yes (3)\n $ 2,000.00?");
+    expect(`.o_group_header:first`).toHaveText("No (1) $ 0.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes (3) $ 2,000.00?", { inline: true });
     expect(`.o_list_footer .o_list_number span`).toHaveText("$ 2,000.00?");
 });
 
@@ -4772,7 +4788,7 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
         actionMenus: {},
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(`.o_group_header:last`).toHaveText("Yes (3)\n $ 2,000.00?");
+    expect(`.o_group_header:last`).toHaveText("Yes (3) $ 2,000.00?", { inline: true });
     await contains(`.o_group_header:last`).click();
     expect(`.o_data_row`).toHaveCount(3);
     await selectAllRecords();
@@ -4781,7 +4797,7 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
     await toggleMenuItem("Delete");
     await contains(`.o_dialog footer .btn-primary`).click(); // confirm
     expect(`.o_data_row`).toHaveCount(0);
-    expect(`.o_group_header:last`).toHaveText("Yes (0)\n 0.00");
+    expect(`.o_group_header:last`).toHaveText("Yes (0) 0.00", { inline: true });
 });
 
 test(`list with monetary field with attribute column_invisible="1"`, async () => {
@@ -4834,8 +4850,9 @@ test(`handle false values in aggregates`, async () => {
         groupBy: ["bar"],
     });
     expect.verifySteps(["web_read_group"]);
-    expect(`.o_group_header:first`).toHaveText("No (1)\n 9.00 $ 0.00 $ 0.00");
-    expect(`.o_group_header:last`).toHaveText("Yes (3)\n $ 2,000.00?", {
+    expect(`.o_group_header:first`).toHaveText("No (1) 9.00 $ 0.00 $ 0.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes (3) $ 2,000.00?", {
+        inline: true,
         message: "false values are just hidden except for monetary field with multiple currencies",
     });
 });
@@ -4879,7 +4896,10 @@ test(`date field aggregates in grouped lists`, async () => {
         `,
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([`Value 1 (3)`, `Value 2 (1)`]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        `Value 1 (3)`,
+        `Value 2 (1)`,
+    ]);
 });
 
 test(`hide aggregated value in grouped lists when no data provided by RPC call`, async () => {
@@ -5136,8 +5156,8 @@ test(`groups can be sorted on the first field of the groupBy`, async () => {
         arch: `<list default_order="bar desc"><field name="foo"/><field name="bar"/></list>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("Yes (3)");
-    expect(`.o_group_header:eq(-1)`).toHaveText("No (1)");
+    expect(`.o_group_header:eq(0)`).toHaveText("Yes (3)", { inline: true });
+    expect(`.o_group_header:eq(-1)`).toHaveText("No (1)", { inline: true });
     expect.verifySteps(["web_read_group"]);
 });
 
@@ -6013,9 +6033,9 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
         groupBy: ["foo", "bar"],
         actionMenus: {},
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("blip (6)");
-    expect(`.o_group_header:eq(1)`).toHaveText("No (2)");
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes (4)");
+    expect(`.o_group_header:eq(0)`).toHaveText("blip (6)", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("No (2)", { inline: true });
+    expect(`.o_group_header:eq(2)`).toHaveText("Yes (4)", { inline: true });
 
     await contains(`.o_group_header:eq(2)`).click();
     expect(`.o_data_row`).toHaveCount(4);
@@ -6024,8 +6044,8 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
     await toggleActionMenu();
     await toggleMenuItem("Delete");
     await contains(`.modal .btn-primary`).click();
-    expect(`.o_group_header:eq(0)`).toHaveText("blip (5)");
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes (3)");
+    expect(`.o_group_header:eq(0)`).toHaveText("blip (5)", { inline: true });
+    expect(`.o_group_header:eq(2)`).toHaveText("Yes (3)", { inline: true });
 });
 
 test(`grouped list, reload aggregates when a record is deleted`, async () => {
@@ -8496,7 +8516,10 @@ test(`list view with nested groups`, async () => {
 
     // basic rendering tests
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (4)", "Value 2 (2)"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 1 (4)",
+        "Value 2 (2)",
+    ]);
     expect(`.o_group_name .fa-caret-right`).toHaveCount(2);
     expect(`.o_group_header:eq(0) span:first`).toHaveStyle({ "--o-list-group-level": "0" });
     expect(queryAllTexts(`.o_group_header .o_list_number`)).toEqual(["16", "14"]);
@@ -8504,7 +8527,7 @@ test(`list view with nested groups`, async () => {
     // open the first group
     await contains(`.o_group_header:eq(0)`).click();
     expect.verifySteps(["web_read_group"]);
-    expect(queryAllTexts(`.o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
         "Value 1 (4)",
         "blip (2)",
         "gnap (1)",
@@ -8584,7 +8607,7 @@ test(`grouped list on selection field at level 2`, async () => {
     expect(`.o_group_header`).toHaveCount(5, {
         message: "should contain 2 groups at first level and 3 groups at second level",
     });
-    expect(queryAllTexts(`.o_group_header .o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_header .o_group_name`, { inline: true })).toEqual([
         "Value 1 (5)",
         "Low (3)",
         "Medium (1)",
@@ -10475,8 +10498,8 @@ test(`editable grouped list with handle widget`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("No (1)\n 0");
-    expect(`.o_group_header:last`).toHaveText("Yes (3)\n 2,000");
+    expect(`.o_group_header:first`).toHaveText("No (1) 0", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes (3) 2,000", { inline: true });
     expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("0", {
         message: "default fourth record should have amount 0",
     });
@@ -10499,8 +10522,8 @@ test(`editable grouped list with handle widget`, async () => {
         ["web_resequence", [3], "int_field", 2],
     ]);
     // Aggregates are not updated, todo later?
-    expect(`.o_group_header:first`).toHaveText("No (2)\n 0");
-    expect(`.o_group_header:last`).toHaveText("Yes (2)\n 2,000");
+    expect(`.o_group_header:first`).toHaveText("No (2) 0", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes (2) 2,000", { inline: true });
     expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("300", {
         message: "new first record should have amount 300",
     });
@@ -10535,8 +10558,8 @@ test(`editable grouped list with handle widget (group by date)`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("January 2017 (1)\n 1,200");
-    expect(`.o_group_header:last`).toHaveText("None (3)\n 800");
+    expect(`.o_group_header:first`).toHaveText("January 2017 (1) 1,200", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("None (3) 800", { inline: true });
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
@@ -10555,8 +10578,8 @@ test(`editable grouped list with handle widget (multiple group by)`, async () =>
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:eq(1)`).click(); // sub group
-    expect(`.o_group_header:first`).toHaveText("No (1)\n 0");
-    expect(`.o_group_header:eq(1)`).toHaveText("blip (1)\n 0");
+    expect(`.o_group_header:first`).toHaveText("No (1) 0", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("blip (1) 0", { inline: true });
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
@@ -12534,9 +12557,12 @@ test(`list grouped by date:month`, async () => {
         arch: `<list><field name="date"/></list>`,
         groupBy: ["date:month"],
     });
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["January 2017 (1)", "None (3)"], {
-        message: "the group names should be correct",
-    });
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(
+        ["January 2017 (1)", "None (3)"],
+        {
+            message: "the group names should be correct",
+        }
+    );
 });
 
 test(`grouped list edition with boolean_favorite widget`, async () => {
@@ -12790,8 +12816,8 @@ test(`grouped list view move to next page when all records from the current page
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1 (6)");
-    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2 (1)");
+    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1 (6)", { inline: true });
+    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2 (1)", { inline: true });
 
     const firstGroup = queryFirst(`tr.o_group_header:eq(0)`);
     await contains(firstGroup).click();
@@ -12803,7 +12829,9 @@ test(`grouped list view move to next page when all records from the current page
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
     await contains(`.modal .btn-primary`).click();
-    expect(`.o_group_header:eq(0) .o_group_name`).toHaveText(`Value 1 (4)\n1-2 / 4`);
+    expect(`.o_group_header:eq(0) .o_group_name`).toHaveText(`Value 1 (4) 1-2 / 4`, {
+        inline: true,
+    });
     expect(queryAllTexts(`.o_data_row`)).toEqual(["yop3", "yop4"]);
 });
 
@@ -13091,14 +13119,18 @@ test(`multi level grouped list with groups_limit attribute`, async () => {
         message: "pager should be correct",
     });
     expect(`.o_pager_limit`).toHaveText("4");
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["blip (2)", "foo (5)", "gnap (1)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "blip (2)",
+        "foo (5)",
+        "gnap (1)",
+    ]);
 
     // open foo group
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_group_header`).toHaveCount(6);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
         "blip (2)",
-        "foo (5)\n1-3 / 5",
+        "foo (5) 1-3 / 5",
         "50 (1)",
         "51 (1)",
         "52 (1)",
@@ -13193,7 +13225,7 @@ test(`grouped lists with expand attribute and a lot of groups`, async () => {
     expect(`.o_group_header`).toHaveCount(10); // page 1
     expect(`.o_data_row`).toHaveCount(10); // two groups contains two records
     expect(`.o_pager`).toHaveCount(1); // has a pager
-    expect(queryAllTexts(`.o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
         "-4 (1)",
         "0 (1)",
         "1 (1)",
@@ -13209,7 +13241,7 @@ test(`grouped lists with expand attribute and a lot of groups`, async () => {
     await pagerNext(); // switch to page 2
     expect(`.o_group_header`).toHaveCount(7); // page 2
     expect(`.o_data_row`).toHaveCount(9); // two groups contains two records
-    expect(queryAllTexts(`.o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
         "9 (2)",
         "10 (2)",
         "11 (1)",
@@ -14184,7 +14216,7 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     expect(`.o_selected_row`).toHaveCount(0);
 
     // Click on last data row of first group
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (1) -4", { inline: true });
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
     expect(`.o_data_row:eq(0) [name=foo] input`).toBeFocused();
 
@@ -14192,13 +14224,13 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (2) -4", { inline: true });
 
     // Enter should discard the edited row as it is pristine + get to next data row
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (1) -4", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -14210,12 +14242,12 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (2) -4", { inline: true });
 
     // Edit the row and press enter: should add a new row
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (3)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (3) -4", { inline: true });
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -14286,7 +14318,7 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
     expect(`.o_selected_row`).toHaveCount(0);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (1) -4", { inline: true });
 
     // Click on last data row of first group
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
@@ -14296,13 +14328,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (2) -4", { inline: true });
 
     // Enter should discard the edited row as it is pristine + get to next data row
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (1) -4", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -14314,13 +14346,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (2) -4", { inline: true });
 
     // Edit the row and press enter: should add a new row
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (3)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (3) -4", { inline: true });
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -14431,22 +14463,22 @@ test(`editable grouped list: adding a second record pass the first in readonly`,
     await contains(`.o_group_header:eq(0)`).click();
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_data_row`).toHaveCount(4);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)");
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes (3)");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (1)", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("Yes (3)", { inline: true });
 
     // add a row in first group
     await contains(`.o_group_field_row_add:eq(0) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)");
+    expect(`.o_group_header:eq(0)`).toHaveText("No (2)", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // add a row in second group
     await contains(`.o_group_field_row_add:eq(1) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes (4)");
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)");
+    expect(`.o_group_header:eq(1)`).toHaveText("Yes (4)", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No (1)", { inline: true });
     expect(`.o_data_row:eq(4) [name=foo] input`).toBeFocused();
 });
 
@@ -14779,6 +14811,7 @@ test(`add a new row in grouped editable="top" list`, async () => {
 
     await contains(`.o_group_field_row_add a:eq(1)`).click(); // create row in second group "Yes"
     expect(`.o_group_name:eq(1)`).toHaveText("Yes (4)", {
+        inline: true,
         message: "group should have correct name and count",
     });
     expect(`.o_data_row`).toHaveCount(5);
@@ -16203,7 +16236,7 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
     });
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No (1)");
+    expect(`.o_group_header`).toHaveText("No (1)", { inline: true });
 
     // unfold the second group
     await contains(`.o_group_header`).click();
@@ -16216,11 +16249,11 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
 
     await contains(`.breadcrumb-item a, .o_back_button`).click();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No (1)");
+    expect(`.o_group_header`).toHaveText("No (1)", { inline: true });
 
     await pagerNext();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("Yes (3)");
+    expect(`.o_group_header`).toHaveText("Yes (3)", { inline: true });
 });
 
 test(`keep order after grouping`, async () => {
@@ -16243,7 +16276,11 @@ test(`keep order after grouping`, async () => {
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Foo");
-    expect(queryAllTexts`.o_group_name`).toEqual(["yop (1)", "gnap (1)", "blip (2)"]);
+    expect(queryAllTexts`.o_group_name`, { inline: true }).toEqual([
+        "yop (1)",
+        "gnap (1)",
+        "blip (2)",
+    ]);
 
     await toggleMenuItem("Foo");
     expect(queryAllTexts`.o_data_row td[name=foo]`).toEqual(["yop", "gnap", "blip", "blip"]);
@@ -16619,7 +16656,7 @@ test(`have some records, then go to next page in pager then group by some field:
     await toggleSearchBarMenu();
     await toggleMenuItem("Bar");
     expect(`tbody .o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`tbody .o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`tbody .o_group_header`, { inline: true })).toEqual(["No (1)", "Yes (3)"]);
 
     await removeFacet("Bar");
     expect(`tbody .o_data_row`).toHaveCount(2);
@@ -16632,7 +16669,7 @@ test(`have some records, then go to next page in pager then group by some field:
     await toggleSearchBarMenu();
     await toggleMenuItem("Bar");
     expect(`tbody .o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`tbody .o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`tbody .o_group_header`, { inline: true })).toEqual(["No (1)", "Yes (3)"]);
 });
 
 test(`optional field selection do not unselect current row`, async () => {
@@ -18546,7 +18583,7 @@ test(`display 'None' for false group, when grouped by char field`, async () => {
         groupBy: ["foo"],
     });
 
-    expect(`tbody tr:nth-child(3)`).toHaveText("None (1)");
+    expect(`tbody tr:nth-child(3)`).toHaveText("None (1)", { inline: true });
 });
 
 test(`display '0' for false group, when grouped by int field`, async () => {
@@ -18559,7 +18596,7 @@ test(`display '0' for false group, when grouped by int field`, async () => {
         groupBy: ["int_field"],
     });
 
-    expect(`tbody tr:nth-child(2)`).toHaveText("0 (1)");
+    expect(`tbody tr:nth-child(2)`).toHaveText("0 (1)", { inline: true });
 });
 
 test(`display the field's falsy_value_label for false group, if defined`, async () => {
@@ -18573,7 +18610,7 @@ test(`display the field's falsy_value_label for false group, if defined`, async 
         groupBy: ["foo"],
     });
 
-    expect(`tbody tr:nth-child(3)`).toHaveText("I'm the false group (1)");
+    expect(`tbody tr:nth-child(3)`).toHaveText("I'm the false group (1)", { inline: true });
 });
 
 test(`hide pager in the list view with sample data`, async () => {
@@ -19048,7 +19085,7 @@ test(`cache web_read_group (no change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No (1)", "Yes (3)"]);
 
     // execute another action to remove the list from the DOM
     await getService("action").doAction(2);
@@ -19059,14 +19096,14 @@ test(`cache web_read_group (no change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No (1)", "Yes (3)"]);
 
     // simulate the return of web_read_group => nothing should have changed
     def.resolve();
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No (1)", "Yes (3)"]);
 });
 
 test(`cache web_read_group (change)`, async () => {
@@ -19107,7 +19144,12 @@ test(`cache web_read_group (change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["-4 (1)", "9 (1)", "10 (1)", "17 (1)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "-4 (1)",
+        "9 (1)",
+        "10 (1)",
+        "17 (1)",
+    ]);
 
     // simulate the create of new records by someone else
     MockServer.env.foo.create([{ int_field: 44 }, { int_field: -4 }]);
@@ -19121,14 +19163,19 @@ test(`cache web_read_group (change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["-4 (1)", "9 (1)", "10 (1)", "17 (1)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "-4 (1)",
+        "9 (1)",
+        "10 (1)",
+        "17 (1)",
+    ]);
 
     // simulate the return of web_read_group => the data should have been updated
     def.resolve();
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(5);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
         "-4 (2)",
         "9 (1)",
         "10 (1)",
@@ -19247,7 +19294,7 @@ test(`cache web_read_group (with sample data, change)`, async () => {
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["-4 (1)", "44 (1)"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["-4 (1)", "44 (1)"]);
 });
 
 test.tags("desktop");
@@ -19467,4 +19514,23 @@ test("scroll position is restored when coming back to list view", async () => {
     await animationFrame();
     expect(".o_list_renderer").toHaveCount(1);
     expect(".o_list_view").toHaveProperty("scrollTop", 200);
+});
+
+test(`groupby use odoomark`, async () => {
+    patchWithCleanup(Foo.prototype, {
+        _getFormattedDisplayName(record) {
+            return `**${record.name}** \`tag\``;
+        },
+    });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list><field name="foo"/><field name="m2o"/></list>`,
+        groupBy: ["m2o"],
+    });
+
+    expect(`.o_group_name`).toHaveCount(2);
+    expect(`.o_group_name b`).toHaveCount(2);
+    expect(`.o_group_name span.o_badge`).toHaveCount(2);
 });


### PR DESCRIPTION
Now, web_read_group uses the context key formatted_display_name.
That means, the returned value is no more (id, display_name), but,
(id, formatted_display_name).
The groupby on the list and kanban view are now using odoomark
to markup this formatted_display_name.

TASK-5208278
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
