### PR TITLE
[FIX] website: prevent click blocking when reopening mega menu on mobile

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1710,6 +1710,7 @@ header {
         z-index: $o-mega-menu-zindex;
         max-width: $offcanvas-horizontal-width;
         opacity: 0;
+        pointer-events: none;
 
         section {
             @include transition(transform $offcanvas-transition-duration ease-in-out, visibility $offcanvas-transition-duration ease-in-out);
@@ -1721,6 +1722,7 @@ header {
         @include transition(opacity $offcanvas-transition-duration ease-in-out, visibility $offcanvas-transition-duration ease-in-out);
         visibility: visible !important;
         opacity: 1;
+        pointer-events: auto;
 
         section {
             @include transition(transform $offcanvas-transition-duration ease-in-out, visibility $offcanvas-transition-duration ease-in-out);


### PR DESCRIPTION
Steps to reproduce:
====================
1. Add a mega menu.
2. Add effects to the mega menu columns ex (Animation on appearance,
Fade, direction from bottom)
3. Switch the website display to mobile view.
4. Click on the mega menu.
5. Go back and try to click again.

→ The mega menu cannot be opened again.
Cause:
======
When the mega menu is hidden, its section remains in the DOM and still captures pointer events.
As a result, clicks on the screen (including attempts to reopen the mega menu) are intercepted by the hidden element instead of reaching the intended target.

Solution:
=========
Disable pointer events on the mega menu section once it is hidden to ensure subsequent clicks behave correctly.

opw-5129316
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
