### PR TITLE
[FIX] hr_work_entry: admin delete work entries

### DIFF
--- a/addons/hr_work_entry/security/ir.model.access.csv
+++ b/addons/hr_work_entry/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_hr_work_entry_officer,access_hr_work_entry_officer,model_hr_work_entry,hr.group_hr_manager,1,1,1,0
+access_hr_work_entry_officer,access_hr_work_entry_officer,model_hr_work_entry,hr.group_hr_manager,1,1,1,1
 access_hr_work_entry_system,access_hr_work_entry_system,model_hr_work_entry,base.group_system,1,1,1,1
 access_hr_work_entry_type_officer,access_hr_work_entry_type_officer,model_hr_work_entry_type,hr.group_hr_user,1,0,0,0
 access_hr_work_entry_type_manager,access_hr_work_entry_type_manager,model_hr_work_entry_type,hr.group_hr_manager,1,1,1,1


### PR DESCRIPTION
- fixed the access error when a user with `group_hr_manager` access right (and without `group_system` access right) tries to delete work entries

task-id: 5177443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
