### PR TITLE
[FIX] {sale_,}loyalty: fix archived loyalty cards still being claimable

### DIFF
--- a/addons/loyalty/views/loyalty_card_views.xml
+++ b/addons/loyalty/views/loyalty_card_views.xml
@@ -65,8 +65,23 @@
                 <field name="partner_id"/>
                 <field name="program_id"/>
                 <separator/>
-                <filter name="active" string="Active" domain="['&amp;', ('program_id.active', '=', True), '&amp;', ('points', '>', 0), '|', ('expiration_date', '>=', context_today().strftime('%Y-%m-%d 00:00:00')), ('expiration_date', '=', False)]"/>
-                <filter name="inactive" string="Inactive" domain="['|', ('program_id.active', '=', False), '|', ('points', '&lt;=', 0), ('expiration_date', '&lt;', context_today().strftime('%Y-%m-%d 23:59:59'))]"/>
+                <filter
+                    name="active"
+                    string="Active"
+                    domain="[
+                        '&amp;', ('active', '=', True),
+                        '&amp;', ('program_id.active', '=', True),
+                        '|', ('expiration_date', '>=', context_today().strftime('%Y-%m-%d 00:00:00')), ('expiration_date', '=', False)
+                    ]"
+                />
+                <filter
+                    name="inactive"
+                    string="Inactive"
+                    domain="[
+                        '|', ('active', '=', False),
+                        '|', ('program_id.active', '=', False), ('expiration_date', '&lt;', context_today().strftime('%Y-%m-%d 23:59:59'))
+                    ]"
+                />
             </search>
         </field>
     </record>

--- a/addons/sale_loyalty/models/loyalty_card.py
+++ b/addons/sale_loyalty/models/loyalty_card.py
@@ -42,3 +42,10 @@ class LoyaltyCard(models.Model):
 
     def _has_source_order(self):
         return super()._has_source_order() or bool(self.order_id)
+
+    def action_archive(self):
+        self.env['sale.order.coupon.points'].search([
+            ('coupon_id', 'in', self.ids),
+            ('order_id.state', '=', 'draft'),
+        ]).unlink()
+        return super().action_archive()

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -1145,3 +1145,50 @@ class TestLoyalty(TestSaleCouponCommon):
 
         self.assertEqual(len(order.order_line.ids), 2)
         self.assertEqual(order.order_line[1].name, updated_description)
+
+    def test_archiving_loyalty_card_unlinks_draft_points_from_sale_order(self):
+        """
+        When a loyalty card has points accrued from a draft sale order, archiving the
+        card should unlink those draft points so they are no longer claimable on that order
+        """
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Loyalty Program',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [
+                Command.create({
+                    'reward_point_mode': 'unit',
+                    'reward_point_amount': 100,
+                    'product_ids': [self.product_a.id],
+                }),
+            ],
+            'reward_ids': [
+                Command.create({
+                    'reward_type': 'discount',
+                    'discount': 50,
+                    'discount_mode': 'percent',
+                    'discount_applicability': 'order',
+                    'required_points': 10,
+                }),
+            ],
+        })
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner.id,
+            'points': 0,
+        })
+        sale_order = self.empty_order
+        sale_order.write({
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                }),
+            ]
+        })
+        sale_order._update_programs_and_rewards()
+        claimable_rewards = sale_order._get_claimable_rewards()
+        self.assertTrue(claimable_rewards[loyalty_card])
+        loyalty_card.action_archive()
+        claimable_rewards = sale_order._get_claimable_rewards()
+        self.assertFalse(claimable_rewards.get(loyalty_card))


### PR DESCRIPTION
## Issue 1:
In this issue, active/inactive filter is not working correctly.

#### To reproduce:
1- Install `Sale`
2- Active `Promotions, Loyalty & Gift Card`
3- In `Discount & Loyalty` create a loyalty program
4- Create a `Loyalty Card` for the program
5- Archive the card
6- In search, click on `inactive` filter

As you see, you can't find the archived card.

### Cause:
This is caused due to setting the filter on `program_id.active` rather than `loyalty_card.active`.

## Issue 2:
In this bug, earned points on archived loyalty can be used to claim rewards.

#### To reproduce:
1- Install `Sale` and `Ecommerce`
2- Active `Promotions, Loyalty & Gift Card`
3- In `Discount & Loyalty` create a loyalty program
4- Add a rule to grant 10 points per order
5- Apply a reward in exchange of 10 points
6- Create a `Loyalty Card` for the admin with 0 points.
7- In Ecommerce, add a product to your cart
8- Remove the product from the cart
9- Archive the loyalty card created for the admin
10- In Ecommerce, add another product to cart
11- As you see, you still can use the loyalty card

### Cause:
When a product is first added to the cart, a `sale.order.coupon.points` record is created to grant points. Even if the cart is later emptied, the created `coupon_point_id` still exists. After the loyalty card is archived, points are still granted to this existing `coupon_point_id`, allowing it to be used to claim rewards.
To prevent this, we can unlink points from draft sale order when the card is archived.

opw-5166696