### PR TITLE
[FIX] sale_stock, stock: do not ignore route on sale order line

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2402,3 +2402,88 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             {'product_id': self.product_a.id, 'product_uom_qty': 1, 'qty_delivered': 2},
             {'product_id': self.new_product.id, 'product_uom_qty': 0, 'qty_delivered': 3},
         ])
+
+    def test_sale_line_route_overrides_product_routes(self):
+        """
+        Test that a route defined on the sale order line takes precedence over
+        product-level routes when selecting the procurement rule.
+        """
+        warehouse = self.company_data['default_warehouse']
+        customer_location = self.env.ref('stock.stock_location_customers')
+        transit_location = self.env['stock.location'].create({
+            'name': 'Transit',
+            'usage': 'transit',
+            'location_id': warehouse.view_location_id.id,
+        })
+
+        route_product, route_so = self.env['stock.route'].create([
+            {
+                'name': 'Route set in the product',
+                'warehouse_ids': [Command.link(warehouse.id)],
+                'rule_ids': [
+                    Command.create({
+                        'name': 'Stock to transit',
+                        'action': 'pull',
+                        'location_src_id': warehouse.lot_stock_id.id,
+                        'location_dest_id': transit_location.id,
+                        'picking_type_id': warehouse.int_type_id.id,
+                        'procure_method': 'make_to_stock',
+                    }),
+                    Command.create({
+                        'name': 'Transit to Customer',
+                        'action': 'pull',
+                        'location_src_id': transit_location.id,
+                        'location_dest_id': customer_location.id,
+                        'picking_type_id': warehouse.out_type_id.id,
+                        'procure_method': 'make_to_order',
+                    }),
+                ],
+            },
+            {
+                'name': 'Route set in the SOL',
+                'warehouse_ids': [Command.link(warehouse.id)],
+                'sale_selectable': True,
+                'rule_ids': [
+                    Command.create({
+                        'name': 'Stock to transit',
+                        'action': 'pull',
+                        'location_src_id': warehouse.lot_stock_id.id,
+                        'location_dest_id': transit_location.id,
+                        'picking_type_id': warehouse.int_type_id.id,
+                        'procure_method': 'make_to_stock',
+                    }),
+                    Command.create({
+                        'name': 'Transit to Customer',
+                        'action': 'pull',
+                        'location_src_id': transit_location.id,
+                        'location_dest_id': customer_location.id,
+                        'picking_type_id': warehouse.out_type_id.id,
+                        'procure_method': 'make_to_order',
+                    }),
+                ],
+            },
+        ])
+
+        product = self.env['product.product'].create({
+            'name': 'SuperProduct',
+            'is_storable': True,
+            'route_ids': [route_product.id],
+        })
+
+        so = self.env['sale.order'].create([
+            {
+                'partner_id': self.partner_a.id,
+                'order_line': [Command.create(
+                    {
+                        'name': product.name,
+                        'product_id': product.id,
+                        'product_uom_qty': 8.0,
+                        'price_unit': product.list_price,
+                        'route_ids': [route_so.id],
+                    }),
+                ],
+            },
+        ])
+        so.action_confirm()
+
+        self.assertRecordValues(so.picking_ids.move_ids.rule_id, [{'route_id': route_so.id}] * 2)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1671,16 +1671,16 @@ Please change the quantity done or the rounding precision in your settings.""",
 
         product_id = self.product_id.with_context(lang=self._get_lang())
         dates_info = {'date_planned': self._get_mto_procurement_date()}
-        route = []
+        route = self.route_ids
+        if not route:
+            related_packages = self.env['stock.package'].search_fetch([('id', 'parent_of', self.move_line_ids.result_package_id.ids)], ['package_type_id'])
+            route = related_packages.package_type_id.route_ids
         if self.location_id.warehouse_id and self.location_id.warehouse_id.lot_stock_id.parent_path in self.location_id.parent_path:
-            dates_info = self.product_id._get_dates_info(self.date, self.location_id, route_ids=self.route_ids)
+            dates_info = self.product_id._get_dates_info(self.date, self.location_id, route_ids=route)
         warehouse = self.warehouse_id or self.picking_type_id.warehouse_id
         if not self.location_id.warehouse_id:
-            warehouse = self.env['stock.warehouse']
-            route = self.route_ids
-            if not route:
-                related_packages = self.env['stock.package'].search_fetch([('id', 'parent_of', self.move_line_ids.result_package_id.ids)], ['package_type_id'])
-                route = related_packages.package_type_id.route_ids
+            warehouse = self.rule_id.route_id.supplier_wh_id
+
         move_dest_ids = False
         if self.procure_method == "make_to_order":
             move_dest_ids = self

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -364,7 +364,7 @@ class StockRule(models.Model):
             'origin': origin,
             'picking_type_id': self.picking_type_id.id,
             'procurement_values': self._serialize_procurement_values(values),
-            'route_ids': [Command.clear()] + [Command.link(route.id) for route in values.get('route_ids', [])] + [Command.link(self.route_id.id)],
+            'route_ids': [Command.clear()] + [Command.link(route.id) for route in values.get('route_ids', [])],
             'never_product_template_attribute_value_ids': values.get('never_product_template_attribute_value_ids'),
             'warehouse_id': self.warehouse_id.id,
             'date': date_scheduled,


### PR DESCRIPTION
**Issue**
A route explicitly set on a sale order line is ignored: the system falls back to product-level routes.

**Steps to reproduce**
1. Activate multi-route.
2. Unarchive the MTO route.
3. Create a product.
4. Enable MTO + Manufacture on the product.
5. Create a sale order using this product.
6. Set the Buy route on the SO line.
7. Confirm the order.
→ A Manufacturing Order is created instead of a PO.

**Cause**
This regression originates from the changes introduced in https://github.com/odoo-dev/odoo/commit/2713876dbc70d3984e584a9037a2206dcda4e84a, where `propagate_warehouse_id` was removed and associated info began to be propagated
through stock moves instead.

In 19.0, the route of the rule started being injected into the move:
https://github.com/odoo/odoo/blob/af4365421bc7ba990420789c12c98270d723fa1a/addons/stock/models/stock_rule.py#L367

To avoid infinite loops (e.g., WH1 resupplying WH2 and vice-versa), `_prepare_procurement_values` then filters out these injected routes:
https://github.com/odoo/odoo/blob/af4365421bc7ba990420789c12c98270d723fa1a/addons/stock/models/stock_move.py#L1674-L1683

Unfortunately, whenever the `location_id` has a warehouse, the filtering applies to all `route_ids`, including those explicitly set by the user (e.g., on a sale order line)

As soon as `route_ids` is cleared, `_get_rule` stops considering SO-line routes
(first priority):
https://github.com/odoo/odoo/blob/dab7c5821e627bc7120660778a288cb521a223d3/addons/stock/models/stock_rule.py#L599C13-L600C89

and falls back to product routes:
https://github.com/odoo/odoo/blob/dab7c5821e627bc7120660778a288cb521a223d3/addons/stock/models/stock_rule.py#L604

**Solution**
Revert the workaround that injected the rule's `route_id` into the move (added because `propagate_warehouse_id` no longer existed), and instead propagate the warehouse information directly in the inter-company case.

Concretely:
- Stop injecting the rule's `route_id` into the move:
  https://github.com/odoo/odoo/blob/af4365421bc7ba990420789c12c98270d723fa1a/addons/stock/models/stock_rule.py#L367
- Always keep the user's `route_ids` intact, no more filtering.
- Explicitly propagate the warehouse coming from the rule in the inter-company
  case, restoring the intent of `propagate_warehouse_id`:
  https://github.com/odoo/odoo/blob/a7b504a3f5845feff8b676cc02ecf2d7b3489b7f/addons/stock/models/stock_move.py#L1655-L1656

This preserves manually-set routes (such as on SO lines) while still ensuring inter-company transfers work reliably.

opw-5170290