### PR TITLE
[FIX] web: review datetime_picker hover and darkmode

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -56,13 +56,9 @@
     // Utilities
 
     .o_date_item_picker .o_datetime_button {
-        &.o_selected,
-        &:hover,
-        &.o_today:not(.o_selected):hover {
-            &:not(.o_select_start):not(.o_select_end) {
-                background: $o-component-active-bg;
-                color: $o-component-active-color;
-            }
+        &.o_selected:not(.o_select_start, .o_select_end) {
+            background: $o-component-active-bg;
+            color: $o-component-active-color;
         }
     }
 
@@ -73,5 +69,24 @@
 
     .o_date_item_cell {
         aspect-ratio: 1;
+        position: relative;
+
+        &:hover, &:focus {
+            --DateTimePicker__date-cell-border-color-hover: #{$o-component-active-border};
+        }
+
+        &:not([disabled])::before {
+            @include o-position-absolute(0,0,0,0);
+
+            content: '';
+            aspect-ratio: 1;
+            border: $border-width solid var(--DateTimePicker__date-cell-border-color-hover);
+            border-radius: $border-radius-pill;
+            pointer-events: none;
+        }
+    }
+
+    .o_week_number_cell {
+        font-variant: tabular-nums;
     }
 }

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -4,7 +4,7 @@
         <div class="d-flex gap-3">
             <t t-foreach="items" t-as="month" t-key="month.id">
                 <div
-                    class="o_date_picker d-grid flex-grow-1 bg-view rounded overflow-auto"
+                    class="o_date_picker d-grid flex-grow-1 rounded overflow-auto"
                     t-on-pointerleave="() => (state.hoveredDate = null)"
                 >
                     <t t-foreach="month.daysOfWeek" t-as="dayOfWeek" t-key="dayOfWeek[0]">
@@ -18,7 +18,7 @@
                     <t t-foreach="month.weeks" t-as="week" t-key="week.number">
                         <t t-if="props.showWeekNumbers">
                             <div
-                                class="o_week_number_cell d-flex align-items-center ps-2 fw-bolder"
+                                class="o_week_number_cell d-flex justify-content-end align-items-center pe-3 fw-bolder"
                                 t-esc="week.number"
                             />
                         </t>
@@ -58,6 +58,7 @@
                     onChange="(newTime) => this.onTimeChange(0, newTime)"
                     minutesRounding="props.rounding"
                     showSeconds="props.rounding === 0"
+                    inputCssClass="'o_input'"
                 />
                 <i t-if="state.timeValues[0] and state.timeValues[1]" class="fa fa-long-arrow-right"/>
                 <TimePicker
@@ -66,6 +67,7 @@
                     onChange="(newTime) => this.onTimeChange(1, newTime)"
                     minutesRounding="props.rounding"
                     showSeconds="props.rounding === 0"
+                    inputCssClass="'o_input'"
                 />
             </div>
             <t t-slot="buttons" />


### PR DESCRIPTION
The `DateTimePicker` lacks hover and focus states. In darkmode the calendar doesn't have the proper elevation background color and the input border on `TimePicker` is not visible.

task-4900904


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
