### PR TITLE
[FIX] html_editor: have FEFF in inline a.nav-link edition

### DIFF
--- a/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
@@ -9,7 +9,6 @@ export class OdooLinkSelectionPlugin extends Plugin {
                 [link, ...link.querySelectorAll("*")].some(
                     (el) => el.nodeName === "IMG" || isBlock(el)
                 ),
-            (link) => link.matches("a.nav-link"),
         ],
         ineligible_link_for_selection_indication_predicates: (link) => link.matches(".btn"),
     };

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -318,10 +318,19 @@ describe("should zwnbsp-pad simple text link", () => {
     });
 });
 
-test("should not zwnbsp-pad nav-link", async () => {
+test("should not zwnbsp-pad display block link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="http://test.test/" class="nav-link">[]b</a>c</p>',
-        contentBeforeEdit: '<p>a<a href="http://test.test/" class="nav-link">[]b</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/" style="display: block;">[]b</a>c</p>',
+        contentBeforeEdit: '<p>a<a href="http://test.test/" style="display: block;">[]b</a>c</p>',
+    });
+});
+
+test("should zwnbsp-pad inline nav-link", async () => {
+    await testEditor({
+        contentBefore:
+            '<p>a<a href="http://test.test/" class="nav-link" style="display: inline;">[]b</a>c</p>',
+        contentBeforeEdit:
+            '<p>a\ufeff<a href="http://test.test/" class="nav-link o_link_in_selection" style="display: inline;">\ufeff[]b\ufeff</a>\ufeffc</p>',
     });
 });
 


### PR DESCRIPTION
Context:

There was an issue that prevented translating link that was solved in
this commit: d4d428ff1d5be46135973aa806f206a1076bfcf7. While
investigating, it was seen that preventing FEFF in a.nav-link (that was
a component of the issue) seemed to not be useful anymore.

Scenario:

- have <a class="nav-link d-inline"><span id="x">ab</span></a>
- select full link (from first to last letter) in chromium
- type 'c' letter

Result: the link is removed and replaced by "c"

Expectation: as happen in eg. firefox, the link and content is kept,
with just "ab" that is replaced by "c"

Cause:

Because this is a a.nav-link, no FEFF character is added around the
link. And when you select a whole link, chrome removes it which differs
from other browser ([1] here is where it's introduced, [2] is a small
reproducton).

Fix:

The "a.nav-link" exception to added U+FEFF was added because the link
were meant to be edited by a snippet which does not seem to be the case
anymore (see aac752abdf1c7c35b7c856dbfe33c7f0ba56fff7).

Note: this is removing code that seems dead but should have nearly no
effect in normal use case since an a.nav-link is not usually an inline
element, so the U+FEFF will still not be added because of the
"isBlock(el)" check that prevent complex element to receives U+FEFF.

[1] https://chromium.googlesource.com/chromium/src.git/+/742c6a488e68cd9f8d5a5a0ff47c6cb9bf728c60
[2] https://jsfiddle.net/trjxq75e/

opw-5045798
opw-5159026