### PR TITLE
[IMP] website_sale: automatic rating request

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -17,10 +17,10 @@
         'security/res_groups.xml',
 
         # Record data
-        'data/data.xml',
-        'data/digest_data.xml',
-        'data/ir_cron_data.xml',
         'data/mail_template_data.xml',
+        'data/data.xml',  # Needs mail_template_data
+        'data/digest_data.xml',  # Needs mail_template_data
+        'data/ir_cron_data.xml',
         'data/product_ribbon_data.xml',
         'data/tour.xml',
         'data/website_checkout_step_data.xml',

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -25,6 +25,7 @@
         <record model="website" id="website.default_website">
             <field name="salesteam_id" ref="sales_team.salesteam_website_sales"/>
             <field name="salesperson_id" ref="base.user_admin"/>
+            <field name="rating_email_template_id" ref="website_sale.mail_template_sale_order_rating"/>
         </record>
 
         <record id="delivery.free_delivery_carrier" model="delivery.carrier" forcecreate="False">

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -3,6 +3,7 @@
 
         <record model="website" id="website.website2">
             <field name="salesteam_id" ref="sales_team.salesteam_website_sales"/>
+            <field name="rating_email_template_id" ref="website_sale.mail_template_sale_order_rating"/>
         </record>
 
         <record id="product.pa_color" model="product.attribute">

--- a/addons/website_sale/data/ir_cron_data.xml
+++ b/addons/website_sale/data/ir_cron_data.xml
@@ -10,4 +10,12 @@
         <field name="state">code</field>
     </record>
 
+    <record id="ir_cron_send_order_rating_emails" model="ir.cron">
+        <field name="name">eCommerce: send order rating request emails</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="code">model._cron_send_order_rating_emails()</field>
+        <field name="state">code</field>
+    </record>
 </odoo>

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -218,5 +218,71 @@
             </field>
             <field name="auto_delete" eval="False"/>
         </record>
+        <record id="mail_template_sale_order_rating" model="mail.template">
+            <field name="name">Ecommerce: Order Rating Request</field>
+            <field name="model_id" ref="sale.model_sale_order"/>
+            <field name="subject">Review your recent order!</field>
+            <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
+            <field name="partner_to" eval="False"/>
+            <field name="use_default_to" eval="True"/>
+            <field name="description">Sent to customers to request feedback on their order</field>
+            <field name="email_layout_xmlid">mail.mail_notification_light</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <t t-set="secondary_color" t-value="object.company_id.email_secondary_color or '#875A7B'"/>
+                    <t t-set="primary_color" t-value="object.company_id.email_primary_color or '#FFFFFF'"/>
+                    <t
+                        t-if="'website_id' in object and object.website_id"
+                        t-set="logo_src"
+                        t-value="object.website_id.image_url(object.website_id, 'logo')"
+                    />
+                    <t t-else="" t-set="logo_src" t-valuef="/logo.png?company=#{object.company_id.id}"/>
+                    <img t-att-src="logo_src" style="display: block; height: 50px; margin: 0 0 16px;" alt="Logo"/>
+                    <p style="margin: 0 0 12px; padding: 0px; line-height: 18px; font-size: 14px;">
+                        Hello <t t-out="object.partner_id.display_name"/>,
+                        <br/><br/>
+                        Take a minute to rate your order!
+                        <br/>
+                        <t t-if="not is_html_empty(object.user_id.signature)">
+                            <div style="font-size: 14px; margin: 0 0 16px;"><t t-out="object.user_id.signature"/></div>
+                        </t>
+                        <br/>
+                        <t t-foreach="object.order_line.filtered(lambda l: l._is_sellable())" t-as="line">
+                            <t t-set="product" t-value="line.product_id"/>
+                            <table width="100%" t-attf-style="font-size: 14px; border-collapse: collapse; margin-bottom: 10px; max-width: 590px; {{not line_last and 'border-bottom: 1px solid #dee2e6;'}}">
+                                <tr>
+                                    <td style="width: 84px; padding: 10px 10px 10px 0; vertical-align: top;">
+                                        <img
+                                            t-attf-src="/web/image/product.product/{{ product.id }}/image_128"
+                                            t-attf-style="width: 64px; height: {{object.website_id and object.website_id._get_product_image_ratio_height() or '64px'}}; object-fit: cover; object-position: center;"
+                                            alt="Product image"
+                                        />
+                                    </td>
+                                    <td style="padding: 10px 10px 10px 0;">
+                                        <div>
+                                            <h3 t-attf-style="font-size: 14px; margin-bottom: {{line.product_id.product_template_attribute_value_ids and '6px' or '0'}};">
+                                                <strong t-attf-style="color: {{secondary_color}};" t-out="product.name"/>
+                                            </h3>
+                                        </div>
+                                        <div>
+                                            <span t-if="line.product_id.product_template_attribute_value_ids" style="color: #6c757d;">
+                                                <t t-out="', '.join(line.product_id.product_template_attribute_value_ids.mapped('name'))" />
+                                            </span>
+                                        </div>
+                                    </td>
+                                    <td style="padding: 10px 0; text-align: right;">
+                                        <a t-att-href="product.website_absolute_url + '#o_product_page_reviews'" t-attf-style="border-radius: 5px; background-color: {{secondary_color}}; padding: 8px 16px 8px 16px; color: {{primary_color}}; text-decoration: none; font-size:13px; white-space: nowrap;" target="_blank">
+                                            Review Now
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </t>
+                    </p>
+                </div>
+            </field>
+            <field name="report_template_ids" eval="[]"/>
+            <field name="auto_delete" eval="True"/>
+        </record>
     </data>
 </odoo>

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -64,6 +64,13 @@ class ResConfigSettings(models.TransientModel):
     confirmation_email_template_id = fields.Many2one(
         related='website_id.confirmation_email_template_id', readonly=False
     )
+    send_order_rating_emails = fields.Boolean(
+        related='website_id.send_order_rating_emails', readonly=False
+    )
+    rating_email_delay = fields.Integer(related='website_id.rating_email_delay', readonly=False)
+    rating_email_template_id = fields.Many2one(
+        related='website_id.rating_email_template_id', readonly=False
+    )
 
     # Additional settings
     account_on_checkout = fields.Selection(
@@ -117,6 +124,11 @@ class ResConfigSettings(models.TransientModel):
                 )
             ):
                 website._populate_product_feeds()
+        # if Request ratings option is enabled activate Customer Reviews view
+        if self.send_order_rating_emails:
+            view = self.env.ref('website_sale.product_comment', raise_if_not_found=False)
+            if view and not view.active:
+                view.active = True
 
     # === ACTION METHODS === #
 

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -116,6 +116,15 @@ class Website(models.Model):
         compute='_compute_send_abandoned_cart_email_activation_time',
         store=True,
     )
+    send_order_rating_emails = fields.Boolean(string="Request ratings", default=False)
+    rating_email_delay = fields.Integer(string="Days After Order to Send Rating Email", default=5)
+    rating_email_template_id = fields.Many2one(
+        comodel_name='mail.template',
+        domain=[('model', '=', 'sale.order')],
+        default=lambda self: (
+            self.env.ref('website_sale.mail_template_sale_order_rating', raise_if_not_found=False)
+        )
+    )
     shop_page_container = fields.Selection(
         selection=[
             ('regular', "Regular"),

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -235,6 +235,23 @@
                         <button type="object" name="action_open_abandoned_cart_mail_template" string="Customize Abandoned Email Template" class="btn-link" icon="oi-arrow-right"/>
                     </div>
                 </setting>
+                <setting
+                    id="send_order_rating_emails_setting"
+                    help="Send a rating request for each order"
+                >
+                    <field name="send_order_rating_emails"/>
+                    <div invisible="not send_order_rating_emails" class="mt-1">
+                        <field name="rating_email_delay" class="oe_inline" /> days after order confirmation
+                    </div>
+                    <div invisible="not send_order_rating_emails" class="mt-2">
+                        <label
+                            string="Email"
+                            for="rating_email_template_id"
+                            class="o_light_label me-2"
+                        />
+                        <field name="rating_email_template_id" class="oe_inline"/>
+                    </div>
+                </setting>
                 <setting string="Orders Assignment" help="Assignment of online orders">
                     <div class="content-group">
                         <div class="row mt16">


### PR DESCRIPTION
Add a new rating email template and the _get_rating_request_template
method to fetch it. Implement a scheduled cron
_cron_send_order_rating_emails to automatically send
feedback requests for orders confirmed a configurable
number of days ago. Include settings to enable the feature,
set the delay, and select the email template, integrating
these with website configuration. The email sending logic
respects user settings and prevents duplicate emails.

task-5129654
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
