### PR TITLE
[FIX] point_of_sale: fix prices sign in pos_order_line_accounting

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -98,7 +98,7 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
             currency = order.session_id.currency_id
 
             for line in order.lines:
-                if line.price_subtotal_incl >= 0:
+                if not line.order_id.is_refund:
                     products_sold, taxes = self._get_products_and_taxes_dict(line, products_sold, taxes, currency)
                 else:
                     refund_done, refund_taxes = self._get_products_and_taxes_dict(line, refund_done, refund_taxes, currency)
@@ -381,7 +381,8 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
             taxes['taxes'].setdefault(0, {'name': _('No Taxes'), 'tax_amount': 0.0, 'base_amount': 0.0})
             taxes['taxes'][0]['base_amount'] += line.price_subtotal_incl
 
-        taxes['base_amount'] += line.price_subtotal
+        refund_sign = -1 if line.order_id.is_refund else 1
+        taxes['base_amount'] += line.price_subtotal * refund_sign
         return products, taxes
 
     def _get_total_and_qty_per_category(self, categories):

--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -28,14 +28,19 @@
                     </div>
                 </div>
                 <div t-if="props.mode !== 'receipt'" class="order-summary d-flex flex-column gap-1 p-2 border-bottom fw-bolder lh-sm">
-                    <div t-if="order.prices.taxDetails.has_tax_groups" class="tax-info subentry d-flex justify-content-between w-100 fs-6 text-muted ">
+                    <div t-if="this.order.config_id.iface_tax_included != 'total' and order.prices.taxDetails.has_tax_groups" class="tax-info subentry d-flex justify-content-between w-100 fs-6 text-muted">
+                        <span>Subtotal</span>
+                        <span t-esc="order.currencyDisplayPriceExcl" class="subtotal"/>
+                    </div>
+                    <div t-if="order.prices.taxDetails.has_tax_groups" class="tax-info subentry d-flex justify-content-between w-100 fs-6 text-muted">
                         Taxes
                         <div id="order-widget-taxes">
                             <span t-esc="order.currencyAmountTaxes" class="tax"/>
                         </div>
                     </div>
                     <div class="d-flex justify-content-between w-100 fs-3">
-                        Total <span t-esc="order.currencyDisplayPrice" class="total"/>
+                        <span>Total</span>
+                        <span t-esc="order.currencyDisplayPriceIncl" class="total"/>
                     </div>
                 </div>
             </div>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
@@ -9,7 +9,7 @@
             <div class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2">
                 <div class="payment-status-amount d-flex justify-content-between flex-grow-1">
                     <span class="label pe-2" t-out="statusText" />
-                    <span class="amount align-self-end me-5 pe-5" t-att-class="{ 'highlight text-danger fw-bolder': !isComplete }">
+                    <span class="amount align-self-end me-5 pe-5" t-att-amount="amountText" t-att-class="{ 'highlight text-danger fw-bolder': !isComplete }">
                         <PriceFormatter price="amountText" />
                     </span>
                 </div>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -42,7 +42,7 @@
                 <!-- Total -->
                 <div class="pos-receipt-amount receipt-total fw-bolder">
                     <span class="label-total">Total</span>
-                    <span t-out="order.currencyDisplayPrice" class="pos-receipt-right-align font-monospace"/>
+                    <span t-out="order.currencyDisplayPriceIncl" class="pos-receipt-right-align font-monospace"/>
                 </div>
                 <t t-if="order.appliedRounding">
                     <div class="pos-receipt-amount receipt-rounding">

--- a/addons/point_of_sale/static/tests/generic_helpers/order_widget_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/order_widget_util.js
@@ -101,6 +101,20 @@ export function hasTotal(amount) {
         },
     ];
 }
+export function hasSubtotal(amount) {
+    return [
+        {
+            isActive: ["desktop"],
+            content: `order total amount is '${amount}'`,
+            trigger: `.product-screen .order-summary .subtotal:contains("${amount}")`,
+        },
+        {
+            isActive: ["mobile"],
+            content: `order total amount is '${amount}'`,
+            trigger: `.product-screen .order-summary .subtotal:contains("${amount}"):not(:visible)`,
+        },
+    ];
+}
 export function hasTax(amount) {
     return {
         content: `order total tax is '${amount}'`,

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -352,7 +352,8 @@ registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
             Dialog.confirm("Open Register"),
 
             ProductScreen.clickDisplayedProduct("Test Product", true, "1", "100.0"),
-            ProductScreen.totalAmountIs("100.0"), // Order total is also displayed excluding tax
+            ProductScreen.totalAmountIs("110.0"), // Order total is also displayed excluding tax
+            ProductScreen.subtotalAmountIs("100.0"),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -648,6 +648,9 @@ export function searchProduct(string) {
         },
     ];
 }
+export function subtotalAmountIs(amount) {
+    return inLeftSide(...Order.hasSubtotal(amount));
+}
 export function totalAmountIs(amount) {
     return inLeftSide(...Order.hasTotal(amount));
 }

--- a/addons/point_of_sale/static/tests/unit/components/order_summary.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/order_summary.test.js
@@ -1,8 +1,9 @@
-import { test, expect } from "@odoo/hoot";
+import { test, expect, animationFrame } from "@odoo/hoot";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 import { setupPosEnv, getFilledOrder } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
+import { queryAll, queryOne } from "@odoo/hoot-dom";
 
 definePosModels();
 
@@ -14,4 +15,23 @@ test("getNewLine", async () => {
     const newLine = orderSummary.getNewLine();
     expect(newLine.order_id.id).toBe(order.id);
     expect(newLine.qty).toBe(0);
+});
+
+test("Display tax include/exclude subtotal label", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+
+    order.config.iface_tax_included = "total";
+    await mountWithCleanup(OrderSummary, {});
+    const total = queryOne(".total");
+    const subtotal = queryAll(".subtotal");
+    expect(subtotal).toHaveLength(0);
+    expect(total.innerHTML).toBe("$&nbsp;17.85");
+
+    order.config.iface_tax_included = "subtotal";
+    await animationFrame();
+    const total2 = queryOne(".total");
+    const subtotal2 = queryOne(".subtotal");
+    expect(total2.innerHTML).toBe("$&nbsp;17.85");
+    expect(subtotal2.innerHTML).toBe("$&nbsp;15.00");
 });

--- a/addons/point_of_sale/static/tests/unit/components/payment_screen.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/payment_screen.test.js
@@ -1,0 +1,27 @@
+import { test, animationFrame } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv, getFilledOrder, expectFormattedPrice } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+import { queryOne } from "@odoo/hoot-dom";
+import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
+
+definePosModels();
+
+test("Change always incl", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+    const firstPm = store.models["pos.payment.method"].getFirst();
+    order.config.iface_tax_included = "total";
+    const comp = await mountWithCleanup(PaymentScreen, {
+        props: { orderUuid: order.uuid },
+    });
+    await comp.addNewPaymentLine(firstPm);
+    order.payment_ids[0].setAmount(20);
+    await animationFrame();
+    const total = queryOne(".amount");
+    expectFormattedPrice(total.attributes.amount.value, "$ -2.15");
+    order.config.iface_tax_included = "subtotal";
+    await animationFrame();
+    const subtotal = queryOne(".amount");
+    expectFormattedPrice(subtotal.attributes.amount.value, "$ -2.15");
+});

--- a/addons/point_of_sale/static/tests/unit/components/receipt_screen.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/receipt_screen.test.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv, getFilledOrder } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+import { queryOne } from "@odoo/hoot-dom";
+import { ReceiptScreen } from "@point_of_sale/app/screens/receipt_screen/receipt_screen";
+
+definePosModels();
+
+test("Total on receipt always incl", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+    order.config.iface_tax_included = "total";
+    await mountWithCleanup(ReceiptScreen, {
+        props: { orderUuid: order.uuid },
+    });
+    const total = queryOne(".pos-receipt-amount .pos-receipt-right-align");
+    expect(total.innerHTML).toBe("$&nbsp;17.85");
+    order.config.iface_tax_included = "subtotal";
+    const subtotal = queryOne(".pos-receipt-amount .pos-receipt-right-align");
+    expect(subtotal.innerHTML).toBe("$&nbsp;17.85");
+});

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -100,6 +100,7 @@ test("getTotalDiscount", async () => {
     const line2 = order.lines[1];
     line1.setDiscount(20);
     line2.setDiscount(50);
+
     expect(order.getTotalDiscount()).toBe(5.82);
     const taxTotalsWDiscount = order.prices.taxDetails;
     expect(taxTotalsWDiscount.base_amount).toBe(10.2);

--- a/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
@@ -90,7 +90,8 @@ test("[get prices()] with multiple taxes settings", async () => {
     // Test with "include_base_amount" and "include_base_amount" to true for both taxes
     models["account.tax"].get(1).include_base_amount = true;
     models["account.tax"].get(2).include_base_amount = true;
-    const updatedLineTax = data["pos.order.line"][0].prices;
+    orderLine.order_id.triggerRecomputeAllPrices(); // Force the recompute because updating taxes do not trigger it
+    const updatedLineTax = orderLine.prices;
     expect(updatedLineTax.total_excluded).toBe(100.0);
     expect(updatedLineTax.total_included).toBe(143.75);
     expect(updatedLineTax.taxes_data[0].tax_amount).toBe(15.0);
@@ -98,7 +99,7 @@ test("[get prices()] with multiple taxes settings", async () => {
 
     // Test without any taxes
     product.taxes_id = [];
-    data["pos.order.line"][0].tax_ids = [];
+    orderLine.tax_ids = []; // Do not need to force the recompute here, changing line taxes does it for us
     const noTaxLine = data["pos.order.line"][0].prices;
     expect(noTaxLine.total_excluded).toBe(100.0);
     expect(noTaxLine.total_included).toBe(100.0);

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -435,5 +435,38 @@ describe("pos_store.js", () => {
             expect.verifySteps([`Company logo ${companyId} fetched`]);
             expect(store.config.receiptLogoUrl).toInclude(getCompanyLogo256Url(companyId));
         });
+
+        test("preSyncAllOrders", async () => {
+            // This test check prices sign on preSyncAllOrders for refunds
+            const store = await setupPosEnv();
+            const order = await getFilledOrder(store);
+
+            await store.preSyncAllOrders([order]);
+            expect(order.amount_total).toEqual(17.85);
+            expect(order.amount_tax).toEqual(2.85);
+            expect(order.lines[0].qty).toEqual(3);
+            expect(order.lines[0].price_unit).toEqual(3);
+            expect(order.lines[0].price_subtotal).toEqual(3);
+            expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
+            expect(order.lines[1].qty).toEqual(2);
+            expect(order.lines[1].price_unit).toEqual(3);
+            expect(order.lines[1].price_subtotal).toEqual(3);
+            expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
+
+            order.is_refund = true;
+            order.lines.forEach((line) => (line.qty = -line.qty));
+            await store.preSyncAllOrders([order]);
+
+            expect(order.amount_total).toEqual(-17.85);
+            expect(order.amount_tax).toEqual(-2.85);
+            expect(order.lines[0].qty).toEqual(-3);
+            expect(order.lines[0].price_unit).toEqual(3);
+            expect(order.lines[0].price_subtotal).toEqual(3);
+            expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
+            expect(order.lines[1].qty).toEqual(-2);
+            expect(order.lines[1].price_unit).toEqual(3);
+            expect(order.lines[1].price_subtotal).toEqual(3);
+            expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
+        });
     });
 });

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,4 +1,4 @@
-import { useState, onWillRender } from "@odoo/owl";
+import { useState } from "@odoo/owl";
 import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { TextInputPopup } from "@point_of_sale/app/components/popups/text_input_popup/text_input_popup";
@@ -12,10 +12,6 @@ patch(ControlButtons.prototype, {
         super.setup(...arguments);
         this.state = useState({
             nbrRewards: [],
-        });
-
-        onWillRender(() => {
-            this.state.nbrRewards = this.getPotentialRewards().length;
         });
     },
     _getEWalletRewards(order) {


### PR DESCRIPTION
Before this commit, the prices in the pos_order_line_accounting model
were taking into account the order sign 2 times, leading to incorrect
display of prices in accounting reports.

This commit fixes the issue by removing the redundant sign application,
ensuring that prices are displayed correctly according to the order type

---

From a performance standpoint, the `get prices` getter has been removed
because it was being called too often. We now calculate prices globally,
which requires calculating all order lines at the same time.

When refreshing the interface, each line called the getter, which caused
slowdowns when many lines were added to the order.

Now, the price is recalculated and cached on the order when a line is
modified or added.