### PR TITLE
[IMP] mail: custom notification subtypes

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -185,7 +185,11 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                     },
                 ),
                 "mail.message.subtype": [
-                    {"description": False, "id": self.env.ref("mail.mt_note").id}
+                    {
+                        "description": False,
+                        "id": self.env.ref("mail.mt_note").id,
+                        "field_tracked": False,
+                    }
                 ],
                 "mail.thread": self._filter_threads_fields(
                     {
@@ -294,7 +298,11 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                     },
                                 ),
                                 "mail.message.subtype": [
-                                    {"description": False, "id": self.env.ref("mail.mt_comment").id}
+                                    {
+                                        "description": False,
+                                        "id": self.env.ref("mail.mt_comment").id,
+                                        "field_tracked": False,
+                                    }
                                 ],
                                 "mail.thread": self._filter_threads_fields(
                                     {

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -65,6 +65,7 @@ For more specific needs, you may also assign custom-defined actions
         'wizard/mail_activity_schedule_views.xml',
         'wizard/mail_blacklist_remove_views.xml',
         'wizard/mail_compose_message_views.xml',
+        'wizard/mail_custom_message_subtype_views.xml',
         'wizard/mail_template_preview_views.xml',
         'wizard/mail_followers_edit_views.xml',
         'wizard/mail_template_reset_views.xml',

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -126,8 +126,11 @@ class ThreadController(http.Controller):
         record = request.env[follower.res_model].browse(follower.res_id)
         record.check_access("read")
         # find current model subtypes, add them to a dictionary
-        subtypes = record._mail_get_message_subtypes()
-        store = Store().add(subtypes, ["name"]).add(follower, ["subtype_ids"])
+        subtypes = record._mail_get_message_subtypes(target=follower.partner_id)
+        store = Store().add(subtypes, [
+            "name",
+            "field_tracked",
+        ]).add(follower, ["subtype_ids"])
         return {
             "store_data": store.get_result(),
             "subtype_ids": subtypes.sorted(

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1092,7 +1092,7 @@ class MailMessage(models.Model):
             Store.Many("ended_poll_ids", predicate=lambda m: m.message_type == "mail_poll", sudo=True),
             "subject",
             # sudo: mail.message.subtype - reading subtype on accessible message is allowed
-            Store.One("subtype_id", ["description"], sudo=True),
+            Store.One("subtype_id", ["description", "field_tracked"], sudo=True),
             "write_date",
             *self._get_store_linked_messages_fields(),
             *self._get_store_message_link_previews_fields(),

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -33,7 +33,7 @@ access_mail_gateway_allowed_system,mail.gateway.allowed.system,model_mail_gatewa
 access_mail_message_reaction_system,mail.message.reaction.system,model_mail_message_reaction,base.group_system,1,1,1,1
 access_mail_message_subtype_public,mail.message.subtype.all,model_mail_message_subtype,base.group_public,1,0,0,0
 access_mail_message_subtype_portal,mail.message.subtype.all,model_mail_message_subtype,base.group_portal,1,0,0,0
-access_mail_message_subtype_user,mail.message.subtype.user,model_mail_message_subtype,base.group_user,1,0,0,0
+access_mail_message_subtype_user,mail.message.subtype.user,model_mail_message_subtype,base.group_user,1,1,1,1
 access_mail_message_subtype_system,mail.message.subtype.system,model_mail_message_subtype,base.group_system,1,1,1,1
 access_mail_presence,mail.presence,model_mail_presence,base.group_system,1,1,1,1
 access_mail_tracking_value_system,mail.tracking.value.system,model_mail_tracking_value,base.group_system,1,1,1,1
@@ -73,3 +73,4 @@ access_mail_scheduled_message,access.mail.scheduled.message,model_mail_scheduled
 access_mail_poll_erp_manager,access.mail.poll.erp_manager,model_mail_poll,base.group_erp_manager,1,1,1,1
 access_mail_poll_option_erp_manager,access.mail.poll.option.erp_manager,model_mail_poll_option,base.group_erp_manager,1,1,1,1
 access_mail_poll_vote_erp_manager,access.mail.poll.vote.erp_manager,model_mail_poll_vote,base.group_erp_manager,1,1,1,1
+access_mail_custom_message_subtype,access_mail_custom_message_subtype,model_mail_custom_message_subtype,base.group_user,1,1,1,0

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -236,7 +236,27 @@
             <field name="domain_force">[('internal', '=', False)]</field>
             <field name="groups" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
         </record>
-
+        <record id="mail_message_subtype_rule_admin" model="ir.rule">
+            <field name="name">mail.message.subtype: admin: read/update all subtypes</field>
+            <field name="model_id" ref="model_mail_message_subtype"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+        <record id="mail_message_subtype_rule_user" model="ir.rule">
+            <field name="name">mail.message.subtype: user: read/update all subtypes related to user</field>
+            <field name="model_id" ref="model_mail_message_subtype"/>
+            <field name="domain_force">['&amp;', ('user_ids', 'in', user.id), ('field_tracked', '!=', False)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+        </record>
+        <record id="mail_message_subtype_rule_user_non_linked" model="ir.rule">
+            <field name="name">mail.message.subtype: user: read all subtypes non-related to user</field>
+            <field name="model_id" ref="model_mail_message_subtype"/>
+            <field name="domain_force">[('user_ids', 'not in', user.id)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
         <record id="mail_activity_rule_user" model="ir.rule">
             <field name="name">mail.activity: user: write/unlink only (created or assigned)</field>
             <field name="model_id" ref="model_mail_activity"/>
@@ -349,6 +369,15 @@
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record id="mail_custom_message_subtype_rule" model="ir.rule">
+            <field name="name">Mail Custom Message Subtype Rule</field>
+            <field name="model_id" ref="model_mail_custom_message_subtype"/>
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
             <field name="perm_unlink" eval="False"/>
         </record>
 </odoo>

--- a/addons/mail/static/src/core/common/mail_message_subtype_model.js
+++ b/addons/mail/static/src/core/common/mail_message_subtype_model.js
@@ -1,4 +1,5 @@
 import { Record } from "@mail/model/record";
+import { fields } from "./record";
 
 export class MailMessageSubtype extends Record {
     static id = "id";
@@ -6,9 +7,22 @@ export class MailMessageSubtype extends Record {
 
     /** @type {string} */
     description;
+    /** @type {string} */
+    domain;
     /** @type {number} */
     id;
     /** @type {string} */
     name;
+
+    is_custom = fields.Attr(false, {
+        compute() {
+            return this.field_tracked && this.field_tracked !== "";
+        },
+    });
+    /** @type {string} */
+    field_tracked;
+    user_ids = fields.Many("res.users");
+    /** @type {string} */
+    value_update;
 }
 MailMessageSubtype.register();

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -294,7 +294,10 @@ export class Message extends Record {
     }
 
     get isNotification() {
-        return this.message_type === "notification" && this.thread?.model === "discuss.channel";
+        return (
+            this.message_type === "notification" &&
+            (this.thread?.model === "discuss.channel" || this.subtype_id?.is_custom)
+        );
     }
 
     get isSubjectSimilarToThreadName() {
@@ -389,7 +392,7 @@ export class Message extends Record {
     }
 
     get notificationHidden() {
-        return false;
+        return this.subtype_id?.is_custom;
     }
 
     inlineBody = fields.Html("", {

--- a/addons/mail/static/src/core/web/follower_subtype_dialog.xml
+++ b/addons/mail/static/src/core/web/follower_subtype_dialog.xml
@@ -3,18 +3,32 @@
     <t t-name="mail.FollowerSubtypeDialog">
         <Dialog t-if="props.follower.partner_id" bodyClass="'d-flex flex-column'" contentClass="'o-mail-FollowerSubtypeDialog'" size="'sm'" title="title">
             <t t-set-slot="default">
-                <div
-                    t-foreach="state.subtypes"
-                    t-as="subtype"
-                    t-key="subtype.id"
-                    class="o-mail-FollowerSubtypeDialog-subtype"
-                    t-att-data-follower-subtype-id="subtype.id"
-                >
-                    <label class="flex-grow-1 align-items-center d-flex mb-0 p-2 cursor-pointer">
-                        <input class="form-check-input me-2" type="checkbox" t-att-checked="subtype.in(this.props.follower.subtype_ids) ? 'checked': ''" t-on-change="(ev) => this.onChangeCheckbox(ev, subtype)"/>
-                        <t t-esc="subtype.name"/>
-                    </label>
+                <div class="overflow-auto d-flex flex-column flex-grow-1">
+                    <div
+                        t-foreach="state.subtypes"
+                        t-as="subtype"
+                        t-key="subtype.id"
+                        class="o-mail-FollowerSubtypeDialog-subtype"
+                        t-att-data-follower-subtype-id="subtype.id"
+                    >
+                        <label class="flex-grow-1 align-items-center d-flex mb-0 p-2 cursor-pointer">
+                            <input class="form-check-input me-2" type="checkbox" t-att-checked="subtype.in(this.props.follower.subtype_ids) ? 'checked': ''" t-on-change="(ev) => this.onChangeCheckbox(ev, subtype)"/>
+                            <span class="d-flex flex-grow-1">
+                                <t t-esc="subtype.name"/>
+                            </span>
+                            <span
+                                class="me-1"
+                                title="Edit custom notification"
+                                t-if="subtype.field_tracked"
+                                t-on-click.stop="() => this.editCustomSubtype(subtype)">
+                                <i class="fa fa-fw fa-pencil" />
+                            </span>
+                        </label>
+                    </div>
                 </div>
+                <button t-if="isForSelf" t-on-click="addCustomSubtype" class="btn btn-link d-flex flex-shrink-0 align-items-center mt-2">
+                    <i class="fa fa-plus fa-fw" />Add Notification
+                </button>
             </t>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="onClickApply">

--- a/addons/mail/static/src/views/web/fields/dynamic_domain.js
+++ b/addons/mail/static/src/views/web/fields/dynamic_domain.js
@@ -1,0 +1,18 @@
+import { domainField } from "@web/views/fields/domain/domain_field";
+import { registry } from "@web/core/registry";
+
+registry.category("fields").add("dynamic_domain", {
+    ...domainField,
+    extractProps({ options }, dynamicInfo) {
+        const context = dynamicInfo.context || {};
+        return {
+            editInDialog: options.in_dialog || context.default_dynamic_domain_in_dialog,
+            isFoldable: options.foldable || context.default_dynamic_domain_foldable,
+            allowExpressions:
+                options.allow_expressions || context.default_dynamic_domain_allow_expressions,
+            resModel: options.model || context.default_dynamic_domain_model,
+            countLimit: options.count_limit || context.default_dynamic_domain_count_limit,
+            context: dynamicInfo.context,
+        };
+    },
+});

--- a/addons/mail/static/src/views/web/fields/mail_field_selector.js
+++ b/addons/mail/static/src/views/web/fields/mail_field_selector.js
@@ -1,0 +1,56 @@
+import { onWillStart } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import {
+    fieldSelectorField,
+    FieldSelectorField,
+} from "@web/views/fields/field_selector/field_selector_field";
+
+export class MailFieldSelectorField extends fieldSelectorField.component {
+    static props = {
+        ...FieldSelectorField.props,
+        onlyTracking: { type: Boolean, optional: true },
+    };
+    setup() {
+        super.setup();
+        this.fieldService = useService("field");
+        onWillStart(async () => {
+            const fields = await this.fieldService.loadFields(this.resModel, {
+                attributes: ["tracking"],
+            });
+            this.tracking_fields_name = Object.entries(fields)
+                .filter(([, finfo]) => finfo.tracking)
+                .map(([name]) => name);
+        });
+    }
+
+    filter(fieldDef) {
+        if (this.props.onlyTracking && !this.tracking_fields_name.includes(fieldDef.name)) {
+            return false;
+        }
+        return super.filter(fieldDef);
+    }
+}
+
+export const mailFieldSelectorField = {
+    ...fieldSelectorField,
+    component: MailFieldSelectorField,
+    supportedOptions: [
+        ...fieldSelectorField.supportedOptions,
+        {
+            label: _t("Only tracking"),
+            name: "only_tracking",
+            type: "boolean",
+            default: false,
+        },
+    ],
+    extractProps({ options }, dynamicInfo) {
+        return {
+            ...fieldSelectorField.extractProps({ options }, dynamicInfo),
+            onlyTracking: options.only_tracking ?? false,
+        };
+    },
+};
+
+registry.category("fields").add("mail_field_selector", mailFieldSelectorField);

--- a/addons/mail/static/src/views/web/fields/mail_field_selector_value.js
+++ b/addons/mail/static/src/views/web/fields/mail_field_selector_value.js
@@ -1,0 +1,174 @@
+import { Component, useEffect, useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { getValueEditorInfo } from "@web/core/tree_editor/tree_editor_value_editors";
+import { getOperatorEditorInfo } from "@web/core/tree_editor/tree_editor_operator_editor";
+import { Select } from "@web/core/tree_editor/tree_editor_components";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export class MailSelect extends Select {
+    static template = "mail.MailSelect";
+}
+
+function parseValue(fieldType, value) {
+    if (fieldType !== "boolean" && !value) {
+        return value;
+    }
+    switch (fieldType) {
+        case "many2one":
+        case "integer":
+            return parseInt(value, 10);
+        case "float":
+        case "monetary":
+            return parseFloat(value);
+        case "boolean":
+            if (value === "True") {
+                return "set";
+            }
+            return "not set";
+        default:
+            return value;
+    }
+}
+
+export class MailFieldSelectorValueField extends Component {
+    static props = {
+        ...standardFieldProps,
+        resModel: { type: String, required: true },
+        valueField: { type: String, required: true },
+        acceptedTypes: { type: Array, of: String, optional: true },
+    };
+    static template = "mail.MailFieldSelectorValueField";
+    setup() {
+        this.fieldService = useService("field");
+        this.state = useState({
+            field: undefined,
+            value: false,
+            previousValueField: this.valueField,
+        });
+        this.loadField().then(() => {
+            this.state.value =
+                this.value !== undefined && this.state.field
+                    ? parseValue(this.state.field.type, this.value)
+                    : false;
+        });
+        useEffect(
+            () => {
+                if (this.state.previousValueField === this.valueField) {
+                    return;
+                }
+                this.state.previousValueField = this.valueField;
+                this.state.value = false;
+                this.loadField().then(() => {
+                    this.state.value = parseValue(this.state.field?.type, this.state.value);
+                });
+            },
+            () => [this.valueField]
+        );
+    }
+
+    async loadField() {
+        if (!this.valueField) {
+            return;
+        }
+        const fieldsInfo = await this.fieldService.loadFields(this.resModel, {
+            fieldNames: [this.valueField],
+        });
+        this.state.field = fieldsInfo[this.valueField];
+    }
+
+    updateValue(value) {
+        let valueRecord = value;
+        if (this.state.field?.type === "boolean") {
+            valueRecord = "set" === value ? true : false;
+        }
+        this.props.record.update({ [this.props.name]: valueRecord });
+        this.state.value = value;
+    }
+
+    get value() {
+        return this.props.record.data[this.props.name];
+    }
+
+    get unsupportedTypesMessage() {
+        return _t("The field type is not supported for %s.", this.props.name);
+    }
+
+    get field() {
+        if (!this.state.field) {
+            return undefined;
+        }
+        let field;
+        if (this.state.field.type === "boolean") {
+            field = getOperatorEditorInfo(["set", "not set"], this.state.field);
+        } else {
+            field = getValueEditorInfo(this.state.field, "=");
+        }
+        if (field.component === Select) {
+            field.component = MailSelect;
+        }
+        return field;
+    }
+
+    get fieldComponentProps() {
+        const tmp = {
+            ...this.field?.extractProps({
+                value: this.state.field?.type === "boolean" ? [this.state.value] : this.state.value,
+                update: this.updateValue.bind(this),
+            }),
+            ...(this.state.field?.type !== "many2one" ? { addBlankOption: true } : {}),
+        };
+        return tmp;
+    }
+
+    get acceptedType() {
+        return (
+            this.state.field &&
+            (this.props.acceptedTypes.length === 0 ||
+                this.props.acceptedTypes.includes(this.state.field.type))
+        );
+    }
+
+    get resModel() {
+        return this.props.record.data[this.props.resModel];
+    }
+
+    get valueField() {
+        return this.props.record.data[this.props.valueField];
+    }
+}
+
+export const mailFieldSelectorValueField = {
+    component: MailFieldSelectorValueField,
+    displayName: _t("Mail Field Selector Value"),
+    supportedTypes: ["char"],
+    supportedOptions: [
+        {
+            label: _t("Model"),
+            name: "model",
+            type: "string",
+            required: true,
+        },
+        {
+            label: _t("Value field"),
+            name: "value",
+            type: "string",
+            required: true,
+        },
+        {
+            label: _t("Accepted field types"),
+            name: "accepted_types",
+            type: "string[]",
+        },
+    ],
+    extractProps({ options }) {
+        return {
+            resModel: options.model,
+            valueField: options.value,
+            acceptedTypes: options.accepted_types || [],
+        };
+    },
+};
+
+registry.category("fields").add("mail_field_selector_value", mailFieldSelectorValueField);

--- a/addons/mail/static/src/views/web/fields/mail_field_selector_value.xml
+++ b/addons/mail/static/src/views/web/fields/mail_field_selector_value.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.MailFieldSelectorValueField">
+        <t t-component="field.component" t-props="fieldComponentProps" t-if="acceptedType and field"/>
+        <t t-else="" t-esc="unsupportedTypesMessage"/>
+    </t>
+    <t t-name="mail.MailSelect" t-inherit="web.TreeEditor.Select">
+        <xpath expr="//t[@t-foreach='props.options']" position="replace">
+            <t t-foreach="props.options" t-as="option" t-key="serialize(option[0])">
+                <option class="text-black o_mail" t-att-value="serialize(option[0])" t-att-selected="option[0] === props.value" t-esc="option[1]" />
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/tests/chatter/web/follower_subtype.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_subtype.test.js
@@ -36,6 +36,7 @@ test("simplest layout of a followed subtype", async () => {
     await contains(
         `.o-mail-FollowerSubtypeDialog-subtype[data-follower-subtype-id='${subtypeId}'] input[type='checkbox']:checked`
     );
+    await contains(`button.btn-link`, { text: "Add Notification" });
 });
 
 test("simplest layout of a not followed subtype", async () => {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -54,6 +54,7 @@ import { MailActivitySchedule } from "./mock_server/mock_models/mail_activity_sc
 import { MailActivityType } from "./mock_server/mock_models/mail_activity_type";
 import { MailCannedResponse } from "./mock_server/mock_models/mail_canned_response";
 import { MailComposeMessage } from "./mock_server/mock_models/mail_composer_message";
+import { MailCustomMessageSubtype } from "./mock_server/mock_models/mail_custom_message_subtype";
 import { MailFollowers } from "./mock_server/mock_models/mail_followers";
 import { MailGuest } from "./mock_server/mock_models/mail_guest";
 import { MailLinkPreview } from "./mock_server/mock_models/mail_link_preview";
@@ -124,6 +125,7 @@ export const mailModels = {
     MailActivitySchedule,
     MailActivityType,
     MailComposeMessage,
+    MailCustomMessageSubtype,
     MailCannedResponse,
     MailFollowers,
     MailGuest,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_custom_message_subtype.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_custom_message_subtype.js
@@ -1,0 +1,36 @@
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+
+import { models, fields, Command, makeKwArgs } from "@web/../tests/web_test_helpers";
+
+export class MailCustomMessageSubtype extends models.Model {
+    _name = "mail.custom.message.subtype";
+
+    model = fields.Char();
+    name = fields.Char({ required: true });
+    field_tracked = fields.Char({ string: "Tracked Field", required: true });
+    value_update = fields.Char();
+    domain = fields.Char();
+    default = fields.Boolean({ string: "Default Notification", default: true });
+
+    create_subtype_with_options() {
+        const subtype = this.env["mail.message.subtype"].create({
+            name: this.name,
+            description: this.name,
+            field_tracked: this.field_tracked,
+            value_update: this.value_update,
+            domain: this.domain,
+            default: this.default,
+            user_ids: [Command.link(this.env.user.id)],
+        });
+        return {
+            type: "ir.actions.act_window_close",
+            infos: {
+                store_data: new mailDataHelpers.Store(
+                    this.browse(subtype.id),
+                    makeKwArgs({ fields: ["name", "field_tracked"] })
+                ).get_result(),
+                subtype_id: subtype.id,
+            },
+        };
+    }
+}

--- a/addons/mail/static/tests/widgets/dynamic_domain.test.js
+++ b/addons/mail/static/tests/widgets/dynamic_domain.test.js
@@ -1,0 +1,31 @@
+import {
+    click,
+    contains,
+    openFormView,
+    start,
+    defineMailModels,
+} from "@mail/../tests/mail_test_helpers";
+import { test } from "@odoo/hoot";
+import { defineModels } from "@web/../tests/web_test_helpers";
+import { TestTrackModel, TestTrackOtherModel } from "./field_selector_helper";
+
+defineMailModels();
+defineModels([TestTrackModel, TestTrackOtherModel]);
+
+test("Dynamic domain takes context into account", async () => {
+    await start();
+    await openFormView("mail.message.subtype", false, {
+        arch: `<form>
+            <field name="res_model" invisible="1"/>
+            <field name="domain" widget="dynamic_domain" context="{'default_dynamic_domain_model': res_model}"/>
+        </form>`,
+        context: { default_res_model: "test.track.model" },
+    });
+    await click("a", { text: "New Rule" });
+    await click(".o_model_field_selector_value");
+    await contains(".o_model_field_selector_popover_item", { count: 10 });
+    await click("button", { text: "Selection" });
+    await contains("option", { text: "Option 1" });
+    await contains("option", { text: "Option 2" });
+    await contains("option", { text: "Option 3" });
+});

--- a/addons/mail/static/tests/widgets/field_selector_helper.js
+++ b/addons/mail/static/tests/widgets/field_selector_helper.js
@@ -1,0 +1,30 @@
+import { fields, models } from "@web/../tests/web_test_helpers";
+
+export class TestTrackModel extends models.Model {
+    _name = "test.track.model";
+
+    char = fields.Char({ tracking: true });
+    many2one = fields.Many2one({ relation: "test.track.other.model", tracking: true });
+    boolean = fields.Boolean({ tracking: true });
+    selection = fields.Selection({
+        selection: [
+            ["option_1", "Option 1"],
+            ["option_2", "Option 2"],
+            ["option_3", "Option 3"],
+        ],
+        tracking: true,
+    });
+    integer = fields.Integer({ tracking: true });
+    float = fields.Float({ tracking: true });
+}
+
+export class TestTrackOtherModel extends models.Model {
+    _name = "test.track.other.model";
+
+    name = fields.Char();
+
+    _records = [
+        { id: 1, name: "Other 1" },
+        { id: 2, name: "Other 2" },
+    ];
+}

--- a/addons/mail/static/tests/widgets/mail_field_selector_value_widget.test.js
+++ b/addons/mail/static/tests/widgets/mail_field_selector_value_widget.test.js
@@ -1,0 +1,53 @@
+import {
+    click,
+    contains,
+    openFormView,
+    start,
+    defineMailModels,
+} from "@mail/../tests/mail_test_helpers";
+import { test } from "@odoo/hoot";
+import { defineModels } from "@web/../tests/web_test_helpers";
+import { TestTrackModel, TestTrackOtherModel } from "./field_selector_helper";
+
+defineMailModels();
+defineModels([TestTrackModel, TestTrackOtherModel]);
+
+test("mail field selector value changes with the selected field type", async () => {
+    await start();
+    await openFormView("mail.message.subtype", false, {
+        arch: `<form>
+            <field name="res_model" invisible="1"/>
+            <field name="field_tracked" widget="mail_field_selector" options="{'model': 'res_model', 'only_tracking': True, 'follow_relations': False}" />
+            <field name="value_update" widget="mail_field_selector_value" options="{'model': 'res_model', 'value': 'field_tracked', 'accepted_types': ['boolean', 'many2one', 'selection']}"/>
+        </form>`,
+        context: { default_res_model: "test.track.model" },
+    });
+    async function clickSelectorAndChooseField(fieldName, options = {}) {
+        await click(`div[name='field_tracked'].o_field_widget .o_model_field_selector`);
+        await click(".o_model_field_selector_popover_item button", { text: fieldName });
+        await contains("div[name='field_tracked'].o_field_widget", { text: fieldName });
+        if (options.isNotSupported) {
+            await contains("div[name='value_update'].o_field_widget", {
+                text: "The field type is not supported for value_update.",
+            });
+        }
+    }
+
+    await clickSelectorAndChooseField("Char", { isNotSupported: true });
+    await clickSelectorAndChooseField("Integer", { isNotSupported: true });
+    await clickSelectorAndChooseField("Float", { isNotSupported: true });
+    await clickSelectorAndChooseField("Many2one");
+    await click("div[name='value_update'].o_field_widget input");
+    await contains(".o-autocomplete--dropdown-item", { text: "Other 1" });
+    await contains(".o-autocomplete--dropdown-item", { text: "Other 2" });
+    await contains(".o-autocomplete--dropdown-item", { count: 2 });
+    await clickSelectorAndChooseField("Selection");
+    await contains("div[name='value_update'] option", { text: "Option 1" });
+    await contains("div[name='value_update'] option", { text: "Option 2" });
+    await contains("div[name='value_update'] option", { text: "Option 3" });
+    await contains("div[name='value_update'] option", { count: 4 }); // including the empty option
+    await clickSelectorAndChooseField("Boolean");
+    await contains("div[name='value_update'] option", { text: "is set" });
+    await contains("div[name='value_update'] option", { text: "is not set" });
+    await contains("div[name='value_update'] option", { count: 3 }); // including the empty option
+});

--- a/addons/mail/static/tests/widgets/mail_field_selector_widget.test.js
+++ b/addons/mail/static/tests/widgets/mail_field_selector_widget.test.js
@@ -1,0 +1,29 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    openFormView,
+    start,
+} from "@mail/../tests/mail_test_helpers";
+import { test } from "@odoo/hoot";
+import { defineModels } from "@web/../tests/web_test_helpers";
+import { TestTrackModel, TestTrackOtherModel } from "./field_selector_helper";
+
+defineMailModels();
+defineModels([TestTrackModel, TestTrackOtherModel]);
+
+test("mail field selector takes the given model and opens a popup with the tracking fields", async () => {
+    await start();
+    await openFormView("mail.message.subtype", false, {
+        arch: `<form>
+            <field name="res_model" invisible="1"/>
+            <field name="field_tracked" widget="mail_field_selector" options="{'model': 'res_model', 'only_tracking': True, 'follow_relations': False}"/>
+        </form>`,
+        context: { default_res_model: "test.track.model" },
+    });
+    await click("div[name='field_tracked'].o_field_widget .o_model_field_selector");
+    await contains(".o_model_field_selector_popover_item", { text: "Boolean" });
+    await contains(".o_model_field_selector_popover_item", { count: 6 });
+    await click(".o_model_field_selector_popover_item button", { text: "Boolean" });
+    await contains("div[name='field_tracked'].o_field_widget", { text: "Boolean" });
+});

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -116,7 +116,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         "write_date": fields.Datetime.to_string(message.write_date),
                                     },
                                 ),
-                                "mail.message.subtype": [{"description": False, "id": self.env.ref("mail.mt_comment").id}],
+                                "mail.message.subtype": [{
+                                    "description": False,
+                                    "id": self.env.ref("mail.mt_comment").id,
+                                    "field_tracked": False,
+                                }],
                                 "mail.thread": self._filter_threads_fields(
                                     {
                                         "display_name": "Group",

--- a/addons/mail/views/mail_message_subtype_views.xml
+++ b/addons/mail/views/mail_message_subtype_views.xml
@@ -21,6 +21,8 @@
             <field name="model">mail.message.subtype</field>
             <field name="arch" type="xml">
                 <form string="Email message">
+                    <field name="is_custom" invisible="1"/>
+                    <field name="user_ids" invisible="1"/>
                     <sheet>
                         <group>
                             <group string='Description'>
@@ -36,6 +38,12 @@
                             <group string='Auto subscription'>
                                 <field name="parent_id"/>
                                 <field name="relation_field"/>
+                            </group>
+                            <group string="custom notifications" invisible="not is_custom and not user_ids">
+                                <field name="field_tracked" widget="mail_field_selector" options="{'model': 'res_model', 'only_tracking': True, 'follow_relations': False}" required="1" groups="!base.group_system"/>
+                                <field name="field_tracked" widget="mail_field_selector" options="{'model': 'res_model', 'only_tracking': True, 'follow_relations': False}" optional="1" groups="base.group_system"/>
+                                <field name="value_update" widget="mail_field_selector_value" options="{'model': 'res_model', 'value': 'field_tracked', 'accepted_types': ['boolean', 'many2one', 'selection']}"/>
+                                <field name="domain" widget="dynamic_domain" context="{'default_dynamic_domain_model': res_model}"/>
                             </group>
                         </group>
                     </sheet>

--- a/addons/mail/wizard/__init__.py
+++ b/addons/mail/wizard/__init__.py
@@ -5,6 +5,7 @@ from . import base_module_uninstall
 from . import base_partner_merge_automatic_wizard
 from . import mail_blacklist_remove
 from . import mail_compose_message
+from . import mail_custom_message_subtype
 from . import mail_activity_schedule
 from . import mail_activity_schedule_summary
 from . import mail_template_preview

--- a/addons/mail/wizard/mail_custom_message_subtype.py
+++ b/addons/mail/wizard/mail_custom_message_subtype.py
@@ -1,0 +1,47 @@
+from odoo import fields, models
+from odoo.addons.mail.tools.discuss import Store
+from odoo.fields import Command
+
+
+class MailCustomMessageSubtype(models.TransientModel):
+    _name = "mail.custom.message.subtype"
+    _description = "Custom Message Subtype"
+
+    model = fields.Char()
+    name = fields.Char(required=True, help="The name of the notification message")
+    field_tracked = fields.Char(required=True, help="Get notified when this field is updated")
+    value_update = fields.Char(
+        help="The notification will be sent only if the tracked field changes "
+        "to the selected value. If no value is selected, "
+        "it will be sent for all updates."
+    )
+    domain = fields.Char(
+        help="The notification will be sent only for records that match the selected domain."
+    )
+    default = fields.Boolean(
+        string="Default Notification",
+        default=True,
+        help="Choose whether you want to be notified by default on all records you're following or "
+        "if you prefer to manually subscribe to this notification.",
+    )
+
+    def create_subtype_with_options(self):
+        """Save custom message subtype and return its ID."""
+        subtype = self.env["mail.message.subtype"].create(
+            {
+                "name": self.name,
+                "description": self.name,
+                "default": self.default,
+                "field_tracked": self.field_tracked,
+                "value_update": self.value_update,
+                "domain": self.domain,
+                "user_ids": [Command.link(self.env.user.id)],
+            }
+        )
+        return {
+            "type": "ir.actions.act_window_close",
+            "infos": {
+                "store_data": Store().add(subtype, ["name", "field_tracked"]).get_result(),
+                "subtype_id": subtype.id,
+            },
+        }

--- a/addons/mail/wizard/mail_custom_message_subtype_views.xml
+++ b/addons/mail/wizard/mail_custom_message_subtype_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="mail_custom_message_subtype_form_view">
+        <field name="name">mail.custom.message.subtype.form.view</field>
+        <field name="model">mail.custom.message.subtype</field>
+        <field name="group_ids" eval="[Command.link(ref('base.group_user'))]"/>
+        <field name="arch" type="xml">
+            <form string="Custom Notification">
+                <sheet>
+                    <group>
+                        <field name="model" invisible="1"/>
+                        <field name="name"/>
+                        <field name="field_tracked" widget="mail_field_selector" options="{'model': 'model', 'only_tracking': True, 'follow_relations': False}"/>
+                        <field name="value_update" widget="mail_field_selector_value" options="{'model': 'model', 'value': 'field_tracked', 'accepted_types': ['boolean', 'many2one', 'selection']}"/>
+                        <field name="domain" widget="dynamic_domain" context="{'default_dynamic_domain_model': context.get('default_model')}"/>
+                    </group>
+                    <group>
+                        <field name="default"/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button string="Save" type="object" name="create_subtype_with_options" class="btn btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -832,8 +832,8 @@ class ProjectProject(models.Model):
             return self.env.ref('project.mt_project_stage_change')
         return super()._track_subtype(init_values)
 
-    def _mail_get_message_subtypes(self):
-        res = super()._mail_get_message_subtypes()
+    def _mail_get_message_subtypes(self, target=None):
+        res = super()._mail_get_message_subtypes(target=target)
         if len(self) == 1:
             waiting_subtype = self.env.ref('project.mt_project_task_waiting')
             if not self.allow_task_dependencies and waiting_subtype in res:

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1590,8 +1590,8 @@ class ProjectTask(models.Model):
             return self.env.ref(mail_message_subtype_per_state[self.state])
         return super()._track_subtype(init_values)
 
-    def _mail_get_message_subtypes(self):
-        res = super()._mail_get_message_subtypes()
+    def _mail_get_message_subtypes(self, target=None):
+        res = super()._mail_get_message_subtypes(target=target)
         if not self.stage_id.rating_active:
             res -= self.env.ref('project.mt_task_rating')
         if len(self) == 1:

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -576,8 +576,16 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self._expected_result_for_notification(self.channel_channel_public_1),
             ],
             "mail.message.subtype": [
-                {"description": False, "id": self.env.ref("mail.mt_note").id},
-                {"description": False, "id": self.env.ref("mail.mt_comment").id},
+                {
+                    "description": False,
+                    "id": self.env.ref("mail.mt_note").id,
+                    "field_tracked": False,
+                },
+                {
+                    "description": False,
+                    "id": self.env.ref("mail.mt_comment").id,
+                    "field_tracked": False,
+                },
             ],
             "mail.thread": self._filter_threads_fields(
                 self._expected_result_for_thread(self.channel_general),

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -264,7 +264,7 @@ class TestBaseMailPerformance(BaseMailPerformance):
             'partner_id': self.res_partner_12.id,
         })
 
-        with self.assertQueryCount(admin=3, demo=3):
+        with self.assertQueryCount(admin=4, demo=4):
             record.track = 'X'
 
     @users('admin', 'demo')
@@ -343,7 +343,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(admin=8, employee=8):  # tm: 6 / 6
+        with self.assertQueryCount(admin=9, employee=9):  # tm: 6 / 6
 
             activity.action_feedback(feedback='Zizisse Done !')
 
@@ -379,7 +379,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=12, employee=12):  # tm: 8 / 8
+        with self.assertQueryCount(admin=13, employee=13):  # tm: 8 / 8
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -405,7 +405,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=14, employee=14):  # tm 10 / 10
+        with self.assertQueryCount(admin=15, employee=15):  # tm 10 / 10
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications
@@ -655,7 +655,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=41, employee=40):
+        with self.assertQueryCount(admin=42, employee=41):
             record.write({
                 'user_id': self.user_emp_email.id,
             })
@@ -664,7 +664,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=21, employee=20):
+        with self.assertQueryCount(admin=22, employee=21):
             record.write({
                 'user_id': self.user_emp_inbox.id,
             })
@@ -714,7 +714,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_log_with_post(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=6, employee=6):
             record.message_post(
                 body=Markup('<p>Test message_post as log</p>'),
                 subtype_xmlid='mail.mt_note',
@@ -725,7 +725,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_no_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=8, employee=8):
             record.message_post(
                 body=Markup('<p>Test Post Performances basic</p>'),
                 partner_ids=[],
@@ -787,13 +787,13 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_track(self):
         record = self.env['mail.performance.tracking'].create({'name': 'Zizizatestname'})
-        with self.assertQueryCount(admin=3, employee=3):
+        with self.assertQueryCount(admin=4, employee=4):
             record.write({'name': 'Zizizanewtestname'})
 
-        with self.assertQueryCount(admin=3, employee=3):
+        with self.assertQueryCount(admin=4, employee=4):
             record.write({'field_%s' % (i): 'Tracked Char Fields %s' % (i) for i in range(3)})
 
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=5, employee=5):
             record.write({'field_%s' % (i): 'Field Without Cache %s' % (i) for i in range(3)})
             record.flush_recordset()
             record.write({'field_%s' % (i): 'Field With Cache %s' % (i) for i in range(3)})
@@ -1152,7 +1152,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=42, employee=42):
+        with self.assertQueryCount(admin=43, employee=43):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -1202,7 +1202,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
 
-        with self.assertQueryCount(admin=58, employee=58):
+        with self.assertQueryCount(admin=59, employee=59):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1239,7 +1239,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=64, employee=64):
+        with self.assertQueryCount(admin=65, employee=65):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -1272,7 +1272,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=34, employee=34):
+        with self.assertQueryCount(admin=35, employee=35):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,
@@ -1560,6 +1560,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     {
                                         "description": False,
                                         "id": self.env.ref("mail.mt_comment").id,
+                                        "field_tracked": False,
                                     },
                                 ],
                                 "mail.notification": [
@@ -1673,6 +1674,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     {
                                         "description": False,
                                         "id": self.env.ref("mail.mt_comment").id,
+                                        "field_tracked": False,
                                     },
                                 ],
                                 "mail.notification": [

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -49,7 +49,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         # runbot needs +101 compared to local
         with (
             self.mock_mail_gateway(mail_unlink_sent=True),
-            self.assertQueryCount(__system__=1379, marketing=1383),  # 1227, 1229
+            self.assertQueryCount(__system__=1380, marketing=1383),  # 1227, 1229
         ):
             mailing.action_send_mail()
 
@@ -93,7 +93,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +153 compared to local
-        with self.assertQueryCount(__system__=1410, marketing=1417):  # 1258, 1261
+        with self.assertQueryCount(__system__=1411, marketing=1417):  # 1258, 1261
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1808,8 +1808,15 @@ export class Model extends Array {
         if (!attributes) {
             return fields;
         }
-
-        return fields.map((field) => pick(field, ...attributes));
+        if (fieldNames) {
+            return fields.map((field) => pick(field, ...attributes));
+        }
+        return Object.fromEntries(
+            Object.entries(fields).map(([fieldName, field]) => [
+                fieldName,
+                pick(field, ...attributes),
+            ])
+        );
     }
 
     /**


### PR DESCRIPTION
Before this commit, the user had no choice on the notification types
available.

Now, it is possible to create a custom notification subtype.

Those subtypes are mainly defined by 3 characteristics that should be
respected to create the notification:
- The tracked field: a field change (with `tracking=True`) has been
detected.
- The value update: the notification is created only if the value of the
tracked field is the one of this field (or not set)
- The domain: the end state after the change should match the given
domain.

The `tracked_field` and `value_update` are applied at the source of the
change since they are static.
The `domain` is applied when checking the recipients of the notification
message and is filtering to ensure that the domain is respected by user.

The solution creates new messages (if matching the 3 conditions) after
the initial notification or message log of tracked fields, with the
initial notification being their parent. The main reason being that we
want to keep at most one subtype by message.

task-5147099


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
