### PR TITLE
[FIX] base: prevent compute method failed to assign smtp_authentication_info value

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -178,7 +178,7 @@ class IrMailServer(models.Model):
                 server.smtp_authentication_info = _(
                     'Use the SMTP configuration set in the "Command Line Interface" arguments.')
             else:
-                server.smtp_authentication = False
+                server.smtp_authentication_info = False
 
     @api.constrains('smtp_authentication', 'smtp_ssl_certificate', 'smtp_ssl_private_key')
     def _check_smtp_ssl_files(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the compute method of `smtp_authentication_info` field in `ir.mail_server`, the [else statement](https://github.com/odoo/odoo/blob/f417f35bcc63ae3177a369e9a11d8f6f63b92a77/odoo/addons/base/models/ir_mail_server.py#L181) seems to set the value of the wrong field

Desired behavior after PR is merged:
Set value for `smtp_authentication_info` instead of `smtp_authentication`




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
