### PR TITLE
[FIX] pos_online_payment_self_order: failing tour when running no demo data

### DIFF
--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
@@ -41,6 +41,6 @@ registry
                 CartPage.checkProduct("Fanta", "2.53", "1"),
                 CartPage.checkProduct("Coca-Cola", "2.53", "1"),
                 Utils.clickBtn("Pay"),
-                CartPage.selectTable("3"),
+                ...CartPage.selectTable("303"),
             ].flat(),
     });

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -61,6 +61,11 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
             'self_order_online_payment_method_id': self.online_payment_method.id,
             'use_presets': False,
         })
+        self.env['restaurant.table'].create({
+            'table_number': 303,
+            'floor_id': self.pos_main_floor.id,
+            'shape': 'square'
+        })
 
         self.pos_config.with_user(self.pos_user).open_ui()
         self.pos_config.current_session_id.set_opening_control(0, "")


### PR DESCRIPTION
The following tours were failing when executed without a demo database: `test_online_payment_mobile_self_order_preparation_changes`

This commit fixes the issue by selecting the table number,
ensuring consistent behavior in both demo and non-demo environments.

Runbot error-[232944](https://runbot.odoo.com/odoo/runbot.build.error/232944)
