### PR TITLE
[IMP] stock: make picking report labels generic

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -27,7 +27,7 @@
                         <div class="col-7" name="div_incoming_address">
                             <t t-set="show_partner" t-value="False" />
                             <div name="vendor_address" t-if="o.picking_type_id.code=='incoming' and partner">
-                                <strong>Vendor Address</strong>
+                                <strong>From</strong>
                                 <t t-set="show_partner" t-value="True" />
                             </div>
                             <div name="customer_address" t-if="o.picking_type_id.code=='outgoing' and partner and partner != partner.commercial_partner_id">

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -90,7 +90,7 @@
                                     <div t-field="o.picking_warning_text"/>
                                 </div>
                                 <div name="div_vendor" t-if="o.picking_type_id.code=='incoming' and o.partner_id">
-                                    <strong>Vendor:</strong>
+                                    <strong>From:</strong>
                                     <div t-field="o.partner_id.commercial_partner_id"
                                         t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True, "phone_icons": True}'>
                                     </div>


### PR DESCRIPTION
Purpose
------------
- The current PDF report for completed receipts displays the label _"Vendor address"_ for all receipt types.
- This label can be misleading when the receipt is not from a vendor. for example, during customer returns or inter-warehouse transfers.
- To make the report terminology more consistent and context-agnostic, the label has been made more generic.

With this commit
-----------------------
- Renamed the label in the receipt PDF report of the **delivery slip**. `Vendor address` to  `From`
- Renamed the label in the receipt PDF report of the **picking operations**. `Vendor` to  `From`
- The new label provides a more generic, accurate and suitable for all types of receipts, including vendor receipts, customer returns, and internal transfers.

Task - 5112782