### PR TITLE
[FIX] html_editor: toggle list content misaligned inside banner

### DIFF
--- a/addons/html_editor/static/src/main/banner.scss
+++ b/addons/html_editor/static/src/main/banner.scss
@@ -1,4 +1,3 @@
-.o_editor_banner .o-paragraph:last-child {
-    // Force margin to align the text container with the icon.
+.o_editor_banner_content > :last-child {
     margin-bottom: 1rem !important;
 }

--- a/addons/html_editor/static/src/main/hint.scss
+++ b/addons/html_editor/static/src/main/hint.scss
@@ -5,7 +5,7 @@
         content: attr(placeholder);
         position: absolute;
         top: 0;
-        left: var(--placeholder-left, 0);
+        inset-inline-start: var(--placeholder-offset, 0);
         display: block;
         color: inherit;
         opacity: 0.4;

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -40,7 +40,10 @@ export class TextDirectionPlugin extends Plugin {
         ].filter((n) => isTextNode(n) && isContentEditable(n) && n.nodeValue.trim().length);
         const blocks = new Set(
             targetedTextNodes.map(
-                (textNode) => closestElement(textNode, "ul,ol") || closestBlock(textNode)
+                (textNode) =>
+                    closestElement(textNode, "ul,ol") ||
+                    closestElement(textNode, "[data-embedded='toggleBlock']") ||
+                    closestBlock(textNode)
             )
         );
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -465,7 +465,12 @@ export class ToggleBlockPlugin extends Plugin {
             if (beforeSplit && afterSplit) {
                 if (content.parentElement.matches(".d-none") || insertBefore) {
                     const newToggle = this.renderToggleBlock();
+                    const newToggleBlock = newToggle.querySelector(toggleSelector);
                     const newTitleEl = newToggle.querySelector(titleSelector);
+                    const dir = toggle.getAttribute("dir");
+                    if (dir) {
+                        newToggleBlock.setAttribute("dir", dir);
+                    }
                     if (insertBefore) {
                         toggle.before(newToggle);
                         newTitleEl.replaceChildren(beforeSplit);

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -9,6 +9,7 @@ import {
     keydownShiftTab,
     keydownTab,
     splitBlock,
+    switchDirection,
 } from "../_helpers/user_actions";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import {
@@ -915,6 +916,119 @@ describe("Insert (paste, drop) inside toggle title", () => {
                 <div class="oe_unbreakable">brol</div>
                 <div class="o-paragraph">[]World</div>
             `)
+        );
+    });
+});
+
+describe("Toggle block: Switch Direction", () => {
+    test("should properly switch the direction of the toggle block (rtl)", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld[]</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        await embeddedToggleMountedPromise;
+        switchDirection(editor);
+        expect(getContent(el)).toBe(
+            unformat(
+                `
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false" dir="rtl">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld[]</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf</p>
+                        </div>
+                    </div>
+                </div>
+            `
+            )
+        );
+    });
+    test("should insert a new sibling toggle block with RTL direction on Enter", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false" dir="rtl">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld[]</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        patchWithCleanup(ToggleBlockPlugin.prototype, {
+            getUniqueIdentifier() {
+                return "2";
+            },
+        });
+        embeddedToggleMountedPromise = new Deferred();
+        splitBlock(editor);
+        await embeddedToggleMountedPromise;
+        expect(getContent(el)).toBe(
+            unformat(
+                `
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false" dir="rtl">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p>HelloWorld</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p>asdf</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{"toggleBlockId":"2"}' dir="rtl">
+                    <div class="d-flex flex-row align-items-center">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                            <i class="fa align-self-center fa-caret-right"></i>
+                        </button>
+                        <div class="flex-fill ms-1">
+                            <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
+                                <p placeholder="Toggle title" class="o-we-hint">[]<br></p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ps-4 ms-1 d-none">
+                        <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
+                            <p placeholder="Add something inside this toggle" class="o-we-hint"><br></p>
+                        </div>
+                    </div>
+                </div>
+            `
+            )
         );
     });
 });


### PR DESCRIPTION
**Steps to reproduce:**

- Create a banner.
- Create a toggle list inside the banner.
-  Notice that the content inside the toggle list is not properly aligned.

**Description of the issue:**

- This happens because a margin-bottom is applied to all last `o-paragraph` elements inside the `o_editor_banner class`. Since the toggle list also contains `o-paragraph` elements that are the last child within it, the margin-bottom style is incorrectly applied to those as well.

**Solution:**

- Apply the margin-bottom only to the last direct child of `.o_editor_banner_content`.

task-5213985