### PR TITLE
[IMP] l10n_in_edi: remove `account_edi` dependency from manifest

### DIFF
--- a/addons/l10n_in_edi/__manifest__.py
+++ b/addons/l10n_in_edi/__manifest__.py
@@ -4,7 +4,6 @@
     'countries': ['in'],
     'category': "Accounting/Localizations/EDI",
     'depends': [
-        "account_edi",
         "l10n_in",
     ],
     'description': """


### PR DESCRIPTION
Following the commit- https://github.com/odoo/odoo/commit/c5f059e4e952070c36b61c12c4775106e18ff0aa

The l10n_in_edi module was made independent from `account_edi`, but the module dependency still exists in manifest.

This commit removes the leftover dependency from manifest of l10n_in_edi



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
