### PR TITLE
[FIX] website_sale: make "Add to Cart" translatable

### DIFF
--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -17,8 +17,8 @@
         >
             <attribute name="class" remove="oi oi-plus" add="fa fa-shopping-cart" separator=" "/>
         </xpath>
-        <span name="add_button" position="attributes">
-            <attribute name="t-out">'Add to Cart'</attribute>
+        <span name="add_button" position="replace">
+            <span name="add_button" class="ms-2 d-none d-md-inline">Add to Cart</span>
         </span>
 
         <button name="sale_product_configurator_add_button" position="after">


### PR DESCRIPTION
- t-out is used for variables, so static text inside it isn’t picked up for translation.
- Replaced it with a direct <span> so the text is automatically translatable

**Before Fix:**
<img width="1185" height="915" alt="image" src="https://github.com/user-attachments/assets/dc035e6a-25d1-4b88-9b8f-c013a0aeb75b" />

**After Fix:**
<img width="1185" height="915" alt="image" src="https://github.com/user-attachments/assets/80bd5e7b-c705-49a8-a785-86e32bc54daf" />
**Steps to reproduce before the fix:**
Go to Website → change the website language to any non-English language. Add any product to the cart.
A Product Configuration wizard (for options) will open. The “Add to Cart” button for options is not translated.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
