### PR TITLE
[FIX] html_builder: prevent copy `data-oe-*` attributes

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -19,9 +19,21 @@ export class SetupEditorPlugin extends Plugin {
     static shared = ["getEditableAreas"];
     /** @type {import("plugins").BuilderResources} */
     resources = {
+        system_classes: "o_editable",
         clean_for_save_handlers: this.cleanForSave.bind(this),
         closest_savable_providers: withSequence(10, (el) => el.closest(".o_editable")),
         unremovable_node_predicates: (node) => node.classList?.contains("o_editable"),
+        clipboard_content_processors: withSequence(20, (clonedContents) => {
+            for (const node of clonedContents.querySelectorAll("*")) {
+                for (const attr of [...node.attributes]) {
+                    if (attr.name.startsWith("data-oe-")) {
+                        node.removeAttribute(attr.name);
+                    }
+                }
+                node.removeAttribute("contenteditable");
+                node.classList.remove("o_dirty");
+            }
+        }),
     };
 
     setup() {

--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -3,7 +3,7 @@ declare module "plugins" {
     import { Plugin } from "@html_editor/plugin";
 
     import { BaseContainerShared, invalid_for_base_container_predicates } from "@html_editor/core/base_container_plugin";
-    import { after_paste_handlers, before_paste_handlers, clipboard_content_processors, clipboard_text_processors, ClipboardShared, paste_text_overrides } from "@html_editor/core/clipboard_plugin";
+    import { after_paste_handlers, before_paste_handlers, clipboard_content_processors, clipboard_text_processors, ClipboardShared, paste_text_overrides, pasted_html_processors } from "@html_editor/core/clipboard_plugin";
     import { content_editable_providers, content_not_editable_providers, contenteditable_to_remove_selector, valid_contenteditable_predicates } from "@html_editor/core/content_editable_plugin";
     import { before_delete_handlers, delete_backward_line_overrides, delete_backward_overrides, delete_backward_word_overrides, delete_forward_line_overrides, delete_forward_overrides, delete_forward_word_overrides, delete_handlers, delete_range_overrides, DeleteShared, functional_empty_node_predicates, is_empty_predicates, removable_descendants_providers, unremovable_node_predicates } from "@html_editor/core/delete_plugin";
     import { DialogShared } from "@html_editor/core/dialog_plugin";
@@ -204,6 +204,7 @@ declare module "plugins" {
         clipboard_content_processors: clipboard_content_processors;
         clipboard_text_processors: clipboard_text_processors;
         node_to_insert_processors: node_to_insert_processors;
+        pasted_html_processors: pasted_html_processors;
         serializable_descendants_processors: serializable_descendants_processors;
         targeted_nodes_processors: targeted_nodes_processors;
 

--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -6,6 +6,11 @@ export class TranslateLinkInlinePlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         create_link_handlers: (linkEl) => linkEl.classList.add("o_translate_inline"),
+        pasted_html_processors: (fragment) => {
+            for (const linkEl of fragment.querySelectorAll("a")) {
+                linkEl.classList.add("o_translate_inline");
+            }
+        },
     };
 }
 

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -1,7 +1,7 @@
 import { Builder } from "@html_builder/builder";
 import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
-import { insertText, pasteText } from "@html_editor/../tests/_helpers/user_actions";
+import { insertText, pasteHtml, pasteText } from "@html_editor/../tests/_helpers/user_actions";
 import { beforeEach, describe, expect, press, test } from "@odoo/hoot";
 import {
     animationFrame,
@@ -316,6 +316,19 @@ test("copy of a translated span should not copy branding attributes", async () =
     expect(clipboardData.getData("text/html")).toBe(
         `<p><span class="translate_branding"><b>c</b></span></p>`
     );
+});
+
+test("paste html in a translated span should not add blocks", async () => {
+    const { getEditor } = await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({ inWrap: "a<b>c</b>a" }),
+    });
+    await contains(":iframe [contenteditable=true]").focus();
+    const editor = getEditor();
+    const textNode = editor.editable.querySelector("b").firstChild;
+    expect(textNode.nodeType).toBe(Node.TEXT_NODE);
+    setSelection({ anchorNode: textNode, anchorOffset: 0, focusNode: textNode, focusOffset: 1 });
+    pasteHtml(editor, `<h1><u>hello</u></h1>`);
+    expect(":iframe [contenteditable=true]").toHaveInnerHTML(`a<b><u>hello</u></b>a`);
 });
 
 describe("save translation", () => {

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -294,7 +294,6 @@ test("test that powerbox should not open in translate mode", async () => {
     const textNode = editor.editable.querySelector("span").firstChild;
     expect(textNode.nodeType).toBe(Node.TEXT_NODE);
     setSelection({ anchorNode: textNode, anchorOffset: 0 });
-    await animationFrame();
     // Simulate typing `/`
     await insertText(editor, "/");
     await animationFrame();

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -2,7 +2,7 @@ import { Builder } from "@html_builder/builder";
 import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
 import { insertText, pasteText } from "@html_editor/../tests/_helpers/user_actions";
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, press, test } from "@odoo/hoot";
 import {
     animationFrame,
     manuallyDispatchProgrammaticEvent,
@@ -299,6 +299,23 @@ test("test that powerbox should not open in translate mode", async () => {
     await insertText(editor, "/");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
+});
+
+test("copy of a translated span should not copy branding attributes", async () => {
+    const { getEditor } = await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({ inWrap: "a<b>c</b>a" }),
+    });
+    await contains(":iframe [contenteditable=true]").focus();
+    const editor = getEditor();
+    const textNode = editor.editable.querySelector("b").firstChild;
+    expect(textNode.nodeType).toBe(Node.TEXT_NODE);
+    setSelection({ anchorNode: textNode, anchorOffset: 0, focusNode: textNode, focusOffset: 1 });
+    const clipboardData = new DataTransfer();
+    await press(["ctrl", "c"], { dataTransfer: clipboardData });
+    expect(clipboardData.getData("text/plain")).toBe("c");
+    expect(clipboardData.getData("text/html")).toBe(
+        `<p><span class="translate_branding"><b>c</b></span></p>`
+    );
 });
 
 describe("save translation", () => {


### PR DESCRIPTION
When the user copies a range of the html in the page, they may copy nodes with attributes that mark them to be saved. This happens if they select around a savable node, or if they select inside a savable node and the format plugin include clones of the ancestors (to keep matching style).

This commit filters the attributes on the nodes that are copied, to prevent the user from pasting nodes marked as they should be saved.

Steps to reproduce:
- Open website builder
- Select a link of the menu in the header
- Copy
- Move the selection to "normal" text (like in the footer)
- Paste
- Save
- Bug: the website cannot render

###
- Open website builder in translate mode, on a blog post
- Select a word in the middle of a paragraph
- Copy
- Paste
- Bug: The paragraph gets replicated inside itself

opw-5053872
task-5222402
