### PR TITLE
[IMP] l10n_in: improve GSTR section assignment logic

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -725,6 +725,6 @@ class AccountMove(models.Model):
     @contextmanager
     def _sync_l10n_in_gstr_section(self, moves):
         yield
-        for move in moves:
-            # we set the section on the invoice lines
-            move.line_ids._set_l10n_in_gstr_section()
+        tax_tags_dict = self.env['account.move.line']._get_l10n_in_tax_tag_ids()
+        # we set the section on the invoice lines
+        moves.line_ids._set_l10n_in_gstr_section(tax_tags_dict)

--- a/addons/l10n_in_pos/models/account_move_line.py
+++ b/addons/l10n_in_pos/models/account_move_line.py
@@ -4,8 +4,25 @@ from odoo import models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    def _set_l10n_in_gstr_section(self):
-        super()._set_l10n_in_gstr_section()
+    def _get_l10n_in_gstr_section(self, tax_tags_dict):
+        result = super()._get_l10n_in_gstr_section(tax_tags_dict)
+
+        eco_9_5_tag = tax_tags_dict['eco_9_5']
+        all_gst_tags = tax_tags_dict['cgst'] + tax_tags_dict['sgst'] + tax_tags_dict['igst'] + tax_tags_dict['cess']
+
+        def get_section(line):
+            tax_tags = line.tax_tag_ids.ids
+            if any(tag == eco_9_5_tag for tag in tax_tags):
+                return 'sale_eco_9_5'
+            if any(tag in tax_tags for tag in all_gst_tags):
+                return 'sale_b2cs'
+            if any(tax.l10n_in_tax_type == 'nil_rated' for tax in line.tax_ids):
+                return 'sale_nil_rated'
+            if any(tax.l10n_in_tax_type == 'exempt' for tax in line.tax_ids):
+                return 'sale_exempt'
+            if any(tax.l10n_in_tax_type == 'non_gst' for tax in line.tax_ids):
+                return 'sale_non_gst_supplies'
+            return 'sale_out_of_scope'
 
         in_pos_closing_and_reversed_lines = self.filtered(
             lambda l: l.move_id.country_code == 'IN'
@@ -14,23 +31,11 @@ class AccountMoveLine(models.Model):
             and (l.move_id.sudo().pos_session_ids or l.move_id.sudo().reversed_pos_order_id)
         )
         if not in_pos_closing_and_reversed_lines:
-            return
+            return result
 
-        tax_tags_dict = self._get_l10n_in_tax_tag_ids()
-        eco_9_5_tag = tax_tags_dict.get('eco_9_5')
-        all_gst_tags = tax_tags_dict.get('cgst') + tax_tags_dict.get('sgst') + tax_tags_dict.get('igst') + tax_tags_dict.get('cess')
+        move_lines_by_gstr_section = in_pos_closing_and_reversed_lines.grouped(get_section)
 
-        for line in in_pos_closing_and_reversed_lines:
-            tax_tags = line.tax_tag_ids.ids
-            if any(tag == eco_9_5_tag for tag in tax_tags):
-                line.l10n_in_gstr_section = 'sale_eco_9_5'
-            elif any(tag in tax_tags for tag in all_gst_tags):
-                line.l10n_in_gstr_section = 'sale_b2cs'
-            elif any(tax.l10n_in_tax_type == 'nil_rated' for tax in line.tax_ids):
-                line.l10n_in_gstr_section = 'sale_nil_rated'
-            elif any(tax.l10n_in_tax_type == 'exempt' for tax in line.tax_ids):
-                line.l10n_in_gstr_section = 'sale_exempt'
-            elif any(tax.l10n_in_tax_type == 'non_gst' for tax in line.tax_ids):
-                line.l10n_in_gstr_section = 'sale_non_gst_supplies'
-            else:
-                line.l10n_in_gstr_section = 'sale_out_of_scope'
+        for section, lines in move_lines_by_gstr_section.items():
+            result[section] = result.get(section, self.env['account.move.line']) | lines
+
+        return result


### PR DESCRIPTION
This PR introduces enhancements to the `_set_l10n_in_gstr_section` method, including:
-Calling `_get_l10n_in_tax_tag_ids` directly on all moves instead of ines. -Improving the logic for assigning GSTR section values.

