### PR TITLE
[FIX] account: fix tax string computation issue

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -82,7 +82,7 @@ class ProductTemplate(models.Model):
 
     def _construct_tax_string(self, price):
         currency = self.currency_id
-        res = self.taxes_id.filtered(lambda t: t.company_id == self.env.company).compute_all(
+        res = self.taxes_id._filter_taxes_by_company(self.env.company).compute_all(
             price, product=self, partner=self.env['res.partner']
         )
         joined = []


### PR DESCRIPTION
Steps:
- Install account app.
- Create a branch company under the main company.
- Create a tax for the branch company.
- Add a main company tax on a product.
- Switch to branch company.

Issue:
- Tax string is not displaying on the product form even though its setting tax from parent company on invoice line and SO line so its displaying wrong sale price on product form.

Cause:
- After [PR] taxes are only consider from current company even though company is branch company but in [17.0 PR] we share taxed and other accounting related data b/w main and branch company so if branch does not it's specific tax applied on product then it should take tax from its parent company.

Fix:
- Compute tax_string in product the way we compute tax on invoice line, SOL etc using `_filter_taxes_by_company` method this way it'll give proper tax which will be applied on related documents.

[PR]: https://github.com/odoo/odoo/pull/194881
[17.0 PR]: https://github.com/odoo/odoo/pull/125642

opw-5042833
