### PR TITLE
[FIX] base_import,test_import_export: handle datetime mapping to bool, o2M

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1645,7 +1645,7 @@ class Base_ImportImport(models.TransientModel):
                             for idx in indexes if record[idx]
                         )
                     )
-                elif field_type == 'text':
+                elif field_type == 'text' or field_type == 'boolean' or field_type == 'one2many':
                     new_record.append(
                         '\n'.join(
                             self._stringify_date_like_objects(record[idx], import_options)

--- a/addons/test_import_export/models/models_import.py
+++ b/addons/test_import_export/models/models_import.py
@@ -91,6 +91,8 @@ class ImportPreview(models.Model):
     othervalue = fields.Integer(string='Other Variable')
     date = fields.Date(string='Date')
     datetime = fields.Datetime(string='Datetime')
+    is_company = fields.Boolean(string='Is Company')
+    some_ids = fields.One2many('import.o2m.child', 'parent_id', string='Some IDs')
 
 
 class ImportFloat(models.Model):


### PR DESCRIPTION
When mapping a datetime value to fields of type boolean or one2many, an error is raised.

Steps to Reproduce:
1) Install CRM
2) Navigate to CRM and upload [this file](https://docs.google.com/spreadsheets/d/1eRhIy3Zt8kD-_sH8Lp2N9IE9zflYB5CX/edit?usp=sharing&ouid=101212513075316114369&rtpof=true&sd=true) 
3) Map 'Created on' with 'Active' and click on Test.

Error-1 :
`AttributeError: 'datetime.date' object has no attribute 'lower'`

If you upload [this file](https://docs.google.com/spreadsheets/d/18xTvxjc9EsXf86N5Y8ekq-AZocQSNwEM/edit?usp=sharing&ouid=101212513075316114369&rtpof=true&sd=true) and click on Test, the following error is raised:

Error-2:
`AttributeError: 'datetime.date' object has no attribute 'split'`

Root Cause:
This type of issue was previously addressed in [commit 1](https://github.com/odoo/odoo/commit/83034f4752fd2a126851d6308a3ad39221dcab6a), but its changes were reverted in [commit 2], which only handled char fields. As a result, cases for `bool` and `one2many` fields were missed. Since the `_parse_datetime_data` check at [1] was removed after [commit 2], the error reappears.

Fix:
Following the logic of [commit 2], this fix extends the handling to bool and one2many fields.

[1]- https://github.com/odoo/odoo/blob/462f620803e22da4a2d08915eb31fcda876ec73e/addons/base_import/models/base_import.py#L1466-L1467

[commit 2]: https://github.com/odoo/odoo/commit/743ae7f6555160415b33ba3afb3de7bc78cede81

sentry-6979678378,6924909613

