### PR TITLE
[FIX] mail: make message read / search symmetric

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -349,7 +349,7 @@ class Message(models.Model):
         allowed = self.browse(id_ for id_ in ids if id_ in allowed_ids)
         return allowed._as_query(order)
 
-    def _filter_records_for_message_operation(self, doc_model, doc_res_ids, operation):
+    def _filter_records_for_message_operation(self, doc_model, doc_res_ids, operation, filter_python=False):
         """ Helper returning records on which 'operation' on mail.message is
         allowed, based on '_get_mail_message_access' behavior and potential
         model override. """
@@ -366,7 +366,8 @@ class Message(models.Model):
         for record_operation, records in documents_per_operation.items():
             operation_allowed = records.check_access_rights(record_operation, raise_exception=False)
             if operation_allowed:
-                allowed += records._filter_access_rules(record_operation)
+                filter_method = records._filter_access_rules_python if filter_python else records._filter_access_rules
+                allowed += filter_method(record_operation)
         return allowed
 
     @api.model

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -274,14 +274,18 @@ class Message(models.Model):
         ids uid could not see according to our custom rules. Please refer to
         check_access_rule for more details about those rules.
 
-        Non employees users see only message with subtype (aka do not see
-        internal logs).
+        Non employees users see only message with subtype, and cannot see
+        internal messages, either coming from message 'is_internal' flag,
+        subtype 'internal' flag, or being pure logs (no subtype). See
+        `_get_search_domain_share` which generates the domain.
 
         After having received ids of a classic search, keep only:
         - if author_id == pid, uid is the author, OR
         - uid belongs to a notified channel, OR
         - uid is in the specified recipients, OR
-        - uid has a notification on the message
+        - uid has a notification on the message, OR
+        - uid has acces to the message linked document for messages that are not
+          'user_notification'
         - otherwise: remove the id
         """
         # Rules do not apply to administrator
@@ -353,6 +357,20 @@ class Message(models.Model):
 
     @api.model
     def _find_allowed_doc_ids(self, model_ids):
+        """ Filters out message user cannot read due to missing document access.
+
+        :param dict model_ids: dictionary giving messages IDs per document id,
+            for each model, like {
+                'document_model_name': {
+                    'document_id_1': set(message IDs),
+                    'document_id_2': set(message IDs),
+                },
+                [...]
+            }
+
+        :return: set of allowed message IDs to read, based on document check
+        :rtype: set
+        """
         IrModelAccess = self.env['ir.model.access']
         allowed_ids = set()
         for doc_model, doc_dict in model_ids.items():

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -351,9 +351,26 @@ class Message(models.Model):
 
     @api.model
     def _find_allowed_model_wise(self, doc_model, doc_dict):
-        doc_ids = list(doc_dict)
-        allowed_doc_ids = self.env[doc_model].with_context(active_test=False).search([('id', 'in', doc_ids)]).ids
-        return set([message_id for allowed_doc_id in allowed_doc_ids for message_id in doc_dict[allowed_doc_id]])
+        # filter for each operation
+        documents_all = self.env[doc_model].with_context(active_test=False).browse(list(doc_dict))
+        documents_per_operation = defaultdict(self.env[doc_model].browse)
+        for document in documents_all:
+            if hasattr(document, '_get_mail_message_access'):
+                doc_operation = document._get_mail_message_access(document.ids, 'read')  # why not giving model here?
+            else:
+                doc_operation = self.env['mail.thread']._get_mail_message_access(document.ids, 'read', model_name=document._name)
+            documents_per_operation[doc_operation] |= document
+
+        allowed = self.env[doc_model]
+        for record_operation, records in documents_per_operation.items():
+            operation_allowed = records.check_access_rights(record_operation, raise_exception=False)
+            if operation_allowed:
+                allowed += records._filter_access_rules(record_operation)
+        allowed_ids = {
+            msg_id for document_id in allowed.ids for msg_id in doc_dict[document_id]
+        }
+
+        return allowed_ids
 
     @api.model
     def _find_allowed_doc_ids(self, model_ids):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4382,16 +4382,18 @@ class MailThread(models.AbstractModel):
         res = {'hasWriteAccess': False, 'hasReadAccess': True}
         if not self:
             res['hasReadAccess'] = False
+            res['canPostOnReadonly'] = False
             return res
-        res['canPostOnReadonly'] = self._mail_post_access == 'read'
 
         self.ensure_one()
+        res['canPostOnReadonly'] = self._get_mail_message_access(self.ids, 'create') == "read"
         try:
             self.check_access_rights("write")
             self.check_access_rule("write")
             res['hasWriteAccess'] = True
         except AccessError:
             pass
+
         if 'activities' in request_list:
             res['activities'] = self.with_context(active_test=True).activity_ids.activity_format()
         if 'attachments' in request_list:

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -373,6 +373,10 @@ export class Thread extends Record {
         );
     }
 
+    get canPostMessage() {
+        return this.hasWriteAccess || (this.hasReadAccess && this.canPostOnReadonly);
+    }
+
     get hasMemberList() {
         return ["channel", "group"].includes(this.type);
     }

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -10,18 +10,20 @@
                     'btn-secondary': state.composerType === 'note',
                     'active': state.composerType === 'message',
                     'my-2': !props.compactHeight
-                }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
+                }" t-att-disabled="!state.thread.canPostMessage and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                     Send message
                 </button>
                 <button t-if="props.hasMessageList" class="o-mail-Chatter-logNote btn text-nowrap me-1" t-att-class="{
                     'btn-primary active': state.composerType === 'note',
                     'btn-secondary': state.composerType !== 'note',
                     'my-2': !props.compactHeight
-                }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                }" t-att-disabled="!state.thread.canPostMessage and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                     Log note
                 </button>
                 <div class="flex-grow-1 d-flex">
-                    <button t-if="props.hasActivities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">
+                    <button t-if="props.hasActivities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }"
+                            t-att-disabled="!state.thread.canPostMessage and props.threadId"
+                            data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activities</span>
                     </button>
                     <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
@@ -110,7 +112,7 @@
                         />
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                             <t t-set-slot="toggler">
-                                <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">
+                                <button class="btn btn-link" type="button" t-att-disabled="!state.thread.canPostMessage">
                                     <i class="fa fa-plus-square"/>
                                     Attach files
                                 </button>
@@ -147,7 +149,8 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments"
+            t-att-disabled="state.isSearchOpen || (!state.thread.canPostMessage and attachments.length === 0)">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -36,7 +36,7 @@ class MailTestAccessCusto(models.Model):
     or partner which have their own set of ACLs. """
     _description = 'Mail Access Test with Custo'
     _name = 'mail.test.access.custo'
-    _inherit = ['mail.thread.blacklist']
+    _inherit = ['mail.thread.blacklist', 'mail.activity.mixin']
     _mail_post_access = 'write'  # default value but ease mock
     _order = 'id DESC'
     _primary_email = 'email_from'

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -203,7 +203,7 @@ class MailTestMultiCompanyRead(models.Model):
     even if the user has no write access. """
     _description = 'Simple Chatter Model '
     _name = 'mail.test.multi.company.read'
-    _inherit = ['mail.test.multi.company']
+    _inherit = ['mail.test.multi.company', 'mail.activity.mixin']
     _mail_post_access = 'read'
 
 

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -10,6 +10,7 @@
         <field name="domain_force">[('email_from', '!=', 'donotsetmewiththisvalue')]</field>
     </record>
 
+    <!-- MAIL.TEST.ACCESS -->
     <record id="ir_rule_mail_test_access_public" model="ir.rule">
         <field name="name">Public: public only</field>
         <field name="model_id" ref="test_mail.model_mail_test_access"/>
@@ -64,7 +65,39 @@
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
+    <!-- MAIL.TEST.ACCESS.CUSTO -->
+    <record id="ir_rule_mail_test_access_custo_portal_read" model="ir.rule">
+        <field name="name">Portal: read unlocked</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[('is_locked', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="ir_rule_mail_test_access_custo_update" model="ir.rule">
+        <field name="name">Internal: create/write/unlink unlocked and not readonly</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[('is_readonly', '=', False), ('is_locked', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user')), (4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_custo_update_admin" model="ir.rule">
+        <field name="name">Admin: all</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
 
+    <!-- MAIL.TEST.MULTI.COMPANY -->
     <record id="mail_test_multi_company_rule" model="ir.rule">
         <field name="name">Mail Test Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -761,6 +761,46 @@ class TestMailMessageAccess(MessageAccessCommon):
                 domain = [('subject', 'like', '_ZTest')] + add_domain
                 self.assertEqual(self.env['mail.message'].with_user(test_user).search(domain), exp_messages)
 
+    def test_search_customized(self):
+        """ Test '_get_mail_message_access' support in search """
+        records = self.env['mail.test.access.custo'].with_user(self.user_admin).create([
+            {'name': 'Open'},
+            {'name': 'Open RO', 'is_readonly': True},  # internal can read thus search
+            {'name': 'Soonish Locked'},
+        ])
+        messages_all = self.env['mail.message'].sudo()
+        for user in self.user_employee + self.user_portal:
+            for record in records:
+                new = record.message_post(
+                    body=f'AnchorForSearch / A message from {user.name}',
+                    subtype_id=self.env.ref('mail.mt_comment').id,
+                )
+                messages_all += new.sudo()
+
+        found_emp = self.env['mail.message'].with_user(self.user_employee).search([
+            ('body', 'ilike', 'AnchorForSearch')
+        ])
+        self.assertEqual(found_emp, messages_all)
+        found_por = self.env['mail.message'].with_user(self.user_portal).search([
+            ('body', 'ilike', 'AnchorForSearch')
+        ])
+        self.assertEqual(found_por, messages_all)
+
+        # lock -> locked records need 'write' access, as defined in '_get_mail_message_access'
+        # hence messages are out of search, symmetrical to reading therm
+        records[2].write({'is_locked': True, 'name': 'Locked !'})
+        records[2].flush_recordset()
+        found_emp = self.env['mail.message'].with_user(self.user_employee).search([
+            ('body', 'ilike', 'AnchorForSearch')
+        ])
+        self.assertEqual(found_emp, messages_all.filtered(lambda m: m.res_id != records[2].id), 'Should filter like read')
+        found_emp.read(['subject'])
+        found_por = self.env['mail.message'].with_user(self.user_portal).search([
+            ('body', 'ilike', 'AnchorForSearch')
+        ])
+        self.assertEqual(found_por, messages_all.filtered(lambda m: m.res_id != records[2].id), 'Should filter like read')
+        found_por.read(['subject'])
+
 
 @tagged('mail_message', 'security', 'post_install', '-at_install')
 class TestMessageSubModelAccess(MessageAccessCommon):

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -219,6 +219,7 @@ class TestMailMessageAccess(MessageAccessCommon):
         for user in self.user_employee + self.user_portal:
             with self.subTest(user_name=user.name):
                 _message = record.with_user(user).message_post(
+                    attachments=[('Attachment', b'My attachment')],
                     body='A message',
                     subtype_id=self.env.ref('mail.mt_comment').id,
                 )
@@ -242,6 +243,7 @@ class TestMailMessageAccess(MessageAccessCommon):
                     record.with_user(user).write({'name': 'Can Update'})
                 # can post
                 _message = record.with_user(user).message_post(
+                    attachments=[('Attachment', b'My attachment')],
                     body='Another portal message',
                     subtype_id=self.env.ref('mail.mt_comment').id,
                 )

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -2,12 +2,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import random
+
 from markupsafe import Markup
 
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessDenied, AccessError, UserError
-from odoo.tools import html_escape
-
 
 
 class CrmLead(models.Model):
@@ -344,3 +343,13 @@ class CrmLead(models.Model):
                     'url': '/my/opportunity/%s' % record.id,
                 }
         return super(CrmLead, self)._get_access_action(access_uid=access_uid, force_website=force_website)
+
+    @api.model
+    def _get_mail_message_access(self, res_ids, operation, model_name=None):
+        # Allow readonly posting for assigned users, to avoid ACLs issue in frontend
+        # as they do not have write access anymore on the lead itself, just specific
+        # controllers and UI
+        if operation == 'create' and res_ids and (not model_name or model_name == 'crm.lead'):
+            if all(lead.partner_assigned_id == self.env.user.partner_id for lead in self.browse(res_ids)):
+                return 'read'
+        return super()._get_mail_message_access(res_ids, operation, model_name=model_name)


### PR DESCRIPTION
Message access is notably based on related document, given their
(model, res_id) pair. Model may customize the required access on
it in order to access their message. For example, you generally
need write access to create a message (post) but on some models
you can post when you can read. Calendar events message access depends
on calendar privacy settings.

This is controlled via '_get_mail_message_access'. However currently
it is "globally called", for all documents. It should be done on a
per-document basis, as each document could define different access
check.

Keep code somewhat optimized by doing access checks in batch for a
given operation.

Make _search and read symmetric. Reading documents should be allowed
on search results, and search results should match what is available
for reading.

Portal users have some specific domains applied when accessing
messages, see notably odoo/odoo@9cd9aaaa174ae1f2a0af12143a34eb4682ea6f59 (but also check for
'website_message_ids' domain, mail controllers, ...). However there
are still some cases where search and read are not coherent with
portal users. This is not really annoying as most messages are accessed
using sudo and correctly tailored domains via controllers but let
us try to have a more correct code.

Fix discuss display of chatter-related buttons
* not taking into account '_get_mail_message_access' to check if
  user has right to post (generally used to indicate users can
  post on readonly records, but not limited to that);
* not adding the same check on Activities button as on Send message
  and Log note. We consider generally that rights should be aligned
  and UX should match that behavior;
* not adding the same check on attachments buttons, currently limited
  to write access (or always accessible). This is a preliminary work
  for attachments, further fixes are probably incoming;

Mainly a backport of master improvement done at https://github.com/odoo/odoo/pull/214705 .

Task-5138368
opw-4785878