### PR TITLE
[FIX] calendar: prevent error on rescheduling meeting when timezone is not set

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -20,7 +20,7 @@ class MailActivity(models.Model):
             date_deadline = self[0].date_deadline  # updated, hence all same value
             # also protect against loops in case of ill-managed timezones
             events = self.calendar_event_id.with_context(mail_activity_meeting_update=True)
-            user_tz = self.env.context.get('tz', 'UTC')
+            user_tz = self.env.context.get('tz') or 'UTC'
             for event in events:
                 # allday: just apply diff between dates
                 if event.allday and event.start_date != date_deadline:


### PR DESCRIPTION
Currently, an error occurs when scheduling or updating a meeting for an applicant if the user's timezone is not set.

**Steps to Reproduce:**
1. In the user's profile, remove the TimeZone.
2. Now, install the "**Recruitment**" module.
3. Create an application and schedule a meeting for the applicant.
4. After saving the record, change the start time and try to save the record.

**Error:**
`AttributeError - 'bool' object has no attribute 'upper'`

**Cause:**
At [1], system gets the timezone from the context, but in this case, `'tz'` is `False`. As a result, `user_tz` becomes False, and using `upper()` method on a bool value triggers an error.

**Fix:**
This commit ensures that the 'UTC' timezone is assigned when the context does not include a valid timezone ('tz' is missing or False).

[1] -  https://github.com/odoo/odoo/blob/78bd84c7b91f11780f152c29c8f595e3d9ed3d68/addons/calendar/models/mail_activity.py#L23

sentry-6952137101