### PR TITLE
[IMP] iot_drivers: logger on service startup

### DIFF
--- a/addons/iot_drivers/__init__.py
+++ b/addons/iot_drivers/__init__.py
@@ -18,7 +18,7 @@ from . import websocket_client
 from . import webrtc_client
 
 _logger = logging.getLogger(__name__)
-_logger.warning("==== Starting Odoo ====")
+_logger.info("==== Starting Odoo IoT Box service ====")
 
 _get = requests.get
 _post = requests.post


### PR DESCRIPTION
We previously added a logger on IoT Box service startup to simplify logs reading.

We updated this logger from `warning` to `info`, to avoid runbot tests failing.

odoo/enterprise#96760