### PR TITLE
[FIX] sale_mrp: find backorders through procurement group in tests

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2750,11 +2750,11 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
 
         mo = self.env['mrp.production'].search([('product_id', '=', product.id)], limit=1)
         Form.from_action(self.env, mo.action_split()).save().action_split()
-        self.assertEqual(len(mo.backorder_ids), 2)
+        self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 2)
 
-        mo.backorder_ids[0].button_mark_done()
+        mo.procurement_group_id.mrp_production_ids[0].button_mark_done()
         self.assertEqual(sale_picking.move_ids.quantity, 1)
-        mo.backorder_ids[1].button_mark_done()
+        mo.procurement_group_id.mrp_production_ids[1].button_mark_done()
         self.assertEqual(sale_picking.move_ids.quantity, 2)
         sale_picking.button_validate()
         self.assertEqual(sale_order.order_line.qty_delivered, 2.0)


### PR DESCRIPTION
Cause
-----
Test introduced in 2da1c78 uses the field `backorder_ids` which is only present when enterprise is installed
https://github.com/odoo/enterprise/blob/67fdbc5ae724a184d62d8cfa23403b8c759b9317/stock_barcode_mrp/models/mrp_production.py#L10

-----
Error: 233584