### PR TITLE
[FIX] l10n_tr_nilvera_edispatch: add tax office in e-dispatch XML

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/i18n/l10n_tr_nilvera_edispatch.pot
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/l10n_tr_nilvera_edispatch.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-17 14:00+0000\n"
-"PO-Revision-Date: 2025-08-17 14:00+0000\n"
+"POT-Creation-Date: 2025-10-31 12:26+0000\n"
+"PO-Revision-Date: 2025-10-31 12:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -316,6 +316,13 @@ msgid "Printed Delivery Note Number of 16 characters is required."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
+#, python-format
+msgid "Reference field must be set to the tax office name"
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_seller_supplier_id
 msgid "Seller Supplier"
 msgstr ""
@@ -484,11 +491,6 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "e-Dispatch will not be generated as the Delivery Address is not set."
-msgstr ""
-
-#. module: l10n_tr_nilvera_edispatch
-#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
-msgid "false"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch

--- a/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
@@ -6,16 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-11 06:16+0000\n"
-"PO-Revision-Date: 2025-08-11 14:53+0400\n"
+"POT-Creation-Date: 2025-10-31 12:26+0000\n"
+"PO-Revision-Date: 2025-10-31 12:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.2\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -159,6 +157,10 @@ msgstr "Şoför Bilgileri"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
 #, python-format
 msgid "Drivers"
@@ -237,7 +239,7 @@ msgstr "Son Güncelleme Tarihi"
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
 msgid "MATBU"
-msgstr "MATBU"
+msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.actions.server,name:l10n_tr_nilvera_edispatch.action_mark_l10n_tr_nilvera_edispatch_status
@@ -320,6 +322,13 @@ msgid "Printed Delivery Note Number of 16 characters is required."
 msgstr "16 karakterden oluşan basılı irsaliye numarası girilmelidir."
 
 #. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
+#, python-format
+msgid "Reference field must be set to the tax office name"
+msgstr "Referans alanı vergi dairesi adına ayarlanmış olmalıdır"
+
+#. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_seller_supplier_id
 msgid "Seller Supplier"
 msgstr "Satıcı Tedarikçi"
@@ -348,7 +357,7 @@ msgstr "Cadde"
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
 #, python-format
 msgid "TCKN/VKN"
-msgstr "TCKN/VKN"
+msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_res_partner__l10n_tr_nilvera_edispatch_customs_zip
@@ -372,7 +381,7 @@ msgstr "Römork Plakaları"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_stock_picking
 msgid "Transfer"
-msgstr "Transfer"
+msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
@@ -395,8 +404,8 @@ msgstr "Mal edinme ve talep sürecinin asıl başlatıcısı için kullanılır.
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_id
 msgid ""
-"Used for the original party who purchases the good when the Delivery Address "
-"is for another recipient"
+"Used for the original party who purchases the good when the Delivery Address"
+" is for another recipient"
 msgstr ""
 "Teslimat Adresi başka bir alıcıya ait olduğunda malı satın alan asıl taraf "
 "için kullanılır"
@@ -454,6 +463,7 @@ msgstr "Araç plakası zorunludur."
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "View %s"
 msgstr "%s'i Görüntüle"
@@ -492,6 +502,7 @@ msgstr "e-İrsaliye XML dosyası başarıyla oluşturuldu."
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "e-Dispatch will not be generated as the Delivery Address is not set."
 msgstr "Teslimat Adresi belirtilmediği için e-İrsaliye oluşturulmayacaktır."
@@ -499,4 +510,4 @@ msgstr "Teslimat Adresi belirtilmediği için e-İrsaliye oluşturulmayacaktır.
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
 msgid "Şoför"
-msgstr "Şoför"
+msgstr ""

--- a/addons/l10n_tr_nilvera_edispatch/models/res_partner.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/res_partner.py
@@ -10,7 +10,7 @@ class ResPartner(models.Model):
         size=5,
     )
 
-    def _l10n_tr_nilvera_validate_partner_details(self, is_delivery_partner=False):
+    def _l10n_tr_nilvera_validate_partner_details(self, is_delivery_partner=False, tax_office_required=False):
         error_messages = {}
 
         for record in self:
@@ -38,6 +38,9 @@ class ResPartner(models.Model):
                 or len(record.l10n_tr_nilvera_edispatch_customs_zip) != 5
             ):
                 msg.append(_("Customs ZIP of 5 characters must be present"))
+
+            if tax_office_required and country_code == 'TR' and not record.ref:
+                msg.append(_("Reference field must be set to the tax office name"))
 
             if msg:
                 # Instead of using name, display_name is used, since name is not required

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -108,16 +108,21 @@ class StockPicking(models.Model):
 
     def _l10n_tr_validate_edispatch_on_done(self):
         partners = (
-            self.company_id.partner_id
-            | self.partner_id
-            | self.partner_id.commercial_partner_id
-            | self.l10n_tr_nilvera_carrier_id
+            self.partner_id
             | self.l10n_tr_nilvera_buyer_id
             | self.l10n_tr_nilvera_seller_supplier_id
             | self.l10n_tr_nilvera_buyer_originator_id
         )
+        partners_requiring_tax_office = (
+            self.company_id.partner_id
+            | self.partner_id.commercial_partner_id
+            | self.l10n_tr_nilvera_carrier_id
+        )
 
-        error_messages = partners._l10n_tr_nilvera_validate_partner_details()
+        error_messages = (
+            partners._l10n_tr_nilvera_validate_partner_details() |
+            partners_requiring_tax_office._l10n_tr_nilvera_validate_partner_details(tax_office_required=True)
+        )
 
         if self.l10n_tr_nilvera_dispatch_type == 'MATBUDAN':
             if not self.l10n_tr_nilvera_delivery_date:

--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -31,6 +31,11 @@
                 <cbc:Name t-out="tr_country.name"/>
             </cac:Country>
         </cac:PostalAddress>
+        <cac:PartyTaxScheme t-if="tax_office_required">
+            <cac:TaxScheme>
+                <cbc:Name t-out="partner.ref"/>
+            </cac:TaxScheme>
+        </cac:PartyTaxScheme>
         <cac:Contact>
             <cbc:Telephone t-out="partner.phone"/>
             <cbc:ElectronicMail t-out="partner.email"/>
@@ -109,11 +114,13 @@
             <cac:DespatchSupplierParty>
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="current_company"/>
+                    <t t-set="tax_office_required" t-value="partner.country_code == 'TR'"/>
                 </t>
             </cac:DespatchSupplierParty>
             <cac:DeliveryCustomerParty>
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="picking.partner_id.commercial_partner_id"/>
+                    <t t-set="tax_office_required" t-value="partner.country_code == 'TR'"/>
                 </t>
             </cac:DeliveryCustomerParty>
             <cac:BuyerCustomerParty t-if="picking.l10n_tr_nilvera_buyer_id">
@@ -167,6 +174,7 @@
                     <cac:CarrierParty t-if="picking.l10n_tr_nilvera_carrier_id">
                         <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_details">
                             <t t-set="partner" t-value="picking.l10n_tr_nilvera_carrier_id"/>
+                            <t t-set="tax_office_required" t-value="partner.country_code == 'TR'"/>
                         </t>
                     </cac:CarrierParty>
                     <cac:Despatch>


### PR DESCRIPTION
Problem:
- The generated e-dispatch XML was missing the customer tax office name, marking XML to be rejected or incomplete in GIB validation.

After this commit:
- Added the missing customer tax office name in the e-dispatch XML.
- Introduced a validation check to ensure the tax office field is set before XML generation.

task-5013706

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
