### PR TITLE
[IMP] l10n_tr_nilvera_*: add tax office in e-dispatch XML

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -31,6 +31,11 @@
                 <cbc:Name t-out="tr_country.name"/>
             </cac:Country>
         </cac:PostalAddress>
+        <cac:PartyTaxScheme t-if="tax_office_required">
+            <cac:TaxScheme>
+                <cbc:Name t-out="partner._get_tax_office_for_edispatch()"/>
+            </cac:TaxScheme>
+        </cac:PartyTaxScheme>
         <cac:Contact>
             <cbc:Telephone t-out="partner.phone"/>
             <cbc:ElectronicMail t-out="partner.email"/>
@@ -109,11 +114,13 @@
             <cac:DespatchSupplierParty>
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="current_company"/>
+                    <t t-set="tax_office_required" t-value="partner.country_code == 'TR'"/>
                 </t>
             </cac:DespatchSupplierParty>
             <cac:DeliveryCustomerParty>
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="picking.partner_id.commercial_partner_id"/>
+                    <t t-set="tax_office_required" t-value="partner.country_code == 'TR'"/>
                 </t>
             </cac:DeliveryCustomerParty>
             <cac:BuyerCustomerParty t-if="picking.l10n_tr_nilvera_buyer_id">
@@ -167,6 +174,7 @@
                     <cac:CarrierParty t-if="picking.l10n_tr_nilvera_carrier_id">
                         <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_details">
                             <t t-set="partner" t-value="picking.l10n_tr_nilvera_carrier_id"/>
+                            <t t-set="tax_office_required" t-value="partner.country_code == 'TR'"/>
                         </t>
                     </cac:CarrierParty>
                     <cac:Despatch>

--- a/addons/l10n_tr_nilvera_einvoice_extended/models/res_partner.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class ResPartner(models.Model):
@@ -15,3 +15,13 @@ class ResPartner(models.Model):
         for partner in tr_partners_with_tax_office:
             if not partner.env.context.get("formatted_display_name"):
                 partner.display_name = (f"{partner.display_name}\n{partner.l10n_tr_tax_office_id.name}")
+
+    def _get_tax_office_missing_message(self):
+        # OVERRIDE
+        self.ensure_one()
+        return _("The Turkish Tax Office field must be filled") if not self.l10n_tr_tax_office_id else None
+
+    def _get_tax_office_for_edispatch(self):
+        # OVERRIDE
+        self.ensure_one()
+        return self.l10n_tr_tax_office_id.name


### PR DESCRIPTION
Problem:
- The generated e-dispatch XML was missing the customer tax office name, marking XML to be rejected or incomplete in GIB validation.
- Error banners had yellow background, conveying warnings even for blocking errors.

After this commit:
- Added the missing customer tax office name in the e-dispatch XML.
- Introduced a validation check to ensure the tax office field is set before XML generation.
- Changed banner level to 'danger' for blocking errors.

task-5013706

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
