### PR TITLE
[FIX] website: correct wrong resources

### DIFF
--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -27,8 +27,8 @@ class accordionOptionPlugin extends Plugin {
             DefineCustomIconAction,
             CustomAccordionIconAction,
         },
-        force_not_editable_selector: [".accordion-button"],
-        force_editable_selector: [".accordion-button span"],
+        content_not_editable_selectors: [".accordion-button"],
+        content_editable_selectors: [".accordion-button span"],
     };
 }
 


### PR DESCRIPTION
Since [1], the `force_editable_selector` resource has been renamed into `content_editable_selectors` and `force_not_editable_selector` into `content_not_editable_selectors`. However, resources introduced by [2] have not been converted by mistake. This commit fixes it.

[1]: https://github.com/odoo/odoo/commit/13565e0330bbc44eeecbb5d2ecd3acd7b4cdded4
[2]: https://github.com/odoo/odoo/commit/627c1a5a3a113014d1d586a5179ebfe88549f809

task-5222853


