### PR TITLE
[IMP] mail,web: track properties field

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -174,7 +174,7 @@ class MailTrackingValue(models.Model):
         return values
 
     @api.model
-    def _create_tracking_values_property(self, initial_value, col_name, col_info, record):
+    def _create_tracking_values_property(self, initial_value, new_value, col_name, col_info, record):
         """Generate the values for the <mail.tracking.values> corresponding to a property."""
         col_info = col_info | {'type': initial_value['type'], 'selection': initial_value.get('selection')}
 
@@ -188,7 +188,7 @@ class MailTrackingValue(models.Model):
             value = [t for t in initial_value.get('tags', []) if t[0] in value]
 
         tracking_values = self.env['mail.tracking.value']._create_tracking_values(
-            value, False, col_name, col_info, record)
+            value, new_value.get('value', False), col_name, col_info, record)
         return {**tracking_values, 'field_info': field_info}
 
     def _tracking_value_format(self):

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -14,10 +14,8 @@
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking" role="group">
                                     <span class="o-mail-Message-trackingOld text-muted fw-bold" t-out="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
-                                    <t t-if="!trackingValue.fieldInfo.isPropertyField">
-                                        <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
-                                        <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-out="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
-                                    </t>
+                                    <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
+                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-out="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
                                     <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-out="props.messageSearch?.highlight(trackingValue.fieldInfo.changedField) ?? trackingValue.fieldInfo.changedField"/>)</span>
                                 </li>
                             </t>

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -390,6 +390,18 @@ export class PropertyDefinition extends Component {
     }
 
     /**
+     * @param {boolean} tracking
+     */
+    onTrackingChange(tracking) {
+        const propertyDefinition = {
+            ...this.state.propertyDefinition,
+            tracking,
+        };
+        this.props.onChange(propertyDefinition);
+        this.state.propertyDefinition = propertyDefinition;
+    }
+
+    /**
      * We activate / deactivate the property in the kanban view.
      *
      * @param {boolean} newValue

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -176,20 +176,23 @@
                             t-on-change="onSuffixChange"
                         />
                     </div>
+                    <div class="o_field_property_definition_kanban d-contents mb-3 mb-sm-0">
+                        <label t-att-for="getUniqueDomID('kanban')" class="o_form_label align-self-center text-900">
+                            Display in Cards
+                            <sup class="text-info" title="Whether or not this Property Field is displayed in the Calendar, Cards &amp; Kanban views">?</sup>
+                        </label>
+                        <CheckBox
+                            id="getUniqueDomID('kanban')"
+                            value="props.propertyDefinition.view_in_cards"
+                            disabled="props.readonly"
+                            onChange.bind="onViewInKanbanChange"
+                        />
+                    </div>
+                    <div t-if="!['html', 'many2many', 'tags'].includes(state.propertyDefinition.type)" class="o_field_property_definition_tracking d-contents mb-3 mb-sm-0">
+                        <label t-att-for="getUniqueDomID('tracking')" class="o_form_label align-self-center text-900">Track in chatter</label>
+                        <CheckBox id="getUniqueDomID('tracking')" value="props.propertyDefinition.tracking" disabled="props.readonly" onChange.bind="onTrackingChange"/>
+                    </div>
                 </t>
-                <div t-if="!['separator', 'signature'].includes(state.propertyDefinition.type)"
-                    class="o_field_property_definition_kanban d-contents mb-3 mb-sm-0">
-                    <label t-att-for="getUniqueDomID('kanban')" class="o_form_label align-self-center text-900">
-                        Display in Cards
-                        <sup class="text-info" title="Whether or not this Property Field is displayed in the Calendar, Cards &amp; Kanban views">?</sup>
-                    </label>
-                    <CheckBox
-                        id="getUniqueDomID('kanban')"
-                        value="props.propertyDefinition.view_in_cards"
-                        disabled="props.readonly"
-                        onChange.bind="onViewInKanbanChange"
-                    />
-                </div>
                 <div t-elif="state.propertyDefinition.type === 'separator'" class="o_field_property_definition_kanban d-contents mb-3 mb-sm-0">
                     <t t-set="separatorId" t-value="getUniqueDomID('separator')"/>
                     <label t-att-for="separatorId" class="o_form_label align-self-center text-900">

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -984,7 +984,7 @@ class PropertiesDefinition(Field):
     ALLOWED_KEYS = (
         'name', 'string', 'type', 'comodel', 'default', 'suffix',
         'selection', 'tags', 'domain', 'view_in_cards', 'fold_by_default',
-        'currency_field', 'hidden',
+        'currency_field', 'hidden', 'tracking',
     )
     # those keys will be removed if the types does not match
     PROPERTY_PARAMETERS_MAP = {


### PR DESCRIPTION
Before this commit, properties could be tracked by setting `tracking=True` on the field definition. Each property of the field was tracked and the changes were logged only if the parent field was changed. This commit adds a track setting on each property which able to log changes per property. The changes are now logged everytime if the setting is on.

task-5131127