### PR TITLE
[IMP] *: add dropzones for controller pages

### DIFF
--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -6,12 +6,14 @@
 <template id="index" name="Blog Navigation">
     <t t-call="website.layout">
         <div id="wrap" class="js_blog website_blog">
+            <t t-set="editor_message">Drag blocks here to add them on all blogs</t>
+            <!-- Droppable-area shared across all blog's pages -->
+            <div class="oe_structure oe_empty" id="oe_structure_blog_header" t-att-data-editor-message="editor_message"/>
+
             <t t-out="0"/>
 
             <!-- Droppable-area shared across all blog's pages -->
-            <div class="oe_structure oe_empty oe_structure_not_nearest"
-                id="oe_structure_blog_footer"
-                data-editor-message.translate="Drag blocks here to add them on all blogs"/>
+            <div class="oe_structure oe_empty" id="oe_structure_blog_footer" t-att-data-editor-message="editor_message"/>
         </div>
     </t>
 </template>
@@ -39,17 +41,17 @@ list of filtered posts (by date or tag).
             <t t-if="not tag and not date_begin and not search">
                 <div id="o_wblog_blog_top_droppable"/>
                 <t t-if="blog">
-                    <div t-field="blog.content" t-attf-data-editor-sub-message.translate="Edit the '{{blog.name}}' page header."/>
+                    <div t-field="blog.content" t-attf-data-editor-message.translate='Drag blocks here to customize the header of the "{{blog.name}}" category.'/>
                 </t>
                 <t t-elif="blogs">
-                    <div class="oe_structure" data-editor-sub-message.translate="Edit the 'All Blogs' page header."/>
+                    <div class="oe_structure oe_empty" data-editor-message.translate="Drag blocks here to customize the Blog page header"/>
                 </t>
             </t>
             <t t-else="">
                 <!-- Droppable-area for filtered results (tags or date) -->
                 <div class="oe_structure"
                     id="oe_structure_blog_filtered_header"
-                    data-editor-sub-message.translate="Edit the 'Filter Results' page header."/>
+                    data-editor-message.translate='Drag blocks here to customize the "Filter Results" page header'/>
             </t>
         </div>
 

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -6,12 +6,14 @@
 <template id="index" name="Blog Navigation">
     <t t-call="website.layout">
         <div id="wrap" class="js_blog website_blog">
+            <t t-set="editor_message">Drag blocks here to add them on all blogs</t>
+            <!-- Droppable-area shared across all blog's pages -->
+            <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_blog_header" t-att-data-editor-message="editor_message"/>
+
             <t t-out="0"/>
 
             <!-- Droppable-area shared across all blog's pages -->
-            <div class="oe_structure oe_empty oe_structure_not_nearest"
-                id="oe_structure_blog_footer"
-                data-editor-message.translate="Drag blocks here to add them on all blogs"/>
+            <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_blog_footer" t-att-data-editor-message="editor_message"/>
         </div>
     </t>
 </template>
@@ -42,7 +44,7 @@ list of filtered posts (by date or tag).
                     <div t-field="blog.content" t-attf-data-editor-sub-message.translate="Edit the '{{blog.name}}' page header."/>
                 </t>
                 <t t-elif="blogs">
-                    <div class="oe_structure" data-editor-sub-message.translate="Edit the 'All Blogs' page header."/>
+                    <div class="oe_structure oe_empty" data-editor-sub-message.translate="Edit the 'All Blogs' page header."/>
                 </t>
             </t>
             <t t-else="">

--- a/addons/website_event/tests/test_event_menus.py
+++ b/addons/website_event/tests/test_event_menus.py
@@ -25,7 +25,7 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         self.assertTrue(event.website_menu)
         self.assertTrue(event.introduction_menu)
         self.env['ir.ui.view'].create({
-            'arch_db': '<xpath expr="//div[@id=\'oe_structure_website_event_intro_2\']" position="replace"><p>This is an intro</p></xpath>',
+            'arch_db': '<xpath expr="//div[@id=\'oe_structure_website_event_intro\']" position="replace"><p>This is an intro</p></xpath>',
             'inherit_id': event.introduction_menu_ids.view_id.id,
             'key': 'website_event.intro-test-child',
         })

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -7,9 +7,11 @@
         opt_events_list_categories="is_view_active('website_event.opt_events_list_categories')">
         <!-- Options -->
         <div id="wrap" t-attf-class="o_wevent_event js_event d-flex flex-column h-100 #{'o_wevent_hide_sponsors' if hide_sponsors else ''}">
+            <t t-set="editor_message">Drag blocks here to add them on all events</t>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_0" t-att-data-editor-message="editor_message"/>
             <t t-if="not hide_submenu" t-call="website_event.navbar"/>
             <t t-out="0"/>
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" data-editor-message.translate="Drag blocks here to add them on all events"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" t-att-data-editor-message="editor_message"/>
         </div>
 
         <!-- The registration modal is available in any event page  -->

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -5,7 +5,7 @@
 <template id="template_intro">
     <t t-call="website_event.layout">
         <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_1"/>
-        <div class="oe_structure">
+        <div class="oe_structure oe_structure_solo">
             <section class="s_title pt32 pb32" data-vcss="001" data-snippet="s_title" data-name="Title">
                 <div class="container s_allow_columns">
                     <h1 class="display-3" style="text-align: center;">Introduction</h1>

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -4,15 +4,13 @@
 <!-- Multipage event - Default template for the Introduction page -->
 <template id="template_intro">
     <t t-call="website_event.layout">
-        <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_1"/>
-        <div class="oe_structure">
+        <div class="oe_structure" id="oe_structure_website_event_intro">
             <section class="s_title pt32 pb32" data-vcss="001" data-snippet="s_title" data-name="Title">
                 <div class="container s_allow_columns">
                     <h1 class="display-3" style="text-align: center;">Introduction</h1>
                 </div>
             </section>
         </div>
-        <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_2"/>
     </t>
 </template>
 

--- a/addons/website_forum/static/tests/tours/forum_cover_dropzone.js
+++ b/addons/website_forum/static/tests/tours/forum_cover_dropzone.js
@@ -20,7 +20,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Check that the 'Title' snippet was inserted in the forum cover.",
-            trigger: ":iframe .s_cover .s_title",
+            trigger: ":iframe #oe_structure_website_forum_header_2 .s_title",
         },
         // Add a snippet with drag and drop.
         {

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -195,7 +195,10 @@
             </div>
         </t>
         <t t-else="">
-            <div class="oe_structure" id="oe_structure_website_forum_header_1"/>
+            <t t-set="editor_message">Drag blocks here to add them on all forum</t>
+            <div class="oe_structure oe_empty" id="oe_structure_website_forum_header_1" t-att-data-editor-message="editor_message"/>
+            <div id="website_forum_welcome_header"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_forum_header_2" t-att-data-editor-message="editor_message"/>
             <div id="wrap" t-attf-class="o_wforum_wrapper position-relative container row mx-auto px-0 #{ 'h-100' if forum_welcome_message else ''} #{website_forum_action}">
                 <t t-set="_forum_slug" t-value="slug(forum) if forum else 'all'"/>
                 <t t-set="_forum_path" t-value="url_for('/forum') + '/' + _forum_slug"/>
@@ -212,6 +215,7 @@
                     </div>
                 </div>
             </div>
+            <div class="oe_structure oe_empty" id="oe_structure_website_forum_footer_1" t-att-data-editor-message="editor_message"/>
         </t>
     </t>
 </template>
@@ -336,9 +340,9 @@
     </div>
 </template>
 
-<template id="header_welcome_message" inherit_id="website_forum.header" name="Forum Welcome Message (oe_structure_forum_top)">
-    <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_forum_header_1']" position="replace">
-        <div t-if="forum" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1">
+<template id="header_welcome_message" inherit_id="website_forum.header" name="Forum Welcome Message">
+    <xpath expr="//div[@id='website_forum_welcome_header']" position="inside">
+        <div t-if="forum">
             <section t-if="editable or translatable or (is_public_user and not forum_welcome_message)" t-attf-class="s_cover parallax s_parallax_is_fixed bg-black-50 pt48 pb48 #{'css_non_editable_mode_hidden' if editable or translatable else 'forum_intro'}" data-scroll-background-ratio="1" data-snippet="s_cover">
                 <t t-if="forum.image_1920">
                     <span class="s_parallax_bg_wrap">

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -214,6 +214,7 @@
                     </div>
                 </div>
             </div>
+            <div class="oe_structure" id="oe_structure_website_forum_footer_1"/>
         </t>
     </t>
 </template>
@@ -340,7 +341,7 @@
 
 <template id="header_welcome_message" inherit_id="website_forum.header" name="Forum Welcome Message (oe_structure_forum_top)">
     <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_forum_header_1']" position="replace">
-        <div t-if="forum" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1">
+        <div t-if="forum" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1" t-ignore="true">
             <section t-if="editable or (is_public_user and not forum_welcome_message)" t-attf-class="s_cover parallax s_parallax_is_fixed bg-black-50 pt48 pb48 #{'css_non_editable_mode_hidden' if editable else 'forum_intro'}" data-scroll-background-ratio="1" data-snippet="s_cover">
                 <t t-if="forum.image_1920">
                     <span class="s_parallax_bg_wrap">

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -103,6 +103,8 @@
 <template id="detail" name="Job Detail">
     <t t-call="website.layout">
         <!-- Topbar -->
+        <t t-set="editor_message">Drag blocks here to add them on all jobs</t>
+        <div class="oe_structure oe_empty" id="oe_structure_hr_recruitment_index_0" t-att-data-editor-message="editor_message"/>
         <nav class="navbar navbar-light border-top shadow-sm d-print-none">
             <div class="container">
                 <div class="d-flex flex-column flex-md-row flex-md-wrap flex-lg-nowrap justify-content-between w-100">
@@ -115,6 +117,7 @@
                 </div>
             </div>
         </nav>
+        <div class="oe_structure oe_empty" id="oe_structure_hr_recruitment_index_1" t-att-data-editor-message="editor_message"/>
         <!-- Content -->
         <div id="wrap" class="js_hr_recruitment">
             <div itemscope="itemscope" itemtype="https://schema.org/JobPosting">
@@ -183,6 +186,7 @@
                 </div>
             </div>
         </div>
+        <div class="oe_structure oe_empty" id="oe_structure_hr_recruitment_index_2" t-att-data-editor-message="editor_message"/>
     </t>
 </template>
 

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -101,6 +101,8 @@
 <template id="detail" name="Job Detail" track="1">
     <t t-call="website.layout">
         <!-- Topbar -->
+         <t t-set="editor_message">Drag blocks here to add them on all jobs</t>
+        <div class="oe_structure oe_empty" id="oe_structure_hr_recruitment_index_0" t-att-data-editor-message="editor_message"/>
         <nav class="navbar navbar-light border-top shadow-sm d-print-none">
             <div class="container">
                 <div class="d-flex flex-column flex-md-row flex-md-wrap flex-lg-nowrap justify-content-between w-100">
@@ -113,6 +115,7 @@
                 </div>
             </div>
         </nav>
+        <div class="oe_structure oe_empty" id="oe_structure_hr_recruitment_index_1" t-att-data-editor-message="editor_message"/>
         <!-- Content -->
         <div id="wrap" class="js_hr_recruitment">
             <div itemscope="itemscope" itemtype="https://schema.org/JobPosting">
@@ -181,6 +184,7 @@
                 </div>
             </div>
         </div>
+        <div class="oe_structure oe_empty" id="oe_structure_hr_recruitment_index_2" t-att-data-editor-message="editor_message"/>
     </t>
 </template>
 


### PR DESCRIPTION
*: html_builder, website, website_blog, website_event,
website_forum, website_hr_recruitment

This commit introduces the missing dropzones for controller
pages and standardizes the dropzone messages.

task-4430461

Enterprise: https://github.com/odoo/enterprise/pull/98446/files
