### PR TITLE
[IMP] html_editor: shortcut tooltips in toolbar

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -124,6 +124,7 @@ export class FormatPlugin extends Plugin {
         toolbar_items: [
             {
                 id: "bold",
+                description: _t("Bold (Ctrl + B)"),
                 groupId: "decoration",
                 namespaces: ["compact", "expanded"],
                 commandId: "formatBold",
@@ -131,6 +132,7 @@ export class FormatPlugin extends Plugin {
             },
             {
                 id: "italic",
+                description: _t("Italic (Ctrl + I)"),
                 groupId: "decoration",
                 namespaces: ["compact", "expanded"],
                 commandId: "formatItalic",
@@ -138,6 +140,7 @@ export class FormatPlugin extends Plugin {
             },
             {
                 id: "underline",
+                description: _t("Underline (Ctrl + U)"),
                 groupId: "decoration",
                 namespaces: ["compact", "expanded"],
                 commandId: "formatUnderline",
@@ -145,6 +148,7 @@ export class FormatPlugin extends Plugin {
             },
             {
                 id: "strikethrough",
+                description: _t("Strikethrough (Ctrl + 5)"),
                 groupId: "decoration",
                 commandId: "formatStrikethrough",
                 isActive: isFormatted(this, "strikeThrough"),

--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -8,10 +8,10 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { weakMemoize } from "@html_editor/utils/functions";
 
 const alignmentItems = [
-    { mode: "left" },
-    { mode: "center" },
-    { mode: "right" },
-    { mode: "justify" },
+    { mode: "left", description: _t("Left align") },
+    { mode: "center", description: _t("Center align") },
+    { mode: "right", description: _t("Right align") },
+    { mode: "justify", description: _t("Justify") },
 ];
 
 export class AlignPlugin extends Plugin {

--- a/addons/html_editor/static/src/main/align/align_selector.xml
+++ b/addons/html_editor/static/src/main/align/align_selector.xml
@@ -10,6 +10,7 @@
                 <div data-prevent-closing-overlay="true">
                     <t t-foreach="items" t-as="item" t-key="item_index">
                         <button
+                            t-att-title="item.description"
                             t-attf-class="btn btn-light fa fa-align-{{item.mode}}"
                             t-att-class="{ active: item.mode === state.displayName }"
                             t-on-click="() => this.onSelected(item)"

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -189,6 +189,7 @@ export class LinkPlugin extends Plugin {
         toolbar_items: [
             {
                 id: "link",
+                description: _t("Insert link (Ctrl + K)"),
                 groupId: "link",
                 commandId: "openLinkTools",
                 isActive: isLinkActive,

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -50,16 +50,19 @@ const listSelectorItems = [
         id: "bulleted_list",
         commandId: "toggleListUL",
         mode: "UL",
+        description: _t("Bulleted list (Ctrl + Shift + 8)"),
     },
     {
         id: "numbered_list",
         commandId: "toggleListOL",
         mode: "OL",
+        description: _t("Numbered list (Ctrl + Shift + 7)"),
     },
     {
         id: "checklist",
         commandId: "toggleListCL",
         mode: "CL",
+        description: _t("Checklist (Ctrl + Shift + 9)"),
     },
 ];
 
@@ -1271,7 +1274,7 @@ export class ListPlugin extends Plugin {
                 return {
                     ...pick(button, "id", "icon", "run", "mode"),
                     // We want short descriptions for these buttons.
-                    description: command.title,
+                    description: item.description,
                 };
             });
     }

--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -38,7 +38,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_compo
         },
         {
             content: "Bold the text",
-            trigger: ".o-we-toolbar button[title='Toggle bold']",
+            trigger: ".o-we-toolbar button[title='Bold (Ctrl + B)']",
             run: "click",
         },
         {
@@ -69,12 +69,12 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_compo
         },
         {
             content: "Remove the Bold",
-            trigger: ".o-we-toolbar button[title='Toggle bold']",
+            trigger: ".o-we-toolbar button[title='Bold (Ctrl + B)']",
             run: "click",
         },
         {
             content: "Italicize the text",
-            trigger: ".o-we-toolbar button[title='Toggle italic']",
+            trigger: ".o-we-toolbar button[title='Italic (Ctrl + I)']",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -46,7 +46,12 @@ registerWebsitePreviewTour(
             trigger: FIRST_PARAGRAPH,
             run: "editor Paragraph", // Make sure the selection is set in the paragraph
         },
-        ...clickToolbarButton("Paragraph", "#wrap .s_text_image p", "Add a link", false),
+        ...clickToolbarButton(
+            "Paragraph",
+            "#wrap .s_text_image p",
+            "Insert link (Ctrl + K)",
+            false
+        ),
         ...editLinkAndApply("/contactus"),
         ...openLinkPopup(`${FIRST_PARAGRAPH} a`, "/contactus", 1, true),
         {

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -266,7 +266,7 @@ registerWebsitePreviewTour(
         ...clickToolbarButton(
             "h4 of first menu link of the first column",
             ".s_mega_menu_big_icons_subtitles .row > div:first-child .nav > :first-child h4",
-            "Toggle bold"
+            "Bold (Ctrl + B)"
         ),
         ...clickOnSave(),
         clickOnExtraMenuItem({}, true),


### PR DESCRIPTION
This PR updates toolbar button tooltips to display their corresponding keyboard shortcuts.

Enterprise PR: https://github.com/odoo/enterprise/pull/98451

task-5160025






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
