### PR TITLE
[FIX] sale{,_stock{,_margin}}: allow SOL cost update post-cancel

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1316,7 +1316,7 @@ class SaleOrderLine(models.Model):
         return amount
 
     def has_valued_move_ids(self):
-        return self.move_ids
+        return None  # TODO: remove in master
 
     def _sellable_lines_domain(self):
         discount_products_ids = self.env.companies.sale_discount_product_id.ids

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -388,3 +388,9 @@ class SaleOrderLine(models.Model):
             )
         )
         return res
+
+    def has_valued_move_ids(self):
+        return (
+            any(move.state not in ('cancel', 'draft') for move in self.move_ids)
+            or super().has_valued_move_ids()  # TODO: remove in master
+        )

--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -49,6 +49,17 @@ class TestSaleStockMargin(TestStockValuationCommon):
         product_template.categ_id.property_cost_method = 'fifo'
         return product_template.product_variant_ids
 
+    def _setup_multicurrency(self):
+        usd = self.env.ref('base.USD')
+        self.company_currency = self.env.company.currency_id
+        self.other_currency = self.env.ref('base.EUR') if self.company_currency == usd else usd
+        date = fields.Date.today()
+        self.env['res.currency.rate'].create([
+            {'currency_id': self.company_currency.id, 'rate': 1, 'name': date},
+            {'currency_id': self.other_currency.id, 'rate': 2, 'name': date},
+        ])
+        return self.company_currency, self.other_currency
+
     #########
     # TESTS #
     #########
@@ -202,18 +213,7 @@ class TestSaleStockMargin(TestStockValuationCommon):
         self.assertEqual(order_line_2.purchase_price, 40, "Sales order line cost should be 40.00")
 
     def test_so_and_multicurrency(self):
-        ResCurrencyRate = self.env['res.currency.rate']
-        company_currency = self.env.company.currency_id
-        other_currency = self.env.ref('base.EUR') if company_currency == self.env.ref('base.USD') else self.env.ref('base.USD')
-
-        date = fields.Date.today()
-        ResCurrencyRate.create({'currency_id': company_currency.id, 'rate': 1, 'name': date})
-        other_currency_rate = ResCurrencyRate.search([('name', '=', date), ('currency_id', '=', other_currency.id)])
-        if other_currency_rate:
-            other_currency_rate.rate = 2
-        else:
-            ResCurrencyRate.create({'currency_id': other_currency.id, 'rate': 2, 'name': date})
-
+        _company_currency, other_currency = self._setup_multicurrency()
         so = self._create_sale_order()
         so.pricelist_id = self.env['product.pricelist'].create({
             'name': 'Super Pricelist',
@@ -299,6 +299,7 @@ class TestSaleStockMargin(TestStockValuationCommon):
         self.assertEqual(sol.margin, 100)
 
     def test_purchase_price_changes(self):
+        self._setup_multicurrency()
         so = self._create_sale_order()
         product = self._create_product()
         product.categ_id.property_cost_method = 'standard'
@@ -320,6 +321,13 @@ class TestSaleStockMargin(TestStockValuationCommon):
         self.assertEqual(so.order_line[0].purchase_price, 15)
         so.action_confirm()
         self.assertEqual(so.order_line[0].purchase_price, 15)
+
+        # Set SO back to draft, and trigger purchase price recompute via currency change
+        so.with_context(disable_cancel_warning=True).action_cancel()
+        so.action_draft()
+        so.currency_id = self.other_currency
+        self.assertEqual(so.order_line.move_ids.state, 'cancel')
+        self.assertEqual(so.order_line.purchase_price, 40)
 
     def test_add_product_on_delivery_price_unit_on_sale(self):
         """ Adding a product directly on a sale order's delivery should result in the new SOL


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a product with a purchase cost;
2. have sale margins enabled;
3. add a the product to a quotation;
4. change pricelist to one with a different currency;
5. note that the line's cost gets updated;
6. change order state to confirmed, then canceled, then back to draft;
7. change pricelist again.

Issue
-----
The purchase cost no longer update.

Cause
-----
The `_compute_purchase_price` override in `sale_stock_margin` doesn't pass the line to `super` if it `has_valued_move_ids`. This hook only checks for the existence of linked `move_ids` on the record with no regard for their state.

Solution
--------
1. Move the `has_valued_move_ids` hook from `sale` to `sale_stock`.
2. Only return `True` if any of the moves aren't in draft or canceled.

opw-5147321