### PR TITLE
[FIX] hw_drivers: chromium process name

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -44,8 +44,7 @@ class DisplayDriver(Driver):
         self.rendered_html = ''
         if self.device_identifier != 'distant_display':
             # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
-            self.browser = 'chromium-browser' if float(helpers.get_version()[1:8]) >= 24.10 else 'firefox'
-            self.browser_process_name = 'chromium' if self.browser == 'chromium-browser' else self.browser
+            self.browser = 'chromium' if float(helpers.get_version()[1:8]) >= 24.10 else 'firefox'
             self._x_screen = device.get('x_screen', '0')
             self.load_url()
 
@@ -125,7 +124,7 @@ class DisplayDriver(Driver):
                 '--screen',
                 self._x_screen,
                 '--class',
-                self.browser_process_name,
+                self.browser,
                 'key',
                 keystroke,
             ], check=False)


### PR DESCRIPTION
To ensure compatibility with the last image version 2025.11.02, we need to update `chromium-browser` executable name to `chromium`

