### PR TITLE
[IMP] web: Hoot - log root suites at end of run

### DIFF
--- a/addons/web/static/lib/hoot/core/expect.js
+++ b/addons/web/static/lib/hoot/core/expect.js
@@ -545,6 +545,7 @@ export function makeExpect(params) {
             /** @type {import("../hoot_utils").Reporting} */
             const report = {
                 assertions: assertionCount,
+                duration: test.lastResults?.duration || 0,
                 tests: 1,
             };
             if (!currentResult.pass) {

--- a/addons/web/static/lib/hoot/core/logger.js
+++ b/addons/web/static/lib/hoot/core/logger.js
@@ -190,7 +190,7 @@ class Logger {
                 `(${withArgs.shift()}`,
                 ...withArgs,
                 "time:",
-                suite.jobs.reduce((acc, job) => acc + (job.duration || 0), 0),
+                suite.reporting.duration,
                 "ms)"
             );
         }

--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -1161,6 +1161,17 @@ export class Runner {
 
         await this._callbacks.call("after-all", this, logger.error);
 
+        if (this.headless) {
+            // Log root suite results in headless
+            const restoreLogLevel = logger.setLogLevel("suites");
+            for (const suite of this.suites.values()) {
+                if (!suite.parent) {
+                    logger.logSuite(suite);
+                }
+            }
+            restoreLogLevel();
+        }
+
         const { passed, failed, assertions } = this.reporting;
         if (failed > 0) {
             const errorMessage = ["Some tests failed: see above for details"];

--- a/addons/web/static/lib/hoot/hoot_utils.js
+++ b/addons/web/static/lib/hoot/hoot_utils.js
@@ -740,6 +740,7 @@ export function createReporting(parentReporting) {
 
     const reporting = reactive({
         assertions: 0,
+        duration: 0,
         failed: 0,
         passed: 0,
         skipped: 0,


### PR DESCRIPTION
This commit makes the unit test runner log all root suites results after each test run, only in headless mode.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
