### PR TITLE
[FIX] sale: portal report studio edit

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -658,6 +658,11 @@
             <t t-call="#{sale_order._get_name_tax_totals_view()}">
                 <t t-set="tax_totals" t-value="sale_order.tax_totals"/>
                 <t t-set="currency" t-value="sale_order.currency_id"/>
+                <!--
+                NOTE: This variable should not be used in templates before version 19.1, as it might
+                not be available in earlier versions if customer does not upgrade the `sale` module.
+                -->
+                <t t-set="doc" t-value="sale_order"/>
             </t>
         </table>
     </template>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Edit the `sale.report_saleorder` report using `web_studio`.
2. Add the `amount_untaxed` field next to the "Untaxed Amount" subtitle.
3. Create or navigate to a quotation and click on the "Preview" action.

Issue
-----
A traceback occurs during the rendering of the
`sale.sale_order_portal_template` template.
```
Error while render the template
KeyError: 'doc'
Template: sale.document_tax_totals
Path: /t/t/tr/td[1]/span
Node: <span t-field="doc.amount_untaxed"/>
The error occurred while rendering the template sale.document_tax_totals and evaluating the following expression: <span t-field="doc.amount_untaxed"/>
```

Cause
-----
In the `sale.report_saleorder_document` template, `doc` is used as the variable name for the current sale order. Consequently, the studio edit uses this variable name to modify the `sale.document_tax_totals` template called within `sale.report_saleorder_document`. However, the `sale.sale_order_portal_template` template, used for the portal preview, also calls `sale.document_tax_totals` but uses `sale_order` as the variable name for the current order.

Solution
--------
Add an alias `doc` for `sale_order` during the rendering of `sale.document_tax_totals` when called in the portal report preview.

opw-5136553

