### PR TITLE
[FIX] portal,website: prevent revoked portal user set as website default public user

### DIFF
--- a/addons/portal/tests/test_portal_wizard.py
+++ b/addons/portal/tests/test_portal_wizard.py
@@ -108,9 +108,8 @@ class TestPortalWizard(MailCommon):
             portal_user.action_revoke_access()
 
         self.assertEqual(portal_user.user_id, self.public_user, 'Must keep the user even if it is archived')
-        self.assertEqual(group_public, portal_user.user_id.groups_id, 'Must add the group public after removing the portal group')
         self.assertFalse(portal_user.user_id.active, 'Must have archived the user')
-        self.assertFalse(portal_user.is_portal)
+        self.assertTrue(portal_user.is_portal)
         self.assertFalse(portal_user.is_internal)
         self.assertNotSentEmail()
 

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -163,16 +163,14 @@ class PortalWizardUser(models.TransientModel):
         return self.action_refresh_modal()
 
     def action_revoke_access(self):
-        """Remove the user of the partner from the portal group.
+        """Archive the portal user of the partner.
 
-        If the user was only in the portal group, we archive it.
+        User is kept in `group_portal` as `group_public` should only be
+        used for automated tasks and guest interactions.
         """
         self.ensure_one()
         if not self.is_portal:
             raise UserError(_('The partner "%s" has no portal access or is internal.', self.partner_id.name))
-
-        group_portal = self.env.ref('base.group_portal')
-        group_public = self.env.ref('base.group_public')
 
         self._update_partner_email()
 
@@ -181,9 +179,8 @@ class PortalWizardUser(models.TransientModel):
 
         user_sudo = self.user_id.sudo()
 
-        # remove the user from the portal group
         if user_sudo and user_sudo.has_group('base.group_portal'):
-            user_sudo.write({'groups_id': [(3, group_portal.id), (4, group_public.id)], 'active': False})
+            user_sudo.write({'active': False})
 
         return self.action_refresh_modal()
 


### PR DESCRIPTION
**Steps to reproduce:**
- Go to a Contact
- Go to the actions dropdown menu of the record
- Grant Portal Access
- Revoke that Access
- Create a new Website in the same Company that Portal Access was granted
- That Contact's user will be set as the Public User for the new Website
- New orders and other default public user behavior will be assigned to this user
- The user will be mentionned in non-logged interactions

**Issue:**
Archived portal user are set as public user when revoked, and the default public user of a website is set on create to the first public user it finds in `_get_public_user`:
```
public_users = self.env.ref('base.group_public').sudo().with_context(active_test=False).users
public_users_for_company = public_users.filtered(lambda user: user.company_id == self)

if public_users_for_company:
    return public_users_for_company[0]
```

This seems to be an issue as such user can be reactivated or be assigned to some transactions it has not made (confidentiality issue).

**Fix:**
Not sure of the best way to fix this. We could ensure new website always creates a new public user, or find a better way to use by default the `self.env.ref('base.public_user')` (or its company-specific copies) for the company of the website during creation (or in `_get_public_user`).

For now the fix remove the public group on the revoked portal user, to still be able to reactivate it later on, without mistaking it for the default public user of a company.

Also we can't remove the `with_context(active_test=False)` as default public user always seems to be disabled.

related: https://github.com/odoo/odoo/commit/83e22fd0636748c4fe1058fb93adfad2623fc31b

opw-4760550

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
