### PR TITLE
[FIX] l10n_sa_edi_pos: skip forced zatca invoice for settlement due

### DIFF
--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -11,7 +11,13 @@ patch(PaymentScreen.prototype, {
         const order = this.currentOrder;
         // note: isSACompany guarantees order.is_to_invoice()
         // note: Skips entirely if journal is not onboarded or electronic invoicing is not selected
-        if (order.isSACompany && order.finalized && !order.l10n_sa_invoice_qr_code_str) {
+        // Also skip if invoice is not mandatory(Ex: settlement)
+        if (
+            order.isSACompany &&
+            order.finalized &&
+            !order.l10n_sa_invoice_qr_code_str &&
+            order.isInvoiceMandatoryForSA
+        ) {
             const orderError = _t("%s by going to Backend > Orders > Invoice", order.pos_reference);
             const href = `/odoo/customer-invoices/${this.currentOrder?.raw?.account_move}`;
             const link = markup(

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/models.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/models.js
@@ -6,24 +6,43 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrder.prototype, {
     setup(_defaultObj, options) {
         super.setup(...arguments);
-        if (this.isSACompany) {
+        if (this.isInvoiceMandatoryForSA) {
             this.to_invoice = true;
         }
     },
     is_to_invoice() {
-        if (this.isSACompany) {
+        if (this.isInvoiceMandatoryForSA) {
             return true;
         }
         return super.is_to_invoice(...arguments);
     },
     set_to_invoice(to_invoice) {
-        if (this.isSACompany) {
+        if (this.isInvoiceMandatoryForSA) {
             this.assert_editable();
             this.to_invoice = true;
         } else {
             super.set_to_invoice(...arguments);
         }
     },
+
+    set_partner(partner) {
+        /*
+        The settlement dialog sets is_settling_account = true after creating the order
+        So making it default to false here as this is called after is_settling_account is set
+        is_settling_account is only applicable if enterprise:pos_settle_due module is installed
+        */
+        super.set_partner(partner);
+        if (this.is_settling_account) {
+            this.set_to_invoice(false);
+        }
+    },
+
+    get isInvoiceMandatoryForSA() {
+        // Zatca enforces invoice, but for settlement due, invoices are not needed
+        // Only applicable if enterprise:pos_settle_due module is installed
+        return this.isSACompany && !this.is_settling_account;
+    },
+
     get isSACompany() {
         return this.company.country_id?.code == "SA";
     },

--- a/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
@@ -1,0 +1,47 @@
+/* global posmodel */
+
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_settlement", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            {
+                content: "Set the pos_settle_due to True and open payment screen",
+                trigger: "body",
+                run: () => {
+                    posmodel.get_order().is_settling_account = true;
+                    posmodel.showScreen("PaymentScreen", { orderUuid: posmodel.selectedOrderUuid });
+                },
+            },
+            PaymentScreen.clickPartnerButton(),
+            PaymentScreen.clickCustomer("AAA Partner"),
+            PaymentScreen.isInvoiceButtonUnchecked(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_not_settlement", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            {
+                content: "Set the pos_settle_due to False and open payment screen",
+                trigger: "body",
+                run: () => {
+                    posmodel.get_order().is_settling_account = false;
+                    posmodel.showScreen("PaymentScreen", { orderUuid: posmodel.selectedOrderUuid });
+                },
+            },
+            PaymentScreen.clickPartnerButton(),
+            PaymentScreen.clickCustomer("AAA Partner"),
+            PaymentScreen.isInvoiceButtonChecked(),
+            // Try to uncheck it and verify it remains checked
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.isInvoiceButtonChecked(),
+        ].flat(),
+});

--- a/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
+++ b/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
@@ -1,7 +1,11 @@
+from unittest.mock import patch
+
+from odoo.tests import tagged
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.l10n_sa_edi.tests.common import AccountEdiTestCommon
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
-from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install', 'post_install_l10n')
@@ -28,3 +32,39 @@ class TestGenericSAEdi(TestGenericLocalization):
             'zip': '42317',
             'l10n_sa_edi_building_number': '1234',
         })
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+
+    @classmethod
+    @AccountEdiTestCommon.setup_country('sa')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
+           new=lambda self: True)
+    def test_ZATCA_invoice_not_mandatory_if_settlement(self):
+        """
+        Tests that the invoice is  not mandatory in POS payment for ZATCA if it's a settlement.
+        """
+        self.test_partner = self.env["res.partner"].create({"name": "AAA Partner"})
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            'ZATCA_invoice_not_mandatory_if_settlement',
+            login="pos_admin",
+        )
+
+    @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
+           new=lambda self: True)
+    def test_ZATCA_invoice_mandatory_if_not_settlement(self):
+        """
+        Tests that the invoice is mandatory in POS payment for ZATCA.
+        Also is by default checked.
+        """
+        self.test_partner = self.env["res.partner"].create({"name": "AAA Partner"})
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            'ZATCA_invoice_mandatory_if_not_settlement',
+            login="pos_admin",
+        )

--- a/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
@@ -359,3 +359,12 @@ export function shippingLaterHighlighted() {
         trigger: ".button:contains('Ship Later').highlight",
     };
 }
+
+export function isInvoiceButtonUnchecked() {
+    return [
+        {
+            content: "check invoice button is not highlighted",
+            trigger: ".js_invoice:not(.highlight)",
+        },
+    ];
+}


### PR DESCRIPTION
## Dependent PR
https://github.com/odoo/enterprise/pull/98463

## Description of the issue/feature this PR addresses:
Users are blocked when trying to use the **Settle Due** feature in Point of Sale if the ZATCA (l10n_sa_edi_pos) integration is enabled.

## Current behavior before PR:
When a PoS order is created using a "Pay Later" payment method, an invoice is correctly generated and sent to ZATCA.

However, when the user later tries to settle that customer's due balance (using the **Settle Due** option), the l10n_sa_edi_pos module incorrectly forces the Invoice option to be enabled and makes the field read-only. This blocks the user because:

- Settlement orders do not contain any lines, so a new invoice cannot be generated.
- The original invoice was already sent to ZATCA, and the settlement payment should not be sent as a new e-invoice.

Thus, the user cannot proceed with the settlement.

## Desired behavior after PR is merged:
After this fix, the **Invoice** checkbox will no longer be forced or marked as read-only during **Settle Due** operations. The field will default to False, aligning with standard Odoo behavior for settlements and allowing the user to complete the payment.

task-5144679

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
