### PR TITLE
[IMP] account_edi_ubl_cii_tax_extension: optional tax exemption reason

### DIFF
--- a/addons/account_edi_ubl_cii_tax_extension/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii_tax_extension/models/account_edi_common.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import models, _
 
 TAX_EXEMPTION_MAPPING = {
     'VATEX-EU-79-C': 'Exempt based on article 79, point c of Council Directive 2006/112/EC',
@@ -84,7 +84,7 @@ class AccountEdiCommon(models.AbstractModel):
         if tax.ubl_cii_tax_category_code:
             reason_code = tax.ubl_cii_tax_exemption_reason_code
             reason_code = FIX_WRONG_CODES_MAPPING.get(reason_code, reason_code)
-            tax_exemption_reason = TAX_EXEMPTION_MAPPING.get(reason_code)
+            tax_exemption_reason = TAX_EXEMPTION_MAPPING.get(reason_code, _("Exempt from tax") if tax._requires_exemption_reason() else None)
             return {
                 'tax_category_code': tax.ubl_cii_tax_category_code,
                 'tax_exemption_reason_code': reason_code,

--- a/addons/account_edi_ubl_cii_tax_extension/views/account_tax_views.xml
+++ b/addons/account_edi_ubl_cii_tax_extension/views/account_tax_views.xml
@@ -9,7 +9,6 @@
                 <field name="ubl_cii_tax_category_code"/>
                 <field name="ubl_cii_tax_exemption_reason_code"
                        invisible="ubl_cii_tax_category_code not in ('AE', 'E', 'G', 'O', 'K')"
-                       required="ubl_cii_tax_category_code in ('AE', 'E', 'G', 'O', 'K')"
                        />
             </xpath>
         </field>


### PR DESCRIPTION
According to the ubl documentation the tax exemption reason code is not
always required on the document. But when no exemption reason code is 
given, we have a default exemption reason for the appropriate tax 
categories.


task: 5223145

