### PR TITLE
[IMP] website: allow restricting to 1 value many2many fields in forms

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_field_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_field_option.js
@@ -99,6 +99,7 @@ export class FormFieldOption extends BaseOptionComponent {
         onWillStart(async () => {
             const el = this.env.getEditingElement();
             const fieldOptionData = await loadFieldOptionData(el);
+            this.state.fields = fieldOptionData.fields;
             this.state.availableFields.push(...fieldOptionData.availableFields);
             this.state.conditionInputs.push(...fieldOptionData.conditionInputs);
             this.state.valueList = fieldOptionData.valueList;
@@ -107,6 +108,7 @@ export class FormFieldOption extends BaseOptionComponent {
         onWillUpdateProps(async (props) => {
             const el = this.env.getEditingElement();
             const fieldOptionData = await loadFieldOptionData(el);
+            this.state.fields = fieldOptionData.fields;
             this.state.availableFields.length = 0;
             this.state.availableFields.push(...fieldOptionData.availableFields);
             this.state.conditionInputs.length = 0;
@@ -178,7 +180,15 @@ export class FormFieldOption extends BaseOptionComponent {
     }
     get isExistingFieldSelectType() {
         const el = this.env.getEditingElement();
-        return !isFieldCustom(el) && ["selection", "many2one"].includes(el.dataset.type);
+        return (
+            !isFieldCustom(el) &&
+            ["selection", "many2one", "many2many"].includes(el.dataset.type) &&
+            !el.querySelector("input[type='file']")
+        );
+    }
+    get isExistingFieldSelectTypeMultiple() {
+        const el = this.env.getEditingElement();
+        return !isFieldCustom(el) && this.state.fields[getFieldName(el)].type === "many2many";
     }
     get isMultipleInputs() {
         const el = this.env.getEditingElement();

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -129,10 +129,11 @@
             <BuilderSelectItem actionValue="'url'">Url</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Selection type">
+    <BuilderRow label.translate="Selection type" level="1">
         <BuilderSelect t-if="isExistingFieldSelectType"
             id="'existing_field_select_type_opt'" preview="false" action="'existingFieldSelectType'"
         >
+            <BuilderSelectItem actionValue="'many2many'" t-if="isExistingFieldSelectTypeMultiple">Checkbox</BuilderSelectItem>
             <BuilderSelectItem actionValue="'many2one'">Dropdown List</BuilderSelectItem>
             <BuilderSelectItem actionValue="'selection'">Radio</BuilderSelectItem>
         </BuilderSelect>


### PR DESCRIPTION
User may need to select a "selection type" on existing fields. For example, users would like to restrict the selection of only one value of a M2M field like we have for M2O (like Author field, for example)

task-5126727