### PR TITLE
[IMP] tests: add dynamic config files

### DIFF
--- a/odoo/tests/runbot/parallel_testing.json
+++ b/odoo/tests/runbot/parallel_testing.json
@@ -1,0 +1,70 @@
+{
+    "name": "Parallel testing",
+    "vars": {
+        "module_filter": "*,-hw_*,-*l10n_*,-theme_*,-account_bacs,-account_reports_cash_basis,-auth_ldap,-base_gengo,-document_ftp,-iot_drivers,-note_pad,-odoo_referral,-odoo_referral_portal,-pad,-pad_project,-pos_blackbox_be,-pos_cache,-pos_six,-social_demo,-website_gengo,-website_instantclick,test_l10n_be_hr_payroll_account,test_l10n_us_hr_payroll_account"
+    },
+    "steps": [
+        {
+            "name": "Create at install",
+            "job_type": "create_build",
+            "children": [
+                {
+                    "name": "Test at install",
+                    "steps":[{
+                        "name": "Start at install",
+                        "job_type": "odoo",
+                        "install_modules": "{{module_filter}},-test_lint",
+                        "test_tags": "-post_install,-/test_lint"
+                        }]
+                },
+                {
+                    "name": "Test pylint",
+                    "steps":[{
+                        "name": "Start test lint",
+                        "job_type": "odoo",
+                        "install_modules": "test_lint",
+                        "test_tags": "-post_install,/test_lint"
+                    }]
+                }
+            ]
+        },
+        {
+            "name": "Install all",
+            "db_name": "all",
+            "job_type": "odoo",
+            "install_modules": "{{module_filter}}"
+        },
+        {
+            "name": "Create post install",
+            "job_type": "create_build",
+            "for_each_vars": [
+                {"test_module_filter": "-> !account_auto_transfer"},
+                {"test_module_filter": "account_auto_transfer -> !auth_totp"},
+                {"test_module_filter": "auth_totp -> !mrp"},
+                {"test_module_filter": "mrp -> !pos"},
+                {"test_module_filter": "pos -> !sale"},
+                {"test_module_filter": "sale -> !sale_timesheet"},
+                {"test_module_filter": "sale_timesheet -> !stock_barcode_mrp_subcontracting"},
+                {"test_module_filter": "stock_barcode_mrp_subcontracting -> !test_main_flows"},
+                {"test_module_filter": "test_main_flows -> !web"},
+                {"test_module_filter": "web -> web"},
+                {"test_module_filter": "!web -> !website"},
+                {"test_module_filter": "website -> website"},
+                {"test_module_filter": "!website -> "}
+            ],
+            "children": [{
+                "name": "Test Post Install",
+                "description": "Post install tests for **{{test_module_filter}}**",
+                "steps": [
+                    {"name": "restore", "job_type": "restore", "db_name": "all"},
+                    {
+                        "name": "Start post install tests",
+                        "job_type": "odoo",
+                        "test_tags": "-at_install,{{test_module_filter|filter_all_modules|make_module_test_tags}}",
+                        "db_name": "all"
+                    }
+                ]
+            }]
+        }
+    ]
+}

--- a/odoo/tests/runbot/readme.md
+++ b/odoo/tests/runbot/readme.md
@@ -1,0 +1,10 @@
+# Runbot config
+
+This direcory defines config that will be loaded by runbot to define how to run specifics test
+
+## Parallel testing
+The parallel_testing.json file describes how to run the test for all modules in parallel, starting first subbuilds for the at install tests, then installing a database with all modules, and finally starting multiple subuilds to test all post install in parallel.
+
+Note that the test-tags do not use the blacklist, this is to replicate the default odoo --test-enable behaviour. 
+Even if a module is blacklisted, it could be installed via an auto_install or if required by another module, and should be tested.
+


### PR DESCRIPTION
A new mechanism was added on runbot, allowing to specify how to run the tests from a json file located in the code. 

Those file are currently located in odoo/tests/runbot/ but this could change in the future.

The main motivation is to be able to define how to split the modules from the odoo code, allowing easier testing and different split per versions.
This should also help external runbot deployment to use similar config without needing to create the same config, either by copying the file of using the config extension mechanism (change the modules to install as an example)
Finally, some basic config will be added in the code to help to debug some use cases (enabling the profiler, running basic multibuild, faketime,...)

More config will be moved from runbot database to the community code in the future.

Note that this version is only a prototype and may change in the following weeks.

The current version is trying to be as intuitive and as simple as possible while being able to describe with precision how to run the tests. The module selection range was created for this specific use case and went over many iterations. 

The goal is to be able to filter a range of module, while including or not the boundaries. 
In this branch the used notation is `a -> !b` to define a range going from a (included) to b (excluded)

The usual mathematical notion in Belgium (and some other European countries) would be `[a,b[` but this is unfortunately not the same as the more international `[a,b)` notation, not intuitive when showed to some odoo developer. 
In general the mathematical notation can be difficult to read inside a json structure, because of the use of [ ].

Another possibility would have been to use the python notation, `a <= x < b` but this was more complex to parse, and also to powerful with the added complexity to add a placeholder for the module name. 

We finally decided to settle on something like `a -> !b`. 
Note that other considered option were `a..!b` (or even `a..b^`) to get closer to git notations.
