### PR TITLE
[IMP] l10n_ee: merge KMD & KMD INF, auto-generate Intrastat & EC List

### DIFF
--- a/addons/l10n_ee/data/account_tax_report_data.xml
+++ b/addons/l10n_ee/data/account_tax_report_data.xml
@@ -3,7 +3,7 @@
     <record id="tax_report" model="account.report">
         <field name="name">KMD Report</field>
         <field name="name@et">KMD aruanne</field>
-        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="root_report_id" eval="False"/>
         <field name="country_id" ref="base.ee"/>
         <field name="allow_foreign_vat" eval="True"/>
         <field name="availability_condition">country</field>
@@ -547,5 +547,19 @@
                 </field>
             </record>
         </field>
+    </record>
+
+    <record id="kmd_inf_tax_report" model="account.report">
+        <field name="name">KMD Report</field>
+        <field name="name@et">KMD aruanne</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.ee"/>
+        <field name="allow_foreign_vat" eval="True"/>
+        <field name="availability_condition">country</field>
+        <field name="use_sections" eval="True"/>
+        <field name="section_report_ids" eval="[
+            Command.set([
+                ref('l10n_ee.tax_report'),
+            ])]"/>
     </record>
 </odoo>


### PR DESCRIPTION
Current behavior before PR:
- KMD Report & VAT Report Annex (KMD INF Part A & Part B) were separate reports.

Desired behavior after PR is merged:
- KMD Report and VAT Report Annex (KMD INF Part A & Part B) are now merged into single combined report (`kmd_inf_tax_report`). Each report appears as a section within the merged report.

Changes implemented:
- Added a new combined report (`kmd_inf_tax_report`) that includes the KMD Report as a section. When the `l10n_ee_reports` module is installed, it also includes KMD INF (Part A & Part  B)  as additional sections.


related pr: odoo/enterprise#98471
task-5136165

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
