### PR TITLE
[FIX] stock_account: create journal item with correct total qty value

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -119,7 +119,7 @@ class AccountMove(models.Model):
                 # Compute accounting fields.
                 sign = -1 if move.move_type == 'out_refund' else 1
                 price_unit = line.with_context(anglo_saxon_price_ctx)._get_cogs_value()
-                amount_currency = sign * line.quantity * price_unit
+                amount_currency = sign * line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id) * price_unit
 
                 if move.currency_id.is_zero(amount_currency) or float_is_zero(price_unit, precision_digits=price_unit_prec):
                     continue

--- a/addons/stock_account/tests/common.py
+++ b/addons/stock_account/tests/common.py
@@ -24,6 +24,7 @@ class TestStockValuationCommon(BaseCommon):
         if kwargs.get('reversed_entry_id'):
             invoice_vals["reversed_entry_id"] = kwargs['reversed_entry_id']
         invoice = self.env["account.move"].create(invoice_vals)
+        product_uom = kwargs.get('product_uom') or product.uom_id
         self.env["account.move.line"].create({
             "move_id": invoice.id,
              "display_type": "product",
@@ -31,7 +32,7 @@ class TestStockValuationCommon(BaseCommon):
              "price_unit": price_unit,
              "quantity": quantity,
              "product_id": product.id,
-             "product_uom_id": product.uom_id.id,
+             "product_uom_id": product_uom.id,
              "tax_ids": [(5, 0, 0)],
         })
         if post:

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2845,3 +2845,20 @@ class TestStockValuation(TestStockValuationCommon):
             self._get_stock_valuation_move_lines().move_id.date,
             past_accounting_date
         )
+
+    def test_journal_entry_with_packaging_uom_cogs(self):
+        """Test that journal entries for COGS and stock valuation are correctly computed
+        when selling a product using a different UoM (e.g., pack of 6).
+        The COGS amount should reflect the total quantity converted to the product's base UoM.
+        """
+        invoice = self._create_invoice(self.product_avco_auto, quantity=10, price_unit=100, product_uom=self.env.ref('uom.product_uom_pack_6'))
+        self.assertEqual(self.product_avco_auto.standard_price, 10)
+        self.assertRecordValues(
+            invoice.journal_line_ids,
+            [
+                {'account_id': self.category_avco_auto.property_account_income_categ_id.id, 'credit': 1000.0, 'debit': 0.0},
+                {'account_id': self.account_receivable.id, 'credit': 0.0, 'debit': 1000.0},
+                {'account_id': self.account_stock_valuation.id, 'credit': 600.0, 'debit': 0.0},
+                {'account_id': self.account_expense.id, 'credit': 0.0, 'debit': 600.0},
+            ]
+        )


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - Cost: $10
    - UoM: Unit
    - Sales tab:
        - Packaging: Pack of 6
    - Category: Goods - Costing Method: AVCO - Inventory Valuation: Perpetual (at invoicing) - Expense Account: 500000 Cost of Goods Sold - Stock Account: 110100 Stock Valuation

- Create an invoice:
    - Customer: Azure Interior
    - Product: P1
    - Quantity: 10
    - UoM: Pack of 6
    - Confirm

Problem:
The journal items created for Stock Valuation and Cost of Goods Sold are computed with an incorrect amount: $100 instead of $600.

Explanation:
In the `_stock_account_prepare_realtime_out_lines_vals` method, the unit price is first computed for a single unit, regardless of the costing method (AVCO, Standard, or FIFO), using the helper method `_get_cogs_value`:

- https://github.com/odoo/odoo/blob/08b62a4bbcc6f9a391b2cc00a621ef4c76100229/addons/stock_account/models/account_move.py#L121
- https://github.com/odoo/odoo/blob/08b62a4bbcc6f9a391b2cc00a621ef4c76100229/addons/stock_account/models/account_move_line.py#L66-L67

In the FIFO case, the computation is based on the stock move value, but still returns the price per single unit:
- https://github.com/odoo/odoo/blob/08b62a4bbcc6f9a391b2cc00a621ef4c76100229/addons/stock_account/models/account_move_line.py#L70-L71

opw-5215191
