### PR TITLE
[FIX] project_sale_expense: Keep Analytic distribution when reinvoicing expenses

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -49,6 +49,16 @@ class AnalyticMixin(models.AbstractModel):
             self._field_to_sql(table or self._table, 'analytic_distribution'),
         )
 
+    @api.model
+    def _get_analytic_account_ids_from_distributions(self, distributions):
+        if not distributions:
+            return []
+
+        if isinstance(distributions, (list, tuple, set)):
+            return {int(_id) for distribution in distributions for key in (distribution or {}) for _id in key.split(',')}
+        else:
+            return {int(_id) for key in (distributions or {}) for _id in key.split(',')}
+
     @api.depends('analytic_distribution')
     def _compute_distribution_analytic_account_ids(self):
         all_ids = {int(_id) for rec in self for key in (rec.analytic_distribution or {}) for _id in key.split(',')}

--- a/addons/project_sale_expense/models/hr_expense.py
+++ b/addons/project_sale_expense/models/hr_expense.py
@@ -9,5 +9,29 @@ class Expense(models.Model):
     def _compute_analytic_distribution(self):
         super()._compute_analytic_distribution()
         if not self.env.context.get('project_id'):
+            expenses_to_recompute = self.env['hr.expense']
+            prefetch_ids = set()
             for expense in self.filtered('sale_order_id'):
-                expense.analytic_distribution = expense.sale_order_id.project_id._get_analytic_distribution()
+                expenses_to_recompute += expense
+                prefetch_ids.update(self.env['analytic.mixin']._get_analytic_account_ids_from_distributions(expense.analytic_distribution))
+                prefetch_ids.update(self.env['analytic.mixin']._get_analytic_account_ids_from_distributions(expense.sale_order_id.project_id._get_analytic_distribution()))
+
+            if expenses_to_recompute:
+                analytic_account_model = self.env['account.analytic.account'].with_prefetch(prefetch_ids)
+                for expense in expenses_to_recompute:
+                    expense_account_ids = self.env['analytic.mixin']._get_analytic_account_ids_from_distributions(expense.analytic_distribution)
+                    project_analytic_distribution = expense.sale_order_id.project_id._get_analytic_distribution()
+                    project_account_ids = self.env['analytic.mixin']._get_analytic_account_ids_from_distributions(project_analytic_distribution)
+
+                    project_analytic_distribution_accounts = self.env['account.analytic.account'].browse(project_account_ids)
+                    expense_analytic_accounts = analytic_account_model.browse(expense_account_ids)
+
+                    if not any(project_account.root_plan_id in expense_analytic_accounts.root_plan_id for project_account in project_analytic_distribution_accounts):
+                        # If it is possible we keep both analytic distributions
+                        expense.analytic_distribution = {
+                            **(expense.analytic_distribution or {}),
+                            **(project_analytic_distribution or {})
+                        }
+                    else:
+                        # If not we keep the most prioritized one -> project
+                        expense.analytic_distribution = expense.sale_order_id.project_id._get_analytic_distribution() or expense.analytic_distribution or {}

--- a/addons/sale_expense/models/account_move_line.py
+++ b/addons/sale_expense/models/account_move_line.py
@@ -34,6 +34,7 @@ class AccountMoveLine(models.Model):
         if self.expense_id:
             res['name'] = self.name
             res['product_uom_qty'] = self.expense_id.quantity
+            res['analytic_distribution'] = self.analytic_distribution
         return res
 
     def _sale_create_reinvoice_sale_line(self):


### PR DESCRIPTION
Steps to reproduce the flow:
- Create an expensable product “Hotel” that can be reinvoiced to a customer
- Create an analytic distribution model that automatically applies the analytic account “Commercial &Marketing” to the previous created product “Hotel”
- Create an SO for a customer “Gilles”. The SO is linked to the analytic account “Home Construction”
- Create an expense which category is “Hotel”. The analytic distribution is automatically set to “Commercial & Marketing”
- Reinvoice this expense to “Gilles”. The analytic distribution automatically changes to “Home Construction”. -> Wrong. We lose part of the information
- When posting the expense report, the expense is added in the SO through a dedicated SO line. The analytic account previously set as “Home Construction” is now transformed, for an unknown reason, into “Commercial & Marketing”. -> Wrong.
- On the vendor bill, the analytic distribution is “Home Construction”

Now:
1. The analytic plans from the expense and from the SO are different. Simply add the analytic account from the SO
2. The analytic plans are the same. There are conflicts. In this case, the analytic distribution set on the SO is prioritary. We ensure that costs incurred or sales generated from the expense are reflected in the SO's analytic plan rather than the generic one. In the previous example, Home Construction is the only analytic account that should be considered on the expense, bill and SO.

task-4564463