### PR TITLE
[FIX] mrp: split multiple MOs at once

### DIFF
--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -666,6 +666,15 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(mo.product_qty, 1)
         self.assertEqual(mo.move_raw_ids.mapped('product_uom_qty'), [0.5, 1])
 
+    def test_split_multiple_mo(self):
+        """ Checks that we can open the `split_production` wizard with multiple MOs at once
+        """
+        productions = self.env['mrp.production'].create([{
+            'product_qty': 5,
+            'bom_id': self.bom_1.id,
+        } for _ in range(2)])
+        Form.from_action(self.env, productions.action_split())
+
     def test_split_mo_partially_available(self):
         """
         Test that an MO components availability is correct after split.

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -47,13 +47,13 @@ class MrpProductionSplit(models.TransientModel):
             for _ in range(wizard.counter - 1):
                 commands.append(Command.create({
                     'quantity': quantity,
-                    'user_id': wizard.production_id.user_id,
+                    'user_id': wizard.production_id.user_id.id,
                     'date': wizard.production_id.date_start,
                 }))
                 remaining_quantity = float_round(remaining_quantity - quantity, precision_rounding=wizard.product_uom_id.rounding)
             commands.append(Command.create({
                 'quantity': remaining_quantity,
-                'user_id': wizard.production_id.user_id,
+                'user_id': wizard.production_id.user_id.id,
                 'date': wizard.production_id.date_start,
             }))
             wizard.production_detailed_vals_ids = commands


### PR DESCRIPTION
Steps to reproduce:
- Create two Manufacturing Orders
- From the list, select them and click on cog -> Split

Issue:
A traceback appears, as we try to insert `res.users` records in the database rather than their id.

Since #154607, the wizard's `counter` has its default set to 2. However, when opening the wizard with multiple MOs at once, even if the `counter` isn't displayed, the details will be computed for each MO.

This didn't cause issue in previous versions as we always went through a `web_save` that sent their ID, but now its possible to have this whole process server-side at the creation of the wizard, exposing the error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
