### PR TITLE
[FIX] hr_timesheet: correct timesheet value conversion in project dashboard

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -230,8 +230,8 @@ class ProjectProject(models.Model):
         encode_uom = self.env.company.timesheet_encode_uom_id
         uom_ratio = self.env.ref('uom.product_uom_hour').factor / encode_uom.factor
 
-        allocated = self.allocated_hours / uom_ratio
-        effective = self.total_timesheet_time / uom_ratio
+        allocated = self.allocated_hours * uom_ratio
+        effective = self.total_timesheet_time
         color = ""
         if allocated:
             number = f"{round(effective)} / {round(allocated)} {encode_uom.name}"

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -655,6 +655,9 @@ class TestTimesheet(TestCommonTimesheet):
         })
         self.env.company.timesheet_encode_uom_id = self.env.ref('uom.product_uom_day')
         self.assertEqual(project.total_timesheet_time, 1, "Total timesheet time should be 1 day")
+        project.allocated_hours = 0.0
+        panel_data = project.get_panel_data()
+        self.assertEqual(panel_data['buttons'][1]['number'], "1 Days", "Should display '1 Days'")
         self.assertEqual(project.timesheet_encode_uom_id, self.env.company.timesheet_encode_uom_id, "Timesheet encode uom should be the one from the company of the env, since the project has no company.")
 
     def test_unlink_task_with_timesheet(self):


### PR DESCRIPTION
Steps to reproduce:
--------------------
1. Install hr_timesheet
2. Create a new project and a task
3. On the task, add a timesheet line with some time (e.g., 20 hours)
4. Open the project dashboard and check the Timesheets stat button
5. Go to Timesheets > Configuration > Settings
6. Set "Encoding method" to "Days/Half-days"
7. Reopen the project dashboard and check the Timesheets stat button again

Issue:
------
Incorrect value displayed in the Timesheets stat button.
(e.g., 16 Days instead of 2 Days)

Cause:
-------
After this 28b69da, UoM model got restructured and the conversion logic between hours and days changed.
https://github.com/odoo/odoo/blob/aeda822db05b218fd1271c7666307950b7a98512/addons/hr_timesheet/models/project_project.py#L137-L143

The `total_timesheet_time` value is now already stored in the final unit (e.g., days). The subsequent division in `_get_stat_buttons()` was a redundant **double conversion**, resulting in incorrect display.
https://github.com/odoo/odoo/blob/aeda822db05b218fd1271c7666307950b7a98512/addons/hr_timesheet/models/project_project.py#L231-L234


**Before**
Case 1: Encoding method = Hours/Minutes
Consider allocated_hours = 80 Hours,
total_timesheet_time = 20 Hours

Then:
uom_ratio = 1/1 => 1
allocated = 80/1 => 80 Hours
effective = 20/1 => 20 Hours --> CORRECT

Case 2: Encoding method = Days/Half-days
Consider allocated_hours = 80 Hours,
total_timesheet_time = 2 Days (already in days — no conversion needed, but the system incorrectly tries to convert it)

Then:
uom_ratio = 1/8 => 0.125
allocated = 80/.125 => 640 Days
effective = 2/0.125 => 16 Days --> INCORRECT

**After**
Consider allocated_hours = 80 Hours (needs conversion to days as per encoding method)
and total_timesheet_time = 2 Days (already in days, no conversion).

Then:
uom_ratio = 1/8 => 0.125
allocated = 80*.125 => 10 Days
effective = 2 => 2 Days --> CORRECT

Reference: The [UoM’s factor ](https://github.com/odoo/odoo/blob/ca9df34f3a29796596f92e55647f61f95a95af52/addons/uom/data/uom_data.xml#L29-L37)has also been changed.

Solution:
----------
This commit ensures accurate conversion of timesheet values between hours and days

opw-5184077

Related enterprise PR: https://github.com/odoo/enterprise/pull/98545





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
