### PR TITLE
[FIX] im_livechat, *: last agent leaving from chat window ends convo

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
@@ -8,13 +8,13 @@ patch(ChatWindow.prototype, {
             this.thread.livechatVisitorMember?.persona?.notEq(this.store.self)
         ) {
             const thread = this.thread; // save ref before delete
-            super._onClose();
+            super._onClose(...arguments);
             this.delete();
             if (options.notifyState) {
                 thread.leaveChannel({ force: true });
             }
         } else {
-            super._onClose();
+            super._onClose(...arguments);
         }
     },
 });

--- a/addons/im_livechat/static/tests/im_livechat_shared_tests.js
+++ b/addons/im_livechat/static/tests/im_livechat_shared_tests.js
@@ -1,0 +1,43 @@
+import { expect } from "@odoo/hoot";
+import {
+    click,
+    contains,
+    setupChatHub,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { Command, onRpc, serverState } from "@web/../tests/web_test_helpers";
+
+export async function livechatLastAgentLeaveFromChatWindow() {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], {
+        group_ids: pyEnv["res.groups"]
+            .search_read([["id", "=", serverState.groupLivechatId]])
+            .map(({ id }) => id),
+    });
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const livechatChannelId = pyEnv["im_livechat.channel"].create({
+        name: "HR",
+        user_ids: [serverState.userId],
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        livechat_channel_id: livechatChannelId,
+        livechat_operator_id: serverState.partnerId,
+        create_uid: serverState.publicUserId,
+    });
+    setupChatHub({ opened: [channelId] });
+    onRpc("discuss.channel", "action_unfollow", () => {
+        expect.step("action_unfollow");
+    });
+    await start();
+    await contains(".o-mail-ChatWindow");
+    await click("button[title*='Close Chat Window']");
+    await click("button:contains('Yes, leave conversation')");
+    await expect.waitForSteps(["action_unfollow"]);
+    await contains(".o-mail-ChatWindow", { count: 0 });
+}

--- a/addons/mail/static/src/core/web/chat_window_model_patch.js
+++ b/addons/mail/static/src/core/web/chat_window_model_patch.js
@@ -17,6 +17,6 @@ patch(ChatWindow.prototype, {
             // ensure messaging menu is opened before chat window is closed
             await Promise.resolve();
         }
-        await super._onClose(options);
+        await super._onClose(...arguments);
     },
 });


### PR DESCRIPTION
*: mail

Before this commit, when the last agent from a live chat conversation leave, the live chat conversation did not end.

Steps to reproduce:
- install "ai" and "im_livechat" modules
- have a visitor initiate a live chat conversation with 1 available human agent
- have have human agent open conversation in chat window and close chat window + confirm button
=> the live chat conversation does not end

When live chat agent is about to close the chat window of live chat, there's a warning to tell that this will make him/her leave the conversation and thus end the conversation. When proceeding, it doesn't actually do this.

This is a bug caused by overrides of `ChatWindow._onClose()`, which is a function invoked during the closing of chat window, that has an option `notifyState` that determines whether the user leaves the conversation or not. The overridden code had to ensure the param is preserved and passed to `super` calls, but they fail to do this, and thus the closing of chat window is not making the user leave the conversation.

This commit fixes the issue by passing `...arguments` to super calls to make sure the params are preserved as expected by original code of the `_onClose` function.

Note that we had a test for the good working of the feature, but this test run with `im_livechat` assets and not overrides on top of it such as `ai` module. The main culpit of the problem was caused by the override in `ai` module. To have test coverage for this problem, the test is not executed in both `im_livechat` test suite and the `test_discuss_full_enterprise`, which is a module whose HOOT suite runs code of discuss with all overrides such as `ai` module.