### PR TITLE
[FIX] website_sale: fix rtl product list card

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -588,6 +588,9 @@
         --o-wsale-card-thumb-min-heigh: 100%;
         --o-wsale-card-thumb-size: min(13rem, 30vw);
         --o-wsale-card-thumb-border-radius: #{$-br-top} 0 0 #{$-br-top};
+        /* rtl:raw:
+          --o-wsale-card-thumb-border-radius: 0 #{$-br-top} #{$-br-top} 0;
+        */
         --o-wsale-card-thumb-position: center;
         --o-wsale-card-sub-display: contents;
         --o-wsale-card-info-margin: 0px;


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Enable Arabic (or any RTL language) for the website.
2. Navigate to the shop page.
3. Edit "Product Design" to be "Cards" list.

Issue
-----
The rights corners of the product images are not rounded, and are sticking out of the container, while the left corners are rounded, when they should be straight.

Cause
-----
The rounded corners of the image are applied the same way regardless of the direction of the whole page, while the rest of the elements, including the container for the image, are flipped.

Solution
--------
Add a CSS rule to handle specifically the RTL case.

opw-5173879
