### PR TITLE
[IMP] mail: return thread instead of thread_id in message_process

### DIFF
--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -367,11 +367,8 @@ Content-Transfer-Encoding: quoted-printable
 
 --000000000000a47519057e029630--
 """
-        crm_lead0_id = self.env['mail.thread'].message_process('crm.lead', new_message0)
-        crm_lead1_id = self.env['mail.thread'].message_process('crm.lead', new_message1)
-
-        crm_lead0 = self.env['crm.lead'].browse(crm_lead0_id)
-        crm_lead1 = self.env['crm.lead'].browse(crm_lead1_id)
+        crm_lead0 = self.env['mail.thread'].message_process('crm.lead', new_message0)
+        crm_lead1 = self.env['mail.thread'].message_process('crm.lead', new_message1)
 
         self.assertEqual(crm_lead0.team_id, crm_team0)
         self.assertEqual(crm_lead1.team_id, crm_team1)

--- a/addons/hr_recruitment/tests/test_recruitment_process.py
+++ b/addons/hr_recruitment/tests/test_recruitment_process.py
@@ -184,8 +184,7 @@ Content-Type: text/plain; charset="UTF-8"
 
 I want to work for you!"""
 
-        applicant_from_email = self.env["mail.thread"].message_process("hr.applicant", email)
-        applicant = self.env["hr.applicant"].browse(applicant_from_email)
+        applicant = self.env["mail.thread"].message_process("hr.applicant", email)
         self.assertEqual(
             applicant.department_id, mystery_department, "Applicant should be assigned to the right department"
         )

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1344,7 +1344,7 @@ class MailThread(models.AbstractModel):
         self = self.with_context(attachments_mime_plainxml=True) # import XML attachments as text
         # postpone setting message_dict.partner_ids after message_post, to avoid double notifications
         original_partner_ids = message_dict.pop('partner_ids', [])
-        thread_id = False
+        thread = self.browse()
         for model, thread_id, custom_values, user_id, alias in routes or ():
             subtype_id = False
             related_user = self.env['res.users'].browse(user_id)
@@ -1428,7 +1428,7 @@ class MailThread(models.AbstractModel):
                 # postponed after message_post, because this is an external message and we don't want to create
                 # duplicate emails due to notifications
                 new_msg.write({'partner_ids': original_partner_ids})
-        return thread_id
+        return thread.with_env(self.env)
 
     @api.model
     def message_process(self, model, message, custom_values=None,
@@ -1496,8 +1496,7 @@ class MailThread(models.AbstractModel):
         msg_dict.update(**self._message_parse_post_process(message, msg_dict, routes))
 
         # process routes
-        thread_id = self._message_route_process(message, msg_dict, routes)
-        return thread_id
+        return self._message_route_process(message, msg_dict, routes)
 
     @api.model
     def message_new(self, msg_dict, custom_values=None):

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -632,30 +632,24 @@ Content-Type: text/html;
 """
 
         with self.mock_mail_gateway():
-            gmail_task_id = self.env['mail.thread'].message_process(
+            gmail_task = self.env['mail.thread'].message_process(
                 model='project.task',
                 message=gmail_email_source,
                 custom_values={'project_id': self.project_followers.id}
             )
-            outlook_task_id = self.env['mail.thread'].message_process(
+            outlook_task = self.env['mail.thread'].message_process(
                 model='project.task',
                 message=outlook_email_source,
                 custom_values={'project_id': self.project_followers.id}
             )
 
         # Verify Gmail signature removal
-        self.assertTrue(gmail_task_id, "Gmail task creation should return a valid ID.")
-        gmail_task = self.env['project.task'].browse(gmail_task_id)
-
         self.assertIn("This is the main email content that should be kept", gmail_task.description)
         self.assertNotIn("--", gmail_task.description, "The Gmail signature separator should have been removed.")
         self.assertNotIn("John Doe", gmail_task.description, "The Gmail signature should have been removed.")
         self.assertNotIn("Software Engineer", gmail_task.description, "The Gmail signature should have been removed.")
 
         # Verify Outlook signature removal
-        self.assertTrue(outlook_task_id, "Outlook task creation should return a valid ID.")
-        outlook_task = self.env['project.task'].browse(outlook_task_id)
-
         self.assertIn("This is the main email content that should be kept", outlook_task.description)
         self.assertNotIn("John Smith", outlook_task.description, "The Outlook signature should have been removed.")
         self.assertNotIn("Software Developer", outlook_task.description, "The Outlook signature should have been removed.")
@@ -673,7 +667,7 @@ Content-Type: text/html;
             'user': 'test@example.com',
             'password': '',
         })
-        task_id = self.env["mail.thread"].with_context(
+        task = self.env["mail.thread"].with_context(
             default_fetchmail_server_id=server.id
         ).message_process(
             server.object_id.model,
@@ -687,6 +681,5 @@ Content-Type: text/html;
             save_original=server.original,
             strip_attachments=not server.attach,
         )
-        task = self.env['project.task'].browse(task_id)
         self.assertEqual(task.name, "In a cage")
         self.assertEqual(task.project_id, self.project_pigs)


### PR DESCRIPTION
Up until [1] the way to retrieve the model corresponding to the id returned by `message_process` was by checking the `thread_model` key in the context after calling it.

Since then there hasn't been a way to know where a message was posted as part of processing after calling `message_process` programatically.

We can instead return the recordset so that the model can be known in python. This effectively does not change RPC results since recordsets are converted to numbers either way.

[1]: https://github.com/odoo/odoo/commit/4b122ad41d873febe288ab1f8c6cdc078ca2a479
