### PR TITLE
[FIX] web: invoice totals amount color fix (SA)

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -896,6 +896,10 @@
                         color: <t t-esc='primary'/>;
                     }
 
+                    .o_total td {
+                        color: <t t-esc='primary'/>;
+                    }
+
                     .o_company_tagline {
                         color: <t t-esc='primary'/>
                     }
@@ -903,9 +907,10 @@
                 &amp;.o_report_layout_boxed {
                     #total .o_total td {
                         background-color: <t t-esc='primary'/>;
+                        color: preview-color-contrast(<t t-esc='primary'/>);
 
                         strong {
-                            color: preview-color-contrast(<t t-esc='primary'/>);
+                            color: inherit;
                         }
                     }
                 }


### PR DESCRIPTION
Issue:
- Totals amount text stayed black in invoices when using SA (and other) templates.
- Only the label (inside strong) changed color, the value (inside span) did not.
- In Boxed/Bubble, totals row has a colored background but text didn’t always switch to a readable .

Repro steps:
- Create company in Saudia Arabia
- Company → Document Layout: Light or Boxed (others also affected).
- Create a customer invoice with taxes and print without payment.
- Observe totals: label colored, amount remains black. In Boxed, amount can be unreadable over the colored background.

Cause:
- CSS targeted .o_total strong only; amounts are in span, so they weren’t colored.
Boxed sets totals cell background to the company primary, but text color didn’t flip to a contrast color.

Solution:
- General (all layouts): color the whole totals cells so label + amount are styled:
.o_total td { color: <company primary>; }

- Boxed override: ensure readable contrast on colored background:
#total .o_total td { background-color: <primary>; color: preview-color-contrast(<primary>); }
#total .o_total td strong { color: inherit; }

opw-5169079

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
