### PR TITLE
[FIX] mail: rename composer plugin

### DIFF
--- a/addons/mail/static/src/core/common/plugin/discuss_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/discuss_composer_plugin.js
@@ -4,8 +4,8 @@ import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
-export class MailComposerPlugin extends Plugin {
-    static id = "mail.composer";
+export class DiscussComposerPlugin extends Plugin {
+    static id = "discuss_composer";
     static dependencies = ["clipboard", "hint", "input", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -9,17 +9,17 @@ import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 
-import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
+import { DiscussComposerPlugin } from "@mail/core/common/plugin/discuss_composer_plugin";
 
 export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
     ChatGPTTranslatePlugin,
     ColorPlugin,
+    DiscussComposerPlugin,
     FeffPlugin,
     HintPlugin,
     InlineCodePlugin,
     LinkPlugin,
-    MailComposerPlugin,
     ShortCutPlugin,
     TabulationPlugin,
 ];


### PR DESCRIPTION
Rename the MailComposerPlugin to DiscussComposerPlugin so that it is not lead to the misunderstanding that it is used in the full mail composer as well.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
