### PR TITLE
[FIX] mail: id in mail_composer_plugin

### DIFF
--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -4,8 +4,12 @@ import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * This plugin works with the composer used in Discuss, ChatWindow and Chatter.
+ * For the full composer, it is using HtmlComposerMessageField.
+ */
 export class MailComposerPlugin extends Plugin {
-    static id = "mail.composer";
+    static id = "mail_composer";
     static dependencies = ["clipboard", "hint", "input", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),


### PR DESCRIPTION
The id used for the mail_composer_plugin had dots, which leads to issues that it cannot be used as a dependency or shared in other plugins.

Updated the static id format in mail_composer_plugin.js to use underscores instead of dots.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
