### PR TITLE
[REV] pos_restaurant_appointment: revert no autofocus on mobile POS

### DIFF
--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -10,7 +10,6 @@ import { useService } from "@web/core/utils/hooks";
 import { useTrackedAsync } from "@point_of_sale/app/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
-import { hasTouch } from "@web/core/browser/feature_detection";
 
 async function updatePosKanbanViewState(orm, stateObj) {
     const result = await orm.call("pos.config", "get_pos_kanban_view_state");
@@ -29,8 +28,6 @@ export class PosKanbanController extends KanbanController {
             show_predefined_scenarios: true,
             is_main_company: true,
         };
-        this.autofocus = hasTouch() ? false : true;
-
         onWillStart(() => updatePosKanbanViewState(this.orm, this.initialPosState));
     }
 }

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -4,10 +4,6 @@
         <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
             <attribute name="initialPosState">initialPosState</attribute>
         </xpath>
-
-        <xpath expr="//t[@t-set-slot='layout-actions']/SearchBar" position="attributes">
-            <attribute name="autofocus">this.autofocus</attribute>
-        </xpath>
     </t>
 
     <t t-name="point_of_sale.PosKanbanRenderer">


### PR DESCRIPTION
Task: [#5016943](https://www.odoo.com/odoo/project/1737/tasks/5016943) Revert PR:
 - [odoo/231045](https://github.com/odoo/odoo/pull/231045)
 - [enterprise/96873](https://github.com/odoo/enterprise/pull/96873)

---

The purpose of this task was to remove the autofocus for certain views concerning the POS on mobile devices. However, this is no longer needed, since the root of the issue was global and had to be fixed across all views.

While this task addressed the issue on a few specific views, [PR #232054](https://github.com/odoo/odoo/pull/232054) provides a global fix.