### PR TITLE
[FIX] - l10n_ch: Remove newlines in swiss QR code fields

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -112,7 +112,7 @@ class ResPartnerBank(models.Model):
 
         currency = currency or self.currency_id or self.company_id.currency_id
 
-        return [
+        result = [
             'SPC',                                                # QR Type
             '0200',                                               # Version
             '1',                                                  # Coding Type
@@ -145,6 +145,9 @@ class ResPartnerBank(models.Model):
             comment,                                              # Unstructured Message
             'EPD',                                                # Mandatory trailer part
         ]
+
+        # newlines shift field content to a different line, causing the QR code to be rejected
+        return [line.replace('\n', ' ') for line in result]
 
     def _get_qr_vals(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
         if qr_method == 'ch_qr':


### PR DESCRIPTION
Swiss QR codes have required information for each line of the QR code. Newline characters present in a field's content shift the content to a different line than intended, causing the QR code to be rejected.

This commit removes newline characters from the field elements and alters a unit test to check if this issue occurs again.

opw-5095997

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr