### PR TITLE
[FIX] account: avoid constraint error on equity_unaffected with archived companies

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -32,8 +32,11 @@ class AccountAccount(models.Model):
 
     @api.constrains('account_type')
     def _check_account_type_unique_current_year_earning(self):
-        result = self.with_context(active_test=False)._read_group(
-            domain=[('account_type', '=', 'equity_unaffected')],
+        result = self._read_group(
+            domain=[
+                ("account_type", "=", "equity_unaffected"),
+                ("company_ids.active", "=", True),
+            ],
             groupby=['company_ids'],
             aggregates=['id:recordset'],
             having=[('__count', '>', 1)],


### PR DESCRIPTION
**Description**
In migrated databases, accounts of type Current Year Earnings (equity_unaffected) may remain linked only to archived companies.
Because Odoo automatically filters out inactive companies in company_ids, these accounts appear as having no company (company_ids = False).
The constraint _check_account_type_unique_current_year_earning groups accounts by company_ids, which can incorrectly raise a ValidationError when all linked companies are archived.
This fix adds a filter to only consider active companies in the _read_group domain, ensuring the uniqueness constraint works correctly even with archived companies in legacy data.

**Current behavior**
Accounts linked only to archived companies are grouped under company_ids = False.
Updating or validating any account may trigger a false ValidationError:
You cannot have more than one account with "Current Year Earnings" as type.

Occurs primarily in migrated databases; does not affect fresh Odoo instances.

**Desired behavior**
The constraint only considers active companies.
Accounts linked exclusively to archived companies no longer trigger false-positive errors.
All uniqueness checks remain intact for active companies.

**Technical details**
_read_group by default filters inactive many2many records.
Adding ("company_ids.active", "=", True) ensures proper grouping and avoids spurious validation errors.
Safe and backward-compatible; only affects migrated or legacy datasets.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
