### PR TITLE
[FIX] base: state of add-ons is not reset

### DIFF
--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -57,3 +57,4 @@ Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes
 Rafael Lima rafael.lima@camptocamp.com https://github.com/rlimaeco
 Luca Policastro luca.policastro@camptocamp.com https://github.com/Luca-Policastro
 Tomasz Walter tomasz.walter@camptocamp.com https://github.com/twalter-c2c
+Florent Xicluna florent.xicluna@camptocamp.com https://github.com/florentx

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -483,12 +483,12 @@ class IrModuleModule(models.Model):
     def button_reset_state(self):
         # reset the transient state for all modules in case the module operation is stopped in an unexpected way.
         self.search([('state', '=', 'to install')]).state = 'uninstalled'
-        self.search([('state', 'in', ('to update', 'to remove'))]).state = 'installed'
+        self.search([('state', 'in', ('to upgrade', 'to remove'))]).state = 'installed'
         return True
 
     @api.model
     def check_module_update(self):
-        return bool(self.sudo().search_count([('state', 'in', ('to install', 'to update', 'to remove'))], limit=1))
+        return bool(self.sudo().search_count([('state', 'in', ('to install', 'to upgrade', 'to remove'))], limit=1))
 
     @assert_log_admin_access
     def module_uninstall(self):


### PR DESCRIPTION
There is a typo in Odoo 19 and master: module state is not reset when upgrade action is aborted.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
