### PR TITLE
[FIX] sale_management: quotation preview display description only

### DIFF
--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -102,5 +102,5 @@ class SaleOrderTemplateLine(models.Model):
             'sequence': self.sequence,
         }
         if self.name:
-            vals['name'] = self.name
+            vals['name'] = (self.product_id.display_name + "\n" + self.name) if self.product_id.display_name else self.name
         return vals

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -492,7 +492,7 @@ class TestSaleOrder(SaleManagementCommon):
         sale_order._onchange_sale_order_template_id()
         self.assertEqual(
             sale_order.order_line[0].name,
-            quotation_template_with_description.sale_order_template_line_ids[0].name,
+            f"{self.product_1.name}\n{quotation_template_with_description.sale_order_template_line_ids[0].name}",
             "The sale order line should use the quotation template's description when both \
             product and the quotation template descriptions are set."
         )


### PR DESCRIPTION
When you create a quotation, and add a quotation template, the name of the order line of quotation template (which is the description) is added to the name of order line of the quotation. In the quotation, the name should be "product_name\ndescription". When you add a product and type description manually, it hits the updatelabel function which updates the name to "product_name\ndescription".

Steps to Reproduce:
1. Create a quotation template, add a product and description.
2. Create a quotation template adding the quotation template just created.
3. Go to preview. You'll only see the description.

Also for the test test_product_description_with_template_description:
quotation_template_with_description.sale_order_template_line_ids[0].name
is being compared to sale_order.order_line[0].name. The name in the
sale order line has format (product_name\nproduct_description). We're
missing the product_name, so we'll fix it by adding
self.product_1.name.

enterprise  PR -> https://github.com/odoo/enterprise/pull/99750

opw-5009068