### PR TITLE
[IMP] hr_timesheet: remove separator when viewing task timesheets on mobile

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -91,7 +91,7 @@
                         </form>
                     </field>
                     <group invisible="not analytic_account_active">
-                        <group class="oe_subtotal_footer d-flex justify-content-end mb-0" name="project_hours">
+                        <group class="oe_subtotal_footer d-flex justify-content-end mb-0 border-top-0" name="project_hours">
                             <div class="container">
                                 <!-- Time Spent -->
                                 <div class="row align-items-center mb-2">


### PR DESCRIPTION

The separator between the 'add timesheets' button and the total 'time spent' was visually distracting in mobile view. Removing it provides a cleaner interface.

task-5223266

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
