### PR TITLE
[FIX] mail: prevent error when disabling blur background in CallPreview

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_preview.js
+++ b/addons/mail/static/src/discuss/call/common/call_preview.js
@@ -28,6 +28,7 @@ export class CallPreview extends Component {
 
     setup() {
         this.dialog = useService("dialog");
+        this.notification = useService("notification");
         this.rtc = useService("discuss.rtc");
         this.store = useService("mail.store");
         this.state = useState({ audioStream: null, blurManager: null, videoStream: null });


### PR DESCRIPTION
Before this PR, disabling blur background right after enabling it would crash because the notification service was not initialized in the `CallPreview` component.

This PR adds the missing notification service to fix the crash.

Task-5223992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr