### PR TITLE
[FIX] hr_attendance: set default value for field timing_type

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -95,7 +95,7 @@ class HrAttendanceOvertimeRule(models.Model):
         # ('employee', "Outside the employee's working schedule"),
         # ('off_time', "When employee is off"),  # TODO in ..._holidays
         # ('public_leave', "On a holiday"), ......
-    ])
+    ], default='work_days')
     timing_start = fields.Float("From", default=0)
     timing_stop = fields.Float("To", default=24)
     expected_hours_from_contract = fields.Boolean("Hours from employee schedule", default=True)

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1018,3 +1018,17 @@ class TestHrAttendanceOvertime(TransactionCase):
     def test_overtime_rule_combined(self):
         # TODO
         pass
+
+    def test_overtime_rule_timing_type_not_set(self):
+        ruleset = self.env['hr.attendance.overtime.ruleset'].create({
+            'name': 'Test Timing Ruleset',
+            'rule_ids': [
+                Command.create({
+                    'name': "Company Schedule",
+                    'base_off': 'timing',
+                }),
+            ],
+        })
+
+        self.assertEqual(ruleset.rule_ids.timing_type, 'work_days',
+                 "Employee work Timing type should default to 'work_days' when not set.")


### PR DESCRIPTION
This error occurs when no `timing_type` is set for the timing in the rule.

Steps to reproduce:
---
- Install `hr_attendance` module(without demo)
- Attendance > Configurations > Overtime Rulesets
- Create New Rule >  Add an overtime rule in this ruleset with:
    - Rule is based on: `Timing`
    - Save & Close
- Now Save Rule

Traceback:
---
`KeyError: False`

At [1], this error occurs because the rule has no `timing_type` set, as no default value for field is defined.

[1]- https://github.com/odoo/odoo/blob/6e5146113adbdce3cbe317a7b3ef16be0a244b6a/addons/hr_attendance/models/hr_attendance_overtime_rule.py#L453

sentry-6986530016

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
