### PR TITLE
[FIX] mail: prevent crash when showing result of unknown poll

### DIFF
--- a/addons/mail/models/mail_poll.py
+++ b/addons/mail/models/mail_poll.py
@@ -58,14 +58,13 @@ class MailPoll(models.Model):
             poll.end_message_id = thread.message_post(
                 body="", message_type="mail_poll", subtype_xmlid="mail.mt_comment"
             )
-            Store(**thread._get_store_target()).add(poll).bus_send()
+            Store(**thread._get_store_target()).add(poll, extra_fields=[Store.One("start_message_id")]).bus_send()
 
     @api.model
     def _end_expired_polls(self):
-        self.env["mail.poll"].search_fetch([
-            ("poll_end_dt", "<=", "now"),
-            ("end_message_id", "=", None),
-        ])._end_and_notify()
+        self.env["mail.poll"].search_fetch(
+            [("poll_end_dt", "<=", "now"), ("end_message_id", "=", None)],
+        )._end_and_notify()
 
     @api.ondelete(at_uninstall=False)
     def _poll_on_delete(self):

--- a/addons/mail/static/src/core/common/mail_poll_model.js
+++ b/addons/mail/static/src/core/common/mail_poll_model.js
@@ -36,7 +36,7 @@ export class MailPollModel extends Record {
         return _t(
             '%(author)s\'s poll %(strong_tag_start)s"%(question)s"%(strong_tag_end)s has closed.',
             {
-                author: this.start_message_id.author_id.name,
+                author: this.start_message_id.authorName,
                 question: this.poll_question,
                 strong_tag_start: markup`<strong>`,
                 strong_tag_end: markup`</strong>`,

--- a/addons/mail/static/tests/tours/mail_poll_tour.js
+++ b/addons/mail/static/tests/tours/mail_poll_tour.js
@@ -1,5 +1,7 @@
+import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 
+const pollId = new URL(window.location.href).searchParams.get("test_poll_id");
 registry.category("web_tour.tours").add("mail_poll_tour.js", {
     steps: () => [
         { trigger: ".o-mail-Composer [title='More Actions']", run: "click" },
@@ -44,12 +46,25 @@ registry.category("web_tour.tours").add("mail_poll_tour.js", {
         { trigger: "button:contains('End Poll')", run: "click" },
         { trigger: ".o-mail-PollResult:contains(Blue)" },
         { trigger: ".o-mail-PollResult:contains('Winning Answer∙100%')" },
-        { trigger: ".o-mail-Message:has(.o-mail-Poll)", run: "hover && click [title='Expand']" },
+        {
+            trigger: ".o-mail-Message:has(.o-mail-Poll)",
+            run: "hover && click .o-mail-Message:has(.o-mail-Poll) [title='Expand']",
+        },
         { trigger: "button:contains('Delete')", run: "click" },
         { trigger: ".modal .btn:contains(Delete)", run: "click" },
         {
             trigger:
                 ".o-mail-Message:contains('This message has been removed'):not(:has(.o-mail-Poll))",
+        },
+        // End a poll that was not loaded to ensure all the information required by the end poll UI
+        // is provided by the `_end_and_notify` method.
+        {
+            trigger: "body",
+            run: () => rpc("/mail/poll/end", { poll_id: pollId }),
+        },
+        {
+            trigger:
+                '.o-mail-PollResult:contains(internal user (base.group_user)\'s poll "???" has ended.)',
         },
     ],
 });

--- a/addons/mail/tests/test_mail_poll.py
+++ b/addons/mail/tests/test_mail_poll.py
@@ -130,9 +130,24 @@ class TestMailPoll(HttpCase):
                     )
 
     def test_poll_ui(self):
+        self.authenticate(self.internal.login, self.internal.login)
         channel = self.env["discuss.channel"].create({"name": "General"})
+        poll_id = self.make_jsonrpc_request(
+            "/mail/poll/create",
+            {
+                "duration": 1,
+                "option_labels": ["foo", "bar", "baz"],
+                "question": "???",
+                "thread_id": channel.id,
+                "thread_model": "discuss.channel",
+            },
+        )
+        # Posting enough message so that the poll message isn't loaded when
+        # opening the channel.
+        for i in range(50):
+            channel.message_post(body=f"message_{i}", message_type="comment")
         self.start_tour(
-            f"/odoo/discuss?active_id={channel.id}",
+            f"/odoo/discuss?active_id={channel.id}&test_poll_id={poll_id}",
             "mail_poll_tour.js",
             login=self.internal.login,
         )


### PR DESCRIPTION
When a poll result of an unknown poll is displayed, an error occurs. It happens because the poll ended text relies on the poll start message author which is not sent when closing a poll.

As a result, when the start message of the poll has not been loaded, the author is not available.

This commit updates the poll ended UI to use the `create_uid` of the poll instead and by ensuring the relying partner is always sent.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
