### PR TITLE
[FIX] web_editor: fix non-deterministic link test

### DIFF
--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -3,6 +3,7 @@
 import { click, editInput, getFixture, makeDeferred, mockSendBeacon, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { contains } from "@web/../tests/utils";
 import { FileSelectorControlPanel } from "@web_editor/components/media_dialog/file_selector";
 import { FormController } from '@web/views/form/form_controller';
 import { HtmlField } from "@web_editor/js/backend/html_field";
@@ -1076,11 +1077,18 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
     QUnit.module("Link");
 
     QUnit.test("link preview in Link Dialog", async (assert) => {
-        assert.expect(6);
+        assert.expect(7);
 
         serverData.models.partner.records.push({
             id: 1,
             txt: "<p class='test_target'><a href='/test'>This website</a></p>",
+        });
+        const wysiwygPromise = makeDeferred();
+        patchWithCleanup(HtmlField.prototype, {
+            async startWysiwyg() {
+                await super.startWysiwyg(...arguments);
+                wysiwygPromise.resolve();
+            },
         });
         await makeView({
             type: "form",
@@ -1092,6 +1100,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
                     <field name="txt" widget="html"/>
                 </form>`,
         });
+        await wysiwygPromise;
 
         // Test the popover option to edit the link
         const a = document.querySelector(".test_target a");
@@ -1103,6 +1112,8 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         document.querySelector("a.mx-1.o_we_edit_link.text-dark").click();
         // Make sure popover is closed
         await new Promise(resolve => $(a).on('hidden.bs.popover.link_popover', resolve));
+        // Make sure modal is open
+        await contains(".modal input#o_link_dialog_label_input");
         let labelInputField = document.querySelector(".modal input#o_link_dialog_label_input");
         let linkPreview = document.querySelector(".modal a#link-preview");
         assert.strictEqual(labelInputField.value, 'This website',


### PR DESCRIPTION
This test was not awaiting each step properly, which becomes visible when the runbot is overloaded and the querySelector calls return null, at which point accessing `click` or `value` would trigger a traceback.

runbot-161423
