### PR TITLE
[FIX] crm: we don't have `/crm` in the URL anymore

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1201,6 +1201,7 @@
 
         <record model="ir.actions.act_window" id="crm_lead_action_pipeline">
             <field name="name">Pipeline</field>
+            <field name="path">crm</field>
             <field name="res_model">crm.lead</field>
             <field name="view_mode">kanban,list,graph,pivot,form,calendar,activity</field>
             <field name="domain">[('type','=','opportunity')]</field>


### PR DESCRIPTION
Bug
===
Since b422372df8274db923aff53d624b83dcfdbc6605 , the action has been refactored, but we forgot to set the `path` field on the action.

Task-5225750