### PR TITLE
[FIX] sale: Empty deposit invoice

### DIFF
--- a/addons/sale/tests/test_taxes_downpayment.py
+++ b/addons/sale/tests/test_taxes_downpayment.py
@@ -799,3 +799,22 @@ class TestTaxesDownPaymentSale(TestTaxCommonSale, TestTaxesDownPayment):
         downpayment.create_invoices()
         invoice = sale_order.invoice_ids
         self.assertEqual(invoice.invoice_line_ids.account_id, self.company_data['default_account_revenue'])
+
+    def test_downpayment_on_so_with_zero_ordered_quantity(self):
+        product = self.company_data['product_service_delivery']
+        tax_15 = self.percent_tax(15.0)
+
+        so = self._create_sale_order_one_line(
+            price_unit=1000.0,
+            product_id=product,
+            tax_ids=tax_15,
+            product_uom_qty=0,
+        )
+        so.order_line.write({'qty_delivered': 15.0})
+        invoice = self._create_down_payment_invoice(so, 'percent', 50)
+
+        self.assertRecordValues(invoice, [{
+            'amount_untaxed': 7500.0,
+            'amount_tax': 1125.0,
+            'amount_total': 8625.0,
+        }])

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -146,7 +146,11 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
             AccountTax = self.env['account.tax']
             order_lines = order.order_line.filtered(lambda x: not x.display_type)
-            base_lines = [line._prepare_base_line_for_taxes_computation() for line in order_lines]
+            base_lines = [
+                line._prepare_base_line_for_taxes_computation(
+                    quantity=line.product_uom_qty or line.qty_delivered
+                ) for line in order_lines
+            ]
             AccountTax._add_tax_details_in_base_lines(base_lines, order.company_id)
             AccountTax._round_base_lines_tax_details(base_lines, order.company_id)
 


### PR DESCRIPTION
**Issue:**
When creating a deposit invoice for a sale order having a service with an ordered quantity = 0, the invoice is created but empty.

**Steps to reproduce:**
1. Create a service product with an Invoicing Policy = Based on Timesheets and Create on Order = Project & Task
2. Create a sale order with a service with that product
3. Set the quantity to 0
4. Confirm the sale order
5. Click on the Recorded smart button and add a new line
6. Go back to the so, the delivered quantity should be the amount set in the previous step
7. Click on "Create Invoice" and select a Down payment option
8. An invoice is created but is empty

**Root cause:**
The amount to invoice of the sale order was based on the ordered quantity instead of the delivered quantity

**Fix:**
Changed _compute_amount_to_invoice to use the delivered quantity if the invoicing policy of the product is not based on ordered quantities

opw-5142968

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
