### PR TITLE
[IMP] website: add an outline option for gallery miniatures

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
@@ -85,15 +85,19 @@
      </BuilderRow>
 
     <BuilderRow label.translate="Indicators" level="1" t-if="this.state.isSlideShow">
-        <BuilderSelect>
-            <BuilderSelectItem classAction="'s_image_gallery_indicators_bars'">Bars</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_indicators_dots'">Dots</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_indicators_numbers'">Numbers</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_indicators_squared'">Squared Miniatures</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_indicators_rounded'">Rounded Miniatures</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_indicators_hidden'">Hidden</BuilderSelectItem>
+        <BuilderSelect action="'indicatorsStyle'">
+            <BuilderSelectItem actionParam="'s_image_gallery_indicators_bars'">Bars</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'s_image_gallery_indicators_dots'">Dots</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'s_image_gallery_indicators_numbers'">Numbers</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'s_image_gallery_indicators_squared'" id="'indicators_squared_opt'">Squared Miniatures</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'s_image_gallery_indicators_rounded'" id="'indicators_rounded_opt'">Rounded Miniatures</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'s_image_gallery_indicators_hidden'">Hidden</BuilderSelectItem>
         </BuilderSelect>
      </BuilderRow>
+
+    <BuilderRow label.translate="Outline" level="2" t-if="isActiveItem('indicators_squared_opt') || isActiveItem('indicators_rounded_opt')">
+        <BuilderCheckbox classAction="'s_image_gallery_indicators_outline'"/>
+    </BuilderRow>
 
     <t t-call="website.ImagePopUpOption"/>
 

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -10,6 +10,7 @@ import { SNIPPET_SPECIFIC, SNIPPET_SPECIFIC_END } from "@html_builder/utils/opti
 import { uniqueId } from "@web/core/utils/functions";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { forwardToThumbnail } from "@html_builder/utils/utils_css";
+import { ClassAction } from "@html_builder/core/core_builder_action_plugin";
 
 export class ImageGalleryImagesOption extends BaseOptionComponent {
     static template = "website.ImageGalleryImagesOption";
@@ -39,6 +40,7 @@ class ImageGalleryOption extends Plugin {
             SetImageGalleryLayoutAction,
             SetImageGalleryColumnsAction,
             SetCarouselSpeedAction,
+            IndicatorsStyleClassAction,
         },
         system_classes: ["o_empty_gallery_alert"],
         get_gallery_items_handlers: this.getGalleryItems.bind(this),
@@ -521,6 +523,25 @@ export class SetCarouselSpeedAction extends BuilderAction {
     }
     getValue({ editingElement }) {
         return editingElement.dataset.bsInterval / 1000;
+    }
+}
+
+export class IndicatorsStyleClassAction extends ClassAction {
+    static id = "indicatorsStyle";
+    apply({ editingElement, params: { mainParam: className } }) {
+        super.apply(...arguments);
+        if (editingElement.matches(".s_image_gallery_indicators_outline")) {
+            // Remove the outline helper when the chosen indicator style no
+            // longer offers that option.
+            if (
+                ![
+                    "s_image_gallery_indicators_squared",
+                    "s_image_gallery_indicators_rounded",
+                ].includes(className)
+            ) {
+                editingElement.classList.remove("s_image_gallery_indicators_outline");
+            }
+        }
     }
 }
 

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -213,6 +213,22 @@
                     opacity: 1;
                 }
             }
+
+            &.s_image_gallery_indicators_outline .carousel {
+                --indicators-border-color: #{$carousel-indicator-active-bg};
+
+                &.carousel-dark {
+                    --indicators-border-color: #{$carousel-dark-indicator-active-bg};
+                }
+
+                .carousel-indicators > button {
+                    box-shadow: inset 0 0 0 0.5px color-mix(
+                        in srgb,
+                        var(--indicators-border-color),
+                        transparent 40%
+                    );
+                }
+            }
         }
 
         // Indicators - Rounded Miniatures

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -10,6 +10,7 @@ import { uniqueId } from "@web/core/utils/functions";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 
 defineWebsiteModels();
@@ -277,4 +278,21 @@ test("Changing layout of an image gallery to grid should remove size option on i
     expect(queryOne("[data-label='Mode'] .dropdown-toggle").textContent).toBe("Grid");
     await contains(":iframe .first_img").click();
     expect("[data-label='Size']").toHaveCount(0);
+});
+
+test("Click the outline option for the image gallery thumbnails", async () => {
+    await setupWebsiteBuilderWithSnippet("s_image_gallery");
+    await contains(":iframe .s_image_gallery").click();
+    await contains(".options-container [data-label='Indicators'] .dropdown-toggle").click();
+    await contains(
+        ".o-dropdown--menu [data-action-param='s_image_gallery_indicators_squared']"
+    ).click();
+    expect(":iframe section.o_slideshow").not.toHaveClass("s_image_gallery_indicators_outline");
+    await contains("[data-class-action='s_image_gallery_indicators_outline'] .o-checkbox").click();
+    expect(":iframe section.o_slideshow").toHaveClass("s_image_gallery_indicators_outline");
+    await contains(".options-container [data-label='Indicators'] .dropdown-toggle").click();
+    await contains(
+        ".o-dropdown--menu [data-action-param='s_image_gallery_indicators_dots']"
+    ).click();
+    expect(":iframe section.o_slideshow").not.toHaveClass("s_image_gallery_indicators_outline");
 });


### PR DESCRIPTION
This commit adds an option to show a border around image indicators of type "miniatures". It helps when the image has a transparent background (e.g., PNG) or a background color similar to the snippet background, as the rounded contour of the thumbnail becomes invisible in those cases. The border makes the shape clearly visible.

Steps to reproduce:

- Add an image gallery to a page.
- Choose the "Rounded Miniatures" indicator type.
- Replace one image with a PNG that has a transparent background.
- Problem: the rounded contour of this PNG miniature is no longer visible because its transparent background blends with the snippet background. The same issue occurs if the image background matches the snippet background color.

task-5219701