### PR TITLE
[FIX] website: keep font plugin in translate mode

### DIFF
--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -183,7 +183,6 @@ export class WebsiteBuilder extends Component {
             "ImagePlugin",
             "AlignPlugin",
             "ListPlugin",
-            "FontPlugin",
             "FontFamilyPlugin",
         ];
         const pluginsToRemove = this.props.translation


### PR DESCRIPTION
The commit 6e1e359ec6a7ae23cfa7d7c96380f845c7fdcfe5, in addition to its main changes, removed a few plugins from translation mode.

This was not needed, and it removed the font plugin, preventing the user from changing the size on a range of text.

This commit undo that changes.

Steps to reproduce:
- Open website builder in translate mode
- Select a range of editable text
- Bug: you cannot change the size of the text

task-5222402