### PR TITLE
[FIX] web: prevent traceback in pivot view when currencyIds is undefined

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -874,7 +874,7 @@ export class PivotModel extends Model {
      */
     _getCellCurrency(groupId, measure, config) {
         var key = JSON.stringify(groupId);
-        if (!config.data.currencyIds[key]) {
+        if (!config.data.currencyIds[key] || !Object.keys(!config.data.currencyIds[key]).length) {
             return;
         }
         return config.data.currencyIds[key][measure];


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the module `project_timesheet_forecast_sale`.
2. Go to Project > Configuration > Projects and open any project.
3. On the project's dashboard, click the Dashboard stat button.
4. In the stats dialog, click "Timesheets and Planning".

**Issue:**
- Opening the Timesheets and Planning stat button from a Project dashboard (after installing `project_timesheet_forecast_sale`) raises the following error:

    TypeError: Cannot read properties of undefined (reading 'length')

**Cause:**
- The method _getCellCurrency() expected every dataset to have corresponding currencyIds, but the Timesheet/Forecast report does not include any currency information in its configuration data.
As a result, config.data.currencyIds[key] was empty, leading to the crash when trying to access .length.

**Solution:**
- Handle missing currencyIds in _getCellCurrency() by checking for an empty or undefined entry before accessing it.
If no currency is defined (as is the case for timesheet/forecast reports), the method now simply returns.

**opw-5179265**