### PR TITLE
[IMP] html_builder: enhance background position orientation interface

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_position_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_option.xml
@@ -8,7 +8,7 @@
                 <BuilderSelectItem actionValue="'cover'">Cover</BuilderSelectItem>
                 <BuilderSelectItem actionValue="'repeat-pattern'" id="'background_repeat_opt'">Repeat pattern</BuilderSelectItem>
             </BuilderSelect>
-            <BuilderButton icon="'fa-crosshairs'" title.translate="Background Position" preview="false" action="'backgroundPositionOverlay'"/>
+            <BuilderButton icon="'fa-arrows-alt'" title.translate="Background Position" preview="false" action="'backgroundPositionOverlay'"/>
         </BuilderRow>
         <BuilderContext t-if="isActiveItem('background_repeat_opt')" action="'setBackgroundSize'">
             <BuilderRow label.translate="Width" level="3">

--- a/addons/html_builder/static/src/plugins/image/image_position_overlay.edit.scss
+++ b/addons/html_builder/static/src/plugins/image/image_position_overlay.edit.scss
@@ -3,6 +3,8 @@
 }
 
 // ":not(.s_parallax_bg)" is kept for compatibility.
-.o_we_image_positioning > *:not(.s_parallax_bg_wrap, .s_parallax_bg) {
+// ":not(.o_we_bg_filter, .o_we_shape)" is kept for shape and background filter
+// elements to ensure they appear above it.
+.o_we_image_positioning > *:not(.s_parallax_bg_wrap, .s_parallax_bg, .o_we_bg_filter, .o_we_shape) {
     visibility: hidden;
 }

--- a/addons/html_builder/static/src/plugins/image/image_position_overlay.xml
+++ b/addons/html_builder/static/src/plugins/image/image_position_overlay.xml
@@ -7,7 +7,7 @@
         <div class="o_we_overlay_content position-absolute" t-ref="overlayContent">
             <div class="o_we_overlay_dragger" t-ref="dragger" title="Click and drag the image to adjust its position!"
                 t-on-mousedown.prevent.stop="onDragStart" t-on-pointerdown.stop="" />
-            <div class="o_we_overlay_buttons position-absolute d-flex m-1" style="top: 0">
+            <div class="o_we_overlay_buttons position-absolute d-flex m-1" style="top: 0; right: 0;">
                 <button class="btn btn-primary me-1 o_btn_apply" t-on-click="apply" t-on-pointerdown.stop="">Apply</button>
                 <button class="btn btn-danger o_btn_discard" t-on-click="discard" t-on-pointerdown.stop="">Discard</button>
             </div>


### PR DESCRIPTION
Improve usability of background image positioning for shaped snippets. Users can now see the working area on covers when editing snippet shapes.

This update includes:
1. Moving the position overlay buttons to the `top-right` corner.
2. Updating the position icon to `fa-arrows-alt`.
3. While editing shapes on snippets, users can now see the background's working area, allowing more precise adjustments.

task-4600335