### PR TITLE
[FIX] html_editor: remove empty text nodes after FEFF replacement

### DIFF
--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -231,6 +231,7 @@ export class SplitPlugin extends Plugin {
      * @returns { Node }
      */
     splitAroundUntil(elements, limitAncestor) {
+        this.dispatchTo("before_split_around_until_handlers", limitAncestor);
         elements = Array.isArray(elements) ? elements : [elements];
         const firstNode = elements[0];
         const lastNode = elements[elements.length - 1];

--- a/addons/html_editor/static/src/main/feff_plugin.js
+++ b/addons/html_editor/static/src/main/feff_plugin.js
@@ -33,6 +33,7 @@ export class FeffPlugin extends Plugin {
             char === "\uFEFF" && (ev.shiftKey || lastSkipped !== "\uFEFF"),
         clipboard_content_processors: this.processContentForClipboard.bind(this),
         clipboard_text_processors: (text) => text.replace(/\ufeff/g, ""),
+        before_split_around_until_handlers: (root) => this.cleanForSave({ root, preserveSelection: true }),
     };
 
     cleanForSave({ root, preserveSelection = false }) {

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -1,5 +1,5 @@
 import { closestBlock, isBlock } from "./blocks";
-import { isParagraphRelatedElement, isShrunkBlock, isVisible } from "./dom_info";
+import { isEmptyTextNode, isParagraphRelatedElement, isShrunkBlock, isVisible } from "./dom_info";
 import { callbacksForCursorUpdate } from "./selection";
 import { isEmptyBlock, isPhrasingContent } from "../utils/dom_info";
 import { childNodes } from "./dom_traversal";
@@ -245,11 +245,16 @@ export function cleanTextNode(node, char, cursors) {
         removedIndexes.push(offset);
         return "";
     });
-    cursors?.update((cursor) => {
-        if (cursor.node === node) {
-            cursor.offset -= removedIndexes.filter((index) => cursor.offset > index).length;
-        }
-    });
+    if (isEmptyTextNode(node)) {
+        cursors?.update(callbacksForCursorUpdate.remove(node));
+        node.remove();
+    } else {
+        cursors?.update((cursor) => {
+            if (cursor.node === node) {
+                cursor.offset -= removedIndexes.filter((index) => cursor.offset > index).length;
+            }
+        });
+    }
 }
 
 /**

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -567,7 +567,7 @@ test("should be able to apply color on icon along with text", async () => {
         contentAfterEdit:
             '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
         contentAfter:
-            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><font style="color: rgb(255, 0, 0);"><span class="fa fa-glass"></span></font><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
+            '<p>a<font style="color: rgb(255, 0, 0);">[bc<span class="fa fa-glass"></span>de]</font>f</p>',
     });
 });
 
@@ -643,7 +643,7 @@ test("should be able to remove color applied by 'text-*' classes (1)", async () 
     });
 });
 
-test.todo("should be able to remove color applied by 'text-*' classes (2)", async () => {
+test("should be able to remove color applied by 'text-*' classes (2)", async () => {
     await testEditor({
         contentBefore: '<p><a href="#" class="text-muted">[a]</a></p>',
         stepFunction: setColor("", "color"),

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -488,7 +488,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]<br></div>`,
             });
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -402,6 +402,22 @@ test("should focus the editable area after selecting a font size item", async ()
     expect(getContent(el)).toBe(`<p><span class="h2-fs">[test]</span></p>`);
 });
 
+test("should not create empty extra nodes while changing format of link", async () => {
+    const { el } = await setupEditor(
+        `<p>[\ufeff<a href="http://test.com">\ufefftest.com\ufeff</a>\ufeff]</p>`
+    );
+    await expectElementCount(".o-we-toolbar", 1);
+    const iframeEl = queryOne(".o-we-toolbar [name='font_size_selector'] iframe");
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
+    await contains(".o-we-toolbar [name='font_size_selector']").click();
+    expect(getActiveElement()).toBe(inputEl);
+    await waitFor(".o_font_size_selector_menu .dropdown-item:contains('80')");
+    await contains(".o_font_size_selector_menu .dropdown-item:contains('80')").click();
+    expect(getContent(el)).toBe(
+        `<p><span class="display-1-fs">\ufeff<a href="http://test.com" class="o_link_in_selection">\ufeff[test.com]\ufeff</a>\ufeff</span></p>`
+    );
+});
+
 test.tags("desktop");
 test("toolbar works: display correct font size on select all", async () => {
     const { el } = await setupEditor("<p>test</p>");


### PR DESCRIPTION
Steps to Reproduce:

- Create a link in the editor (e.g., "abc").
- Select all and change the font size from 14 to 80.
- Two empty tags are created before and after the formatted <span><a></a></span> with only FEFF Characters.
- Change the font size again (e.g., back to 14).
- Multiple empty tags remain in the DOM.

Description of the issue this PR addresses:

- In the removeFeffs method, FEFF characters are replaced with empty text nodes, which can lead to unwanted empty elements and empty text nodes being left in the DOM.

Desired behavior after PR is merged:

- Empty text nodes resulting from FEFF replacement are now properly removed, preventing leftover empty elements in the DOM.

task-5097770

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
