### PR TITLE
[FIX] hr_timesheet: add freeze_time to assume timesheets created in working day

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from lxml import etree
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.fields import Command
@@ -866,6 +865,7 @@ class TestTimesheet(TestCommonTimesheet):
         timesheet.invalidate_recordset(['calendar_display_name'])
         self.assertEqual(timesheet.calendar_display_name, f"{self.project_customer.name} (1.5d)")
 
+    @freeze_time("2025-10-31 08:00:00")
     def test_multi_create_timesheets_from_calendar(self):
         """
         Simulate creating timesheets using the multi-create feature in the calendar view


### PR DESCRIPTION
Before this commit, `test_multi_create_timesheets_from_calendar` test fails during the weekend because the first timesheet created inside that test assumes it is created during working date but if the current date is a weekend it is not the case.

This commit adds freeze_time on that test to make sure the current date is a working day.

runbot-error-233318