### PR TITLE
[IMP] account: reports text engine POC

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -588,6 +588,7 @@ class AccountReportExpression(models.Model):
             ('account_codes', "Prefix of Account Codes"),
             ('external', "External Value"),
             ('custom', "Custom Python Function"),
+            ('text', "Plain Text"),
         ],
         required=True
     )


### PR DESCRIPTION
Add a simple text engine to reports to be able to add multiple text columns.

This is useful for reports that have box numbers. See the DE/ZA/MK VAT reports.