### PR TITLE
[IMP] website, website_payment: re-use real snippets in tests

### DIFF
--- a/addons/website/static/tests/builder/options/card_option.test.js
+++ b/addons/website/static/tests/builder/options/card_option.test.js
@@ -1,24 +1,15 @@
 import { expect, test } from "@odoo/hoot";
 import {
     defineWebsiteModels,
-    setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
-import { dummyBase64Img } from "@html_builder/../tests/helpers";
 import { contains } from "@web/../tests/web_test_helpers";
 import { animationFrame, click, queryOne, setInputRange, waitFor } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
-const simpleCardHtml = `
-    <div class="s_card" data-snippet="s_card" data-name="Card">
-        <div class="card-body">
-            <h5 class="card-title">Card title</h5>
-            <p class="card-text">Card text</p>
-        </div>
-    </div>`;
-
 test("set card width", async () => {
-    await setupWebsiteBuilder(simpleCardHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='setCardWidth']");
     expect("[data-action-id='setCardWidth']").toHaveCount(1);
@@ -32,47 +23,38 @@ test("set card width", async () => {
 });
 
 test("set card alignment", async () => {
-    await setupWebsiteBuilder(simpleCardHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='setCardWidth'] input");
     expect("[data-action-id='setCardWidth'] input").toHaveValue(100);
     // Alignment option not available when card width is 100%
-    expect("[data-label='Alignment']").toHaveCount(0);
+    expect("[data-label='Card Width']+[data-label='Alignment']").toHaveCount(0);
 
     await setInputRange("[data-action-id='setCardWidth'] input", 50);
-    await waitFor("[data-label='Alignment']");
-    expect("[data-label='Alignment']").toHaveCount(1);
+    await waitFor("[data-label='Card Width']+[data-label='Alignment']");
+    expect("[data-label='Card Width']+[data-label='Alignment']").toHaveCount(1);
 
     expect(":iframe .s_card").not.toHaveClass(["me-auto", "mx-auto", "ms-auto"]);
     // Left alignment button is active by default
-    expect("[data-label='Alignment'] button[title='Left']").toHaveClass("active");
+    expect("[data-label='Card Width']+[data-label='Alignment'] button[title='Left']").toHaveClass(
+        "active"
+    );
 
-    await click("[data-label='Alignment'] button[title='Center']");
+    await click("[data-label='Card Width']+[data-label='Alignment'] button[title='Center']");
     await animationFrame();
     expect(":iframe .s_card").toHaveClass("mx-auto");
 
-    await click("[data-label='Alignment'] button[title='Right']");
+    await click("[data-label='Card Width']+[data-label='Alignment'] button[title='Right']");
     await animationFrame();
     expect(":iframe .s_card").toHaveClass("ms-auto");
 
-    await click("[data-label='Alignment'] button[title='Left']");
+    await click("[data-label='Card Width']+[data-label='Alignment'] button[title='Left']");
     await animationFrame();
     expect(":iframe .s_card").toHaveClass("me-auto");
 });
 
-const cardWithImageHtml = `
-    <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001" data-snippet="s_card" data-name="Card">
-        <figure class="o_card_img_wrapper ratio ratio-16x9 mb-0">
-            <img class="o_card_img card-img-top" src="${dummyBase64Img}" alt="" loading="lazy">
-        </figure>
-        <div class="card-body">
-            <h5 class="card-title">Card title</h5>
-            <p class="card-text">Card content</p>
-        </div>
-    </div>`;
-
 test("remove/add cover image", async () => {
-    await setupWebsiteBuilder(cardWithImageHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='removeCoverImage']");
     // Button to remove cover image is available
@@ -94,7 +76,7 @@ test("remove/add cover image", async () => {
 });
 
 test("set cover image position", async () => {
-    await setupWebsiteBuilder(cardWithImageHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='setCoverImagePosition']");
     // As per html content: image is on top
@@ -134,7 +116,7 @@ async function openRatioDropdownMenu() {
 }
 
 test("set cover image ratio", async () => {
-    await setupWebsiteBuilder(cardWithImageHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
 
     // As per html content: image has a 16x9 ratio
@@ -167,7 +149,7 @@ test("set cover image ratio", async () => {
 });
 
 test("ratios only supported for top image", async () => {
-    await setupWebsiteBuilder(cardWithImageHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-label='Ratio'] ");
     await openRatioDropdownMenu();
@@ -197,7 +179,7 @@ test("ratios only supported for top image", async () => {
 });
 
 test("set cover image width", async () => {
-    await setupWebsiteBuilder(cardWithImageHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
 
     // Width option not available when image is on top
@@ -216,7 +198,7 @@ test("set cover image width", async () => {
 });
 
 test("cover image set to wide aspect ratio can be vertically aligned", async () => {
-    await setupWebsiteBuilder(cardWithImageHtml);
+    await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='alignCoverImage']");
     expect("[data-label='Alignment'] [data-action-id='alignCoverImage'").toHaveCount(1);

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -180,17 +180,7 @@ test("Use the 'remove' overlay buttons: removing the last element will remove th
 });
 
 test("Use the 'clone' overlay buttons", async () => {
-    await setupWebsiteBuilder(`
-        <section class="s_text_image" data-snippet="s_text_image" data-name="Text - Image">
-            <div class="container">
-                <div class="row">
-                    <div class="col-lg-5">
-                        <p>TEST</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-    `);
+    await setupWebsiteBuilderWithSnippet("s_text_image");
 
     await contains(":iframe .col-lg-5").click();
     expect(".overlay .o_snippet_clone").toHaveCount(1);

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -7,6 +7,7 @@ import {
     addOption,
     defineWebsiteModels,
     setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 
 defineWebsiteModels();
@@ -409,14 +410,7 @@ test("changing shape's background color doesn't hide the shape itself", async ()
 });
 
 test("remove background image removes color filter", async () => {
-    const backgroundImageUrl = "url('/web/image/123/transparent.png')";
-    await setupWebsiteBuilder(`
-        <section>
-            <span class="s_parallax_bg_wrap">
-                <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
-            </span>
-            <div class="o_we_bg_filter bg-black-50"><br></div>
-        </section>`);
+    await setupWebsiteBuilderWithSnippet("s_cover");
     await contains(":iframe section").click();
     await contains("[data-action-id='toggleBgImage']").click();
     expect(":iframe section .o_we_bg_filter").not.toHaveCount();

--- a/addons/website/static/tests/builder/website_builder/carousel.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel.test.js
@@ -1,80 +1,14 @@
 import { expect, test } from "@odoo/hoot";
 import {
     defineWebsiteModels,
-    setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { contains } from "@web/../tests/web_test_helpers";
 
 defineWebsiteModels();
 
-const defaultCarouselStyleSnippet = `
-    <section class="s_carousel_wrapper p-0" data-snippet="s_carousel" data-vcss="001">
-        <div id="slideshow_sample" class="s_carousel s_carousel_default carousel slide o_colored_level" data-bs-ride="carousel" data-bs-interval="10000">
-            <div class="carousel-inner">
-                <div class="carousel-item active">
-                    <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
-                </div>
-                <div class="carousel-item">
-                    <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
-                </div>
-                <div class="carousel-item">
-                    <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
-                </div>
-            </div>
-            <div class="o_carousel_controllers">
-                <button class="carousel-control-prev o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="prev" aria-label="Previous" title="Previous">
-                    <span class="carousel-control-prev-icon" aria-hidden="true"/>
-                    <span class="visually-hidden">Previous</span>
-                </button>
-                <div class="carousel-indicators">
-                    <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active" aria-label="Carousel indicator"/>
-                    <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator"/>
-                    <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator"/>
-                </div>
-                <button class="carousel-control-next o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
-                    <span class="carousel-control-next-icon" aria-hidden="true"/>
-                    <span class="visually-hidden">Next</span>
-                </button>
-            </div>
-        </div>
-    </section>`;
-
-const imageGalleryCarouselStyleSnippet = `
-    <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-snippet="s_image_gallery" data-vcss="002" data-columns="3">
-        <div class="o_container_small overflow-hidden">
-            <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="carousel" data-bs-interval="10000">
-                <div class="carousel-inner">
-                    <div class="carousel-item active">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
-                    </div>
-                    <div class="carousel-item">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
-                    </div>
-                    <div class="carousel-item">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
-                    </div>
-                </div>
-                <div class="o_carousel_controllers">
-                    <button class="carousel-control-prev o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="prev" aria-label="Previous" title="Previous">
-                        <span class="carousel-control-prev-icon" aria-hidden="true"/>
-                        <span class="visually-hidden">Previous</span>
-                    </button>
-                    <div class="carousel-indicators">
-                        <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active" aria-label="Carousel indicator"/>
-                        <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator"/>
-                        <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator"/>
-                    </div>
-                    <button class="carousel-control-next o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
-                        <span class="carousel-control-next-icon" aria-hidden="true"/>
-                        <span class="visually-hidden">Next</span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </section>`;
-
 test("Test Carousel Option (s_carousel)", async () => {
-    const { getEditableContent } = await setupWebsiteBuilder(defaultCarouselStyleSnippet);
+    const { getEditableContent } = await setupWebsiteBuilderWithSnippet("s_carousel");
     const carouselEl = getEditableContent().querySelector(".carousel");
     await contains(":iframe .carousel").click();
 
@@ -82,17 +16,17 @@ test("Test Carousel Option (s_carousel)", async () => {
 
     await contains(".hb-row[data-label='Transition'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('None')").click();
-    expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
+    expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
 
     await contains(".hb-row[data-label='Transition'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('Slide')").click();
-    expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
+    expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
 
     await contains(".hb-row[data-label='Transition'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('Fade')").click();
-    expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
+    expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
 
     // Editing the Autoplay
@@ -131,7 +65,7 @@ test("Test Carousel Option (s_carousel)", async () => {
 });
 
 test("Test Carousel Option (s_image_gallery)", async () => {
-    const { getEditableContent } = await setupWebsiteBuilder(imageGalleryCarouselStyleSnippet);
+    const { getEditableContent } = await setupWebsiteBuilderWithSnippet("s_image_gallery");
     const carouselEl = getEditableContent().querySelector(".carousel");
     await contains(":iframe .carousel").click();
 
@@ -140,34 +74,34 @@ test("Test Carousel Option (s_image_gallery)", async () => {
     await contains(".hb-row[data-label='Transition'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('None')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
-    expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
+    expect(carouselEl).toHaveAttribute("data-bs-interval", "0");
 
     await contains(".hb-row[data-label='Transition'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('Slide')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
-    expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
+    expect(carouselEl).toHaveAttribute("data-bs-interval", "0");
 
     await contains(".hb-row[data-label='Transition'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('Fade')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
-    expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
+    expect(carouselEl).toHaveAttribute("data-bs-interval", "0");
 
     // Editing the Autoplay
 
     await contains(".hb-row[data-label='Autoplay'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('Always')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "carousel");
-    expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
+    expect(carouselEl).toHaveAttribute("data-bs-interval", "0");
 
     await contains(".hb-row[data-label='Autoplay'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('Never')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "false");
-    expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
+    expect(carouselEl).toHaveAttribute("data-bs-interval", "0");
 
     await contains(".hb-row[data-label='Autoplay'] button").click();
     await contains(".o-hb-select-dropdown-item:contains('After First Hover')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
-    expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
+    expect(carouselEl).toHaveAttribute("data-bs-interval", "0");
 
     // Editing the Speed
 

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -62,15 +62,7 @@ test("change action of form changes available options", async () => {
             formFields: [{ type: "char", name: "name", fillWith: "name", string: "Your Name" }],
         });
 
-    await setupWebsiteBuilder(
-        `<section class="s_website_form"><form data-model_name="mail.mail">
-            <div class="s_website_form_field"><label class="s_website_form_label" for="contact1">Name</label><input id="contact1" class="s_website_form_input"/></div>
-            <div class="s_website_form_submit">
-                <div class="s_website_form_label"/>
-                <a>Submit</a>
-            </div>
-        </form></section>`
-    );
+    await setupWebsiteBuilderWithSnippet("s_website_form");
 
     await contains(":iframe section").click();
     await contains("div:has(>span:contains('Action')) + div button").click();

--- a/addons/website/static/tests/builder/website_builder/rating_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/rating_option.test.js
@@ -1,29 +1,12 @@
 import {
     defineWebsiteModels,
-    setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { expect, test } from "@odoo/hoot";
 
 defineWebsiteModels();
 
 test("rating snippet should not be user-selectable", async () => {
-    await setupWebsiteBuilder(
-        `
-            <div class="s_rating pt16 pb16" data-icon="fa-star" data-vcss="001" data-snippet="s_rating" data-name="Rating">
-                <strong class="s_rating_title">Quality</strong>
-                <div class="s_rating_icons o_not_editable">
-                    <span class="s_rating_active_icons">
-                        <i class="fa fa-star"></i>
-                        <i class="fa fa-star"></i>
-                        <i class="fa fa-star"></i>
-                    </span>
-                    <span class="s_rating_inactive_icons">
-                        <i class="fa fa-star-o"></i>
-                        <i class="fa fa-star-o"></i>
-                    </span>
-                </div>
-            </div>`,
-        { loadIframeBundles: true }
-    );
+    await setupWebsiteBuilderWithSnippet("s_rating", { loadIframeBundles: true });
     expect(":iframe .s_rating").toHaveStyle({ "user-select": "none" });
 });

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -1,7 +1,6 @@
-import { expect, test } from "@odoo/hoot";
+import { expect, queryAll, test } from "@odoo/hoot";
 import {
     defineWebsiteModels,
-    setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
@@ -9,6 +8,13 @@ import { getDragHelper, waitForEndOfOperation } from "@html_builder/../tests/hel
 import { click, queryOne } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
+
+async function setupEmptySocialMedia(options) {
+    const builder = await setupWebsiteBuilderWithSnippet("s_social_media", options);
+    queryAll(":iframe div.s_social_media a").forEach((el) => el.remove());
+    builder.getEditor().shared.history.addStep();
+    return builder;
+}
 
 test("add social medias", async () => {
     onRpc("website", "read", ({ args }) => {
@@ -18,7 +24,7 @@ test("add social medias", async () => {
         return [{ id: 1, social_facebook: "https://fb.com/odoo", social_twitter: false }];
     });
 
-    await setupWebsiteBuilder(`<div class="s_social_media"><h4>Social Media</h4></div>`);
+    await setupEmptySocialMedia();
 
     await click(":iframe h4");
 
@@ -46,7 +52,8 @@ test("reorder social medias", async () => {
         { id: 1, social_facebook: "https://fb.com/odoo", social_twitter: "https://x.com/odoo" },
     ]);
 
-    await setupWebsiteBuilder(`<div class="s_social_media"><h4>Social Media</h4></div>`);
+    await setupEmptySocialMedia();
+    queryAll(":iframe div.s_social_media a").forEach((el) => el.remove());
 
     await click(":iframe h4");
 
@@ -157,7 +164,8 @@ test("save social medias", async () => {
     onRpc("website", "read", ({ args }) => [
         { id: 1, social_facebook: "https://fb.com/odoo", social_twitter: "https://x.com/odoo" },
     ]);
-    await setupWebsiteBuilder(`<div class="s_social_media"><h4>Social Media</h4></div>`);
+    await setupEmptySocialMedia();
+    queryAll(":iframe div.s_social_media a").forEach((el) => el.remove());
 
     await click(":iframe h4");
 
@@ -178,21 +186,12 @@ test("save social medias", async () => {
 });
 
 test("social media snippet should not be user-selectable", async () => {
-    await setupWebsiteBuilder(
-        `<div class="s_social_media o_not_editable"><h4>Social Media</h4></div>`,
-        { loadIframeBundles: true }
-    );
+    await setupEmptySocialMedia({ loadIframeBundles: true });
     expect(":iframe .s_social_media").toHaveStyle({ "user-select": "none" });
 });
 
 test("share snippet should not be editable (except title) nor user-selectable", async () => {
-    await setupWebsiteBuilder(
-        `<div class="s_share">
-            <h4 class="s_share_title">Share</h4>
-            <a href="#"><i class="fa fa-facebook"/></a>
-        </div>`,
-        { loadIframeBundles: true }
-    );
+    await setupWebsiteBuilderWithSnippet("s_share", { loadIframeBundles: true });
     expect(queryOne(":iframe .s_share").isContentEditable).toBe(false);
     expect(queryOne(":iframe .s_share_title").isContentEditable).toBe(true);
     expect(":iframe .s_share").toHaveStyle({ "user-select": "none" });

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -416,7 +416,9 @@ export async function setupWebsiteBuilderWithSnippet(snippetName, options = {}) 
 export async function getStructureSnippet(snippetName) {
     const html = await getWebsiteSnippets();
     const snippetsDocument = new DOMParser().parseFromString(html, "text/html");
-    return snippetsDocument.querySelector(`[data-snippet=${snippetName}]`).cloneNode(true);
+    return snippetsDocument
+        .querySelector(`[data-snippet=${snippetName}]:not([data-snippet] [data-snippet])`)
+        .cloneNode(true);
 }
 
 export async function insertStructureSnippet(editor, snippetName) {

--- a/addons/website_payment/static/tests/builder/donation_option.test.js
+++ b/addons/website_payment/static/tests/builder/donation_option.test.js
@@ -2,37 +2,14 @@ import { beforeEach, expect, test } from "@odoo/hoot";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
-    setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { queryAll } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
 beforeEach(async () => {
-    await setupWebsiteBuilder(
-        `<div class="s_donation" data-name="Donation Button" data-donation-email="info@yourcompany.example.com" data-custom-amount="freeAmount" data-prefilled-options="true" data-descriptions="true" data-donation-amounts="[&quot;10&quot;]" data-minimum-amount="5" data-maximum-amount="100" data-slider-step="5" data-default-amount="25" data-snippet="s_donation_button" data-display-options="true">
-        <form class="s_donation_form" action="/donation/pay" method="post" enctype="multipart/form-data">
-            <span id="s_donation_description_inputs">
-                <input type="hidden" class="o_translatable_input_hidden d-block mb-1 w-100" name="donation_descriptions" value="value1">
-            </span>
-            <div class="s_donation_prefilled_buttons my-4">
-                <div class="s_donation_btn_description o_not_editable o_translate_mode_hidden">
-                    <button class="s_donation_btn" type="button" data-donation-value="10">
-                        <span class="s_donation_currency">$</span>10
-                    </button>
-                    <p class="s_donation_description">value1</p>
-                </div>
-                <div>
-                    <span class="s_donation_btn s_donation_custom_btn">
-                        <span class="s_donation_currency">$</span>
-                        <input id="s_donation_amount_input" type="number" placeholder="Custom Amount" aria-label="Amount" min="5" style="max-width: 162px;">
-                    </span>
-                </div>
-            </div>
-            <a href="#" type="button" class="s_donation_donate_btn">Donate Now</a>
-        </form>
-    </div>`
-    );
+    await setupWebsiteBuilderWithSnippet("s_donation");
 });
 
 test("display/hide donation options", async () => {


### PR DESCRIPTION
A few tests used copies of real snippet. This commit directly uses the snippets, to prevent mismatches between the tested copy and the real snippet. To do that, it leverages `setupWebsiteBuilderWithSnippet`.

task-5215644