### PR TITLE
[FIX] pos*: reward line visibility issue with courses

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -347,7 +347,7 @@ export class PosData extends Reactive {
 
     async sanitizeData() {
         const order_to_delete = this.models["pos.order"].filter((order) =>
-            order.lines.some((line) => line.is_reward_line && !line.coupon_id)
+            order.lines.some((line) => line.is_reward_line && !line.coupon_id && !line.reward_id)
         );
         for (const order of order_to_delete) {
             for (let i = order.lines.length - 1; i >= 0; i--) {

--- a/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_order.js
@@ -1,0 +1,16 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    _getRewardLineValues(args) {
+        const lineValues = super._getRewardLineValues(args);
+        // Assign last course to reward lines
+        if (this.hasCourses()) {
+            const course = this.getLastCourse();
+            lineValues.forEach((line) => {
+                line.course_id = course;
+            });
+        }
+        return lineValues;
+    },
+});

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
@@ -1,9 +1,12 @@
-import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ProductScreenPos from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
+import * as BackendUtils from "@point_of_sale/../tests/pos/tours/utils/backend_utils";
 import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
+const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
 registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
     steps: () =>
@@ -17,6 +20,36 @@ registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
             Chrome.clickBtn("second floor"),
             Chrome.clickBtn("main floor"),
             FloorScreen.clickTable("5"),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_loyalty_reward_with_courses", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            // Add product after selecting a course
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickCourseButton(),
+            ProductScreen.clickDisplayedProduct("Water"),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
+            Chrome.clickPlanButton(),
+            // Add product before selecting a course
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
+            ProductScreen.clickCourseButton(),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
+            Chrome.clickPlanButton(),
+            // Switch to backend and return to POS
+            Chrome.clickMenuButton(),
+            Chrome.clickMenuDropdownOption("Backend"),
+            BackendUtils.openShopSession("Bar Prout"),
+            FloorScreen.clickTable("5"),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("2"),
             PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
         ].flat(),
 });

--- a/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
+++ b/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
@@ -30,3 +30,33 @@ class TestPoSRestaurantLoyalty(TestFrontend):
         self.start_pos_tour("PosRestaurantRewardStay")
         order = self.env['pos.order'].search([])
         self.assertEqual(order.currency_id.round(order.amount_total), 1.98)
+
+    def test_loyalty_reward_with_courses(self):
+        """
+        Ensure that a loyalty reward line remains in the cart
+        when courses are applied in a restaurant POS order.
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['loyalty.program'].create({
+            'name': '10% Discount on All Products',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+            })],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_loyalty_reward_with_courses')
+        orders = self.pos_config.current_session_id.order_ids
+        self.assertEqual(len(orders), 2)
+        self.assertEqual(orders[0].currency_id.round(orders[0].amount_total), 1.98)
+        self.assertEqual(len(orders[0].lines.filtered(lambda line: line.is_reward_line)), 1)
+        self.assertEqual(orders[1].currency_id.round(orders[1].amount_total), 1.98)
+        self.assertEqual(len(orders[1].lines.filtered(lambda line: line.is_reward_line)), 1)


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant_loyalty

Steps to reproduce:
- Open a table in the Restaurant UI.
- Click the Course button.
- Add products that trigger a reward line creation.

Issues:
- The reward line is not visible in the order.
- After switching to the backend and returning to the POS, no order lines are visible for that order.

Fixes:
- Ensure the reward line is created within the proper course.
- Prevent deletion of the reward line when switching between backend and POS.

Task: 5215920

