### PR TITLE
[IMP] point_of_sale: add tour utils function to manage slots orders

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -188,6 +188,18 @@ export function presetTimingSlotHourNotExists(hour) {
 export function presetTimingSlotHourExists(hour) {
     return { trigger: `.modal button:contains('${hour}')` };
 }
+export function selectSlotDays(d) {
+    return {
+        trigger: `.modal .d-flex.w-100.flex-wrap.gap-2.mt-2 button:nth-of-type(${d})`,
+        run: "click",
+    };
+}
+export function selectPresetTimingSlotIndex(index) {
+    return {
+        trigger: `.modal .row div:not(.d-none) .d-flex.flex-wrap.gap-1 button:nth-of-type(${index})`,
+        run: "click",
+    };
+}
 export function clickRegister() {
     return { trigger: ".pos-leftheader .register-label", run: "click" };
 }


### PR DESCRIPTION
Add utils function `selectSlotDays` & `selectPresetTimingSlotIndex` to select the nth day and nth timing slot in the slot selection dialog. These functions will be used in POS tours to manage orders with slots.

enterprise PR: https://github.com/odoo/enterprise/pull/95136



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
