### PR TITLE
[FIX] point_of_sale: support product packaging with GS1

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -330,6 +330,11 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
         ) {
             customProductOptions.quantity = qty.value;
         }
+        if (product?._getPackagingQty(productBarcode)) {
+            customProductOptions.quantity = customProductOptions.quantity
+                ? customProductOptions.quantity * product._getPackagingQty(productBarcode)
+                : product._getPackagingQty(productBarcode);
+        }
         return { product, lotBarcode, customProductOptions };
     }
     /**

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -182,8 +182,8 @@ export class Product extends PosModel {
         let attribute_custom_values = {};
         let extras = {};
 
-        if (code && this.pos.db.product_packaging_by_barcode[code.code]) {
-            quantity = this.pos.db.product_packaging_by_barcode[code.code].qty;
+        if (code && this._getPackagingQty(code) !== undefined) {
+            quantity = this._getPackagingQty(code);
         }
 
         if (this.isConfigurable()) {
@@ -269,6 +269,11 @@ export class Product extends PosModel {
             attribute_value_ids,
             extras,
         };
+    }
+    _getPackagingQty(code) {
+        if (this.pos.db.product_packaging_by_barcode[code.code]) {
+            return this.pos.db.product_packaging_by_barcode[code.code].qty;
+        }
     }
     isPricelistItemUsable(item, date) {
         const categories = this.parent_category_ids.concat(this.categ.id);

--- a/addons/point_of_sale/static/tests/tours/BarcodeScanning.tour.js
+++ b/addons/point_of_sale/static/tests/tours/BarcodeScanning.tour.js
@@ -88,6 +88,12 @@ registry.category("web_tour.tours").add("GS1BarcodeScanningTour", {
             ProductScreen.selectedOrderlineHas("Product 3"),
             scan_barcode("3760171283370"),
             ProductScreen.selectedOrderlineHas("Product 3", 2),
+
+            // Add product packaging with GS1 barcode
+            scan_barcode("0108431673020132"),
+            ProductScreen.selectedOrderlineHas("Product 1", 17 + 10),
+            scan_barcode("0108431673020132305"),
+            ProductScreen.selectedOrderlineHas("Product 1", 27 + 5 * 10),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1021,7 +1021,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'nomenclature_id': barcodes_gs1_nomenclature.id
         })
 
-        self.env['product.product'].create({
+        product_1 = self.env['product.product'].create({
             'name': 'Product 1',
             'available_in_pos': True,
             'list_price': 10,
@@ -1044,6 +1044,13 @@ class TestUi(TestPointOfSaleHttpCommon):
             'list_price': 10,
             'taxes_id': False,
             'barcode': '3760171283370',
+        })
+
+        self.env['product.packaging'].create({
+            'name': 'Product Packaging 10 Products',
+            'qty': 10,
+            'product_id': product_1.id,
+            'barcode': '08431673020132',
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()


### PR DESCRIPTION
Before this commit, scanning a GS1 barcode for a product packaging did not add the quantity.

opw-5003035

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
