### PR TITLE
[FIX] l10n_tr_nilvera_einvoice_extended: Tax Amount in Withholding Invoices

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
@@ -229,7 +229,7 @@ class AccountEdiXmlUblTr(models.AbstractModel):
                     "taxable_amount": get_withholding_taxable_amount() if withholding else vals.get("base_amount_currency"),
                     "tax_amount": abs(vals.get("tax_amount_currency")),
                     "tax_category_vals": tax_category_vals,
-                    "percent": subtotal_percent if withholding else tax_category_vals.get("percent"),
+                    "percent": subtotal_percent if withholding else vals.get("_tax_category_vals_", {}).get("percent"),
                 },
             )
 

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_withholding_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_withholding_einvoice.xml
@@ -110,6 +110,7 @@
     <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
       <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
       <cac:TaxCategory>
         <cac:TaxScheme>
           <cbc:Name>Gerçek Usulde KDV</cbc:Name>
@@ -153,6 +154,7 @@
       <cac:TaxSubtotal>
         <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
         <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
         <cac:TaxCategory>
           <cac:TaxScheme>
             <cbc:Name>Gerçek Usulde KDV</cbc:Name>


### PR DESCRIPTION
Before this commit:
For withholding invoices, the VAT percentage was not included inside the <cac:TaxTotals> node, due to this, the VAT amount was not displayed in the PDF in Nilvera.

After this commit:
The VAT amount is shown correctly in the <cbc:Percent> node inside the <cac:TaxTotals> node and percent amount appears correctly in the PDF.

task-5225600

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
