### PR TITLE
[FIX] point_of_sale: prevent selling archived products in combo

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -818,7 +818,7 @@ class PosConfig(models.Model):
         product_ids = self.env.cr.fetchall()
         products = self.env['product.product'].search([('id', 'in', product_ids)])
         product_combo = products.filtered(lambda p: p['detailed_type'] == 'combo')
-        product_in_combo = product_combo.combo_ids.combo_line_ids.product_id
+        product_in_combo = product_combo.combo_ids.combo_line_ids.product_id.filtered(lambda p: p.active)
         products_available = products | product_in_combo
         return products_available.read(fields)
 

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
@@ -59,4 +59,9 @@ export class ComboConfiguratorPopup extends AbstractAwaitablePopup {
             }
         }
     }
+    getAvailableComboLines(combo) {
+        return combo.combo_line_ids
+            .map((combo_line_id) => this.pos.db.combo_line_by_id[combo_line_id])
+            .filter((line) => this.pos.db.product_by_id[line.product_id[0]]?.active);
+    }
 }

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -9,18 +9,17 @@
                     <t t-set="combo" t-value="pos.db.combo_by_id[combo_id]"/>
                     <h3 class="me-auto mb-3" t-esc="combo.name"/>
                     <div class="product-list d-grid gap-1">
-                        <div t-foreach="combo.combo_line_ids" t-as="combo_line_id" t-key="combo_line_id">
-                            <t t-set="combo_line" t-value="pos.db.combo_line_by_id[combo_line_id]"/>
+                        <div t-foreach="getAvailableComboLines(combo)" t-as="combo_line" t-key="combo_line.id">
                             <t t-set="product" t-value="pos.db.product_by_id[combo_line.product_id[0]]"/>
                             <input 
                                 type="radio" 
                                 t-attf-name="combo-{{combo_id}}" 
-                                t-attf-id="combo-{{combo_id}}-combo_line-{{combo_line_id}}"
-                                t-attf-value="{{combo_line_id}}" 
+                                t-attf-id="combo-{{combo_id}}-combo_line-{{combo_line.id}}"
+                                t-attf-value="{{combo_line.id}}" 
                                 t-model="state.combo[combo_id]"
-                                t-att-class="{ 'selected': state.combo[combo_id] == combo_line_id }"
+                                t-att-class="{ 'selected': state.combo[combo_id] == combo_line.id }"
                                 />
-                            <label t-attf-for="combo-{{combo_id}}-combo_line-{{combo_line_id}}" class="combo-line h-100 w-100 rounded cursor-pointer transition-base">
+                            <label t-attf-for="combo-{{combo_id}}-combo_line-{{combo_line.id}}" class="combo-line h-100 w-100 rounded cursor-pointer transition-base">
                                 <ProductCard
                                     class="'flex-column h-100 border'"
                                     name="product.display_name"

--- a/addons/point_of_sale/static/tests/tours/PosComboTour.js
+++ b/addons/point_of_sale/static/tests/tours/PosComboTour.js
@@ -16,6 +16,7 @@ registry.category("web_tour.tours").add("PosComboPriceTaxIncludedTour", {
         ...ProductScreen.confirmOpeningPopup(),
         ...ProductScreen.clickDisplayedProduct("Office Combo"),
         combo.isPopupShown(),
+        combo.isNotPresent("Combo Product 1"),
         combo.select("Combo Product 3"),
         combo.select("Combo Product 9"),
         ...ProductConfigurator.isShown(),

--- a/addons/point_of_sale/static/tests/tours/helpers/ComboPopupMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ComboPopupMethods.js
@@ -47,3 +47,11 @@ export function confirm() {
         trigger: confirmationButtonTrigger,
     };
 }
+
+export function isNotPresent(productName) {
+    return {
+        content: `Check that ${productName} is not present in the combo options`,
+        trigger: isNot(productTrigger(productName)),
+        isCheck: true,
+    };
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -938,6 +938,8 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_07_pos_combo(self):
         setup_pos_combo_items(self)
         self.office_combo.write({'lst_price': 50})
+        # Archive a product to test that combo lines with archived products do not appear
+        self.office_combo.combo_ids.combo_line_ids.product_id.filtered(lambda p: p.name == 'Combo Product 1').active = False
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboPriceTaxIncludedTour', login="pos_user")
         order = self.env['pos.order'].search([])


### PR DESCRIPTION
Before this commit, when a product used in a combo was archived, it was still possible to sell it through the combo in the PoS.

After this commit, archived products are excluded from combos, preventing them from being sold inadvertently.

opw-5180301

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
