### PR TITLE
[FIX] hr_attendance: typo error

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -42,7 +42,7 @@
                                 <field name="employer_tolerance" widget="float_time" string="With a tolerance in favor of the employer of"/>
                                 <!-- TIMING -->
                                 <field name="timing_type" widget="radio" string="If the employee works" invisible="base_off != 'timing'"/>
-                                <span class="fw-bold" invisible="base_off != 'timing' or timing_type not in ['work_days', 'non_work_days']">Beetween</span>
+                                <span class="fw-bold" invisible="base_off != 'timing' or timing_type not in ['work_days', 'non_work_days']">Between</span>
                                 <span class="d-flex gap-1" invisible="base_off != 'timing' or timing_type not in ['work_days', 'non_work_days']">
                                     <field nolabel="1" name="timing_start" widget="float_time" style="width:10ch"/>
                                     <label for="expected_hours_from_contract" string="and"/>


### PR DESCRIPTION
This pull request fixes a typo in the hr_attendance module where the word `Beetween` was displayed instead of `Between`.

Before Fix:
<img width="1920" height="927" alt="before_fix" src="https://github.com/user-attachments/assets/ffe5e7c2-1d87-47fd-ac82-2b7d80f36448" />

After Fix:
<img width="1920" height="927" alt="after_fix" src="https://github.com/user-attachments/assets/961f1f9f-9318-4ab0-8c61-56b8e87b9924" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
