### PR TITLE
[FIX] project: hide slider options in project sharing form view

### DIFF
--- a/addons/project/static/src/project_sharing/search/control_panel/control_panel.xml
+++ b/addons/project/static/src/project_sharing/search/control_panel/control_panel.xml
@@ -3,8 +3,18 @@
 
     <t t-inherit="project.ProjectTaskControlPanel" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o_control_panel_main_buttons')]" position="before">
-            <a class="btn btn-link" href="/my/projects" title="Go back to 'My Projects'"><i class="fa fa-arrow-left"/></a>
+            <t t-call="project.ProjectSharingControlPanelNavigationButton" />
         </xpath>
+    </t>
+
+    <t t-inherit="web.ControlPanel" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_control_panel_main_buttons')]" position="before">
+            <t t-call="project.ProjectSharingControlPanelNavigationButton" />
+        </xpath>
+    </t>
+
+    <t t-name="project.ProjectSharingControlPanelNavigationButton">
+        <a class="btn btn-link" href="/my/projects" title="Go back to 'My Projects'"><i class="fa fa-arrow-left"/></a>
     </t>
 
 </templates>

--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_view.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_view.js
@@ -1,8 +1,6 @@
 import { formView } from '@web/views/form/form_view';
-import { ProjectTaskControlPanel } from "@project/views/project_task_control_panel/project_task_control_panel";
 import { ProjectSharingFormController } from './project_sharing_form_controller';
 import { ProjectSharingFormRenderer } from './project_sharing_form_renderer';
 
 formView.Controller = ProjectSharingFormController;
-formView.ControlPanel = ProjectTaskControlPanel;
 formView.Renderer = ProjectSharingFormRenderer;


### PR DESCRIPTION
Steps to reproduce:

- Open any shared project from portal account.
- Open any task

Issue:

- Visible slider with Show Sub Tasks option.

Reason:

- Unwantedly added ControlPanel into FormView of Project Sharing View.
- Issue from https://github.com/odoo/odoo/pull/224203.

Fix:

- Remove the ControlPanel in Form View and extend web Control in xml to acheive the button.
