### PR TITLE
[IMP] mass_mailing(_sms): open campaign mailing in full form view

### DIFF
--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -26,14 +26,20 @@ registry.category('web_tour.tours').add('mailing_campaign', {
             run: "click",
         },
         {
-            content: 'Pick the basic theme',
-            trigger: ".o_mailing_template_preview_wrapper [data-name='basic']",
+            content: 'Fill in Subject',
+            trigger: 'div[name="mailing_mail_ids"] div[name="subject"] input',
+            run: "edit TestFromTour",
+        },
+        ...stepUtils.saveForm(),
+        {
+            content: 'Open newly created mailing',
+            trigger: '.o_data_row:has(.o_data_cell[name="subject"]:contains("TestFromTour")) .o_list_record_open_form_view button',
             run: "click",
         },
         {
-            content: 'Fill in Subject',
-            trigger: '#subject_0',
-            run: "edit TestFromTour",
+            content: 'Pick the basic theme',
+            trigger: ".o_mailing_template_preview_wrapper [data-name='basic']",
+            run: "click",
         },
         {
             content: 'Fill in Mailing list',
@@ -45,18 +51,15 @@ registry.category('web_tour.tours').add('mailing_campaign', {
             trigger: '.o_input_dropdown a:contains(Newsletter)',
             run: "click",
         },
+        ...stepUtils.saveForm(),
         {
-            content: 'Save form',
-            trigger: ".modal .o_form_button_save:contains(Save & Close)",
+            content: "Go back to Campaign",
+            trigger: ".o_breadcrumb .o_back_button",
             run: "click",
-        },
-        {
-            trigger: "body:not(:has(.modal))",
         },
         {
             content: 'Check that newly created record is on the list',
             trigger: '[name="mailing_mail_ids"] td[name="subject"]:contains("TestFromTour")',
         },
-        ...stepUtils.saveForm(),
     ],
 });

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -9,7 +9,7 @@
                 <field name="is_mailing_campaign_activated" invisible="1"/>
                 <button name="%(action_create_mass_mailings_from_campaign)d"
                     type="action" class="oe_highlight" invisible="not is_mailing_campaign_activated"
-                    groups="mass_mailing.group_mass_mailing_user" string="Send Mailing"/>
+                    groups="mass_mailing.group_mass_mailing_user" string="New Mailing"/>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button name="%(action_view_mass_mailings_from_campaign)d"
@@ -24,7 +24,7 @@
                     invisible="mailing_mail_count == 0 or not is_mailing_campaign_activated"
                     groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_mail_ids" nolabel="1">
-                        <list>
+                        <list editable="bottom" open_form_view="1" delete="0">
                             <field name="calendar_date" string="Date"/>
                             <field name="subject" readonly="state in ('sending', 'done')"/>
                             <field name="mailing_model_id" string="Recipients" optional="hide"/>
@@ -69,9 +69,8 @@
                 <field name="is_mailing_campaign_activated"/>
             </xpath>
             <xpath expr="//ul[@id='o_utm_actions']">
-                <a name="%(action_view_mass_mailings_from_campaign)d" type="action"
-                    t-attf-class="pe-2 oe_mailings #{record.mailing_mail_ids.raw_value.length === 0 ? 'text-muted' : ''}"
-                    t-if="record.is_mailing_campaign_activated.raw_value"
+                <a name="%(action_view_mass_mailings_from_campaign)d" type="action" class="pe-2"
+                    t-if="record.is_mailing_campaign_activated.raw_value and record.mailing_mail_ids.raw_value.length !== 0"
                     groups="mass_mailing.group_mass_mailing_user">
                     <t t-out="record.mailing_mail_ids.raw_value.length"/> Mailings
                 </a>

--- a/addons/mass_mailing_sms/views/utm_campaign_views.xml
+++ b/addons/mass_mailing_sms/views/utm_campaign_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <button name="action_create_mass_sms" type="object"  class="oe_highlight" string="Send SMS"
+                <button name="action_create_mass_sms" type="object"  class="oe_highlight" string="New SMS"
                     invisible="not is_mailing_campaign_activated"
                     groups="mass_mailing.group_mass_mailing_user"/>
             </xpath>
@@ -58,9 +58,8 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//ul[@id='o_utm_actions']">
-                <a name="action_redirect_to_mailing_sms" type="object"
-                    t-attf-class="pe-2 oe_mailings #{record.mailing_sms_count.raw_value === 0 ? 'text-muted' : ''}"
-                    t-if="record.is_mailing_campaign_activated.raw_value"
+                <a name="action_redirect_to_mailing_sms" type="object" class="pe-2"
+                    t-if="record.is_mailing_campaign_activated.raw_value and record.mailing_sms_count.raw_value !== 0"
                     groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_sms_count"/> SMS
                 </a>


### PR DESCRIPTION
When we open the campaign mailing, it opens in a dialog, which is a bad user experience.

This commit ensures that it opens in full form view and not in a dialog, which makes it easier to edit.

Task-5182993

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
