### PR TITLE
[FIX] core: fix monetary cache compare

### DIFF
--- a/odoo/orm/fields_numeric.py
+++ b/odoo/orm/fields_numeric.py
@@ -283,8 +283,8 @@ class Monetary(Field[float]):
                 records._ids, records.sudo().with_context(prefetch_fields=False)
             )
             if not (
-                (value := field_cache.get(record_id))
+                (value := field_cache.get(record_id)) is not None
                 and (currency := currency_field.__get__(record_sudo))
-                and currency.with_env(env).round(value) == cache_value
+                and currency.with_env(env).round(cache_value) == value
             )
         )


### PR DESCRIPTION
according to the comment the method is from 
odoo/odoo#177200

but in the PR, we round the value of the argument but not the value from the cache
this PR revert the implemented logic of the original PR

However is it really necessary to have the method?
Since the `cache_value` is always `convert_to_cache` before and we
`raise ValueError("Got multiple currencies while assigning values of monetary field %s" % str(self))`
when there are multiple currencies for records.

[Description](url) of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
