### PR TITLE
[FIX] mail: send feched_message_id on channel fetch

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -27,6 +27,7 @@ class DiscussChannelWebclientController(WebclientController):
         if request.env.context["add_channels_last_message"]:
             # fetch channels data before messages to benefit from prefetching (channel info might
             # prefetch a lot of data that message format could use)
+            channels.channel_fetched()
             store.add(channels._get_last_messages())
 
     @classmethod

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
@@ -51,7 +51,7 @@ export class MessageSeenIndicator extends Component {
         const [user1, user2, user3] = seenMembers.map((member) => member.name);
         switch (seenMembers.length) {
             case 0:
-                return _t("Sent");
+                return _t("Received");
             case 1:
                 return _t("Seen by %(user)s", { user: user1 });
             case 2:

--- a/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
@@ -8,7 +8,7 @@ import { patch } from "@web/core/utils/patch";
 const StorePatch = {
     setup() {
         super.setup(...arguments);
-        this.channels = this.makeCachedFetchData("channels_as_member");
+        this.channels = this.makeCachedFetchData("channels_as_member", { readonly: false });
         this.fetchSsearchConversationsSequential = useSequential();
     },
     /** @param {string} searchValue */


### PR DESCRIPTION
Before this commit, the `fetched_message_id` field (indicating the newest message fetched by a channel member) was only sent after receiving a `discuss.channel/new_message` bus notification.

This would result in potentially not broadcasting the `fetched_message_id` if the `new_message` notification gets discarded.

This commit fixes the issue by broadcasting the `fetched_message_id` whenever channels are fetched. This commit also renames the fetched indicator from "Sent" to "Received" as it more accurately represents the state of the message (non-temporary messages are always "sent").

task-5177299