### PR TITLE
[FIX] account: prevent error when adding lines to non-default journal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -884,7 +884,7 @@ class AccountMove(models.Model):
         return ['general']
 
     def _search_default_journal(self):
-        if self.statement_line_ids.statement_id.journal_id:
+        if self.statement_line_ids.statement_id._origin.journal_id:
             return self.statement_line_ids.statement_id.journal_id[:1]
 
         journal_types = self._get_valid_journal_types()


### PR DESCRIPTION
The system will crash when user tries to create new bank statement line.

**Steps to produce:**
- Install `Invoicing` module without demo data.
- Go to `Configuration > Journals` and duplicate the default Bank journal to create Bank (Copy).
- `Dashboard` and Click on 3 dots of Bank(Copy) and click on `Transactions`.
- Create a new transaction and set the Statement also(Create new and assign it).
- Go to that statements and Add a line and set the foreign currency as `USD`.

**Error:**
`ValueError: Wrong value for account.bank.statement.journal_id: account.journal(7, 6)`

**Cause:**
- During an onchange on a new, unsaved `statement line`, our code tried to read the `statement_id.journal_id` ([1]). This forced to compute the journal on the unsaved parent statement, which failed with a error.

**Solution:**
- We use `self.statement_line_id.statement_id._origin.journal_id` to read the journal's stored value

[1]
https://github.com/odoo/odoo/blob/ec2d8d026d9f13c8fb869ad1f7b8026a144e85ec/addons/account/models/account_move.py#L887

**sentry-6928858335**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
