### PR TITLE
[FIX] mail: fix use foward refs to parent

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -679,7 +679,7 @@ export class UseForwardRefsToParent {
         useEffect(
             (map, key) => {
                 this.registerRef(map, key);
-                () => this.removeRef(map, key);
+                return () => this.removeRef(map, key);
             },
             () => [component.props[propName], getRefIdFn(component.props)]
         );


### PR DESCRIPTION
The `useForwardRefsToParent` hook forwards child refs to a parent component. To do so, it relies on `useEffect` and it cleanup. However, the cleanup function is not returned which prevent children that unmount from being removed. This commit fixes this typo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
