### PR TITLE
[IMP] google_calendar: add setting disabling link creation

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -341,7 +341,12 @@ class CalendarEvent(models.Model):
                 'useDefault': False,
             }
         }
-        if not self.google_id and not self.videocall_location and not self.location:
+        if (
+            not self.google_id
+            and not self.videocall_location
+            and not self.location
+            and not self.env['ir.config_parameter'].sudo().get_bool('google_calendar.disable_auto_videocall_link')
+        ):
             values['conferenceData'] = {'createRequest': {'requestId': uuid4().hex}}
         if self.google_id and not self.videocall_location:
             values['conferenceData'] = None

--- a/addons/google_calendar/models/res_config_settings.py
+++ b/addons/google_calendar/models/res_config_settings.py
@@ -10,3 +10,5 @@ class ResConfigSettings(models.TransientModel):
     cal_client_secret = fields.Char("Client_key", config_parameter='google_calendar_client_secret')
     cal_sync_paused = fields.Boolean("Google Synchronization Paused", config_parameter='google_calendar_sync_paused',
         help="Indicates if synchronization with Google Calendar is paused or not.")
+    cal_google_disable_auto_videocall_link = fields.Boolean("Disable videocall generation",
+        config_parameter="google_calendar.disable_auto_videocall_link")

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -13,21 +13,31 @@ from odoo.tests import tagged
 from odoo import tools
 
 
-@tagged('odoo2google', 'calendar_performance', 'is_query_count')
+@tagged('odoo2google')
 @patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
-@tagged('at_install', '-post_install')  # LEGACY at_install
-class TestSyncOdoo2Google(TestSyncGoogle):
+class TestSyncOdoo2GoogleCommon(TestSyncGoogle):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env.user.partner_id.tz = "Europe/Brussels"
         cls.google_service = GoogleCalendarService(cls.env['google.service'])
+        cls.partner_jean_luc = cls.env["res.partner"].create({
+            "name": "Jean-Luc",
+            "email": "jean-luc@opoo.com"
+        })
         # Make sure this test will work for the next 30 years
         cls.env['ir.config_parameter'].set_int('google_calendar.sync.range_days', 10000)
+        cls.env["ir.config_parameter"].set_bool("google_calendar.disable_auto_videocall_link", False)
+
+
+@tagged('calendar_performance', 'is_query_count')
+@patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
+@tagged('at_install', '-post_install')  # LEGACY at_install
+class TestSyncOdoo2Google(TestSyncOdoo2GoogleCommon):
 
     @patch_api
     def test_event_creation(self):
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
         alarm = self.env['calendar.alarm'].create({
             'name': 'Notif',
             'alarm_type': 'notification',
@@ -39,7 +49,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'name': "Event",
             'start': datetime(2020, 1, 15, 8, 0),
             'stop': datetime(2020, 1, 15, 18, 0),
-            'partner_ids': [(4, partner.id)],
+            'partner_ids': [(4, self.partner_jean_luc.id)],
             'alarm_ids': [(4, alarm.id)],
             'privacy': 'private',
             'need_sync': False,
@@ -99,7 +109,6 @@ class TestSyncOdoo2Google(TestSyncGoogle):
     @users('__system__')
     @warmup
     def test_recurring_event_creation_perf(self):
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
         alarm = self.env['calendar.alarm'].create({
             'name': 'Notif',
             'alarm_type': 'notification',
@@ -112,7 +121,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'name': "Event",
                 'start': datetime(2020, 1, 15, 8, 0),
                 'stop': datetime(2020, 1, 15, 18, 0),
-                'partner_ids': [(4, partner.id)],
+                'partner_ids': [(4, self.partner_jean_luc.id)],
                 'alarm_ids': [(4, alarm.id)],
                 'privacy': 'private',
                 'need_sync': False,
@@ -121,7 +130,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'rrule_type': 'daily',
                 'end_type': 'forever',
                 'res_model_id': partner_model.id,
-                'res_id': partner.id,
+                'res_id': self.partner_jean_luc.id,
             })
 
         with self.assertQueryCount(__system__=29):
@@ -141,7 +150,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
 
     @patch_api
     def test_event_without_attendee_state(self):
-        partner_1 = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
+        partner_1 = self.partner_jean_luc
         partner_2 = self.env['res.partner'].create({'name': 'Phineas', 'email': 'phineas@opoo.com'})
         partner_3 = self.env['res.partner'].create({'name': 'Ferb'})
         event = self.env['calendar.event'].create({
@@ -363,11 +372,10 @@ class TestSyncOdoo2Google(TestSyncGoogle):
     def test_restart_synchronization(self):
         # Test new event created after stopping synchronization are correctly patched when restarting sync.
         google_id = 'aaaaaaaaa'
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
         user = self.env['res.users'].create({
             'name': 'Test user Calendar',
             'login': 'jean-luc@opoo.com',
-            'partner_id': partner.id,
+            'partner_id': self.partner_jean_luc.id,
         })
         user.stop_google_synchronization()
         event = self.env['calendar.event'].with_user(user).create({
@@ -375,7 +383,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'name': "Event",
             'start': datetime(2020, 1, 15, 8, 0),
             'stop': datetime(2020, 1, 15, 18, 0),
-            'partner_ids': [(4, partner.id)],
+            'partner_ids': [(4, self.partner_jean_luc.id)],
         })
 
         user.with_user(user).restart_google_synchronization()
@@ -532,14 +540,13 @@ class TestSyncOdoo2Google(TestSyncGoogle):
     @patch_api
     def test_attendee_state(self):
         """ Sync attendee state immediately """
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
         event = self.env['calendar.event'].create({
             'name': "Event with attendees",
             'start': datetime(2020, 1, 15),
             'stop': datetime(2020, 1, 15),
             'allday': True,
             'need_sync': False,
-            'partner_ids': [(4, partner.id)],
+            'partner_ids': [(4, self.partner_jean_luc.id)],
             'google_id': 'aaaaaaaaa',
         })
         self.assertEqual(event.attendee_ids.state, 'needsAction',
@@ -736,20 +743,6 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         self.assertFalse(record.active, "Event must be archived in Odoo after unlinking it")
         self.assertTrue(record.need_sync, "Sync variable must be true for updating event in Google when sync re-activates")
         self.assertGoogleEventNotDeleted()
-
-    @patch_api
-    def test_videocall_location_on_location_set(self):
-        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
-        event = self.env['calendar.event'].create({
-            'name': "Event",
-            'start': datetime(2020, 1, 15, 8, 0),
-            'stop': datetime(2020, 1, 15, 18, 0),
-            'partner_ids': [(4, partner.id)],
-            'need_sync': False,
-            'location' : 'Event Location'
-        })
-        event._sync_odoo2google(self.google_service)
-        self.assertGoogleEventInserted({'conferenceData': False})
 
     @patch_api
     def test_event_available_privacy(self):
@@ -1117,3 +1110,51 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
             'transparency': 'opaque',
         }, timeout=3)
+
+
+@patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
+@tagged('-at_install', 'post_install')
+class TestSyncOdoo2GooglePostInstall(TestSyncOdoo2GoogleCommon):
+
+    @patch_api
+    @users('organizer_user')
+    def test_videocall_location_generation(self):
+        """
+        Test the automated generation of the videocall link. We make sure that
+        cal_google_disable_auto_videocall_link setting is correctly handled on creating
+        new meetings without location, and that links are not created when location is set.
+        """
+        self.assertGoogleEventNotInserted()
+        for location, disable_link_generation_setting, expected_link_generation in [
+            ("Location Set", False, False),
+            ("Location Set", True, False),
+            (False, False, True),
+            (False, True, False),
+        ]:
+            with self.subTest(
+                location=location,
+                disable_link_generation_setting=disable_link_generation_setting,
+            ):
+                # Reset insert values manually as we are doing subtests
+                self._gsync_insert_values = []
+                self.env["ir.config_parameter"].sudo().set_bool(
+                    "google_calendar.disable_auto_videocall_link",
+                    disable_link_generation_setting
+                )
+                event = self.env["calendar.event"].create({
+                    "name": "test-disable-link-generation",
+                    "start": datetime(2020, 1, 15, 8, 0),
+                    "stop": datetime(2020, 1, 15, 18, 0),
+                    "partner_ids": [(4, self.partner_jean_luc.id)],
+                    "need_sync": False,
+                    "location": location,
+                })
+
+                event._sync_odoo2google(self.google_service)
+                self.assertGoogleEventInserted({"summary": "test-disable-link-generation"})
+                insert_values, _unused = self._gsync_insert_values[0]
+
+                if expected_link_generation:
+                    self.assertTrue(insert_values["conferenceData"]["createRequest"]["requestId"])
+                else:
+                    self.assertFalse(insert_values.get("conferenceData"))

--- a/addons/google_calendar/views/res_config_settings_views.xml
+++ b/addons/google_calendar/views/res_config_settings_views.xml
@@ -19,6 +19,16 @@
                             <label for="cal_sync_paused" string="Pause Synchronization" class="o_light_label"/>
                             <field name="cal_sync_paused" class="ml16"/>
                         </div>
+                        <div class="mt16">
+                            <div class="d-flex">
+                                <label for="cal_google_disable_auto_videocall_link" string="Disable automatic meeting links" class="o_light_label"/>
+                                <field name="cal_google_disable_auto_videocall_link" class="ml16 pb-0"/>
+                            </div>
+                            <div class="text-muted text-small">
+                                <i class="fa fa-info-circle fa-sm me-1"/>
+                                When checked, Google Calendar will not automatically add a video call link to events without a location.
+                            </div>
+                        </div>
                     </div>
                 </div>
             </field>


### PR DESCRIPTION

Add a boolean res.config.setting disabling the automatic
video call link generation on synchronizing calendar.event
records in google calendar, when they have not location set.

This way the users gain flexibility, as this was always
done, even if the link was not meant to be used in practice.

A test covers all cases, and some test data is moved to a new class
that serves as a Common for Odoo2Google test classes. As we test
as an internal user, and use their permissions in the test, we need
to set the added test in a post-install test class to correctly
handle registry.

Task-5059137
