### PR TITLE
[IMP] web: datetime_picker: new way to toggle range

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -143,7 +143,7 @@ const PRECISION_LEVELS = new Map()
         nextTitle: _t("Next month"),
         prevTitle: _t("Previous month"),
         step: { month: 1 },
-        getTitle: (date) => `${date.monthLong} ${date.year}`,
+        getTitle: (date) => `${date.monthShort} ${date.year}`,
         getItems: (date, { maxDate, minDate, showWeekNumbers, isDateValid, dayCellClass }) => {
             const startDates = [date];
 

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -9,7 +9,7 @@
                 >
                     <t t-foreach="month.daysOfWeek" t-as="dayOfWeek" t-key="dayOfWeek[0]">
                         <div
-                            class="o_day_of_week_cell fw-bolder d-flex align-items-center justify-content-center"
+                            class="o_day_of_week_cell bg-100 fw-bolder d-flex align-items-center justify-content-center"
                             t-att-title="dayOfWeek[1]"
                         >
                             <div class="text-nowrap overflow-hidden" t-esc="props.daysOfWeekFormat === 'narrow' ? dayOfWeek[2] : dayOfWeek[0]"/>
@@ -18,7 +18,7 @@
                     <t t-foreach="month.weeks" t-as="week" t-key="week.number">
                         <t t-if="props.showWeekNumbers">
                             <div
-                                class="o_week_number_cell d-flex justify-content-end align-items-center pe-3 fw-bolder"
+                                class="o_week_number_cell d-flex justify-content-end align-items-center pe-3 bg-100 fw-bolder"
                                 t-esc="week.number"
                             />
                         </t>
@@ -131,16 +131,27 @@
                         />
                     </t>
                 </button>
-                <button
-                    t-if="props.showRangeToggler"
-                    class="o_toggle_range btn btn-secondary btn-sm ms-auto"
-                    tabindex="-1"
-                    title="Toggle date range mode"
-                    t-on-click="props.onToggleRange"
-                    t-att-class="{'active': props.range}"
-                >
-                    <i class="fa fa-calendar-plus-o" />
-                </button>
+                <div t-if="props.showRangeToggler" class="btn-group ms-auto">
+                    <button
+                        class="o_toggle_range btn btn-secondary btn-sm"
+                        tabindex="-1"
+                        title="Single date"
+                        t-on-click="props.onToggleRange"
+                        t-att-class="{'active': !props.range}"
+                    >
+                        Date
+                    </button>
+                    <button
+                        class="o_toggle_range btn btn-secondary btn-sm"
+                        tabindex="-1"
+                        title="Date range"
+                        t-on-click="props.onToggleRange"
+                        t-att-class="{'active': props.range}"
+                    >
+                        Range
+                    </button>
+                </div>
+
             </nav>
             <t t-if="state.precision === 'days'">
                 <t t-call="web.DateTimePicker.Days" />

--- a/addons/web/static/tests/core/components/datetime/datetime_input.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_input.test.js
@@ -56,7 +56,7 @@ describe("DateTimeInput (date)", () => {
         await animationFrame();
 
         assertDateTimePicker({
-            title: "January 1997",
+            title: "Jan 1997",
             date: [
                 {
                     cells: [
@@ -269,7 +269,7 @@ describe("DateTimeInput (datetime)", () => {
         await contains(".o_datetime_input").click();
 
         assertDateTimePicker({
-            title: "January 1997",
+            title: "Jan 1997",
             date: [
                 {
                     cells: [

--- a/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
@@ -54,7 +54,7 @@ test("default params", async () => {
     await mountWithCleanup(DateTimePicker);
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -92,7 +92,7 @@ test("minDate: correct days/month/year/decades are disabled", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -175,7 +175,7 @@ test("minDate: correct days/month/year/decades are disabled", async () => {
     await animationFrame();
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -202,7 +202,7 @@ test("maxDate: correct days/month/year/decades are disabled", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -298,7 +298,7 @@ test("maxDate: correct days/month/year/decades are disabled", async () => {
     await animationFrame();
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -330,7 +330,7 @@ test("min+max date: correct days/month/year/decades are disabled", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -420,7 +420,7 @@ test("min+max date: correct days/month/year/decades are disabled", async () => {
     await animationFrame();
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -474,7 +474,7 @@ test("twelve-hour clock", async () => {
     await mountWithCleanup(DateTimePicker);
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -513,7 +513,7 @@ test("hide time picker", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -566,7 +566,7 @@ test("next month and previous month", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -587,7 +587,7 @@ test("next month and previous month", async () => {
     await animationFrame();
 
     assertDateTimePicker({
-        title: "March 2023",
+        title: "Mar 2023",
         date: [
             {
                 cells: [
@@ -608,7 +608,7 @@ test("next month and previous month", async () => {
     await animationFrame();
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -660,7 +660,7 @@ test("range value", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -705,7 +705,7 @@ test("range value on small device", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -746,7 +746,7 @@ test("range value, previous month", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -768,7 +768,7 @@ test("range value, previous month", async () => {
     await animationFrame();
 
     assertDateTimePicker({
-        title: "March 2023",
+        title: "Mar 2023",
         date: [
             {
                 cells: [
@@ -795,7 +795,7 @@ test("days of week narrow format", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -975,7 +975,7 @@ test("custom invalidity function", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -1184,7 +1184,7 @@ test("focus proper month when changing props out of current month", async () => 
     const parent = await mountWithCleanup(Parent);
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [
@@ -1229,7 +1229,7 @@ test("disable show week numbers", async () => {
     });
 
     assertDateTimePicker({
-        title: "April 2023",
+        title: "Apr 2023",
         date: [
             {
                 cells: [

--- a/addons/web/static/tests/views/calendar/calendar_date_picker.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_date_picker.test.js
@@ -40,7 +40,7 @@ test(`Mount a CalendarDatePicker`, async () => {
     expect(`.o_datetime_picker`).toHaveCount(1);
     expect(`.o_datetime_picker .o_selected`).toHaveCount(1);
     expect(`.o_datetime_picker .o_selected`).toHaveText("14");
-    expect(`.o_datetime_picker_header .o_datetime_button`).toHaveText("August 2021");
+    expect(`.o_datetime_picker_header .o_datetime_button`).toHaveText("Aug 2021");
     expect(queryAllTexts`.o_datetime_picker .o_day_of_week_cell`).toEqual([
         "S",
         "M",

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -91,7 +91,7 @@ test("open datepicker on Control+Enter", async () => {
     await press(["ctrl", "enter"]);
     await animationFrame();
     assertDateTimePicker({
-        title: "January 1997",
+        title: "Jan 1997",
         date: [
             {
                 cells: [
@@ -395,7 +395,7 @@ test("date field supports internationalization", async () => {
     expect(".o_field_date").toHaveText("3. feb. 2017");
     await contains(".o_field_date button").click();
     expect(".o_field_date input").toHaveValue("02/03/2017");
-    expect(".o_zoom_out strong").toHaveText("februar 2017");
+    expect(".o_zoom_out strong").toHaveText("feb 2017");
 
     await contains(getPickerCell("22")).click();
     await clickSave();

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -445,7 +445,7 @@ test("Render with initial empty value and optional start date", async () => {
 
     await contains("input[data-field=datetime_end]").click();
     expect(".o_datetime_picker").toHaveCount(1);
-    expect(".o_toggle_range").toHaveCount(1);
+    expect(".o_toggle_range").toHaveCount(2);
 
     // Select a value (today)
     await contains(".o_today").click();


### PR DESCRIPTION
Before this commit, we had only one button to toggle the date picker mode, but the icon representing it wasn't very clear for people, even with a title attribute.

Now we have two distinct buttons. The disadvantage of this change is that we have to handle text length depending on the translation. That's why we've reduced the month name to its abbreviated version.

task-5208130

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
