### PR TITLE
 [IMP] hr_recruitment_skills: move & rename "Search Matching Applicants" cog menu action

### DIFF
--- a/addons/hr_recruitment_skills/views/hr_job_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_job_views.xml
@@ -18,19 +18,14 @@
         <field name="model">hr.job</field>
         <field name="inherit_id" ref="hr_skills.view_hr_job_form"/>
         <field name="arch" type="xml">
+            <header position="inside">
+                <button name="action_search_matching_applicants" string="Matching Talents" type="object" class="btn-secondary"
+                    groups="hr_recruitment.group_hr_recruitment_user"/>
+            </header>
             <xpath expr="//group[@id='job_skills']/field[@name='current_job_skill_ids']" position="attributes">
                 <attribute name="groups">!hr.group_hr_user,!hr_recruitment.group_hr_recruitment_interviewer</attribute>
             </xpath>
         </field>
-    </record>
-
-    <record id="action_applicant_search_applicant" model="ir.actions.server">
-        <field name="name">Search Matching Applicants</field>
-        <field name="model_id" ref="hr_recruitment.model_hr_job"/>
-        <field name="binding_model_id" ref="hr_recruitment.model_hr_job"/>
-        <field name="binding_view_types">form</field>
-        <field name="state">code</field>
-        <field name="code">action = records.with_context({'search_default_talents': 1}).action_search_matching_applicants()</field>
     </record>
 
     <record id="view_hr_job_kanban" model="ir.ui.view">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit is part of a 9-part task aiming to improve the user experience of multiple apps related to hr_recruitment.

This commit:
    - removes the "Search Matching Applicants" cog menu action and adds it as a header button instead, and renames it "Matching Talents".

task-5184168

Current behavior before PR:
The Job Form view has a cog menu item "Search Matching Applicants" and no "Matching Talents" button in the header. The "Search Matching Applicants" button opens a list view of Applicants filtered to match the current job offer.

Desired behavior after PR is merged:
The Job Form view has no cog menu item "Search Matching Applicants" and a "Matching Talents" button in the header performing the exact same action as the previous "Search Matching Applicants" cog menu item. 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
