### PR TITLE
[FIX] point_of_sale: prevent error when downloading Gift Card coupon

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/report_service.js
+++ b/addons/point_of_sale/static/src/app/utils/report_service.js
@@ -4,8 +4,8 @@ import { user } from "@web/core/user";
 import { downloadReport } from "@web/webclient/actions/reports/utils";
 
 export const reportService = {
-    dependencies: ["ui", "orm", "pos"],
-    start(env, { ui, orm, pos }) {
+    dependencies: ["ui"],
+    start(env, { ui }) {
         const reportActionsCache = {};
         return {
             async doAction(reportXmlId, active_ids) {

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -1,5 +1,5 @@
 import { patch } from "@web/core/utils/patch";
-import { PosStore } from "@point_of_sale/app/store/pos_store";
+import { PosStore, posService } from "@point_of_sale/app/store/pos_store";
 import { _t } from "@web/core/l10n/translation";
 import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -25,11 +25,16 @@ function inverted(fn) {
     return (arg) => !fn(arg);
 }
 
+patch(posService, {
+    dependencies: [...posService.dependencies, "report"],
+});
+
 patch(PosStore.prototype, {
-    async setup() {
+    async setup(env, { report }) {
         this.couponByLineUuidCache = {};
         this.rewardProductByLineUuidCache = {};
         await super.setup(...arguments);
+        this.report = report;
 
         effect(
             batched((orders) => {
@@ -887,12 +892,15 @@ patch(PosStore.prototype, {
                 }
             }
             if (payload.coupon_report) {
-                for (const [actionId, active_ids] of Object.entries(payload.coupon_report)) {
-                    await this.report.doAction(actionId, active_ids);
+                if (this.get_order() && this.get_order().uuid == order.uuid) {
+                    for (const [actionId, active_ids] of Object.entries(payload.coupon_report)) {
+                        await this.report.doAction(actionId, active_ids);
+                    }
                 }
                 order.has_pdf_gift_card = Object.keys(payload.coupon_report).length > 0;
             }
             order.new_coupon_info = payload.new_coupon_info;
+            return payload;
         }
     },
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -527,6 +527,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.env.ref('loyalty.gift_card_product_50').write({'active': True})
         # Create gift card program
         gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+        gift_card_program.pos_report_print_id = self.env.ref('loyalty.report_gift_card')
         # Run the tour to create a gift card
         self.start_pos_tour("GiftCardProgramTour1")
         # Check that gift cards are created


### PR DESCRIPTION
Before this commit, an error was raised when selling a gift card and attempting to download its document.

opw-5219703

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
