### PR TITLE
[IMP] product: add `net_weight` to products

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -63,6 +63,7 @@ class ProductProduct(models.Model):
         Used to compute margins on sale orders.""")
     volume = fields.Float('Volume', digits='Volume')
     weight = fields.Float('Weight', digits='Stock Weight')
+    net_weight = fields.Float('Weight (net)', digits='Stock Weight')
 
     pricelist_rule_ids = fields.One2many(
         string="Pricelist Rules",

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -111,6 +111,9 @@ class ProductTemplate(models.Model):
         'Weight', compute='_compute_weight', digits='Stock Weight',
         inverse='_set_weight', store=True)
     weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name')
+    net_weight = fields.Float(
+        'Weight (net)', compute='_compute_net_weight',
+        inverse='_set_net_weight', digits='Stock Weight', store=True)
 
     sale_ok = fields.Boolean('Sales', default=True)
     purchase_ok = fields.Boolean('Purchase', default=True, compute='_compute_purchase_ok', store=True, readonly=False)
@@ -327,6 +330,13 @@ class ProductTemplate(models.Model):
     def _set_weight(self):
         self._set_product_variant_field('weight')
 
+    @api.depends('product_variant_ids.net_weight')
+    def _compute_net_weight(self):
+        self._compute_template_field_from_variant_field('net_weight')
+
+    def _set_net_weight(self):
+        self._set_product_variant_field('net_weight')
+
     def _compute_is_product_variant(self):
         self.is_product_variant = False
 
@@ -501,7 +511,7 @@ class ProductTemplate(models.Model):
 
     def _get_related_fields_variant_template(self):
         """ Return a list of fields present on template and variants models and that are related"""
-        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'product_properties']
+        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'net_weight', 'product_properties']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -209,12 +209,12 @@
                                 <group name="group_lots_and_weight" string="Logistics" invisible="type != 'consu'">
                                     <label for="weight" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
                                     <div class="o_row" name="weight" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                                        <field name="weight" class="oe_inline" style="max-width: 7rem;"/>
+                                        <field name="weight" class="oe_inline" style="max-width: 5rem;"/>
                                         <field name="weight_uom_name"/>
                                     </div>
                                     <label for="volume" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
                                     <div class="o_row" name="volume" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                                        <field name="volume" string="Volume" class="oe_inline" style="max-width: 7rem;"/>
+                                        <field name="volume" string="Volume" class="oe_inline" style="max-width: 5rem;"/>
                                         <field name="volume_uom_name"/>
                                     </div>
                                 </group>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -200,7 +200,7 @@
                 <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
                     <label for="sale_delay" invisible="not sale_ok"/>
                     <div invisible="not sale_ok">
-                        <field name="sale_delay" class="oe_inline" style="vertical-align:baseline"/> days
+                        <field name="sale_delay" class="oe_inline" style="vertical-align:baseline; max-width: 5rem;"/> days
                     </div>
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="before">


### PR DESCRIPTION
New field to differentiate between Gross weight and weight of the product on its own.

Gross weight = Net weight + Tare Weight
(Total weight including packaging, pallets, etc..) 

Task: 5207999





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
