### PR TITLE
[FIX] website_sale: fix `remove_main_product_image*` tours

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -34,11 +34,13 @@ const removeImg = [
         trigger: "we-customizeblock-options:has(we-title:contains('Image')) we-button[data-name='media_wsale_remove']",
         run: "click",
     },
-    // If the snippet editor is not visible, the remove process is considered as
-    // finished.
     {
         content: "Check that the snippet editor is not visible",
         trigger: ".o_we_customize_panel:not(:has(we-customizeblock-options:has(we-title:contains('Re-order'))))",
+    },
+    {
+        content: "Wait until the the image removal is saved",
+        trigger: ':iframe #o-carousel-product div:not(.o_dirty) > img',
     },
 ];
 
@@ -53,7 +55,7 @@ registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
     },
     {
         content: "Click on the new image",
-        trigger: ".o_select_media_dialog img[title='s_default_image.jpg']",
+        trigger: ".o_select_media_dialog img[title='green.jpg']",
         run: "click",
     },
     {


### PR DESCRIPTION
Versions
--------
18.0+

Issue
-----
The `test_website_sale_add_and_remove_main_product_image_no_variant` and `test_website_sale_remove_main_product_image_with_variant` tours fail because the main product image is not removed as expected after the tour completes.

Cause
-----
Both tours assume that once the product `<img>` element is removed from the DOM, the action is fully completed. The tour then ends, and the remaining Python code verifies the result. However, this assumption can lead to issues. If the save request takes longer than expected, the Python code may execute prematurely and fail.

Solution
--------
Add a step at the end of both tours to wait for the `<img>` element to be fully saved and updated in the preview DOM.

Additionally, during debugging, it was observed that using an alias URL (i.e., a redirect) to an `ir.attachment` could introduce further issues or slow down the test due to the server fetching the image with a remote call. To address this, this commit replaces the alias URL with a simple binary attachment.

opw-5159593
runbot-163025
runbot-163615
