### PR TITLE
[FIX] google_calendar: sync event at creation

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -78,8 +78,12 @@ class GoogleCalendarSync(models.AbstractModel):
 
     @api.model_create_multi
     def create(self, vals_list):
-        if self.env.user.google_synchronization_stopped:
-            for vals in vals_list:
+        user_ids = {v['user_id'] for v in vals_list if v.get('user_id')}
+        users_with_sync = self.env['res.users'].browse(user_ids).filtered(lambda u: not u.sudo().google_synchronization_stopped)
+        users_with_sync_set = set(users_with_sync.ids)
+
+        for vals in vals_list:
+            if vals.get('user_id', False) and vals['user_id'] not in users_with_sync_set:
                 vals.update({'need_sync': False})
         records = super().create(vals_list)
         self._handle_allday_recurrences_edge_case(records, vals_list)


### PR DESCRIPTION
**Issue**
Events were not synchonized if created by a user with google synchronization stopped, for a user with an active google synchronization. To reproduce:
- Have user A with google synchronization stopped and user B with google synchronization enabled.
- With user A, create an event with user B as the organizer.
- Open the Google calendar of user B and notice the event is not present.

In our own database, it was causing issues for meetings booked from website and created by the public user.

**Change**
The user returned by `_get_event_user` is the one who needs to perform the sync to google, so we check the status of its google sync.

opw-4795476
