### PR TITLE
[FIX] payment: provider should be published

### DIFF
--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -317,8 +317,7 @@ class TestFlows(PaymentHttpCommon):
         self.authenticate(self.portal_user.login, self.portal_user.login)
 
         token = self._create_token()
-        provider_b = self.provider.copy()
-        provider_b.state = 'test'
+        provider_b = self.provider.copy({'is_published': True, 'state': 'test'})
         token_b = self._create_token(provider_id=provider_b.id)
 
         # User must see both tokens and compatible payment methods.


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/230755
Following commit https://github.com/odoo/odoo/commit/d2949c8f11547cf2d34ddfacfd1ff046f204021d, the copied provider is no longer published by default.

runbot-233300

