### PR TITLE
[IMP] crm: adapt crm teams data for crm_livechat

### DIFF
--- a/addons/crm/data/crm_team_demo.xml
+++ b/addons/crm/data/crm_team_demo.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="sales_team.team_sales_department" model="crm.team" forcecreate="False">
-            <field name="assignment_domain">[['probability', '>=', 20]]</field>
-        </record>
-
         <record id="sales_team.crm_team_1" model="crm.team">
             <field name="use_leads">True</field>
-            <field name="assignment_domain">[['phone', '!=', False]]</field>
         </record>
     </data>
 </odoo>

--- a/addons/crm/data/crm_team_member_demo.xml
+++ b/addons/crm/data/crm_team_member_demo.xml
@@ -2,12 +2,10 @@
 <odoo><data noupdate="1">
 
     <record id="sales_team.crm_team_member_admin_sales" model="crm.team.member">
-        <field name="assignment_max">30</field>
-        <field name="assignment_domain">[['probability', '>=', 20]]</field>
+        <field name="assignment_max">300</field>
     </record>
     <record id="sales_team.crm_team_member_demo_team_1" model="crm.team.member">
-        <field name="assignment_max">45</field>
-        <field name="assignment_domain">[['probability', '>=', 5]]</field>
+        <field name="assignment_max">450</field>
     </record>
 
 </data></odoo>


### PR DESCRIPTION
This commit loosens the lead assignment rules for the demo data crm teams and team members.

The purpose of this change is to facilitate the testing of the "Create Lead & Forward" chatbot step, which has been mistakenly reported as not working while actually the forwarding was stopped by the lead assignment rules.

task-5137022