### PR TITLE
[FIX] hr_holidays_attendance: Fix traceback on hourly extra hours

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -127,7 +127,7 @@
         <field name="name">hr.attendance.list</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <list sample="1" js_class="extra_hours_list_view">
+            <list sample="1">
                 <field name="check_in"/>
                 <field name="check_out"/>
                 <field name="worked_hours" string="Work Hours" widget="float_time"/>

--- a/addons/hr_holidays_attendance/static/src/views/extra_hours_list_view.js
+++ b/addons/hr_holidays_attendance/static/src/views/extra_hours_list_view.js
@@ -1,10 +1,10 @@
 import { Component, useState, useEffect } from "@odoo/owl";
-
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { listView } from "@web/views/list/list_view";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
+// Adds an overtime summary at the top of the monthly hours list
 export class ExtraHoursSummary extends Component {
     static template = "hr_attendance.ExtraHoursSummary";
     static props = {};
@@ -14,8 +14,9 @@ export class ExtraHoursSummary extends Component {
         this.floatTime = registry.category("formatters").get("float_time");
         this.state = useState({
             totalExtraHours: 0,
+            compensableExtraHours: 0,
             totalOvertimeAdjustment: 0,
-            remainingExtraHours: 0
+            remainingExtraHours: 0,
         });
 
         useEffect(() => {
@@ -31,16 +32,14 @@ export class ExtraHoursSummary extends Component {
         if (!this.shouldDisplay) {
             return;
         }
-        const { context, domain } = this.env.searchModel;
-        const employeeId = context.employee_id;
-        const { overtime_adjustments = {}, validated_overtime = {} } =
-            await this.orm.call("hr.employee", "get_overtime_data", [domain, employeeId]);
-        const validatedOvertimeHours = validated_overtime[employeeId] || 0;
-        const adjustmentOvertimeHours = overtime_adjustments[employeeId] || 0;
-        const remainingOvertimeHours = validatedOvertimeHours + adjustmentOvertimeHours;
-        this.state.totalExtraHours = this.floatTime(validatedOvertimeHours);
-        this.state.totalOvertimeAdjustment = this.floatTime(adjustmentOvertimeHours);
-        this.state.remainingExtraHours = this.floatTime(remainingOvertimeHours);
+        const employeeId = this.env.searchModel.context.employee_id;
+        const overtime_data = (await this.orm.call("hr.employee", "get_overtime_data_by_employee", [employeeId]))[employeeId];
+        /* overtime_data is currently in float value. We need to format it
+           before showing it in the UI */
+        this.state.totalExtraHours = this.floatTime(overtime_data['compensable_overtime'] + overtime_data['not_compensable_overtime']);
+        this.state.compensableExtraHours = this.floatTime(overtime_data['compensable_overtime']);
+        this.state.totalOvertimeAdjustment = this.floatTime(overtime_data['compensable_overtime'] - overtime_data['unspent_compensable_overtime']);
+        this.state.remainingExtraHours = this.floatTime(overtime_data['unspent_compensable_overtime']);
     }
 }
 

--- a/addons/hr_holidays_attendance/static/src/views/extra_hours_list_view.xml
+++ b/addons/hr_holidays_attendance/static/src/views/extra_hours_list_view.xml
@@ -9,6 +9,10 @@
                     <span><t t-out="this.state.totalExtraHours"/></span>
                 </div>
                 <div class="d-flex justify-content-between">
+                    <span>Total Compensable Extra Hours:</span>
+                    <span><t t-out="this.state.compensableExtraHours"/></span>
+                </div>
+                <div class="d-flex justify-content-between">
                     <span>Time Off Taken from Extra Hours:</span>
                     <span><t t-out="this.state.totalOvertimeAdjustment"/></span>
                 </div>

--- a/addons/hr_holidays_attendance/views/hr_employee_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_employee_views.xml
@@ -20,4 +20,14 @@
         </field>
     </record>
 
+    <record id="hr_attendance_employee_simple_tree_view" model="ir.ui.view">
+        <field name="name">hr.attendance.employee.simple.tree.view.inherit.hr_holidays_attendance</field>
+        <field name="model">hr.attendance</field>
+        <field name="inherit_id" ref="hr_attendance.hr_attendance_employee_simple_tree_view"/>
+        <field name="arch" type="xml">
+            <list position="attributes">
+                <attribute name="js_class">extra_hours_list_view</attribute>
+            </list>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
A stacktrace would be shown when clicking on the "Monthly Hours" smart button, when "Display Extra Hours" is checked in Configuration/Settings

This was due to a missing comma in the domain creation. When reviewing the code that was causing the crash, we noticed that the wrong domain was used on the wrong model to fetch overtime data.

Also, the function needed logic from hr_holidays (and not just hr_attendance). So I needed to move that to the hr_holidays_attendance.

Moreover, the correct values were not displayed in the JS list view (that adds a small summary on top of the list). I had to investigate and fetch the correct info about the selected employee's overtime.

task-5106638