### PR TITLE
[FIX] account: keep accounts on payment method lines compute

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -387,11 +387,21 @@ class AccountJournal(models.Model):
         for journal in self:
             pay_method_line_ids_commands = [Command.clear()]
             if journal.type in ('bank', 'cash', 'credit'):
+                existing_method_lines = journal.inbound_payment_method_line_ids
                 default_methods = journal._default_inbound_payment_methods()
-                pay_method_line_ids_commands += [Command.create({
-                    'name': pay_method.name,
-                    'payment_method_id': pay_method.id,
-                }) for pay_method in default_methods]
+                for pay_method in default_methods:
+                    payment_account = existing_method_lines.filtered(lambda m: m.payment_method_id == pay_method).payment_account_id
+                    pay_method_line_ids_commands += [
+                        Command.create({
+                            'name': pay_method.name,
+                            'payment_method_id': pay_method.id,
+                            'payment_account_id': (
+                                payment_account.id
+                                if not payment_account.currency_id or payment_account.currency_id == journal.currency_id
+                                else False
+                            ),
+                        })
+                    ]
             journal.inbound_payment_method_line_ids = pay_method_line_ids_commands
 
     @api.depends('type', 'currency_id')
@@ -399,11 +409,21 @@ class AccountJournal(models.Model):
         for journal in self:
             pay_method_line_ids_commands = [Command.clear()]
             if journal.type in ('bank', 'cash', 'credit'):
+                existing_method_lines = journal.outbound_payment_method_line_ids
                 default_methods = journal._default_outbound_payment_methods()
-                pay_method_line_ids_commands += [Command.create({
-                    'name': pay_method.name,
-                    'payment_method_id': pay_method.id,
-                }) for pay_method in default_methods]
+                for pay_method in default_methods:
+                    payment_account = existing_method_lines.filtered(lambda m: m.payment_method_id == pay_method).payment_account_id
+                    pay_method_line_ids_commands += [
+                        Command.create({
+                            'name': pay_method.name,
+                            'payment_method_id': pay_method.id,
+                            'payment_account_id': (
+                                payment_account.id
+                                if not payment_account.currency_id or payment_account.currency_id == journal.currency_id
+                                else False
+                            ),
+                        })
+                    ]
             journal.outbound_payment_method_line_ids = pay_method_line_ids_commands
 
     @api.depends('outbound_payment_method_line_ids', 'inbound_payment_method_line_ids')

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -438,3 +438,37 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
             journal_form.default_account_id = default_account
             journal_2 = journal_form.save()
         self.assertNotEqual(journal_1.alias_id.alias_name, journal_2.alias_id.alias_name)
+
+    def test_payment_method_line_accounts_on_recompute(self):
+        """
+        Test that outstanding payments/receipts accounts are not removed during the computation of the payment method lines
+        """
+        bank_journal = self.company_data['default_journal_bank']
+        outstanding_receipt_account = self.env['account.chart.template'].ref('account_journal_payment_debit_account_id')
+        outstanding_payment_account = self.env['account.chart.template'].ref('account_journal_payment_credit_account_id')
+
+        inbound_method_lines = bank_journal.inbound_payment_method_line_ids
+        inbound_method_lines_names = inbound_method_lines.mapped('name')
+        inbound_method_lines[0].payment_account_id = outstanding_receipt_account
+
+        outbound_method_lines = bank_journal.outbound_payment_method_line_ids
+        outbound_method_lines_names = outbound_method_lines.mapped('name')
+        outbound_method_lines[0].payment_account_id = outstanding_payment_account
+        new_outbound_payment_line = outbound_method_lines[0].copy({'payment_account_id': outstanding_payment_account.id})
+        bank_journal.outbound_payment_method_line_ids = [Command.link(new_outbound_payment_line.id)]
+
+        # Set currency_id to trigger the compute of {in,out}bound_payment_method_line_ids
+        bank_journal.currency_id = self.company_data['currency']
+
+        self.assertRecordValues(bank_journal.inbound_payment_method_line_ids, [
+            {
+                'name': name,
+                'payment_account_id': outstanding_receipt_account.id if index == 0 else False,
+            } for index, name in enumerate(inbound_method_lines_names)
+        ])
+        self.assertRecordValues(bank_journal.outbound_payment_method_line_ids, [
+            {
+                'name': name,
+                'payment_account_id': outstanding_payment_account.id if index == 0 else False,
+            } for index, name in enumerate(outbound_method_lines_names)
+        ])


### PR DESCRIPTION
Changing the currency on a journal triggers the compute of
inbound/outbound method lines, which clears the method lines before
reasign the default method lines. This leads to the loss of any
outstanding account set on the method lines.

Steps:

- Have a bank journal with outstanding accounts set on the payment
  method lines
- Change the currency (in our case, this is the bank sync that changed
  the currency of the journal)
-> Outstanding accounts are missing on the payment method lines,
   even if the accounts currency is the same as the journals or no
   currency is set on the accounts.

opw-5175794
