### PR TITLE
[FIX] l10n_ar: avoid UserError by checking if es_AR exists before amount_to_text

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -363,6 +363,14 @@ class AccountMove(models.Model):
             return 'l10n_ar.report_invoice_document'
         return super()._get_name_invoice_report()
 
+    def _l10n_ar_get_lang_code_for_report(self):
+        """Get the language code for the Argentina invoice report. 
+        Prefers 'es_419' if available, otherwise uses the context language."""
+        self.ensure_one()
+        if lang := self.env['res.lang'].search([('code', 'like', 'es_%')], limit=1):
+            return lang.code
+        return self.env.context.get('lang', self.env.user.lang)
+
     def _l10n_ar_get_invoice_totals_for_report(self):
         """If the invoice document type indicates that vat should not be detailed in the printed report (result of _l10n_ar_include_vat()) then we overwrite tax_totals field so that includes taxes in the total amount, otherwise it would be showing amount_untaxed in the amount_total"""
         self.ensure_one()

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -259,8 +259,10 @@
         <!-- Show total amount in letters for MiPyMEs document types according to the law
          http://biblioteca.afip.gob.ar/dcp/LEY_C_027440_2018_05_09 article 5.f -->
         <xpath expr="//div[@id='total']/div/table" position="after">
-            <t t-if="o.l10n_latam_document_type_id.code in ['201', '202', '203', '206', '207', '208', '211', '212', '213']">
-                <strong>Son: </strong><span t-out="o.currency_id.with_context(lang='es_AR').amount_to_text(o.amount_total)"/>
+            <t t-set="lang_code" t-value="o._l10n_ar_get_lang_code_for_report()"/>
+            <t t-if="o.l10n_latam_document_type_id.code in ['201','202','203','206','207','208','211','212','213'] and lang_code">
+                <strong>Son: </strong>
+                <span t-out="o.currency_id.with_context(lang=lang_code).amount_to_text(o.amount_total)"/>
             </t>
         </xpath>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Rendering the Argentine invoice report fails with:
UserError: Invalid language code: es_AR
when the language 'es_AR' is not active in res.lang.

**Current behavior before PR:**
The report template (l10n_ar.report_invoice_document) always forces
lang='es_AR' when calling amount_to_text, causing a crash if that
language is not available.

**Desired behavior after PR is merged:**
The template now checks dynamically if 'es_AR' exists in res.lang before
using it. If not, it safely skips rendering to avoid breaking the report.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
