### PR TITLE
[FIX] account: convert invoice/refund while storno

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -771,7 +771,9 @@ class AccountMove(models.Model):
     @api.depends('move_type')
     def _compute_is_storno(self):
         for move in self:
-            move.is_storno = move.is_storno or (move.move_type in ('out_refund', 'in_refund') and move.company_id.account_storno)
+            is_invoice = move.move_type in ('in_invoice', 'out_invoice')
+            is_refund = move.move_type in ('out_refund', 'in_refund')
+            move.is_storno = not is_invoice and (move.is_storno or (is_refund and move.company_id.account_storno))
 
     @api.depends('company_id', 'invoice_filter_type_domain')
     def _compute_suitable_journal_ids(self):

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1879,6 +1879,80 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'amount_untaxed': self.move_vals['amount_untaxed'],
         })
 
+    def test_in_invoice_switch_type_storno(self):
+        # Test creating an account_move with an in_invoice_type and switch it in an in_refund,
+        # then switching it back to an in_invoice. When storno accounting is enabled.
+        self.env.company.account_storno = True
+
+        move = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+            'invoice_line_ids': [
+                Command.create({
+                    'price_unit': 800.0,
+                    'quantity': 1,
+                }),
+                Command.create({
+                    'price_unit': 160.0,
+                    'quantity': 1,
+                }),
+            ],
+        })
+        move.action_switch_move_type()  # Switch to refund.
+
+        self.assertRecordValues(move, [{'move_type': 'in_refund'}])
+        self.assertInvoiceValues(move, [
+            {
+                'amount_currency': -800.0,
+                'credit': 0.0,
+                'debit': -800.0,
+            },
+            {
+                'amount_currency': -160.0,
+                'credit': 0.0,
+                'debit': -160.0,
+            },
+            {
+                'amount_currency': 960.0,
+                'debit': 0.0,
+                'credit': -960.0,
+            },
+        ], {
+            'partner_id': self.partner_a.id,
+            'amount_untaxed': 960.0,
+            'amount_tax': 0.0,
+            'amount_total': 960.0,
+            'date': fields.Date.from_string('2019-01-31'),
+        })
+
+        move.action_switch_move_type()  # Switch back to invoice.
+
+        self.assertRecordValues(move, [{'move_type': 'in_invoice'}])
+        self.assertInvoiceValues(move, [
+            {
+                'amount_currency': 160.0,
+                'credit': 0.0,
+                'debit': 160.0,
+            },
+            {
+                'amount_currency': 800.0,
+                'credit': 0.0,
+                'debit': 800.0,
+            },
+            {
+                'amount_currency': -960.0,
+                'debit': 0.0,
+                'credit': 960,
+            },
+        ], {
+            'partner_id': self.partner_a.id,
+            'amount_untaxed': 960.0,
+            'amount_tax': 0.0,
+            'amount_total': 960.0,
+            'date': fields.Date.from_string('2019-01-31'),
+        })
+
     def test_in_invoice_change_period_accrual_1(self):
         move = self.env['account.move'].create({
             'move_type': 'in_invoice',


### PR DESCRIPTION
This commit fixes the amounts of move lines when converting from invoice to credit note and vice versa when storno is enabled. Previously, when converting from invoice/credit note, the amounts remained negative and switches from debit/credit.

The quantities should remain in same debit/credit position and only change sign as I switch from invoice/credit note.

task-5226311





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
