### PR TITLE
[FIX] mail, *: fix test_discuss_full_enterprise HOOT test failure

### DIFF
--- a/addons/hr/static/tests/hr_test_helpers.js
+++ b/addons/hr/static/tests/hr_test_helpers.js
@@ -9,8 +9,6 @@ import { HrVersion } from "./mock_server/mock_models/hr_version";
 import { HrJob } from "./mock_server/mock_models/hr_job";
 import { HrWorkLocation } from "./mock_server/mock_models/hr_work_location";
 import { ResourceResource } from "@resource/../tests/mock_server/mock_models/resource_resource";
-import { ResUsers } from "./mock_server/mock_models/res_users";
-import { ResPartner } from "./mock_server/mock_models/res_partner";
 
 export function defineHrModels() {
     return defineModels(hrModels);
@@ -27,6 +25,4 @@ export const hrModels = {
     HrJob,
     HrWorkLocation,
     ResourceResource,
-    ResUsers,
-    ResPartner,
 };

--- a/addons/hr/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/hr/static/tests/mock_server/mock_models/res_partner.js
@@ -1,13 +1,16 @@
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { fields, makeKwArgs } from "@web/../tests/web_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import { patch } from "@web/core/utils/patch";
 
-export class ResPartner extends mailModels.ResPartner {
-    employee_ids = fields.One2many({
-        relation: "hr.employee",
-        inverse: "work_contact_id",
-    });
-
+patch(mailModels.ResPartner.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.employee_ids = fields.One2many({
+            relation: "hr.employee",
+            inverse: "work_contact_id",
+        });
+    },
     _get_store_avatar_card_fields() {
         return [
             ...super._get_store_avatar_card_fields(),
@@ -19,5 +22,5 @@ export class ResPartner extends mailModels.ResPartner {
                 })
             ),
         ];
-    }
-}
+    },
+});

--- a/addons/hr/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/hr/static/tests/mock_server/mock_models/res_users.js
@@ -1,22 +1,26 @@
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { fields } from "@web/../tests/web_test_helpers";
+import { patch } from "@web/core/utils/patch";
 
-export class ResUsers extends mailModels.ResUsers {
-    employee_id = fields.Many2one({ relation: "hr.employee" });
-    employee_ids = fields.One2many({
-        relation: "hr.employee",
-        inverse: "user_id",
-    });
-    department_id = fields.Many2one({
-        related: "employee_id.department_id",
-        relation: "hr.department",
-    });
-    work_email = fields.Char({ related: "employee_id.work_email" });
-    work_phone = fields.Char({ related: "employee_id.work_phone" });
-    work_location_type = fields.Char({ related: "employee_id.work_location_type" });
-    work_location_id = fields.Many2one({
-        related: "employee_id.work_location_id",
-        relation: "hr.work.location",
-    });
-    job_title = fields.Char({ related: "employee_id.job_title" });
-}
+patch(mailModels.ResUsers.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.employee_id = fields.Many2one({ relation: "hr.employee" });
+        this.employee_ids = fields.One2many({
+            relation: "hr.employee",
+            inverse: "user_id",
+        });
+        this.department_id = fields.Many2one({
+            related: "employee_id.department_id",
+            relation: "hr.department",
+        });
+        this.work_email = fields.Char({ related: "employee_id.work_email" });
+        this.work_phone = fields.Char({ related: "employee_id.work_phone" });
+        this.work_location_type = fields.Char({ related: "employee_id.work_location_type" });
+        this.work_location_id = fields.Many2one({
+            related: "employee_id.work_location_id",
+            relation: "hr.work.location",
+        });
+        this.job_title = fields.Char({ related: "employee_id.job_title" });
+    },
+});

--- a/addons/hr_holidays/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/hr_holidays/static/tests/mock_server/mock_models/res_partner.js
@@ -1,8 +1,8 @@
-import { hrModels } from "@hr/../tests/hr_test_helpers";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { fields } from "@web/../tests/web_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-export class ResPartner extends hrModels.ResPartner {
+export class ResPartner extends mailModels.ResPartner {
     leave_date_to = fields.Date({ related: false });
 
     compute_im_status(partner) {

--- a/addons/hr_holidays/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/hr_holidays/static/tests/mock_server/mock_models/res_users.js
@@ -1,6 +1,6 @@
-import { hrModels } from "@hr/../tests/hr_test_helpers";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { fields } from "@web/../tests/web_test_helpers";
 
-export class ResUsers extends hrModels.ResUsers {
+export class ResUsers extends mailModels.ResUsers {
     leave_date_to = fields.Date({ related: false });
 }

--- a/addons/hr_holidays/static/tests/radio_image_field.test.js
+++ b/addons/hr_holidays/static/tests/radio_image_field.test.js
@@ -1,6 +1,13 @@
-import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { expect, test } from "@odoo/hoot";
-import { clickSave, contains, defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+import {
+    clickSave,
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+} from "@web/../tests/web_test_helpers";
+import { defineHrHolidaysModels } from "./hr_holidays_test_helpers";
 
 class Partner extends models.Model {
     _records = [{ id: 1, product_id: false }];
@@ -19,7 +26,7 @@ class Product extends models.Model {
 }
 
 defineModels([Partner, Product]);
-defineMailModels();
+defineHrHolidaysModels();
 
 test(`field is correctly renderered`, async () => {
     await mountView({

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1647,6 +1647,7 @@ export class Model extends Array {
 
     constructor() {
         super(...arguments);
+        this.setup();
 
         if (!modelInstanceLock) {
             const modelInstance = this.constructor.definition;
@@ -1665,6 +1666,9 @@ export class Model extends Array {
             this._views = modelInstance._views;
         }
     }
+
+    /** To define new fields in patches */
+    setup() {}
 
     //-------------------------------------------------------------------------
     // Public


### PR DESCRIPTION
*: hr, web

Follow-up of https://github.com/odoo/enterprise/pull/98481

PR above added a new HOOT test in test_discuss_full_enterprise that is duplicate of a livechat tests, to cover good working of feature when overrides like `ai` module are applied in code.

It replaced a `defineHrModels()` into a
`defineTestDiscussFullEnterprise()`, which is shortcut for the test helper `defineWebsiteHelpdeskLivechatModels`. This is because the new test needs livechat models, and it's hard to combine defineModels for odoo modules that do not strictly patch on top of each other.

While it doesn't look like it, the test "can handle command and disable mentions in AI composer" sometimes asks for hr models and can fail non-deterministically because of that.

This commit fixes the issue by adding hr models in the helper of `test_discuss_full_enterprise`. To combine same models together with ease, instead of defining subclasses for extension, the models are instead patched. Since the patch is made in place, they combine nicely without puzzling with combining models in the right order, something that even the actual models in python don't have to care about.

Fixes https://runbot.odoo.com/runbot/build/92414152