### PR TITLE
[FIX] account_edi_proxy_client: auth resilience

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -142,11 +142,8 @@ class AccountEdiProxyClientUser(models.Model):
             error_code = proxy_error['code']
             if error_code == 'refresh_token_expired':
                 self._renew_token()
-                self.env.cr.commit() # We do not want to lose it if in the _make_request below something goes wrong
+                self.env.cr.commit()  # We do not want to lose it if in the _make_request below something goes wrong
                 return self._make_request(url, params)
-            if error_code == 'no_such_user':
-                # This error is also raised if the user didn't exchange data and someone else claimed the edi_identificaiton.
-                self.sudo().active = False
             if error_code == 'invalid_signature':
                 raise AccountEdiProxyError(
                     error_code,

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import _, api, fields, models, modules, tools
+from odoo import _, api, fields, models, tools
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 from odoo.addons.account_peppol.tools.demo_utils import handle_demo
 from odoo.exceptions import UserError
@@ -22,7 +22,6 @@ class AccountEdiProxyClientUser(models.Model):
     # HELPER METHODS
     # -------------------------------------------------------------------------
 
-
     def _make_request(self, url, params=False):
         if self.proxy_type == 'peppol':
             return self._make_request_peppol(url, params=params)
@@ -30,27 +29,7 @@ class AccountEdiProxyClientUser(models.Model):
 
     @handle_demo
     def _make_request_peppol(self, url, params=False):
-        # extends account_edi_proxy_client to update peppol_proxy_state
-        # of archived users
-        try:
-            result = super()._make_request(url, params)
-        except AccountEdiProxyError as e:
-            if (
-                e.code == 'no_such_user'
-                and not self.active
-                # only soft-delete the user in case we were actually waiting for a migration
-                and self.company_id.account_peppol_migration_key
-                and not self.company_id.account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')
-            ):
-                self.company_id.write({
-                    'account_peppol_proxy_state': 'not_registered',
-                    'account_peppol_migration_key': False,
-                })
-                # commit the above changes before raising below
-                if not tools.config['test_enable'] and not modules.module.current_test:
-                    self.env.cr.commit()
-            raise AccountEdiProxyError(e.code, e.message)
-        return result
+        return super()._make_request(url, params)
 
     def _get_proxy_urls(self):
         urls = super()._get_proxy_urls()


### PR DESCRIPTION
We already have had multiple IAP-side incidents leading to IAP API returning `no_such_user`. This error code should not lead to user deletion client-side.

Thus this commit addresses this by avoiding to archive long-standing IAP connections even when `no_such_user` error is received.