### PR TITLE
[stock] FIX: Expected singleton in move merge during demo install

### DIFF
--- a/addons/stock/data/stock_demo2.xml
+++ b/addons/stock/data/stock_demo2.xml
@@ -485,11 +485,7 @@
                 obj().env.ref('stock.outgoing_shipment_main_warehouse6').id,
                 obj().env.ref('stock.incomming_shipment1').id,
                 obj().env.ref('stock.incomming_shipment2').id,
-                obj().env.ref('stock.incomming_shipment3').id]"/>
-        </function>
-
-        <function model="stock.picking" name="action_confirm">
-            <value model="stock.picking" eval="[
+                obj().env.ref('stock.incomming_shipment3').id,
                 obj().env.ref('stock.outgoing_chicago_warehouse1').id,
                 obj().env.ref('stock.outgoing_chicago_warehouse2').id,
                 obj().env.ref('stock.outgoing_chicago_warehouse3').id,

--- a/addons/stock/data/stock_demo2.xml
+++ b/addons/stock/data/stock_demo2.xml
@@ -485,7 +485,11 @@
                 obj().env.ref('stock.outgoing_shipment_main_warehouse6').id,
                 obj().env.ref('stock.incomming_shipment1').id,
                 obj().env.ref('stock.incomming_shipment2').id,
-                obj().env.ref('stock.incomming_shipment3').id,
+                obj().env.ref('stock.incomming_shipment3').id]"/>
+        </function>
+
+        <function model="stock.picking" name="action_confirm">
+            <value model="stock.picking" eval="[
                 obj().env.ref('stock.outgoing_chicago_warehouse1').id,
                 obj().env.ref('stock.outgoing_chicago_warehouse2').id,
                 obj().env.ref('stock.outgoing_chicago_warehouse3').id,

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1373,7 +1373,6 @@ Please change the quantity done or the rounding precision of your unit of measur
         self.ensure_one()
         return bool(not self.picking_id and self.picking_type_id)
 
-
     def _action_confirm(self, merge=True, merge_into=False):
         """Confirms stock moves, handling multi-company recordsets safely.
 
@@ -1534,7 +1533,6 @@ Please change the quantity done or the rounding precision of your unit of measur
             )
 
         return moves
-
 
     def _prepare_procurement_origin(self):
         self.ensure_one()

--- a/doc/cla/individual/jeevanism.md
+++ b/doc/cla/individual/jeevanism.md
@@ -1,0 +1,11 @@
+United Kingdom, 2025-10-26
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jeevachaithanyan Sivanandan jeevanism@gmail.com https://github.com/jeevanism


### PR DESCRIPTION
**Problem:**
When installing the `stock` module with demo data enabled, a `ValueError: Expected singleton: res.currency(...)` error occurs. 
This bug is tracked in: **odoo/odoo#230965**

Currently, calling `_action_confirm()` on a batch of `stock.move` records belonging to **multiple companies** can lead to incorrect behavior—such as wrong currency usage, valuation errors, or company context leakage—because the method assumes all moves belong to the same company.

This PR fixes that by **grouping moves by `company_id`** and processing each group in its correct company context using `.with_company()`.


---

**Fix:**
- Refactor `stock.move._action_confirm()` to:
  - Group moves by `company_id`
  - Call core confirmation logic (`_action_confirm_single_company`) per company
  - Preserve all original behavior for single-company cases
- Add `_action_confirm_single_company()` containing the original confirmation logic (now scoped to one company)
- Improve docstrings for clarity
- Add a dedicated unit test: `test_move_confirm_multi_company_batch`
---

**Result:**

The core fix is in `addons/stock/models/stock_move.py`.  
The test is in `addons/stock/tests/test_stock_move.py`.

This addresses the reviewer's earlier feedback:  
> “It would be better to handle the multi currency case inside `_action_confirm()` instead. For instance group stock moves by company.”

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr