### PR TITLE
[FIX] web, website: checkered background display in the color presets

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -196,6 +196,8 @@
 .o_cc_preview_wrapper {
     @for $index from 1 through 5 {
         .o_cc#{$index} {
+            --PreviewAlphaBg-background-size: 32px;
+            @extend %o-preview-alpha-background;
             background-color: var(--hb-cp-o-cc#{$index}-bg);
             background-image: var(--hb-cp-o-cc#{$index}-bg-gradient), url('/web/static/img/transparent.png');
             color: var(--hb-cp-o-cc#{$index}-text);

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -131,4 +131,23 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         '/website/static/src/scss/options/user_values.scss {"test-gradient":"NULL"}',
         "asset reload",
     ]);
+    def = new Deferred();
+    await contains('.o-snippets-tabs button[data-name="theme"]').click();
+    await contains('.o_theme_tab div[data-label="Color Presets"] button').click();
+    await contains('div[id^="builder_collapse_content_"] button').click();
+    await contains('div[data-label="Background"] .o_we_color_preview').click();
+    await contains(".o-hb-colorpicker .custom-tab").click();
+    await contains(".o_color_picker_inputs input.o_hex_input").edit("#77FF006E");
+    await def;
+    expect.verifySteps([
+        '/website/static/src/scss/options/colors/user_color_palette.scss {"o-cc1-bg":"#77FF00"}',
+        '/website/static/src/scss/options/user_values.scss {"o-cc1-bg-gradient":"null"}',
+        "asset reload",
+    ]);
+    const colorPresetEl = document.querySelector(
+        'div[id^="builder_collapse_content_"] .o_cc_preview_wrapper div'
+    );
+    const presetElStyles = window.getComputedStyle(colorPresetEl, "::before");
+    expect(presetElStyles.backgroundImage).toInclude("transparent.png");
+    expect(presetElStyles.backgroundSize).toBe("32px");
 });


### PR DESCRIPTION
Steps to reproduce:
1. Go to website and click edit.
2. Switch to the _Theme_ tab and click on _Color Presets_.
3. Click on first color preset, then open the background color picker.
4. Switch to gradient tab, select any gradient, and adjust the opacity.
5. Now, click on second color preset, open the background color picker.
6. Switch to the custom tab, select any color, and adjust its opacity.

Issue:
When a gradient is selected (first color preset), the color preset preview area correctly displays a checkered background to indicate transparency. However, when a plain custom color is selected (second color preset), the checkered transparency background is missing from the color preset preview area.

Fix:
Set the value of `--PreviewAlphaBg-background-size` variable as `32px`. Moreover, extended the `%o-preview-alpha-background` placeholder in the `color_picker.scss` file to ensure the checkered background is consistently applied for both gradient and custom color selections.

| Before | After |
|-----------------------------|---------------------------------|
| <img width="363" height="308" alt="image" src="https://github.com/user-attachments/assets/dbb64116-70d6-4475-9d41-90c0b591efcd" /> | <img width="363" height="308" alt="image" src="https://github.com/user-attachments/assets/ea8caa90-3518-4219-a980-a2a22f2f427d" /> |

task-5226064