### PR TITLE
[FIX] web_editor, *: disable add button when video URL is empty

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -251,6 +251,11 @@ export class MediaDialog extends Component {
     }
 
     selectMedia(media, tabId, multiSelect) {
+        if (media && !Object.keys(media).length) {
+            // Clear media selection when an empty object is passed
+            this.selectedMedia[tabId] = [];
+            return;
+        }
         if (multiSelect) {
             const isMediaSelected = this.selectedMedia[tabId].map(({ id }) => id).includes(media.id);
             if (!isMediaSelected) {

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -34,6 +34,45 @@ wTourUtils.registerWebsitePreviewTour(
             trigger: "a:contains('Videos')",
         },
         {
+            content: "Enter text in video link input to enable add button",
+            trigger: "#o_video_text",
+            run: "text https://youtu.be/nbso3NVz3p8",
+        },
+        {
+            content: "Wait for add button to be enabled",
+            trigger: ".modal-footer button:contains('Add'):not([disabled])",
+            run: () => {},
+        },
+        {
+            content: "Remove video link",
+            trigger: "#o_video_text",
+            run() {
+                const inputEl = this.$anchor[0];
+                inputEl.value = "";
+                inputEl.dispatchEvent(new Event("input", { bubbles: true }));
+            },
+        },
+        {
+            content: "Video input field should not be in valid state",
+            trigger: "#o_video_text:not(.is-valid)",
+            run: () => {},
+        },
+        {
+            content: "Check that the preview is not shown",
+            trigger: ".media_iframe_video:not(:has(iframe))",
+            run: () => {},
+        },
+        {
+            content: "Check that the add button is disabled in footer",
+            trigger: ".modal-footer",
+            run: function () {
+                const addButton = this.$anchor[0].querySelector(".btn.btn-primary");
+                if (!addButton.disabled) {
+                    console.error("Add button is not disabled.");
+                }
+            },
+        },
+        {
             content: "Enter video link",
             trigger: "#o_video_text",
             run: "text https://youtu.be/nbso3NVz3p8",


### PR DESCRIPTION
*=website

**Steps to reproduce:**
1. Drop a video
2. Reopen the media dialog
3. Remove the URL
4. Confirm

**Issue:**
When the URL was removed and confirmed, an iframe without a valid source was saved, leading to a 404 error.

**Fix:**
When the video URL is cleared, VideoSelector component calls selectMedia with an empty object. MediaDialog did not previously handle this case, so the media selection was not cleared. Now we Update MediaDialog to treat an empty object as a clear-selection signal and disable the Add button accordingly.

task-5190485
