### PR TITLE
[IMP] account_peppol: wizard improvements

### DIFF
--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -40,14 +40,6 @@
                             </div>
                         </div>
 
-                        <!-- Optional: field related to registering as a receiver -->
-                        <div invisible="account_peppol_proxy_state != 'sender'" groups="base.group_no_one">
-                            <p colspan="2" class="mt-4 mb-2">
-                                I want to migrate my existing Peppol connection to Odoo (optional):
-                            </p>
-                            <field name="account_peppol_migration_key"/>
-                        </div>
-
                         <div class="mt-4"
                              invisible="account_peppol_proxy_state != 'receiver'"
                              groups="base.group_no_one">

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -109,7 +109,7 @@ class PeppolRegistration(models.TransientModel):
                     'message': _("The endpoint number might not be correct. "
                                 "Please check if you entered the right identification number."),
                 }
-            if not wizard.smp_registration:
+            if wizard.peppol_endpoint and not wizard.smp_registration:
                 peppol_warnings['company_on_another_smp'] = {
                     'message': _("Your company is already registered on another Access Point for receiving invoices."
                                  "We will register you as a sender only.")

--- a/addons/account_peppol/wizard/peppol_registration_views.xml
+++ b/addons/account_peppol/wizard/peppol_registration_views.xml
@@ -24,7 +24,7 @@
                                        placeholder="Peppol ID"
                                        nolabel="1"
                                        class="o_field_peppol_eas_selection"/>
-                                <field name="peppol_endpoint" nolabel="1" placeholder="Your endpoint"/>
+                                <field name="peppol_endpoint" nolabel="1"/>
                                 <field name="contact_email" string="Email"/>
                                 <field name="phone_number" required="edi_mode not in ('demo', 'test')" string="Phone"/>
                             </group>


### PR DESCRIPTION
In the Peppol Registration Wizard:
- Warning banner should only show up when endpoint as been filled
- Remove placeholder
- Remove the "in" migration

Ref PR for master: odoo/odoo#234088
Task [link](https://www.odoo.com/odoo/project/967/tasks/5170831?debug=assets)
task-5170831

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
