### PR TITLE
[FIX] sale: fetch all linked combo lines correctly

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1629,7 +1629,7 @@ class SaleOrderLine(models.Model):
         and its linked lines are saved in the DB, which we can't ensure.
         """
         self.ensure_one()
-        return (
+        linked_lines = (
             self._origin and self.order_id.order_line.filtered(
                 lambda line: line.linked_line_id._origin == self._origin
             )
@@ -1638,6 +1638,15 @@ class SaleOrderLine(models.Model):
                 lambda line: line.linked_virtual_id == self.virtual_id
             )
         ) or self.env['sale.order.line']
+
+        if not linked_lines:
+            return self.env['sale.order.line']
+
+        all_linked_lines = linked_lines
+        for line in linked_lines:
+            all_linked_lines |= line._get_linked_lines()
+
+        return all_linked_lines
 
     def _sellable_lines_domain(self):
         discount_products_ids = self.env.companies.sale_discount_product_id.ids


### PR DESCRIPTION
Currently, an error occurs when a combo product is added to a sales order, and one of its combo items is replaced with another combo product, then the original parent combo product is deleted.

Steps to reproduce:
- Create a sales order and add a combo product to it.
- Modify one of the combo items by replacing it with another combo product.
- Delete the original parent combo product from the order lines and save. (Note: Make sure to not save the sale order while doing steps 1 & 2)

Error:
`ValueError: Expected singleton: sale.order.line()`

The error occurs because the parent combo item is deleted, which causes `line.virtual_id` to become False. As a result, the filter [1] returns no matching records, and `ensure_one()` fails by raising a singleton error due to receiving zero records.

This happens because the function [2] called from onchange in `sales_order` [3] that performs all the changes only checks the first level of combo items and doesn’t handle cases where those items are also combo products with their own linked items.

Solution:
- This commit fixes the error by properly fetching all nested combo items in the sales order, ensuring no leftover items from nested combos remain that could cause errors.

[1] - https://github.com/odoo/odoo/blob/7bb84621b773cdd7e9984222d61d70d622f8ac43/addons/sale/models/sale_order_line.py#L1567-L1569
[2] - https://github.com/odoo/odoo/blob/57b4056798b9a380027fd3da1c4f3965249a4509/addons/sale/models/sale_order_line.py#L1572-L1591
[3] - https://github.com/odoo/odoo/blob/7bb84621b773cdd7e9984222d61d70d622f8ac43/addons/sale/models/sale_order.py#L922

sentry-6979144433,6653847384
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
