### PR TITLE
[FIX] web,test_orm: allow group by for property type tag

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -552,7 +552,7 @@ class Base(models.AbstractModel):
             fold = group.pop('__fold', False)
 
             groupby_value = group[groupby_spec]
-            # For relational/date/datetime field
+            # For relational/date/datetime/property tags field
             raw_groupby_value = groupby_value[0] if isinstance(groupby_value, tuple) else groupby_value
 
             limit = unfold_read_default_limit
@@ -1163,7 +1163,7 @@ class Base(models.AbstractModel):
 
         if property_type == 'tags':
             tags = definition.get('tags') or []
-            tags = {tag[0]: tag for tag in tags}
+            tags = {tag[0]: tuple(tag) for tag in tags}
 
             def formatter_property_tags(value):
                 if not value:
@@ -1172,7 +1172,7 @@ class Base(models.AbstractModel):
                         AND([[(fullname, 'not in', tag)] for tag in tags]),
                     ]) if tags else []
 
-                # replace tag raw value with list of raw value, label and color
+                # replace tag raw value with tuple of raw value, label and color
                 return tags.get(value), [(fullname, 'in', value)]
 
             return formatter_property_tags

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -664,6 +664,9 @@ function getValueFromGroupData(field, rawValue) {
     if (field.type === "many2many") {
         return value ? value[0] : false;
     }
+    if (field.type === "tags") {
+        return value ? value[0] : false;
+    }
     return value;
 }
 

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -2578,6 +2578,35 @@ class PropertiesGroupByCase(TestPropertiesMixin):
         # group False
         self.assertEqual(groups[2]['__records'], [{'id': self.message_4.id}])
 
+    def test_properties_tags_field_web_read_group(self):
+        self.discussion_1.attributes_definition = [
+            {
+                'name': 'my_tags',
+                'string': 'My Tags',
+                'type': 'tags',
+                'tags': [
+                    ('be', 'BE', 1),
+                    ('it', 'IT', 2),
+                ],
+                'default': ['be'],
+            },
+        ]
+        self.env['test_orm.message'].create(
+            {'discussion': self.discussion_1.id, 'author': self.user.id})
+
+        self.env.flush_all()
+        result = self.env['test_orm.message'].web_read_group(
+            domain=[],
+            aggregates=['__count'],
+            groupby=['attributes.my_tags'],
+            opening_info=[{'folded': True, 'value': '1'}],
+            unfold_read_specification={'id': {}},
+        )
+
+        self.assertEqual(len(result['groups']), 2)
+        self.assertEqual(result['groups'][0]['attributes.my_tags'], ('be', 'BE', 1))
+        self.assertEqual(result['groups'][1]['attributes.my_tags'], False)
+
     @mute_logger('odoo.fields')
     def test_properties_field_read_progress_bar(self):
         """Test "_read_progress_bar" with a properties field."""
@@ -3190,7 +3219,7 @@ class PropertiesGroupByCase(TestPropertiesMixin):
         self.assertEqual(len(result), 6)
 
         all_tags = self.message_1.read(['attributes'])[0]['attributes'][0]['tags']
-        all_tags = {tag[0]: tag for tag in all_tags}
+        all_tags = {tag[0]: tuple(tag) for tag in all_tags}
 
         for group, (tag, count) in zip(result, (('a', 3), ('c', 1), ('d', 1), ('e', 2), ('g', 2))):
             self.assertEqual(group['attributes.mytags'], all_tags[tag])


### PR DESCRIPTION
Step to reproduce:
- open crm and add a property tags field in a lead
- add that tags in few leads
- go to list view and group by that property tags field
- search for a lead (keep groupby as it is)

Observation:
- we receive a traceback
```
 File "/home/odoo/odoo/codebase/odoo/saas-18.4/addons/web/models/models.py", line 396, in web_read_group
    self._open_groups(
  File "/home/odoo/odoo/codebase/odoo/saas-18.4/addons/web/models/models.py", line 537, in _open_groups
    info_opening['value']: info_opening
TypeError: unhashable type: 'list'
```

Cause:
- `formatter_property_tags` returns a list in case of tags field.
https://github.com/odoo/odoo/blob/5186fd202373a67f56688c234fcde15cc1997721/addons/web/models/models.py#L1176
- these values are used as a key for dict in `_open_groups`, hence only hashable values are allowed; list is not hashable
https://github.com/odoo/odoo/blob/5186fd202373a67f56688c234fcde15cc1997721/addons/web/models/models.py#L536-L539
Fix:
- cast the list to tuple

opw-5188961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
