### PR TITLE
[FIX] account_fleet: move fleet tax report test and query to enterprise

### DIFF
--- a/addons/account_fleet/models/account_move.py
+++ b/addons/account_fleet/models/account_move.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-from odoo.tools import SQL
+from odoo import fields, models, _
 
 
 class AccountMove(models.Model):
@@ -60,12 +59,3 @@ class AccountMoveLine(models.Model):
     def unlink(self):
         self.sudo().vehicle_log_service_ids.with_context(ignore_linked_bill_constraint=True).unlink()
         return super().unlink()
-
-    @api.model
-    def _get_extra_query_base_tax_line_mapping(self) -> SQL:
-        """Override to add vehicle_id matching condition for tax details query.
-        This ensures that tax lines are only matched with base lines that have the same vehicle_id,
-        preventing tax lines from being incorrectly merged when different vehicles are used.
-        """
-        query = super()._get_extra_query_base_tax_line_mapping()
-        return SQL("%s AND COALESCE(base_line.vehicle_id, 0) = COALESCE(account_move_line.vehicle_id, 0)", query)

--- a/addons/account_fleet/tests/test_account_fleet.py
+++ b/addons/account_fleet/tests/test_account_fleet.py
@@ -1,13 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from freezegun import freeze_time
-from odoo import Command
-from odoo.addons.account.tests.test_account_move_line_tax_details import TestAccountTaxDetailsReport
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install')
-class TestAccountFleet(TestAccountTaxDetailsReport):
+class TestAccountFleet(AccountTestInvoicingCommon):
 
     @freeze_time('2021-09-15')
     def test_transfer_wizard_vehicle_info_propagation(self):
@@ -45,57 +44,3 @@ class TestAccountFleet(TestAccountTaxDetailsReport):
         result_action = wizard.do_action()
         transfer_moves = self.env['account.move'].search(result_action['domain'])
         self.assertEqual(transfer_moves.line_ids.filtered(lambda l: l.account_id == expense_account).vehicle_id, car_1, "Vehicle info is missing")
-
-    def test_tax_report_with_vehicle_split_repartition(self):
-        """Test tax report with split repartition lines across different vehicles."""
-        ChartTemplate = self.env['account.chart.template']
-        brand = self.env["fleet.vehicle.model.brand"].create({"name": "Audi"})
-        model = self.env["fleet.vehicle.model"].create({"brand_id": brand.id, "name": "A3"})
-        cars = self.env["fleet.vehicle"].create([
-            {"model_id": model.id, "plan_to_change_car": False},
-            {"model_id": model.id, "plan_to_change_car": False},
-        ])
-
-        expense_account = ChartTemplate.ref('expense')
-        asset_account = ChartTemplate.ref('current_assets')
-
-        tax = self.env['account.tax'].create({
-            'name': 'Split Tax',
-            'amount': 10,
-            'invoice_repartition_line_ids': [
-                Command.create({'repartition_type': 'base', 'factor_percent': 100}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': expense_account.id}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': asset_account.id}),
-            ],
-            'refund_repartition_line_ids': [
-                Command.create({'repartition_type': 'base', 'factor_percent': 100}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': expense_account.id}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': asset_account.id}),
-            ],
-        })
-
-        bill = self.init_invoice('in_invoice', invoice_date='2025-10-16', post=False)
-        bill.write({
-            'invoice_line_ids': [
-                Command.create({
-                    'product_id': self.product_a.id,
-                    'account_id': expense_account.id,
-                    'price_unit': 100,
-                    'tax_ids': [Command.set(tax.ids)],
-                    'vehicle_id': cars[0].id
-                }),
-                Command.create({
-                    'product_id': self.product_a.id,
-                    'account_id': expense_account.id,
-                    'price_unit': 100,
-                    'tax_ids': [Command.set(tax.ids)],
-                    'vehicle_id': cars[1].id
-                }),
-            ]
-        })
-        bill.action_post()
-
-        tax_details = self._get_tax_details()
-        self.assertEqual(len(tax_details), 2)
-        for line in tax_details:
-            self.assertEqual(line['tax_amount'], 5)


### PR DESCRIPTION
Community build was failing with:
```
FAIL: TestAccountFleet.test_tax_report_with_vehicle_split_repartition
Traceback (most recent call last):
File '/data/build/odoo/addons/account_fleet/tests/test_account_fleet.py',
line 99, in test_tax_report_with_vehicle_split_repartition
self.assertEqual(len(tax_details), 2)
AssertionError: 0 != 2
```

The test and SQL join logic relied on `vehicle_id` propagation that only exists in the enterprise addon `account_accountant_fleet`. Since the community edition cannot populate `vehicle_id` on tax lines, the query always returned zero rows, causing the failure.

To fix this, the fleet-specific tax report query and test have been moved to the enterprise module, where the vehicle-aware tax reporting functionality actually resides. This keeps community builds green while retaining the intended behavior in enterprise.

runbot error:233462