### PR TITLE
[FIX] mail: prevent crash when scrolling to poll

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1088,7 +1088,12 @@ class MailMessage(models.Model):
             "record_name",  # keep for iOS app
             "res_id",  # keep for iOS app
             # sudo - mail.poll: reading poll of accessible message is allowed.
-            Store.Many("started_poll_ids", predicate=lambda m: m.message_type == "mail_poll", sudo=True),
+            Store.Many(
+                "started_poll_ids",
+                fields=self.env["mail.poll"]._to_store_defaults(target, with_start_message_id=False),
+                predicate=lambda m: m.message_type == "mail_poll",
+                sudo=True,
+            ),
             Store.Many("ended_poll_ids", predicate=lambda m: m.message_type == "mail_poll", sudo=True),
             "subject",
             # sudo: mail.message.subtype - reading subtype on accessible message is allowed


### PR DESCRIPTION
Before this PR, clicking "View Poll" from a poll result could sometimes cause a crash. This occurred because the highlight message function expects a thread to be passed, but we were passing the `start_message_id` thread, which might be undefined.

Similar to [1], the poll ended UI requires the start message to be passed. This commit ensures that the necessary data are sent along with the end message.

[1]: https://github.com/odoo/odoo/pull/233897

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
