### PR TITLE
[FIX] pos_online_payment_self_order: remove unnecessary test flag from tour

### DIFF
--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
@@ -57,7 +57,6 @@ registry
     });
 
 registry.category("web_tour.tours").add("test_kiosk_cart_restore_and_cancel", {
-    test: true,
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Coca-Cola"),


### PR DESCRIPTION
In this commit:
- Removed the `test: true` flag from the `test_kiosk_cart_restore_and_cancel` tour.
- The flag is not required for tours and can cause issues when running in debug mode.
- This issue only occurs in local environments when debug mode is enabled.
- After this fix, no issue is generated in debug mode.