### PR TITLE
[FIX] sale_product_matrix: variant grid combo filter

### DIFF
--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -58,6 +58,7 @@ class SaleOrder(models.Model):
                 order_lines = self.order_line.filtered(
                     lambda line: line.product_id.id == product.id
                     and line.product_no_variant_attribute_value_ids.ids == no_variant_attribute_values.ids
+                    and not line.combo_item_id
                 )
 
                 # if product variant already exist in order lines
@@ -141,7 +142,7 @@ class SaleOrder(models.Model):
                 for cell in line:
                     if not cell.get('name', False):
                         line = order_lines.filtered(lambda line: has_ptavs(line, cell['ptav_ids']))
-                        if line:
+                        if line and not line.combo_item_id:
                             cell.update({
                                 'qty': sum(line.mapped('product_uom_qty'))
                             })


### PR DESCRIPTION
Steps:
- create a product with attributes of create_variant=never
- set variant selection to order grid entry
- add this product as a combo choice and set extra_price>1
- In sale order form first add the new combo product with the previously created product
- add the new product with same selection of attribute values as combo

Issue:
- The separately added product should create a new line, but since it was added as a part of the combo, the product's price is summed with extra price and added to the combo itself

Cause:
- the grid field that is responsible for adding product using product matrix does not filter combo lines

Fix:
- added filter for combo lines when matrix opens and saves

opw-5164789


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
