### PR TITLE
[FIX] web_editor: Ensure snippets are visible in RTL (Arabic)

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2933,6 +2933,7 @@ we-select.o_grid we-toggler {
         transform-origin: top left;
         width: 333%;
         height: 100%;
+        left: 0;
 
         .o_snippet_preview_wrap {
             min-height: 100px;


### PR DESCRIPTION
Steps to reproduce:
===================
- Set arabic as default language for website
- Try to add a snippet
-> you can't see the snippets

Cause:
======
Snippets were fetched correctly but were not visible.
In RTL languages (like Arabic), the CSS `transform-origin`
was set to 'top right', rendering the snippets off-screen.
This is due to the browser's interpretation of positioning
in RTL mode. For more details, see MDN:
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position

Solution:
=========
Force the snippet preview's position by setting `left: 0`.
This ensures its positioning is always aligned to the left,
regardless of the `transform-origin` value dynamically
set by the browser in RTL mode.

opw-5214703