### PR TITLE
[FIX] web: tests - restore mock fields defaults

### DIFF
--- a/addons/web/static/tests/_framework/mock_server/mock_fields.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_fields.js
@@ -1,3 +1,4 @@
+import { deepCopy } from "@web/core/utils/objects";
 import { MockServerError } from "./mock_server_utils";
 
 /**
@@ -91,6 +92,21 @@ const R_CAMEL_CASE = /_([a-z])/g;
 const R_ENDS_WITH_ID = /_id(s)?$/i;
 const R_LOWER_FOLLOWED_BY_UPPER = /([a-z])([A-Z])/g;
 const R_SPACE_OR_UNDERSCORE = /[\s_]+/g;
+
+/**
+ * @param {Record<string, FieldDefinition & MockFieldProperties>} fields
+ */
+export function copyFields(fields) {
+    const fieldsCopy = {};
+    for (const [fieldName, field] of Object.entries(fields)) {
+        const fieldCopy = {};
+        for (const [property, value] of Object.entries(field)) {
+            fieldCopy[property] = typeof value === "object" ? deepCopy(value) : value;
+        }
+        fieldsCopy[fieldName] = fieldCopy;
+    }
+    return fieldsCopy;
+}
 
 /**
  * @param {FieldDefinition & MockFieldProperties} field

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -25,6 +25,7 @@ const {
     DEFAULT_RELATIONAL_FIELD_VALUES,
     DEFAULT_SELECTION_FIELD_VALUES,
     S_FIELD,
+    copyFields,
     isComputed,
 } = fields;
 
@@ -384,12 +385,11 @@ function getModelDefinition(previous, constructor) {
                 }
             }
             for (const [key, map] of INHERITED_OBJECT_KEYS) {
-                for (const subKey in previous[key]) {
+                const previousValue = map ? map(previous[key]) : previous[key];
+                for (const subKey in previousValue) {
                     // Assign only if empty
                     if (isEmptyValue(model[key][subKey])) {
-                        model[key][subKey] = map
-                            ? map(previous[key][subKey])
-                            : previous[key][subKey];
+                        model[key][subKey] = previousValue[subKey];
                     }
                 }
             }
@@ -865,7 +865,7 @@ function parseView(model, params) {
     const { arch } = params;
     const level = params.level || 0;
     const editable = params.editable || true;
-    const fields = deepCopy(model._fields);
+    const fields = copyFields(model._fields);
 
     const { _onChanges } = model;
     const fieldNodes = {};
@@ -1340,7 +1340,7 @@ const DATETIME_FORMAT = {
 };
 const INHERITED_OBJECT_KEYS = [
     ["_computes", null],
-    ["_fields", deepCopy],
+    ["_fields", copyFields],
     ["_onChanges", null],
     ["_toolbar", deepCopy],
     ["_views", null],

--- a/addons/web/static/tests/mock_server/mock_model.test.js
+++ b/addons/web/static/tests/mock_server/mock_model.test.js
@@ -158,10 +158,11 @@ describe("level 1", () => {
         await makeMockEnv();
 
         await expect(
-            getService("orm").searchRead("oui", [], ["id", "name", "age", "surname"])
+            getService("orm").searchRead("oui", [], ["id", "name", "age", "surname", "create_date"])
         ).resolves.toEqual([
             {
                 id: 1,
+                create_date: luxon.DateTime.utc().toSQL().slice(0, 19),
                 name: "John Doe",
                 age: 42,
                 surname: "doedoe",


### PR DESCRIPTION
Before this commit, default values in mock fields defined by functions would be lost when extending a model, because by doing so the fields were JSON-copied and the default functions were lost.

To fix this, this commit introduces another way to copy field definitions that preserves functions, allowing default values (typically for the 'create_date' and 'write_date' fields) to be applied correctly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
