### PR TITLE
[FIX] website_slides: adapt fullscreen highlighting interaction

### DIFF
--- a/addons/website/static/src/interactions/text_highlights.js
+++ b/addons/website/static/src/interactions/text_highlights.js
@@ -8,7 +8,7 @@ import {
 } from "@website/js/text_processing";
 
 export class TextHighlight extends Interaction {
-    static selector = "#wrapwrap";
+    static selector = "#wrapwrap, .o_wslides_fs_content";
     dynamicContent = {
         _root: {
             "t-on-text_highlight_added": this.onTextHighlightAdded,

--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -542,14 +542,6 @@
                 const slide = this._slideValue;
                 var $content = this.$('.o_wslides_fs_content');
                 $content.empty();
-                if (this.websiteAnimateWidget) {
-                    this.websiteAnimateWidget.destroy()
-                    this.websiteAnimateWidget = null;
-                }
-                if (this.textHighlightWidget) {
-                    this.textHighlightWidget.destroy()
-                    this.textHighlightWidget = null;
-                }
 
                 // display quiz slide, or quiz attached to a slide
                 if (slide.category === 'quiz' || slide.isQuiz) {
@@ -576,9 +568,6 @@
                     this.trigger_up('widgets_start_request', {
                         $target: $content,
                     });
-                    this.websiteAnimateWidget.attachTo($wpContainer);
-                    this.textHighlightWidget = new publicWidget.registry.TextHighlight();
-                    this.textHighlightWidget.attachTo($wpContainer);
                 }
                 unhideConditionalElements();
             } finally {

--- a/addons/website_slides/static/tests/tours/slides_text_highlights.js
+++ b/addons/website_slides/static/tests/tours/slides_text_highlights.js
@@ -54,6 +54,10 @@ registerWebsitePreviewTour('fullscreen_slide_text_highlights', {
         {
             content: "Click on the fullscreen button",
             trigger: ':iframe #wrapwrap a[aria-label="Fullscreen"]',
+            run: "click",
+        }, {
+            content: "Wait for fullscreen",
+            trigger: ':iframe #wrapwrap a[title="Exit Fullscreen"]',
         }, {
             content: "Check that the highlight was applied in fullscreen",
             trigger: ":iframe .s_text_block p span.o_text_highlight > .o_text_highlight_item > svg:has(.o_text_highlight_path_underline)",


### PR DESCRIPTION
**Issue:**
`this.websiteAnimateWidget` is undefined
Also the fix wasn't working properly in later versions.

This is due to an incorrect conflict resolution in the forward port
of the related fix.

**Fix:**
The fix for websiteAnimateWidget was made obsolete in these versions with:
https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba

But the original issue of `textHighlightWidget` was still present and not
properly caught by the tour. The new fix add the fullscreen slide to the
selector of the TextHighlight interaction which is restarted when fullscreen
is enabled.

related: https://github.com/odoo/odoo/commit/184c6f855f703239864f482ff252beb1293c343d

opw-4978798

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
