### PR TITLE
[FIX] stock: correct route domain in Replenishment menu and wizard

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -75,7 +75,7 @@ class StockWarehouseOrderpoint(models.Model):
     lead_days = fields.Float(compute='_compute_lead_days')
     route_id = fields.Many2one(
         'stock.route', string='Route',
-        domain="['|', ('product_selectable', '=', True), ('rule_ids.action', 'in', ['buy', 'manufacture'])]",
+        domain="[('rule_ids.action', 'in', ['buy', 'manufacture', 'pull_push', 'pull']), ('rule_ids.location_dest_id.warehouse_id', '=', warehouse_id)]",
         inverse='_inverse_route_id')
     route_id_placeholder = fields.Char(compute='_compute_route_id_placeholder')
     effective_route_id = fields.Many2one(


### PR DESCRIPTION
Issue:
--------------------------------------------
When multiple warehouses exist and a resupply route is configured from WH2 to WH1, it should only apply to WH2.
However, when opening the Replenishment or Replenishment wizard, this route incorrectly appears as a preferred route for WH1.

Steps to Reproduce:
--------------------------------------------
1. Install the `stock` module.
2. Create a second warehouse WH2 and enable resupply from WH1.
3. Open any product and, in the Forecast Report, click “Replenish.”
4. The default warehouse is set to WH1.
5. Check the Preferred Route; it incorrectly includes the resupply route.
6. If this route is selected and replenishment is applied, a normal receipt is created for WH1’s location.

Cause:
--------------------------------------------
The domain used for both the Replenishment menu and wizard did not properly filter routes. It allowed routes unrelated to the selected warehouse or location to appear as valid options.

Solution:
--------------------------------------------
This commit introduces a more accurate domain that ensures only valid and applicable routes appear when replenishing a product for a specific location. The domain now:
- Includes only rules of type Buy, Manufacture, Pull From, or Pull & Push.
- Ensures that the destination location in the stock rule matches either the selected location or the warehouse’s main stock location.

And also updates the `Preferred Routes` dynamically when changing the warehouse in the wizard.

After this Commit:
--------------------------------------------
Only relevant and valid routes appear in the Replenishment menu and wizard. This prevents incorrect route selection and ensures replenishment reflects real routing logic per warehouse and location.

Issue: [233682](https://github.com/odoo/odoo/issues/233682)