### PR TITLE
[FIX] mail: fa-user(s)-plus should be oi-user

### DIFF
--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -18,7 +18,7 @@
                     </t>
                 </t>
             </t>
-            <div t-elif="props.thread.channel_type === 'group'" class="o-mail-ThreadIcon fa fa-fw fa-users" t-att-class="largeClass" title="Grouped Chat"/>
+            <div t-elif="props.thread.channel_type === 'group'" class="o-mail-ThreadIcon oi fa-fw oi-users" t-att-class="largeClass" title="Grouped Chat"/>
             <t t-elif="props.thread.model === 'mail.box'">
                 <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="largeClass"/>
                 <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="largeClass"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -44,7 +44,7 @@
                 <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>
             </div>
             <span class="ms-auto">
-                <span t-if="member.in(props.thread.invited_member_ids)" class="p-1 fa fa-user-plus opacity-75"/>
+                <span t-if="member.in(props.thread.invited_member_ids)" class="p-1 oi oi-user-plus opacity-75"/>
                 <span t-if="member.rtcSession?.is_muted and !member.rtcSession?.is_deaf" class="p-1 fa fa-microphone-slash opacity-75"/>
                 <span t-elif="member.rtcSession?.is_deaf" class="p-1 fa fa-deaf opacity-75"/>
                 <span t-if="member.rtcSession?.raisingHand" class="p-1 fa fa-hand-paper-o"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
@@ -42,7 +42,7 @@ const discussAppPatch = {
             addTitle: _t("Start a conversation"),
             canView: false,
             extraClass: "o-mail-DiscussSidebarCategory-chat",
-            icon: "fa fa-users",
+            icon: "oi oi-users",
             id: "chats",
             name: _t("Direct messages"),
             sequence: 30,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -287,7 +287,7 @@ export class DiscussCommandPalette {
                 },
                 name: _t("Create Chat"),
                 className: "d-flex",
-                props: { action: { icon: "fa fa-fw fa-users" } },
+                props: { action: { icon: "oi fa-fw oi-users" } },
             };
         }
         throw new Error(`Unsupported use of makeDiscussCommand("${threadOrPersona}")`);

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -42,7 +42,7 @@
     <Dialog size="'md'" title.translate="Make Chat" contentClass="'o-mail-CreateChatDialog'" bodyClass="'py-0'">
         <div class="d-flex flex-column flex-grow-1 bg-inherit w-100">
             <div class="d-flex align-items-center px-0 mb-1 gap-1">
-                <span class="ms-2 my-1 text-uppercase text-muted o-xsmaller opacity-75"><i class="fa fa-user-plus"/> Invite people</span>
+                <span class="ms-2 my-1 text-uppercase text-muted o-xsmaller opacity-75"><i class="oi oi-user-plus"/> Invite people</span>
             </div>
             <ChannelInvitation state="invitePeopleState"/>
         </div>


### PR DESCRIPTION
Icon of invite-people and chats were changed from `fa-user-plus` and `fa-users` to respectively `oi-user-plus` and `oi-users`.

Some occurrences of use of these icons were still using the `fa-` version, which looked off on UI. This commit replaces them to `oi-` as it should.

Before
<img width="653" height="530" alt="Screenshot 2025-11-03 at 11 28 41" src="https://github.com/user-attachments/assets/f76777d5-1b68-4d66-b465-e06e83862e17" />

After
<img width="656" height="536" alt="Screenshot 2025-11-03 at 11 28 08" src="https://github.com/user-attachments/assets/8caef6bd-3c03-40c1-8a8b-0593753e6f24" />
