### PR TITLE
[FIX] web: avoid cropped embedded button and excess height

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -258,6 +258,9 @@ function makeDOMHelpers(cleanup) {
             return {};
         }
         const rect = el.getBoundingClientRect();
+
+        rect.height = el.offsetHeight;
+
         if (options.adjust) {
             const style = getComputedStyle(el);
             const [pl, pr, pt, pb] = [

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -139,6 +139,10 @@
         background-color: $border-color;
         content: "";
     }
+
+    &:where(:not(:has(.o_dragged_embedded_action))) {
+        overflow: hidden;
+    }
 }
 
 .o_embedded_actions_dropdown_menu {

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -4,7 +4,7 @@
     <t t-name="web.ControlPanel">
         <div class="o_control_panel d-flex flex-column gap-3 px-3 pt-2 pb-3" t-ref="root" data-command-category="actions">
             <Transition t-if="!env.isSmall" visible="state.embeddedInfos.showEmbedded" name="'o-fade'" t-slot-scope="transition" leaveDuration="500">
-                <div class="o_embedded_actions overflow-hidden d-flex flex-wrap w-100 align-items-center justify-content-center gap-2" t-att-class="transition.className">
+                <div class="o_embedded_actions d-flex flex-wrap w-100 align-items-center justify-content-center gap-2" t-att-class="transition.className">
                     <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
                         <t t-if="_checkValueLocalStorage(action)">
                             <button class="btn btn-secondary o_draggable"


### PR DESCRIPTION
The `o_embedded_actions` buttons are getting cropped when they are long enough. This is due to the `overflow-hidden` property which is now applied when no element are actively dragged.

When an element is dragged after a css transformation, eg. the `o_dragged_embedded_action`, `getBoundingClientRect()` is returning the element height with the transformation. This creates an excess height on the `o_embedded_actions` due to the placeholder button having it's transformed height instead of the button height.

Using offsetHeight returns the element size without the transform. Note this is not done on the width, because the width without the transform can lead to text-truncation.

task-5225696




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
