### PR TITLE
[FIX] portal_rating: prevent rating widget from overlapping in portal chatter

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/portal_chatter_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/portal_chatter_patch.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="portal.Chatter" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o-mail-Chatter-top')]/*[1]" position="before">
-            <div t-if="ratingStats" class="my-2" t-att-class="{ 'mb-4':props.twoColumns }">
+        <xpath expr="//div[hasclass('o-mail-Chatter-top')]" position="before">
+            <div t-if="ratingStats" class="container my-2" t-att-class="{ 'mb-4':props.twoColumns }">
                 <t t-call="portal_rating.rating_card">
                     <t t-set="two_columns" t-value="props.twoColumns"/>
                     <t t-set="rating_stats" t-value="ratingStats"/>


### PR DESCRIPTION
Before this PR, 
the rating widget in the portal chatter overlapped other elements when 
scrolling because it was positioned as sticky at the top of the screen.

This PR fixes the layout by adjusting the widget’s positioning, ensuring 
that only the composer remains sticky while the rating widget scrolls normally.

Before:
https://github.com/user-attachments/assets/4ad2eb34-0773-4812-ad74-cdb49f0bafa0

After:
https://github.com/user-attachments/assets/f2e9df3e-7305-4582-b1e5-f7ec9fafea94

task-[5138987](https://www.odoo.com/odoo/project/1519/tasks/5138987)