### PR TITLE
[FIX] html_editor: traceback on adding vimeo link in knowledge

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -423,7 +423,7 @@ export class VideoSelector extends Component {
      * @returns {string} - The start time in seconds.
      */
     parseTimeToSeconds(value) {
-        const match = value.match(/^(?:(\d+)m(\d+)s|(\d+)m|(\d+)s|(\d+))$/);
+        const match = value?.match(/^(?:(\d+)m(\d+)s|(\d+)m|(\d+)s|(\d+))$/);
         if (!match) {
             return value;
         }

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1157,6 +1157,47 @@ test("should display overlay on video hover and handle video replacement and rem
     await expectElementCount('div[data-embedded="video"]', 0);
 });
 
+test.tags("desktop");
+test("add Vimeo video link in 'Videos' tab of MediaDialog", async () => {
+    const vimeoVideoLink = "https://vimeo.com/1128489814?fl=wc";
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    setSelectionInHtmlField();
+
+    await onRpc("/html_editor/video_url/data", async () => {
+        return {
+            video_id: "1128489814",
+            platform: "vimeo",
+            embed_url: vimeoVideoLink,
+        };
+    });
+
+    // Insert Vimeo video link
+    await insertText(htmlEditor, "/video");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toBe("Media");
+
+    await press("Enter");
+    await contains(".modal-body .nav-link:contains('Videos')").click();
+    await waitFor("textarea[id='o_video_text']");
+
+    const input = queryOne("textarea[id='o_video_text']");
+    input.value = vimeoVideoLink;
+    manuallyDispatchProgrammaticEvent(input, "input", {
+        inputType: "insertText",
+    });
+    await waitFor(".o_video_dialog_options", { timeout: 1500 });
+    expect(input).toHaveClass("is-valid");
+    await click(queryOne(".modal-footer").firstChild);
+});
+
 test("MediaDialog contains 'Videos' tab by default in html field", async () => {
     await mountView({
         type: "form",


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install the Knowledge app
2. Open any document and use `/media` to open the media dialog
3. Go to the Videos tab in the dialog
4. In another browser tab, open the Vimeo website
5. Copy any Vimeo video link and paste it into the dialog

Observation:
-------------------------
When pasting a Vimeo link, a traceback occurs:
```
TypeError: Cannot read properties of undefined (reading 'match')
    at EmbeddedVideoSelector.parseTimeToSeconds
```

Issue:
-------------------------
In the following function,
https://github.com/odoo/odoo/blob/b5ed2d5a3e4ac9379ed15549dd9c8e08547181bb/addons/html_editor/static/src/main/media/media_dialog/video_selector.js#L350-L353 This happens because the code splits the Vimeo URL using `#t`. If the URL does not contain `#t`, the result is undefined, which is then passed to the `parseTimeToSeconds` function.

Solution:
-------------------------
Added optional chain operator in `parseTimeToSeconds` for safe validation of
`value` before calling `.match()`

opw-5221403
