### PR TITLE
[REF] mail, *: replace core/common/record imports by model/export

### DIFF
--- a/addons/crm/static/src/core/common/crm_lead_model.js
+++ b/addons/crm/static/src/core/common/crm_lead_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { router } from "@web/core/browser/router";
 
 export class CrmLead extends Record {

--- a/addons/crm/static/src/core/common/res_partner_model_patch.js
+++ b/addons/crm/static/src/core/common/res_partner_model_patch.js
@@ -1,5 +1,5 @@
 import { ResPartner } from "@mail/core/common/res_partner_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/hr/static/src/core/common/hr_department_model.js
+++ b/addons/hr/static/src/core/common/hr_department_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class HrDepartment extends Record {
     static _name = "hr.department";

--- a/addons/hr/static/src/core/common/hr_employee_model.js
+++ b/addons/hr/static/src/core/common/hr_employee_model.js
@@ -1,4 +1,4 @@
-import { Record, fields } from "@mail/core/common/record";
+import { Record, fields } from "@mail/model/export";
 
 export class HrEmployee extends Record {
     static _name = "hr.employee";

--- a/addons/hr/static/src/core/common/hr_work_location_model.js
+++ b/addons/hr/static/src/core/common/hr_work_location_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class HrWorkLocation extends Record {
     static _name = "hr.work.location";

--- a/addons/hr_recruitment/static/src/js/hr_applicant_model.js
+++ b/addons/hr_recruitment/static/src/js/hr_applicant_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class HrApplicant extends Record {
     static _name = "hr.applicant";

--- a/addons/hr_recruitment/static/src/js/res_partner_model_patch.js
+++ b/addons/hr_recruitment/static/src/js/res_partner_model_patch.js
@@ -1,5 +1,5 @@
 import { ResPartner } from "@mail/core/common/res_partner_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -1,4 +1,4 @@
-import { AND, fields, Record } from "@mail/core/common/record";
+import { AND, fields, Record } from "@mail/model/export";
 import { rpc } from "@web/core/network/rpc";
 import { browser } from "@web/core/browser/browser";
 import { debounce } from "@web/core/utils/timing";

--- a/addons/im_livechat/static/src/core/common/chatbot_script_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_script_model.js
@@ -1,4 +1,4 @@
-import { Record, fields } from "@mail/core/common/record";
+import { Record, fields } from "@mail/model/export";
 
 export class ChatbotScript extends Record {
     static _name = "chatbot.script";

--- a/addons/im_livechat/static/src/core/common/chatbot_script_step_answer_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_script_step_answer_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class ChatbotScriptStepAnswer extends Record {
     static id = "id";

--- a/addons/im_livechat/static/src/core/common/chatbot_script_step_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_script_step_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class ChatbotScriptStep extends Record {
     static id = "id";

--- a/addons/im_livechat/static/src/core/common/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_step_model.js
@@ -1,4 +1,4 @@
-import { AND, fields, Record } from "@mail/core/common/record";
+import { AND, fields, Record } from "@mail/model/export";
 import { createDocumentFragmentFromContent } from "@web/core/utils/html";
 
 export class ChatbotStep extends Record {

--- a/addons/im_livechat/static/src/core/common/livechat_channel_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class LivechatChannel extends Record {
     static _name = "im_livechat.channel";

--- a/addons/im_livechat/static/src/core/common/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_model_patch.js
@@ -1,6 +1,6 @@
 import { LivechatChannel } from "@im_livechat/core/common/livechat_channel_model";
 
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/im_livechat/static/src/core/common/livechat_expertise_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_expertise_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class LivechatExpertise extends Record {
     static id = "id";

--- a/addons/im_livechat/static/src/core/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/message_model_patch.js
@@ -1,5 +1,5 @@
 import { Message } from "@mail/core/common/message_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";

--- a/addons/im_livechat/static/src/core/public_web/discuss_app/discuss_app_category_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/discuss_app_category_model_patch.js
@@ -1,6 +1,6 @@
 import { patch } from "@web/core/utils/patch";
 import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 patch(DiscussAppCategory.prototype, {
     setup() {

--- a/addons/im_livechat/static/src/core/public_web/discuss_app/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/discuss_app_model_patch.js
@@ -1,5 +1,5 @@
 import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";

--- a/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
@@ -1,5 +1,5 @@
 import { LivechatChannel } from "@im_livechat/core/common/livechat_channel_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 import { _t } from "@web/core/l10n/translation";
 

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 import "@mail/discuss/core/common/thread_model_patch";
 import { generateEmojisOnHtml } from "@mail/utils/common/format";

--- a/addons/mail/static/src/chatter/web/scheduled_message_model.js
+++ b/addons/mail/static/src/chatter/web/scheduled_message_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { htmlToTextContentInline } from "@mail/utils/common/format";
 import { _t } from "@web/core/l10n/translation";
 

--- a/addons/mail/static/src/chatter/web/thread_model_patch.js
+++ b/addons/mail/static/src/chatter/web/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 import "@mail/chatter/web_portal/thread_model_patch";
 

--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { assignDefined } from "@mail/utils/common/misc";
 
 export class Activity extends Record {

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { assignDefined } from "@mail/utils/common/misc";
 import { generatePdfThumbnail } from "@mail/utils/common/pdf_thumbnail";
 

--- a/addons/mail/static/src/core/common/canned_response_model.js
+++ b/addons/mail/static/src/core/common/canned_response_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class CannedResponse extends Record {
     static _name = "mail.canned.response";

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -1,5 +1,5 @@
 import { browser } from "@web/core/browser/browser";
-import { fields, Record } from "./record";
+import { fields, Record } from "@mail/model/export";
 
 import { Deferred, Mutex } from "@web/core/utils/concurrency";
 

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 /** @typedef {{ thread?: import("models").Thread }} ChatWindowData */
 

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,4 +1,4 @@
-import { fields, OR, Record } from "@mail/core/common/record";
+import { fields, OR, Record } from "@mail/model/export";
 import {
     convertBrToLineBreak,
     getNonEditableMentions,

--- a/addons/mail/static/src/core/common/country_model.js
+++ b/addons/mail/static/src/core/common/country_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class Country extends Record {
     static id = "id";

--- a/addons/mail/static/src/core/common/data_response_model.js
+++ b/addons/mail/static/src/core/common/data_response_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 import { Deferred } from "@web/core/utils/concurrency";
 

--- a/addons/mail/static/src/core/common/discuss_call_history_model.js
+++ b/addons/mail/static/src/core/common/discuss_call_history_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class DiscussCallHistory extends Record {
     static id = "id";

--- a/addons/mail/static/src/core/common/failure_model.js
+++ b/addons/mail/static/src/core/common/failure_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { markRaw } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { rpc } from "@web/core/network/rpc";
 
 export class Follower extends Record {

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { convertToEmbedURL } from "@mail/utils/common/misc";
 
 const VIDEO_EXTENSIONS = new Set(["mp4", "mov", "avi", "mkv", "webm", "mpeg", "mpg", "ogv", "3gp"]);

--- a/addons/mail/static/src/core/common/mail_activity_type_model.js
+++ b/addons/mail/static/src/core/common/mail_activity_type_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class MailActivityType extends Record {
     static _name = "mail.activity.type";

--- a/addons/mail/static/src/core/common/mail_guest_model.js
+++ b/addons/mail/static/src/core/common/mail_guest_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { imageUrl } from "@web/core/utils/urls";
 import { rpc } from "@web/core/network/rpc";
 import { debounce } from "@web/core/utils/timing";

--- a/addons/mail/static/src/core/common/message_link_preview_model.js
+++ b/addons/mail/static/src/core/common/message_link_preview_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 import { rpc } from "@web/core/network/rpc";
 

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -1,6 +1,6 @@
 import { isEmptyBlock } from "@html_editor/utils/dom_info";
 
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import {
     EMOJI_REGEX,
     convertBrToLineBreak,

--- a/addons/mail/static/src/core/common/message_reactions_model.js
+++ b/addons/mail/static/src/core/common/message_reactions_model.js
@@ -1,4 +1,4 @@
-import { AND, fields, Record } from "@mail/core/common/record";
+import { AND, fields, Record } from "@mail/model/export";
 import { rpc } from "@web/core/network/rpc";
 
 export class MessageReactions extends Record {

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 import { _t } from "@web/core/l10n/translation";
 

--- a/addons/mail/static/src/core/common/record.js
+++ b/addons/mail/static/src/core/common/record.js
@@ -1,1 +1,0 @@
-export * from "@mail/model/export";

--- a/addons/mail/static/src/core/common/res_company_model.js
+++ b/addons/mail/static/src/core/common/res_company_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class ResCompany extends Record {
     static _name = "res.company";

--- a/addons/mail/static/src/core/common/res_groups_model.js
+++ b/addons/mail/static/src/core/common/res_groups_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class ResGroups extends Record {
     static _name = "res.groups";

--- a/addons/mail/static/src/core/common/res_groups_privilege_model.js
+++ b/addons/mail/static/src/core/common/res_groups_privilege_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class ResGroupsPrivilege extends Record {
     static _name = "res.groups.privilege";

--- a/addons/mail/static/src/core/common/res_lang_model.js
+++ b/addons/mail/static/src/core/common/res_lang_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class ResLang extends Record {
     static id = "id";

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -1,5 +1,5 @@
 import { Store } from "@mail/core/common/store_service";
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { imageUrl } from "@web/core/utils/urls";
 import { debounce } from "@web/core/utils/timing";
 

--- a/addons/mail/static/src/core/common/res_role_model.js
+++ b/addons/mail/static/src/core/common/res_role_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class ResRole extends Record {
     static id = "id";

--- a/addons/mail/static/src/core/common/res_users_model.js
+++ b/addons/mail/static/src/core/common/res_users_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class ResUsers extends Record {
     static _name = "res.users";

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -1,7 +1,7 @@
 import { hasHardwareAcceleration } from "@mail/utils/common/misc";
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
-import { fields, Record } from "./record";
+import { fields, Record } from "@mail/model/export";
 import { debounce } from "@web/core/utils/timing";
 import { rpc } from "@web/core/network/rpc";
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -1,4 +1,4 @@
-import { Store as BaseStore, fields, makeStore } from "@mail/core/common/record";
+import { Store as BaseStore, fields, makeStore } from "@mail/model/export";
 import { threadCompareRegistry } from "@mail/core/common/thread_compare";
 import { cleanTerm, generateEmojisOnHtml, prettifyMessageText } from "@mail/utils/common/format";
 

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -1,7 +1,7 @@
 import { DateSection } from "@mail/core/common/date_section";
 import { Message } from "@mail/core/common/message";
 import { NotificationMessage } from "./notification_message";
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 import { useChildRefs, useVisible } from "@mail/utils/common/hooks";
 
 import {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -1,4 +1,4 @@
-import { AND, fields, Record } from "@mail/core/common/record";
+import { AND, fields, Record } from "@mail/model/export";
 import { generateEmojisOnHtml } from "@mail/utils/common/format";
 import { rpc } from "@web/core/network/rpc";
 

--- a/addons/mail/static/src/core/common/volume_model.js
+++ b/addons/mail/static/src/core/common/volume_model.js
@@ -1,4 +1,4 @@
-import { OR, fields, Record } from "./record";
+import { OR, fields, Record } from "@mail/model/export";
 
 export class Volume extends Record {
     static id = OR("partner_id", "guest_id");

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { browser } from "@web/core/browser/browser";
 
 const NO_MEMBERS_DEFAULT_OPEN_LS = "mail.user_setting.no_members_default_open";

--- a/addons/mail/static/src/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/core/public_web/store_service_patch.js
@@ -1,5 +1,5 @@
 import { Store, storeService } from "@mail/core/common/store_service";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { router } from "@web/core/browser/router";
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Store } from "@mail/core/common/store_service";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -1,7 +1,7 @@
 import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
-import { fields } from "../common/record";
+import { fields } from "@mail/model/export";
 import { compareDatetime } from "@mail/utils/common/misc";
 import { rpc } from "@web/core/network/rpc";
 

--- a/addons/mail/static/src/discuss/call/common/channel_member_patch.js
+++ b/addons/mail/static/src/discuss/call/common/channel_member_patch.js
@@ -1,5 +1,5 @@
 import { ChannelMember } from "@mail/discuss/core/common/channel_member_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { browser } from "@web/core/browser/browser";
 import { patch } from "@web/core/utils/patch";

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { BlurManager } from "@mail/discuss/call/common/blur_manager";
 import { CallPermissionDialog } from "@mail/discuss/call/common/call_permission_dialog";
 import { monitorAudio } from "@mail/utils/common/media_monitoring";

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { Deferred } from "@web/core/utils/concurrency";
 
 /**

--- a/addons/mail/static/src/discuss/call/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/call/common/store_service_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Store } from "@mail/core/common/store_service";
 import { router } from "@web/core/browser/router";
 

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -1,5 +1,5 @@
 import { Store } from "@mail/core/common/store_service";
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { Deferred } from "@web/core/utils/concurrency";
 
 export class DiscussChannel extends Record {

--- a/addons/mail/static/src/discuss/core/common/mail_guest_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/mail_guest_model_patch.js
@@ -1,5 +1,5 @@
 import { MailGuest } from "@mail/core/common/mail_guest_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -1,5 +1,5 @@
 import { Message } from "@mail/core/common/message_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/mail/static/src/discuss/core/common/res_partner_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/res_partner_model_patch.js
@@ -1,5 +1,5 @@
 import { ResPartner } from "@mail/core/common/res_partner_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 import { useSequential } from "@mail/utils/common/hooks";
 import { compareDatetime, nearestGreaterThanOrEqual } from "@mail/utils/common/misc";

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
@@ -1,5 +1,5 @@
 import { compareDatetime } from "@mail/utils/common/misc";
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 import { browser } from "@web/core/browser/browser";
 
 export const DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS = "discuss_sidebar_category_folded_";

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
 
 import { _t } from "@web/core/l10n/translation";

--- a/addons/mail/static/src/discuss/core/public_web/discuss_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_category_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class DiscussCategory extends Record {
     static _name = "discuss.category";

--- a/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
@@ -1,6 +1,6 @@
 import { patch } from "@web/core/utils/patch";
 import { Message } from "@mail/core/common/message_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { _t } from "@web/core/l10n/translation";
 import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { Deferred } from "@web/core/utils/concurrency";

--- a/addons/mail/static/src/discuss/message_pin/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_model_patch.js
@@ -1,5 +1,5 @@
 import { patch } from "@web/core/utils/patch";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 
 import { rpc } from "@web/core/network/rpc";

--- a/addons/mail/static/src/discuss/voice_message/common/attachment_model_patch.js
+++ b/addons/mail/static/src/discuss/voice_message/common/attachment_model_patch.js
@@ -1,5 +1,5 @@
 import { Attachment } from "@mail/core/common/attachment_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { patch } from "@web/core/utils/patch";
 
 /** @type {import("models").Attachment} */

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@odoo/hoot";
 import { markup, reactive, toRaw } from "@odoo/owl";
 import { mockService } from "@web/../tests/web_test_helpers";
 
-import { Record, Store, makeStore } from "@mail/core/common/record";
+import { Record, Store, makeStore } from "@mail/model/export";
 import { AND, fields } from "@mail/model/misc";
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";

--- a/addons/rating/static/src/core/common/message_model_patch.js
+++ b/addons/rating/static/src/core/common/message_model_patch.js
@@ -1,5 +1,5 @@
 import { Message } from "@mail/core/common/message_model";
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/rating/static/src/core/common/rating_model.js
+++ b/addons/rating/static/src/core/common/rating_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class Rating extends Record {
     static _name = "rating.rating";

--- a/addons/website/static/src/common/website_model.js
+++ b/addons/website/static/src/common/website_model.js
@@ -1,4 +1,4 @@
-import { Record } from "@mail/core/common/record";
+import { Record } from "@mail/model/export";
 
 export class Website extends Record {
     static id = "id";

--- a/addons/website/static/src/common/website_visitor_model.js
+++ b/addons/website/static/src/common/website_visitor_model.js
@@ -1,4 +1,4 @@
-import { fields, Record } from "@mail/core/common/record";
+import { fields, Record } from "@mail/model/export";
 
 export class WebsiteVisitor extends Record {
     static _name = "website.visitor";

--- a/addons/website_livechat/static/src/common/thread_model_patch.js
+++ b/addons/website_livechat/static/src/common/thread_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 import { Thread } from "@mail/core/common/thread_model";
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/website_livechat/static/src/web/website_visitor_model_patch.js
+++ b/addons/website_livechat/static/src/web/website_visitor_model_patch.js
@@ -1,4 +1,4 @@
-import { fields } from "@mail/core/common/record";
+import { fields } from "@mail/model/export";
 
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { patch } from "@web/core/utils/patch";


### PR DESCRIPTION
Imports of `@mail/src/model` should be made through `@mail/model/export`. In the past the source code of JS models was also in `@mail/core/common` but was moved in its `model/` folder. `@mail/core/common/record` was kept for backward compatibility.