### PR TITLE
[FIX] core: fix migration order

### DIFF
--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -115,7 +115,7 @@ class MigrationManager(object):
 
         def _get_migration_versions(pkg, stage):
             versions = sorted({
-                ver
+                ver: None
                 for lv in self.migrations[pkg.name].values()
                 for ver, lf in lv.items()
                 if lf


### PR DESCRIPTION
When we list the versions to upgrade we go over the values in `self.migrations[pkg.name]`. This object is a mapping of mappings `{script_location: {version: scripts_list}}`. The location could be `module` or `module_upgrades` for local scripts, or `upgrade` for scripts in any of the extra upgrade paths.

The problem is that if we have a minor version that matches a major one in different locations the order is non-deterministic. For example if we have a local upgrade script in `1.2`, and an extra upgrade script in `16.0.1.2`. Both `version` keys (`1.2` and `16.0.1.2`) will resolve to `16.0.1.2` when ordering. But the order they _actually_ appear in the set of versions is non-deterministic --due to the `set` implementation in Python.

The solution is to use a container that keeps the order, in this case a `dict`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
