### PR TITLE
[FIX] payment: prevent tooltip disposal on already disposed elements

### DIFF
--- a/addons/payment/static/src/interactions/payment_form.js
+++ b/addons/payment/static/src/interactions/payment_form.js
@@ -27,7 +27,7 @@ export class PaymentForm extends Interaction {
         )?.textContent;
 
         // Enable tooltips.
-        this.el.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+        this.el.querySelectorAll('#o_payment_form [data-bs-toggle="tooltip"]').forEach(el => {
             const tooltip = window.Tooltip.getOrCreateInstance(el);
             this.registerCleanup(() => tooltip.dispose());
         });


### PR DESCRIPTION
Following commits odoo/odoo@d37d90891c15b188c2bcb01a51e2ce85cefe287c and odoo/enterprise@901b8eac67324d392ed88997aa9fd1be12dc3752, the tooltip cleanup logic disposes elements in `website_sale_renting`, and when the same logic runs again
 in `payment`, it tries to dispose them a second time, causing
 a null element error.

Steps to reproduce:
1. Install `website_sale_renting`
2. Install a demo payment method
3. Go to the shop, add any product to the cart, proceed to payment
4. Click the "Edit" button on the website → observe the error

```js
web.assets_frontend_lazy.min.js:3912 TypeError: Cannot read properties of null (reading 'closest')
    at Tooltip.dispose (web.assets_frontend_lazy.min.js:2710:70)
    at PaymentForm.<anonymous> (web.assets_frontend_…zy.min.js:8282:1450)
    at Colibri.destroyInteraction (web.assets_frontend_lazy.min.js:6472:68)
    at Colibri.destroy (web.assets_frontend_lazy.min.js:6524:55)
    at InteractionService.stopInteractions (web.assets_frontend_lazy.min.js:6584:162)
    at InteractionService.stopInteractions (web.assets_frontend_lazy.min.js:6625:907)
    at stop (website.assets_insid…rame.min.js:137:290)
    at HTMLDocument.<anonymous> (website.assets_insid…rame.min.js:153:450)
    at WebsiteBuilderClientAction.onEditPage (web.assets_web.min.js:22215:55)
```

This fix ensures tooltip cleanup is performed safely without re-disposing already disposed elements.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
