### PR TITLE
[FIX] web: datetime: avoid double picker

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker_hook.js
+++ b/addons/web/static/src/core/datetime/datetime_picker_hook.js
@@ -1,4 +1,4 @@
-import { useRef } from "@odoo/owl";
+import { onWillDestroy, useRef } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 /**
@@ -28,5 +28,9 @@ export function useDateTimePicker(params) {
         useOwlHooks: true,
     });
 
-    return useService("datetime_picker").create(serviceParams);
+    const picker = useService("datetime_picker").create(serviceParams);
+    onWillDestroy(() => {
+        picker.disable();
+    });
+    return picker;
 }

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -74,6 +74,7 @@ const parsers = {
 export const datetimePickerService = {
     dependencies: ["popover"],
     start(env, { popover: popoverService }) {
+        const dateTimePickerList = new Set();
         return {
             /**
              * @param {DateTimePickerServiceParams} [params]
@@ -264,6 +265,9 @@ export const datetimePickerService = {
                             restoreTargetMargin = async () => {
                                 popoverTarget.style.marginBottom = marginBottom;
                             };
+                        }
+                        for (const picker of dateTimePickerList) {
+                            picker.close();
                         }
                         popover.open(popoverTarget, { pickerProps });
                     }
@@ -529,8 +533,16 @@ export const datetimePickerService = {
                         `datetime picker service error: cannot use target as ref name when not using Owl hooks`
                     );
                 }
-
-                return { enable, isOpen, open, state: pickerProps };
+                const picker = {
+                    enable,
+                    disable: () => dateTimePickerList.delete(picker),
+                    isOpen,
+                    open,
+                    close: () => popover.close(),
+                    state: pickerProps,
+                };
+                dateTimePickerList.add(picker);
+                return picker;
             },
         };
     },

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { expect, queryFirst, test } from "@odoo/hoot";
 import { click, edit, press, queryAllTexts, queryOne, scroll } from "@odoo/hoot-dom";
 import { animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import {
@@ -59,6 +59,26 @@ test("toggle datepicker", async () => {
 
     await fieldInput("char_field").click();
     expect(".o_datetime_picker").toHaveCount(0);
+});
+
+test("Ensure only one datepicker is open", async () => {
+    Partner._fields.date_start = fields.Date();
+
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        arch: `
+            <form>
+                <field name="date_start"/>
+                <field name="date"/>
+            </form>`,
+        resId: 1,
+    });
+
+    await queryFirst("[data-field='date_start']").click();
+    await queryFirst("[data-field='date']").click();
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(1);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
Before this commit, it was possible to have multiple pickers open if you programmatically set the focus on several date inputs. This could occur in a form view when the first date field was a `button` rather than an `input` and the second one is date field as an input. The autofocus feature only selects `input` elements (see `relational_utils.js`).

We agree that this behavior should be improved in the future, but for now we prefer a simpler fix.

Now, all pickers are closed before opening a new one. This ensures that only one picker is open, even if the focus changes multiple times.

Steps to reproduce:
- Go to Employees
- Click on create
- Go in the Certifications tab
- Click on "Add a line" => The `valid_from` picker and the `valid_to` picker are open.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
