### PR TITLE
[IMP] tests, web: start js test per module

### DIFF
--- a/addons/web/static/lib/hoot/core/expect.js
+++ b/addons/web/static/lib/hoot/core/expect.js
@@ -545,6 +545,7 @@ export function makeExpect(params) {
             /** @type {import("../hoot_utils").Reporting} */
             const report = {
                 assertions: assertionCount,
+                duration: test.lastResults?.duration || 0,
                 tests: 1,
             };
             if (!currentResult.pass) {

--- a/addons/web/static/lib/hoot/core/logger.js
+++ b/addons/web/static/lib/hoot/core/logger.js
@@ -190,7 +190,7 @@ class Logger {
                 `(${withArgs.shift()}`,
                 ...withArgs,
                 "time:",
-                suite.jobs.reduce((acc, job) => acc + (job.duration || 0), 0),
+                suite.reporting.duration,
                 "ms)"
             );
         }

--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -1161,6 +1161,17 @@ export class Runner {
 
         await this._callbacks.call("after-all", this, logger.error);
 
+        if (this.headless) {
+            // Log root suite results in headless
+            const restoreLogLevel = logger.setLogLevel("suites");
+            for (const suite of this.suites.values()) {
+                if (!suite.parent) {
+                    logger.logSuite(suite);
+                }
+            }
+            restoreLogLevel();
+        }
+
         const { passed, failed, assertions } = this.reporting;
         if (failed > 0) {
             const errorMessage = ["Some tests failed: see above for details"];

--- a/addons/web/static/lib/hoot/hoot_utils.js
+++ b/addons/web/static/lib/hoot/hoot_utils.js
@@ -740,6 +740,7 @@ export function createReporting(parentReporting) {
 
     const reporting = reactive({
         assertions: 0,
+        duration: 0,
         failed: 0,
         passed: 0,
         skipped: 0,

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -10,6 +10,7 @@ from werkzeug.urls import url_quote_plus
 
 RE_FORBIDDEN_STATEMENTS = re.compile(r'test.*\.(only|debug)\(')
 RE_ONLY = re.compile(r'QUnit\.(only|debug)\(')
+RE_ASSET_ADDON = re.compile(r'^/(\w+)/')
 
 
 def unit_test_error_checker(message):
@@ -46,12 +47,152 @@ def _get_filters(test_params):
             filters.append((part_sign, part))
     return sorted(filters)
 
-@odoo.tests.tagged('post_install', '-at_install')
-class QunitCommon(odoo.tests.HttpCase):
 
+class HootCommon(odoo.tests.HttpCase):
+    def _check_forbidden_statements(self, bundle):
+        # As we currently are not in a request context, we cannot render `web.layout`.
+        # We then re-define it as a minimal proxy template.
+        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><html><head><meta charset="utf-8"/><link/><script id="web.layout.odooscript"/><meta/><t t-out="head"/></head><body><t t-out="0"/></body></html></t>'})
+        for asset in self._get_bundle_assets(bundle):
+            filename = asset['filename']
+            if not filename.endswith('.test.js'):
+                continue
+            with suppress(FileNotFoundError):
+                with file_open(filename, 'rb', filter_ext=('.js',)) as fp:
+                    if RE_FORBIDDEN_STATEMENTS.search(fp.read().decode('utf-8')):
+                        self.fail("`only()` or `debug()` used in file %r" % asset['url'])
+
+    def _generate_hash(self, test_string):
+        hash = 0
+        for char in test_string:
+            hash = (hash << 5) - hash + ord(char)
+            hash = hash & 0xFFFFFFFF
+        return f'{hash:08x}'
+
+    def _get_addons_from_asset_bundle(self, bundle):
+        return {
+            RE_ASSET_ADDON.match(asset['url'])[1]
+            for asset in self._get_bundle_assets(bundle)
+            if asset['filename'].endswith('.test.js')
+        }
+
+    def _get_bundle_assets(self, bundle):
+        assets = self.env['ir.qweb']._get_asset_content(bundle)[0]
+        if len(assets) == 0:
+            self.fail("No assets found in the given test bundle")
+        return assets
+
+    def _get_hoot_module_filters(self, addons_from_asset_bundle, available_modules):
+        module_filter = ''
+        for module in available_modules:
+            if module in addons_from_asset_bundle:
+                module_filter += f'&id={self._generate_hash(f'@{module}')}'
+        return module_filter
+
+    def _get_hoot_param_filters(self):
+        filters = _get_filters(self._test_params)
+        filter = ''
+        for sign, f in filters:
+            h = self._generate_hash(f)
+            if sign == '-':
+                h = f'-{h}'
+            # Since we don't know if the descriptor we have is a test or a suite, we need to provide the hash for a generic "job"
+            filter += f'&id={h}'
+        return filter
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class HootSuite(HootCommon):
+    def test_check_suite(self):
+        self._check_forbidden_statements('web.assets_unit_tests')
+
+    def test_generate_hoot_hash(self):
+        self.assertEqual(self._generate_hash('@web/core'), 'e39ce9ba')
+        self.assertEqual(self._generate_hash('@web/core/autocomplete'), '69a6561d') # suite
+        self.assertEqual(self._generate_hash('@web/core/autocomplete/open dropdown on input'), 'ee565d54') # test
+
+    def test_get_hoot_module_filters(self):
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], []), '')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['account']), '&id=b21ec1ed')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['mail']), '&id=03b8e5f7')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['web']), '&id=001ee314')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['account', 'web']), '&id=b21ec1ed&id=001ee314')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['account', 'mail', 'web']), '&id=b21ec1ed&id=03b8e5f7&id=001ee314')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['project']), '')
+        self.assertEqual(self._get_hoot_module_filters(['account', 'mail', 'web'], ['project', 'web']), '&id=001ee314')
+
+    def test_get_hoot_param_filters(self):
+        self._test_params = []
+        self.assertEqual(self._get_hoot_param_filters(), '')
+        expected = '&id=e39ce9ba&id=-69a6561d'
+        self._test_params = [('+', '@web/core,-@web/core/autocomplete')]
+        self.assertEqual(self._get_hoot_param_filters(), expected)
+        self._test_params = [('+', '@web/core'), ('-', '@web/core/autocomplete')]
+        self.assertEqual(self._get_hoot_param_filters(), expected)
+        self._test_params = [('+', '-@web/core/autocomplete,-@web/core/autocomplete2')]
+        self.assertEqual(self._get_hoot_param_filters(), '&id=-69a6561d&id=-cb246db5')
+        self._test_params = [('-', '-@web/core/autocomplete,-@web/core/autocomplete2')]
+        self.assertEqual(self._get_hoot_param_filters(), '&id=69a6561d&id=cb246db5')
+
+    @odoo.tests.no_retry
+    def test_hoot(self):
+        # HOOT tests suite
+        self.browser_js('/web/static/lib/hoot/tests/index.html?headless&loglevel=2', "", "", login='admin', timeout=1800, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+
+
+@odoo.tests.tagged('hoot', 'post_install', '-at_install')
+class WebSuite(HootCommon, odoo.tests.CrossModule):
+    @odoo.tests.no_retry
+    def test_unit_desktop(self, modules):
+        # Unit tests suite (desktop)
+        addons_from_asset_bundle = self._get_addons_from_asset_bundle('web.assets_unit_tests')
+        filters = self._get_hoot_module_filters(addons_from_asset_bundle, modules)
+        if not filters:
+            return
+        filters += self._get_hoot_param_filters()
+        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=desktop&timeout=15000{filters}', "", "", login='admin', timeout=3000, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+
+
+@odoo.tests.tagged('hoot', 'post_install', '-at_install')
+class MobileWebSuite(HootCommon, odoo.tests.CrossModule):
+    browser_size = '375x667'
+    touch_enabled = True
+
+    @odoo.tests.no_retry
+    def test_unit_mobile(self, modules):
+        # Unit tests suite (mobile)
+        addons_from_asset_bundle = self._get_addons_from_asset_bundle('web.assets_unit_tests')
+        filters = self._get_hoot_module_filters(addons_from_asset_bundle, modules)
+        if not filters:
+            return
+        filters += self._get_hoot_param_filters()
+        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=mobile&tag=-headless&timeout=15000{filters}', "", "", login='admin', timeout=2100, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class LegacyWebSuite(odoo.tests.HttpCase):
     def setUp(self):
         super().setUp()
         self.qunit_filters = self.get_qunit_filters()
+
+    def _check_only_call(self, suite):
+        # ! DEPRECATED
+        # As we currently aren't in a request context, we can't render `web.layout`.
+        # redefinied it as a minimal proxy template.
+        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><html><head><meta charset="utf-8"/><link/><script id="web.layout.odooscript"/><meta/><t t-out="head"/></head><body><t t-out="0"/></body></html></t>'})
+
+        assets = self.env['ir.qweb']._get_asset_content(suite)[0]
+        if len(assets) == 0:
+            self.fail("No assets found in the given test suite")
+
+        for asset in assets:
+            filename = asset['filename']
+            if not filename.endswith('.js'):
+                continue
+            with suppress(FileNotFoundError):
+                with file_open(filename, 'rb', filter_ext=('.js',)) as fp:
+                    if RE_ONLY.search(fp.read().decode('utf-8')):
+                        self.fail("`QUnit.only()` or `QUnit.debug()` used in file %r" % asset['url'])
 
     def get_qunit_regex(self, test_params):
         filters = _get_filters(test_params)
@@ -72,6 +213,10 @@ class QunitCommon(odoo.tests.HttpCase):
             url_filter = url_quote_plus(filter)
             filter_param = f'&filter=/{url_filter}/'
         return filter_param
+
+    def test_check_suite(self):
+        # Checks that no test is using `only` or `debug` as it prevents other tests to be run
+        self._check_only_call('web.qunit_suite_tests')
 
     def test_get_qunit_regex(self):
         f = self.get_qunit_regex([('+', 'utils,mail,-utils > bl1,-utils > bl2')])
@@ -96,116 +241,7 @@ class QunitCommon(odoo.tests.HttpCase):
             self.assertNotRegex('utils > bl1', f)
             self.assertNotRegex('utils > bl2', f)
 
-@odoo.tests.tagged('post_install', '-at_install')
-class HOOTCommon(odoo.tests.HttpCase):
-
-    def setUp(self):
-        super().setUp()
-        self.hoot_filters = self.get_hoot_filters()
-
-    def _generate_hash(self, test_string):
-        hash = 0
-        for char in test_string:
-            hash = (hash << 5) - hash + ord(char)
-            hash = hash & 0xFFFFFFFF
-        return f'{hash:08x}'
-
-    def get_hoot_filters(self):
-        filters = _get_filters(self._test_params)
-        filter = ''
-        for sign, f in filters:
-            h = self._generate_hash(f)
-            if sign == '-':
-                h = f'-{h}'
-            # Since we don't know if the descriptor we have is a test or a suite, we need to provide the hash for a generic "job"
-            filter += f'&id={h}'
-        return filter
-
-    def test_generate_hoot_hash(self):
-        self.assertEqual(self._generate_hash('@web/core'), 'e39ce9ba')
-        self.assertEqual(self._generate_hash('@web/core/autocomplete'), '69a6561d') # suite
-        self.assertEqual(self._generate_hash('@web/core/autocomplete/open dropdown on input'), 'ee565d54') # test
-
-    def test_get_hoot_filter(self):
-        self._test_params = []
-        self.assertEqual(self.get_hoot_filters(), '')
-        expected = '&id=e39ce9ba&id=-69a6561d'
-        self._test_params = [('+', '@web/core,-@web/core/autocomplete')]
-        self.assertEqual(self.get_hoot_filters(), expected)
-        self._test_params = [('+', '@web/core'), ('-', '@web/core/autocomplete')]
-        self.assertEqual(self.get_hoot_filters(), expected)
-        self._test_params = [('+', '-@web/core/autocomplete,-@web/core/autocomplete2')]
-        self.assertEqual(self.get_hoot_filters(), '&id=-69a6561d&id=-cb246db5')
-        self._test_params = [('-', '-@web/core/autocomplete,-@web/core/autocomplete2')]
-        self.assertEqual(self.get_hoot_filters(), '&id=69a6561d&id=cb246db5')
-
-@odoo.tests.tagged('post_install', '-at_install')
-class WebSuite(QunitCommon, HOOTCommon):
-
     @odoo.tests.no_retry
-    def test_unit_desktop(self):
-        # Unit tests suite (desktop)
-        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=3000, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
-
-    @odoo.tests.no_retry
-    def test_hoot(self):
-        # HOOT tests suite
-        self.browser_js(f'/web/static/lib/hoot/tests/index.html?headless&loglevel=2{self.hoot_filters}', "", "", login='admin', timeout=1800, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
-
-    @odoo.tests.no_retry
-    def test_qunit_desktop(self):
+    def test_qunit(self):
         # ! DEPRECATED
         self.browser_js(f'/web/tests/legacy?mod=web{self.qunit_filters}', "", "", login='admin', timeout=1800, success_signal="QUnit test suite done.", error_checker=qunit_error_checker)
-
-    def test_check_suite(self):
-        self._check_forbidden_statements('web.assets_unit_tests')
-        # Checks that no test is using `only` or `debug` as it prevents other tests to be run
-        self._check_only_call('web.qunit_suite_tests')
-
-    def _check_forbidden_statements(self, bundle):
-        # As we currently are not in a request context, we cannot render `web.layout`.
-        # We then re-define it as a minimal proxy template.
-        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><html><head><meta charset="utf-8"/><link/><script id="web.layout.odooscript"/><meta/><t t-out="head"/></head><body><t t-out="0"/></body></html></t>'})
-
-        assets = self.env['ir.qweb']._get_asset_content(bundle)[0]
-        if len(assets) == 0:
-            self.fail("No assets found in the given test bundle")
-
-        for asset in assets:
-            filename = asset['filename']
-            if not filename.endswith('.test.js'):
-                continue
-            with suppress(FileNotFoundError):
-                with file_open(filename, 'rb', filter_ext=('.js',)) as fp:
-                    if RE_FORBIDDEN_STATEMENTS.search(fp.read().decode('utf-8')):
-                        self.fail("`only()` or `debug()` used in file %r" % asset['url'])
-
-    def _check_only_call(self, suite):
-        # ! DEPRECATED
-        # As we currently aren't in a request context, we can't render `web.layout`.
-        # redefinied it as a minimal proxy template.
-        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><html><head><meta charset="utf-8"/><link/><script id="web.layout.odooscript"/><meta/><t t-out="head"/></head><body><t t-out="0"/></body></html></t>'})
-
-        assets = self.env['ir.qweb']._get_asset_content(suite)[0]
-        if len(assets) == 0:
-            self.fail("No assets found in the given test suite")
-
-        for asset in assets:
-            filename = asset['filename']
-            if not filename.endswith('.js'):
-                continue
-            with suppress(FileNotFoundError):
-                with file_open(filename, 'rb', filter_ext=('.js',)) as fp:
-                    if RE_ONLY.search(fp.read().decode('utf-8')):
-                        self.fail("`QUnit.only()` or `QUnit.debug()` used in file %r" % asset['url'])
-
-
-@odoo.tests.tagged('post_install', '-at_install')
-class MobileWebSuite(QunitCommon, HOOTCommon):
-    browser_size = '375x667'
-    touch_enabled = True
-
-    @odoo.tests.no_retry
-    def test_unit_mobile(self):
-        # Unit tests suite (mobile)
-        self.browser_js(f'/web/tests?headless&loglevel=2&preset=mobile&tag=-headless&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=2100, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -940,6 +940,15 @@ class BaseCase(case.TestCase):
                 additional_tags.append('is_query_count')
         return additional_tags
 
+
+class CrossModule(case.TestCase):
+    _cross_module = True
+    _test_modules = []
+
+    def _callTestMethod(self, method):
+        method(self._test_modules)
+
+
 class Like:
     """
         A string-like object comparable to other strings but where the substring

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -95,8 +95,9 @@ def make_suite(module_names, position='at_install'):
     :param list[str] module_names: modules to load tests from
     :param str position: "at_install" or "post_install"
     """
-    config_tags = TagsSelector(tools.config['test_tags'])
-    position_tag = TagsSelector(position)
+    available_modules = module_names if position == 'post_install' else None
+    config_tags = TagsSelector(tools.config['test_tags'], available_modules)
+    position_tag = TagsSelector(position, available_modules)
     tests = (
         t
         for module_name in module_names

--- a/odoo/tests/runbot/parallel_testing.json
+++ b/odoo/tests/runbot/parallel_testing.json
@@ -40,9 +40,11 @@
             "for_each_vars": [
                 {"test_module_filter": "-> !account_auto_transfer"},
                 {"test_module_filter": "account_auto_transfer -> !auth_totp"},
-                {"test_module_filter": "auth_totp -> !mrp"},
+                {"test_module_filter": "auth_totp -> !mail"},
+                {"test_module_filter": "mail -> !mrp"},
                 {"test_module_filter": "mrp -> !pos"},
-                {"test_module_filter": "pos -> !sale"},
+                {"test_module_filter": "pos -> !pos_restaurant"},
+                {"test_module_filter": "pos_restaurant -> !sale"},
                 {"test_module_filter": "sale -> !sale_timesheet"},
                 {"test_module_filter": "sale_timesheet -> !stock_barcode_mrp_subcontracting"},
                 {"test_module_filter": "stock_barcode_mrp_subcontracting -> !test_main_flows"},

--- a/odoo/tests/runbot/parallel_testing.json
+++ b/odoo/tests/runbot/parallel_testing.json
@@ -1,0 +1,70 @@
+{
+    "name": "Parallel testing",
+    "vars": {
+        "module_filter": "*,-hw_*,-*l10n_*,-theme_*,-account_bacs,-account_reports_cash_basis,-auth_ldap,-base_gengo,-document_ftp,-iot_drivers,-note_pad,-odoo_referral,-odoo_referral_portal,-pad,-pad_project,-pos_blackbox_be,-pos_cache,-pos_six,-social_demo,-website_gengo,-website_instantclick,test_l10n_be_hr_payroll_account,test_l10n_us_hr_payroll_account"
+    },
+    "steps": [
+        {
+            "name": "Create at install",
+            "job_type": "create_build",
+            "children": [
+                {
+                    "name": "Test at install",
+                    "steps":[{
+                        "name": "Start at install",
+                        "job_type": "odoo",
+                        "install_modules": "{{module_filter}},-test_lint",
+                        "test_tags": "-post_install,-/test_lint"
+                        }]
+                },
+                {
+                    "name": "Test pylint",
+                    "steps":[{
+                        "name": "Start test lint",
+                        "job_type": "odoo",
+                        "install_modules": "test_lint",
+                        "test_tags": "-post_install,/test_lint"
+                    }]
+                }
+            ]
+        },
+        {
+            "name": "Install all",
+            "db_name": "all",
+            "job_type": "odoo",
+            "install_modules": "{{module_filter}}"
+        },
+        {
+            "name": "Create post install",
+            "job_type": "create_build",
+            "for_each_vars": [
+                {"test_module_filter": "-> !account_auto_transfer"},
+                {"test_module_filter": "account_auto_transfer -> !auth_totp"},
+                {"test_module_filter": "auth_totp -> !mrp"},
+                {"test_module_filter": "mrp -> !pos"},
+                {"test_module_filter": "pos -> !sale"},
+                {"test_module_filter": "sale -> !sale_timesheet"},
+                {"test_module_filter": "sale_timesheet -> !stock_barcode_mrp_subcontracting"},
+                {"test_module_filter": "stock_barcode_mrp_subcontracting -> !test_main_flows"},
+                {"test_module_filter": "test_main_flows -> !web"},
+                {"test_module_filter": "web -> web"},
+                {"test_module_filter": "!web -> !website"},
+                {"test_module_filter": "website -> website"},
+                {"test_module_filter": "!website -> "}
+            ],
+            "children": [{
+                "name": "Test Post Install",
+                "description": "Post install tests for **{{test_module_filter}}**",
+                "steps": [
+                    {"name": "restore", "job_type": "restore", "db_name": "all"},
+                    {
+                        "name": "Start post install tests",
+                        "job_type": "odoo",
+                        "test_tags": "-at_install,{{test_module_filter|filter_all_modules|make_module_test_tags}}",
+                        "db_name": "all"
+                    }
+                ]
+            }]
+        }
+    ]
+}

--- a/odoo/tests/runbot/readme.md
+++ b/odoo/tests/runbot/readme.md
@@ -1,0 +1,12 @@
+# Runbot config
+
+This directory contains configuration files that will be loaded by runbot to define how to run specific tests.
+
+## Parallel testing
+The parallel_testing.json file describes how to run the test for all modules in parallel
+- starting first subbuild for the at install tests
+- then installing a database with all modules
+- and finally starting multiple subbuilds to test all post install in parallel.
+
+Note that the test-tags do not use the blacklist, this is to replicate the default odoo --test-enable behaviour. 
+Even if a module is blacklisted, it could be installed via an auto_install or if required by another module, and should be tested.

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -19,14 +19,15 @@ class TagsSelector(object):
                                 (?:\[(.*)\])?               # parameters
                                 $''', re.VERBOSE)  # [-][tag][/module][:class][.method][[params]]
 
-    def __init__(self, spec):
+    def __init__(self, spec, available_modules=None):
         """ Parse the spec to determine tags to include and exclude. """
         parts = re.split(r',(?![^\[]*\])', spec)  # split on all comma not inside [] (not followed by ])
         filter_specs = [t.strip() for t in parts if t.strip()]
         self.exclude = set()
         self.include = set()
         self.parameters = OrderedSet()
-
+        self.available_modules = available_modules and set(available_modules)
+        self.has_include = False
         for filter_spec in filter_specs:
             match = self.filter_spec_re.match(filter_spec)
             if not match:
@@ -51,11 +52,18 @@ class TagsSelector(object):
                 is_exclude = False
 
             if is_include:
+                self.has_include = True  # this is important for tags like /nonexistingmodule,-test_x
+
+            if is_include and module and self.available_modules and module not in self.available_modules:
+                _logger.debug("Module '%s' in tag selector not in the list of installed modules %s", module, available_modules)
+                continue
+
+            if is_include:
                 self.include.add(test_filter)
             if is_exclude:
                 self.exclude.add(test_filter)
 
-        if (self.exclude or self.parameters) and not self.include:
+        if (self.exclude or self.parameters) and not self.has_include:
             self.include.add(('standard', None, None, None, None))
 
     def check(self, test):
@@ -76,29 +84,63 @@ class TagsSelector(object):
         test_module_path = test_module_path.replace('.', '/') + '.py'
 
         test._test_params = []
+        included_modules = set()
+        excluded_modules = set()
+
+        cross_module_test = hasattr(test, '_cross_module')
+
+        if cross_module_test and not self.available_modules:
+            _logger.debug("Skipping test '%s' because no available modules found.", test)
+            return False
 
         def _is_matching(test_filter):
             (tag, module, klass, method, file_path) = test_filter
             if tag and tag not in test_tags:
                 return False
-            elif file_path and not file_path.endswith(test_module_path):
+            if file_path and not file_path.endswith(test_module_path):
                 return False
-            elif not file_path and module and module != test_module:
+            if not file_path and module and module != test_module and not cross_module_test:
                 return False
-            elif klass and klass != test_class:
+            if klass and klass != test_class:
                 return False
-            elif method and test_method and method != test_method:
+            if method and test_method and method != test_method:  # noqa: SIM103
                 return False
             return True
 
-        if any(_is_matching(test_filter) for test_filter in self.exclude):
+        match_include = False
+        for test_filter in self.include:
+            if _is_matching(test_filter):
+                match_include = True
+                if cross_module_test:
+                    test_filter_module = test_filter[1]
+                    if test_filter_module:
+                        included_modules.add(test_filter_module)
+                    else:
+                        included_modules |= self.available_modules
+                else:
+                    break
+
+        if not match_include:
             return False
 
-        if not any(_is_matching(test_filter) for test_filter in self.include):
-            return False
-        
+        for test_filter in self.exclude:
+            if _is_matching(test_filter):
+                if cross_module_test:
+                    test_filter_module = test_filter[1]
+                    if test_filter_module:
+                        excluded_modules.add(test_filter_module)
+                    else:
+                        return False
+                else:
+                    return False
+
         for test_filter, parameter in self.parameters:
             if _is_matching(test_filter):
                 test._test_params.append(parameter)
+
+        test._test_modules = sorted(included_modules - excluded_modules)
+
+        if cross_module_test and not test._test_modules:  # noqa: SIM103
+            return False
 
         return True


### PR DESCRIPTION
The web module tests became a bottleneck regarding testing and splitting. 
Moreover the js tests are run only in web, meaning that to run all tests of a module, the correct way would be to make
/module,/web.tests_unit_descktop[web],/web.tests_unit_mobile[web], ...

This pr add a new way to declare a test so that it will run in all modules, but only for the part of the module that are being tested. So /module will run all test of the module, including js tests.  

This pr combines 
#233788
#232264
#232268

Note that the current configuration format is a prototype and subject to breaking changes in a near future.
