### PR TITLE
[FIX] web_editor: fix image upload error handling V2 dtda

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -140,7 +140,11 @@ export class ImageSelector extends FileSelector {
     }
 
     async uploadFiles(files) {
-        await this.uploadService.uploadFiles(files, { resModel: this.props.resModel, resId: this.props.resId, isImage: true }, (attachment) => this.onUploaded(attachment));
+        try {
+            await this.uploadService.uploadFiles(files, { resModel: this.props.resModel, resId: this.props.resId, isImage: true }, (attachment) => this.onUploaded(attachment));
+        } catch (error) {
+            console.error("Something went wrong while uploading:", error);
+        }
     }
 
     async uploadUrl(url) {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -290,6 +290,13 @@ export class MediaDialog extends Component {
     onTabChange(tab) {
         this.state.activeTab = tab;
     }
+
+    async close() {
+        if (this.uploadService) {
+            await this.uploadService.destroyUpload();
+        }
+        await this.props.close();
+    }
 }
 MediaDialog.template = 'web_editor.MediaDialog';
 MediaDialog.defaultProps = {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
@@ -8,7 +8,7 @@
         <Notebook pages="tabs" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">
             <button class="btn btn-primary" t-on-click="() => this.save()" t-ref="add-button">Add</button>
-            <button class="btn btn-secondary" t-on-click="() => this.props.close()">Discard</button>
+            <button class="btn btn-secondary" t-on-click="() => this.close()">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
@@ -38,6 +38,7 @@ export const uploadService = {
             if (!Object.keys(progressToast.files).length) {
                 progressToast.isVisible = false;
             }
+            delete this.addAttachmentRpc;
         };
         return {
             get progressToast() {
@@ -120,7 +121,7 @@ export const uploadService = {
                             // Don't show yet success as backend code only starts now
                             file.progress = 100;
                         });
-                        const attachment = await rpc('/web_editor/attachment/add_data', {
+                        this.addAttachmentRpc = rpc('/web_editor/attachment/add_data', {
                             'name': file.name,
                             'data': dataURL.split(',')[1],
                             'res_id': resId,
@@ -129,6 +130,7 @@ export const uploadService = {
                             'width': 0,
                             'quality': 0,
                         }, {xhr});
+                        const attachment = await this.addAttachmentRpc;
                         if (attachment.error) {
                             file.hasError = true;
                             file.errorMessage = attachment.error;
@@ -166,7 +168,11 @@ export const uploadService = {
                         throw error;
                     }
                 }
-            }
+            },
+            destroyUpload: () => {
+                this.addAttachmentRpc?.abort();
+                Object.keys(progressToast.files).forEach(fileId => deleteFile(fileId));
+            },
         };
     },
 };


### PR DESCRIPTION
Steps to Reproduce:
1. Open the website module.
2. Open the media upload dialog to upload an image by either double-clicking the logo or replacing the existing image.
3. Upload a large file.
4. Abort the upload before it finishes by clicking the 'Discard' button in the media dialog box.
After performing these steps, a traceback is observed.

Before this commit:
- Image upload failures would throw uncaught exceptions.
- These exceptions would interrupt the flow and result in a poor user experience with no clear feedback.
- Even after clicking the discard button the image was still getting uploaded.

After this commit:
- The upload process is wrapped in a try-catch block.
- If an error occurs, it no longer breaks the flow.
- The error is logged to the console for debugging purposes.
- Discard button stops the upload of image.

task-4752497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
