### PR TITLE
[FIX] l10n_in: Use partner autocomplete data to set GST Treatment

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -91,7 +91,7 @@ class ResPartner(models.Model):
             'country_id': partner_data.get('country_id', {}).get('id'),
             'state_id': partner_data.get('state_id', {}).get('id'),
             'company_type': 'company',
-            'l10n_in_gst_treatment': 'regular',
+            'l10n_in_gst_treatment': partner_data.get('l10n_in_gst_treatment', 'regular'),
         })
         return partner_data
 


### PR DESCRIPTION
Before this commit:
We used to set `regular` treatment when using QR Vendor Scan or Fetching bill with IRN

After this commit:
We use the GST Treatment received from Partner Autocomplete to set the GST Treatment

task-none


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
