### PR TITLE
[IMP] html_editor: auto replace ASCII arrows with Unicode on space

### DIFF
--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
-import { deleteBackward, insertText } from "../_helpers/user_actions";
+import { deleteBackward, insertSpace, insertText } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
 import { press } from "@odoo/hoot-dom";
@@ -92,6 +92,33 @@ describe("collapsed selection", () => {
                 </div>
             `),
         });
+    });
+
+    test("should replace '->' with '→' and be a undoable step", async () => {
+        const { editor, el } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "->");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>ab→&nbsp;[]</p>");
+        execCommand(editor, "historyUndo");
+        expect(getContent(el)).toBe("<p>ab->&nbsp;[]</p>");
+    });
+
+    test("should replace '<-' with '←' and be a undoable step", async () => {
+        const { editor, el } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "<-");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>ab←&nbsp;[]</p>");
+        execCommand(editor, "historyUndo");
+        expect(getContent(el)).toBe("<p>ab<-&nbsp;[]</p>");
+    });
+
+    test("should replace '=>' with '⮕' and be a undoable step", async () => {
+        const { editor, el } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "=>");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>ab⮕&nbsp;[]</p>");
+        execCommand(editor, "historyUndo");
+        expect(getContent(el)).toBe("<p>ab=>&nbsp;[]</p>");
     });
 });
 

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { setupEditor } from "../_helpers/editor";
-import { insertText } from "../_helpers/user_actions";
+import { insertSpace, insertText } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
 import { unformat } from "../_helpers/format";
 import { animationFrame } from "@odoo/hoot-mock";
@@ -9,7 +9,8 @@ import { execCommand } from "../_helpers/userCommands";
 
 test("typing '1. ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "1. ");
+    await insertText(editor, "1.");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(`<ol><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`);
 });
 
@@ -29,7 +30,8 @@ test("typing '1. ' should create number list (with linebreak)", async () => {
 
 test("typing '1) ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "1) ");
+    await insertText(editor, "1)");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(`<ol><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`);
 });
 
@@ -41,7 +43,8 @@ test("Typing '1. ' at the start of existing text should create a numbered list",
 
 test("should convert simple number list into bullet list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "1. ");
+    await insertText(editor, "1.");
+    await insertSpace(editor);
     await insertText(editor, "/bulletedlist");
     await press("Enter");
     expect(getContent(el)).toBe(`<ul><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ul>`);
@@ -49,7 +52,8 @@ test("should convert simple number list into bullet list", async () => {
 
 test("typing 'a. ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "a. ");
+    await insertText(editor, "a.");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(
         `<ol style="list-style: lower-alpha;"><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`
     );
@@ -57,7 +61,8 @@ test("typing 'a. ' should create number list", async () => {
 
 test("typing 'a) ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "a) ");
+    await insertText(editor, "a)");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(
         `<ol style="list-style: lower-alpha;"><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`
     );
@@ -65,7 +70,8 @@ test("typing 'a) ' should create number list", async () => {
 
 test("should convert lower-alpha list into bullet list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "a. ");
+    await insertText(editor, "a.");
+    await insertSpace(editor);
     await insertText(editor, "/bulletedlist");
     await press("Enter");
     expect(getContent(el)).toBe(
@@ -75,7 +81,8 @@ test("should convert lower-alpha list into bullet list", async () => {
 
 test("typing 'A. ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "A. ");
+    await insertText(editor, "A.");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(
         `<ol style="list-style: upper-alpha;"><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`
     );
@@ -83,7 +90,8 @@ test("typing 'A. ' should create number list", async () => {
 
 test("typing 'A) ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "A) ");
+    await insertText(editor, "A)");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(
         `<ol style="list-style: upper-alpha;"><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`
     );
@@ -91,7 +99,8 @@ test("typing 'A) ' should create number list", async () => {
 
 test("should convert upper-alpha list into bullet list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "A. ");
+    await insertText(editor, "A.");
+    await insertSpace(editor);
     await insertText(editor, "/bulletedlist");
     await press("Enter");
     expect(getContent(el)).toBe(
@@ -106,7 +115,8 @@ test("creating list directly inside table column (td)", async () => {
     await animationFrame();
     await press("Enter");
     await press("Backspace");
-    await insertText(editor, "A. ");
+    await insertText(editor, "A.");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(
         unformat(`
             <p data-selection-placeholder=""><br></p>
@@ -135,7 +145,8 @@ test("creating list directly inside table column (td)", async () => {
 
 test("typing '* ' should create bullet list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "* ");
+    await insertText(editor, "*");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(`<ul><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ul>`);
 });
 
@@ -147,13 +158,15 @@ test("Typing '* ' at the start of existing text should create a bullet list", as
 
 test("typing '- ' should create bullet list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "- ");
+    await insertText(editor, "-");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(`<ul><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ul>`);
 });
 
 test("should convert a bullet list into a numbered list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "- ");
+    await insertText(editor, "-");
+    await insertSpace(editor);
     await insertText(editor, "/numberedlist");
     await press("Enter");
     expect(getContent(el)).toBe(`<ol><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`);
@@ -161,13 +174,14 @@ test("should convert a bullet list into a numbered list", async () => {
 
 test("typing '[] ' should create checklist and restore the original text when undo", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "[] ");
+    await insertText(editor, "[]");
+    await insertSpace(editor);
     expect(getContent(el)).toBe(
         `<ul class="o_checklist"><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ul>`
     );
 
     execCommand(editor, "historyUndo");
-    expect(getContent(el)).toBe(`<p>[] []</p>`);
+    expect(getContent(el)).toBe(`<p>[]&nbsp;[]</p>`);
 });
 
 test("Typing '[] ' at the start of existing text should create a checklist and restore the original text when undo", async () => {
@@ -181,7 +195,8 @@ test("Typing '[] ' at the start of existing text should create a checklist and r
 
 test("should convert a checklist into a numbered list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    await insertText(editor, "[] ");
+    await insertText(editor, "[]");
+    await insertSpace(editor);
     await insertText(editor, "/numberedlist");
     await press("Enter");
     expect(getContent(el)).toBe(`<ol><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`);

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -1,7 +1,7 @@
 import { describe, test } from "@odoo/hoot";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { base64Img, testEditor } from "./_helpers/editor";
-import { insertText } from "./_helpers/user_actions";
+import { insertSpace, insertText } from "./_helpers/user_actions";
 
 describe("inline code", () => {
     test("should convert text into inline code (start)", async () => {
@@ -303,7 +303,7 @@ describe("pre", () => {
     test("should create pre block on triple-backtick", async () => {
         await testEditor({
             contentBefore: "<p>```[]</p>",
-            stepFunction: async (editor) => await insertText(editor, " "),
+            stepFunction: async (editor) => await insertSpace(editor),
             contentAfterEdit: '<pre o-we-hint-text="Code" class="o-we-hint">[]<br></pre>',
             contentAfter: "<pre>[]<br></pre>",
         });

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import { press, queryFirst } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
-import { insertText, tripleClick, undo } from "./_helpers/user_actions";
+import { insertSpace, insertText, tripleClick, undo } from "./_helpers/user_actions";
 import { animationFrame } from "@odoo/hoot-mock";
 import { defineStyle } from "@web/../tests/web_test_helpers";
 
@@ -1320,22 +1320,25 @@ describe("to blockquote", () => {
 describe("transform", () => {
     test("should transform space preceding by a hashtag to heading 1", async () => {
         const { el, editor } = await setupEditor("<p>[]</p>");
-        await insertText(editor, "# ");
+        await insertText(editor, "#");
+        await insertSpace(editor);
         expect(getContent(el)).toBe(`<h1 o-we-hint-text="Heading 1" class="o-we-hint">[]<br></h1>`);
 
         undo(editor);
-        expect(getContent(el)).toBe(`<p># []</p>`);
+        expect(getContent(el)).toBe(`<p>#&nbsp;[]</p>`);
     });
 
     test("should transform space preceding by two hashtags to heading 2", async () => {
         const { el, editor } = await setupEditor("<p>[]</p>");
-        await insertText(editor, "## ");
+        await insertText(editor, "##");
+        await insertSpace(editor);
         expect(getContent(el)).toBe(`<h2 o-we-hint-text="Heading 2" class="o-we-hint">[]<br></h2>`);
     });
 
     test("should transform space preceding by three hashtags to heading 3", async () => {
         const { el, editor } = await setupEditor("<p>[]<br></p>");
-        await insertText(editor, "### ");
+        await insertText(editor, "###");
+        await insertSpace(editor);
         expect(getContent(el)).toBe(`<h3 o-we-hint-text="Heading 3" class="o-we-hint">[]<br></h3>`);
     });
 
@@ -1368,7 +1371,8 @@ describe("transform", () => {
 
     test("should transform three dashes in an empty block to separator before the block", async () => {
         const { el, editor } = await setupEditor("<p>[]<br></p>");
-        await insertText(editor, "--- ");
+        await insertText(editor, "---");
+        await insertSpace(editor);
         expect(getContent(el)).toBe(
             `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p><hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
@@ -1384,7 +1388,8 @@ describe("transform", () => {
 
     test("should transform space preceding by greater-than symbol to blockquote", async () => {
         const { el, editor } = await setupEditor("<p>[]<br></p>");
-        await insertText(editor, "> ");
+        await insertText(editor, ">");
+        await insertSpace(editor);
         expect(getContent(el)).toBe(
             `<blockquote o-we-hint-text="Quote" class="o-we-hint">[]<br></blockquote>`
         );


### PR DESCRIPTION
Description of the feature this PR addresses:

- To improve text formatting usability, typing ASCII arrows such as '->', '<-', or '=>' followed by a space will automatically replace them with their corresponding Unicode arrow symbols.
- The replacement is reversible using Ctrl + Z (undo), restoring the original typed ASCII sequence.

Supported replacements:
- '->' to '→'
- '<-' to '←'
- '=>' to '⮕'


task-5226088

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
