### PR TITLE
[FIX] web: remaining days use formatter

### DIFF
--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
@@ -1,13 +1,12 @@
 import { Component } from "@odoo/owl";
 import { evaluateExpr } from "@web/core/py_js/py";
-import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 import { getClassNameFromDecoration } from "@web/views/utils";
-import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { DateTimeField } from "../datetime/datetime_field";
 import { standardFieldProps } from "../standard_field_props";
 import { capitalize } from "@web/core/utils/strings";
+import { formatDate } from "../formatters";
 
 const { DateTime } = luxon;
 
@@ -54,9 +53,12 @@ export class RemainingDaysField extends Component {
 
     get formattedValue() {
         const { record, name } = this.props;
-        return record.fields[name].type === "datetime"
-            ? formatDateTime(record.data[name], { format: localization.dateFormat })
-            : formatDate(record.data[name]);
+        return formatDate(record.data[name]);
+    }
+
+    get numericValue() {
+        const { record, name } = this.props;
+        return formatDate(record.data[name], { numeric: true });
     }
 
     get classNames() {

--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
@@ -4,7 +4,7 @@
         <t t-if="props.readonly">
             <div
                 t-att-class="classNames"
-                t-att-title="formattedValue"
+                t-att-title="numericValue"
             >
                 <t t-esc="diffString"/>
             </div>

--- a/addons/web/static/tests/views/fields/remaining_days_field.test.js
+++ b/addons/web/static/tests/views/fields/remaining_days_field.test.js
@@ -2,7 +2,14 @@ import { beforeEach, expect, test } from "@odoo/hoot";
 import { click, edit, queryAll, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, mockDate } from "@odoo/hoot-mock";
 import { getPickerCell } from "@web/../tests/core/datetime/datetime_test_helpers";
-import { defineModels, fields, models, mountView, onRpc, contains } from "@web/../tests/web_test_helpers";
+import {
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+    contains,
+} from "@web/../tests/web_test_helpers";
 
 class Partner extends models.Model {
     date = fields.Date({ string: "A date", searchable: true });
@@ -39,8 +46,8 @@ test("RemainingDaysField on a date field in list view", async () => {
     expect(cells[2]).toHaveText("Yesterday");
     expect(cells[3]).toHaveText("In 2 days");
     expect(cells[4]).toHaveText("3 days ago");
-    expect(cells[5]).toHaveText("02/08/2018");
-    expect(cells[6]).toHaveText("06/08/2017");
+    expect(cells[5]).toHaveText("Feb 8, 2018");
+    expect(cells[6]).toHaveText("Jun 8");
     expect(cells[7]).toHaveText("");
 
     expect(queryOne(".o_field_widget > div", { root: cells[0] })).toHaveAttribute(
@@ -286,8 +293,8 @@ test("RemainingDaysField on a datetime field in list view in UTC", async () => {
         "Yesterday",
         "In 2 days",
         "3 days ago",
-        "02/08/2018",
-        "06/08/2017",
+        "Feb 8, 2018",
+        "Jun 8",
         "",
     ]);
 


### PR DESCRIPTION
Before this commit, remaining_days widget was not
using the new date formatter when showing the date.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
