### PR TITLE
[FIX] html_builder: use BaseOptionComponent in test

### DIFF
--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -2,7 +2,7 @@ import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpe
 import { BuilderList } from "@html_builder/core/building_blocks/builder_list";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { expect, test, describe } from "@odoo/hoot";
-import { Component, onError, xml } from "@odoo/owl";
+import { onError, xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
@@ -150,7 +150,7 @@ test("reorder items", async () => {
 });
 
 async function testBuilderListFaultyProps(template) {
-    class Test extends Component {
+    class Test extends BaseOptionComponent {
         static template = xml`${template}`;
         static components = { BuilderList };
         static props = ["*"];
@@ -262,7 +262,7 @@ test("hides hiddenProperties from options", async () => {
 });
 
 test("do not lose id when adjusting 'selected'", async () => {
-    class Test extends Component {
+    class Test extends BaseOptionComponent {
         static template = xml`
             <BuilderList
                 dataAttributeAction="'list'"

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -11,7 +11,7 @@ import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { withSequence } from "@html_editor/utils/resource";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
-import { Component, onWillStart, xml } from "@odoo/owl";
+import { onWillStart, xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
@@ -477,7 +477,7 @@ test("no need to define 'isApplied' method for custom action if the widget alrea
 test("useDomState callback shouldn't be called when the editingElement is removed", async () => {
     let editor;
     let count = 0;
-    class TestOption extends Component {
+    class TestOption extends BaseOptionComponent {
         static template = xml`<div class="test_option">test</div>`;
         static selector = ".s_test";
         static editableOnly = false;


### PR DESCRIPTION
In PR https://github.com/odoo/odoo/pull/220746, we forgot to replace the use of Component with BaseOptionComponent in few tests. This commit fixes that.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
