### PR TITLE
[IMP] orm: SQL alias to ease building queries

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -52,7 +52,7 @@ class AccountAccount(models.Model):
     code_store = fields.Char(company_dependent=True)
     placeholder_code = fields.Char(string="Display code", compute='_compute_placeholder_code', search='_search_placeholder_code', compute_sql='_compute_sql_placeholder_code', compute_sudo=True)
     active = fields.Boolean(default=True, tracking=True)
-    used = fields.Boolean(compute='_compute_used', search='_search_used')
+    used = fields.Boolean(compute='_compute_used', compute_sql='_compute_sql_used', compute_sudo=True)
     account_type = fields.Selection(
         selection=[
             ("asset_receivable", "Receivable"),
@@ -269,25 +269,16 @@ class AccountAccount(models.Model):
         if not accounts:
             return
 
-        self.env['account.journal'].flush_model(['company_id', 'default_account_id'])
-        self.env['account.payment.method.line'].flush_model(['journal_id', 'payment_account_id'])
+        query = self.env['account.payment.method.line'].sudo()._search(
+            Domain('payment_account_id', 'in', accounts.ids))
+        apml = query.table
+        journal_t = apml._join('journal_id', kind='JOIN')
+        query.add_where(SQL("%s <> %s", apml.payment_account_id, journal_t.default_account_id))
 
-        self.env.cr.execute('''
-            SELECT journal.id
-            FROM account_journal journal
-            JOIN res_company company on journal.company_id = company.id
-            LEFT JOIN account_payment_method_line apml ON journal.id = apml.journal_id
-            WHERE (
-                apml.payment_account_id IN %(accounts)s
-                AND apml.payment_account_id != journal.default_account_id
-            )
-        ''', {
-            'accounts': tuple(accounts.ids),
-        })
+        journals = self.env['account.journal'].browse(
+            id_ for id_, in self.env.execute_query(query.select(SQL("DISTINCT %s", journal_t.id))))
 
-        rows = self.env.cr.fetchall()
-        if rows:
-            journals = self.env['account.journal'].browse([r[0] for r in rows])
+        if journals:
             raise ValidationError(_(
                 "This account is configured in %(journal_names)s journal(s) (ids %(journal_ids)s) as payment debit or credit account. This means that this account's type should be reconcilable.",
                 journal_names=journals.mapped('display_name'),
@@ -479,22 +470,16 @@ class AccountAccount(models.Model):
         for account in accounts_with_code:
             account.group_id = group_by_code[account.code]
 
-    def _get_used_account_ids(self):
-        rows = self.env.execute_query(SQL("""
-            SELECT id FROM account_account account
-            WHERE EXISTS (SELECT 1 FROM account_move_line aml WHERE aml.account_id = account.id LIMIT 1)
-        """))
-        return [r[0] for r in rows]
-
-    def _search_used(self, operator, value):
-        if operator not in ('in', 'not in'):
-            return NotImplemented
-        return [('id', operator, self._get_used_account_ids())]
-
     def _compute_used(self):
-        ids = set(self._get_used_account_ids())
+        domain = Domain('id', 'in', self.ids) & Domain('used', '=', True)
+        used_ids = set(self.sudo().with_context(active_test=False)._search(domain))
         for record in self:
-            record.used = record.id in ids
+            record.used = record.id in used_ids
+
+    def _compute_sql_used(self, table):
+        query = Query(table._model.sudo().env['account.move.line'])
+        query.add_where(SQL("%s = %s", query.table.account_id, table.id))
+        return SQL("EXISTS %s", query.subselect(''))
 
     @api.model
     def _search_new_account_code(self, start_code, cache=None):
@@ -779,39 +764,41 @@ class AccountAccount(models.Model):
         :param limit: the maximum number of accounts to retrieve
         :returns: List of account ids, ordered by frequency (from most to least frequent)
         """
+        account_domain = Domain('active', '=', True)
+        if move_type in self.env['account.move'].get_inbound_types(include_receipts=True):
+            account_domain &= Domain('internal_group', '=', 'income')
+        elif move_type in self.env['account.move'].get_outbound_types(include_receipts=True):
+            account_domain &= Domain('internal_group', '=', 'expense')
         domain = [
             *self.env['account.move.line']._check_company_domain(company_id),
             ('partner_id', '=', partner_id),
-            ('account_id.active', '=', True),
+            ('account_id', 'any', account_domain),
             ('date', '>=', fields.Date.add(fields.Date.today(), days=-365 * 2)),
         ]
-        if move_type in self.env['account.move'].get_inbound_types(include_receipts=True):
-            domain.append(('account_id.internal_group', '=', 'income'))
-        elif move_type in self.env['account.move'].get_outbound_types(include_receipts=True):
-            domain.append(('account_id.internal_group', '=', 'expense'))
+        company = self.env['res.company'].browse(company_id)
 
         query = self.env['account.move.line']._search(domain, bypass_access=True)
-        if not filter_never_user_accounts:
-            _kind, rhs_table, condition = query._joins['account_move_line__account_id']
-            query._joins['account_move_line__account_id'] = (SQL("RIGHT JOIN"), rhs_table, condition)
+        query.groupby = query.table.account_id.id
+        if filter_never_user_accounts:
+            account_t = query.groupby._table
+            code_sql = account_t._with_model(self.with_company(company)).code
+            query.order = SQL("COUNT(%s) DESC, MAX(%s)", query.table.id, code_sql)
+            query.limit = limit
+            sql = query.select(query.groupby)
+        else:
+            aml_sql = query.subselect(
+                query.groupby,
+                SQL("COUNT(%s) AS num", query.table.id),
+            )
+            query = self._search(account_domain)
+            account_t = query.table
+            query.add_join('LEFT JOIN', 'counts', aml_sql, SQL("%s = counts.id", account_t.id))
+            code_sql = account_t._with_model(self.with_company(company)).code
+            query.order = SQL('counts.num DESC NULLS LAST, %s', code_sql)
+            query.limit = limit
+            sql = query.select()
 
-        company = self.env['res.company'].browse(company_id)
-        code_sql = self.with_company(company)._field_to_sql('account_move_line__account_id', 'code', query)
-
-        return [r[0] for r in self.env.execute_query(SQL(
-            """
-                SELECT account_move_line__account_id.id
-                  FROM %(from_clause)s
-                 WHERE %(where_clause)s
-              GROUP BY account_move_line__account_id.id
-              ORDER BY COUNT(account_move_line.id) DESC, MAX(%(code_sql)s)
-                %(limit_clause)s
-            """,
-            from_clause=query.from_clause,
-            where_clause=query.where_clause or SQL("TRUE"),
-            code_sql=code_sql,
-            limit_clause=SQL("LIMIT %s", limit) if limit else SQL(),
-        ))]
+        return [id_ for id_, in self.env.execute_query(sql)]
 
     @api.model
     def _get_most_frequent_account_for_partner(self, company_id, partner_id, move_type=None):

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -822,21 +822,21 @@ class AccountAccount(models.Model):
     def _order_accounts_by_frequency_for_partner(self, company_id, partner_id, move_type=None):
         return self._get_most_frequent_accounts_for_partner(company_id, partner_id, move_type)
 
-    def _order_to_sql(self, order: str, query: Query, alias: (str | None) = None, reverse: bool = False) -> SQL:
-        sql_order = super()._order_to_sql(order, query, alias, reverse)
+    def _order_to_sql(self, table, order: str, reverse=False) -> SQL:
+        sql_order = super()._order_to_sql(table, order, reverse)
 
         if order == self._order and (preferred_account_type := self.env.context.get('preferred_account_type')):
             sql_order = SQL(
                 "%(field_sql)s = %(preferred_account_type)s %(direction)s, %(base_order)s",
-                field_sql=self._field_to_sql(alias or self._table, 'account_type'),
+                field_sql=table.account_type,
                 preferred_account_type=preferred_account_type,
                 direction=SQL('ASC') if reverse else SQL('DESC'),
                 base_order=sql_order,
             )
         if order == self._order and (preferred_account_ids := self.env.context.get('preferred_account_ids')):
             sql_order = SQL(
-                "%(alias)s.id in %(preferred_account_ids)s %(direction)s, %(base_order)s",
-                alias=SQL.identifier(alias or self._table),
+                "%(id)s in %(preferred_account_ids)s %(direction)s, %(base_order)s",
+                id=table.id,
                 preferred_account_ids=tuple(map(int, preferred_account_ids)),
                 direction=SQL('ASC') if reverse else SQL('DESC'),
                 base_order=sql_order,

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1274,8 +1274,8 @@ class AccountAccount(models.Model):
             with contextlib.suppress(ValueError):
                 query = Query(self.env[model])
                 return query.select(
-                    SQL('%s AS id', self.env[model]._field_to_sql(query.table, 'id')),
-                    SQL('%s AS company_id', self.env[model]._field_to_sql(query.table, company_id_field, query)),
+                    SQL('%s AS id', query.table.id),
+                    SQL('%s AS company_id', query.table[company_id_field]),
                 )
 
         # Step 1: Check access rights.

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -41,9 +41,9 @@ class AccountAccountTag(models.Model):
         self.check_access('read')
         query = self._as_query(ordered=False)
         id2expression = {tag_id: vals for tag_id, *vals in self.env.execute_query(query.select(
-            SQL.identifier(query.table, 'id'),
-            self._field_to_sql(query.table, 'report_expression_id', query),
-            self._field_to_sql(query.table, 'balance_negate', query),
+            query.table.id,
+            query.table.report_expression_id,
+            query.table.balance_negate,
         ))}
         for tag in self:
             tag.report_expression_id, tag.balance_negate = id2expression.get(tag._origin.id, (False, False))

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -48,24 +48,23 @@ class AccountAccountTag(models.Model):
         for tag in self:
             tag.report_expression_id, tag.balance_negate = id2expression.get(tag._origin.id, (False, False))
 
-    def _compute_sql_report_expression_id(self, alias, query):
-        rhs_alias = query.make_alias(alias, 'expression')
-        query.add_join(
-            kind='LEFT JOIN',
-            alias=rhs_alias,
-            table='account_report_expression',
-            condition=SQL(
+    def _join_report_expression(self, table):
+        expr_t = table._make_alias('expression', self.env['account.report.expression'])
+        table._query.add_join(
+            'LEFT JOIN', expr_t, None, SQL(
                 "%s->>'en_US' = LTRIM(%s, '-')",
-                SQL.identifier(alias, 'name'),
-                SQL.identifier(rhs_alias, 'formula'),
+                SQL.identifier(table._alias, 'name'),
+                expr_t.formula,
             ),
         )
-        return SQL.identifier(rhs_alias, 'id')
+        return expr_t
 
-    def _compute_sql_balance_negate(self, alias, query):
-        self._compute_sql_report_expression_id(alias, query)  # generate the join
-        rhs_alias = query.make_alias(alias, 'expression')
-        return SQL("STARTS_WITH(%s, '-')", SQL.identifier(rhs_alias, 'formula'))
+    def _compute_sql_report_expression_id(self, table):
+        return self._join_report_expression(table).id
+
+    def _compute_sql_balance_negate(self, table):
+        expr_t = self._join_report_expression(table)
+        return SQL("STARTS_WITH(%s, '-')", expr_t.formula)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -818,9 +818,8 @@ class AccountMove(models.Model):
         for move in self:
             move.move_sent_values = 'sent' if move.is_move_sent else 'not_sent'
 
-    def _compute_sql_move_sent_values(self, alias, query):
-        is_move_sent = self._field_to_sql(alias, 'is_move_sent', query)
-        return SQL("CASE WHEN %s THEN 'sent' ELSE 'not_sent' END", is_move_sent)
+    def _compute_sql_move_sent_values(self, table):
+        return SQL("CASE WHEN %s THEN 'sent' ELSE 'not_sent' END", table.is_move_sent)
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (
@@ -1327,10 +1326,10 @@ class AccountMove(models.Model):
             if not move.status_in_payment:
                 move.status_in_payment = move.state
 
-    def _compute_sql_status_in_payment(self, alias, query):
+    def _compute_sql_status_in_payment(self, table):
         # TODO not the same logic as the compute?
-        state = self._field_to_sql(alias, 'state', query)
-        payment_state = self._field_to_sql(alias, 'payment_state', query)
+        state = table.state
+        payment_state = table.payment_state
         return SQL("""CASE
             WHEN %s = 'draft' THEN 'draft'
             WHEN %s = 'cancel' THEN 'cancel'

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1157,15 +1157,15 @@ class AccountMoveLine(models.Model):
         for line in self:
             line.payment_date = line.discount_date if line.discount_date and date.today() <= line.discount_date else line.date_maturity
 
-    def _compute_sql_payment_date(self, alias, query):
+    def _compute_sql_payment_date(self, table):
         return SQL("""
             CASE
                 WHEN %(discount_date)s IS NOT NULL AND %(today)s <= %(discount_date)s THEN %(discount_date)s
                 ELSE %(date_maturity)s
             END""",
             today=fields.Date.context_today(self),
-            discount_date=self._field_to_sql(alias, "discount_date", query),
-            date_maturity=self._field_to_sql(alias, "date_maturity", query),
+            discount_date=table.discount_date,
+            date_maturity=table.date_maturity,
         )
 
     @api.depends('matched_debit_ids', 'matched_credit_ids')

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1960,24 +1960,12 @@ class AccountMoveLine(models.Model):
             return {}
 
         # Override in order to not read the complete move line table and use the index instead
-        query_account = self.env['account.account']._search([('company_ids', 'in', self.env.companies.ids), ('code', '!=', False)])
-        account_code_alias = self.env['account.account']._field_to_sql('account_account', 'code', query_account)
-
-        query_line = self._search(domain, limit=1)
-        query_line.add_where('account_account.id = account_move_line.account_id')
-
-        account_codes = self.env.execute_query(SQL(
-            """
-            SELECT %(account_code_alias)s AS code
-              FROM %(account_table)s
-             WHERE EXISTS(%(line_select)s)
-               AND %(where_clause)s
-            """,
-            account_code_alias=account_code_alias,
-            account_table=query_account.from_clause,
-            line_select=query_line.select(),
-            where_clause=query_account.where_clause,
-        ))
+        query_account = self.env['account.account']._search([
+            ('company_ids', 'in', self.env.companies.ids),
+            ('code', '!=', False),
+            ('line_ids', 'any', domain),
+        ])
+        account_codes = self.env.execute_query(query_account.select(SQL("DISTINCT %s", query_account.table.code)))
         return {
             (root := self.env['account.root']._from_account_code(code)).id: {'id': root.id, 'display_name': root.display_name}
             for code, in account_codes

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -762,7 +762,7 @@ class AccountMoveLine(models.Model):
 
         # get the where clause
         query = self._search(self.env.context.get('domain_cumulated_balance') or [], bypass_access=True)
-        sql_order = self._order_to_sql(self.env.context.get('order_cumulated_balance'), query, reverse=True)
+        sql_order = self._order_to_sql(query.table, self.env.context.get('order_cumulated_balance'), reverse=True)
         result = dict(self.env.execute_query(query.select(
             query.table.id,
             SQL(

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -764,10 +764,10 @@ class AccountMoveLine(models.Model):
         query = self._search(self.env.context.get('domain_cumulated_balance') or [], bypass_access=True)
         sql_order = self._order_to_sql(self.env.context.get('order_cumulated_balance'), query, reverse=True)
         result = dict(self.env.execute_query(query.select(
-            SQL.identifier(query.table, "id"),
+            query.table.id,
             SQL(
                 "SUM(%s) OVER (ORDER BY %s ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
-                SQL.identifier(query.table, "balance"),
+                query.table.balance,
                 sql_order,
             ),
         )))

--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -6,7 +6,7 @@ from odoo.fields import Domain
 
 def _subselect_domain(model, field_name, domain):
     query = model._search(Domain(field_name, '!=', False) & domain, active_test=False, bypass_access=True)
-    return Domain('id', 'in', query.subselect(model._field_to_sql(query.table, field_name, query)))
+    return Domain('id', 'in', query.subselect(query.table[field_name]))
 
 
 bypass_token = object()

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -1,5 +1,5 @@
 from odoo import models, fields, api
-from odoo.models import Query
+from odoo.models import TableSQL
 from odoo.tools import SQL
 from odoo.addons.account.models.account_move import PAYMENT_STATE_SELECTION
 
@@ -153,14 +153,12 @@ class AccountInvoiceReport(models.Model):
             ''',
         )
 
-    def _read_group_select(self, aggregate_spec: str, query: Query) -> SQL:
+    def _read_group_select(self, table: TableSQL, aggregate_spec: str) -> SQL:
         """ This override allows us to correctly calculate the average price of products. """
         if aggregate_spec != 'price_average:avg':
-            return super()._read_group_select(aggregate_spec, query)
+            return super()._read_group_select(table, aggregate_spec)
         return SQL(
-            'COALESCE(SUM(%(f_price)s) / NULLIF(SUM(%(f_qty)s), 0.0), 0)',
-            f_qty=self._field_to_sql(self._table, 'quantity', query),
-            f_price=self._field_to_sql(self._table, 'price_subtotal', query),
+            'COALESCE(SUM(%s) / NULLIF(SUM(%s), 0.0), 0)', table.price_subtotal, table.quantity,
         )
 
 

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -125,7 +125,7 @@ class AccountAnalyticAccount(models.Model):
             self_context = self.with_context(analytic_plan_id=self.plan_id.id)
         return super(AccountAnalyticAccount, self_context).web_read(specification)
 
-    def _read_group_select(self, aggregate_spec, query):
+    def _read_group_select(self, table, aggregate_spec):
         # flag balance/debit/credit as aggregatable, and manually sum the values
         # from the records in the group
         if aggregate_spec in (
@@ -136,8 +136,8 @@ class AccountAnalyticAccount(models.Model):
             'credit:sum',
             'credit:sum_currency',
         ):
-            return super()._read_group_select('id:recordset', query)
-        return super()._read_group_select(aggregate_spec, query)
+            aggregate_spec = 'id:recordset'
+        return super()._read_group_select(table, aggregate_spec)
 
     def _read_group_postprocess_aggregate(self, aggregate_spec, raw_values):
         if aggregate_spec in (

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -108,15 +108,16 @@ class AnalyticMixin(models.AbstractModel):
                 table.analytic_distribution,
             ))
 
-    def _read_group_groupby(self, alias: str, groupby_spec: str, query: Query) -> SQL:
+    def _read_group_groupby(self, table, groupby_spec) -> SQL:
         """To group by `analytic_distribution`, we first need to separate the analytic_ids and associate them with the ids to be counted
         Do note that only '__count' can be passed in the `aggregates`"""
         if groupby_spec == 'analytic_distribution':
+            query = table._query
             query._joins = {
                 'distribution': (SQL(), SQL(
                     r"""(SELECT DISTINCT %s, (regexp_matches(jsonb_object_keys(%s), '\d+', 'g'))[1]::int AS account_id FROM %s WHERE %s)""",
                     self._get_count_id(query),
-                    self._field_to_sql(self._table, 'analytic_distribution', query),
+                    table.analytic_distribution,
                     query.from_clause,
                     query.where_clause,
                 ), SQL())
@@ -126,7 +127,7 @@ class AnalyticMixin(models.AbstractModel):
             query._where_clauses = []
             return SQL("account_id")
 
-        return super()._read_group_groupby(alias, groupby_spec, query)
+        return super()._read_group_groupby(table, groupby_spec)
 
     def _read_group_select(self, aggregate_spec: str, query: Query) -> SQL:
         if query.table._alias == 'distribution' and aggregate_spec != '__count':

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
-from odoo.models import Query
 from odoo.tools import SQL, unique
 from odoo.tools.float_utils import float_compare, float_round
 
@@ -129,10 +128,10 @@ class AnalyticMixin(models.AbstractModel):
 
         return super()._read_group_groupby(table, groupby_spec)
 
-    def _read_group_select(self, aggregate_spec: str, query: Query) -> SQL:
-        if query.table._alias == 'distribution' and aggregate_spec != '__count':
+    def _read_group_select(self, table, aggregate_spec: str) -> SQL:
+        if table._alias == 'distribution' and aggregate_spec != '__count':
             raise ValueError(f"analytic_distribution grouping does not accept {aggregate_spec} as aggregate.")
-        return super()._read_group_select(aggregate_spec, query)
+        return super()._read_group_select(table, aggregate_spec)
 
     def _get_count_id(self, query):
         match query.table._alias:

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -95,17 +95,17 @@ class AnalyticMixin(models.AbstractModel):
         # keys can be comma-separated ids, we will split those into an array and then make an array comparison with the list of ids to check
         ids = [str(id_) for id_ in ids if id_]  # list of ids -> list of string
         if operator == 'in':
-            return Domain.custom(to_sql=lambda model, alias, query: SQL(
+            return Domain.custom(to_sql=lambda table: SQL(
                 "%s && %s",
-                self._query_analytic_accounts(alias),
+                self._query_analytic_accounts(table._alias),
                 ids,
             ))
         else:
-            return Domain.custom(to_sql=lambda model, alias, query: SQL(
+            return Domain.custom(to_sql=lambda table: SQL(
                 "(NOT %s && %s OR %s IS NULL)",
-                self._query_analytic_accounts(alias),
+                self._query_analytic_accounts(table._alias),
                 ids,
-                model._field_to_sql(alias, 'analytic_distribution', query),
+                table.analytic_distribution,
             ))
 
     def _read_group_groupby(self, alias: str, groupby_spec: str, query: Query) -> SQL:

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2774,21 +2774,23 @@ class CrmLead(models.Model):
             # active_test = False as domain should take active into 'active' field it self
             query = self.env['crm.lead'].with_context(active_test=False)._search(domain, bypass_access=True)
             table = query.table
-            query.order = SQL("%(table)s.team_id asc, %(table)s.id desc", table=SQL.identifier(table))
-            sql_fields = [SQL.identifier(field) for field in pls_fields]
+            query.order = SQL("%s asc, %s desc", table.team_id, table.id)
             self.env.cr.execute(query.select(
-                SQL("id"),
-                SQL("probability"),
-                *sql_fields,
+                table.id,
+                table.probability,
+                *(
+                    table[field]
+                    for field in pls_fields
+                ),
             ))
             lead_results = self.env.cr.dictfetchall()
 
             if use_tags:
                 # Get tags values
-                tag_rel_alias = query.left_join(table, 'id', 'crm_tag_rel', 'lead_id', 'crm_tag_rel')
+                tag_rel_alias = query.left_join(table._alias, 'id', 'crm_tag_rel', 'lead_id', 'crm_tag_rel')
                 tag_alias = query.left_join(tag_rel_alias, 'tag_id', 'crm_tag', 'id', 'crm_tag')
                 self.env.cr.execute(query.select(
-                    SQL("%s AS lead_id", SQL.identifier(table, "id")),
+                    SQL("%s AS lead_id", table.id),
                     SQL("%s AS tag_id", SQL.identifier(tag_alias, "id")),
                 ))
                 tag_results = self.env.cr.dictfetchall()

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -13,7 +13,7 @@ from odoo.addons.phone_validation.tools import phone_validation
 from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.fields import Domain
 from odoo.tools.translate import _
-from odoo.tools import date_utils, email_normalize_all, is_html_empty, groupby, parse_contact_from_email, SQL
+from odoo.tools import email_normalize_all, is_html_empty, groupby, parse_contact_from_email, SQL
 from odoo.tools.misc import get_lang
 
 from . import crm_stage
@@ -282,16 +282,10 @@ class CrmLead(models.Model):
             else:
                 lead.company_currency = lead.company_id.currency_id
 
-    def _compute_sql_company_currency(self, alias, query):
-        alias_company = query.make_alias(alias, 'company_id')
-        company_field_sql = self._field_to_sql(alias, 'company_id', query)
-        query.add_join('LEFT JOIN', alias_company, 'res_company', SQL(
-            "%s = %s", company_field_sql, SQL.identifier(alias_company, 'id'),
-        ))
-        company_currency_expr = self.env['res.company']._field_to_sql(alias_company, 'currency_id', query)
+    def _compute_sql_company_currency(self, table):
         return SQL(
             '(CASE WHEN %s IS NOT NULL THEN %s ELSE %s END)',
-            company_field_sql, company_currency_expr, self.env.company.currency_id.id
+            table.company_id, table.company_id.currency_id, self.env.company.currency_id.id
         )
 
     @api.depends('user_id', 'type')

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2781,11 +2781,10 @@ class CrmLead(models.Model):
 
             if use_tags:
                 # Get tags values
-                tag_rel_alias = query.left_join(table._alias, 'id', 'crm_tag_rel', 'lead_id', 'crm_tag_rel')
-                tag_alias = query.left_join(tag_rel_alias, 'tag_id', 'crm_tag', 'id', 'crm_tag')
+                tag_t = table._join('tag_ids', only_ids=True)
                 self.env.cr.execute(query.select(
                     SQL("%s AS lead_id", table.id),
-                    SQL("%s AS tag_id", SQL.identifier(tag_alias, "id")),
+                    SQL("%s AS tag_id", tag_t.id),
                 ))
                 tag_results = self.env.cr.dictfetchall()
             else:

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -628,10 +628,10 @@ class HrEmployee(models.Model):
         domain = Domain('id', operator, value)
         return Domain('id', 'in', self.env['hr.version']._search(domain).select('employee_id'))
 
-    def _compute_sql_version_id(self, alias, query):
+    def _compute_sql_version_id(self, table):
         # HACK required to make inherits work on a computed field
         # (could be a CASE WHEN with the version_id from the content for the current user)
-        return self._field_to_sql(alias, 'current_version_id', query)
+        return table.current_version_id
 
     def _get_version(self, date=fields.Date.today()):
         """

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -153,10 +153,10 @@ class HrJob(models.Model):
         favorited_jobs.write({'favorite_user_ids': [(4, self.env.uid)]})
         unfavorited_jobs.write({'favorite_user_ids': [(3, self.env.uid)]})
 
-    def _compute_sql_is_favorite(self, alias, query):
+    def _compute_sql_is_favorite(self, table):
         return SQL(
             "%s IN (SELECT job_id FROM job_favorite_user_rel WHERE user_id = %s)",
-            SQL.identifier(alias, 'id'), self.env.uid,
+            table.id, self.env.uid,
         )
 
     def _compute_document_ids(self):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -134,22 +134,15 @@ class DiscussChannelMember(models.Model):
         if operator != 'in':
             return NotImplemented
 
-        def custom_pinned(model: models.BaseModel, alias, query):
-            channel_model = model.browse().channel_id
-            channel_alias = query.make_alias(alias, 'channel_id')
-            query.add_join("LEFT JOIN", channel_alias, channel_model._table, SQL(
-                "%s = %s",
-                model._field_to_sql(alias, 'channel_id'),
-                channel_model._field_to_sql(channel_alias, 'id'),
-            ))
+        def custom_pinned(table):
             return SQL(
                 """(%(unpin)s IS NULL
                     OR %(last_interest)s >= %(unpin)s
                     OR %(channel_last_interest)s >= %(unpin)s
                 )""",
-                unpin=model._field_to_sql(alias, "unpin_dt", query),
-                last_interest=model._field_to_sql(alias, "last_interest_dt", query),
-                channel_last_interest=channel_model._field_to_sql(channel_alias, "last_interest_dt", query),
+                unpin=table.unpin_dt,
+                last_interest=table.last_interest_dt,
+                channel_last_interest=table.channel_id.last_interest_dt,
             )
 
         return Domain.custom(to_sql=custom_pinned)

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -54,12 +54,12 @@ class ProductProduct(models.Model):
         'total_margin', 'expected_margin', 'total_margin_rate', 'expected_margin_rate',
     )}
 
-    def _read_group_select(self, aggregate_spec, query):
+    def _read_group_select(self, table, aggregate_spec):
         # the purpose of this override is to flag the aggregates above as such:
         # field._description_aggregator() should simply not fail
         if aggregate_spec in self._SPECIAL_SUM_AGGREGATES:
             return SQL()
-        return super()._read_group_select(aggregate_spec, query)
+        return super()._read_group_select(table, aggregate_spec)
 
     @api.model
     def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None):

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -77,10 +77,10 @@ class ProjectProject(models.Model):
         for project in self:
             project.is_favorite = project in favorite_project_ids
 
-    def _compute_sql_is_favorite(self, alias, query):
+    def _compute_sql_is_favorite(self, table):
         return SQL(
             "%s IN (SELECT project_id FROM project_favorite_user_rel WHERE user_id = %s)",
-            SQL.identifier(alias, 'id'), self.env.uid,
+            table.id, self.env.uid,
         )
 
     def _set_favorite_user_ids(self, is_favorite):

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -66,7 +66,6 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
         # to be able to reduce the number of treated records in the query by limiting them to the one corresponding to
         # the ids that are returned from this sub query.
         project_task_query = self.env['project.task']._search(task_specific_domain, **kwargs)
-        self.env.flush_query(project_task_query.subselect())
 
         # Get the stage_id `ir.model.fields`'s id in order to inject it directly in the query and avoid having to join
         # on `ir_model_fields` table.

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -237,10 +237,10 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
         non_task_specific_domain = filter_domain_leaf(domain, lambda field: field not in self.task_specific_fields)
         return non_task_specific_domain, task_specific_domain
 
-    def _read_group_select(self, aggregate_spec, query):
+    def _read_group_select(self, table, aggregate_spec):
         if aggregate_spec == '__count':
             return SQL("SUM(%s)", SQL.identifier(self._table, '__count'))
-        return super()._read_group_select(aggregate_spec, query)
+        return super()._read_group_select(table, aggregate_spec)
 
     def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None):
         self._validate_group_by(groupby)

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.models import TableSQL
 from odoo.tools import SQL
 from odoo.addons.resource.models.utils import filter_domain_leaf
 
@@ -78,7 +79,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
         interval = date_groupby.split(':')[1]
         sql_interval = '1 %s' % interval if interval != 'quarter' else '3 month'
 
-        simple_date_groupby_sql = self._read_group_groupby('project_task_burndown_chart_report', f"date:{interval}", main_query)
+        simple_date_groupby_sql = self._read_group_groupby(TableSQL('project_task_burndown_chart_report', self, main_query), f"date:{interval}")
         # Removing unexistant table name from the expression
         simple_date_groupby_sql = self.env.cr.mogrify(simple_date_groupby_sql).decode()
         simple_date_groupby_sql = simple_date_groupby_sql.replace('"project_task_burndown_chart_report".', '')

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -367,11 +367,7 @@ class PurchaseOrder(models.Model):
             return NotImplemented
         purchase_domain = Domain('state', '=', 'purchase') & Domain('date_planned', '<=', fields.Datetime.now())
         line_domain = Domain('order_id', 'any', purchase_domain) & Domain.custom(
-            to_sql=lambda model, alias, query: SQL(
-                "%s < %s",
-                model._field_to_sql(alias, 'qty_received', query),
-                model._field_to_sql(alias, 'product_qty', query),
-            )
+            to_sql=lambda table: SQL("%s < %s", table.qty_received, table.product_qty),
         )
         return Domain('order_line', 'any', line_domain)
 

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -5,7 +5,6 @@
 #
 
 from odoo import fields, models
-from odoo.models import Query
 from odoo.tools.sql import SQL
 
 
@@ -150,12 +149,12 @@ class PurchaseReport(models.Model):
             """,
         )
 
-    def _read_group_select(self, aggregate_spec: str, query: Query) -> SQL:
+    def _read_group_select(self, table, aggregate_spec: str) -> SQL:
         """ This override allows us to correctly calculate the average price of products. """
         if aggregate_spec != 'price_average:avg':
-            return super()._read_group_select(aggregate_spec, query)
+            return super()._read_group_select(table, aggregate_spec)
         return SQL(
             'SUM(%(f_price)s * %(f_qty)s) / NULLIF(SUM(%(f_qty)s), 0.0)',
-            f_qty=self._field_to_sql(self._table, 'qty_ordered', query),
-            f_price=self._field_to_sql(self._table, 'price_average', query),
+            f_price=table.price_average,
+            f_qty=table.qty_ordered,
         )

--- a/addons/purchase_stock/report/vendor_delay_report.py
+++ b/addons/purchase_stock/report/vendor_delay_report.py
@@ -51,16 +51,14 @@ FROM   stock_move m
 GROUP  BY pol.id
 )""")
 
-    def _read_group_select(self, aggregate_spec, query):
+    def _read_group_select(self, table, aggregate_spec):
         if aggregate_spec == 'on_time_rate:sum':
             # Make a weigthed average instead of simple average for these fields
             return SQL(
                 'CASE WHEN SUM(%s) !=0 THEN SUM(%s) / SUM(%s) * 100 ELSE 100 END',
-                self._field_to_sql(self._table, 'qty_total', query),
-                self._field_to_sql(self._table, 'qty_on_time', query),
-                self._field_to_sql(self._table, 'qty_total', query),
+                table.qty_total, table.qty_on_time, table.qty_total,
             )
-        return super()._read_group_select(aggregate_spec, query)
+        return super()._read_group_select(table, aggregate_spec)
 
     def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None):
         if 'on_time_rate:sum' in aggregates:

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -386,9 +386,8 @@ class ProductProduct(models.Model):
             dest_loc_domain = Domain('location_dest_id', 'in', locations.ids)
             dest_loc_domain_out = Domain('location_dest_id', 'not in', locations.ids)
         elif locations:
-            alias = locations._table + '_inner'
-            paths_query = models.Query(locations.env, alias, SQL.identifier(locations._table))
-            paths_query.add_where(alias + '.parent_path LIKE ANY(%s)', [[loc.parent_path + '%' for loc in locations]])
+            paths_query = models.Query(locations)
+            paths_query.add_where(SQL('%s LIKE ANY(%s)', paths_query.table.parent_path, [[loc.parent_path + '%' for loc in locations]]))
             loc_domain = Domain('location_id', 'in', paths_query)
             # The condition should be split for done and not-done moves as the final_dest_id only make sense
             # for the part of the move chain that is not done yet.

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -242,10 +242,10 @@ class StockPickingType(models.Model):
         to_fav.write({'favorite_user_ids': [(4, self.env.uid)]})
         (sudoed_self - to_fav).write({'favorite_user_ids': [(3, self.env.uid)]})
 
-    def _compute_sql_is_favorite(self, alias, query):
+    def _compute_sql_is_favorite(self, table):
         return SQL(
             "%s IN (SELECT picking_type_id FROM picking_type_favorite_user_rel WHERE user_id = %s)",
-            SQL.identifier(alias, 'id'), self.env.uid,
+            table.id, self.env.uid,
         )
 
     @api.depends('code')

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -325,16 +325,16 @@ class StockQuant(models.Model):
         """ Only allowed fields should be modified """
         return super(StockQuant, self.with_context(inventory_mode=True))._load_records_write(values)
 
-    def _read_group_select(self, aggregate_spec, query):
+    def _read_group_select(self, table, aggregate_spec):
         if aggregate_spec == 'inventory_quantity:sum' and self.env.context.get('inventory_report_mode'):
             return SQL("NULL")
         if aggregate_spec == 'available_quantity:sum':
-            sql_quantity = self._read_group_select('quantity:sum', query)
-            sql_reserved_quantity = self._read_group_select('reserved_quantity:sum', query)
+            sql_quantity = self._read_group_select(table, 'quantity:sum')
+            sql_reserved_quantity = self._read_group_select(table, 'reserved_quantity:sum')
             return SQL("%s - %s", sql_quantity, sql_reserved_quantity)
         if aggregate_spec == 'inventory_quantity_auto_apply:sum':
-            return self._read_group_select('quantity:sum', query)
-        return super()._read_group_select(aggregate_spec, query)
+            return self._read_group_select(table, 'quantity:sum')
+        return super()._read_group_select(table, aggregate_spec)
 
     @api.model
     def get_import_templates(self):

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -64,12 +64,12 @@ class StockQuant(models.Model):
                 continue
             quant.value = quant.quantity * value / quantity
 
-    def _read_group_select(self, aggregate_spec, query):
+    def _read_group_select(self, table, aggregate_spec):
         # flag value as aggregatable, and manually sum the values from the
         # records in the group
         if aggregate_spec in ('value:sum', 'value:sum_currency'):
-            return super()._read_group_select('id:recordset', query)
-        return super()._read_group_select(aggregate_spec, query)
+            aggregate_spec = 'id:recordset'
+        return super()._read_group_select(table, aggregate_spec)
 
     def _read_group_postprocess_aggregate(self, aggregate_spec, raw_values):
         if aggregate_spec in ('value:sum', 'value:sum_currency'):

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -295,7 +295,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 52  # To increase this number you must ask the permission to al
+        query_count = 51  # To increase this number you must ask the permission to al
         queries = {
             'orm_signaling_registry': 1,
             'website': 2,
@@ -303,7 +303,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             'product_pricelist': 4,
             'product_template': 6,
             'product_tag': 1,
-            'product_public_category': 6,
+            'product_public_category': 5,
             'product_product': 1,
             'product_template_attribute_line': 3,
             'res_users': 1,

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -318,7 +318,7 @@ class Export(http.Controller):
             # Depends of the records selected to avoid showing useless Properties
             if domain:
                 self_subquery = Model.with_context(active_test=False)._search(domain)
-                field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
+                field_to_get = self_subquery.table[definition_record]
                 domain_definition.append(('id', 'in', self_subquery.subselect(field_to_get)))
 
             definition_records = target_model.search_fetch(

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -2177,7 +2177,7 @@ class Website(models.Model):
                 similarities=SQL(", ").join(
                     SQL("word_similarity(%(search)s, %(field)s)",
                         search=unaccent(SQL("%s", search)),
-                        field=unaccent(model._field_to_sql(model._table, field, subquery)),
+                        field=unaccent(subquery.table[field]),
                     )
                     for field in fields
                 ),
@@ -2186,18 +2186,16 @@ class Website(models.Model):
             for field_name in fields:
                 field = model._fields[field_name]
                 if field.translate:
-                    alias = model._table
-                    if field.related and not field.store:
-                        _model, field, alias = field.traverse_related_sql(model, model._table, subquery)
+                    raw_field = subquery.table._with_model(model.with_context(prefetch_langs=True))[field_name]
                     where_clauses.append(SQL("(%(search)s <%% %(jsonb_path)s AND %(search)s <%% (%(field)s))",
                         search=unaccent(SQL("%s", search)),
-                        jsonb_path=unaccent(SQL("jsonb_path_query_array(%s, '$.*')::text", SQL.identifier(alias, field.name))),
-                        field=unaccent(model._field_to_sql(model._table, field_name, subquery)),
+                        jsonb_path=unaccent(SQL("jsonb_path_query_array(%s, '$.*')::text", raw_field)),
+                        field=unaccent(subquery.table[field_name]),
                     ))
                 else:
                     where_clauses.append(SQL("%(search)s <%% %(field)s",
                         search=unaccent(SQL("%s", search)),
-                        field=unaccent(model._field_to_sql(model._table, field_name, subquery)),
+                        field=unaccent(subquery.table[field_name]),
                     ))
             subquery.add_where(SQL(' OR ').join(where_clauses))
             tbl_alias = model._table
@@ -2205,7 +2203,7 @@ class Website(models.Model):
                 rel_alias = subquery.make_alias(rel_table, rel_joinkey)
                 subquery.add_join("JOIN", rel_alias, rel_table, SQL("%s = %s",
                         SQL.identifier(rel_alias, rel_joinkey),
-                        SQL.identifier(model._table, "id"),
+                        subquery.table.id,
                     ),
                 )
                 tbl_alias = rel_alias

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -123,7 +123,7 @@ class WebsiteForum(WebsiteProfile):
             # retro-compatibility for V8 and google links
             try:
                 sorting = werkzeug.urls.url_unquote_plus(sorting)
-                Post._order_to_sql(sorting, Post._search([], bypass_access=True))
+                Post._order_to_sql(Post._search([], bypass_access=True).table, sorting)
             except (UserError, ValueError):
                 sorting = False
 

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -89,8 +89,9 @@ def query_insert(cr, table, rows):
         SQL.identifier(table),
         SQL(",").join(map(SQL.identifier, cols)),
     )
-    assert not query.params
-    str_query = query.code + " VALUES %s RETURNING id"
+    str_query, params, _to_flush = query._sql_tuple
+    assert not params
+    str_query += " VALUES %s RETURNING id"
     params = [tuple(row[col] for col in cols) for row in rows]
     cr.execute_values(str_query, params)
     return [row[0] for row in cr.fetchall()]

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -722,14 +722,15 @@ actual arch.
             return self.browse()
         domain = self._get_inheriting_views_domain()
         query = self._search(domain)
-        where_clause = query.where_clause
-        assert query.from_clause == SQL.identifier('ir_ui_view'), f"Unexpected from clause: {query.from_clause}"
 
         field_names = [f.name for f in self._fields.values() if f.prefetch is True and not f.groups]
         aliased_names = SQL(', ').join(
-            SQL("%s AS %s", self._field_to_sql('ir_ui_view', name), SQL.identifier(name))
+            SQL("%s AS %s", query.table[name], SQL.identifier(name))
             for name in field_names
         )
+
+        assert query.from_clause == SQL.identifier('ir_ui_view'), f"Unexpected from clause: {query.from_clause}"
+        where_clause = query.where_clause
 
         query = SQL("""
             WITH RECURSIVE ir_ui_view_inherits AS (

--- a/odoo/addons/base/models/properties_base_definition_mixin.py
+++ b/odoo/addons/base/models/properties_base_definition_mixin.py
@@ -27,7 +27,7 @@ class PropertiesBaseDefinitionMixin(models.AbstractModel):
         self.properties_base_definition_id = self.env["properties.base.definition"] \
             ._get_definition_for_property_field(self._name, "properties")
 
-    def _compute_sql_properties_base_definition_id(self, alias, query):
+    def _compute_sql_properties_base_definition_id(self, table):
         # Allow the export to work
         parent = self.env["properties.base.definition"] \
             ._get_definition_id_for_property_field(self._name, "properties")

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -62,10 +62,10 @@ class ResDeviceLog(models.Model):
                 ))
             )
 
-    def _order_field_to_sql(self, alias, field_name, direction, nulls, query):
-        if field_name == 'is_current' and request and request.session.sid:
+    def _order_field_to_sql(self, table, field_expr, direction, nulls):
+        if field_expr == 'is_current' and request and request.session.sid:
             return SQL("session_identifier = %s DESC", request.session.sid[:STORED_SESSION_BYTES])
-        return super()._order_field_to_sql(alias, field_name, direction, nulls, query)
+        return super()._order_field_to_sql(table, field_expr, direction, nulls)
 
     def _is_mobile(self, platform):
         if not platform:

--- a/odoo/addons/base/tests/test_query.py
+++ b/odoo/addons/base/tests/test_query.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.models import Query, TableSQL
+from odoo.models import Query
 from odoo.tests.common import BaseCase, TransactionCase, tagged
 from odoo.tools import SQL
 
@@ -125,7 +125,7 @@ class TestQuery(TransactionCase):
 
     def test_raw_aliases(self):
         query = Query(None, 'foo', SQL('SELECT id FROM table'))
-        table = TableSQL(query.table, None, query)
+        table = query.table
         self.assertEqual(table._alias, 'foo')
         self.assertIsInstance(table, SQL)
         self.assertEqual(table._sql_tuple[0], '"foo"')
@@ -145,7 +145,7 @@ class TestQuery(TransactionCase):
     def test_model_aliases(self):
         model = self.env['res.partner.category']
         query = Query(model)
-        category = TableSQL(query.table, model, query)
+        category = query.table
         self.assertIsInstance(category, SQL)
         self.assertEqual(category._alias, model._table)
         self.assertIs(category._model, model)
@@ -166,7 +166,7 @@ class TestQuery(TransactionCase):
 
         model = self.env['res.partner']
         query = Query(model)
-        partner = TableSQL(query.table, model, query)
+        partner = query.table
 
         field = partner.company_id
         code, params, to_flush = field._sql_tuple

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -835,14 +835,14 @@ class TestPrivateReadGroup(common.TransactionCase):
         # (same than many2one) ? for public methods ?
         expected = """
             SELECT
-                "test_read_group_task__user_ids"."user_id",
+                "test_read_group_task__user_ids__rel"."user_id",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id")
             FROM "test_read_group_task"
-                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids"
-                    ON ("test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id")
+                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids__rel"
+                    ON ("test_read_group_task"."id" = "test_read_group_task__user_ids__rel"."task_id")
             WHERE "test_read_group_task"."id" IN %s
-            GROUP BY "test_read_group_task__user_ids"."user_id"
-            ORDER BY "test_read_group_task__user_ids"."user_id" ASC
+            GROUP BY "test_read_group_task__user_ids__rel"."user_id"
+            ORDER BY "test_read_group_task__user_ids__rel"."user_id" ASC
         """
         with self.assertQueries([expected]):
             self.assertEqual(tasks._read_group(
@@ -860,14 +860,14 @@ class TestPrivateReadGroup(common.TransactionCase):
         # Inverse the order, only inverse depending of id (see TODO above)
         expected = """
             SELECT
-                "test_read_group_task__user_ids"."user_id",
+                "test_read_group_task__user_ids__rel"."user_id",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id")
             FROM "test_read_group_task"
-                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids"
-                    ON ("test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id")
+                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids__rel"
+                    ON ("test_read_group_task"."id" = "test_read_group_task__user_ids__rel"."task_id")
             WHERE "test_read_group_task"."id" IN %s
-            GROUP BY "test_read_group_task__user_ids"."user_id"
-            ORDER BY "test_read_group_task__user_ids"."user_id" DESC
+            GROUP BY "test_read_group_task__user_ids__rel"."user_id"
+            ORDER BY "test_read_group_task__user_ids__rel"."user_id" DESC
         """
         with self.assertQueries([expected]):
             self.assertEqual(tasks._read_group(
@@ -898,20 +898,20 @@ class TestPrivateReadGroup(common.TransactionCase):
 
         expected = """
             SELECT
-                "test_read_group_task__user_ids"."user_id",
+                "test_read_group_task__user_ids__rel"."user_id",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id")
             FROM "test_read_group_task"
-            LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids"
+            LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids__rel"
                 ON (
-                    "test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id"
-                    AND "test_read_group_task__user_ids"."user_id" IN (
+                    "test_read_group_task"."id" = "test_read_group_task__user_ids__rel"."task_id"
+                    AND "test_read_group_task__user_ids__rel"."user_id" IN (
                         SELECT "test_read_group_user"."id"
                         FROM "test_read_group_user"
                         WHERE "test_read_group_user"."id" IN %s
                     )
                 )
-            GROUP BY "test_read_group_task__user_ids"."user_id"
-            ORDER BY "test_read_group_task__user_ids"."user_id" ASC
+            GROUP BY "test_read_group_task__user_ids__rel"."user_id"
+            ORDER BY "test_read_group_task__user_ids__rel"."user_id" ASC
         """
         with self.assertQueries([expected]):
             self.assertEqual(
@@ -948,13 +948,13 @@ class TestPrivateReadGroup(common.TransactionCase):
 
         with self.assertQueries([
             """
-            SELECT "test_read_group_task__tag_ids"."tag_id",
+            SELECT "test_read_group_task__tag_ids__rel"."tag_id",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id")
             FROM "test_read_group_task"
-            LEFT JOIN "test_read_group_task_tag_rel" AS "test_read_group_task__tag_ids"
+            LEFT JOIN "test_read_group_task_tag_rel" AS "test_read_group_task__tag_ids__rel"
                 ON (
-                    "test_read_group_task"."id" = "test_read_group_task__tag_ids"."task_id"
-                    AND "test_read_group_task__tag_ids"."tag_id" IN (
+                    "test_read_group_task"."id" = "test_read_group_task__tag_ids__rel"."task_id"
+                    AND "test_read_group_task__tag_ids__rel"."tag_id" IN (
                         SELECT
                             "test_read_group_tag"."id"
                         FROM
@@ -964,8 +964,8 @@ class TestPrivateReadGroup(common.TransactionCase):
                     )
                 )
             WHERE "test_read_group_task"."id" IN %s
-            GROUP BY "test_read_group_task__tag_ids"."tag_id"
-            ORDER BY "test_read_group_task__tag_ids"."tag_id" ASC
+            GROUP BY "test_read_group_task__tag_ids__rel"."tag_id"
+            ORDER BY "test_read_group_task__tag_ids__rel"."tag_id" ASC
             """,
         ]):
             self.assertEqual(
@@ -982,13 +982,13 @@ class TestPrivateReadGroup(common.TransactionCase):
 
         with self.assertQueries([
             """
-            SELECT "test_read_group_task__active_tag_ids"."tag_id",
+            SELECT "test_read_group_task__active_tag_ids__rel"."tag_id",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id")
             FROM "test_read_group_task"
-            LEFT JOIN "test_read_group_task_tag_rel" AS "test_read_group_task__active_tag_ids"
+            LEFT JOIN "test_read_group_task_tag_rel" AS "test_read_group_task__active_tag_ids__rel"
                 ON (
-                    "test_read_group_task"."id" = "test_read_group_task__active_tag_ids"."task_id"
-                    AND "test_read_group_task__active_tag_ids"."tag_id" IN (
+                    "test_read_group_task"."id" = "test_read_group_task__active_tag_ids__rel"."task_id"
+                    AND "test_read_group_task__active_tag_ids__rel"."tag_id" IN (
                         SELECT
                             "test_read_group_tag"."id"
                         FROM
@@ -998,8 +998,8 @@ class TestPrivateReadGroup(common.TransactionCase):
                     )
                 )
             WHERE "test_read_group_task"."id" IN %s
-            GROUP BY "test_read_group_task__active_tag_ids"."tag_id"
-            ORDER BY "test_read_group_task__active_tag_ids"."tag_id" ASC
+            GROUP BY "test_read_group_task__active_tag_ids__rel"."tag_id"
+            ORDER BY "test_read_group_task__active_tag_ids__rel"."tag_id" ASC
             """,
         ]):
             self.assertEqual(
@@ -1016,16 +1016,16 @@ class TestPrivateReadGroup(common.TransactionCase):
 
         with self.assertQueries([
             """
-            SELECT "test_read_group_task__all_tag_ids"."tag_id",
+            SELECT "test_read_group_task__all_tag_ids__rel"."tag_id",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id")
             FROM "test_read_group_task"
-            LEFT JOIN "test_read_group_task_tag_rel" AS "test_read_group_task__all_tag_ids"
+            LEFT JOIN "test_read_group_task_tag_rel" AS "test_read_group_task__all_tag_ids__rel"
                 ON (
-                    "test_read_group_task"."id" = "test_read_group_task__all_tag_ids"."task_id"
+                    "test_read_group_task"."id" = "test_read_group_task__all_tag_ids__rel"."task_id"
                 )
             WHERE "test_read_group_task"."id" IN %s
-            GROUP BY "test_read_group_task__all_tag_ids"."tag_id"
-            ORDER BY "test_read_group_task__all_tag_ids"."tag_id" ASC
+            GROUP BY "test_read_group_task__all_tag_ids__rel"."tag_id"
+            ORDER BY "test_read_group_task__all_tag_ids__rel"."tag_id" ASC
             """,
         ]):
             self.assertEqual(
@@ -1234,15 +1234,15 @@ class TestPrivateReadGroup(common.TransactionCase):
         # warmup
         RelatedFoo._read_group([], ['bar_base_ids'], ['__count'])
         with self.assertQueries(["""
-            SELECT "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id",
+            SELECT "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id",
                     COUNT(*)
             FROM "test_read_group_related_foo"
             LEFT JOIN "test_read_group_related_bar" AS "test_read_group_related_foo__bar_id"
                 ON ("test_read_group_related_foo"."bar_id" = "test_read_group_related_foo__bar_id"."id")
-            LEFT JOIN "test_read_group_related_bar_test_read_group_related_base_rel" AS "test_read_group_related_foo__bar_id__base_ids"
-                ON ("test_read_group_related_foo__bar_id"."id" = "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_bar_id")
-            GROUP BY "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id"
-            ORDER BY "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id" ASC
+            LEFT JOIN "test_read_group_related_bar_test_read_group_related_base_rel" AS "test_read_group_related_foo__bar_id__base_ids__rel"
+                ON ("test_read_group_related_foo__bar_id"."id" = "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_bar_id")
+            GROUP BY "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id"
+            ORDER BY "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id" ASC
         """]):
             RelatedFoo._read_group([], ['bar_base_ids'], ['__count'])
 
@@ -1261,20 +1261,20 @@ class TestPrivateReadGroup(common.TransactionCase):
         RelatedFoo._read_group([], ['bar_base_ids'], ['__count'])
         # The related_sudo=True should not bypass ir_rule of the comodel
         with self.assertQueries(["""
-            SELECT "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id", COUNT(*)
+            SELECT "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id", COUNT(*)
             FROM "test_read_group_related_foo"
             LEFT JOIN "test_read_group_related_bar" AS "test_read_group_related_foo__bar_id"
                 ON ("test_read_group_related_foo"."bar_id" = "test_read_group_related_foo__bar_id"."id")
-            LEFT JOIN "test_read_group_related_bar_test_read_group_related_base_rel" AS "test_read_group_related_foo__bar_id__base_ids"
-                ON ("test_read_group_related_foo__bar_id"."id" = "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_bar_id"
-                    AND "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id" IN (
+            LEFT JOIN "test_read_group_related_bar_test_read_group_related_base_rel" AS "test_read_group_related_foo__bar_id__base_ids__rel"
+                ON ("test_read_group_related_foo__bar_id"."id" = "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_bar_id"
+                    AND "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id" IN (
                         SELECT "test_read_group_related_base"."id"
                         FROM "test_read_group_related_base"
                         WHERE "test_read_group_related_base"."id" IN %s
                     )
                 )
-            GROUP BY "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id"
-            ORDER BY "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id" ASC
+            GROUP BY "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id"
+            ORDER BY "test_read_group_related_foo__bar_id__base_ids__rel"."test_read_group_related_base_id" ASC
         """]):
             RelatedFoo._read_group([], ['bar_base_ids'], ['__count'])
 

--- a/odoo/addons/test_orm/tests/test_read_grouping_sets.py
+++ b/odoo/addons/test_orm/tests/test_read_grouping_sets.py
@@ -139,21 +139,21 @@ class TestPrivateReadGroupingSets(common.TransactionCase):
         with self.assertQueries([
             """
             SELECT
-                GROUPING("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
-                "test_read_group_task__user_ids"."user_id",
+                GROUPING("test_read_group_task__user_ids__rel"."user_id", "test_read_group_task"."key"),
+                "test_read_group_task__user_ids__rel"."user_id",
                 "test_read_group_task"."key",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id"),
                 COUNT(*),
                 SUM("test_read_group_task"."integer")
             FROM "test_read_group_task"
-                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids" ON (
-                    "test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id"
+                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids__rel" ON (
+                    "test_read_group_task"."id" = "test_read_group_task__user_ids__rel"."task_id"
                 )
             WHERE "test_read_group_task"."id" IN %s
             GROUP BY GROUPING SETS (
-                ("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
-                ("test_read_group_task__user_ids"."user_id"))
-            ORDER BY "test_read_group_task__user_ids"."user_id" ASC,
+                ("test_read_group_task__user_ids__rel"."user_id", "test_read_group_task"."key"),
+                ("test_read_group_task__user_ids__rel"."user_id"))
+            ORDER BY "test_read_group_task__user_ids__rel"."user_id" ASC,
                 "test_read_group_task"."key" ASC
             """,
             """
@@ -186,21 +186,21 @@ class TestPrivateReadGroupingSets(common.TransactionCase):
         with self.assertQueries([
             """
             SELECT
-                GROUPING("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
-                "test_read_group_task__user_ids"."user_id",
+                GROUPING("test_read_group_task__user_ids__rel"."user_id", "test_read_group_task"."key"),
+                "test_read_group_task__user_ids__rel"."user_id",
                 "test_read_group_task"."key",
                 ARRAY_AGG("test_read_group_task"."name" ORDER BY "test_read_group_task"."id"),
                 COUNT(*),
                 SUM("test_read_group_task"."integer")
             FROM "test_read_group_task"
-                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids" ON (
-                    "test_read_group_task"."id" = "test_read_group_task__user_ids"."task_id"
+                LEFT JOIN "test_read_group_task_user_rel" AS "test_read_group_task__user_ids__rel" ON (
+                    "test_read_group_task"."id" = "test_read_group_task__user_ids__rel"."task_id"
                 )
             WHERE "test_read_group_task"."id" IN %s
             GROUP BY GROUPING SETS (
-                ("test_read_group_task__user_ids"."user_id", "test_read_group_task"."key"),
-                ("test_read_group_task__user_ids"."user_id"))
-            ORDER BY "test_read_group_task__user_ids"."user_id" DESC,
+                ("test_read_group_task__user_ids__rel"."user_id", "test_read_group_task"."key"),
+                ("test_read_group_task__user_ids__rel"."user_id"))
+            ORDER BY "test_read_group_task__user_ids__rel"."user_id" DESC,
                 "test_read_group_task"."key" ASC
             """,
             """

--- a/odoo/addons/test_web/tests/test_properties.py
+++ b/odoo/addons/test_web/tests/test_properties.py
@@ -1254,7 +1254,6 @@ class PropertiesGroupByCase(TestPropertiesMixin):
         Model = self.env['test_orm.message']
 
         hour_min = " 00:00:00" if date_type == "datetime" else ""
-        hour_max = " 00:00:59" if date_type == "datetime" else ""
 
         # Initial web_read_group everything folded (list view)
         self.assertEqual(
@@ -1266,12 +1265,12 @@ class PropertiesGroupByCase(TestPropertiesMixin):
             {
                 "groups": [
                     {
-                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2023-01-01{hour_min}'), ('attributes.mydate', '<', f'2024-01-01{hour_max}')],
+                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2023-01-01{hour_min}'), ('attributes.mydate', '<', f'2024-01-01{hour_min}')],
                         "attributes.mydate:year": (f'2023-01-01{hour_min}', "2023"),
                         "__count": 4,
                     },
                     {
-                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2077-01-01{hour_min}'), ('attributes.mydate', '<', f'2078-01-01{hour_max}')],
+                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2077-01-01{hour_min}'), ('attributes.mydate', '<', f'2078-01-01{hour_min}')],
                         "attributes.mydate:year": (f'2077-01-01{hour_min}', "2077"),
                         "__count": 1,
                     },
@@ -1307,12 +1306,12 @@ class PropertiesGroupByCase(TestPropertiesMixin):
             {
                 "groups": [
                     {
-                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2023-01-01{hour_min}'), ('attributes.mydate', '<', f'2024-01-01{hour_max}')],
+                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2023-01-01{hour_min}'), ('attributes.mydate', '<', f'2024-01-01{hour_min}')],
                         "attributes.mydate:year": (f'2023-01-01{hour_min}', "2023"),
                         "__count": 4,
                     },
                     {
-                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2077-01-01{hour_min}'), ('attributes.mydate', '<', f'2078-01-01{hour_max}')],
+                        "__extra_domain": ['&', ('attributes.mydate', '>=', f'2077-01-01{hour_min}'), ('attributes.mydate', '<', f'2078-01-01{hour_min}')],
                         "attributes.mydate:year": (f'2077-01-01{hour_min}', "2077"),
                         '__records': [{'id': self.message_5.id}],
                         "__count": 1,

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -8,7 +8,6 @@ from odoo.orm.models import (
     LOG_ACCESS_COLUMNS,
     MAGIC_COLUMNS,
     READ_GROUP_DISPLAY_FORMAT,
-    READ_GROUP_NUMBER_GRANULARITY,
     AbstractModel,
     BaseModel,
     MetaModel,
@@ -25,6 +24,7 @@ from odoo.orm.models_transient import TransientModel
 from odoo.orm.query import Query, TableSQL
 from odoo.orm.table_objects import Constraint, Index, UniqueIndex
 from odoo.orm.utils import (
+    READ_GROUP_NUMBER_GRANULARITY,
     READ_GROUP_TIME_GRANULARITY,
     check_object_name,
     check_pg_name,

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -22,7 +22,7 @@ from odoo.orm.models import (
 )
 from odoo.orm.model_classes import is_model_class, is_model_definition
 from odoo.orm.models_transient import TransientModel
-from odoo.orm.query import Query
+from odoo.orm.query import Query, TableSQL
 from odoo.orm.table_objects import Constraint, Index, UniqueIndex
 from odoo.orm.utils import (
     READ_GROUP_TIME_GRANULARITY,

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -989,7 +989,11 @@ class DomainCondition(Domain):
 
     def _optimize_field_search_method(self, model: BaseModel) -> Domain:
         field = self._field(model)
-        model._check_field_access(field, 'read')
+        if not model.env.su:
+            model._check_field_access(field, 'read')
+            if field.compute_sudo:
+                # run search in sudo because the compute is done in sudo as well
+                model = model.sudo()
         operator, value = self.operator, self.value
         # use the `Field.search` function
         original_exception = None

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1101,7 +1101,7 @@ class DomainCondition(Domain):
         model = table._model
         field = self._field(model)
         model._check_field_access(field, 'read')
-        return field.condition_to_sql(field_expr, operator, value, model, table._alias, table._query)
+        return field.condition_to_sql(table, field_expr, operator, value)
 
 
 # --------------------------------------------------

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -286,7 +286,7 @@ class Domain:
     @staticmethod
     def custom(
         *,
-        to_sql: Callable[[BaseModel, str, Query], SQL],
+        to_sql: Callable[[TableSQL], SQL],
         predicate: Callable[[BaseModel], bool] | None = None,
     ) -> DomainCustom:
         """Create a custom domain.
@@ -753,7 +753,7 @@ class DomainCustom(Domain):
 
     def __new__(
         cls,
-        sql: Callable[[BaseModel, str, Query], SQL],
+        sql: Callable[[TableSQL], SQL],
         filtered: Callable[[BaseModel], bool] | None = None,
     ):
         """Create a new domain.
@@ -790,7 +790,7 @@ class DomainCustom(Domain):
         yield self
 
     def _to_sql(self, table: TableSQL) -> SQL:
-        return self._sql(table._model, table._alias, table._query)
+        return self._sql(table)
 
 
 class DomainCondition(Domain):

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -850,8 +850,8 @@ class Cache:
 
             # select the column for the given ids
             query = Query(model)
-            sql_id = SQL.identifier(model._table, 'id')
-            sql_field = model._field_to_sql(model._table, field.name, query)
+            sql_id = query.table.id
+            sql_field = query.table[field.name]
             if field.type == 'binary' and (
                 model.env.context.get('bin_size') or model.env.context.get('bin_size_' + field.name)
             ):

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -528,25 +528,19 @@ class Environment(Mapping[str, "BaseModel"]):
     def _field_depends_context(self):
         return self.registry.field_depends_context
 
-    def flush_query(self, query: SQL) -> None:
-        """ Flush all the fields in the metadata of ``query``. """
-        fields_to_flush = tuple(query.to_flush)
-        if not fields_to_flush:
-            return
-
-        fnames_to_flush = defaultdict[str, OrderedSet[str]](OrderedSet)
-        for field in fields_to_flush:
-            fnames_to_flush[field.model_name].add(field.name)
-        for model_name, field_names in fnames_to_flush.items():
-            self[model_name].flush_model(field_names)
-
     def execute_query(self, query: SQL) -> list[tuple]:
         """ Execute the given query, fetch its result and it as a list of tuples
         (or an empty list if no result to fetch).  The method automatically
         flushes all the fields in the metadata of the query.
         """
         assert isinstance(query, SQL)
-        self.flush_query(query)
+        _, _, fields_to_flush = query._sql_tuple
+        if fields_to_flush:
+            fnames_to_flush = defaultdict[str, OrderedSet[str]](OrderedSet)
+            for field in fields_to_flush:
+                fnames_to_flush[field.model_name].add(field.name)
+            for model_name, field_names in fnames_to_flush.items():
+                self[model_name].flush_model(field_names)
         self.cr.execute(query)
         return [] if self.cr.description is None else self.cr.fetchall()
 

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -953,10 +953,9 @@ class Field(typing.Generic[T]):
             return True
 
         model = env[self.model_name]
-        query = model._as_query(ordered=False)
         groupby = self.name if self.type not in ('date', 'datetime') else f"{self.name}:month"
         try:
-            model._read_group_groupby(model._table, groupby, query)
+            model._read_group_groupby(Query(model).table, groupby)
             return True
         except (ValueError, AccessError):
             return False

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1240,6 +1240,7 @@ class Field(typing.Generic[T]):
 
         The query object is necessary for fields that need to add tables to the query.
         """
+        model._check_field_access(self, 'read')
         if self.compute_sql:
             if self.compute_sudo:
                 model = model.sudo()

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -943,7 +943,7 @@ class Field(typing.Generic[T]):
         model = env[self.model_name]
         query = model._as_query(ordered=False)
         try:
-            model._order_field_to_sql(model._table, self.name, SQL(), SQL(), query)
+            model._order_field_to_sql(query.table, self.name, SQL(), SQL())
             return True
         except (ValueError, AccessError):
             return False

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1189,10 +1189,9 @@ class Field(typing.Generic[T]):
                 if not field.required or not field.store:
                     return
                 if field.compute:
-                    records = model.browse(id_ for id_, in model.env.execute_query(SQL(
-                        "SELECT id FROM %s AS t WHERE %s IS NULL",
-                        SQL.identifier(model._table), model._field_to_sql('t', field.name),
-                    )))
+                    query = Query(model.sudo())
+                    query.add_where(SQL("%s IS NULL", query.table[field.name]))
+                    records = model.browse(id_ for id_, in model.env.execute_query(query.select()))
                     model.env.add_to_compute(field, records)
                 # Flush values before adding NOT NULL constraint.
                 model.flush_model([field.name])

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -967,7 +967,7 @@ class Field(typing.Generic[T]):
         model = env[self.model_name]
         query = model._as_query(ordered=False)
         try:
-            model._read_group_select(f"{self.name}:{self.aggregator}", query)
+            model._read_group_select(query.table, f"{self.name}:{self.aggregator}")
             return self.aggregator
         except (ValueError, AccessError):
             return None

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -19,7 +19,7 @@ from .utils import SQL_OPERATORS
 
 if typing.TYPE_CHECKING:
     from .models import BaseModel
-    from .query import Query
+    from .query import TableSQL
 
 # http://initd.org/psycopg/docs/usage.html#binary-adaptation
 # Received data is returned as buffer (in Python 2) or memoryview (in Python 3).
@@ -236,15 +236,15 @@ class Binary(Field):
             else:
                 atts.unlink()
 
-    def condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
+    def condition_to_sql(self, table: TableSQL, field_expr: str, operator: str, value) -> SQL:
         if not self.attachment or field_expr != self.name:
-            return super().condition_to_sql(field_expr, operator, value, model, alias, query)
+            return super().condition_to_sql(table, field_expr, operator, value)
         assert operator in ('in', 'not in') and set(value) == {False}, "Should have been done in Domain optimization"
         return SQL(
             "%s%s(SELECT res_id FROM ir_attachment WHERE res_model = %s AND res_field = %s)",
-            model._field_to_sql(alias, 'id', query),
+            table.id,
             SQL_OPERATORS['not in' if operator in ('in', '=') else 'in'],
-            model._name,
+            table._model._name,
             self.name,
         )
 

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -13,7 +13,7 @@ from .identifiers import IdType
 
 if typing.TYPE_CHECKING:
     from .models import BaseModel
-    from .query import Query
+    from .query import Query, TableSQL
 
 # integer needs to be imported before Id because of `type` attribute clash
 from . import fields_numeric  # noqa: F401
@@ -34,12 +34,12 @@ class Boolean(Field[bool]):
     def convert_to_export(self, value, record):
         return bool(value)
 
-    def _condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
+    def _condition_to_sql(self, table: TableSQL, field_expr: str, operator: str, value) -> SQL:
         if operator not in ('in', 'not in'):
-            return super()._condition_to_sql(field_expr, operator, value, model, alias, query)
+            return super()._condition_to_sql(table, field_expr, operator, value)
 
         # get field and check access
-        sql_field = model._field_to_sql(alias, field_expr, query)
+        sql_field = table[field_expr]
 
         # express all conditions as (field_expr, 'in', possible_values)
         possible_values = (

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -12,8 +12,7 @@ from .fields import Field
 from .identifiers import IdType
 
 if typing.TYPE_CHECKING:
-    from .models import BaseModel
-    from .query import Query, TableSQL
+    from .query import TableSQL
 
 # integer needs to be imported before Id because of `type` attribute clash
 from . import fields_numeric  # noqa: F401
@@ -119,11 +118,11 @@ class Id(Field[IdType | typing.Literal[False]]):
     def convert_to_column(self, value, record, values=None, validate=True):
         return value
 
-    def to_sql(self, model: BaseModel, alias: str, query: Query | None) -> SQL:
+    def to_sql(self, table: TableSQL) -> SQL:
         # do not flush, just return the identifier
         assert self.store, 'id field must be stored'
         # id is never flushed
-        return SQL.identifier(alias, self.name)
+        return SQL.identifier(table._alias, self.name)
 
     def expression_getter(self, field_expr):
         if field_expr != 'id.origin':

--- a/odoo/orm/fields_numeric.py
+++ b/odoo/orm/fields_numeric.py
@@ -188,7 +188,7 @@ class Monetary(Field[float]):
         # The currency field needs to be aggregable too
         if not currency_field.column_type or not currency_field.store:
             try:
-                model._read_group_select(f"{currency_field_name}:array_agg_distinct", query)
+                model._read_group_select(query.table, f"{currency_field_name}:array_agg_distinct")
             except (ValueError, AccessError):
                 return None
 

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -19,7 +19,7 @@ from .models import BaseModel
 from .utils import COLLECTION_TYPES, SQL_OPERATORS, parse_field_expr, regex_alphanumeric
 
 if typing.TYPE_CHECKING:
-    from .query import Query, TableSQL
+    from .query import TableSQL
 
 NoneType = type(None)
 
@@ -671,7 +671,7 @@ class Properties(Field):
             return lambda rec: getter(rec).filtered_domain(domain)
         return super().filter_function(records, field_expr, operator, value)
 
-    def property_to_sql(self, field_sql: SQL, property_name: str, model: BaseModel, alias: str, query: Query) -> SQL:
+    def property_to_sql(self, field_sql: SQL, property_name: str) -> SQL:
         check_property_field_value_name(property_name)
         return SQL("(%s -> %s)", field_sql, property_name)
 

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -10,16 +10,18 @@ from collections import abc, defaultdict
 from operator import attrgetter
 
 from odoo.exceptions import AccessError, UserError, MissingError
-from odoo.tools import SQL, OrderedSet, is_list_of, html_sanitize
+from odoo.tools import SQL, OrderedSet, is_list_of, html_sanitize, sql
 from odoo.tools.misc import frozendict, has_list_types
 
 from .domains import Domain
 from .fields import Field, _logger
+from .fields_temporal import BaseDate
 from .models import BaseModel
+from .query import Query
 from .utils import COLLECTION_TYPES, SQL_OPERATORS, parse_field_expr, regex_alphanumeric
 
 if typing.TYPE_CHECKING:
-    from .query import TableSQL
+    from .query import FieldSQL, TableSQL
 
 NoneType = type(None)
 
@@ -671,16 +673,129 @@ class Properties(Field):
             return lambda rec: getter(rec).filtered_domain(domain)
         return super().filter_function(records, field_expr, operator, value)
 
-    def property_to_sql(self, field_sql: SQL, property_name: str) -> SQL:
+    def property_to_sql_raw(self, field_sql: SQL, property_name: str) -> SQL:
         check_property_field_value_name(property_name)
         return SQL("(%s -> %s)", field_sql, property_name)
+
+    def property_to_sql(self, field_sql: FieldSQL, property_name: str) -> SQL:
+        # NOTE: This function misbehaves for groupby so that the query rowcount
+        # is duplicated when accessing multi-valued properties (like tags).
+        sql_property = self.property_to_sql_raw(field_sql, property_name)
+        fname = self.name
+        table = field_sql._table
+        model = table._model
+        definition = model.get_property_definition(f"{fname}.{property_name}")
+        property_type = definition.get('type')
+
+        # JOIN on the JSON array
+        if property_type in ('tags', 'many2many'):
+            property_alias = table._make_alias(f'{fname}_{property_name}')
+            sql_property = SQL(
+                """ CASE
+                        WHEN jsonb_typeof(%(property)s) = 'array'
+                        THEN %(property)s
+                        ELSE '[]'::jsonb
+                     END """,
+                property=sql_property,
+            )
+            if property_type == 'tags':
+                # ignore invalid tags
+                tags = [tag[0] for tag in definition.get('tags') or []]
+                # `->>0 : convert "JSON string" into string
+                condition = SQL(
+                    "%s->>0 = ANY(%s::text[])",
+                    property_alias, tags,
+                )
+            else:
+                comodel = model.env.get(definition.get('comodel'))
+                if comodel is None or comodel._transient or comodel._abstract:
+                    raise UserError(model.env._(
+                        "You cannot use “%(property_name)s” because the linked “%(model_name)s” model doesn't exist or is invalid",
+                        property_name=definition.get('string', property_name), model_name=definition.get('comodel'),
+                    ))
+
+                # check the existences of the many2many
+                condition = SQL(
+                    "%s::int IN (SELECT id FROM %s)",
+                    property_alias, SQL.identifier(comodel._table),
+                )
+
+            table._query.add_join(
+                "LEFT JOIN",
+                property_alias,
+                SQL("jsonb_array_elements(%s)", sql_property),
+                condition,
+            )
+
+            return property_alias
+
+        elif property_type == 'selection':
+            options = [option[0] for option in definition.get('selection') or ()]
+
+            # check the existence of the option
+            property_alias = table._make_alias(f'{fname}_{property_name}')
+            table._query.add_join(
+                "LEFT JOIN",
+                property_alias,
+                SQL("(SELECT unnest(%s::text[]) %s)", options, property_alias),
+                SQL("%s->>0 = %s", sql_property, property_alias),
+            )
+
+            return property_alias
+
+        elif property_type == 'many2one':
+            comodel = model.env.get(definition.get('comodel'))
+            if comodel is None or comodel._transient or comodel._abstract:
+                raise UserError(model.env._(
+                    "You cannot use “%(property_name)s” because the linked “%(model_name)s” model doesn't exist or is invalid",
+                    property_name=definition.get('string', property_name), model_name=definition.get('comodel'),
+                ))
+
+            return SQL(
+                """ CASE
+                        WHEN jsonb_typeof(%(property)s) = 'number'
+                         AND (%(property)s)::int IN %(table)s
+                        THEN %(property)s
+                        ELSE NULL
+                     END """,
+                property=sql_property,
+                table=Query(comodel).subselect(),
+            )
+
+        elif property_type == 'date':
+            return SQLWithProperty(
+                """ CASE
+                        WHEN jsonb_typeof(%(property)s) = 'string'
+                        THEN (%(property)s->>0)::DATE
+                        ELSE NULL
+                     END """,
+                property=sql_property,
+                property_func=lambda self, name: BaseDate._generic_property_to_sql('date', self, name, model),
+            )
+
+        elif property_type == 'datetime':
+            return SQLWithProperty(
+                """ CASE
+                        WHEN jsonb_typeof(%(property)s) = 'string'
+                        THEN to_timestamp(%(property)s->>0, 'YYYY-MM-DD HH24:MI:SS')
+                        ELSE NULL
+                     END """,
+                property=sql_property,
+                property_func=lambda self, name: BaseDate._generic_property_to_sql('datetime', self, name, model),
+            )
+
+        elif property_type == 'html':
+            raise UserError(model.env._('Grouping by HTML properties is not supported.'))
+
+        # if the key is not present in the dict, fallback to false instead of none
+        return SQL("COALESCE(%s, 'false')", sql_property)
 
     def condition_to_sql(self, table: TableSQL, field_expr: str, operator: str, value) -> SQL:
         fname, property_name = parse_field_expr(field_expr)
         if not property_name:
             raise ValueError(f"Missing property name for {self}")
         raw_sql_field = table[fname]
-        sql_left = raw_sql_field[property_name]
+        sql_left = self.property_to_sql_raw(raw_sql_field, property_name)
 
         if operator in ('in', 'not in'):
             assert isinstance(value, COLLECTION_TYPES)
@@ -770,6 +885,17 @@ class Properties(Field):
             "%s%s%s",
             unaccent(sql_left), sql_operator, unaccent(sql_right),
         )
+
+
+class SQLWithProperty(sql.LiteralSQL):
+    def __init__(self, code, /, *args, property_func, **kw):
+        super().__init__(code, *args, **kw)
+        self._property = property_func
+
+    def __getitem__(self, name):
+        return self._property(self, name)
+
+    __getattr__ = __getitem__
 
 
 class Property(abc.Mapping):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -510,7 +510,7 @@ class Many2one(_Relational):
             comodel = comodel.with_env(model.env)
             if not positive:
                 value = (~value).optimize_full(comodel)
-            sql = value._to_sql(comodel, coalias, query)
+            sql = value._to_sql(TableSQL(coalias, comodel, query))
             if self.company_dependent:
                 sql = self._condition_to_sql_company(sql, field_expr, operator, value, model, alias, query)
             if can_be_null:
@@ -848,7 +848,7 @@ class _RelationalMulti(_Relational):
             domain = field_domain.optimize_full(comodel)
             if not domain.is_true():
                 # TODO should clone/copy Query value
-                value.add_where(domain._to_sql(comodel, value.table._alias, value))
+                value.add_where(domain._to_sql(value.table._with_model(comodel)))
             return value
         raise NotImplementedError(f"Cannot build query for {value}")
 
@@ -1183,7 +1183,7 @@ class One2many(_RelationalMulti):
 
     def _condition_to_sql_relational(self, model: BaseModel, alias: str, exists: bool, coquery: Query, query: Query) -> SQL:
         if coquery.is_empty():
-            return Domain(not exists)._to_sql(model, alias, query)
+            return Domain(not exists)._to_sql(TableSQL(alias, model, query))
 
         comodel = model.env[self.comodel_name].sudo()
         inverse_field = comodel._fields[self.inverse_name]

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -24,8 +24,7 @@ from .utils import COLLECTION_TYPES, SQL_OPERATORS
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
-    from .models import BaseModel
-    from .query import Query, TableSQL
+    from .query import TableSQL
 
 
 class BaseString(Field[str | typing.Literal[False]]):
@@ -385,15 +384,16 @@ class BaseString(Field[str | typing.Literal[False]]):
         for record, new_translation in zip(records.with_context(prefetch_langs=True), new_translations_list, strict=True):
             self._update_cache(record, new_translation, dirty=True)
 
-    def to_sql(self, model: BaseModel, alias: str, query: Query | None) -> SQL:
-        sql_field = super().to_sql(model.with_context(prefetch_langs=True), alias, query)
-        if self.translate and not model.env.context.get('prefetch_langs'):
-            langs = self.get_translation_fallback_langs(model.env)
-            sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
-            if len(sql_field_langs) == 1:
-                return sql_field_langs[0]
-            return SQL("COALESCE(%s)", SQL(", ").join(sql_field_langs))
-        return sql_field
+    def to_sql(self, table: TableSQL) -> SQL:
+        if not self.translate or table._model.env.context.get('prefetch_langs'):
+            return super().to_sql(table)
+        model = table._model
+        sql_field = super().to_sql(table._with_model(model.with_context(prefetch_langs=True)))
+        langs = self.get_translation_fallback_langs(model.env)
+        sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
+        if len(sql_field_langs) == 1:
+            return sql_field_langs[0]
+        return SQL("COALESCE(%s)", SQL(", ").join(sql_field_langs))
 
     def expression_getter(self, field_expr):
         if field_expr != 'display_name.no_error':
@@ -442,7 +442,7 @@ class BaseString(Field[str | typing.Literal[False]]):
             if value == '%':
                 return base_condition
 
-            raw_sql_field = self.to_sql(model.with_context(prefetch_langs=True), table._alias)
+            raw_sql_field = self.to_sql(table._with_model(model.with_context(prefetch_langs=True)))
             sql_left = SQL("jsonb_path_query_array(%s, '$.*')::text", raw_sql_field)
             sql_operator = SQL_OPERATORS['like' if operator == 'in' else operator]
             sql_right = SQL("%s", self.convert_to_column(value, model, validate=False))

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2014,7 +2014,9 @@ class BaseModel(metaclass=MetaModel):
             if field.type != 'many2one':
                 raise ValueError(f"Only many2one path is accepted for the {groupby_spec!r} groupby spec")
 
-            comodel, coalias = field.join(self, alias, query)
+            cotable = field.join(TableSQL(alias, self, query))
+            comodel = cotable._model
+            coalias = cotable._alias
             return comodel._read_group_groupby(coalias, f"{seq_fnames}:{granularity}" if granularity else seq_fnames, query)
 
         elif granularity and field.type not in ('datetime', 'date', 'properties'):
@@ -4700,7 +4702,7 @@ class BaseModel(metaclass=MetaModel):
             # LEFT JOIN the comodel table, in order to include NULL values, too
             # Run as sudo because we can order by inaccessible models as we can
             # only order by the default order or the id.
-            _comodel, coalias = field.join(self.sudo(), alias, query)
+            coalias = TableSQL(alias, self.sudo(), query)._join(field.name)._alias
 
             # delegate the order to the comodel
             reverse = direction._sql_tuple[0] == 'DESC'

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2024,8 +2024,15 @@ class BaseModel(metaclass=MetaModel):
 
         elif field.type == 'many2many':
             if not field.store:
+                # traverse_related, skip last one if not stored
                 if field.related:
-                    _model, field, alias = field.traverse_related_sql(self, alias, query)
+                    traverse = TableSQL(alias, self, query)
+                    if field.compute_sudo:
+                        traverse = traverse._sudo()
+                    for fname in field.related.split('.')[:-1]:
+                        traverse = traverse[fname]
+                    alias = traverse.id._table._alias
+                    field = field.related_field
                 else:
                     raise ValueError(f"Group by non-stored many2many field: {groupby_spec!r}")
             # special case for many2many fields: prepare a query on the comodel

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4762,7 +4762,7 @@ class BaseModel(metaclass=MetaModel):
             return self.browse()._as_query()
         query = Query(self)
         if not domain.is_true():
-            query.add_where(domain._to_sql(self, self._table, query))
+            query.add_where(domain._to_sql(query.table))
 
         # security access domain
         if check_access:
@@ -4772,7 +4772,7 @@ class BaseModel(metaclass=MetaModel):
             if sec_domain.is_false():
                 return self.browse()._as_query()
             if not sec_domain.is_true():
-                query.add_where(sec_domain._to_sql(self_sudo, self._table, query))
+                query.add_where(sec_domain._to_sql(query.table._with_model(self_sudo)))
 
         # add order and limits
         if order:

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -63,7 +63,7 @@ from .fields_temporal import Date, Datetime
 from .fields_textual import Char
 
 from .identifiers import NewId
-from .query import Query
+from .query import Query, TableSQL
 from .utils import (
     OriginIds, Prefetch, check_object_name, parse_field_expr,
     COLLECTION_TYPES, SQL_OPERATORS,
@@ -2290,15 +2290,10 @@ class BaseModel(metaclass=MetaModel):
         properties fields, where joins are added to the query.
         """
         fname, property_name = parse_field_expr(field_expr)
-        field = self._fields.get(fname)
-        if not field:
-            raise ValueError(f"Invalid field {fname!r} on model {self._name!r}")
-
-        self._check_field_access(field, 'read')
-
-        sql = field.to_sql(self, alias, query)
+        table = TableSQL(alias, self, query)
+        sql = table[fname]
         if property_name:
-            sql = field.property_to_sql(sql, property_name, self, alias, query)
+            sql = sql[property_name]
         return sql
 
     def _read_group_groupby_properties(self, alias: str, field: Field, property_name: str, query: Query) -> SQL:

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1923,7 +1923,7 @@ class BaseModel(metaclass=MetaModel):
         if groupby_terms:
             query.order = self._read_group_orderby(order, groupby_terms, query)
             query.groupby = SQL(", ").join(groupby_terms.values())
-            query.having = self._read_group_having(list(having), query)
+            query.having = self._read_group_having(query.table, list(having))
 
         # row_values: [(a1, b1, c1), (a2, b2, c2), ...]
         row_values = self.env.execute_query(query.select(*select_args))
@@ -2094,7 +2094,7 @@ class BaseModel(metaclass=MetaModel):
 
         return sql_expr
 
-    def _read_group_having(self, having_domain: list, query: Query) -> SQL:
+    def _read_group_having(self, table: TableSQL, having_domain: list) -> SQL:
         """ Return <SQL expression> corresponding to the having domain.
         """
         if not having_domain:
@@ -2113,7 +2113,7 @@ class BaseModel(metaclass=MetaModel):
                 left, operator, right = item
                 if operator not in SUPPORTED:
                     raise ValueError(f"Invalid having clause {item!r}: supported comparators are {SUPPORTED}")
-                sql_left = self._read_group_select(query.table, left)
+                sql_left = self._read_group_select(table, left)
                 stack.append(SQL("%s%s%s", sql_left, SQL_OPERATORS[operator], right))
             else:
                 raise ValueError(f"Invalid having clause {item!r}: it should be a domain-like clause")

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+    from typing import LiteralString
     from .models import BaseModel
 
 from odoo.tools.sql import SQL, make_identifier
@@ -103,7 +104,7 @@ class Query:
             self._joins[alias] = (sql_kind, table, condition)
             self._ids = self._ids and None
 
-    def add_where(self, where_clause: str | SQL, where_params=()):
+    def add_where(self, where_clause: LiteralString | SQL, where_params=()):
         """ Add a condition to the where clause. """
         self._where_clauses.append(SQL(where_clause, *where_params))  # pylint: disable = sql-injection
         self._ids = self._ids and None
@@ -145,7 +146,7 @@ class Query:
         return self._order
 
     @order.setter
-    def order(self, value: SQL | str | None):
+    def order(self, value: SQL | LiteralString | None):
         self._order = SQL(value) if value is not None else None  # pylint: disable = sql-injection
 
     @property
@@ -171,7 +172,7 @@ class Query:
         """ Return whether the query is known to return nothing. """
         return self._ids == ()
 
-    def select(self, *args: str | SQL) -> SQL:
+    def select(self, *args: SQL | LiteralString) -> SQL:
         """ Return the SELECT query as an ``SQL`` object. """
         select_clause = SQL(", ").join(map(SQL, args)) if args else SQL.identifier(self.table, 'id')
         return SQL(
@@ -186,7 +187,7 @@ class Query:
             SQL(f" OFFSET {int(self.offset)}") if self.offset else _SQL_EMPTY,
         )
 
-    def subselect(self, *args: str | SQL) -> SQL:
+    def subselect(self, *args: SQL | LiteralString) -> SQL:
         """ Similar to :meth:`.select`, but for sub-queries.
             This one avoids the ORDER BY clause when possible,
             and includes parentheses around the subquery.

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -131,6 +131,7 @@ class Query:
         :param str link: used to generate the alias for the joined table, this string should
             represent the relationship (the link) between both tables.
         """
+        # TODO use TableSQL._join
         assert lhs_alias in self._joins, "Alias %r not in %s" % (lhs_alias, str(self))
         rhs_alias = self.make_alias(lhs_alias, link)
         condition = SQL("%s = %s", SQL.identifier(lhs_alias, lhs_column), SQL.identifier(rhs_alias, rhs_column))
@@ -144,6 +145,7 @@ class Query:
         See the documentation of :meth:`join` for a better overview of the
         arguments and what they do.
         """
+        # TODO use TableSQL._join
         assert lhs_alias in self._joins, "Alias %r not in %s" % (lhs_alias, str(self))
         rhs_alias = self.make_alias(lhs_alias, link)
         condition = SQL("%s = %s", SQL.identifier(lhs_alias, lhs_column), SQL.identifier(rhs_alias, rhs_column))

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -252,8 +252,7 @@ class Query:
         self._ids = ids
 
     def __str__(self) -> str:
-        sql = self.select()
-        return f"<Query: {sql.code!r} with params: {sql.params!r}>"
+        return f"<Query: {self.select()!r}>"
 
     def __bool__(self):
         return bool(self.get_result_ids())

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -347,7 +347,7 @@ class FieldSQL(SQL):
         self._field = field
         # Generate the SQL eagerly, it may be used multiple times and is easier
         # to debug than generating it lazily.
-        self.__sql_tuple = table._model._field_to_sql(table._alias, field.name, table._query)._sql_tuple
+        self.__sql_tuple = field.to_sql(table._model, table._alias, table._query)._sql_tuple
 
     @property
     def _sql_tuple(self):

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -348,15 +348,14 @@ class FieldSQL(SQL):
         self._field = field
         # Generate the SQL eagerly, it may be used multiple times and is easier
         # to debug than generating it lazily.
-        self.__sql_tuple = field.to_sql(table._model, table._alias, table._query)._sql_tuple
+        self.__sql_tuple = field.to_sql(table)._sql_tuple
 
     @property
     def _sql_tuple(self):
         return self.__sql_tuple
 
     def __getitem__(self, name: str) -> SQL:
-        table = self._table
-        return self._field.property_to_sql(self, name, table._model, table._alias, table._query)
+        return self._field.property_to_sql(self, name)
 
     __getattr__ = __getitem__
 

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -338,7 +338,7 @@ class TableSQL(SQL):
         field = model._fields.get(field_name)
         if not field:
             raise ValueError(f"Invalid field {field_name!r} on model {model._name!r}")
-        if field.type == 'many2one':
+        if hasattr(field, 'join') and callable(field.join):
             return field.join(self, **kw)
         raise ValueError(f"Invalid field {field_name}: _join() not possible")
 

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
     from typing import LiteralString
+    from .fields import Field
     from .models import BaseModel
 
 from odoo.tools.sql import SQL, make_identifier
@@ -49,11 +50,7 @@ def _generate_table_alias(src_table_alias: str, link: str) -> str:
 class Query:
     """ Simple implementation of a query object, managing tables with aliases,
     join clauses (with aliases, condition and parameters), where clauses (with
-    parameters), order, limit and offset.
-
-    :param env: model environment (for lazy evaluation)
-    :param alias: name or alias of the table
-    :param table: a table expression (``str`` or ``SQL`` object), optional
+    parameters), group by, order, limit and offset.
     """
 
     def __init__(self, model: BaseModel | None, alias: (str | None) = None, table: (SQL | None) = None):
@@ -90,11 +87,16 @@ class Query:
         """ Return an alias based on ``alias`` and ``link``. """
         return _generate_table_alias(alias, link)
 
-    def add_join(self, kind: str, alias: str, table: str | SQL | None, condition: SQL):
+    def add_join(self, kind: str, alias: str | TableSQL, table: str | SQL | None, condition: SQL):
         """ Add a join clause with the given alias, table and condition. """
         sql_kind = _SQL_JOINS.get(kind.upper())
         assert sql_kind is not None, f"Invalid JOIN type {kind!r}"
-        table = table or alias
+        if isinstance(alias, TableSQL):
+            if table is None and alias._model is not None:
+                table = alias._model._table_sql
+            alias = alias._alias
+        elif table is None:
+            table = alias
         if isinstance(table, str):
             table = SQL.identifier(table)
 
@@ -269,3 +271,93 @@ class Query:
 
     def __iter__(self) -> Iterator[int]:
         return iter(self.get_result_ids())
+
+
+class TableSQL(SQL):
+    """An alias of a table in a Query."""
+    __slots__ = ('_alias', '_model', '_query')
+
+    def __init__(self, alias: str, model: BaseModel | None, query: Query):
+        assert isinstance(alias, str)
+        self._alias = alias
+        self._model = model
+        self._query = query
+
+    @property
+    def _sql_tuple(self):
+        return SQL.identifier(self._alias)._sql_tuple
+
+    def __getitem__(self, field_name: str) -> SQL:
+        if (model := self._model) is None:
+            return SQL.identifier(self._alias, field_name)
+        field = model._fields.get(field_name)
+        if field is None:
+            raise ValueError(f"Invalid field {field_name!r} on model {model._name!r}")
+        return FieldSQL(self, field)
+
+    __getattr__ = __getitem__
+
+    def __repr__(self):
+        return f"TableSQL({self._alias!r}, {self._model._name if self._model else '-'}, {self._query!r})"
+
+    def _with_model(self, model: BaseModel) -> TableSQL:
+        """ Bind a model to a new instance. """
+        assert self._model is None or self._model._name == model._name
+        return TableSQL(self._alias, model, self._query)
+
+    def _sudo(self, flag: bool = True) -> TableSQL:
+        """ Like `_with_model`, just sudo existing model. """
+        if self._model is None or self._model.env.su == flag:
+            return self
+        return self._with_model(self._model.sudo(flag))
+
+    def _make_alias(self, link: str, model: BaseModel | None = None) -> TableSQL:
+        """ Generate a new table/alias using this as source. """
+        return TableSQL(_generate_table_alias(self._alias, link), model, self._query)
+
+    def _join(
+        self,
+        field_name: str,
+        **kw,
+    ) -> TableSQL:
+        """ Join a table.
+
+        Given a field, use its `Field.join` to join to another model.
+        """
+        model = self._model
+        if model is None:
+            raise ValueError(f"Cannot {self}._join() without a model")
+        field = model._fields.get(field_name)
+        if not field:
+            raise ValueError(f"Invalid field {field_name!r} on model {model._name!r}")
+        if field.type == 'many2one':
+            return field.join(self, **kw)
+        raise ValueError(f"Invalid field {field_name}: _join() not possible")
+
+
+class FieldSQL(SQL):
+    """ An SQL object that represents the expression of a field.
+
+    Accessing an attribute builds the SQL for the property of the field.
+    """
+    __slots__ = ('__sql_tuple', '_field', '_table')
+
+    def __init__(self, table: TableSQL, field: Field):
+        self._table = table
+        self._field = field
+        # Generate the SQL eagerly, it may be used multiple times and is easier
+        # to debug than generating it lazily.
+        self.__sql_tuple = table._model._field_to_sql(table._alias, field.name, table._query)._sql_tuple
+
+    @property
+    def _sql_tuple(self):
+        return self.__sql_tuple
+
+    def __getitem__(self, name: str) -> SQL:
+        table = self._table
+        return self._field.property_to_sql(self, name, table._model, table._alias, table._query)
+
+    __getattr__ = __getitem__
+
+    def __repr__(self):
+        return f"{self._table!r}.{self._field.name}"

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -397,7 +397,7 @@ class Cursor(BaseCursor):
     def mogrify(self, query, params=None) -> bytes:
         if isinstance(query, SQL):
             assert params is None, "Unexpected parameters for SQL query object"
-            query, params = query.code, query.params
+            query, params, _fields = query._sql_tuple
         return self._obj.mogrify(query, params)
 
     def execute(self, query, params=None, log_exceptions: bool = True) -> None:
@@ -405,9 +405,8 @@ class Cursor(BaseCursor):
 
         if isinstance(query, SQL):
             assert params is None, "Unexpected parameters for SQL query object"
-            query, params = query.code, query.params
-
-        if params and not isinstance(params, (tuple, list, dict)):
+            query, params, _fields = query._sql_tuple
+        elif params and not isinstance(params, (tuple, list, dict)):
             # psycopg2's TypeError is not clear if you mess up the params
             raise ValueError(f"SQL query parameters should be a tuple, list or dict; got {params!r}")
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -553,7 +553,10 @@ class BaseCase(case.TestCase):
         Cursor_execute = Cursor.execute
 
         def execute(self, query, params=None, log_exceptions=None):
-            actual_queries.append(query.code if isinstance(query, SQL) else query)
+            if isinstance(query, SQL):
+                assert params is None
+                query, params, _ = query._sql_tuple
+            actual_queries.append(query)
             return Cursor_execute(self, query, params, log_exceptions)
 
         if flush:

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -31,7 +31,7 @@ __all__ = [
 
 _schema = logging.getLogger('odoo.schema')
 
-IDENT_RE = re.compile(r'^[a-z0-9_][a-z0-9_$\-]*$', re.I)
+IDENT_RE = re.compile(r'^[a-z0-9_][a-z0-9_$\-]*$', re.IGNORECASE)
 
 _CONFDELTYPES = {
     'RESTRICT': 'r',
@@ -42,7 +42,18 @@ _CONFDELTYPES = {
 }
 
 
-class SQL:
+class _SQLMeta(type):
+    @staticmethod
+    def identifier(name: str, subname: str | None = None, to_flush: Field | None = None) -> SQL:
+        """ Return an SQL object that represents an identifier. """
+        assert name.isidentifier() or IDENT_RE.match(name), f"{name!r} invalid for SQL.identifier()"
+        if subname is None:
+            return SQL(f'"{name}"', to_flush=to_flush)
+        assert subname.isidentifier() or IDENT_RE.match(subname), f"{subname!r} invalid for SQL.identifier()"
+        return SQL(f'"{name}"."{subname}"', to_flush=to_flush)
+
+
+class SQL(metaclass=_SQLMeta):
     """ An object that wraps SQL code with its parameters, like::
 
         sql = SQL("UPDATE TABLE foo SET a = %s, b = %s", 'hello', 42)
@@ -63,35 +74,57 @@ class SQL:
             SQL("%s = %s", SQL.identifier(columnname), value),
         )
 
-    The combined SQL code is given by ``sql.code``, while the corresponding
-    combined parameters are given by the list ``sql.params``. This allows to
-    combine any number of SQL terms without having to separately combine their
-    parameters, which can be tedious, bug-prone, and is the main downside of
-    `psycopg2.sql <https://www.psycopg.org/docs/sql.html>`.
+    The combined result is available in ``_sql_tuple`` which contains ``code``,
+    ``params``, ``to_flush``. This allows to combine any number of SQL terms
+    without having to separately combine their parameters, which can be tedious,
+    bug-prone, and is the main downside of `psycopg2.sql
+    <https://www.psycopg.org/docs/sql.html>`.
+    The metadata ``to_flush`` contains fields on which the SQL code depends on.
 
     The second purpose of the wrapper is to discourage SQL injections. Indeed,
     if ``code`` is a string literal (not a dynamic string), then the SQL object
     made with ``code`` is guaranteed to be safe, provided the SQL objects
     within its parameters are themselves safe.
-
-    The wrapper may also contain some metadata ``to_flush``.  If not ``None``,
-    its value is a field which the SQL code depends on.  The metadata of a
-    wrapper and its parts can be accessed by the iterator ``sql.to_flush``.
     """
-    __slots__ = ('__code', '__params', '__to_flush')
+    __slots__ = ()
 
-    __code: str
-    __params: tuple
-    __to_flush: tuple[Field, ...]
+    @typing.overload
+    def __new__[T: SQL](cls: type[T], *a, **kw) -> T:
+        ...
 
-    # pylint: disable=keyword-arg-before-vararg
-    def __init__(self, code: (typing.LiteralString | SQL) = "", /, *args, to_flush: (Field | Iterable[Field] | None) = None, **kwargs):
+    @typing.overload
+    def __new__(cls: type[SQL], code: typing.LiteralString | SQL, /, *args, to_flush: Field | Iterable[Field] | None = None, **kw) -> LiteralSQL:
+        ...
+
+    def __new__(cls, *a, **kw):
+        if cls is SQL:
+            cls = LiteralSQL  # noqa: PLW0642
+        return object.__new__(cls)
+
+    _sql_tuple: tuple[str, tuple, tuple[Field, ...]]
+    """ The tuple used to execute the query: (code, params, to_flush) """
+
+    def __eq__(self, other):
+        if not isinstance(other, SQL):
+            return False
+        return self._sql_tuple[:2] == other._sql_tuple[:2]
+
+    def __hash__(self):
+        return hash(self._sql_tuple[:2])
+
+    def __bool__(self):
+        return bool(self._sql_tuple[0])
+
+
+class LiteralSQL(SQL):
+    __slots__ = ('__sql_tuple',)
+    __sql_tuple: tuple[str, tuple, tuple[Field, ...]]
+
+    def __init__(self, code: typing.LiteralString | SQL = "", /, *args, to_flush: Field | Iterable[Field] | None = None, **kwargs):
         if isinstance(code, SQL):
             if args or kwargs or to_flush:
                 raise TypeError("SQL() unexpected arguments when code has type SQL")
-            self.__code = code.__code
-            self.__params = code.__params
-            self.__to_flush = code.__to_flush
+            self.__sql_tuple = code._sql_tuple
             return
 
         # validate the format of code and parameters
@@ -102,14 +135,13 @@ class SQL:
             code, args = named_to_positional_printf(code, kwargs)
         elif not args:
             code % ()  # check that code does not contain %s
-            self.__code = code
-            self.__params = ()
             if to_flush is None:
-                self.__to_flush = ()
+                to_flush = ()
             elif hasattr(to_flush, '__iter__'):
-                self.__to_flush = tuple(to_flush)
+                to_flush = tuple(to_flush)
             else:
-                self.__to_flush = (to_flush,)
+                to_flush = (to_flush,)
+            self.__sql_tuple = (code, (), to_flush)
             return
 
         code_list = []
@@ -117,9 +149,10 @@ class SQL:
         to_flush_list = []
         for arg in args:
             if isinstance(arg, SQL):
-                code_list.append(arg.__code)
-                params_list.extend(arg.__params)
-                to_flush_list.extend(arg.__to_flush)
+                arg_code, arg_params, arg_to_flush = arg._sql_tuple
+                code_list.append(arg_code)
+                params_list.extend(arg_params)
+                to_flush_list.extend(arg_to_flush)
             else:
                 code_list.append("%s")
                 params_list.append(arg)
@@ -129,38 +162,19 @@ class SQL:
             else:
                 to_flush_list.append(to_flush)
 
-        self.__code = code.replace('%%', '%%%%') % tuple(code_list)
-        self.__params = tuple(params_list)
-        self.__to_flush = tuple(to_flush_list)
+        code = code.replace('%%', '%%%%') % tuple(code_list)
+        params = tuple(params_list)
+        to_flush = tuple(to_flush_list)
+        self.__sql_tuple = (code, params, to_flush)
 
     @property
-    def code(self) -> str:
-        """ Return the combined SQL code string. """
-        return self.__code
-
-    @property
-    def params(self) -> list:
-        """ Return the combined SQL code params as a list of values. """
-        return list(self.__params)
-
-    @property
-    def to_flush(self) -> Iterable[Field]:
-        """ Return an iterator on the fields to flush in the metadata of
-        ``self`` and all of its parts.
-        """
-        return self.__to_flush
+    def _sql_tuple(self):
+        # property makes the attribute read-only
+        return self.__sql_tuple
 
     def __repr__(self):
-        return f"SQL({', '.join(map(repr, [self.__code, *self.__params]))})"
-
-    def __bool__(self):
-        return bool(self.__code)
-
-    def __eq__(self, other):
-        return isinstance(other, SQL) and self.__code == other.__code and self.__params == other.__params
-
-    def __hash__(self):
-        return hash((self.__code, self.__params))
+        code, params, _ = self.__sql_tuple
+        return f"SQL({', '.join(map(repr, [code, *params]))})"
 
     def join(self, args: Iterable) -> SQL:
         """ Join SQL objects or parameters with ``self`` as a separator. """
@@ -170,22 +184,14 @@ class SQL:
             return SQL()
         if len(args) == 1 and isinstance(args[0], SQL):
             return args[0]
-        if not self.__params:
-            return SQL(self.__code.join("%s" for arg in args), *args)
+        code, params, to_flush = self.__sql_tuple
+        if not params:
+            return SQL(code.join(("%s",) * len(args)), *args, to_flush=to_flush)
         # general case: alternate args with self
         items = [self] * (len(args) * 2 - 1)
         for index, arg in enumerate(args):
             items[index * 2] = arg
         return SQL("%s" * len(items), *items)
-
-    @classmethod
-    def identifier(cls, name: str, subname: (str | None) = None, to_flush: (Field | None) = None) -> SQL:
-        """ Return an SQL object that represents an identifier. """
-        assert name.isidentifier() or IDENT_RE.match(name), f"{name!r} invalid for SQL.identifier()"
-        if subname is None:
-            return cls(f'"{name}"', to_flush=to_flush)
-        assert subname.isidentifier() or IDENT_RE.match(subname), f"{subname!r} invalid for SQL.identifier()"
-        return cls(f'"{name}"."{subname}"', to_flush=to_flush)
 
 
 def existing_tables(cr, tablenames):
@@ -595,7 +601,7 @@ def add_index(cr, indexname, tablename, definition, *, unique: bool, comment='')
     cr.execute(query, log_exceptions=False)
     if query_comment:
         cr.execute(query_comment, log_exceptions=False)
-    _schema.debug("Table %r: created index %r (%s)", tablename, indexname, definition.code)
+    _schema.debug("Table %r: created index %r (%s)", tablename, indexname, definition)
 
 
 def drop_index(cr, indexname, tablename):

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -6,11 +6,11 @@ import enum
 import json
 import logging
 import re
+import typing
 from binascii import crc32
 from collections import defaultdict
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from odoo.fields import Field
     from collections.abc import Iterable
 
@@ -85,7 +85,7 @@ class SQL:
     __to_flush: tuple[Field, ...]
 
     # pylint: disable=keyword-arg-before-vararg
-    def __init__(self, code: (str | SQL) = "", /, *args, to_flush: (Field | Iterable[Field] | None) = None, **kwargs):
+    def __init__(self, code: (typing.LiteralString | SQL) = "", /, *args, to_flush: (Field | Iterable[Field] | None) = None, **kwargs):
         if isinstance(code, SQL):
             if args or kwargs or to_flush:
                 raise TypeError("SQL() unexpected arguments when code has type SQL")


### PR DESCRIPTION
New way of building SQL queries and facilitate to use the Query object. We also prepare the groundwork for t-strings.
As many framework functions that generate SQL use (alias, model, query) as parameters, we make a class that abstracts this. `TableSQL` is actually (alias, model, query). Accessing a public attribute or getitem resolve to a field `FieldSQL` object that represents a field in a table: actually what `_field_to_sql` does but allow to further access attributes.

Simple use case:
```py
query = Query(model)  # or call model._search(...)
table = query.table  # TableSQL
query.add_where(SQL("%s > %s", table.create_date, table.partner_id.create_date))
```

Bundled features:
- `TableSQL._join` to join by field or to join arbitrary sub-queries
- Simpler traversal of related fields.


https://github.com/odoo/enterprise/pull/98682
https://github.com/odoo/documentation/pull/15257
https://github.com/odoo/upgrade/pull/8757


closes #195822

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
