### PR TITLE
[FIX] account: load CoA data from other modules with demo

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -409,10 +409,11 @@ class AccountChartTemplate(models.AbstractModel):
                             if rename_idx:
                                 tax_to_rename.name = f"[old{rename_idx - 1 if rename_idx > 1 else ''}] {tax_to_rename.name}"
                     else:
-                        fiscal_position_ids = values.get('fiscal_position_ids')
-                        original_tax_ids = values.get('original_tax_ids')
-                        repartition_lines = values.get('repartition_line_ids')
-                        values.clear()
+                        fiscal_position_ids = values.pop('fiscal_position_ids', None)
+                        original_tax_ids = values.pop('original_tax_ids', None)
+                        repartition_lines = values.pop('repartition_line_ids', None)
+                        if not force_update:
+                            values.clear()
                         # taxes will always be (re)linked to fiscal positions (unless the fp doesn't exist and won't be created)
                         if fiscal_position_ids:
                             link_commands = [


### PR DESCRIPTION
Steps to reproduce:
* create a new database with a module inheriting a CoA and demo data activated (i.e. `-i l10n_co_edi --with-demo`)

The demo company won't load the additional data defined in the module, in this case the data for the field `l10n_co_edi_type` with the call from `<account.chart.template>._get_co_edi_account_tax`. 

This is because during the recent refactor, the new flag `force_update` had not been taken into account everywhere it should. 
See: 64f9dcb045231ea8cf2edb14de536decb8b9b508

