### PR TITLE
[FIX] pos_sale: prevent lot lines duplication on SO import

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -161,6 +161,7 @@ patch(PosStore.prototype, {
             newLine.set_unit_price(converted_line.price_unit);
             newLine.set_discount(line.discount);
 
+            const lot_splitted_lines = [];
             const product_unit = line.product_id.uom_id;
             if (product_unit && !product_unit.is_pos_groupable) {
                 let remaining_quantity = newLine.qty;
@@ -172,6 +173,9 @@ patch(PosStore.prototype, {
                     splitted_line.set_quantity(Math.min(remaining_quantity, 1.0), true);
                     splitted_line.set_discount(line.discount);
                     remaining_quantity -= splitted_line.qty;
+                    if (splitted_line.product_id.tracking == "lot") {
+                        lot_splitted_lines.push(splitted_line);
+                    }
                 }
             }
 
@@ -182,16 +186,39 @@ patch(PosStore.prototype, {
                 useLoadedLots
             ) {
                 newLine.delete();
+                let total_lot_quantity = 0;
                 for (const lot of converted_line.lot_names) {
+                    let lot_remaining_quantity = converted_line.lot_qty_by_name[lot] || 0;
+                    while (lot_splitted_lines.length && lot_remaining_quantity > 0) {
+                        const splitted_line = lot_splitted_lines.shift();
+                        splitted_line.setPackLotLines({
+                            modifiedPackLotLines: [],
+                            newPackLotLines: [{ lot_name: lot }],
+                            setQuantity: false,
+                        });
+                        total_lot_quantity += splitted_line.qty;
+                        lot_remaining_quantity -= splitted_line.qty;
+                    }
+                    if (lot_remaining_quantity > 0 && lot_splitted_lines.length == 0) {
+                        const splitted_line = this.models["pos.order.line"].create({
+                            ...newLineValues,
+                        });
+                        splitted_line.set_quantity(lot_remaining_quantity, true);
+                        splitted_line.set_discount(line.discount);
+                        splitted_line.setPackLotLines({
+                            modifiedPackLotLines: [],
+                            newPackLotLines: [{ lot_name: lot }],
+                            setQuantity: false,
+                        });
+                        total_lot_quantity += lot_remaining_quantity;
+                    }
+                }
+                if (total_lot_quantity < newLineValues.qty && lot_splitted_lines.length == 0) {
                     const splitted_line = this.models["pos.order.line"].create({
                         ...newLineValues,
                     });
-                    splitted_line.set_quantity(converted_line.lot_qty_by_name[lot] || 0, true);
-                    splitted_line.setPackLotLines({
-                        modifiedPackLotLines: [],
-                        newPackLotLines: [{ lot_name: lot }],
-                        setQuantity: false,
-                    });
+                    splitted_line.set_quantity(newLineValues.qty - total_lot_quantity, true);
+                    splitted_line.set_discount(line.discount);
                 }
             }
         }

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -132,6 +132,19 @@ registry.category("web_tour.tours").add("PosSettleOrderNotGroupable", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_import_lot_groupable_and_non_groupable", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1, { loadSN: true }),
+            PosSale.selectedOrderLinesHasLots("Groupable Product", []),
+            ProductScreen.checkOrderlinesNumber(5),
+            ProductScreen.totalAmountIs(60),
+            ProductScreen.selectedOrderlineHas("Groupable Product", "1", "10"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("PosSettleOrderWithNote", {
     steps: () =>
         [

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -343,6 +343,67 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_pos_tour('PosSettleOrderNotGroupable', login="accountman")
 
+    def test_import_lot_groupable_and_non_groupable(self):
+        """
+        Test importing a Sale Order in POS containing both groupable and non-groupable
+        lot-tracked products, each with quantities exceeding available lots.
+        Ensures the POS correctly handles lot selection and grouping behavior.
+        """
+        uom_category = self.env['uom.category'].create({
+            'name': 'Non groupable',
+            'is_pos_groupable': False,
+        })
+        non_groupable_uom = self.env['uom.uom'].create({
+            'name': 'Non groupable',
+            'category_id': uom_category.id,
+            'uom_type': 'reference',
+            'rounding': 0.01
+        })
+        groupable_product, non_groupable_product = self.env['product.product'].create([{
+            'name': name,
+            'available_in_pos': True,
+            'is_storable': True,
+            'lst_price': 10.0,
+            'tracking': 'lot',
+            'taxes_id': False,
+        } for name in ('Groupable Product', 'Non Groupable Product')])
+        non_groupable_product.uom_id = non_groupable_uom.id
+
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        stock_location = warehouse.lot_stock_id
+        non_groupable_lot, groupable_lot = self.env['stock.lot'].create([{
+            'name': f'LOT {product.name}',
+            'product_id': product.id,
+            'company_id': self.env.company.id,
+        } for product in (non_groupable_product, groupable_product)])
+        self.env['stock.quant'].with_context(inventory_mode=True).create([{
+            'product_id': lot.product_id.id,
+            'inventory_quantity': 2,
+            'location_id': stock_location.id,
+            'lot_id': lot.id,
+        } for lot in (non_groupable_lot, groupable_lot)]).action_apply_inventory()
+
+        sale_order = self.env['sale.order'].sudo().create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [
+                Command.create({
+                    'product_id': non_groupable_product.id,
+                    'name': non_groupable_product.name,
+                    'product_uom_qty': 3,
+                }),
+                Command.create({
+                    'product_id': groupable_product.id,
+                    'name': groupable_product.name,
+                    'product_uom_qty': 3,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.amount_total, 60)
+
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_import_lot_groupable_and_non_groupable', login="accountman")
+
     def test_customer_notes(self):
         """This test create an order and settle it in the PoS. It also uses multistep delivery
             and we need to make sure that all the picking are cancelled if the order is fully delivered.


### PR DESCRIPTION
## Issue:
After confirming a Sale Order for a lot-tracked product (in grams for example) and having available quantities, importing the SO in POS duplicates the order lines

## Cause:
In the `settleSO` function, the line is first split because the UoM differs and is not `pos_groupable`
Among the default UoMs, only Units, Pack of 6, and Dozen have `is_pos_groupable` = True, meaning most other UoMs will trigger a line split

After duplicating the line due to the UoM split, an additional line is then added for each lot to link, causing duplicate entries in the POS order

## Steps to reproduce:
- In Settings, enable Lots & Serial Numbers and Units of Measure & Packagings
- Create a Product (Tracking: Lot, Sale Unit: g)
- Update the Quantity On Hand (Lot: "LOT", Quantity: 5)
- Create and confirm a Sale Order for the product (Quantity: 2)
- Open POS and import the SO
- Before the fix, there is 3 lines (2x no lots, 1x with lot + qty 2

## Other issues:
- The discount was not imported on the lot lines
- Some lines were missing when importing lines where part of the quantity had no available lot
- (This fix was already made in PR: https://github.com/odoo/odoo/pull/229075/files but was not forward-ported)

opw-5018295