### PR TITLE
[FIX] hr_homeworking: show leave icon before location

### DIFF
--- a/addons/hr_holidays_homeworking/__init__.py
+++ b/addons/hr_holidays_homeworking/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/hr_holidays_homeworking/__manifest__.py
+++ b/addons/hr_holidays_homeworking/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'Holidays with Remote Work',
+    'category': 'Human Resources',
+    'summary': 'Manage holidays with remote work',
+    'depends': [
+        'hr_holidays',
+        'hr_homeworking',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'hr_holidays_homeworking/static/src/**/*',
+        ],
+        'web.assets_unit_tests': [
+            'hr_holidays_homeworking/static/tests/**/*',
+        ],
+    },
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+    'auto_install': True,
+}

--- a/addons/hr_holidays_homeworking/models/__init__.py
+++ b/addons/hr_holidays_homeworking/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_employee

--- a/addons/hr_holidays_homeworking/models/hr_employee.py
+++ b/addons/hr_holidays_homeworking/models/hr_employee.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    def _compute_presence_icon(self):
+        super()._compute_presence_icon()
+        dayfield = self._get_current_day_location_field()
+        for employee in self:
+            today_employee_location_id = employee.sudo().exceptional_location_id or employee[dayfield]
+            if employee.is_absent:
+                employee.hr_icon_display = f'presence_holiday_{"absent" if employee.hr_presence_state != "present" else "present"}'
+                employee.show_hr_icon_display = True
+            elif today_employee_location_id:
+                employee.hr_icon_display = f'presence_{today_employee_location_id.location_type}'
+                employee.show_hr_icon_display = True

--- a/addons/hr_holidays_homeworking/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays_homeworking/static/src/components/hr_presence_status/hr_presence_status.js
@@ -1,0 +1,80 @@
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+import { HrPresenceStatus } from "@hr/components/hr_presence_status/hr_presence_status";
+import { HrPresenceStatusPrivate } from "@hr/components/hr_presence_status_private/hr_presence_status_private";
+
+const patchHrPresenceStatus = () => ({
+    get color() {
+        if (this.value?.includes("holiday")) {
+            return `${this.value === "presence_holiday_present" ? "text-success" : "o_icon_employee_absent"}`;
+        } else if (this.location) {
+            let color = "text-muted";
+            if (this.props.record.data.hr_presence_state !== "out_of_working_hour") {
+                color = this.props.record.data.hr_presence_state === "present" ?  "text-success" : "o_icon_employee_absent";
+            }
+            return color;
+        }
+        return super.color;
+    },
+
+    get icon() {
+        if (this.value?.includes("holiday")) {
+            return "fa-plane";
+        } else if (this.location) {
+            switch (this.location) {
+                case "home":
+                    return "fa-home";
+                case "office":
+                    return "fa-building";
+                case "other":
+                    return "fa-map-marker";
+            }
+        }
+        return super.icon;
+    },
+
+    get label() {
+        if (this.value?.includes("holiday")) {
+            return _t("%(label)s, back on %(date)s",
+                {
+                    label: this.value !== false
+                        ? this.options.find(([value, label]) => value === this.value)[1]
+                        : "",
+                    date: this.props.record.data['leave_date_to'].toLocaleString(
+                        {
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                        }
+                    )
+                }
+            )
+        } else if (this.location) {
+            return this.props.record.data.work_location_name || _t("Unspecified")
+        }
+        return super.label;
+    },
+});
+
+patch(HrPresenceStatus.prototype, patchHrPresenceStatus());
+patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatus());
+
+patch(HrPresenceStatusPrivate.prototype, {
+    get label() {
+        return this.props.record.data.current_leave_id
+            ? _t("%(label)s, back on %(date)s",
+                {
+                    label: this.props.record.data.current_leave_id.display_name,
+                    date: this.props.record.data['leave_date_to'].toLocaleString(
+                        {
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                        }
+                    )
+                }
+            )
+            : super.label;
+    }
+});

--- a/addons/hr_holidays_homeworking/static/tests/hr_presence_status.test.js
+++ b/addons/hr_holidays_homeworking/static/tests/hr_presence_status.test.js
@@ -1,0 +1,36 @@
+import { test, expect } from "@odoo/hoot";
+import { mountView, models, defineModels } from "@web/../tests/web_test_helpers";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+
+class HrEmployee extends models.ServerModel {
+    _name = "hr.employee";
+}
+defineMailModels();
+defineModels([HrEmployee]);
+
+test("Show Time Off before Work Location", async () => {
+    HrEmployee._records = [
+        {
+            id: 1,
+            name: "Employee test",
+            work_location_name: "Office 1",
+            work_location_type: "office",
+            show_hr_icon_display: true,
+            hr_icon_display: "presence_holiday_absent",
+            leave_date_to: "2025-01-06 00:00:00",
+        },
+    ];
+    await mountView({
+        resModel: "hr.employee",
+        type: "form",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="hr_icon_display" widget="hr_presence_status"/>
+            </form>`,
+    });
+    expect("small.fa-building").toHaveCount(0);
+    expect("small.fa-plane").toBeVisible();
+    expect("small.fa-plane").toHaveAttribute("title", "On leave, back on Jan 6, 2025");
+    expect("small.fa-plane").toHaveClass("o_icon_employee_absent");
+});

--- a/addons/hr_homeworking/models/hr_employee.py
+++ b/addons/hr_homeworking/models/hr_employee.py
@@ -57,7 +57,7 @@ class HrEmployee(models.Model):
         dayfield = self._get_current_day_location_field()
         for employee in self:
             today_employee_location_id = employee.sudo().exceptional_location_id or employee[dayfield]
-            if not today_employee_location_id or employee.hr_icon_display.startswith('presence_holiday'):
+            if not today_employee_location_id:
                 continue
             employee.hr_icon_display = f'presence_{today_employee_location_id.location_type}'
             employee.show_hr_icon_display = True


### PR DESCRIPTION
Issue is that when a person is in leave and has a work location set, the work location icon in the presence widget takes presedence before the leave icon. The widget uses a get icon() function to return which icon to display. This function is then patched to add new icons. The plane icon for time off is in the hr_holidays module while the house and building icons in the hr_homeworking module.

The issue is that hr_homeworking overrides the patch from hr_holidays giving it more priority. The fix is a "revert" where if the presence value is holiday the work location will not be set, making the label and icon not be set.

task-5223178