### PR TITLE
[FIX] website: restore missing background color option for category s…

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
@@ -20,7 +20,7 @@ export class WebsiteBackgroundCarouselOption extends BaseWebsiteBackgroundOption
 
 export class WebsiteBackgroundBGColorImageOption extends BaseWebsiteBackgroundOption {
     static selector =
-        "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div";
+        "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .s_ecomm_categories_showcase_block";
     static exclude = `${BASE_ONLY_BG_IMAGE_SELECTOR}, .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_item`;
     static defaultProps = {
         withColors: true,


### PR DESCRIPTION
…nippet

The refactoring of snippet options in PR [1] inadvertently removed the background color options from the category snippet sidebar.

This commit restores the missing background color customization options, reintroducing the behavior originally added in [1].

[1]: https://github.com/odoo/odoo/pull/233376
[2]: https://github.com/odoo/odoo/pull/226114

<img width="1803" height="853" alt="image" src="https://github.com/user-attachments/assets/8fbec534-d25c-4e46-82a0-ddc579d5a02a" />