### PR TITLE
[FIX] point_of_sale: correct price calculation for lot-tracked products

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -206,11 +206,9 @@ export class ProductTemplate extends Base {
         const basePrice = variant ? variant.lst_price : this.list_price;
         let price = basePrice + (price_extra || 0);
 
-        if (original_line && original_line.isLotTracked()) {
+        if (original_line && original_line.isLotTracked() && variant) {
             related_lines.push(
-                ...original_line.order_id.lines.filter(
-                    (line) => line.product_id.product_tmpl_id.id == this.id
-                )
+                ...original_line.order_id.lines.filter((line) => line.product_id.id == variant.id)
             );
             quantity = related_lines.reduce((sum, line) => sum + line.getQuantity(), 0);
         }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -368,10 +368,14 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
             ProductScreen.selectedOrderlineHas("Test Product 1", "1", "80.0"),
 
             scan_barcode("0100201"),
+            ProductScreen.enterLotNumber("1"),
             ProductScreen.selectedOrderlineHas("Test Product 2", "1", "100.0", "White"),
 
             scan_barcode("0100202"),
+            ProductScreen.enterLotNumber("1"),
             ProductScreen.selectedOrderlineHas("Test Product 2", "1", "120.0", "Red"),
+
+            ProductScreen.totalAmountIs("300.0"),
 
             refresh(),
             inLeftSide([

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1299,6 +1299,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'taxes_id': False,
             'available_in_pos': True,
             'pos_categ_ids': [(4, limited_category.id)],
+            'tracking': 'lot',
             'attribute_line_ids': [(0, 0, {
                 'attribute_id': color_attribute.id,
                 'value_ids': [(6, 0, color_attribute.value_ids.ids)]


### PR DESCRIPTION
Before this commit, when a product had multiple variants with different prices and was tracked by lot, adding different variants in the PoS would incorrectly update all product prices.

opw-5228830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
