### PR TITLE
[FIX] account_payment: make previous payment tokens selectable again

### DIFF
--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -550,18 +550,23 @@ class TestAccountPayment(AccountPaymentCommon):
 
     def test_payment_token_for_invoice_partner_is_available(self):
         """Test that the payment token of the invoice partner is available"""
+        Wizard = self.env['account.payment.register'].with_context(active_model='account.move')
         with self.mocked_get_payment_method_information():
             bank_journal = self.company_data['default_journal_bank']
             payment_method_line = bank_journal.inbound_payment_method_line_ids\
                 .filtered(lambda line: line.payment_provider_id == self.dummy_provider)
             self.assertTrue(payment_method_line)
-            child_partner = self.env['res.partner'].create(
-                {
-                    'name': "test_payment_token_for_invoice_partner_is_available",
-                    'is_company': False,
-                    'parent_id': self.partner.id,
-                }
-            )
+
+            def payment_register_wizard(invoices):
+                return Wizard.with_context(active_ids=invoices.ids).create({
+                    'payment_method_line_id': payment_method_line.id,
+                })
+
+            child_partner, other_child = self.env['res.partner'].create([{
+                'name': name,
+                'is_company': False,
+                'parent_id': self.partner.id,
+            } for name in ("child_partner", "other_child")])
             invoice = self.env['account.move'].create({
                 'move_type': 'out_invoice',
                 'partner_id': child_partner.id,
@@ -574,12 +579,21 @@ class TestAccountPayment(AccountPaymentCommon):
             })
             invoice.action_post()
             payment_token = self._create_token(partner_id=child_partner.id)
-            wizard = (
-                self.env["account.payment.register"]
-                .with_context(active_model="account.move", active_ids=invoice.ids)
-                .create({"payment_method_line_id": payment_method_line.id})
-            )
+            wizard = payment_register_wizard(invoice)
             self.assertRecordValues(wizard, [{
                 'suitable_payment_token_ids': payment_token.ids,
                 'payment_token_id': payment_token.id,
             }])
+
+            # Check that tokens assigned to the specific partner as well as their
+            # commercial partner can be selected.
+            parent_token = self._create_token(partner_id=self.partner.id)
+            wizard = payment_register_wizard(invoice)
+            self.assertEqual(wizard.suitable_payment_token_ids, payment_token + parent_token)
+
+            # Check that payments for multiple invoices with multiple partners
+            # only retrieve tokens assigned to a common commercial partner.
+            other_invoice = invoice.copy({'partner_id': other_child.id})
+            other_invoice.action_post()
+            wizard = payment_register_wizard(invoice + other_invoice)
+            self.assertEqual(wizard.suitable_payment_token_ids, parent_token)


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a sales order for a company partner;
2. create & copy a payment link;
3. open payment link in new session;
4. using demo provider, make the payment & save payment details;
5. add an invoice address to the company partner;
6. create an invoice for the company partner using the invoice address;
7. confirm invoice;
8. click "Register Payment";
9. select "Demo" as payment provider.

Issue
-----
The saved payment token cannot be selected.

Cause
-----
Before commit 75f4008, the company partner was used to search for tokens in the payment register wizard. After the commit, the the invoice partner is used, making it impossible to select previously accessible payment tokens.

Solution
--------
Search payment tokens linked to either partner.

opw-5193718