### PR TITLE
[FIX] core: soft session rotation + werkzeug.exceptions.abort

### DIFF
--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -12,12 +12,20 @@ import pytz
 from freezegun import freeze_time
 
 import odoo
-from odoo.http import root, SESSION_DELETION_TIMER, SESSION_LIFETIME, SESSION_ROTATION_INTERVAL, STORED_SESSION_BYTES, _session_identifier_re
+from odoo.http import (
+    SESSION_DELETION_TIMER,
+    SESSION_LIFETIME,
+    SESSION_ROTATION_INTERVAL,
+    STORED_SESSION_BYTES,
+    _session_identifier_re,
+    root,
+)
 from odoo.tests import get_db_name, tagged
 from odoo.tools import config, mute_logger, reset_cached_properties
 
 from .test_common import TestHttpBase
 from odoo.addons.base.tests.common import HttpCase, HttpCaseWithUserDemo
+from odoo.addons.test_http.controllers import CT_JSON
 
 GEOIP_ODOO_FARM_2 = {
     'city': 'Ramillies',
@@ -330,6 +338,17 @@ class TestHttpSession(TestHttpBase):
             "Cannot use both the session_id cookie and the x-odoo-database header.",
             res.text,
         )
+
+    def test_session16_soft_rotate_with_abort(self):
+        session = self.authenticate('admin', 'admin')
+        session['create_time'] -= SESSION_ROTATION_INTERVAL
+        odoo.http.root.session_store.save(session)
+
+        # Any route that uses werkzeug.exceptions.abort would do, here
+        # we call a simple type='jsonrpc' route with bad data to trigger
+        # the abort in odoo.http.JsonRPCDispatcher.dispatch.
+        res = self.url_open('/test_http/echo-json', data="not json", headers=CT_JSON)
+        self.assertEqual(res.status_code, 400, res.text)
 
 
 class TestSessionStore(HttpCaseWithUserDemo):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1009,7 +1009,8 @@ class FilesystemSessionStore(sessions.FilesystemSessionStore):
         else:
             self.delete(session)
             session.sid = self.generate_key()
-        if session.uid and env:
+        if session.uid:
+            assert env, "saving this session requires an environment"
             session.session_token = security.compute_session_token(session, env)
         session.should_rotate = False
         session['create_time'] = time.time()
@@ -2187,19 +2188,27 @@ class Request:
         Dispatch the request to its matching controller in a
         database-free environment.
         """
-        router = root.nodb_routing_map.bind_to_environ(self.httprequest.environ)
         try:
-            rule, args = router.match(return_rule=True)
-        except NotFound as exc:
-            exc.response = Response(NOT_FOUND_NODB, status=exc.code, headers=[
-                ('Content-Type', 'text/html; charset=utf-8'),
-            ])
-            raise
-        self._set_request_dispatcher(rule)
-        self.dispatcher.pre_dispatch(rule, args)
-        response = self.dispatcher.dispatch(rule.endpoint, args)
-        self.dispatcher.post_dispatch(response)
-        return response
+            router = root.nodb_routing_map.bind_to_environ(self.httprequest.environ)
+            try:
+                rule, args = router.match(return_rule=True)
+            except NotFound as exc:
+                exc.response = Response(NOT_FOUND_NODB, status=exc.code, headers=[
+                    ('Content-Type', 'text/html; charset=utf-8'),
+                ])
+                raise
+            self._set_request_dispatcher(rule)
+            self.dispatcher.pre_dispatch(rule, args)
+            response = self.dispatcher.dispatch(rule.endpoint, args)
+            self.dispatcher.post_dispatch(response)
+            return response
+        except HTTPException as exc:
+            if exc.code is not None:
+                raise
+            # Valid response returned via werkzeug.exceptions.abort
+            response = exc.get_response()
+            HttpDispatcher(self).post_dispatch(response)
+            return response
 
     def _serve_db(self):
         """ Load the ORM and use it to process the request. """
@@ -2266,13 +2275,21 @@ class Request:
                 return service_model.retrying(serve_func, env=self.env)
             except Exception as exc:  # noqa: BLE001
                 raise self._update_served_exception(exc)
+        except HTTPException as exc:
+            if exc.code is not None:
+                raise
+            # Valid response returned via werkzeug.exceptions.abort
+            response = exc.get_response()
+            HttpDispatcher(self).post_dispatch(response)
+            return response
         finally:
+            self.env = None
             if cr is not None:
                 cr.close()
 
     def _update_served_exception(self, exc):
         if isinstance(exc, HTTPException) and exc.code is None:
-            return exc  # bubble up to odoo.http.Application.__call__
+            return exc  # bubble up to _serve_db
         if (
             'werkzeug' in config['dev_mode']
             and self.dispatcher.routing_type != JsonRPCDispatcher.routing_type
@@ -2801,12 +2818,6 @@ class Application:
                 return response(environ, start_response)
 
             except Exception as exc:
-                # Valid (2xx/3xx) response returned via werkzeug.exceptions.abort.
-                if isinstance(exc, HTTPException) and exc.code is None:
-                    response = exc.get_response()
-                    HttpDispatcher(request).post_dispatch(response)
-                    return response(environ, start_response)
-
                 # Logs the error here so the traceback starts with ``__call__``.
                 if hasattr(exc, 'loglevel'):
                     _logger.log(exc.loglevel, exc, exc_info=getattr(exc, 'exc_info', None))


### PR DESCRIPTION
Steps to reproduce
------------------

Login to runbot, wait `odoo.http.SESSION_ROTATION_INTERVAL`s (3h) then access any page, then access any bundle using its id (not its `f'{name}-{id}') e.g. `/runbot/bundle/123`. Traceback: cannot use a closed cursor. It occurs when the system tries to save the session.

Traceback, explained
--------------------

1. The previous request session underwent a "soft rotation", its sid changed and it was marked "gc_previous_sessions".
2. The following request matches a route that is website & multilang, it is the case of the runbot bundle route.
3. The session was marked "gc_previous_sessions", it removes *now* the other sessions and removes the mark from the current one, this sets the current session dirty.
4. The request URL is not canonical, `_pre_dispatch` in `http_routing` abords with a redirection to `/runbot/bundle/18.0-123`.
5. The abortion (`werkzeug.exceptions.abort`) is an exception that bubbles up all the way up in the http stack, notably above `_serve_db` where `request.env.cr` is closed.
6. `odoo.http.root.__call__` ultimatelly processes the response received from `_pre_dispatch`: it calls `post_process` which call `_save_session` which sees that the current session is dirty: it attempts to save it.
7. Because there is a `session.uid`, we need to refresh the session token, for that we need an environment and a cursor.
8. Kaboom, the cursor was closed by `_serve_db`.

Problem
-------

When we set/delete items from the session, the changes are only saved in the session object in memory. The modified session is only written once, at the end of the request, if no error occured.

When we save the session, we gotta update the `session_token` value, this token is a SHA over the user's login information: active, email, password, ... and is verified upon loading the session in a future request. Should the user changes its password, a new token would be computed and all the sessions with the old token would become invalid. Should the user uses an old session, he would get redirected to /web/login.

Computing the `session_token` is mandatory when there's a `uid` inside the session, otherwise the session would be invalid. Computing it requires a valid cursor to fetch the user's active, email, password, ...

In our case, the (valid) response contained in `wekzeug.exception.abort` did bubble-up above `_serve_db`: `request.env.cr` is closed.

Solution
--------

Move the exception handling for `werkzeug.exceptions.abort` in both `_serve_nodb` and `_serve_db`. That it is in `_serve_db` makes it possible to call `_post_dispatch` with a cursor and environment that are still alive. This fixes the problem at hand.

With the above fix, comes two sanity things:

The `if session.uid and env` conditional is wrong, it must be only `if session.uid`. When there is a uid stored in the session, updating the `session_token` is mandatory. It MUST crash if `save()` is called for a session with a uid but with no environment.

The `_serve_db` method manages both the request's cursor and the `request.env` attribute. Everytime the cursor is updated (e.g. when changing from a read-only to a read+write one)
