### PR TITLE
[IMP] account: Adding a new concept on the report.

### DIFF
--- a/addons/account/data/account_reports_data.xml
+++ b/addons/account/data/account_reports_data.xml
@@ -8,6 +8,7 @@
             <field name="filter_multi_company">tax_units</field>
             <field name="allow_foreign_vat" eval="1"/>
             <field name="default_opening_date_filter">previous_return_period</field>
+            <field name="use_fiscal_periods">False</field>
             <field name="only_tax_exigible" eval="True"/>
             <field name="column_ids">
                 <record id="generic_tax_report_column_net" model="account.report.column">

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -101,6 +101,12 @@ class AccountReport(models.Model):
         precompute=True,
         readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
+    use_fiscal_periods = fields.Boolean(
+        string="Fiscal Periods",
+        compute=lambda x: x._compute_report_option_filter('use_fiscal_periods', True),
+        precompute=True, readonly=False, store=True,
+        depends=['root_report_id', 'section_main_report_ids'],
+    )
 
     currency_translation = fields.Selection(
         string="Currency Translation",


### PR DESCRIPTION
Adding a boolean field: is_fiscal_year to add more information about how the report dates should behaves. If set to true, the year filter is based on the fiscal year otherwise not.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
