### PR TITLE
[FIX] product: pricelist report

### DIFF
--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -3,7 +3,7 @@
 from odoo import api, models
 
 
-class ReportProductReport_Pricelist(models.AbstractModel):
+class ProductPricelistReport(models.AbstractModel):
     _name = 'report.product.report_pricelist'
     _description = 'Pricelist Report'
 
@@ -38,18 +38,19 @@ class ReportProductReport_Pricelist(models.AbstractModel):
         return {
             'is_html_type': report_type == 'html',
             'is_product_tmpl': is_product_tmpl,
-            'display_pricelist_title': data.get('display_pricelist_title', False) and bool(data['display_pricelist_title']),
+            'display_pricelist_title': bool(data.get('display_pricelist_title', False)),
             'pricelist': pricelist,
             'products': products_data,
             'quantities': quantities,
             'docs': pricelist,
+            'currency': pricelist.currency_id or self.env.company.currency_id,
         }
 
     def _get_product_data(self, is_product_tmpl, product, pricelist, quantities):
         product = product.with_context(display_default_code=False)
         data = {
             'id': product.id,
-            'name': is_product_tmpl and product.name or product.display_name,
+            'name': (is_product_tmpl and product.name) or product.display_name,
             'price': dict.fromkeys(quantities, 0.0),
             'uom': product.uom_id.name,
             'default_code': product.default_code,

--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -47,7 +47,7 @@
                                     <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
                                     <t t-foreach="quantities" t-as="qty">
                                         <td class="text-end px-1">
-                                            <span t-out="product['price'][qty]" t-options='{"widget": "monetary", "display_currency": pricelist.currency_id}'>$15.00</span>
+                                            <span t-out="product['price'][qty]" t-options='{"widget": "monetary", "display_currency": currency}'>$15.00</span>
                                         </td>
                                     </t>
                                 </tr>
@@ -63,7 +63,7 @@
                                         <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
                                         <t t-foreach="quantities" t-as="qty">
                                             <td class="text-end px-1">
-                                                <span t-out="variant['price'][qty]" t-options='{"widget": "monetary", "display_currency": pricelist.currency_id}'>$14.00</span>
+                                                <span t-out="variant['price'][qty]" t-options='{"widget": "monetary", "display_currency": currency}'>$14.00</span>
                                             </td>
                                         </t>
                                     </tr>

--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.js
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.js
@@ -110,7 +110,7 @@ export class ProductPricelistReport extends Component {
             active_model: this.activeModel || 'product.template',
             active_ids: this.activeIds || [],
             display_pricelist_title: this.displayPricelistTitle || '',
-            pricelist_id: this.selectedPricelist.id || '',
+            pricelist_id: this.selectedPricelist?.id || '',
             quantities: this.quantities || [1],
         };
     }

--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
@@ -17,7 +17,7 @@
                     <form class="o_pricelist_report_form d-flex flex-row gap-1">
                         <div class="d-flex align-items-center gap-3 w-100">
                             <label class="visually-hidden" for="pricelists">Username</label>
-                            <div class="input-group w-auto">
+                            <div t-if="pricelists.length > 0" class="input-group w-auto">
                                 <div class="input-group-text fw-bold">Pricelist</div>
                                 <select
                                     name="pricelists"
@@ -33,7 +33,7 @@
                                     </t>
                                 </select>
                             </div>
-                            <div class="form-check w-auto">
+                            <div t-if="pricelists.length > 0" class="form-check w-auto">
                                 <input class="o_display_pricelist_title form-check-input ms-0 me-2"
                                     id="display_pricelist_title"
                                     type="checkbox"

--- a/addons/product/tests/__init__.py
+++ b/addons/product/tests/__init__.py
@@ -1,15 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_barcode
-from . import test_common
-from . import test_import_files
-from . import test_name
-from . import test_pricelist
-from . import test_pricelist_auto_creation
-from . import test_product_attribute_value_config
-from . import test_product_combo
-from . import test_product_pricelist
-from . import test_seller
-from . import test_update_pav_wizard
-from . import test_variants
-from . import test_product_rounding
+from . import (
+    test_barcode,
+    test_common,
+    test_import_files,
+    test_name,
+    test_pricelist,
+    test_pricelist_auto_creation,
+    test_pricelist_report,
+    test_product_attribute_value_config,
+    test_product_combo,
+    test_product_pricelist,
+    test_product_rounding,
+    test_seller,
+    test_update_pav_wizard,
+    test_variants,
+)

--- a/addons/product/tests/test_pricelist_report.py
+++ b/addons/product/tests/test_pricelist_report.py
@@ -1,0 +1,38 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.product.tests.common import ProductCommon
+
+
+@tagged('post_install', '-at_install')
+class TestPricelistReport(ProductCommon):
+
+    def test_product_template_pricelist_report(self):
+        """Load report for `product.template` records."""
+        self.env['report.product.report_pricelist'].get_html(data={
+            'active_ids': self.env['product.template'].search([]).ids,
+        })
+        # Empty report
+        self.env['report.product.report_pricelist'].get_html(data={})
+
+    def test_product_product_pricelist_report(self):
+        """Load report for `product.product` records."""
+        self.env['report.product.report_pricelist'].get_html(data={
+            'active_ids': self.env['product.product'].search([]).ids,
+            'active_model': self.env['product.product']._name,
+        })
+        # Empty report
+        self.env['report.product.report_pricelist'].get_html(data={
+            'active_model': self.env['product.product']._name,
+        })
+
+    def test_no_pricelist_report(self):
+        """Load report when there is no active pricelist.
+
+        Report should fall back on company currency, and hide pricelist choices.
+        """
+        self.env['product.pricelist'].search([]).action_archive()
+        self.env['report.product.report_pricelist'].get_html(data={
+            'active_ids': self.env['product.template'].search([]).ids,
+        })


### PR DESCRIPTION
Make sure the pricelist report display doesn't fail when there are no active pricelist (user must enable pricelist and delete/archive existing pricelists).

Also adds some tests to cover basic cases of pricelist report.

Fixes #233393



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
