### PR TITLE
[FIX] l10n_my_edi: original document id in reversal document xml

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
-from datetime import datetime
 
+from datetime import datetime
 from pytz import UTC
+from lxml import etree
 
 from odoo import _, api, models
 from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
@@ -142,9 +143,19 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         # The original document is mandatory; but in some specific cases it will be empty (sending a credit note for an invoice
         # managed outside Odoo/...)
         if document_type_code in ('02', '03', '04', '12', '13', '14'):
+            original_document_id = None
+            if original_document:
+                if original_document.l10n_my_edi_file_id:
+                    decoded_vals = self._decode_myinvois_attachment(original_document.l10n_my_edi_file_id)
+                    original_document_id = decoded_vals.get('original_document_id')
+                if not original_document_id and self._is_self_billed(document_type_code) and original_document.ref:
+                    original_document_id = original_document.ref
+                if not original_document_id:
+                    original_document_id = original_document.name
+
             vals['vals'].update({
                 'billing_reference_vals': {
-                    'id': (original_document and original_document.name) or 'NA',
+                    'id': original_document_id or 'NA',
                     'uuid': (original_document and original_document.l10n_my_edi_external_uuid) or 'NA',
                 },
             })
@@ -157,6 +168,31 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             },
         })
 
+        return vals
+
+    def _decode_myinvois_attachment(self, attachment):
+        """ Extract data from MyInvois xml. """
+        def get_node(node, xpath):
+            nodes = node.xpath(xpath)
+            return nodes[0] if nodes else None
+
+        def get_value(node):
+            if node is None:
+                return None
+            return node.text
+
+        vals = {}
+        try:
+            root = etree.fromstring(attachment.raw)
+            invoice_id_node = get_node(root, "//*[local-name()='Invoice']/*[local-name()='ID']")
+        except etree.XMLSyntaxError:
+            # Not an xml
+            return {}
+        except AttributeError:
+            # Not a MyInvois xml
+            return {}
+
+        vals['original_document_id'] = get_value(invoice_id_node)
         return vals
 
     def _get_delivery_vals_list(self, invoice):

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -394,6 +394,64 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         prepaid_node = root.xpath('cac:PrepaidPayment/cbc:PaidAmount', namespaces=NS_MAP)
         self.assertEqual(prepaid_node[0].text, '2200.00')
 
+    def test_10_original_document_id(self):
+        """
+        Ensure the original document id is present in the reversed document.
+        """
+        bill = self.init_invoice('in_invoice', currency=self.currency_data['currency'], products=self.product_a, post=True)
+        bill.ref = 'BILL-123'
+        action = bill.action_reverse()
+        reversal_wizard = self.env[action['res_model']].with_context(
+            active_ids=bill.ids,
+            active_model='account.move',
+            default_journal_id=bill.journal_id.id,
+        ).create({})
+        action = reversal_wizard.reverse_moves()
+        credit_note = self.env['account.move'].browse(action['res_id'])
+        credit_note.action_post()
+
+        file, _errors = credit_note._l10n_my_edi_generate_invoice_xml()
+        root = etree.fromstring(file)
+        self._assert_node_values(
+            root,
+            'cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID',
+            'BILL-123',
+        )
+
+    def test_11_original_document_id_from_xml(self):
+        """
+        Ensure the original document id is present in the reversed document even if bill reference has changed after
+        sending.
+        """
+        bill = self.init_invoice('in_invoice', currency=self.currency_data['currency'], products=self.product_a, post=True)
+
+        # Set reference before generating e-invoice
+        bill.ref = 'Initial Reference'
+
+        # Generate e-invoice and mock values
+        bill_file, _errors = bill._l10n_my_edi_generate_invoice_xml()
+        bill.l10n_my_edi_file_id = self.env['ir.attachment'].create({'name': 'test myinvois', 'raw': bill_file})
+        bill.ref = 'Some other reference'
+
+        # Generate credit note
+        action = bill.action_reverse()
+        reversal_wizard = self.env[action['res_model']].with_context(
+            active_ids=bill.ids,
+            active_model='account.move',
+            default_journal_id=bill.journal_id.id,
+        ).create({})
+        action = reversal_wizard.reverse_moves()
+        credit_note = self.env['account.move'].browse(action['res_id'])
+        credit_note.action_post()
+
+        credit_note_file, _errors = credit_note._l10n_my_edi_generate_invoice_xml()
+        root = etree.fromstring(credit_note_file)
+        self._assert_node_values(
+            root,
+            'cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID',
+            'Initial Reference',
+        )
+
     def _assert_node_values(self, root, node_path, text, attributes=None):
         node = root.xpath(node_path, namespaces=NS_MAP)
 


### PR DESCRIPTION
Currently, customers get an error when trying to send the vendor credit note to MyInvoise if a reference has been set on the bill.
```
The validation failed with the following errors:
The reference document UUID [...] does not exist.
The internal ID for DocumentUUID [...] does not match.
```

Steps to reproduce:

- With an MY company setup
- Create a bill and add a custom reference
- Send Bill to MyInvois
- Create credit note for the Bill
- Send Credit note to MyInvoice

Issue:

Validation will fail because the reference does not match. In the reverse bill we always send the original bill name as original bill id, but also the reference could have been used.

Analysis:

A solution would be to send always the reference of the original vendor bill if present. However, the bill reference may be altered after submitting the e-invoice. A safer way is to retrieve the reference from the stored e-invoice.

opw-5057050