### PR TITLE
[FIX] sale_timesheet: Ensure correct selection of SOL with billing rate activated

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -172,7 +172,16 @@ class AccountAnalyticLine(models.Model):
 
     def _get_employee_mapping_entry(self):
         self.ensure_one()
-        return self.env['project.sale.line.employee.map'].search([('project_id', '=', self.project_id.id), ('employee_id', '=', self.employee_id.id or self.env.user.employee_id.id)])
+        if len(self.env.companies) == 1 or self.employee_id:
+            return self.env['project.sale.line.employee.map'].search([
+                ('project_id', '=', self.project_id.id),
+                ('employee_id', '=', self.employee_id.id or self.env.user.employee_id.id)
+            ], limit=1)
+        employees = self.env['project.sale.line.employee.map'].search([
+            ('project_id', '=', self.project_id.id),
+            ('employee_id', 'in', self.env.user.employee_ids.ids),
+            ])
+        return employees.filtered(lambda e: e.employee_id.company_id.id == self.env.company.id)[:1] or employees.filtered(lambda e: e.employee_id.company_id.id in self.env.companies.ids)[:1]
 
     def _hourly_cost(self):
         if self.project_id.pricing_type == 'employee_rate':

--- a/addons/sale_timesheet/tests/test_so_line_determined_in_timesheet.py
+++ b/addons/sale_timesheet/tests/test_so_line_determined_in_timesheet.py
@@ -236,3 +236,90 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
 
         # 6) Check if the task and timesheet has no SOL.
         self.assertFalse(timesheet.so_line, 'No SOL should be linked to the timesheet because the project is non billable')
+
+    def test_sol_determined_with_multi_company_and_billing_rate(self):
+        """ Test the sol give to the timesheet when the pricing type in the project is employee rate
+
+            Test Case:
+            =========
+            1) Create an employee related to the user for each company,
+            2) Define a SO, with 3 SOL creating tasks in a new billable project,
+            3) Check that the default SOL linked to a newly created timesheet is the first one in the list aswell as the default for the project,
+            4) Create SOL mapping between the other SOL and each employee,
+            5) Check that depending on which company is activated, new timesheets linked to the project assign the correct SOL to the user.
+        """
+        # 1) Create an employee related to the user for each company
+
+        comp1 = self.company_data.get('company')
+        comp2 = self.company_data_2.get('company')
+
+        self.env.user.with_company(comp1).action_create_employee()
+        e1 = self.env.user.with_company(comp1).employee_id
+        self.env.user.with_company(comp2).action_create_employee()
+        e2 = self.env.user.with_company(comp2).employee_id
+
+        # 2) Define a SO, with 3 SOL creating tasks in a new billable project
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_b.id,
+            'partner_invoice_id': self.partner_b.id,
+            'partner_shipping_id': self.partner_b.id,
+        })
+
+        so_lines = self.env['sale.order.line'].create([{
+            'order_id': so.id,
+            'product_id': self.product_delivery_timesheet3.id,
+            'product_uom_qty': 1,
+        }, {
+            'order_id': so.id,
+            'product_id': self.product_delivery_timesheet3.id,
+            'product_uom_qty': 1,
+        }, {
+            'order_id': so.id,
+            'product_id': self.product_delivery_timesheet3.id,
+            'product_uom_qty': 1,
+        }])
+
+        so.action_confirm()
+
+        # 3) Check that the default SOL linked to a newly created timesheet is the first one in the list aswell as the default for the project
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'unit_amount': 1,
+            'auto_account_id': self.analytic_account_sale.id,
+            'project_id': so_lines[0].project_id.id,
+        })
+        self.assertTrue(timesheet.so_line == timesheet.project_id.sale_line_id == so_lines[0])
+
+        # 4) Create SOL mapping between the other SOL and each employee
+
+        mapping = self.env['project.sale.line.employee.map'].create([{
+            'project_id': so_lines[0].project_id.id,
+            'employee_id': e1.id,
+            'sale_line_id': so_lines[2].id
+
+        }, {
+            'project_id': so_lines[0].project_id.id,
+            'employee_id': e2.id,
+            'sale_line_id': so_lines[1].id
+        }])
+        so_lines[0].project_id.sale_line_employee_ids = mapping
+
+        # 5) Check that depending on which company is activated, new timesheets linked to the project assign the correct SOL to the user.
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'unit_amount': 1,
+            'auto_account_id': self.analytic_account_sale.id,
+            'project_id': so_lines[0].project_id.id,
+        })
+        self.assertEqual(timesheet.so_line.id, so_lines[2].id)
+
+        timesheet = self.env['account.analytic.line'].sudo().with_company(comp2).create({
+            'name': 'Test Line',
+            'unit_amount': 1,
+            'auto_account_id': self.analytic_account_sale.id,
+            'project_id': so_lines[0].project_id.id,
+        })
+        self.assertEqual(timesheet.so_line.id, so_lines[1].id)


### PR DESCRIPTION
****Behavior:****
**Current:**
In a multi company environment, when a sale contains multiple tasks in some project, and the user has billing rates indicating they should be assigned to a specific task, creating a new timesheet for the project does not set the correct SOL. This only happens if the sale is happening from a company that does not have an employee linked to the user.

**Expected:**
The new timesheet should be able to connect the current user to the related employee in the billing rates to find the right SOL. In the situation in which multiple companies have created an employee for the same user, and more than one of these has been linked to a SOL in the billing rates (unlikely workflow): We choose the SOL linked to the employee record created for the currently activated company, otherwise, we default to the first employee in the list.

**Steps to reproduce:**
- Be in a multicompany environment: company A and B
- Create User with access to both but only one employee record for company A
- Switch to company B
- Create 2 services product, both creating a task in the same project.
- Activate Billable Rate Indicators in the settings
- Create a quote with both services and confirm
- Go to the related project, and in the Invoicing tab, link employee from company A to SOL2
- As the user, check both companies but set company B as current active
- Go to timesheet and create a new timesheet, when setting the project from the quote, you should see SOL1 by default, however we would want SOL2 as it was configured.

opw-5159195