### PR TITLE
[FIX] mail: fix list badge rotting color

### DIFF
--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
@@ -2,9 +2,9 @@ import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import {
-    badgeSelectionField,
-    BadgeSelectionField,
-} from "@web/views/fields/badge_selection/badge_selection_field";
+    listBadgeSelectionField,
+    ListBadgeSelectionField,
+} from "@web/views/fields/badge_selection/list_badge_selection_field";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 export function getRottingDaysTitle(modelName, rotDays) {
@@ -46,7 +46,7 @@ export class KanbanRottingField extends Component {
     }
 }
 
-export class ListBadgeSelectionRotting extends BadgeSelectionField {
+export class ListBadgeSelectionRotting extends ListBadgeSelectionField {
     static template = "mail.ListBadgeSelectionRotting";
     setup() {
         super.setup();
@@ -62,6 +62,6 @@ registry.category("fields").add("kanban.rotting", {
 });
 
 registry.category("fields").add("list.badge_rotting", {
-    ...badgeSelectionField,
+    ...listBadgeSelectionField,
     component: ListBadgeSelectionRotting,
 });

--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.xml
@@ -7,7 +7,7 @@
         </div>
     </t>
 
-    <t t-name="mail.ListBadgeSelectionRotting" t-inherit="web.BadgeSelectionField" t-inherit-mode="primary">
+    <t t-name="mail.ListBadgeSelectionRotting" t-inherit="web.ListBadgeSelectionField" t-inherit-mode="primary">
         <t t-else="" position="after">
             <span class="badge rounded-pill o_mail_resource_rotting_bg ms-2" t-if="props.record.data.is_rotting">
                 <t t-out="dayCount"/>


### PR DESCRIPTION
Purpose
=======
Fix the rotting variant of the badge selection field in list views which should properly support the color field option.

Specification
=============
The 'ListBadgeSelectionRotting' widget was inheriting from the 'BadgeSelectionField' which doesn't support any color in badges. It should inherit from the list variant of the badge selection field called 'ListBadgeSelectionField' which supports the color field option.

Task-5186979



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
