### PR TITLE
[PERF] hr{,_holiday,_work_entry}: Speed-up offer template onchange

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -528,6 +528,8 @@ class HrEmployee(models.Model):
         version_domain = Domain('contract_date_start', '!=', False)
         if self.ids:
             version_domain &= Domain('employee_id', 'in', self.ids)
+        elif not any(self._ids):  # onchange
+            version_domain &= Domain('employee_id', 'in', self._origin.ids)
         if date_start:
             version_domain &= Domain('contract_date_end', '=', False) | Domain('contract_date_end', '>=', date_start)
         if date_end:
@@ -541,7 +543,8 @@ class HrEmployee(models.Model):
         )
         contract_versions_by_employee = defaultdict(lambda: defaultdict(lambda: self.env["hr.version"]))
         for employee, _date_version, version in all_versions:
-            contract_versions_by_employee[employee.id][version.contract_date_start] |= version
+            first_version = next(iter(version), version)
+            contract_versions_by_employee[employee.id][first_version.contract_date_start] |= version
         return contract_versions_by_employee
 
     def _get_all_contract_dates(self):

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -290,23 +290,29 @@ class HrVersion(models.Model):
         for employee, versions in self.grouped('employee_id').items():
 
             dates_vals = {}
+            first_version = next(iter(versions), versions)
 
             if "contract_date_start" in values:
                 dates_vals["contract_date_start"] = fields.Date.to_date(values.get('contract_date_start'))
             else:
-                dates_vals["contract_date_start"] = versions[0].contract_date_start
+                dates_vals["contract_date_start"] = first_version.contract_date_start
             if "contract_date_end" in values:
                 dates_vals["contract_date_end"] = fields.Date.to_date(values.get('contract_date_end'))
             else:
-                dates_vals["contract_date_end"] = versions[0].contract_date_end
+                dates_vals["contract_date_end"] = first_version.contract_date_end
 
-            if versions[0].contract_date_start:
+            if first_version.contract_date_start:
                 versions_to_sync = employee._get_contract_versions(
-                    date_start=versions[0].contract_date_start,
-                    date_end=versions[0].contract_date_end,
+                    date_start=first_version.contract_date_start,
+                    date_end=first_version.contract_date_end,
                 )
+                all_versions_to_sync = self.env['hr.version']
                 for contract_versions in versions_to_sync.values():
-                    next(iter(contract_versions.values())).with_context(sync_contract_dates=True).write(dates_vals)
+                    all_versions_to_sync |= next(iter(contract_versions.values()))
+
+                if all_versions_to_sync:
+                    all_versions_to_sync.with_context(sync_contract_dates=True).write(dates_vals)
+
             else:
                 versions.with_context(sync_contract_dates=True).write(dates_vals)
 

--- a/addons/hr_holidays/models/hr_version.py
+++ b/addons/hr_holidays/models/hr_version.py
@@ -122,9 +122,10 @@ class HrVersion(models.Model):
         overlapping_contracts = leave._get_overlapping_contracts().sorted(
             key=lambda c: c.contract_date_start)
         if len(overlapping_contracts.resource_calendar_id) <= 1:
-            if overlapping_contracts and leave.resource_calendar_id != overlapping_contracts[
-                0].resource_calendar_id:
-                leave.resource_calendar_id = overlapping_contracts[0].resource_calendar_id
+            if overlapping_contracts:
+                first_overlapping_contract = next(iter(overlapping_contracts), overlapping_contracts)
+                if leave.resource_calendar_id != first_overlapping_contract.resource_calendar_id:
+                    leave.resource_calendar_id = first_overlapping_contract.resource_calendar_id
             return False
         return overlapping_contracts
 

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -22,7 +22,7 @@ class HrWorkEntry(models.Model):
     name = fields.Char(required=True, compute='_compute_name', store=True, readonly=False, precompute=True)
     active = fields.Boolean(default=True)
     employee_id = fields.Many2one('hr.employee', required=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", index=True)
-    version_id = fields.Many2one('hr.version', string="Version", required=True)
+    version_id = fields.Many2one('hr.version', string="Version", required=True, index=True)
     work_entry_source = fields.Selection(related='version_id.work_entry_source')
     date_start = fields.Datetime(required=True, string='From')
     date_stop = fields.Datetime(compute='_compute_date_stop', store=True, readonly=False, string='To')


### PR DESCRIPTION
Description
-----------
- Fix performance regressions due to breaking the prefetcher via `[0]` indexing of `hr.version` and batch `write`.
- Evaluate only the current employees contracts in `_get_contract_versions` for an *onchange* context, else the `hr. version` for all employees are fetched and evaluated, leading to significant overhead downstream.
- Add missing index for `_remove_work_entries`

Benchmark
---------
On a database in 19.0, with ~10k employees, ~30k versions and ~5M work-entries, the onchange triggered when changing the contract template on a pending offer for a new lambda employee took:

|             | Before | After  |
|-------------|--------|--------|
| Query Count | 107k   | 349    |
| Time        | 2.9min | ~300ms |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
