### PR TITLE
[IMP] html_builder, *: document services, registry categories and Plugins

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -1,0 +1,144 @@
+declare module "plugins" {
+    import { AnchorShared } from "@html_builder/core/anchor/anchor_plugin";
+    import { builder_components, BuilderComponentShared } from "@html_builder/core/builder_component_plugin";
+    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, no_parent_containers, on_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
+    import { BuilderOverlayShared } from "@html_builder/core/builder_overlay/builder_overlay_plugin";
+    import { CachedModelShared } from "@html_builder/core/cached_model_plugin";
+    import { CloneShared, on_cloned_handlers, on_will_clone_handlers } from "@html_builder/core/clone_plugin";
+    import { CustomizeTabShared } from "@html_builder/core/customize_tab_plugin";
+    import { DisableSnippetsShared } from "@html_builder/core/disable_snippets_plugin";
+    import { dropzone_selector, DropZoneShared } from "@html_builder/core/drop_zone_plugin";
+    import { MediaWebsiteShared } from "@html_builder/core/media_website_plugin";
+    import { OperationShared } from "@html_builder/core/operation_plugin";
+    import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
+    import { empty_node_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
+    import { after_save_handlers, before_save_handlers, get_dirty_els, savable_selectors, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
+    import { after_setup_editor_handlers, before_setup_editor_handlers, o_editable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
+    import { target_hide, target_show, VisibilityShared } from "@html_builder/core/visibility_plugin";
+    import { default_shape_handlers, post_compute_shape_listeners } from "@html_builder/plugins/image/image_shape_option_plugin";
+    import { background_filter_target_providers, get_target_element_providers, on_bg_image_hide_handlers } from "@html_builder/plugins/background_option/background_image_option_plugin";
+    import { is_draggable_handlers, on_element_dragged_handlers, on_element_dropped_handlers, on_element_dropped_near_handlers, on_element_dropped_over_handlers, on_element_move_handlers, on_element_out_dropzone_handlers, on_element_over_dropzone_handlers, on_prepare_drag_handlers } from "@html_builder/core/drag_and_drop_plugin";
+    import { lower_panel_entries, on_mobile_preview_clicked, trigger_dom_updated } from "@html_builder/builder";
+    import { on_reveal_target_handlers } from "@html_builder/sidebar/invisible_elements_panel";
+    import { on_snippet_dropped_handlers } from "@html_builder/sidebar/block_tab";
+    import { snippet_preview_dialog_bundles, snippet_preview_dialog_stylesheets_handlers } from "@html_builder/snippets/add_snippet_dialog";
+    import { background_shape_target_providers } from "@html_builder/plugins/background_option/background_shape_option_plugin";
+    import { mark_color_level_selector_params } from "@html_builder/plugins/background_option/background_option_plugin";
+    import { is_movable_selector } from "@html_builder/core/move_plugin";
+    import { content_editable_selectors, content_not_editable_selectors } from "@html_builder/core/builder_content_editable_plugin";
+    import { builder_actions } from "@html_builder/core/builder_actions_plugin";
+    import { so_content_addition_selector, so_snippet_addition_selector } from "@html_builder/core/dropzone_selector_plugin";
+    import { fontCssVariables } from "@html_builder/plugins/font/font_plugin";
+    import { apply_custom_css_style } from "@html_builder/core/core_builder_action_plugin";
+
+    interface SharedMethods {
+        // Main
+
+        // Core
+        anchor: AnchorShared;
+        builderActions: BuilderActionsShared;
+        builderComponents: BuilderComponentShared;
+        builderOptions: BuilderOptionsShared;
+        builderOverlay: BuilderOverlayShared;
+        cachedModel: CachedModelShared;
+        clone: CloneShared;
+        customizeTab: CustomizeTabShared;
+        disableSnippets: DisableSnippetsShared;
+        dropzone: DropZoneShared;
+        media_website: MediaWebsiteShared;
+        operation: OperationShared;
+        overlayButtons: OverlayButtonsShared;
+        remove: RemoveShared;
+        savePlugin: SaveShared;
+        setup_editor_plugin: SetupEditorShared;
+        visibility: VisibilityShared;
+
+        // Other
+    }
+
+    interface GlobalResources extends BuilderResources {}
+    export type BuilderResources = EditorResources & ResourcesTypesFactory<BuilderResourcesList>;
+    export interface BuilderResourcesList {
+        // Handlers
+        after_save_handlers: after_save_handlers;
+        after_setup_editor_handlers: after_setup_editor_handlers;
+        before_save_handlers: before_save_handlers;
+        before_setup_editor_handlers: before_setup_editor_handlers;
+        change_current_options_containers_listeners: change_current_options_containers_listeners;
+        default_shape_handlers: default_shape_handlers;
+        on_bg_image_hide_handlers: on_bg_image_hide_handlers;
+        on_cloned_handlers: on_cloned_handlers;
+        on_element_dragged_handlers: on_element_dragged_handlers;
+        on_element_dropped_handlers: on_element_dropped_handlers;
+        on_element_dropped_near_handlers: on_element_dropped_near_handlers;
+        on_element_dropped_over_handlers: on_element_dropped_over_handlers;
+        on_element_move_handlers: on_element_move_handlers;
+        on_element_out_dropzone_handlers: on_element_out_dropzone_handlers;
+        on_element_over_dropzone_handlers: on_element_over_dropzone_handlers;
+        on_mobile_preview_clicked: on_mobile_preview_clicked;
+        on_prepare_drag_handlers: on_prepare_drag_handlers;
+        on_removed_handlers: on_removed_handlers;
+        on_restore_containers_handlers: on_restore_containers_handlers;
+        on_reveal_target_handlers: on_reveal_target_handlers;
+        on_snippet_dropped_handlers: on_snippet_dropped_handlers;
+        on_will_clone_handlers: on_will_clone_handlers;
+        on_will_remove_handlers: on_will_remove_handlers;
+        post_compute_shape_listeners: post_compute_shape_listeners;
+        save_element_handlers: save_element_handlers;
+        save_handlers: save_handlers;
+        snippet_preview_dialog_stylesheets_handlers: snippet_preview_dialog_stylesheets_handlers;
+        target_hide: target_hide;
+        target_show: target_show;
+        trigger_dom_updated: trigger_dom_updated;
+
+        // Overrides
+        apply_custom_css_style: apply_custom_css_style;
+        save_elements_overrides: save_elements_overrides;
+
+        // Predicates
+        empty_node_predicates: empty_node_predicates;
+        is_draggable_handlers: is_draggable_handlers;
+
+        // Processors
+
+        // Providers
+        background_filter_target_providers: background_filter_target_providers;
+        background_shape_target_providers: background_shape_target_providers;
+        clone_disabled_reason_providers: clone_disabled_reason_providers;
+        get_dirty_els: get_dirty_els;
+        get_options_container_top_buttons: get_options_container_top_buttons;
+        get_target_element_providers: get_target_element_providers;
+        remove_disabled_reason_providers: remove_disabled_reason_providers;
+
+        // Data
+        builder_actions: builder_actions;
+        builder_components: builder_components;
+        builder_header_middle_buttons: builder_header_middle_buttons;
+        builder_options: builder_options;
+        container_title: container_title;
+        content_editable_selectors: content_editable_selectors;
+        content_not_editable_selectors: content_not_editable_selectors;
+        dropzone_selector: dropzone_selector;
+        elements_to_options_title_components: elements_to_options_title_components;
+        fontCssVariables: fontCssVariables;
+        get_overlay_buttons: get_overlay_buttons;
+        has_overlay_options: has_overlay_options;
+        is_movable_selector: is_movable_selector;
+        is_unremovable_selector: is_unremovable_selector;
+        lower_panel_entries: lower_panel_entries;
+        mark_color_level_selector_params: mark_color_level_selector_params;
+        no_parent_containers: no_parent_containers;
+        o_editable_selectors: o_editable_selectors;
+        /** @deprecated */
+        patch_builder_options: {
+            target_name: string,
+            target_element: "selector" | "exclude" | "applyTo",
+            method: "replace" | "add" | "remove",
+            value: CSSSelector,
+        }[];
+        savable_selectors: savable_selectors;
+        so_content_addition_selector: so_content_addition_selector;
+        so_snippet_addition_selector: so_snippet_addition_selector;
+        snippet_preview_dialog_bundles: snippet_preview_dialog_bundles;
+    }
+}

--- a/addons/html_builder/static/src/@types/services.d.ts
+++ b/addons/html_builder/static/src/@types/services.d.ts
@@ -1,0 +1,7 @@
+declare module "services" {
+    import { snippetService } from "@html_builder/snippets/snippet_service";
+
+    export interface Services {
+        "html_builder.snippets": typeof snippetService;
+    }
+}

--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -26,6 +26,12 @@ import { withSequence } from "@html_editor/utils/resource";
 import { getHtmlStyle } from "@html_editor/utils/formatting";
 import { isVisible } from "@html_builder/utils/utils";
 
+/**
+ * @typedef {(() => void)[]} on_mobile_preview_clicked
+ * @typedef {(() => void)[]} trigger_dom_updated
+ * @typedef {{ Component: Component; props: object; }[]} lower_panel_entries
+ */
+
 export class Builder extends Component {
     static template = "html_builder.Builder";
     static components = { BlockTab, CustomizeTab };

--- a/addons/html_builder/static/src/core/anchor/anchor_plugin.js
+++ b/addons/html_builder/static/src/core/anchor/anchor_plugin.js
@@ -15,10 +15,15 @@ export function canHaveAnchor(element) {
     return element.matches(anchorSelector) && !element.matches(anchorExclude);
 }
 
+/**
+ * @typedef { Object } AnchorShared
+ * @property { AnchorPlugin['createOrEditAnchorLink'] } createOrEditAnchorLink
+ */
 export class AnchorPlugin extends Plugin {
     static id = "anchor";
     static dependencies = ["history"];
     static shared = ["createOrEditAnchorLink"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         on_cloned_handlers: this.onCloned.bind(this),
         get_options_container_top_buttons: withSequence(

--- a/addons/html_builder/static/src/core/builder_actions_plugin.js
+++ b/addons/html_builder/static/src/core/builder_actions_plugin.js
@@ -3,7 +3,13 @@ import { Plugin } from "@html_editor/plugin";
 /**
  * @typedef { import("./builder_action").BuilderAction } BuilderAction
  * @typedef {} BuilderActionConstructor
+ *
+ * @typedef { Object } BuilderActionsShared
+ * @property { BuilderActionsPlugin['getAction'] } getAction
+ * @property { BuilderActionsPlugin['applyAction'] } applyAction
  */
+
+/** @typedef {BuilderAction[]} builder_actions */
 
 export class BuilderActionsPlugin extends Plugin {
     static id = "builderActions";

--- a/addons/html_builder/static/src/core/builder_component_plugin.js
+++ b/addons/html_builder/static/src/core/builder_component_plugin.js
@@ -22,10 +22,19 @@ import { Img } from "./img";
 import { BuilderUrlPicker } from "./building_blocks/builder_urlpicker";
 import { BuilderFontFamilyPicker } from "./building_blocks/builder_fontfamilypicker";
 
+/** @typedef {import("@odoo/owl").Component} Component */
+/**
+ * @typedef { Object } BuilderComponentShared
+ * @property { BuilderComponentPlugin['getComponents'] } getComponents
+ */
+
+/** @typedef {Component[]} builder_components */
+
 export class BuilderComponentPlugin extends Plugin {
     static id = "builderComponents";
     static shared = ["getComponents"];
 
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_components: {
             BuilderContext,

--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -2,8 +2,15 @@ import { Plugin } from "@html_editor/plugin";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { registry } from "@web/core/registry";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {CSSSelector[]} content_editable_selectors
+ * @typedef {CSSSelector[]} content_not_editable_selectors
+ */
+
 export class BuilderContentEditablePlugin extends Plugin {
     static id = "builderContentEditablePlugin";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         content_not_editable_selectors: [
             "section:has(> .o_container_small, > .container, > .container-fluid)",

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -6,6 +6,102 @@ import { getElementsWithOption, isElementInViewport } from "@html_builder/utils/
 import { shouldEditableMediaBeEditable } from "@html_builder/utils/utils_css";
 import { OptionsContainer } from "@html_builder/sidebar/option_container";
 
+/** @typedef {import("@html_builder/core/utils").BaseOptionComponent} BaseOptionComponent */
+/** @typedef {import("@odoo/owl").Component} Component */
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/** @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString */
+/**
+ * @typedef {{
+ *        class: string;
+ *        title: LazyTranslatedString;
+ *        handler: () => Promise<void>;
+ *        disabledReason?: string;
+ * }} BuilderButtonDescriptor
+ *
+ * @typedef {{
+ *     id: string;
+ *     element: HTMLElement;
+ *     options: BaseOptionComponent[];
+ *     optionTitleComponents: BaseOptionComponent[] | [];
+ *     headerMiddleButtons: Component[] | [];
+ *     containerTitle: Component | {};
+ *     hasOverlayOptions: boolean;
+ *     isRemovable: boolean;
+ *     removeDisabledReason: string;
+ *     isClonable: boolean;
+ *     cloneDisabledReason: string;
+ *     optionsContainerTopButtons: BuilderButtonDescriptor[] | [];
+ * }} BuilderOptionContainer
+ */
+
+/**
+ * @typedef { Object } BuilderOptionsShared
+ * @property { BuilderOptionsPlugin['computeContainers'] } computeContainers
+ * @property { BuilderOptionsPlugin['findOption'] } findOption
+ * @property { BuilderOptionsPlugin['getContainers'] } getContainers
+ * @property { BuilderOptionsPlugin['updateContainers'] } updateContainers
+ * @property { BuilderOptionsPlugin['deactivateContainers'] } deactivateContainers
+ * @property { BuilderOptionsPlugin['getTarget'] } getTarget
+ * @property { BuilderOptionsPlugin['getPageContainers'] } getPageContainers
+ * @property { BuilderOptionsPlugin['getRemoveDisabledReason'] } getRemoveDisabledReason
+ * @property { BuilderOptionsPlugin['getCloneDisabledReason'] } getCloneDisabledReason
+ * @property { BuilderOptionsPlugin['getReloadSelector'] } getReloadSelector
+ * @property { BuilderOptionsPlugin['setNextTarget'] } setNextTarget
+ * @property { BuilderOptionsPlugin['getBuilderOptionContext'] } getBuilderOptionContext
+ */
+
+/**
+ * @typedef {((containers: BuilderOptionContainer[]) => void)[]} change_current_options_containers_listeners
+ * @typedef {((newTargetEl: HTMLElement) => void)[]} on_restore_containers_handlers
+ *
+ * @typedef {((el: HTMLElement) => [] | BuilderButtonDescriptor[])[]} get_options_container_top_buttons
+ *
+ * @typedef {{
+ *     Component: Component;
+ *     selector: CSSSelector;
+ *     exclude: CSSSelector;
+ *     applyTo: CSSSelector;
+ *     props: object;
+ *     editableOnly?: boolean;
+ * }[]} builder_header_middle_buttons
+ * @typedef {BaseOptionComponent[]} builder_options
+ * @typedef {{
+ *     selector: CSSSelector;
+ *     getTitleExtraInfo: (editingElement: HTMLElement) => string;
+ * }[]} container_title
+ * @typedef {{
+ *      Component: BaseOptionComponent;
+ *      selector: CSSSelector;
+ * }[]} elements_to_options_title_components
+ * @typedef {{
+ *      hasOption: (el: HTMLElement) => boolean;
+ *      editableOnly?: boolean;
+ * }[]} has_overlay_options
+ * @typedef {CSSSelector[]} no_parent_containers
+ */
+/**
+ * @typedef {((arg: { el: HTMLElement, reasons: [] }) => void)[]} clone_disabled_reason_providers
+ *
+ * Appends new reasons to the `reasons` array given as a parameter.
+ *
+ * Example:
+ *
+ *     ({ el, reasons }) => {
+ *         reasons.push(`I hate ${el.dataset.name}`);
+ *     }
+ */
+/**
+ * @typedef {((arg: { el: HTMLElement, reasons: [] }) => void)[]} remove_disabled_reason_providers
+ *
+ * Appends new reasons to the `reasons` array given as a parameter.
+ *
+ * Example:
+ *
+ *     ({ el, reasons }) => {
+ *         reasons.push(`I hate ${el.dataset.name}`);
+ *     }
+ */
+
 export class BuilderOptionsPlugin extends Plugin {
     static id = "builderOptions";
     static dependencies = [
@@ -30,23 +126,13 @@ export class BuilderOptionsPlugin extends Plugin {
         "setNextTarget",
         "getBuilderOptionContext",
     ];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         before_add_step_handlers: this.onWillAddStep.bind(this),
         step_added_handlers: this.onStepAdded.bind(this),
         post_undo_handlers: (revertedStep) => this.restoreContainers(revertedStep, "undo"),
         post_redo_handlers: (revertedStep) => this.restoreContainers(revertedStep, "redo"),
         clean_for_save_handlers: this.cleanForSave.bind(this),
-        // Resources definitions:
-        remove_disabled_reason_providers: [
-            // ({ el, reasons }) => {
-            //     reasons.push(`I hate ${el.dataset.name}`);
-            // }
-        ],
-        clone_disabled_reason_providers: [
-            // ({ el, reasons }) => {
-            //     reasons.push(`I hate ${el.dataset.name}`);
-            // }
-        ],
         start_edition_handlers: () => {
             if (this.config.initialTarget) {
                 const el = this.editable.querySelector(this.config.initialTarget);

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -12,10 +12,18 @@ function isResizable(el) {
     return isResizableY || isResizableX || isResizableGrid;
 }
 
+/**
+ * @typedef { Object } BuilderOverlayShared
+ * @property { BuilderOverlayPlugin['showOverlayPreview'] } showOverlayPreview
+ * @property { BuilderOverlayPlugin['hideOverlayPreview'] } hideOverlayPreview
+ * @property { BuilderOverlayPlugin['refreshOverlays'] } refreshOverlays
+ */
+
 export class BuilderOverlayPlugin extends Plugin {
     static id = "builderOverlay";
     static dependencies = ["localOverlay", "history", "operation"];
     static shared = ["showOverlayPreview", "hideOverlayPreview", "refreshOverlays"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         step_added_handlers: this.refreshOverlays.bind(this),
         change_current_options_containers_listeners: this.openBuilderOverlays.bind(this),

--- a/addons/html_builder/static/src/core/cached_model_plugin.js
+++ b/addons/html_builder/static/src/core/cached_model_plugin.js
@@ -2,10 +2,18 @@ import { Plugin } from "@html_editor/plugin";
 import { Cache } from "@web/core/utils/cache";
 import { ModelEdit } from "./cached_model_utils";
 
+/**
+ * @typedef { Object } CachedModelShared
+ * @property { CachedModelPlugin['ormRead'] } ormRead
+ * @property { CachedModelPlugin['ormSearchRead'] } ormSearchRead
+ * @property { CachedModelPlugin['useModelEdit'] } useModelEdit
+ */
+
 export class CachedModelPlugin extends Plugin {
     static id = "cachedModel";
     static shared = ["ormRead", "ormSearchRead", "useModelEdit"];
     static dependencies = ["history"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         save_handlers: this.savePendingRecords.bind(this),
     };

--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -5,6 +5,19 @@ import { isElementInViewport } from "@html_builder/utils/utils";
 import { isRemovable } from "./remove_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
+/**
+ * @typedef { Object } CloneShared
+ * @property { ClonePlugin['cloneElement'] } cloneElement
+ */
+
+/**
+ * @typedef {((arg: { cloneEl: HTMLElement, originalEl: HTMLElement }) => Promise<void>)[]} on_cloned_handlers
+ * Called after an element was cloned and inserted in the DOM.
+ *
+ * @typedef {((arg: { originalEl: HTMLElement }) => void)[]} on_will_clone_handlers
+ * Called on the original element before clone.
+ */
+
 const clonableSelector = "a.btn:not(.oe_unremovable)";
 
 export function isClonable(el) {
@@ -17,6 +30,7 @@ export class ClonePlugin extends Plugin {
     static dependencies = ["history", "builderOptions", "dom"];
     static shared = ["cloneElement"];
 
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             // Maybe rename cloneItem ?
@@ -25,17 +39,6 @@ export class ClonePlugin extends Plugin {
         get_overlay_buttons: withSequence(2, {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
-        // Resource definitions:
-        on_will_clone_handlers: [
-            // ({ originalEl: el }) => {
-            //     called on the original element before clone
-            // }
-        ],
-        on_cloned_handlers: [
-            // async ({ cloneEl: cloneEl, originalEl: el }) => {
-            //     called after an element was cloned and inserted in the DOM
-            // }
-        ],
     };
 
     setup() {

--- a/addons/html_builder/static/src/core/color_style_plugin.js
+++ b/addons/html_builder/static/src/core/color_style_plugin.js
@@ -6,6 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 class ColorStylePlugin extends Plugin {
     static id = "colorStyle";
     static dependencies = ["color"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         apply_color_style_overrides: withSequence(5, (element, cssProp, color) => {
             applyNeededCss(element, cssProp, color);

--- a/addons/html_builder/static/src/core/compatibility_inline_border_removal_plugin.js
+++ b/addons/html_builder/static/src/core/compatibility_inline_border_removal_plugin.js
@@ -15,6 +15,7 @@ const OLD_STYLES = ["border-width", "border-radius"];
 
 export class CompatibilityInlineBorderRemovalPlugin extends Plugin {
     static id = "compatibilityInlineBorderRemoval";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         apply_custom_css_style: withSequence(20, this.removeInlineBorderIfNecessary.bind(this)),
     };

--- a/addons/html_builder/static/src/core/composite_action_plugin.js
+++ b/addons/html_builder/static/src/core/composite_action_plugin.js
@@ -6,6 +6,7 @@ export class CompositeActionPlugin extends Plugin {
     static id = "compositeAction";
     static dependencies = ["builderActions"];
 
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             CompositeAction,

--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -9,6 +9,16 @@ import {
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { getValueFromVar } from "@html_builder/utils/utils";
 
+/** @typedef {import("@html_builder/core/builder_action").ActionParams} ActionParams */
+/** @typedef {import("@html_builder/core/builder_action").ActionValue} ActionValue */
+/**
+ * @typedef {((
+ *      editingElement: HTMLElement,
+ *      params: ActionParams,
+ *      value: ActionValue,
+ * ) => boolean)[]} apply_custom_css_style
+ */
+
 export function withoutTransition(editingElement, callback) {
     if (editingElement.classList.contains("o_we_force_no_transition")) {
         return callback();
@@ -23,6 +33,7 @@ export function withoutTransition(editingElement, callback) {
 
 export class CoreBuilderActionPlugin extends Plugin {
     static id = "coreBuilderAction";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             ClassAction,

--- a/addons/html_builder/static/src/core/core_setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/core_setup_editor_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 
 export class CoreSetupEditorPlugin extends Plugin {
     static id = "core_setup_editor_plugin";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         o_editable_selectors: "[data-oe-model]",
     };

--- a/addons/html_builder/static/src/core/customize_tab_plugin.js
+++ b/addons/html_builder/static/src/core/customize_tab_plugin.js
@@ -2,9 +2,17 @@ import { Plugin } from "@html_editor/plugin";
 import { reactive } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 
+/**
+ * @typedef { Object } CustomizeTabShared
+ * @property { CustomizeTabPlugin['getCustomizeComponent'] } getCustomizeComponent
+ * @property { CustomizeTabPlugin['openCustomizeComponent'] } openCustomizeComponent
+ * @property { CustomizeTabPlugin['closeCustomizeComponent'] } closeCustomizeComponent
+ */
+
 export class CustomizeTabPlugin extends Plugin {
     static id = "customizeTab";
     static shared = ["getCustomizeComponent", "openCustomizeComponent", "closeCustomizeComponent"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         post_redo_handlers: () => this.closeCustomizeComponent(),
         post_undo_handlers: () => this.closeCustomizeComponent(),

--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -2,10 +2,16 @@ import { omit } from "@web/core/utils/objects";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef { Object } DisableSnippetsShared
+ * @property { DisableSnippetsPlugin['disableUndroppableSnippets'] } disableUndroppableSnippets
+ */
+
 export class DisableSnippetsPlugin extends Plugin {
     static id = "disableSnippets";
     static dependencies = ["setup_editor_plugin", "dropzone", "dropzone_selector"];
     static shared = ["disableUndroppableSnippets"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         on_removed_handlers: this.disableUndroppableSnippets.bind(this),
         post_undo_handlers: this.disableUndroppableSnippets.bind(this),

--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -8,9 +8,76 @@ import { rowSize } from "@html_builder/utils/grid_layout_utils";
 import { isEditable, isVisible } from "@html_builder/utils/utils";
 import { DragAndDropMoveHandle } from "./drag_and_drop_move_handle";
 
+/**
+ * @typedef {{
+ *     columnWidth: number;
+ *     columnHeight: number;
+ *     columnSpan: number;
+ *     currentDropzoneEl: HTMLElement;
+ *     currentHeight: number;
+ *     draggedEl: HTMLElement;
+ *     dropCloneEl: HTMLElement;
+ *     hasSamePositionAsStart?: () => boolean;
+ *     marginToAdd: string[];
+ *     mousePositionYOnElement: number;
+ *     mousePositionXOnElement: number;
+ *     overFirstDropzone: boolean;
+ *     overGrid: boolean;
+ *     restoreCallbacks?: ReturnType<on_prepare_drag_handlers[0]>[] | null;
+ *     restoreGridItem?: () => void;
+ *     rowSpan: number;
+ *     snippet: { gridColumnSpan?: number };
+ *     startGridArea: string;
+ *     startGridEl: HTMLElement;
+ *     startMiddle: number;
+ *     startNextEl: HTMLElement | undefined;
+ *     startParentEl: HTMLElement;
+ *     startPreviousEl: HTMLElement | undefined;
+ *     startTop: number;
+ *     startZindex: string;
+ * }} DragState
+ */
+/**
+ * @typedef {((arg: {
+ *      draggedEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => void)[]} on_element_dragged_handlers
+ * @typedef {((arg: {
+ *      droppedEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => Promise<boolean>)[]} on_element_dropped_handlers
+ * @typedef {((arg: {
+ *      droppedEl: HTMLElement,
+ *      dropzoneEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => void)[]} on_element_dropped_near_handlers
+ * @typedef {((arg: {
+ *      droppedEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => void)[]} on_element_dropped_over_handlers
+ * @typedef {((arg: {
+ *      draggedEl: HTMLElement,
+ *      dragState: DragState,
+ *      x: number,
+ *      y: number,
+ * }) => void)[]} on_element_move_handlers
+ * @typedef {((arg: {
+ *      draggedEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => void)[]} on_element_out_dropzone_handlers
+ * @typedef {((arg: {
+ *      draggedEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => void)[]} on_element_over_dropzone_handlers
+ * @typedef {(() => (() => void))[]} on_prepare_drag_handlers
+ *
+ * @typedef {((el: HTMLElement) => boolean)[]} is_draggable_handlers
+ */
+
 export class DragAndDropPlugin extends Plugin {
     static id = "dragAndDrop";
     static dependencies = ["dropzone", "history", "operation", "builderOptions"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         has_overlay_options: { hasOption: (el) => this.isDraggable(el) },
         get_overlay_buttons: withSequence(1, {
@@ -162,6 +229,7 @@ export class DragAndDropPlugin extends Plugin {
                 };
 
                 this.dragStarted = true;
+                /** @type {DragState} */
                 this.dragState = {};
                 dropzoneEls = [];
 

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -4,6 +4,29 @@ import { isElement } from "@html_editor/utils/dom_info";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { _t } from "@web/core/l10n/translation";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {{
+ *     selector: CSSSelector;
+ *     exclude: CSSSelector;
+ *     dropIn: CSSSelector;
+ *     dropNear: CSSSelector;
+ *     excludeNearParent: CSSSelector;
+ * }} DropzoneSelector
+ *
+ * @typedef { Object } DropZoneShared
+ * @property { DropZonePlugin['activateDropzones'] } activateDropzones
+ * @property { DropZonePlugin['removeDropzones'] } removeDropzones
+ * @property { DropZonePlugin['getDropRootElement'] } getDropRootElement
+ * @property { DropZonePlugin['getSelectorSiblings'] } getSelectorSiblings
+ * @property { DropZonePlugin['getSelectorChildren'] } getSelectorChildren
+ * @property { DropZonePlugin['getSelectors'] } getSelectors
+ */
+
+/**
+ * @typedef {DropzoneSelector[]} dropzone_selector
+ */
+
 export class DropZonePlugin extends Plugin {
     static id = "dropzone";
     static dependencies = ["history", "setup_editor_plugin"];
@@ -15,6 +38,7 @@ export class DropZonePlugin extends Plugin {
         "getSelectorChildren",
         "getSelectors",
     ];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         savable_mutation_record_predicates: (record) => {
             if (record.type === "childList") {

--- a/addons/html_builder/static/src/core/dropzone_selector_plugin.js
+++ b/addons/html_builder/static/src/core/dropzone_selector_plugin.js
@@ -1,5 +1,11 @@
 import { Plugin } from "@html_editor/plugin";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {CSSSelector[]} so_content_addition_selector
+ * @typedef {CSSSelector[]} so_snippet_addition_selector
+ */
+
 const card_parent_handlers =
     ".s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div, .s_company_team_card .row > div, .s_carousel_cards_item";
 const special_cards_selector = `.s_card.s_timeline_card, div:is(${card_parent_handlers}) > .s_card`;
@@ -11,6 +17,7 @@ const so_snippet_addition_drop_in =
 
 export class DropZoneSelectorPlugin extends Plugin {
     static id = "dropzone_selector";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         dropzone_selector: [
             {

--- a/addons/html_builder/static/src/core/field_change_replication_plugin.js
+++ b/addons/html_builder/static/src/core/field_change_replication_plugin.js
@@ -6,6 +6,7 @@ export class FieldChangeReplicationPlugin extends Plugin {
     static id = "fieldChangeReplication";
     static dependencies = ["dom"];
 
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         handleNewRecords: this.handleMutations.bind(this),
         normalize_handlers: withSequence(9000, this.normalizeHandler.bind(this)),

--- a/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
+++ b/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
@@ -26,6 +26,7 @@ function isGridItem(el) {
 export class GridLayoutPlugin extends Plugin {
     static id = "gridLayout";
     static dependencies = ["selection", "builderOptions"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         get_overlay_buttons: withSequence(0, {
             getButtons: this.getActiveOverlayButtons.bind(this),

--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -5,11 +5,17 @@ import { shouldEditableMediaBeEditable } from "@html_builder/utils/utils_css";
 import { _t } from "@web/core/l10n/translation";
 import { Tooltip } from "@web/core/tooltip/tooltip";
 
+/**
+ * @typedef { Object } MediaWebsiteShared
+ * @property { MediaWebsitePlugin['replaceMedia'] } replaceMedia
+ */
+
 export class MediaWebsitePlugin extends Plugin {
     static id = "media_website";
     static dependencies = ["media", "selection", "builderOptions"];
     static shared = ["replaceMedia"];
 
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         on_replaced_media_handlers: ({ newMediaEl }) =>
             // Activate the new media options.

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -10,9 +10,19 @@ import { isElementInViewport } from "@html_builder/utils/utils";
 import { scrollTo } from "@html_builder/utils/scrolling";
 import { localization } from "@web/core/l10n/localization";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {{
+ *     selector: CSSSelector;
+ *     exclude?: CSSSelector;
+ *     direction: "horizontal" | "vertical";
+ *     noScroll?: boolean;
+ * }[]} is_movable_selector
+ */
 export class MovePlugin extends Plugin {
     static id = "move";
     static dependencies = ["visibility"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         has_overlay_options: { hasOption: (el) => this.isMovable(el) },
         get_overlay_buttons: withSequence(0, {

--- a/addons/html_builder/static/src/core/operation_plugin.js
+++ b/addons/html_builder/static/src/core/operation_plugin.js
@@ -4,6 +4,11 @@ import { useComponent } from "@odoo/owl";
 
 /** @typedef {import("./operation").OperationParams} OperationParams */
 
+/**
+ * @typedef { Object } OperationShared
+ * @property { OperationPlugin['next'] } next
+ */
+
 export class OperationPlugin extends Plugin {
     static id = "operation";
     static dependencies = ["history"];

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -6,6 +6,20 @@ import { checkElement } from "../builder_options_plugin";
 import { OverlayButtons } from "./overlay_buttons";
 import { withSequence } from "@html_editor/utils/resource";
 
+/** @typedef {import("@html_builder/core/builder_options_plugin").BuilderButtonDescriptor} BuilderButtonDescriptor */
+/**
+ * @typedef { Object } OverlayButtonsShared
+ * @property { OverlayButtonsPlugin['hideOverlayButtons'] } hideOverlayButtons
+ * @property { OverlayButtonsPlugin['showOverlayButtons'] } showOverlayButtons
+ * @property { OverlayButtonsPlugin['hideOverlayButtonsUi'] } hideOverlayButtonsUi
+ * @property { OverlayButtonsPlugin['showOverlayButtonsUi'] } showOverlayButtonsUi
+ */
+/**
+ * @typedef {{
+ *      getButtons: (target: HTMLElement) => BuilderButtonDescriptor;
+ * }[]} get_overlay_buttons
+ */
+
 export class OverlayButtonsPlugin extends Plugin {
     static id = "overlayButtons";
     static dependencies = ["selection", "overlay", "history", "operation", "toolbar"];
@@ -15,6 +29,7 @@ export class OverlayButtonsPlugin extends Plugin {
         "hideOverlayButtonsUi",
         "showOverlayButtonsUi",
     ];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         selectionchange_handlers: this.shouldShowToolbar.bind(this),
         selection_leave_handlers: this.showOverlayButtonsUi.bind(this),

--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -6,6 +6,22 @@ import { isUnremovableQWebElement as qwebPluginPredicate } from "@html_editor/ot
 import { isEditable } from "@html_builder/utils/utils";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+
+/**
+ * @typedef { Object } RemoveShared
+ * @property { RemovePlugin['removeElement'] } removeElement
+ */
+
+/**
+ * @typedef {((arg: { removedEl: HTMLElement, nextTargetEl: HTMLElement }) => void)[]} on_removed_handlers
+ * @typedef {((toRemoveEl: HTMLElement) => void)[]} on_will_remove_handlers
+ *
+ * @typedef {((el: HTMLElement) => boolean)[]} empty_node_predicates
+ *
+ * @typedef {CSSSelector[]} is_unremovable_selector
+ */
+
 const unremovableNodePredicates = [
     (node) => !isEditable(node.parentNode),
     ...deletePluginPredicates,
@@ -20,6 +36,7 @@ export function isRemovable(el) {
 export class RemovePlugin extends Plugin {
     static id = "remove";
     static dependencies = ["builderOptions", "visibility"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         get_overlay_buttons: withSequence(3, {
             getButtons: this.getActiveOverlayButtons.bind(this),

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -3,11 +3,37 @@ import { withSequence } from "@html_editor/utils/resource";
 import { groupBy } from "@web/core/utils/arrays";
 import { uniqueId } from "@web/core/utils/functions";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef { Object } SaveShared
+ * @property { SavePlugin['save'] } save
+ * @property { SavePlugin['ignoreDirty'] } ignoreDirty
+ */
+
+/**
+ * @typedef {(() => void)[]} after_save_handlers
+ * @typedef {((el: HTMLElement) => Promise<Map<string,string> | void>)[]} before_save_handlers
+ * Called at the very beginning of the save process.
+ *
+ * @typedef {((el: HTMLElement) => Promise<void>)[]} save_element_handlers
+ * Called when saving an element (in parallel to saving the view).
+ *
+ * @typedef {(() => Promise<boolean>)[]} save_handlers
+ * Called at the very end of the save process.
+ *
+ * @typedef {((cleanedEls: HTMLElement[]) => Promise<boolean>)[]} save_elements_overrides
+ *
+ * @typedef {(() => HTMLElement[] | NodeList)[]} get_dirty_els
+ *
+ * @typedef {CSSSelector[]} savable_selectors
+ */
+
 export class SavePlugin extends Plugin {
     static id = "savePlugin";
     static shared = ["save", "ignoreDirty"];
     static dependencies = ["history"];
 
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         handleNewRecords: this.handleMutations.bind(this),
         start_edition_handlers: this.startObserving.bind(this),
@@ -17,25 +43,10 @@ export class SavePlugin extends Plugin {
             "#wrapwrap [data-oe-field]:not([data-oe-sanitize-prevent-edition])",
             "#wrapwrap .s_cover[data-res-model]",
         ],
-        before_save_handlers: [
-            // async () => {
-            //     called at the very beginning of the save process
-            // }
-        ],
         clean_for_save_handlers: [
             // ({root}) => {
             //     clean DOM before save (leaving edit mode)
             //     root is the clone of a node that was o_dirty
-            // }
-        ],
-        save_element_handlers: [
-            // async (el) => {
-            //     called when saving an element (in parallel to saving the view)
-            // }
-        ],
-        save_handlers: [
-            // async () => {
-            //     called at the very end of the save process
             // }
         ],
         get_dirty_els: () => this.editable.querySelectorAll(".o_dirty"),

--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -15,6 +15,7 @@ function isSavable(el) {
 
 export class SaveSnippetPlugin extends Plugin {
     static id = "saveSnippet";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         get_options_container_top_buttons: withSequence(
             1,

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -2,9 +2,22 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
 
+/**
+ * @typedef { Object } SetupEditorShared
+ * @property { SetupEditorPlugin['getEditableAreas'] } getEditableAreas
+ */
+
+/**
+ * @typedef {(() => void | true)[]} after_setup_editor_handlers
+ * @typedef {(() => void)[]} before_setup_editor_handlers
+ *
+ * @typedef {CSSSelector[]} o_editable_selectors
+ */
+
 export class SetupEditorPlugin extends Plugin {
     static id = "setup_editor_plugin";
     static shared = ["getEditableAreas"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         closest_savable_providers: withSequence(10, (el) => el.closest(".o_editable")),

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -2,6 +2,19 @@ import { Plugin } from "@html_editor/plugin";
 import { getElementsWithOption } from "@html_builder/utils/utils";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef { Object } VisibilityShared
+ * @property { VisibilityPlugin['getVisibleSibling'] } getVisibleSibling
+ * @property { VisibilityPlugin['toggleTargetVisibility'] } toggleTargetVisibility
+ * @property { VisibilityPlugin['onOptionVisibilityUpdate'] } onOptionVisibilityUpdate
+ * @property { VisibilityPlugin['hideElement'] } hideElement
+ */
+
+/**
+ * @typedef {((targetEl: HTMLElement) => void)[]} target_hide
+ * @typedef {((targetEl: HTMLElement) => void)[]} target_show
+ */
+
 const invisibleElementsSelector =
     ".o_snippet_invisible, .o_snippet_mobile_invisible, .o_snippet_desktop_invisible";
 const deviceInvisibleSelector = ".o_snippet_mobile_invisible, .o_snippet_desktop_invisible";
@@ -15,6 +28,7 @@ export class VisibilityPlugin extends Plugin {
         "onOptionVisibilityUpdate",
         "hideElement",
     ];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         on_mobile_preview_clicked: withSequence(10, this.onMobilePreviewClicked.bind(this)),
         system_attributes: ["data-invisible"],

--- a/addons/html_builder/static/src/plugins/alert_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/alert_option_plugin.js
@@ -8,6 +8,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 
 class AlertOptionPlugin extends Plugin {
     static id = "alertOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             AlertIconAction,

--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -9,6 +9,13 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { StyleAction } from "@html_builder/core/core_builder_action_plugin";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef {((editingElement: HTMLElement) => void)[]} on_bg_image_hide_handlers
+ *
+ * @typedef {((editingElement: HTMLElement) => HTMLElement)[]} background_filter_target_providers
+ * @typedef {((el: HTMLElement) => HTMLElement)[]} get_target_element_providers
+ */
+
 export class BackgroundImageOptionPlugin extends Plugin {
     static id = "backgroundImageOption";
     static dependencies = ["builderActions", "media", "style"];
@@ -18,6 +25,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
         "loadReplaceBackgroundImage",
         "applyReplaceBackgroundImage",
     ];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             SelectFilterColorAction,

--- a/addons/html_builder/static/src/plugins/background_option/background_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_option_plugin.js
@@ -2,8 +2,18 @@ import { applyFunDependOnSelectorAndExclude } from "@html_builder/plugins/utils"
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {{
+ *     selector: CSSSelector;
+ *     exclude?: CSSSelector;
+ *     applyTo?: CSSSelector;
+ * }[]} mark_color_level_selector_params
+ */
+
 class BackgroundOptionPlugin extends Plugin {
     static id = "backgroundOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         normalize_handlers: this.normalize.bind(this),
         system_classes: ["o_colored_level"],

--- a/addons/html_builder/static/src/plugins/background_option/background_position_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_option_plugin.js
@@ -15,6 +15,7 @@ const getBgSizeValue = function ({ editingElement, params: { mainParam: styleNam
 class BackgroundPositionOptionPlugin extends Plugin {
     static id = "backgroundPositionOption";
     static dependencies = ["overlay", "overlayButtons"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             BackgroundTypeAction,

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
@@ -12,9 +12,14 @@ import { getBgImageURLFromURL } from "@html_editor/utils/image";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { getHtmlStyle } from "@html_editor/utils/formatting";
 
+/**
+ * @typedef {((editingElement: HTMLElement) => HTMLElement)[]} background_shape_target_providers
+ */
+
 export class BackgroundShapeOptionPlugin extends Plugin {
     static id = "backgroundShapeOption";
     static dependencies = ["customizeTab"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             SetBackgroundShapeAction,

--- a/addons/html_builder/static/src/plugins/badge_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/badge_option_plugin.js
@@ -11,6 +11,7 @@ export class BadgeOption extends BaseOptionComponent {
 
 class BadgeOptionPlugin extends Plugin {
     static id = "badgeOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(before(ANIMATE), BadgeOption)],
         so_content_addition_selector: [".s_badge"],

--- a/addons/html_builder/static/src/plugins/block_alignment_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/block_alignment_option_plugin.js
@@ -6,6 +6,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 
 class BlockAlignmentOptionPlugin extends Plugin {
     static id = "blockAlignmentOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(BLOCK_ALIGN, BlockAlignmentOption)],
     };

--- a/addons/html_builder/static/src/plugins/cta_badge_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/cta_badge_option_plugin.js
@@ -12,6 +12,7 @@ export class CTABadgeOption extends BaseOptionComponent {
 
 class CTABadgeOptionPlugin extends Plugin {
     static id = "ctaBadgeOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [CTABadgeOption],
         so_content_addition_selector: [".s_cta_badge"],

--- a/addons/html_builder/static/src/plugins/date_time_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/date_time_field_plugin.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 
 class DateTimeFieldPlugin extends Plugin {
     static id = "dateTimeField";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         content_not_editable_selectors: [
             "[data-oe-field][data-oe-type=date]",

--- a/addons/html_builder/static/src/plugins/font/font_plugin.js
+++ b/addons/html_builder/static/src/plugins/font/font_plugin.js
@@ -7,10 +7,15 @@ import { loadCSS } from "@web/core/assets";
 import { BuilderFontSizeSelector } from "./font_size_selector";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef {string[]} fontCssVariables
+ */
+
 export class BuilderFontPlugin extends Plugin {
     static id = "builderFont";
     static shared = ["getFontsCache", "getFontsData"];
     static dependencies = ["toolbar"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         // Lists CSS variables that will be reset when a font is deleted if
         // they refer to that font.

--- a/addons/html_builder/static/src/plugins/image/image_filter_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_filter_option_plugin.js
@@ -7,6 +7,7 @@ import { registry } from "@web/core/registry";
 
 class ImageFilterOptionPlugin extends Plugin {
     static id = "ImageFilterOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             GlFilterAction,

--- a/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
@@ -12,6 +12,7 @@ import { selectElements } from "@html_editor/utils/dom_traversal";
 class ImageFormatOptionPlugin extends Plugin {
     static id = "imageFormatOption";
     static shared = ["computeAvailableFormats"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             SetImageFormatAction,

--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -20,6 +20,20 @@ import { _t } from "@web/core/l10n/translation";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { getMimetype } from "@html_editor/utils/image";
 
+/**
+ * @typedef {((dataset: DOMStringMap) => string)[]} default_shape_handlers
+ * @typedef {((
+ *     svg: SVGElement,
+ *     params: {
+ *         shapeId: string,
+ *         shapeFlip: "x" | "y",
+ *         shapeRotate: 0 | "90" | "180" | "270",
+ *         shapeAnimationSpeed: number,
+ *         shapeColors: string,
+ *     }
+ * ) => Promise<void>)[]} post_compute_shape_listeners
+ */
+
 // Regex definitions to apply speed modification in SVG files
 // Note : These regex patterns are duplicated on the server side for
 // background images that are part of a CSS rule "background-image: ...". The
@@ -46,6 +60,7 @@ export class ImageShapeOptionPlugin extends Plugin {
         "getShapeLabel",
         "loadShape",
     ];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             SetImageShapeAction,

--- a/addons/html_builder/static/src/plugins/image/image_size_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_size_plugin.js
@@ -5,6 +5,7 @@ import { ImageSize } from "./image_size";
 class ImageSizePlugin extends Plugin {
     static id = "imageSize";
     static dependencies = ["imagePostProcess"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         elements_to_options_title_components: {
             Component: ImageSize,

--- a/addons/html_builder/static/src/plugins/image/image_snippet_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_snippet_option_plugin.js
@@ -5,6 +5,7 @@ class ImageSnippetOptionPlugin extends Plugin {
     static id = "imageSnippetOption";
     static dependencies = ["media"];
     static shared = ["onSnippetDropped"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         so_content_addition_selector: [".s_image"],

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -35,6 +35,7 @@ class ImageToolOptionPlugin extends Plugin {
         "builderOptions",
     ];
     static shared = ["getCSSColorValue"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [
             withSequence(REPLACE_MEDIA, ReplaceMediaOption),

--- a/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
@@ -6,6 +6,7 @@ import { Deferred } from "@web/core/utils/concurrency";
 
 export class ImageTransformOptionPlugin extends Plugin {
     static id = "imageTransformOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             TransformImageAction,

--- a/addons/html_builder/static/src/plugins/image_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/image_field_plugin.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 
 export class ImageFieldPlugin extends Plugin {
     static id = "imageField";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         content_editable_selectors: "[data-oe-field][data-oe-type=image] img",
         content_not_editable_selectors: "[data-oe-field][data-oe-type=image]",

--- a/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
@@ -9,6 +9,7 @@ import { LAYOUT_COLUMN } from "@html_builder/utils/option_sequence";
 class LayoutColumnOptionPlugin extends Plugin {
     static id = "LayoutColumnOption";
     static dependencies = ["clone", "selection"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(LAYOUT_COLUMN, LayoutColumnOption)],
         on_cloned_handlers: this.onCloned.bind(this),

--- a/addons/html_builder/static/src/plugins/many2one_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/many2one_option_plugin.js
@@ -5,6 +5,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 
 export class Many2OneOptionPlugin extends Plugin {
     static id = "many2OneOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [Many2OneOption],
         builder_actions: {

--- a/addons/html_builder/static/src/plugins/monetary_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/monetary_field_plugin.js
@@ -6,6 +6,7 @@ const monetarySel = "[data-oe-field][data-oe-type=monetary]";
 export class MonetaryFieldPlugin extends Plugin {
     static id = "monetaryField";
     static dependencies = ["selection"];
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         content_editable_selectors: `${monetarySel} .oe_currency_value`,
         content_not_editable_selectors: monetarySel,

--- a/addons/html_builder/static/src/plugins/rating_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/rating_option_plugin.js
@@ -12,6 +12,7 @@ class RatingOptionPlugin extends Plugin {
     static id = "ratingOption";
     static dependencies = ["history", "media"];
     selector = ".s_rating";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: RatingOption,
         so_content_addition_selector: [".s_rating"],

--- a/addons/html_builder/static/src/plugins/separator_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/separator_option_plugin.js
@@ -5,6 +5,7 @@ import { BorderConfigurator } from "./border_configurator_option";
 
 class SeparatorOptionPlugin extends Plugin {
     static id = "separatorOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [SeparatorOption],
         dropzone_selector: {

--- a/addons/html_builder/static/src/plugins/shadow_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/shadow_option_plugin.js
@@ -7,6 +7,7 @@ const shadowClass = "shadow";
 
 export class ShadowOptionPlugin extends Plugin {
     static id = "shadowOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_actions: {
             SetShadowModeAction,

--- a/addons/html_builder/static/src/plugins/text_alignment_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/text_alignment_option_plugin.js
@@ -6,6 +6,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 
 class TextAlignmentOptionPlugin extends Plugin {
     static id = "textAlignmentOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(TEXT_ALIGNMENT, TextAlignmentOption)],
     };

--- a/addons/html_builder/static/src/plugins/vertical_alignment_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/vertical_alignment_option_plugin.js
@@ -7,6 +7,7 @@ import { VERTICAL_ALIGNMENT } from "@html_builder/utils/option_sequence";
 
 export class VerticalAlignmentOptionPlugin extends Plugin {
     static id = "verticalAlignmentOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(VERTICAL_ALIGNMENT, VerticalAlignmentOption)],
         builder_actions: {

--- a/addons/html_builder/static/src/plugins/vertical_justify_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/vertical_justify_option_plugin.js
@@ -6,6 +6,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 
 class VerticalJustifyOptionPlugin extends Plugin {
     static id = "verticalJustifyOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(END, VerticalJustifyOption)],
     };

--- a/addons/html_builder/static/src/plugins/width_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/width_option_plugin.js
@@ -6,6 +6,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 
 class WidthOptionPlugin extends Plugin {
     static id = "widthOption";
+    /** @type {import("plugins").BuilderResources} */
     resources = {
         builder_options: [withSequence(WIDTH, WidthOption)],
     };

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -11,6 +11,10 @@ import { scrollTo } from "@html_builder/utils/scrolling";
 import { Snippet } from "./snippet";
 import { CustomInnerSnippet } from "./custom_inner_snippet";
 
+/**
+ * @typedef {((arg: { snippetEl: HTMLElement }) => void)[]} on_snippet_dropped_handlers
+ */
+
 export class BlockTab extends Component {
     static template = "html_builder.BlockTab";
     static components = { Snippet, CustomInnerSnippet };

--- a/addons/html_builder/static/src/sidebar/invisible_elements_panel.js
+++ b/addons/html_builder/static/src/sidebar/invisible_elements_panel.js
@@ -1,6 +1,10 @@
 import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 import { getSnippetName, isElementInViewport } from "@html_builder/utils/utils";
 
+/**
+ * @typedef {((snippetEl: HTMLElement) => void)[]} on_reveal_target_handlers
+ */
+
 export class InvisibleElementsPanel extends Component {
     static template = "html_builder.InvisibleElementsPanel";
     static props = {

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -8,6 +8,11 @@ import { getFirstAndLastTabableElements } from "@web/core/ui/ui_service";
 import { useChildRef } from "@web/core/utils/hooks";
 import { SnippetViewer } from "./snippet_viewer";
 
+/**
+ * @typedef {((arg: { iframe: HTMLIFrameElement }) => void)[]} snippet_preview_dialog_stylesheets_handlers
+ * @typedef {string[]} snippet_preview_dialog_bundles
+ */
+
 export class AddSnippetDialog extends Component {
     static template = "html_builder.AddSnippetDialog";
     static components = { Dialog };

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -336,7 +336,7 @@ export class SnippetModel extends Reactive {
     }
 }
 
-registry.category("services").add("html_builder.snippets", {
+export const snippetService = {
     dependencies: ["orm", "dialog"],
 
     start(env, { orm, dialog }) {
@@ -363,7 +363,9 @@ registry.category("services").add("html_builder.snippets", {
 
         return { getSnippetModel };
     },
-});
+};
+
+registry.category("services").add("html_builder.snippets", snippetService);
 
 export function useSnippets(snippetsName) {
     const snippetsService = useService("html_builder.snippets");

--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -1,0 +1,253 @@
+declare module "plugins" {
+    import { clean_for_save_handlers, normalize_handlers, start_edition_handlers } from "@html_editor/editor";
+    import { Plugin } from "@html_editor/plugin";
+
+    import { BaseContainerShared, invalid_for_base_container_predicates } from "@html_editor/core/base_container_plugin";
+    import { added_image_handlers, after_paste_handlers, before_paste_handlers, clipboard_content_processors, clipboard_text_processors, ClipboardShared, paste_text_overrides } from "@html_editor/core/clipboard_plugin";
+    import { content_editable_providers, content_not_editable_providers, contenteditable_to_remove_selector, valid_contenteditable_predicates } from "@html_editor/core/content_editable_plugin";
+    import { before_delete_handlers, delete_backward_line_overrides, delete_backward_overrides, delete_backward_word_overrides, delete_forward_line_overrides, delete_forward_overrides, delete_forward_word_overrides, delete_handlers, delete_range_overrides, DeleteShared, functional_empty_node_predicates, is_empty_predicates, removable_descendants_providers, unremovable_node_predicates } from "@html_editor/core/delete_plugin";
+    import { DialogShared } from "@html_editor/core/dialog_plugin";
+    import { after_insert_handlers, before_insert_processors, before_set_tag_handlers, DomShared, node_to_insert_processors, system_attributes, system_classes, system_style_properties } from "@html_editor/core/dom_plugin";
+    import { format_class_predicates, format_selection_handlers, FormatShared, has_format_predicates, remove_all_formats_handlers } from "@html_editor/core/format_plugin";
+    import { attribute_change_handlers, attribute_change_processors, before_add_step_handlers, before_filter_mutation_record_handlers, content_updated_handlers, external_step_added_handlers, handleNewRecords, history_cleaned_handlers, history_reset_from_steps_handlers, history_reset_handlers, HistoryShared, post_redo_handlers, restore_savepoint_handlers, savable_mutation_record_predicates, serializable_descendants_processors, step_added_handlers } from "@html_editor/core/history_plugin";
+    import { beforeinput_handlers, input_handlers } from "@html_editor/core/input_plugin";
+    import { before_line_break_handlers, insert_line_break_element_overrides, LineBreakShared } from "@html_editor/core/line_break_plugin";
+    import { OverlayShared } from "@html_editor/core/overlay_plugin";
+    import { ProtectedNodeShared } from "@html_editor/core/protected_node_plugin";
+    import { SanitizeShared } from "@html_editor/core/sanitize_plugin";
+    import { double_click_overrides, fix_selection_on_editable_root_overrides, fully_selected_node_predicates, intangible_char_for_keyboard_navigation_predicates, is_node_editable_predicates, selection_leave_handlers, selectionchange_handlers, SelectionShared, targeted_nodes_processors, triple_click_overrides } from "@html_editor/core/selection_plugin";
+    import { shortcuts, shorthands } from "@html_editor/core/shortcut_plugin";
+    import { before_split_block_handlers, split_element_block_overrides, SplitShared, unsplittable_node_predicates } from "@html_editor/core/split_plugin";
+    import { StyleShared } from "@html_editor/core/style_plugin";
+    import { user_commands, UserCommandShared } from "@html_editor/core/user_command_plugin";
+
+    import { BannerShared } from "@html_editor/main/banner_plugin";
+    import { EmojiShared } from "@html_editor/main/emoji_plugin";
+    import { feff_providers, FeffShared, legit_feff_predicates, selectors_for_feff_providers } from "@html_editor/main/feff_plugin";
+    import { apply_background_color_processors, apply_color_style_overrides, color_apply_overrides, color_combination_getters, ColorShared, get_background_color_processors } from "@html_editor/main/font/color_plugin";
+    import { ColorUIShared } from "@html_editor/main/font/color_ui_plugin";
+    import { before_insert_within_pre_processors, font_items } from "@html_editor/main/font/font_plugin";
+    import { hint_targets_providers, hints } from "@html_editor/main/hint_plugin";
+    import { paste_url_overrides } from "@html_editor/main/link/link_paste_plugin";
+    import { immutable_link_selectors, is_link_editable_predicates, legit_empty_link_predicates, link_compatible_selection_predicates, link_popovers, LinkShared } from "@html_editor/main/link/link_plugin";
+    import { ineligible_link_for_selection_indication_predicates, ineligible_link_for_zwnbsp_predicates, LinkSelectionShared } from "@html_editor/main/link/link_selection_plugin";
+    import { paste_media_url_command_providers } from "@html_editor/main/link/powerbox_url_paste_plugin";
+    import { LocalOverlayShared } from "@html_editor/main/local_overlay_plugin";
+    import { ImageCropShared } from "@html_editor/main/media/image_crop_plugin";
+    import { delete_image_overrides, image_name_predicates, ImageShared } from "@html_editor/main/media/image_plugin";
+    import { ImagePostProcessShared, process_image_post_handlers, process_image_warmup_handlers } from "@html_editor/main/media/image_post_process_plugin";
+    import { closest_savable_providers, ImageSaveShared } from "@html_editor/main/media/image_save_plugin";
+    import { after_save_media_dialog_handlers, media_dialog_extra_tabs, MediaShared, on_added_media_handlers, on_media_dialog_saved_handlers, on_replaced_media_handlers } from "@html_editor/main/media/media_plugin";
+    import { move_node_blacklist_selectors, move_node_whitelist_selectors } from "@html_editor/main/movenode_plugin";
+    import { layout_geometry_change_handlers } from "@html_editor/main/position_plugin";
+    import { power_buttons, power_buttons_visibility_predicates } from "@html_editor/main/power_buttons_plugin";
+    import { powerbox_categories, powerbox_items, PowerboxShared } from "@html_editor/main/powerbox/powerbox_plugin";
+    import { deselect_custom_selected_nodes_handlers, TableShared } from "@html_editor/main/table/table_plugin";
+    import { shift_tab_overrides, tab_overrides, TabulationShared } from "@html_editor/main/tabulation_plugin";
+    import { can_display_toolbar, collapsed_selection_toolbar_predicate, toolbar_groups, toolbar_items, toolbar_namespaces, ToolbarShared } from "@html_editor/main/toolbar/toolbar_plugin";
+
+    import { CollaborationOdooShared } from "@html_editor/others/collaboration/collaboration_odoo_plugin";
+    import { CollaborationShared, external_history_step_handlers } from "@html_editor/others/collaboration/collaboration_plugin";
+    import { DynamicPlaceholderShared } from "@html_editor/others/dynamic_placeholder_plugin";
+    import { EmbeddedComponentShared, mount_component_handlers, post_mount_component_handlers } from "@html_editor/others/embedded_component_plugin";
+
+    /* Misc */
+    export interface CSSSelector extends String {}
+    export interface LazyTranslatedString extends String {}
+
+    /** Plugin */
+    export type PluginConstructor = (typeof Plugin) & {
+        static id: string;
+        static dependencies: keyof SharedMethods;
+    };
+
+    export interface SharedMethods {}
+    interface SharedMethods {
+        // Core
+        baseContainer: BaseContainerShared;
+        clipboard: ClipboardShared;
+        delete: DeleteShared;
+        dialog: DialogShared;
+        dom: DomShared;
+        format: FormatShared;
+        history: HistoryShared;
+        lineBreak: LineBreakShared;
+        overlay: OverlayShared;
+        protectedNode: ProtectedNodeShared;
+        sanitize: SanitizeShared;
+        selection: SelectionShared;
+        split: SplitShared;
+        style: StyleShared;
+        userCommand: UserCommandShared;
+
+        // Main
+        color: ColorShared;
+        colorUi: ColorUIShared;
+        link: LinkShared;
+        linkSelection: LinkSelectionShared;
+        media: MediaShared;
+        powerbox: PowerboxShared;
+        table: TableShared;
+        toolbar: ToolbarShared;
+        emoji: EmojiShared;
+        localOverlay: LocalOverlayShared;
+        tabulation: TabulationShared;
+        feff: FeffShared;
+        image: ImageShared;
+        imageCrop: ImageCropShared;
+        imagePostProcess: ImagePostProcessShared;
+        banner: BannerShared;
+        imageSave: ImageSaveShared;
+
+        // Others
+        collaborationOdoo: CollaborationOdooShared;
+        collaboration: CollaborationShared;
+        dynamicPlaceholder: DynamicPlaceholderShared;
+        embeddedComponents: EmbeddedComponentShared;
+    }
+
+    export interface GlobalResources {}
+    export type Resources = { [key: string]: any };
+    export type ResourcesTypesFactory<T> = {
+        [R in keyof T]: Array<T[R][0]>;
+    };
+
+    interface GlobalResources extends EditorResources {}
+    export type EditorResources = ResourcesTypesFactory<EditorResourcesList>;
+
+    export interface EditorResourcesList {
+        // Handlers
+        added_image_handlers: added_image_handlers;
+        after_insert_handlers: after_insert_handlers;
+        after_paste_handlers: after_paste_handlers;
+        after_save_media_dialog_handlers: after_save_media_dialog_handlers;
+        attribute_change_handlers: attribute_change_handlers;
+        before_add_step_handlers: before_add_step_handlers;
+        before_delete_handlers: before_delete_handlers;
+        before_filter_mutation_record_handlers: before_filter_mutation_record_handlers;
+        beforeinput_handlers: beforeinput_handlers;
+        before_line_break_handlers: before_line_break_handlers;
+        before_paste_handlers: before_paste_handlers;
+        before_split_block_handlers: before_split_block_handlers;
+        before_set_tag_handlers: before_set_tag_handlers;
+        clean_for_save_handlers: clean_for_save_handlers;
+        content_updated_handlers: content_updated_handlers;
+        delete_handlers: delete_handlers;
+        deselect_custom_selected_nodes_handlers: deselect_custom_selected_nodes_handlers;
+        external_history_step_handlers: external_history_step_handlers;
+        external_step_added_handlers: external_step_added_handlers;
+        format_selection_handlers: format_selection_handlers;
+        handleNewRecords: handleNewRecords;
+        history_cleaned_handlers: history_cleaned_handlers;
+        history_reset_handlers: history_reset_handlers;
+        history_reset_from_steps_handlers: history_reset_from_steps_handlers;
+        input_handlers: input_handlers;
+        layout_geometry_change_handlers: layout_geometry_change_handlers;
+        mount_component_handlers: mount_component_handlers;
+        normalize_handlers: normalize_handlers;
+        on_added_media_handlers: on_added_media_handlers;
+        on_media_dialog_saved_handlers: on_media_dialog_saved_handlers;
+        on_replaced_media_handlers: on_replaced_media_handlers;
+        post_mount_component_handlers: post_mount_component_handlers;
+        post_redo_handlers: post_redo_handlers;
+        post_undo_handlers: post_undo_handlers;
+        process_image_warmup_handlers: process_image_warmup_handlers;
+        process_image_post_handlers: process_image_post_handlers;
+        remove_all_formats_handlers: remove_all_formats_handlers;
+        restore_savepoint_handlers: restore_savepoint_handlers;
+        selectionchange_handlers: selectionchange_handlers;
+        selection_leave_handlers: selection_leave_handlers;
+        start_edition_handlers: start_edition_handlers;
+        step_added_handlers: step_added_handlers;
+
+        // Overrides
+        apply_color_style_overrides: apply_color_style_overrides;
+        color_apply_overrides: color_apply_overrides;
+        delete_backward_overrides: delete_backward_overrides;
+        delete_backward_word_overrides: delete_backward_word_overrides;
+        delete_backward_line_overrides: delete_backward_line_overrides;
+        delete_forward_overrides: delete_forward_overrides;
+        delete_forward_word_overrides: delete_forward_word_overrides;
+        delete_forward_line_overrides: delete_forward_line_overrides;
+        delete_image_overrides: delete_image_overrides;
+        delete_range_overrides: delete_range_overrides;
+        double_click_overrides: double_click_overrides;
+        triple_click_overrides: triple_click_overrides;
+        fix_selection_on_editable_root_overrides: fix_selection_on_editable_root_overrides;
+        insert_line_break_element_overrides: insert_line_break_element_overrides;
+        paste_text_overrides: paste_text_overrides;
+        paste_url_overrides: paste_url_overrides;
+        shift_tab_overrides: shift_tab_overrides;
+        split_element_block_overrides: split_element_block_overrides;
+        tab_overrides: tab_overrides;
+
+        // Predicates
+        can_display_toolbar: can_display_toolbar;
+        collapsed_selection_toolbar_predicate: collapsed_selection_toolbar_predicate;
+        format_class_predicates: format_class_predicates;
+        fully_selected_node_predicates: fully_selected_node_predicates;
+        functional_empty_node_predicates: functional_empty_node_predicates;
+        has_format_predicates: has_format_predicates;
+        image_name_predicates: image_name_predicates;
+        ineligible_link_for_selection_indication_predicates: ineligible_link_for_selection_indication_predicates;
+        ineligible_link_for_zwnbsp_predicates: ineligible_link_for_zwnbsp_predicates;
+        intangible_char_for_keyboard_navigation_predicates: intangible_char_for_keyboard_navigation_predicates;
+        invalid_for_base_container_predicates: invalid_for_base_container_predicates;
+        is_empty_predicates: is_empty_predicates;
+        is_link_editable_predicates: is_link_editable_predicates;
+        is_node_editable_predicates: is_node_editable_predicates;
+        legit_empty_link_predicates: legit_empty_link_predicates;
+        legit_feff_predicates: legit_feff_predicates;
+        link_compatible_selection_predicates: link_compatible_selection_predicates;
+        power_buttons_visibility_predicates: power_buttons_visibility_predicates;
+        savable_mutation_record_predicates: savable_mutation_record_predicates;
+        unremovable_node_predicates: unremovable_node_predicates;
+        unsplittable_node_predicates: unsplittable_node_predicates;
+        valid_contenteditable_predicates: valid_contenteditable_predicates;
+
+        // Processors
+        apply_background_color_processors: apply_background_color_processors;
+        attribute_change_processors: attribute_change_processors;
+        before_insert_processors: before_insert_processors;
+        before_insert_within_pre_processors: before_insert_within_pre_processors;
+        clipboard_content_processors: clipboard_content_processors;
+        clipboard_text_processors: clipboard_text_processors;
+        get_background_color_processors: get_background_color_processors;
+        node_to_insert_processors: node_to_insert_processors;
+        serializable_descendants_processors: serializable_descendants_processors;
+        targeted_nodes_processors: targeted_nodes_processors;
+
+        // Providers
+        closest_savable_providers: closest_savable_providers;
+        color_combination_getters: color_combination_getters;
+        content_editable_providers: content_editable_providers;
+        content_not_editable_providers: content_not_editable_providers;
+        feff_providers: feff_providers;
+        hint_targets_providers: hint_targets_providers;
+        paste_media_url_command_providers: paste_media_url_command_providers;
+        removable_descendants_providers: removable_descendants_providers;
+        selectors_for_feff_providers: selectors_for_feff_providers;
+
+        // Data
+        contenteditable_to_remove_selector: contenteditable_to_remove_selector;
+        font_items: font_items,
+        hints: hints;
+        immutable_link_selectors: immutable_link_selectors;
+        link_popovers: link_popovers;
+        media_dialog_extra_tabs: media_dialog_extra_tabs;
+        move_node_blacklist_selectors: move_node_blacklist_selectors;
+        move_node_whitelist_selectors: move_node_whitelist_selectors;
+        power_buttons: power_buttons;
+        powerbox_categories: powerbox_categories;
+        powerbox_items: powerbox_items;
+        shortcuts: shortcuts;
+        shorthands: shorthands;
+        system_attributes: system_attributes;
+        system_classes: system_classes;
+        system_style_properties: system_style_properties;
+        toolbar_groups: toolbar_groups;
+        toolbar_items: toolbar_items;
+        toolbar_namespaces: toolbar_namespaces;
+        user_commands: user_commands;
+    }
+}

--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -27,6 +27,10 @@ import { childNodeIndex } from "@html_editor/utils/position";
  * @property { BaseContainerPlugin['isCandidateForBaseContainer'] } isCandidateForBaseContainer
  */
 
+/**
+ * @typedef {((node: Node) => boolean)[]} invalid_for_base_container_predicates
+ */
+
 export class BaseContainerPlugin extends Plugin {
     static id = "baseContainer";
     static shared = ["createBaseContainer", "getDefaultNodeName", "isCandidateForBaseContainer"];
@@ -47,6 +51,7 @@ export class BaseContainerPlugin extends Plugin {
      */
     isUnsplittablePredicate = (element) =>
         this.getResource("unsplittable_node_predicates").some((fn) => fn(element));
+    /** @type {import("plugins").EditorResources} */
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         // `baseContainer` normalization should occur after every other normalization

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -97,6 +97,20 @@ const ONLY_LINK_REGEX = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-./?%&=]*)?$/i;
  * @property {ClipboardPlugin['pasteText']} pasteText
  */
 
+/**
+ * @typedef {((img: HTMLImageElement) => void)[]} added_image_handlers
+ * @typedef {(() => void)[]} after_paste_handlers
+ * @typedef {(() => void)[]} before_paste_handlers
+ *
+ * @typedef {((selection: EditorSelection, text: string) => boolean)[]} paste_text_overrides
+ *
+ * @typedef {((
+ *     clonedContents: DocumentFragment,
+ *     selection: EditorSelection
+ *   ) => void | clonedContents)[]} clipboard_content_processors
+ * @typedef {((textContent: string) => string)[]} clipboard_text_processors
+ */
+
 export class ClipboardPlugin extends Plugin {
     static id = "clipboard";
     static dependencies = [

--- a/addons/html_editor/static/src/core/comment_plugin.js
+++ b/addons/html_editor/static/src/core/comment_plugin.js
@@ -4,6 +4,7 @@ import { descendants } from "../utils/dom_traversal";
 
 export class CommentPlugin extends Plugin {
     static id = "comment";
+    /** @type {import("plugins").EditorResources} */
     resources = {
         normalize_handlers: this.removeComment.bind(this),
     };

--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -3,6 +3,18 @@ import { isMediaElement } from "@html_editor/utils/dom_info";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
+/** @typedef {import("@html_editor/editor").EditorContext} EditorContext */
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+
+/**
+ * @typedef {((el: HTMLElement) => boolean)[]} valid_contenteditable_predicates
+ *
+ * @typedef {((root: EditorContext["editable"]) => HTMLElement[])[]} content_editable_providers
+ * @typedef {((root: EditorContext["editable"]) => HTMLElement[])[]} content_not_editable_providers
+ *
+ * @typedef {CSSSelector[]} contenteditable_to_remove_selector
+ */
+
 /**
  * This plugin is responsible for setting the contenteditable attribute on some
  * elements.
@@ -13,6 +25,7 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class ContentEditablePlugin extends Plugin {
     static id = "contentEditablePlugin";
+    /** @type {import("plugins").EditorResources} */
     resources = {
         normalize_handlers: withSequence(5, this.normalize.bind(this)),
         clean_for_save_handlers: withSequence(Infinity, this.cleanForSave.bind(this)),

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -63,6 +63,30 @@ import { normalizeDeepCursorPosition, normalizeFakeBR } from "@html_editor/utils
  * @property { DeletePlugin['deleteForward'] } deleteForward
  */
 
+/**
+ * @typedef {(() => void)[]} before_delete_handlers
+ * @typedef {(() => void)[]} delete_handlers
+ *
+ * @typedef {((range: RangeLike) => void | true)[]} delete_backward_overrides
+ * @typedef {((range: RangeLike) => void | true)[]} delete_backward_word_overrides
+ * @typedef {((range: RangeLike) => void | true)[]} delete_backward_line_overrides
+ * @typedef {((range: RangeLike) => void | true)[]} delete_forward_overrides
+ * @typedef {((range: RangeLike) => void | true)[]} delete_forward_word_overrides
+ * @typedef {((range: RangeLike) => void | true)[]} delete_forward_line_overrides
+ * @typedef {((range: RangeLike) => void | true)[]} delete_range_overrides
+ *
+ * @typedef {((node: Node) => boolean)[]} functional_empty_node_predicates
+ * @typedef {((node: Node) => boolean)[]} is_empty_predicates
+ *
+ * @typedef {((node: Node) => Node[])[]} removable_descendants_providers
+ */
+/**
+ * The `root` argument is used by some predicates in which a node is
+ * conditionally unremovable (e.g. a table cell is only removable if its
+ * ancestor table is also being removed).
+ * @typedef {((node: Node, root: HTMLElement) => boolean)[]} unremovable_node_predicates
+ */
+
 // @todo @phoenix: move these predicates to different plugins
 export const unremovableNodePredicates = [
     (node) => node.classList?.contains("oe_unremovable"),
@@ -74,6 +98,7 @@ export class DeletePlugin extends Plugin {
     static dependencies = ["baseContainer", "selection", "history", "input", "userCommand"];
     static id = "delete";
     static shared = ["deleteBackward", "deleteForward", "deleteRange", "deleteSelection", "delete"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             { id: "deleteBackward", run: () => this.delete("backward", "character") },
@@ -345,7 +370,7 @@ export class DeletePlugin extends Plugin {
         <b>[abc]</b> -> <b>[]ZWS</b>
         <b>[abc</b> <b>d]ef</b> -> <b>[]ZWS</b> <b>ef</b>
         <b>[abc</b> <b>def]</b> -> <b>[]ZWS</b> <b>ZWS</b>
-        
+
     Block:
         Shrunk blocks get filled.
         <p>[abc]</p> -> <p>[]<br></p>

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -70,6 +70,18 @@ function getConnectedParents(nodes) {
  * @property { DomPlugin['removeSystemProperties'] } removeSystemProperties
  */
 
+/**
+ * @typedef {((insertedNodes: Node[]) => void)[]} after_insert_handlers
+ * @typedef {((el: HTMLElement) => void)[]} before_set_tag_handlers
+ *
+ * @typedef {((insertedNode: Node) => insertedNode)[]} before_insert_processors
+ * @typedef {((arg: { nodeToInsert: Node, container: HTMLElement }) => nodeToInsert)[]} node_to_insert_processors
+ *
+ * @typedef {string[]} system_attributes
+ * @typedef {string[]} system_classes
+ * @typedef {string[]} system_style_properties
+ */
+
 export class DomPlugin extends Plugin {
     static id = "dom";
     static dependencies = ["baseContainer", "selection", "history", "split", "delete", "lineBreak"];
@@ -81,6 +93,7 @@ export class DomPlugin extends Plugin {
         "setTagName",
         "removeSystemProperties",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/core/editor_version_plugin.js
+++ b/addons/html_editor/static/src/core/editor_version_plugin.js
@@ -7,6 +7,7 @@ import { Plugin } from "@html_editor/plugin";
 
 export class EditorVersionPlugin extends Plugin {
     static id = "editorVersion";
+    /** @type {import("plugins").EditorResources} */
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         normalize_handlers: this.normalize.bind(this),

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -44,6 +44,17 @@ function isFormatted(formatPlugin, format) {
  * @property { FormatPlugin['formatSelection'] } formatSelection
  */
 
+/**
+ * @typedef {((formatName: string, options: {
+ *      formatProps: object,
+ *      applyStyle: boolean,
+ * }) => void | boolean)[]} format_selection_handlers
+ * @typedef {(() => void)[]} remove_all_formats_handlers
+ *
+ * @typedef {((className: string) => boolean)[]} format_class_predicates
+ * @typedef {((node: Node) => boolean)[]} has_format_predicates
+ */
+
 export class FormatPlugin extends Plugin {
     static id = "format";
     static dependencies = ["selection", "history", "input", "split"];
@@ -54,6 +65,7 @@ export class FormatPlugin extends Plugin {
         "mergeAdjacentInlines",
         "formatSelection",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -137,6 +137,36 @@ import { trackOccurrences, trackOccurrencesPair } from "../utils/tracking";
  * @property { HistoryPlugin['getIsCurrentStepModified'] } getIsCurrentStepModified
  */
 
+/**
+ * @typedef {((record: HistoryMutationRecord) => void)[]} attribute_change_handlers
+ * @typedef {(() => void)[]} before_add_step_handlers
+ * @typedef {((records: HistoryMutationRecord[]) => void)[]} before_filter_mutation_record_handlers
+ * @typedef {((root: HTMLElement) => void)[]} content_updated_handlers
+ * @typedef {(() => void)[]} external_step_added_handlers
+ * @typedef {((records: HistoryMutationRecord[], currentOperation: "original"|"undo"|"redo"|"restore") => void)[]} handleNewRecords
+ * @typedef {(() => void)[]} history_cleaned_handlers
+ * @typedef {(() => void)[]} history_reset_handlers
+ * @typedef {(() => void)[]} history_reset_from_steps_handlers
+ * @typedef {((revertedStep: HistoryStep) => void)[]} post_redo_handlers
+ * @typedef {((revertedStep: HistoryStep) => void)[]} post_undo_handlers
+ * @typedef {(() => void)[]} restore_savepoint_handlers
+ * @typedef {((arg: { stepCommonAncestor: HTMLElement }) => void)[]} step_added_handlers
+ *
+ * @typedef {((record: HistoryMutationRecord) => boolean)[]} savable_mutation_record_predicates
+ *
+ * @typedef {((
+ *    arg: {
+ *      target: Node,
+ *      attributeName: string,
+ *      oldValue: string,
+ *      value: string,
+ *      reverse: boolean,
+ *    },
+ *    options: { forNewStep: boolean }
+ *  ) => void)[]} attribute_change_processors
+ * @typedef {((node: Node, childTreesToSerialize: Tree[]) => Tree[])[]} serializable_descendants_processors
+ */
+
 export class HistoryPlugin extends Plugin {
     static id = "history";
     static dependencies = ["selection", "sanitize"];
@@ -165,6 +195,7 @@ export class HistoryPlugin extends Plugin {
         "setStepExtra",
         "getIsCurrentStepModified",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {
@@ -209,13 +240,6 @@ export class HistoryPlugin extends Plugin {
             this.reset(this.config.content);
         },
         on_prepare_drag_handlers: this.disableIsCurrentStepModifiedWarning.bind(this),
-        // Resource definitions:
-        normalize_handlers: [
-            // (commonRootOfModifiedEl or editableEl) => {
-            //    clean up DOM before taking into account for next history step
-            //    remaining in edit mode
-            // }
-        ],
     };
 
     setup() {

--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -1,5 +1,10 @@
 import { Plugin } from "../plugin";
 
+/**
+ * @typedef {((ev: InputEvent) => void)[]} beforeinput_handlers
+ * @typedef {((ev: InputEvent) => void)[]} input_handlers
+ */
+
 export class InputPlugin extends Plugin {
     static id = "input";
     static dependencies = ["history"];

--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -14,10 +14,16 @@ import { nextLeaf } from "../utils/dom_info";
  * @property { LineBreakPlugin['insertLineBreakNode'] } insertLineBreakNode
  */
 
+/**
+ * @typedef {(() => void)[]} before_line_break_handlers
+ * @typedef {((params: { targetNode: Element, targetOffset: number }) => void | true)[]} insert_line_break_element_overrides
+ */
+
 export class LineBreakPlugin extends Plugin {
     static dependencies = ["selection", "history", "input", "delete"];
     static id = "lineBreak";
     static shared = ["insertLineBreak", "insertLineBreakNode", "insertLineBreakElement"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         beforeinput_handlers: this.onBeforeInput.bind(this),
         legit_feff_predicates: [

--- a/addons/html_editor/static/src/core/no_inline_root_plugin.js
+++ b/addons/html_editor/static/src/core/no_inline_root_plugin.js
@@ -8,6 +8,7 @@ export class NoInlineRootPlugin extends Plugin {
     static id = "noInlineRoot";
     static dependencies = ["baseContainer", "selection", "history"];
 
+    /** @type {import("plugins").EditorResources} */
     resources = {
         fix_selection_on_editable_root_overrides: this.fixSelectionOnEditableRoot.bind(this),
     };

--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -16,6 +16,7 @@ const UNPROTECTED_SELECTOR = `[data-oe-protected="false"]`;
 export class ProtectedNodePlugin extends Plugin {
     static id = "protectedNode";
     static shared = ["setProtectingNode"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),

--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -9,6 +9,7 @@ import { Plugin } from "../plugin";
 export class SanitizePlugin extends Plugin {
     static id = "sanitize";
     static shared = ["sanitize"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         normalize_handlers: this.normalize.bind(this),

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -176,6 +176,21 @@ function scrollToSelection(selection) {
  * @property { SelectionPlugin['selectAroundNonEditable'] } selectAroundNonEditable
  */
 
+/**
+ * @typedef {((selectionData: SelectionData) => void)[]} selectionchange_handlers
+ * @typedef {(() => void)[]} selection_leave_handlers
+ *
+ * @typedef {((ev: PointerEvent) => void | true)[]} double_click_overrides
+ * @typedef {((ev: PointerEvent) => void | true)[]} triple_click_overrides
+ * @typedef {((selection: EditorSelection) => boolean)[]} fix_selection_on_editable_root_overrides
+ *
+ * @typedef {((node: Node, selection: EditorSelection, range: Range) => boolean)[]} fully_selected_node_predicates
+ * @typedef {((ev: Event, char: string, lastSkipped: string) => boolean)[]} intangible_char_for_keyboard_navigation_predicates
+ * @typedef {((node: Node) => boolean)[]} is_node_editable_predicates
+ *
+ * @typedef {((targetedNodes: Node[]) => Node[])[]} targeted_nodes_processors
+ */
+
 export class SelectionPlugin extends Plugin {
     static id = "selection";
     static shared = [
@@ -198,6 +213,7 @@ export class SelectionPlugin extends Plugin {
         "isNodeEditable",
         "selectAroundNonEditable",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: { id: "selectAll", run: this.selectAll.bind(this) },
         shortcuts: [{ hotkey: "control+a", commandId: "selectAll" }],

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -8,23 +8,37 @@ import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
  * @property {string} hotkey
  * @property {string} commandId
  * @property {Object} [commandParams]
+ * @property {boolean} [global]
+ *
+ * @typedef {Shortcut[]} shortcuts
  *
  * Example:
  *
  *     resources = {
+ *         // See UserCommand
  *         user_commands: [
  *             { id: "myCommands", run: myCommandFunction },
  *         ],
+ *         // See Shortcut
  *         shortcuts: [
  *             { hotkey: "control+shift+q", commandId: "myCommands" },
  *         ],
  *     }
  */
 
+/**
+ * @typedef {{
+ *     pattern: RegExp;
+ *     commandId: string;
+ *     commandParams?: object;
+ * }[]} shorthands
+ */
+
 export class ShortCutPlugin extends Plugin {
     static id = "shortcut";
     static dependencies = ["userCommand", "selection"];
 
+    /** @type {import("plugins").EditorResources} */
     resources = {
         input_handlers: this.onInput.bind(this),
     };

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -23,6 +23,14 @@ import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
  * @property { SplitPlugin['splitSelection'] } splitSelection
  */
 
+/**
+ * @typedef {(() => void)[]} before_split_block_handlers
+ *
+ * @typedef {((params: { targetNode: Node, targetOffset: number, blockToSplit: HTMLElement | null }) => void | true)[]} split_element_block_overrides
+ *
+ * @typedef {((node: Node) => boolean)[]} unsplittable_node_predicates
+ */
+
 export class SplitPlugin extends Plugin {
     static dependencies = ["baseContainer", "selection", "history", "input", "delete", "lineBreak"];
     static id = "split";
@@ -35,6 +43,7 @@ export class SplitPlugin extends Plugin {
         "splitSelection",
         "isUnsplittable",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         beforeinput_handlers: this.onBeforeInput.bind(this),
 

--- a/addons/html_editor/static/src/core/user_command_plugin.js
+++ b/addons/html_editor/static/src/core/user_command_plugin.js
@@ -19,6 +19,10 @@ import { Plugin } from "../plugin";
  * @property { UserCommandPlugin['getCommand'] } getCommand
  */
 
+/**
+ * @typedef {UserCommand[]} user_commands
+ */
+
 export class UserCommandPlugin extends Plugin {
     static id = "userCommand";
     static shared = ["getCommand"];

--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -17,6 +17,7 @@ const alignmentItems = [
 export class AlignPlugin extends Plugin {
     static id = "align";
     static dependencies = ["history", "selection"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -26,6 +26,7 @@ export class BannerPlugin extends Plugin {
     // sanitize plugin is required to handle `contenteditable` attribute.
     static dependencies = ["baseContainer", "history", "dom", "emoji", "selection", "sanitize"];
     static shared = ["insertBanner"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_plugin.js
@@ -18,6 +18,7 @@ export class ChatGPTTranslatePlugin extends Plugin {
         "dialog",
         "split",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         toolbar_groups: withSequence(50, {
             id: "ai",

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -32,6 +32,7 @@ function columnIsAvailable(numberOfColumns) {
 export class ColumnPlugin extends Plugin {
     static id = "column";
     static dependencies = ["baseContainer", "selection", "history", "dom"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -11,6 +11,7 @@ export class EmojiPlugin extends Plugin {
     static id = "emoji";
     static dependencies = ["history", "overlay", "dom", "selection"];
     static shared = ["showEmojiPicker"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/feff_plugin.js
+++ b/addons/html_editor/static/src/main/feff_plugin.js
@@ -15,6 +15,12 @@ import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
  */
 
 /**
+ * @typedef {((node: Node) => boolean)[]} legit_feff_predicates
+ * @typedef {((root: EditorContext["editable"], cursors: Cursors) => Node[])[]} feff_providers
+ * @typedef {(() => string)[]} selectors_for_feff_providers
+ */
+
+/**
  * This plugin manages the insertion and removal of the zero-width no-break
  * space character (U+FEFF). These characters enable the user to place the
  * cursor in positions that would otherwise not be easy or possible, such as
@@ -26,6 +32,7 @@ export class FeffPlugin extends Plugin {
     static dependencies = ["selection"];
     static shared = ["addFeff", "removeFeffs", "surroundWithFeffs"];
 
+    /** @type {import("plugins").EditorResources} */
     resources = {
         normalize_handlers: this.updateFeffs.bind(this),
         clean_for_save_handlers: this.cleanForSave.bind(this),

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -31,6 +31,16 @@ const COLOR_COMBINATION_SELECTOR = COLOR_COMBINATION_CLASSES.map((c) => `.${c}`)
  * @property { ColorPlugin['getElementColors'] } getElementColors
  * @property { ColorPlugin['applyColor'] } applyColor
  */
+
+/**
+ * @typedef {((element: HTMLElement, cssProp: string, color: string) => boolean)[]} apply_color_style_overrides
+ * @typedef {((color: string, mode: "color" | "backgroundColor") => void)[]} color_apply_overrides
+ * @typedef {((color: string, mode: "color" | "backgroundColor") => string)[]} apply_background_color_processors
+ * @typedef {((color: string) => string)[]} get_background_color_processors
+ *
+ * @typedef {((el: HTMLElement, actionParam: string) => string)[]} color_combination_getters
+ */
+
 export class ColorPlugin extends Plugin {
     static id = "color";
     static dependencies = ["selection", "split", "history", "format"];
@@ -41,6 +51,7 @@ export class ColorPlugin extends Plugin {
         "getColorCombination",
         "applyColor",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/font/color_ui_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_ui_plugin.js
@@ -19,6 +19,7 @@ export class ColorUIPlugin extends Plugin {
     static id = "colorUi";
     static dependencies = ["color", "history", "selection"];
     static shared = ["getPropsForColorSelector"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         toolbar_items: [
             {

--- a/addons/html_editor/static/src/main/font/font_family_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_family_plugin.js
@@ -32,6 +32,7 @@ export class FontFamilyPlugin extends Plugin {
     static id = "fontFamily";
     static dependencies = ["split", "selection", "dom", "format", "font"];
     fontFamily = reactive({ displayName: defaultFontFamily.nameShort });
+    /** @type {import("plugins").EditorResources} */
     resources = {
         toolbar_items: [
             withSequence(15, {

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -36,6 +36,13 @@ import { FontSizeSelector } from "./font_size_selector";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { weakMemoize } from "@html_editor/utils/functions";
 
+/** @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString */
+
+/**
+ * @typedef {((insertedNode: Node) => insertedNode)[]} before_insert_within_pre_processors
+ * @typedef {{ name: LazyTranslatedString; tagName: string; extraClass?: string; }[]} font_items
+ */
+
 export const fontSizeItems = [
     { variableName: "display-1-font-size", className: "display-1-fs" },
     { variableName: "display-2-font-size", className: "display-2-fs" },
@@ -71,6 +78,7 @@ export class FontPlugin extends Plugin {
         "format",
         "lineBreak",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         font_items: [
             withSequence(10, {

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -4,9 +4,25 @@ import { removeClass } from "@html_editor/utils/dom";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
 
+/**
+ * @typedef {import("@html_editor/editor").EditorContext} EditorContext
+ * @typedef {import("@html_editor/core/selection_plugin").SelectionData} SelectionData
+ * @typedef {import("plugins").CSSSelector} CSSSelector
+ * @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString
+ */
+
+/**
+ * @typedef {((
+ *   selectionData: SelectionData,
+ *   editable: EditorContext["editable"]
+ * ) => HTMLElement[] | NodeList)[]} hint_targets_providers
+ * @typedef {{ selector: CSSSelector; text: LazyTranslatedString; }[]} hints
+ */
+
 export class HintPlugin extends Plugin {
     static id = "hint";
     static dependencies = ["history", "selection"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         selectionchange_handlers: this.updateHints.bind(this),

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -7,6 +7,7 @@ import { DIRECTIONS, nodeSize } from "@html_editor/utils/position";
 export class InlineCodePlugin extends Plugin {
     static id = "inlineCode";
     static dependencies = ["selection", "history", "input", "split", "feff"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         input_handlers: this.onInput.bind(this),
         selectionchange_handlers: this.handleSelectionChange.bind(this),

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -4,9 +4,14 @@ import { isImageUrl } from "@html_editor/utils/url";
 import { Plugin } from "@html_editor/plugin";
 import { childNodeIndex } from "@html_editor/utils/position";
 
+/**
+ * @typedef {((text: string, url: string) => void | true)[]} paste_url_overrides
+ */
+
 export class LinkPastePlugin extends Plugin {
     static id = "linkPaste";
     static dependencies = ["link", "clipboard", "selection", "dom", "history"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         before_paste_handlers: this.selectFullySelectedLink.bind(this),
         paste_text_overrides: this.handlePasteText.bind(this),

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -15,6 +15,8 @@ import { isBlock, closestBlock } from "@html_editor/utils/blocks";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 
+/** @typedef {import("@odoo/owl").Component} Component */
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
 /**
  * @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection
  */
@@ -124,6 +126,18 @@ async function fetchAttachmentMetaData(url, ormService) {
  * @property { LinkPlugin['insertLink'] } insertLink
  */
 
+/**
+ * @typedef {((link: HTMLLinkElement) => boolean)[]} is_link_editable_predicates
+ * @typedef {((link: HTMLLinkElement) => boolean)[]} legit_empty_link_predicates
+ * @typedef {(() => boolean)[]} link_compatible_selection_predicates
+ * @typedef {CSSSelector[]} immutable_link_selectors
+ * @typedef {{
+ *      PopoverClass: Component;
+ *      isAvailable: (linkEl: HTMLLinkElement) => boolean;
+ *      getProps: (props) => props;
+ *  }[]} link_popovers
+ */
+
 export class LinkPlugin extends Plugin {
     static id = "link";
     static dependencies = [
@@ -143,6 +157,7 @@ export class LinkPlugin extends Plugin {
     };
     // @phoenix @todo: do we want to have createLink and insertLink methods in link plugin?
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
@@ -3,6 +3,7 @@ import { isBlock } from "@html_editor/utils/blocks";
 
 export class OdooLinkSelectionPlugin extends Plugin {
     static id = "odooLinkSelection";
+    /** @type {import("plugins").EditorResources} */
     resources = {
         ineligible_link_for_zwnbsp_predicates: [
             (link) =>

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -26,9 +26,15 @@ import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
     - on non-editable links or links that are not within the editable area
  */
 
+/**
+ * @typedef {((link: HTMLLinkElement) => boolean)[]} ineligible_link_for_selection_indication_predicates
+ * @typedef {((link: HTMLLinkElement) => boolean)[]} ineligible_link_for_zwnbsp_predicates
+ */
+
 export class LinkSelectionPlugin extends Plugin {
     static id = "linkSelection";
     static dependencies = ["selection", "feff"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         selectionchange_handlers: this.resetLinkInSelection.bind(this),

--- a/addons/html_editor/static/src/main/link/powerbox_url_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/powerbox_url_paste_plugin.js
@@ -1,8 +1,15 @@
 import { Plugin } from "@html_editor/plugin";
 
+/**
+ * @typedef {import("@html_editor/core/user_command_plugin").UserCommand} UserCommand
+ *
+ * @typedef {((url: string) => UserCommand)[]} paste_media_url_command_providers
+ */
+
 export class MediaUrlPastePlugin extends Plugin {
     static id = "mediaUrlPaste";
     static dependencies = ["link", "dom", "history", "powerbox"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         paste_url_overrides: this.openPowerboxOnUrlPaste.bind(this),
     };

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -80,6 +80,7 @@ export class ListPlugin extends Plugin {
         allowChecklist: true,
     };
     toolbarListSelectorKey = reactive({ value: 0 });
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -13,6 +13,7 @@ export class FilePlugin extends Plugin {
     static defaultConfig = {
         allowFile: true,
     };
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: {
             id: "uploadFile",

--- a/addons/html_editor/static/src/main/media/icon_color_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_color_plugin.js
@@ -7,6 +7,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 export class IconColorPlugin extends Plugin {
     static id = "iconColor";
     static dependencies = ["icon", "colorUi"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         toolbar_groups: withSequence(1, { id: "icon_color", namespaces: ["icon"] }),
         toolbar_items: [

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -8,6 +8,7 @@ import { ICON_SELECTOR, isElement } from "@html_editor/utils/dom_info";
 export class IconPlugin extends Plugin {
     static id = "icon";
     static dependencies = ["history", "selection", "dialog"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/media/image_crop_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_crop_plugin.js
@@ -13,6 +13,7 @@ export class ImageCropPlugin extends Plugin {
     static id = "imageCrop";
     static dependencies = ["selection", "history", "imagePostProcess"];
     static shared = ["openCropImage"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -41,11 +41,17 @@ const IMAGE_SIZE = [
  * @property { ImagePlugin['resetImageTransformation'] } resetImageTransformation
  */
 
+/**
+ * @typedef {((img: HTMLImageElement) => void | true)[]} delete_image_overrides
+ * @typedef {((img: HTMLImageElement) => boolean)[]} image_name_predicates
+ */
+
 export class ImagePlugin extends Plugin {
     static id = "image";
     static dependencies = ["history", "dom", "selection", "overlay"];
     static shared = ["getTargetedImage", "previewImage", "resetImageTransformation"];
     static defaultConfig = { allowImageTransform: true };
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -20,6 +20,27 @@ export const DEFAULT_IMAGE_QUALITY = "75";
  * @property { ImagePostProcessPlugin['getProcessedImageSize'] } getProcessedImageSize
  */
 
+/**
+ * @typedef {(
+ *   (img: HTMLImageElement, newDataset: object) => Promise<{
+ *     getHeight: (canvas: HTMLCanvasElement) => number,
+ *     perspective: string | null,
+ *     newDataset: object,
+ *     postProcessCroppedCanvas: (canvas: HTMLCanvasElement) => Promise<HTMLCanvasElement>,
+ *     svg: SVGElement,
+ *     svgAspectRatio: number,
+ *     svgWidth: number,
+ *   }>
+ * )[]} process_image_warmup_handlers
+ * @typedef {(
+ *   (
+ *     url: string,
+ *     newDataset: object,
+ *     processContext: { svg: SVGElement, svgAspectRatio: number, svgWidth: number }
+ *   ) => Promise<[newUrl: string, handlerDataset: object]>
+ * )[]} process_image_post_handlers
+ */
+
 export class ImagePostProcessPlugin extends Plugin {
     static id = "imagePostProcess";
     static dependencies = ["style"];

--- a/addons/html_editor/static/src/main/media/image_save_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_save_plugin.js
@@ -11,10 +11,15 @@ import { rpc } from "@web/core/network/rpc";
  * @property { ImageSavePlugin['savePendingImages'] } savePendingImages
  */
 
+/**
+ * @typedef {((el: HTMLElement) => HTMLElement)[]} closest_savable_providers
+ */
+
 export class ImageSavePlugin extends Plugin {
     static id = "imageSave";
     static shared = ["savePendingImages"];
 
+    /** @type {import("plugins").EditorResources} */
     resources = {
         before_save_handlers: this.savePendingImages.bind(this),
 

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -23,6 +23,20 @@ import { FORMATTABLE_TAGS } from "@html_editor/utils/formatting";
  * @property { MediaPlugin['openMediaDialog'] } openMediaDialog
  */
 
+/**
+ * @typedef {((mediaEl: HTMLElement) => void)[]} after_save_media_dialog_handlers
+ * @typedef {((arg: { newMediaEl: HTMLElement }) => void)[]} on_added_media_handlers
+ * @typedef {((elements: HTMLElement[], params: { node: Node }) => Promise<void>)[]} on_media_dialog_saved_handlers
+ * @typedef {((arg: { newMediaEl: HTMLElement }) => void)[]} on_replaced_media_handlers
+ *
+ * @typedef {{
+ *      id: "DOCUMENTS" | "ICONS" | "IMAGES" | "VIDEOS";
+ *      title: import("plugins").LazyTranslatedString;
+ *      Component: import("@odoo/owl").Component;
+ *      sequence: number;
+ *  }[]} media_dialog_extra_tabs
+ */
+
 export class MediaPlugin extends Plugin {
     static id = "media";
     static dependencies = ["selection", "history", "dom", "dialog"];
@@ -31,6 +45,7 @@ export class MediaPlugin extends Plugin {
         allowImage: true,
         allowMediaDocuments: true,
     };
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/media/video_plugin.js
+++ b/addons/html_editor/static/src/main/media/video_plugin.js
@@ -7,6 +7,7 @@ export class VideoPlugin extends Plugin {
     static defaultConfig = {
         allowVideo: true,
     };
+    /** @type {import("plugins").EditorResources} */
     resources = {
         ...(this.config.allowVideo && {
             media_dialog_extra_tabs: {

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -7,6 +7,13 @@ import { _t } from "@web/core/l10n/translation";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { getDeepestPosition, isContentEditable } from "@html_editor/utils/dom_info";
 
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+
+/**
+ * @typedef {CSSSelector[]} move_node_blacklist_selectors
+ * @typedef {CSSSelector[]} move_node_whitelist_selectors
+ */
+
 const WIDGET_CONTAINER_WIDTH = 25;
 const WIDGET_MOVE_SIZE = 20;
 
@@ -15,6 +22,7 @@ const ALLOWED_ELEMENTS = "h1, h2, h3, p, hr, pre, blockquote, li";
 export class MoveNodePlugin extends Plugin {
     static id = "movenode";
     static dependencies = ["baseContainer", "selection", "history", "position", "localOverlay"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         layout_geometry_change_handlers: () => {
             if (this.currentMovableElement) {

--- a/addons/html_editor/static/src/main/placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/placeholder_plugin.js
@@ -6,6 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class PlaceholderPlugin extends Plugin {
     static id = "placeholder";
+    /** @type {import("plugins").EditorResources} */
     resources = {
         ...(this.config.placeholder && {
             hints: [

--- a/addons/html_editor/static/src/main/position_plugin.js
+++ b/addons/html_editor/static/src/main/position_plugin.js
@@ -4,11 +4,15 @@ import { throttleForAnimation } from "@web/core/utils/timing";
 import { couldBeScrollableX, couldBeScrollableY } from "@web/core/utils/scrolling";
 
 /**
+ * @typedef {(() => void)[]} layout_geometry_change_handlers
+ */
+/**
  * This plugins provides a way to create a "local" overlays so that their
  * visibility is relative to the overflow of their ancestors.
  */
 export class PositionPlugin extends Plugin {
     static id = "position";
+    /** @type {import("plugins").EditorResources} */
     resources = {
         // todo: it is strange that the position plugin is aware of external_history_step_handlers and history_reset_from_steps_handlers.
         external_history_step_handlers: this.layoutGeometryChange.bind(this),

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -6,6 +6,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 import { omit, pick } from "@web/core/utils/objects";
 
 /** @typedef {import("./powerbox/powerbox_plugin").PowerboxCommand} PowerboxCommand */
+/** @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection */
 
 /**
  * @typedef {Object} PowerButton
@@ -16,29 +17,36 @@ import { omit, pick } from "@web/core/utils/objects";
  * @property {string} [text] Mandatory if `icon` is not provided
  * @property {string} [isAvailable] Can be inferred from the user command
  */
+
 /**
+ * @typedef {((selection: EditorSelection) => boolean)[]} power_buttons_visibility_predicates
+ */
+
+/**
+ * @typedef {{ commandId: string }[]} power_buttons
+ *
  * A power button is added by referencing an existing user command.
  *
  * Example:
  *
- * resources = {
- *      user_commands: [
- *          {
- *              id: myCommand,
- *              run: myCommandFunction,
- *              description: _t("Apply my command"),
- *              icon: "fa-bug",
- *          },
- *      ],
- *      power_buttons: [
- *          {
- *              commandId: "myCommand",
- *              commandParams: { myParam: "myValue" },
- *              description: _t("Do powerfull stuff"), // overrides the user command's `description`
- *              // `icon` is derived from the user command
- *          }
- *      ],
- * };
+ *     resources = {
+ *          user_commands: [
+ *              {
+ *                  id: myCommand,
+ *                  run: myCommandFunction,
+ *                  description: _t("Apply my command"),
+ *                  icon: "fa-bug",
+ *              },
+ *          ],
+ *          power_buttons: [
+ *              {
+ *                  commandId: "myCommand",
+ *                  commandParams: { myParam: "myValue" },
+ *                  description: _t("Do powerfull stuff"), // overrides the user command's `description`
+ *                  // `icon` is derived from the user command
+ *              }
+ *          ],
+ *     };
  */
 
 export class PowerButtonsPlugin extends Plugin {
@@ -52,6 +60,7 @@ export class PowerButtonsPlugin extends Plugin {
         "userCommand",
         "history",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         layout_geometry_change_handlers: this.updatePowerButtons.bind(this),
         selectionchange_handlers: this.updatePowerButtons.bind(this),

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -15,8 +15,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 /**
  * @typedef {Object} PowerboxCategory
  * @property {string} id
- * @property {String} name
- *
+ * @property {TranslatedString} name
  *
  * @typedef {Object} PowerboxItem
  * @property {string} categoryId Id of a powerbox category
@@ -27,40 +26,6 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  * @property {string} [icon] fa-class - Inheritable
  * @property {TranslatedString[]} [keywords]
  * @property {(selection: EditorSelection) => boolean} [isAvailable] Optional and inheritable
- */
-
-/**
- * A powerbox item must derive from a user command ( @see UserCommand )
- * specified by commandId. Properties defined in a powerbox item override those
- * from a user command.
- *
- * Example:
- *
- * resources = {
- *      user_commands: [
- *          @type {UserCommand}
- *          {
- *              id: myCommand,
- *              run: myCommandFunction,
- *              title: _t("My Command"),
- *              description: _t("My command's description"),
- *              icon: "fa-bug",
- *          },
- *      ],
- *      powerbox_categories: [
- *          @type {PowerboxCategory}
- *          { id: "myCategory", name: _t("My Category") }
- *      ],
- *      powerbox_items: [
- *          @type {PowerboxItem}
- *          {
- *              categoryId: "myCategory",
- *              commandId: "myCommand",
- *              title: _t("My Powerbox Command"), // overrides the user command's `title`
- *              // `description` and `icon` are inferred from the user command
- *          }
- *      ],
- * };
  */
 
 /**
@@ -85,6 +50,44 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  * @property { PowerboxPlugin['updatePowerbox'] } updatePowerbox
  */
 
+/** @typedef {PowerboxCategory[]} powerbox_categories */
+/**
+ * @see UserCommand
+ * @typedef {PowerboxItem[]} powerbox_items
+ *
+ * A powerbox item must derive from a user command (see UserCommand) specified
+ * by commandId. Properties defined in a powerbox item override those from a
+ * user command. Other properties are inferred from the UserCommand.
+ *
+ * Example:
+ *
+ *     resources = {
+ *          user_commands: [
+ *              // see {UserCommand}
+ *              {
+ *                  id: myCommand,
+ *                  run: myCommandFunction,
+ *                  title: _t("My Command"),
+ *                  description: _t("My command's description"),
+ *                  icon: "fa-bug",
+ *              },
+ *          ],
+ *          powerbox_categories: [
+ *              // see {PowerboxCategory}
+ *              { id: "myCategory", name: _t("My Category") }
+ *          ],
+ *          powerbox_items: [
+ *              // see {PowerboxItem}
+ *              {
+ *                  categoryId: "myCategory",
+ *                  commandId: "myCommand",
+ *                  title: _t("My Powerbox Command"), // overrides the user command's `title`
+ *                  // `description` and `icon` are inferred from the user command
+ *              }
+ *          ],
+ *     };
+ */
+
 export class PowerboxPlugin extends Plugin {
     static id = "powerbox";
     static dependencies = ["overlay", "selection", "history", "userCommand"];
@@ -94,6 +97,7 @@ export class PowerboxPlugin extends Plugin {
         "openPowerbox",
         "updatePowerbox",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: {
             id: "openPowerbox",

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -9,6 +9,7 @@ import { Plugin } from "../../plugin";
 export class SearchPowerboxPlugin extends Plugin {
     static id = "searchPowerbox";
     static dependencies = ["powerbox", "selection", "history", "input"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         beforeinput_handlers: this.onBeforeInput.bind(this),
         input_handlers: this.onInput.bind(this),

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -15,6 +15,7 @@ import { fillEmpty } from "../utils/dom";
 export class SeparatorPlugin extends Plugin {
     static id = "separator";
     static dependencies = ["selection", "history", "split", "delete", "lineBreak", "baseContainer"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -6,6 +6,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 export class StarPlugin extends Plugin {
     static id = "star";
     static dependencies = ["dom", "history"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/table/table_align_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_align_plugin.js
@@ -23,6 +23,7 @@ export class TableAlignPlugin extends Plugin {
     static id = "tableAlign";
     static dependencies = ["history", "selection"];
 
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -67,6 +67,10 @@ function isUnremovableTableComponent(node, root) {
  */
 
 /**
+ * @typedef {((el: HTMLElement) => void)[]} deselect_custom_selected_nodes_handlers
+ */
+
+/**
  * This plugin only contains the table manipulation and selection features. All UI overlay
  * code is located in the table_ui plugin
  */
@@ -98,6 +102,7 @@ export class TablePlugin extends Plugin {
         "clearRowContent",
         "toggleAlternatingRows",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -13,6 +13,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 export class TableUIPlugin extends Plugin {
     static id = "tableUi";
     static dependencies = ["history", "overlay", "table"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -35,10 +35,16 @@ function isIndentationTab(tab) {
  * @property { TabulationPlugin['outdentBlocks'] } outdentBlocks
  */
 
+/**
+ * @typedef {(() => void | true)[]} shift_tab_overrides
+ * @typedef {(() => void | true)[]} tab_overrides
+ */
+
 export class TabulationPlugin extends Plugin {
     static id = "tabulation";
     static dependencies = ["dom", "selection", "history", "delete"];
     static shared = ["indentBlocks", "outdentBlocks"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -8,6 +8,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 export class TextDirectionPlugin extends Plugin {
     static id = "textDirection";
     static dependencies = ["selection", "history", "split", "format"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -13,6 +13,7 @@ import { memoize } from "@web/core/utils/functions";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 
 /** @typedef { import("@html_editor/core/selection_plugin").EditorSelection } EditorSelection */
+/** @typedef {import("@html_editor/core/selection_plugin").SelectionData} SelectionData */
 /** @typedef { import("@html_editor/core/user_command_plugin").UserCommand } UserCommand */
 /** @typedef { import("@web/core/l10n/translation.js")._t} _t */
 /** @typedef { ReturnType<_t> } TranslatedString */
@@ -62,48 +63,6 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  */
 
 /**
- * A ToolbarCommandItem must derive from a user command ( @see UserCommand )
- * specified by commandId. Properties defined in a toolbar item override those
- * from a user command.
- *
- * Example:
- *
- * resources = {
- *     user_commands: [
- *         @type {UserCommand}
- *         {
- *             id: myCommand,
- *             run: myCommandFunction,
- *             description: _t("My Command"),
- *             icon: "fa-bug",
- *         },
- *     ],
- *     toolbar_groups: [
- *         @type {ToolbarGroup}
- *         { id: "myGroup" },
- *     ],
- *     toolbar_items: [
- *         @type {ToolbarCommandItem}
- *         {
- *             id: "myButton",
- *             groupId: "myGroup",
- *             commandId: "myCommand",
- *             description: _t("My Toolbar Command Button"), // overrides the user command's `description`
- *             // `icon` is inferred from the user command
- *         },
- *         @type {ToolbarComponentItem}
- *         {
- *             id: "myComponentButton",
- *             groupId: "myGroup",
- *             description: _t("My Toolbar Component Button"),
- *             Component: MyComponent,
- *             props: { myProp: "myValue" },
- *         },
- *     ],
- * };
- */
-
-/**
  * Types after conversion to renderable toolbar buttons:
  *
  * @typedef {Object} ToolbarCommandButton
@@ -138,12 +97,67 @@ const MIN_SIZE_FOR_COMPACT = 7;
 /**
  * @typedef { Object } ToolbarShared
  * @property { ToolbarPlugin['getToolbarInfo'] } getToolbarInfo
+ * @property { ToolbarPlugin['getIsToolbarOpen'] } getIsToolbarOpen
+ */
+
+/**
+ * @typedef {((namespace: string) => boolean)[]} can_display_toolbar
+ * @typedef {((selectionData: SelectionData) => boolean)[]} collapsed_selection_toolbar_predicate
+ *
+ * @typedef {ToolbarGroup[]} toolbar_groups
+ * @typedef {ToolbarNamespace[]} toolbar_namespaces
+ */
+
+/**
+ * @see UserCommand
+ * @typedef {(ToolbarCommandItem | ToolbarComponentItem)[]} toolbar_items
+ *
+ * A ToolbarCommandItem must derive from a user command (see UserCommand)
+ * specified by commandId. Properties defined in a toolbar item override those
+ * from a user command.
+ *
+ * Example:
+ *
+ *     resources = {
+ *         // see UserCommand
+ *         user_commands: [
+ *             {
+ *                 id: myCommand,
+ *                 run: myCommandFunction,
+ *                 description: _t("My Command"),
+ *                 icon: "fa-bug",
+ *             },
+ *         ],
+ *         // see ToolbarGroup
+ *         toolbar_groups: [
+ *             { id: "myGroup" },
+ *         ],
+ *         toolbar_items: [
+ *             // See ToolbarCommandItem
+ *             {
+ *                 id: "myButton",
+ *                 groupId: "myGroup",
+ *                 commandId: "myCommand",
+ *                 description: _t("My Toolbar Command Button"), // overrides the user command's `description`
+ *                 // `icon` is inferred from the user command
+ *             },
+ *             // See ToolbarComponentItem
+ *             {
+ *                 id: "myComponentButton",
+ *                 groupId: "myGroup",
+ *                 description: _t("My Toolbar Component Button"),
+ *                 Component: MyComponent,
+ *                 props: { myProp: "myValue" },
+ *             },
+ *         ],
+ *     };
  */
 
 export class ToolbarPlugin extends Plugin {
     static id = "toolbar";
     static dependencies = ["overlay", "selection", "userCommand"];
     static shared = ["getToolbarInfo", "getIsToolbarOpen"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         selectionchange_handlers: this.handleSelectionChange.bind(this),
         selection_leave_handlers: () => this.closeToolbar(),

--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -9,6 +9,7 @@ export const YOUTUBE_URL_GET_VIDEO_ID =
 export class YoutubePlugin extends Plugin {
     static id = "youtube";
     static dependencies = ["history", "dom"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         ...(this.config.allowVideo && {
             paste_media_url_command_providers: this.getCommandForVideoUrlPaste.bind(this),

--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -47,6 +47,7 @@ export class CollaborationOdooPlugin extends Plugin {
     static id = "collaborationOdoo";
     static dependencies = ["baseContainer", "history", "collaboration", "selection"];
     static shared = ["getPeerMetadata"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         selectionchange_handlers: debounce(() => {
             this.ptp?.notifyAllPeers(

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -22,9 +22,14 @@ const HISTORY_SNAPSHOT_BUFFER_TIME = 1000 * 10;
  * @property { CollaborationPlugin['setInitialBranchStepId'] } setInitialBranchStepId
  */
 
+/**
+ * @typedef {(() => void)[]} external_history_step_handlers
+ */
+
 export class CollaborationPlugin extends Plugin {
     static id = "collaboration";
     static dependencies = ["history", "selection", "sanitize"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         history_cleaned_handlers: this.onHistoryClean.bind(this),

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -21,6 +21,7 @@ export const AVATAR_SIZE = 25;
 export class CollaborationSelectionAvatarPlugin extends Plugin {
     static id = "collaborationSelectionAvatar";
     static dependencies = ["history", "position", "localOverlay", "collaborationOdoo"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         collaboration_notification_handlers: this.handleCollaborationNotification.bind(this),

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
@@ -13,6 +13,7 @@ import { _t } from "@web/core/l10n/translation";
 export class CollaborationSelectionPlugin extends Plugin {
     static id = "collaborationSelection";
     static dependencies = ["history", "collaborationOdoo", "position", "localOverlay"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         collaboration_notification_handlers: this.handleCollaborationNotification.bind(this),

--- a/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
@@ -13,6 +13,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
     static id = "dynamicPlaceholder";
     static dependencies = ["overlay", "selection", "history", "dom"];
     static shared = ["updateDphDefaultModel"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -5,6 +5,16 @@ import { memoize } from "@web/core/utils/functions";
 import { renderToElement } from "@web/core/utils/render";
 
 /**
+ * @typedef { Object } EmbeddedComponentShared
+ * @property { EmbeddedComponentPlugin['renderBlueprintToElement'] } renderBlueprintToElement
+ */
+
+/**
+ * @typedef {((arg: { name, env, props }) => void)[]} mount_component_handlers
+ * @typedef {(() => void)[]} post_mount_component_handlers
+ */
+
+/**
  * This plugin is responsible with providing the API to manipulate/insert
  * sub components in an editor.
  */
@@ -12,6 +22,7 @@ export class EmbeddedComponentPlugin extends Plugin {
     static id = "embeddedComponents";
     static dependencies = ["history", "protectedNode", "selection"];
     static shared = ["renderBlueprintToElement"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         normalize_handlers: withSequence(0, this.normalize.bind(this)),

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -19,6 +19,7 @@ export class CaptionPlugin extends Plugin {
         "selection",
         "baseContainer",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin.js
@@ -15,6 +15,7 @@ export class EmbeddedFilePlugin extends FilePlugin {
     static dependencies = [...super.dependencies, "embeddedComponents", "selection"];
 
     // Extends the base class resources
+    /** @type {import("plugins").EditorResources} */
     resources = {
         ...this.resources,
         mount_component_handlers: this.setupNewFile.bind(this),

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -41,6 +41,7 @@ export class SyntaxHighlightingPlugin extends Plugin {
         "protectedNode",
         "embeddedComponents",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         mount_component_handlers: this.setupNewCodeBlock.bind(this),
         normalize_handlers: (root) => this.addCodeBlocks(root, true),

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -10,6 +10,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 export class TableOfContentPlugin extends Plugin {
     static id = "tableOfContent";
     static dependencies = ["dom", "selection", "embeddedComponents", "link", "history"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -34,6 +34,7 @@ export class ToggleBlockPlugin extends Plugin {
         "selection",
         "split",
     ];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         hints: [
             withSequence(20, {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_video_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_video_plugin.js
@@ -9,6 +9,7 @@ export class EmbeddedVideoPlugin extends VideoPlugin {
     static dependencies = ["embeddedComponents", "selection", "history", "overlay", "media"];
 
     // Extends the base class resources
+    /** @type {import("plugins").EditorResources} */
     resources = {
         ...this.resources,
         mount_component_handlers: this.extendEmbeddedVideoProps.bind(this),

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -35,6 +35,7 @@ export const isUnremovableQWebElement = (node) =>
 export class QWebPlugin extends Plugin {
     static id = "qweb";
     static dependencies = ["overlay", "protectedNode", "selection"];
+    /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         selectionchange_handlers: withSequence(8, this.onSelectionChange.bind(this)),

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -6,7 +6,6 @@ export const isValidTargetForDomListener = (target) =>
 /**
  * @typedef { import("./editor").Editor } Editor
  * @typedef { import("./editor").EditorContext } EditorContext
- * @typedef { import("./plugin_sets").SharedMethods } SharedMethods
  */
 
 export class Plugin {
@@ -14,6 +13,9 @@ export class Plugin {
     static dependencies = [];
     static shared = [];
     static defaultConfig = {};
+
+    /** @type {Partial<import("plugins").Resources>} */
+    resources;
 
     /**
      * @param { EditorContext } context

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -79,52 +79,6 @@ import { StylePlugin } from "./core/style_plugin";
 import { ContentEditablePlugin } from "./core/content_editable_plugin";
 import { SelectionPlaceholderPlugin } from "./main/selection_placeholder_plugin";
 
-/**
- * @typedef { Object } SharedMethods
- *
- * Core
- * @property { import("./core/base_container_plugin").BaseContainerShared } baseContainer
- * @property { import("./core/clipboard_plugin").ClipboardShared } clipboard
- * @property { import("./core/delete_plugin").DeleteShared } delete
- * @property { import("./core/dialog_plugin").DialogShared } dialog
- * @property { import("./core/dom_plugin").DomShared } dom
- * @property { import("./core/format_plugin").FormatShared } format
- * @property { import("./core/history_plugin").HistoryShared } history
- * @property { import("./core/line_break_plugin").LineBreakShared } lineBreak
- * @property { import("./core/overlay_plugin").OverlayShared } overlay
- * @property { import("./core/protected_node_plugin").ProtectedNodeShared } protectedNode
- * @property { import("./core/sanitize_plugin").SanitizeShared } sanitize
- * @property { import("./core/selection_plugin").SelectionShared } selection
- * @property { import("./core/split_plugin").SplitShared } split
- * @property { import("./core/style_plugin").StyleShared } style
- * @property { import("./core/user_command_plugin").UserCommandShared } userCommand
-
- *
- * Main
- * @property { import("./main/font/color_plugin").ColorShared } color
- * @property { import("./main/font/color_ui_plugin").ColorUIShared } colorUi
- * @property { import("./main/link/link_plugin").LinkShared } link
- * @property { import ("./main/link/link_selection_plugin").LinkSelectionShared } linkSelection
- * @property { import ("./main/media/media_plugin").MediaShared } media
- * @property { import("./main/powerbox/powerbox_plugin").PowerboxShared } powerbox
- * @property { import ("./main/table/table_plugin").TableShared } table
- * @property { import ("./main/toolbar/toolbar_plugin").ToolbarShared } toolbar
- * @property { import ("./main/emoji_plugin").EmojiShared } emoji
- * @property { import ("./main/local_overlay_plugin").LocalOverlayShared } localOverlay
- * @property { import ("./main/tabulation_plugin").TabulationShared } tabulation
- * @property { import ("./main/feff_plugin").FeffShared } feff
- * @property { import ("./main/media/image_plugin").ImageShared } image
- * @property { import ("./main/media/image_crop_plugin").ImageCropShared } imageCrop
- * @property { import ("./main/media/image_post_process_plugin").ImagePostProcessShared } imagePostProcess
- * @property { import ("./main/banner_plugin").BannerShared } banner
- * @property { import ("./main/media/image_save_plugin").ImageSaveShared } imageSave
- *
- * Others
- * @property { import("./others/collaboration/collaboration_odoo_plugin").CollaborationOdooShared } collaborationOdoo
- * @property { import("./others/collaboration/collaboration_plugin").CollaborationShared } collaboration
- * @property { import("./others/dynamic_placeholder_plugin").DynamicPlaceholderShared } dynamicPlaceholder
- */
-
 export const CORE_PLUGINS = [
     BaseContainerPlugin,
     ClipboardPlugin,

--- a/addons/web/static/src/@types/registries/registries.d.ts
+++ b/addons/web/static/src/@types/registries/registries.d.ts
@@ -2,6 +2,7 @@ declare module "registries" {
     import { Component } from "@odoo/owl";
     import { OdooEnv } from "@web/env";
     import { NotificationOptions } from "@web/core/notifications/notification_service";
+    import { Interaction } from "@web/public/interaction";
     import { Compiler } from "@web/views/view_compiler";
     import { ActionDescription } from "@web/webclient/actions/action_service";
 
@@ -79,6 +80,8 @@ declare module "registries" {
 
     export type IrActionsReportHandlers = (action: ActionRequest, options: ActionOptions, env: OdooEnv) => (void | boolean | Promise<void | boolean>);
 
+    export type InteractionRegistryItemShape = typeof Interaction;
+
     interface GlobalRegistryCategories {
         action_handlers: ActionHandlersRegistryItemShape;
         actions: ActionsRegistryItemShape;
@@ -96,6 +99,7 @@ declare module "registries" {
         main_components: MainComponentsRegistryItemShape;
         parsers: ParsersRegistryItemShape;
         public_components: PublicComponentsRegistryItemShape;
+        "public.interactions": InteractionRegistryItemShape;
         sample_server: SampleServerRegistryItemShape;
         systray: SystrayRegistryItemShape;
         "ir.actions.report handlers": IrActionsReportHandlers;

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -121,6 +121,7 @@ export class Interaction {
         this.__colibri__ = metadata;
         this.el = el;
         this.env = env;
+        /** @type {import("services").ServiceFactories} */
         this.services = env.services;
     }
 

--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -1,0 +1,97 @@
+declare module "plugins" {
+    import { CarouselOptionShared } from "@website/builder/plugins/carousel_option_plugin";
+    import { CustomizeWebsiteShared } from "@website/builder/plugins/customize_website_plugin";
+    import { content_manually_updated_handlers, EditInteractionShared } from "@website/builder/plugins/edit_interaction_plugin";
+    import { WebsiteFontShared } from "@website/builder/plugins/font/font_plugin";
+    import { FormOptionShared } from "@website/builder/plugins/form/form_option_plugin";
+    import { ImageHoverShared } from "@website/builder/plugins/image/image_hover_plugin";
+    import { AddElementOptionShared } from "@website/builder/plugins/layout_option/add_element_option_plugin";
+    import { MenuDataShared } from "@website/builder/plugins/menu_data_plugin";
+    import { hover_effect_allowed_predicates } from "@website/builder/plugins/options/animate_option";
+    import { AnimateOptionShared, remove_hover_effect_handlers, set_hover_effect_handlers } from "@website/builder/plugins/options/animate_option_plugin";
+    import { WebsiteBackgroundVideoShared } from "@website/builder/plugins/options/background_option_plugin";
+    import { CardImageOptionShared } from "@website/builder/plugins/options/card_image_option_plugin";
+    import { ChartOptionShared } from "@website/builder/plugins/options/chart_option_plugin";
+    import { CookiesBarOptionShared } from "@website/builder/plugins/options/cookies_bar_option";
+    import { DynamicSnippetCarouselOptionShared } from "@website/builder/plugins/options/dynamic_snippet_carousel_option_plugin";
+    import { dynamic_snippet_template_updated, DynamicSnippetOptionShared } from "@website/builder/plugins/options/dynamic_snippet_option_plugin";
+    import { footer_templates_providers, FooterOptionShared } from "@website/builder/plugins/options/footer_option_plugin";
+    import { get_gallery_items_handlers, reorder_items_handlers } from "@website/builder/plugins/options/gallery_element_option_plugin";
+    import { GoogleMapsOptionShared } from "@website/builder/plugins/options/google_maps_option/google_maps_option_plugin";
+    import { ImageGalleryOptionShared } from "@website/builder/plugins/options/image_gallery_option_plugin";
+    import { InstagramOptionShared } from "@website/builder/plugins/options/instagram_option_plugin";
+    import { MegaMenuOptionShared } from "@website/builder/plugins/options/mega_menu_option_plugin";
+    import { NavTabsStyleOptionShared } from "@website/builder/plugins/options/navtabs_style_option_plugin";
+    import { WebsiteParallaxShared } from "@website/builder/plugins/options/parallax_option_plugin";
+    import { searchbar_option_display_items, searchbar_option_order_by_items } from "@website/builder/plugins/options/searchbar_option_plugin";
+    import { SocialMediaOptionShared } from "@website/builder/plugins/options/social_media_option_plugin";
+    import { visibility_selector_parameters } from "@website/builder/plugins/options/visibility_option_plugin";
+    import { WebsitePageConfigOptionShared } from "@website/builder/plugins/options/website_page_config_option_plugin";
+    import { PopupVisibilityShared } from "@website/builder/plugins/popup_visibility_plugin";
+    import { SwitchableViewsShared } from "@website/builder/plugins/switchable_views_plugin";
+    import { ThemeTabShared } from "@website/builder/plugins/theme/theme_tab_plugin";
+    import { mark_translatable_nodes } from "@website/builder/plugins/translation_plugin";
+    import { WebsiteSaveShared } from "@website/builder/plugins/website_save_plugin";
+    import { WebsiteSessionShared } from "@website/builder/plugins/website_session_plugin";
+
+    interface SharedMethods {
+        addElementOption: AddElementOptionShared;
+        animateOption: AnimateOptionShared;
+        carouselOption: CarouselOptionShared;
+        cardImageOption: CardImageOptionShared;
+        chartOptionPlugin: ChartOptionShared;
+        CookiesBarOptionPlugin: CookiesBarOptionShared;
+        customizeTranslationTab: CustomizeTranslationTabShared;
+        customizeWebsite: CustomizeWebsiteShared;
+        dynamicSnippetCarouselOption: DynamicSnippetCarouselOptionShared;
+        dynamicSnippetOption: DynamicSnippetOptionShared;
+        edit_interaction: EditInteractionShared;
+        footerOption: FooterOptionShared;
+        googleMapsOption: GoogleMapsOptionShared;
+        imageGalleryOption: ImageGalleryOptionShared;
+        imageHover: ImageHoverShared;
+        instagramOption: InstagramOptionShared;
+        megaMenuOptionPlugin: MegaMenuOptionShared;
+        menuDataPlugin: MenuDataShared;
+        navTabsOptionStyle: NavTabsStyleOptionShared;
+        popupVisibilityPlugin: PopupVisibilityShared;
+        socialMediaOptionPlugin: SocialMediaOptionShared;
+        switchableViews: SwitchableViewsShared;
+        themeTab: ThemeTabShared;
+        websiteBackgroundVideoPlugin: WebsiteBackgroundVideoShared;
+        websiteFont: WebsiteFontShared;
+        websiteFormOption: FormOptionShared;
+        websitePageConfigOptionPlugin: WebsitePageConfigOptionShared;
+        websiteParallaxPlugin: WebsiteParallaxShared;
+        websiteSavePlugin: WebsiteSaveShared;
+        websiteSession: WebsiteSessionShared;
+    }
+
+    interface GlobalResources extends WebsiteResources {}
+    export type WebsiteResources = BuilderResources & ResourcesTypesFactory<WebsiteResourcesList>;
+    export interface WebsiteResourcesList {
+        // Handlers
+        content_manually_updated_handlers: content_manually_updated_handlers;
+        dynamic_snippet_template_updated: dynamic_snippet_template_updated;
+        get_gallery_items_handlers: get_gallery_items_handlers;
+        mark_translatable_nodes: mark_translatable_nodes;
+        remove_hover_effect_handlers: remove_hover_effect_handlers;
+        reorder_items_handlers: reorder_items_handlers;
+        set_hover_effect_handlers: set_hover_effect_handlers;
+
+        // Overrides
+
+        // Predicates
+        hover_effect_allowed_predicates: hover_effect_allowed_predicates;
+
+        // Processors
+
+        // Providers
+        footer_templates_providers: footer_templates_providers;
+
+        // Data
+        searchbar_option_display_items: searchbar_option_display_items;
+        searchbar_option_order_by_items: searchbar_option_order_by_items;
+        visibility_selector_parameters: visibility_selector_parameters;
+    }
+}

--- a/addons/website/static/src/@types/registries.d.ts
+++ b/addons/website/static/src/@types/registries.d.ts
@@ -1,0 +1,22 @@
+
+declare module "registries" {
+    import { Interaction } from "@web/public/interaction";
+
+    type Constructor<T = {}> = new (arg: T) => T;
+    export type EditInteractionMixin = Constructor<Interaction>;
+    export type PreviewInteractionMixin = Constructor<Interaction>;
+
+    export interface EditInteractionRegistryItemShape {
+        Interaction: Interaction;
+        mixin?: EditInteractionMixin;
+    }
+    export interface PreviewInteractionRegistryItemShape {
+        Interaction: Interaction;
+        mixin?: PreviewInteractionMixin;
+    }
+
+    export interface GlobalRegistryCategories {
+        "public.interactions.edit": EditInteractionRegistryItemShape;
+        "public.interactions.preview": PreviewInteractionRegistryItemShape;
+    }
+}

--- a/addons/website/static/src/@types/services.d.ts
+++ b/addons/website/static/src/@types/services.d.ts
@@ -1,0 +1,19 @@
+declare module "services" {
+    import { websiteCookiesService } from "@website/core/website_cookies_service";
+    import { websiteEditService } from "@website/core/website_edit_service";
+    import { websiteMapService } from "@website/core/website_map_service";
+    import { websiteMenusService } from "@website/core/website_menus_service";
+    import { websitePageService } from "@website/core/website_page_service";
+    import { websiteCustomMenus } from "@website/services/website_custom_menus";
+    import { websiteService } from "@website/services/website_service";
+
+    export interface Services {
+        website: typeof websiteService;
+        website_cookies: typeof websiteCookiesService;
+        website_custom_menus: typeof websiteCustomMenus;
+        website_edit: typeof websiteEditService;
+        website_map: typeof websiteMapService;
+        website_menus: typeof websiteMenusService;
+        website_page: typeof websitePageService;
+    }
+}

--- a/addons/website/static/src/builder/builder_urlpicker.js
+++ b/addons/website/static/src/builder/builder_urlpicker.js
@@ -36,6 +36,7 @@ export class WebsiteUrlPicker extends BuilderUrlPicker {
 class UrlPickerPlugin extends Plugin {
     static id = "urlPickerPlugin";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_components: {
             WebsiteUrlPicker,

--- a/addons/website/static/src/builder/plugins/bootstrap_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/bootstrap_option_plugin.js
@@ -6,6 +6,7 @@ class BootstrapOptionPlugin extends Plugin {
     static id = "bootstrapOption";
     static dependencies = ["customizeWebsite"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         savable_mutation_record_predicates: this.filterBootstrapMutations.bind(this),
     };

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -10,6 +10,13 @@ import { WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW } from "@website/builder/
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef { Object } CarouselOptionShared
+ * @property { CarouselOptionPlugin['addSlide'] } addSlide
+ * @property { CarouselOptionPlugin['removeSlide'] } removeSlide
+ * @property { CarouselOptionPlugin['slideCarousel'] } slideCarousel
+ */
+
 export const CAROUSEL_CARDS_SEQUENCE = between(WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW);
 
 const carouselWrapperSelector =
@@ -45,6 +52,7 @@ export class CarouselOptionPlugin extends Plugin {
     static dependencies = ["clone", "builderOptions", "builderActions"];
     static shared = ["addSlide", "removeSlide", "slideCarousel"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             CarouselOption,

--- a/addons/website/static/src/builder/plugins/collapse_plugin.js
+++ b/addons/website/static/src/builder/plugins/collapse_plugin.js
@@ -4,6 +4,7 @@ import { registry } from "@web/core/registry";
 export class CollapsePlugin extends Plugin {
     static id = "collapse";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         on_cloned_handlers: this.onCloned.bind(this),

--- a/addons/website/static/src/builder/plugins/company_team_plugin.js
+++ b/addons/website/static/src/builder/plugins/company_team_plugin.js
@@ -5,6 +5,7 @@ import { selectElements } from "@html_editor/utils/dom_traversal";
 
 class CompanyTeamPlugin extends Plugin {
     static id = "companyTeam";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         content_editable_providers: this.getEditableEls.bind(this),
     };

--- a/addons/website/static/src/builder/plugins/content_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/content_width_option_plugin.js
@@ -15,6 +15,7 @@ export class ContentWidthOption extends BaseOptionComponent {
 
 class ContentWidthOptionPlugin extends Plugin {
     static id = "contentWidthOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(CONTAINER_WIDTH, ContentWidthOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -14,6 +14,25 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { renderToElement } from "@web/core/utils/render";
 import { CompositeAction } from "@html_builder/core/composite_action_plugin";
 
+/**
+ * @typedef { Object } CustomizeWebsiteShared
+ * @property { CustomizeWebsitePlugin['customizeWebsiteColors'] } customizeWebsiteColors
+ * @property { CustomizeWebsitePlugin['customizeWebsiteVariables'] } customizeWebsiteVariables
+ * @property { CustomizeWebsitePlugin['loadTemplateKey'] } loadTemplateKey
+ * @property { CustomizeWebsitePlugin['makeSCSSCusto'] } makeSCSSCusto
+ * @property { CustomizeWebsitePlugin['toggleTemplate'] } toggleTemplate
+ * @property { CustomizeWebsitePlugin['withCustomHistory'] } withCustomHistory
+ * @property { CustomizeWebsitePlugin['populateCache'] } populateCache
+ * @property { CustomizeWebsitePlugin['loadConfigKey'] } loadConfigKey
+ * @property { CustomizeWebsitePlugin['getConfigKey'] } getConfigKey
+ * @property { CustomizeWebsitePlugin['getWebsiteVariableValue'] } getWebsiteVariableValue
+ * @property { CustomizeWebsitePlugin['getPendingThemeRequests'] } getPendingThemeRequests
+ * @property { CustomizeWebsitePlugin['setPendingThemeRequests'] } setPendingThemeRequests
+ * @property { CustomizeWebsitePlugin['isPluginDestroyed'] } isPluginDestroyed
+ * @property { CustomizeWebsitePlugin['reloadBundles'] } reloadBundles
+ * @property { CustomizeWebsitePlugin['setViewsOnSave'] } setViewsOnSave
+ */
+
 export const NO_IMAGE_SELECTION = Symbol.for("NoImageSelection");
 
 export class CustomizeWebsitePlugin extends Plugin {
@@ -37,6 +56,7 @@ export class CustomizeWebsitePlugin extends Plugin {
         "setViewsOnSave",
     ];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             CustomizeWebsiteVariableAction,

--- a/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
@@ -10,6 +10,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 
 class DynamicSvgOptionPlugin extends Plugin {
     static id = "DynamicSvgOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(DYNAMIC_SVG, DynamicSvgOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
+++ b/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
@@ -2,11 +2,22 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 
+/**
+ * @typedef { Object } EditInteractionShared
+ * @property { EditInteractionPlugin['restartInteractions'] } restartInteractions
+ * @property { EditInteractionPlugin['stopInteractions'] } stopInteractions
+ */
+
+/**
+ * @typedef {((commonAncestorEl: HTMLElement) => void)[]} content_manually_updated_handlers
+ */
+
 export class EditInteractionPlugin extends Plugin {
     static id = "edit_interaction";
 
     static shared = ["restartInteractions", "stopInteraction"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         normalize_handlers: this.refreshInteractions.bind(this),
         content_manually_updated_handlers: this.refreshInteractions.bind(this),

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_option_plugin.js
@@ -8,6 +8,7 @@ import { FloatingBlocksBlockMobileOption } from "./floating_blocks_block_mobile_
 
 class FloatingBlocksBlockOptionPlugin extends Plugin {
     static id = "floatingBlocksBlockOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(BEGIN, FloatingBlocksBlockMobileOption),

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
@@ -14,6 +14,7 @@ export class FloatingBlocksOption extends BaseOptionComponent {
 
 export class FloatingBlocksOptionPlugin extends Plugin {
     static id = "floatingBlocksOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(after(DEVICE_VISIBILITY), FloatingBlocksOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/font/font_plugin.js
+++ b/addons/website/static/src/builder/plugins/font/font_plugin.js
@@ -3,6 +3,12 @@ import { Plugin } from "@html_editor/plugin";
 import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { showAddFontDialog } from "./add_font_dialog";
 
+/**
+ * @typedef { Object } WebsiteFontShared
+ * @property { WebsiteFontPlugin['addFont'] } addFont
+ * @property { WebsiteFontPlugin['deleteFont'] } deleteFont
+ */
+
 // TODO Website-specific
 class WebsiteFontPlugin extends Plugin {
     static id = "websiteFont";

--- a/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
@@ -8,6 +8,7 @@ import { BorderConfigurator } from "@html_builder/plugins/border_configurator_op
 
 class FontAwesomeOptionPlugin extends Plugin {
     static id = "fontAwesomeOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(FONT_AWESOME, FontAwesomeOptionComponent)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -45,6 +45,23 @@ import { localization } from "@web/core/l10n/localization";
 import { formatDate } from "@web/core/l10n/dates";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef { Object } FormOptionShared
+ * @property { FormOptionPlugin['prepareFormModel'] } prepareFormModel
+ * @property { FormOptionPlugin['getModelsCache'] } getModelsCache
+ * @property { FormOptionPlugin['applyFormModel'] } applyFormModel
+ * @property { FormOptionPlugin['addHiddenField'] } addHiddenField
+ * @property { FormOptionPlugin['fetchAuthorizedFields'] } fetchAuthorizedFields
+ * @property { FormOptionPlugin['loadFieldOptionData'] } loadFieldOptionData
+ * @property { FormOptionPlugin['prepareFields'] } prepareFields
+ * @property { FormOptionPlugin['replaceField'] } replaceField
+ * @property { FormOptionPlugin['prepareConditionInputs'] } prepareConditionInputs
+ * @property { FormOptionPlugin['setLabelsMark'] } setLabelsMark
+ * @property { FormOptionPlugin['clearValidationDataset'] } clearValidationDataset
+ * @property { FormOptionPlugin['defaultMessage'] } defaultMessage
+ * @property { FormOptionPlugin['fetchModels'] } fetchModels
+ */
+
 const { DateTime } = luxon;
 
 export class WebsiteFormSubmitOption extends BaseOptionComponent {
@@ -72,6 +89,7 @@ export class FormOptionPlugin extends Plugin {
         "defaultMessage",
         "fetchModels",
     ];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_header_middle_buttons: [
             {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -19,6 +19,7 @@ import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 export class HighlightPlugin extends Plugin {
     static id = "highlight";
     static dependencies = ["history", "selection", "split", "format", "edit_interaction"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         toolbar_groups: [withSequence(50, { id: "websiteDecoration" })],
         toolbar_items: [

--- a/addons/website/static/src/builder/plugins/image/grid_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/grid_image_option_plugin.js
@@ -8,6 +8,7 @@ import { GridImageOption } from "./grid_image_option";
 class GridImageOptionPlugin extends Plugin {
     static id = "gridImageOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(GRID_IMAGE, GridImageOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/image/image_hover_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_hover_plugin.js
@@ -3,11 +3,18 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { convertCSSColorToRgba } from "@web/core/utils/colors";
 
+/**
+ * @typedef { Object } ImageHoverShared
+ * @property { ImageHoverPlugin['setHoverEffect'] } setHoverEffect
+ * @property { ImageHoverPlugin['removeHoverEffect'] } removeHoverEffect
+ */
+
 export class ImageHoverPlugin extends Plugin {
     static id = "imageHover";
     static shared = ["setHoverEffect", "removeHoverEffect"];
     static dependencies = ["imagePostProcess", "imageToolOption"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetHoverEffectAction,

--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
@@ -4,10 +4,16 @@ import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
+/**
+ * @typedef { Object } AddElementOptionShared
+ * @property { AddElementOptionPlugin['addGridElement'] } addGridElement
+ */
+
 export class AddElementOptionPlugin extends Plugin {
     static id = "addElementOption";
     static dependencies = ["builderOptions"];
     static shared = ["addGridElement"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             AddGridElementAction,

--- a/addons/website/static/src/builder/plugins/layout_option/grid_column_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/grid_column_option_plugin.js
@@ -7,6 +7,7 @@ import { StyleAction } from "@html_builder/core/core_builder_action_plugin";
 
 export class GridColumnsOptionPlugin extends Plugin {
     static id = "GridColumnsOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(GRID_COLUMNS, GridColumnsOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
@@ -14,6 +14,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 class LayoutOptionPlugin extends Plugin {
     static id = "LayoutOption";
     static dependencies = ["clone", "selection"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(LAYOUT, LayoutOption),

--- a/addons/website/static/src/builder/plugins/layout_option/spacing_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/spacing_option_plugin.js
@@ -6,6 +6,7 @@ import { StyleAction } from "@html_builder/core/core_builder_action_plugin";
 
 class SpacingOptionPlugin extends Plugin {
     static id = "SpacingOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetGridSpacingAction,

--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -4,10 +4,16 @@ import { NavbarLinkPopover } from "./navbar_link_popover/navbar_link_popover";
 import { MenuDialog, EditMenuDialog } from "@website/components/dialog/edit_menu";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef { Object } MenuDataShared
+ * @property { MenuDataPlugin['openEditMenu'] } openEditMenu
+ */
+
 export class MenuDataPlugin extends Plugin {
     static id = "menuDataPlugin";
     static shared = ["openEditMenu"];
     static dependencies = ["savePlugin"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         link_popovers: [
             withSequence(10, {

--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -17,6 +17,7 @@ export class AccordionItemOption extends BaseOptionComponent {
 
 class accordionOptionPlugin extends Plugin {
     static id = "accordionOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(SNIPPET_SPECIFIC, AccordionOption),

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -1,6 +1,10 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { isImageSupportedForStyle } from "@html_builder/plugins/image/replace_media_option";
 
+/**
+ * @typedef {((el: HTMLElement) => Promise<boolean>)[]} hover_effect_allowed_predicates
+ */
+
 export class AnimateOption extends BaseOptionComponent {
     static template = "website.AnimateOption";
     static dependencies = ["animateOption"];

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -12,10 +12,23 @@ import { childNodeIndex, DIRECTIONS, nodeSize } from "@html_editor/utils/positio
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { EmphasizeAnimatedText } from "./emphasize_animated_text";
 
+/**
+ * @typedef { Object } AnimateOptionShared
+ * @property { AnimateOptionPlugin['forceAnimation'] } forceAnimation
+ * @property { AnimateOptionPlugin['getDirectionsItems'] } getDirectionsItems
+ * @property { AnimateOptionPlugin['getEffectsItems'] } getEffectsItems
+ */
+
+/**
+ * @typedef {((editingElement: HTMLElement) => Promise<void>)[]} remove_hover_effect_handlers
+ * @typedef {((editingElement: HTMLElement) => Promise<void>)[]} set_hover_effect_handlers
+ */
+
 export class AnimateOptionPlugin extends Plugin {
     static id = "animateOption";
     static dependencies = ["history", "selection", "split"];
     static shared = ["forceAnimation", "getDirectionsItems", "getEffectsItems"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(ANIMATE, AnimateOption)],
         toolbar_items: [

--- a/addons/website/static/src/builder/plugins/options/announcement_scroll_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/announcement_scroll_option_plugin.js
@@ -26,6 +26,7 @@ export class AnnouncementScrollOption extends BaseOptionComponent {
 export class AnnouncementScrollOptionPlugin extends Plugin {
     static id = "announcementScrollOptionPlugin";
     selector = AnnouncementScrollOption.selector;
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(after(WEBSITE_BACKGROUND_OPTIONS), AnnouncementScrollOption),

--- a/addons/website/static/src/builder/plugins/options/background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/background_option_plugin.js
@@ -5,6 +5,12 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { _t } from "@web/core/l10n/translation";
 import { VideoSelector } from "@html_editor/main/media/media_dialog/video_selector";
 
+/**
+ * @typedef { Object } WebsiteBackgroundVideoShared
+ * @property { WebsiteBackgroundVideoPlugin['loadReplaceBackgroundVideo'] } loadReplaceBackgroundVideo
+ * @property { WebsiteBackgroundVideoPlugin['applyReplaceBackgroundVideo'] } applyReplaceBackgroundVideo
+ */
+
 function getBgVideoOrParallax(editingElement) {
     // Make sure parallax and video element are considered to be below the
     // color filters / shape
@@ -20,6 +26,7 @@ function getBgVideoOrParallax(editingElement) {
 
 class WebsiteBackgroundImageOptionPlugin extends Plugin {
     static id = "websiteBackgroundImageOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         background_filter_target_providers: withSequence(10, getBgVideoOrParallax),
     };
@@ -27,6 +34,7 @@ class WebsiteBackgroundImageOptionPlugin extends Plugin {
 
 class WebsiteBackgroundShapeOptionPlugin extends Plugin {
     static id = "websiteBackgroundShapeOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         background_shape_target_providers: withSequence(10, getBgVideoOrParallax),
     };
@@ -36,6 +44,7 @@ class WebsiteBackgroundVideoPlugin extends Plugin {
     static id = "websiteBackgroundVideoPlugin";
     static dependencies = ["media"];
     static shared = ["loadReplaceBackgroundVideo", "applyReplaceBackgroundVideo"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             ToggleBgVideoAction,

--- a/addons/website/static/src/builder/plugins/options/bento_border_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/bento_border_option_plugin.js
@@ -12,6 +12,7 @@ export class BentoBorderOption extends BaseOptionComponent {
 
 class BentoBorderOptionPlugin extends Plugin {
     static id = "BentoBorderOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(after(WEBSITE_BACKGROUND_OPTIONS), BentoBorderOption)],
     };

--- a/addons/website/static/src/builder/plugins/options/blockquote_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option_plugin.js
@@ -25,6 +25,7 @@ export class WebsiteBackgroundBlockquoteOption extends BaseWebsiteBackgroundOpti
 
 class BlockquoteOptionPlugin extends Plugin {
     static id = "blockquoteOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         mark_color_level_selector_params: [{ selector: ".s_blockquote" }],
         builder_options: [

--- a/addons/website/static/src/builder/plugins/options/border_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/border_option_plugin.js
@@ -19,6 +19,7 @@ export class BorderOption extends BaseOptionComponent {
 
 class BorderOptionPlugin extends Plugin {
     static id = "borderOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(BOX_BORDER_SHADOW, BorderOption)],
     };

--- a/addons/website/static/src/builder/plugins/options/button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/button_option_plugin.js
@@ -15,6 +15,7 @@ const sizeClasses = ["btn-sm", "btn-lg"];
 
 class ButtonOptionPlugin extends Plugin {
     static id = "buttonOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         on_cloned_handlers: this.onCloned.bind(this),
         // Drag and drop from sidebar: manage the button preview.

--- a/addons/website/static/src/builder/plugins/options/card_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_image_option_plugin.js
@@ -4,6 +4,11 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { renderToElement } from "@web/core/utils/render";
 
+/**
+ * @typedef { Object } CardImageOptionShared
+ * @property { CardImageOptionPlugin['adaptRatio'] } adaptRatio
+ */
+
 const ratiosOnlySupportedForTopImage = [
     "ratio ratio-4x3",
     "ratio ratio-16x9",
@@ -26,6 +31,7 @@ class CardImageOptionPlugin extends Plugin {
     static id = "cardImageOption";
     static dependencies = ["remove", "history", "builderOptions"];
     static shared = ["adaptRatio"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetCoverImagePositionAction,

--- a/addons/website/static/src/builder/plugins/options/card_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_option_plugin.js
@@ -23,6 +23,7 @@ export class WebsiteBackgroundCardOption extends BaseWebsiteBackgroundOption {
 class CardOptionPlugin extends Plugin {
     static id = "cardOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             CardOption,

--- a/addons/website/static/src/builder/plugins/options/card_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_width_option_plugin.js
@@ -4,6 +4,7 @@ import { registry } from "@web/core/registry";
 
 class CardWidthOptionPlugin extends Plugin {
     static id = "cardWidthOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetCardWidthAction,

--- a/addons/website/static/src/builder/plugins/options/carousel_slides_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/carousel_slides_option_plugin.js
@@ -13,6 +13,7 @@ export class CarouselSlidesOption extends BaseOptionComponent {
 
 export class CarouselSlidesOptionPlugin extends Plugin {
     static id = "carouselSlidesOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(SNIPPET_SPECIFIC_END, CarouselSlidesOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
@@ -3,11 +3,17 @@ import { ChartOption, DATASET_KEY_PREFIX, getColor } from "./chart_option";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 
+/**
+ * @typedef { Object } ChartOptionShared
+ * @property { ChartOptionPlugin['isPieChart'] } isPieChart
+ */
+
 class ChartOptionPlugin extends Plugin {
     static id = "chartOptionPlugin";
     static dependencies = ["history"];
     static shared = ["isPieChart"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [ChartOption],
         so_content_addition_selector: [".s_chart"],

--- a/addons/website/static/src/builder/plugins/options/controller_page_listing_layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/controller_page_listing_layout_option_plugin.js
@@ -18,6 +18,7 @@ export class ControllerPageListingLayoutOption extends BaseOptionComponent {
 class ControllerPageListingLayoutOptionPlugin extends Plugin {
     static id = "controllerPageListingLayoutOption";
     static dependencies = ["builderActions"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [ControllerPageListingLayoutOption],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/cookies_bar_option.js
+++ b/addons/website/static/src/builder/plugins/options/cookies_bar_option.js
@@ -4,6 +4,11 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { renderToElement } from "@web/core/utils/render";
 
+/**
+ * @typedef { Object } CookiesBarOptionShared
+ * @property { CookiesBarOptionPlugin['getSavedSelectors'] } getSavedSelectors
+ */
+
 export class CookiesBarOption extends BaseOptionComponent {
     static template = "website.CookiesBarOption";
     static selector = "#website_cookies_bar";
@@ -12,6 +17,7 @@ export class CookiesBarOption extends BaseOptionComponent {
 class CookiesBarOptionPlugin extends Plugin {
     static id = "CookiesBarOptionPlugin";
     static shared = ["getSavedSelectors"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [CookiesBarOption],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
@@ -17,6 +17,7 @@ export class CountdownOption extends BaseOptionComponent {
 
 class CountdownOptionPlugin extends Plugin {
     static id = "CountdownOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(before(SNIPPET_SPECIFIC_END), CountdownOption)],
         so_content_addition_selector: [".s_countdown"],

--- a/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
@@ -10,6 +10,7 @@ import { coverSizeClassLabels } from "./cover_properties_option";
 class CoverPropertiesOptionPlugin extends Plugin {
     static id = "coverPropertiesOption";
     static dependencies = ["builderActions", "media", "imagePostProcess"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(COVER_PROPERTIES, CoverPropertiesOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option_plugin.js
@@ -5,6 +5,13 @@ import { DynamicSnippetCarouselOption } from "./dynamic_snippet_carousel_option"
 import { DYNAMIC_SNIPPET, setDatasetIfUndefined } from "./dynamic_snippet_option_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
+/**
+ * @typedef { Object } DynamicSnippetCarouselOptionShared
+ * @property { DynamicSnippetCarouselOptionPlugin['setOptionsDefaultValues'] } setOptionsDefaultValues
+ * @property { DynamicSnippetCarouselOptionPlugin['updateTemplateSnippetCarousel'] } updateTemplateSnippetCarousel
+ * @property { DynamicSnippetCarouselOptionPlugin['getModelNameFilter'] } getModelNameFilter
+ */
+
 export const DYNAMIC_SNIPPET_CAROUSEL = DYNAMIC_SNIPPET;
 
 class DynamicSnippetCarouselOptionPlugin extends Plugin {
@@ -16,6 +23,7 @@ class DynamicSnippetCarouselOptionPlugin extends Plugin {
     ];
     static dependencies = ["dynamicSnippetOption"];
     modelNameFilter = "";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetCarouselSliderSpeedAction,

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -7,6 +7,47 @@ import { Cache } from "@web/core/utils/cache";
 import { DynamicSnippetOption } from "./dynamic_snippet_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
+/**
+ * @typedef {object} Template
+ * @property {string} arrowPosition
+ * @property {string} columnClasses
+ * @property {string} containerClasses
+ * @property {string} contentClasses
+ * @property {string} extraClasses
+ * @property {string} extraSnippetClasses
+ * @property {string} key
+ * @property {string} numberOfElements
+ * @property {string} numberOfElementsSmallDevices
+ * @property {string} numberOfRecords
+ * @property {string} rowPerSlide
+ * @property {string} thumb
+ */
+
+/**
+ * @typedef { Object } DynamicSnippetOptionShared
+ * @property { DynamicSnippetOptionPlugin['fetchDynamicFilters'] } fetchDynamicFilters
+ * @property { DynamicSnippetOptionPlugin['fetchDynamicSnippetTemplates'] } fetchDynamicSnippetTemplates
+ * @property { DynamicSnippetOptionPlugin['getDefaultSnippetFilterId'] } getDefaultSnippetFilterId
+ * @property { DynamicSnippetOptionPlugin['getDefaultSnippetRecordId'] } getDefaultSnippetRecordId
+ * @property { DynamicSnippetOptionPlugin['getDefaultSnippetTemplate'] } getDefaultSnippetTemplate
+ * @property { DynamicSnippetOptionPlugin['getSnippetModelName'] } getSnippetModelName
+ * @property { DynamicSnippetOptionPlugin['getSnippetTitleClasses'] } getSnippetTitleClasses
+ * @property { DynamicSnippetOptionPlugin['getTemplateByKey'] } getTemplateByKey
+ * @property { DynamicSnippetOptionPlugin['isModelSnippetTemplate'] } isModelSnippetTemplate
+ * @property { DynamicSnippetOptionPlugin['isSingleModeSnippet'] } isSingleModeSnippet
+ * @property { DynamicSnippetOptionPlugin['isSingleModeSnippetTemplate'] } isSingleModeSnippetTemplate
+ * @property { DynamicSnippetOptionPlugin['setOptionsDefaultValues'] } setOptionsDefaultValues
+ * @property { DynamicSnippetOptionPlugin['updateTemplate'] } updateTemplate
+ * @property { DynamicSnippetOptionPlugin['getModelNameFilter'] } getModelNameFilter
+ */
+
+/**
+ * @typedef {((arg: {
+ *      el: HTMLElement;
+ *      template: Template;
+ * }) => void)[]} dynamic_snippet_template_updated
+ */
+
 export const DYNAMIC_SNIPPET = SNIPPET_SPECIFIC_END;
 
 class DynamicSnippetOptionPlugin extends Plugin {
@@ -30,6 +71,7 @@ class DynamicSnippetOptionPlugin extends Plugin {
     modelNameFilter = "";
     fetchedDynamicFilters = [];
     fetchedDynamicFilterTemplates = [];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(DYNAMIC_SNIPPET, DynamicSnippetOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/ecomm_categories_showcase_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/ecomm_categories_showcase_option_plugin.js
@@ -40,6 +40,7 @@ class EcommCategoriesShowcaseOptionPlugin extends Plugin {
         "rounded-5",
     ];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(SNIPPET_SPECIFIC_BEFORE, EcommCategoriesShowcaseOption),

--- a/addons/website/static/src/builder/plugins/options/embed_code_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/embed_code_option_plugin.js
@@ -16,6 +16,7 @@ export class EmbedCodeOption extends BaseOptionComponent {
 class EmbedCodeOptionPlugin extends Plugin {
     static id = "embedCodeOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(BEGIN, EmbedCodeOption)],
         so_content_addition_selector: [".s_embed_code"],

--- a/addons/website/static/src/builder/plugins/options/facebook_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/facebook_option_plugin.js
@@ -13,6 +13,7 @@ export class FacebookOption extends BaseOptionComponent {
 class FacebookOptionPlugin extends Plugin {
     static id = "facebookOption";
     static dependencies = ["history"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [FacebookOption],
         so_content_addition_selector: [".o_facebook_page"],

--- a/addons/website/static/src/builder/plugins/options/faq_horizontal_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/faq_horizontal_option_plugin.js
@@ -11,6 +11,7 @@ export class FaqHorizontalOption extends BaseOptionComponent {
 
 class FaqHorizontalOptionPlugin extends Plugin {
     static id = "faqHorizontalOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(BEGIN, FaqHorizontalOption)],
     };

--- a/addons/website/static/src/builder/plugins/options/footer_copyright_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_copyright_option_plugin.js
@@ -5,6 +5,7 @@ import { FooterCopyrightOption } from "@website/builder/plugins/options/footer_c
 class FooterCopyrightOptionPlugin extends Plugin {
     static id = "footerCopyrightOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [FooterCopyrightOption],
     };

--- a/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
@@ -15,6 +15,20 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
 import { ShadowOption } from "@html_builder/plugins/shadow_option";
 
+/** @typedef {import("@odoo/owl").Component} Component */
+
+/**
+ * @typedef { Object } FooterOptionShared
+ * @property { FooterOptionPlugin['getFooterTemplates'] } getFooterTemplates
+ */
+/**
+ * @typedef {(() => Promise<{
+ *     key: string,
+ *     Component: Component,
+ *     props: any,
+ * }[]>)[]} footer_templates_providers
+ */
+
 const [
     FOOTER_TEMPLATE,
     FOOTER_COLORS,
@@ -90,6 +104,7 @@ class FooterOptionPlugin extends Plugin {
     static dependencies = ["customizeWebsite", "builderActions"];
     static shared = ["getFooterTemplates"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(FOOTER_TEMPLATE, FooterTemplateOption),

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
@@ -5,6 +5,18 @@ import { SNIPPET_SPECIFIC } from "@html_builder/utils/option_sequence";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef {((
+ *      activeItemEl: HTMLElement,
+ *      optionName: string
+ * ) => HTMLElement[])[]} get_gallery_items_handlers
+ * @typedef {((
+ *      activeItemEl: HTMLElement,
+ *      itemEls: HTMLElement[],
+ *      optionName: string
+ * ) => void)[]} reorder_items_handlers
+ */
+
 export class GalleryElementOption extends BaseOptionComponent {
     static template = "website.GalleryElementOption";
     static selector =
@@ -14,6 +26,7 @@ export class GalleryElementOption extends BaseOptionComponent {
 export class GalleryElementOptionPlugin extends Plugin {
     static id = "galleryElementOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(SNIPPET_SPECIFIC, GalleryElementOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -26,6 +26,18 @@ import { BuilderAction } from "@html_builder/core/builder_action";
  * @typedef {{ isValid: boolean, message?: string }} ApiKeyValidation
  */
 
+/**
+ * @typedef { Object } GoogleMapsOptionShared
+ * @property { GoogleMapsOptionPlugin['configureGMapsAPI'] } configureGMapsAPI
+ * @property { GoogleMapsOptionPlugin['initializeGoogleMaps'] } initializeGoogleMaps
+ * @property { GoogleMapsOptionPlugin['failedToInitializeGoogleMaps'] } failedToInitializeGoogleMaps
+ * @property { GoogleMapsOptionPlugin['shouldRefetchApiKey'] } shouldRefetchApiKey
+ * @property { GoogleMapsOptionPlugin['shouldNotRefetchApiKey'] } shouldNotRefetchApiKey
+ * @property { GoogleMapsOptionPlugin['commitPlace'] } commitPlace
+ * @property { GoogleMapsOptionPlugin['getPlace'] } getPlace
+ * @property { GoogleMapsOptionPlugin['getMapsAPI'] } getMapsAPI
+ */
+
 export class GoogleMapsOptionPlugin extends Plugin {
     static id = "googleMapsOption";
     static dependencies = ["history", "edit_interaction"];
@@ -39,6 +51,7 @@ export class GoogleMapsOptionPlugin extends Plugin {
         "getPlace",
         "getMapsAPI",
     ];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [GoogleMapsOption],
         so_content_addition_selector: [".s_google_map"],

--- a/addons/website/static/src/builder/plugins/options/header/header_box_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_box_option_plugin.js
@@ -16,6 +16,7 @@ class HeaderBoxOptionPlugin extends Plugin {
     static id = "HeaderBoxOptionPlugin";
     static dependencies = ["customizeWebsite"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(HEADER_BOX, HeaderBoxOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option_plugin.js
@@ -8,6 +8,7 @@ class HeaderNavigationOptionPlugin extends Plugin {
     static id = "HeaderNavigationOptionPlugin";
     static dependencies = ["customizeWebsite"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(HEADER_NAVIGATION, HeaderNavigationOption)],
     };

--- a/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
@@ -40,6 +40,7 @@ class HeaderOptionPlugin extends Plugin {
     static id = "headerOption";
     static dependencies = ["customizeWebsite", "menuDataPlugin"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_header_middle_buttons: [
             {

--- a/addons/website/static/src/builder/plugins/options/icon_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/icon_snippet_option_plugin.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 export class IconSnippetOptionPlugin extends Plugin {
     static id = "iconSnippetOption";
     static dependencies = ["media"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         so_content_addition_selector: [".s_icon"],

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -11,6 +11,15 @@ import { uniqueId } from "@web/core/utils/functions";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { forwardToThumbnail } from "@html_builder/utils/utils_css";
 
+/**
+ * @typedef { Object } ImageGalleryOptionShared
+ * @property { ImageGalleryOption['getColumns'] } getColumns
+ * @property { ImageGalleryOption['getMode'] } getMode
+ * @property { ImageGalleryOption['processImage'] } processImage
+ * @property { ImageGalleryOption['restoreSelection'] } restoreSelection
+ * @property { ImageGalleryOption['setImages'] } setImages
+ */
+
 export class ImageGalleryImagesOption extends BaseOptionComponent {
     static template = "website.ImageGalleryImagesOption";
     static selector = ".s_image_gallery";
@@ -28,6 +37,7 @@ class ImageGalleryOption extends Plugin {
         "imagePostProcess",
     ];
     static shared = ["processImages", "getMode", "setImages", "restoreSelection", "getColumns"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(SNIPPET_SPECIFIC, ImageGalleryImagesOption),

--- a/addons/website/static/src/builder/plugins/options/instagram_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/instagram_option_plugin.js
@@ -7,6 +7,11 @@ import { withSequence } from "@html_editor/utils/resource";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef { Object } InstagramOptionShared
+ * @property { InstagramOptionPlugin['instagramPageNameFromUrl'] } instagramPageNameFromUrl
+ */
+
 export class InstagramOption extends BaseOptionComponent {
     static template = "website.InstagramOption";
     static selector = ".s_instagram_page";
@@ -17,6 +22,7 @@ class InstagramOptionPlugin extends Plugin {
     static dependencies = ["history"];
     static shared = ["instagramPageNameFromUrl"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(SNIPPET_SPECIFIC_END, InstagramOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/language_selector_option.js
+++ b/addons/website/static/src/builder/plugins/options/language_selector_option.js
@@ -17,6 +17,7 @@ const LANGUAGE_SELECTOR = after(HEADER_BOX);
 class LanguageSelectorOptionPlugin extends Plugin {
     static id = "languageSelectorOption";
     static dependencies = ["builderActions"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(LANGUAGE_SELECTOR, LanguageSelectorOption)],
     };

--- a/addons/website/static/src/builder/plugins/options/map_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/map_option_plugin.js
@@ -12,6 +12,7 @@ export class MapOption extends BaseOptionComponent {
 
 class MapOptionPlugin extends Plugin {
     static id = "mapOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [MapOption],
         so_content_addition_selector: [".s_map"],

--- a/addons/website/static/src/builder/plugins/options/media_list_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/media_list_option_plugin.js
@@ -14,6 +14,7 @@ export class MediaListOption extends BaseOptionComponent {
 class MediaListOptionPlugin extends Plugin {
     static id = "mediaListOption";
     mediaListItemOptionSelector = ".s_media_list_item";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(BEGIN, MediaListOption),

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -4,11 +4,17 @@ import { registry } from "@web/core/registry";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC_NEXT } from "@html_builder/utils/option_sequence";
 
+/**
+ * @typedef { Object } MegaMenuOptionShared
+ * @property { MegaMenuOptionPlugin['getTemplatePrefix'] } getTemplatePrefix
+ */
+
 export class MegaMenuOptionPlugin extends Plugin {
     static id = "megaMenuOptionPlugin";
     static dependencies = [];
     static shared = ["getTemplatePrefix"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(SNIPPET_SPECIFIC_NEXT, MegaMenuOption)],
         dropzone_selector: {

--- a/addons/website/static/src/builder/plugins/options/navbar_logo_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navbar_logo_option_plugin.js
@@ -15,6 +15,7 @@ export class NavbarLogoOption extends BaseOptionComponent {
 
 class NavbarLogoOptionPlugin extends Plugin {
     static id = "navbarLogoOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(SNIPPET_SPECIFIC_NEXT, NavbarLogoOption)],
     };

--- a/addons/website/static/src/builder/plugins/options/navtabs_header_buttons_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_header_buttons_plugin.js
@@ -9,6 +9,7 @@ const tabsSectionSelector = "section.s_tabs, section.s_tabs_images";
 class NavTabsOptionPlugin extends Plugin {
     static id = "navTabsOption";
     static dependencies = ["clone"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_header_middle_buttons: {
             Component: NavTabsHeaderMiddleButtons,

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -7,6 +7,13 @@ import { _t } from "@web/core/l10n/translation";
 import { localization } from "@web/core/l10n/localization";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef { Object } NavTabsStyleOptionShared
+ * @property { NavTabsStyleOptionPlugin['isNavItem'] } isNavItem
+ * @property { NavTabsStyleOptionPlugin['getActiveOverlayButtons'] } getActiveOverlayButtons
+ * @property { NavTabsStyleOptionPlugin['moveNavItem'] } moveNavItem
+ */
+
 export class NavTabsStyleOption extends BaseOptionComponent {
     static template = "website.NavTabsStyleOption";
     static selector = ".s_tabs";
@@ -22,6 +29,7 @@ export class NavTabsImagesStyleOption extends BaseOptionComponent {
 class NavTabsStyleOptionPlugin extends Plugin {
     static id = "navTabsOptionStyle";
     static shared = ["isNavItem", "getActiveOverlayButtons", "moveNavItem"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(SNIPPET_SPECIFIC_END, NavTabsStyleOption),

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -5,10 +5,17 @@ import { registry } from "@web/core/registry";
 import { BaseWebsiteBackgroundOption } from "./background_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { withSequence } from "@html_editor/utils/resource";
+
+/**
+ * @typedef { Object } WebsiteParallaxShared
+ * @property { WebsiteParallaxPlugin['applyParallaxType'] } applyParallaxType
+ */
+
 class WebsiteParallaxPlugin extends Plugin {
     static id = "websiteParallaxPlugin";
     static dependencies = ["builderActions", "backgroundImageOption"];
     static shared = ["applyParallaxType"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetParallaxTypeAction,

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -25,6 +25,7 @@ class PopupOptionPlugin extends Plugin {
     static id = "PopupOption";
     static dependencies = ["anchor", "visibility", "history", "popupVisibilityPlugin"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(POPUP, PopupOption),

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option_plugin.js
@@ -28,6 +28,7 @@ export class AddProductPricelistBoxedSectionOption extends BaseAddProductOption 
 
 class PriceListBoxedOptionPlugin extends Plugin {
     static id = "priceListBoxedOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(BEGIN, AddProductPricelistBoxedOption),

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_plugin.js
@@ -35,6 +35,7 @@ export class AddProductPricelistCafeRowOption extends BaseAddProductOption {
 
 class PriceListCafePlugin extends Plugin {
     static id = "priceList";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(BEGIN, AddProductPricelistCafeOption),

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_plugin.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 
 class PriceListPlugin extends Plugin {
     static id = "priceListPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             TogglePriceListDescriptionAction,

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_plugin.js
@@ -28,6 +28,7 @@ export class AddProductCatalogSectionOption extends BaseAddProductOption {
 
 class ProductCatalogOptionPlugin extends Plugin {
     static id = "productCatalogOptionPlugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(BEGIN, AddProductCatalogOption),

--- a/addons/website/static/src/builder/plugins/options/process_steps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/process_steps_option_plugin.js
@@ -20,6 +20,7 @@ export class WebsiteBackgroundProcessStepOption extends BaseWebsiteBackgroundOpt
 
 class ProcessStepsOptionPlugin extends Plugin {
     static id = "processStepsOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(after(CONTAINER_WIDTH), ProcessStepsOption),

--- a/addons/website/static/src/builder/plugins/options/progress_bar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/progress_bar_option_plugin.js
@@ -24,6 +24,7 @@ export class ProgressBarOption extends BaseOptionComponent {
 
 class ProgressBarOptionPlugin extends Plugin {
     static id = "progressBarOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: ProgressBarOption,
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
@@ -9,6 +9,7 @@ import { SCROLL_BUTTON } from "@website/builder/option_sequence";
 
 class ScrollButtonOptionPlugin extends Plugin {
     static id = "scrollButtonOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(SCROLL_BUTTON, ScrollButtonOption)],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
@@ -4,8 +4,58 @@ import { registry } from "@web/core/registry";
 import { SearchbarOption } from "./searchbar_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
+/** @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString */
+
+/**
+ * @typedef {{
+ *      label: LazyTranslatedString;
+ *      orderBy: string;
+ *      dependency?: string;
+ *      id?: string;
+ * }[]} searchbar_option_order_by_items
+ *
+ * Register orderBy options for the website searchbar.
+ * `orderBy` takes a string like `record_field_name` + `asc` or `desc`.
+ * `dependency` takes an id of another builder option. You can omit it if the
+ * orderBy option should always be visible.
+ * You can reference `id` if you need the new option to have an id (if another
+ * option depends on it being active).
+ *
+ * Example:
+ *
+ *      resources: {
+ *          searchbar_option_order_by_items: {
+ *              label: _t("Date (old to new)"),
+ *              orderBy: "published_date asc",
+ *              dependency: "search_blogs_opt",
+ *          },
+ *      };
+ */
+/**
+ * @typedef {{
+ *      label: LazyTranslatedString;
+ *      dataAttribute: string;
+ *      dependency: string;
+ * }[]} searchbar_option_display_items
+ *
+ * Register display options for the website searchbar.
+ * `dataAttribute` is the attribute which will be used to display the data.
+ * `dependency` takes an id of another builder option.
+ *
+ * Example:
+ *
+ *      resources: {
+ *          searchbar_option_display_items: {
+ *              label: _t("Description"),
+ *              dataAttribute: "displayDescription",
+ *              dependency: "search_all_opt",
+ *          },
+ *      };
+ */
+
 class SearchbarOptionPlugin extends Plugin {
     static id = "searchbarOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [SearchbarOption],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -13,6 +13,19 @@ import { AnimateOption } from "./animate_option";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 /**
+ * @typedef { Object } SocialMediaOptionShared
+ * @property { SocialMediaOptionPlugin['newLinkElement'] } newLinkElement
+ * @property { SocialMediaOptionPlugin['getRecordedSocialMedia'] } getRecordedSocialMedia
+ * @property { SocialMediaOptionPlugin['setRecordedSocialMedia'] } setRecordedSocialMedia
+ * @property { SocialMediaOptionPlugin['setRecordedSocialMediaAreEdited'] } setRecordedSocialMediaAreEdited
+ * @property { SocialMediaOptionPlugin['getAssociatedSocialMedia'] } getAssociatedSocialMedia
+ * @property { SocialMediaOptionPlugin['removeSocialMediaClasses'] } removeSocialMediaClasses
+ * @property { SocialMediaOptionPlugin['removeIconClasses'] } removeIconClasses
+ * @property { SocialMediaOptionPlugin['getRecordedSocialMediaNames'] } getRecordedSocialMediaNames
+ * @property { SocialMediaOptionPlugin['reorderSocialMediaLink'] } reorderSocialMediaLink
+ */
+
+/**
  * @typedef { Object } SocialMediaInfo
  * @property { boolean } [recorded] whether the social media is one from the orm
  * @property { string|Markup|LazyTranslatedString } label
@@ -132,6 +145,7 @@ class SocialMediaOptionPlugin extends Plugin {
         "getRecordedSocialMediaNames",
         "reorderSocialMediaLink",
     ];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(TITLE_LAYOUT_SIZE, SocialMediaOption),

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -33,6 +33,7 @@ export class TableOfContentNavbarOption extends BaseOptionComponent {
 class TableOfContentOptionPlugin extends Plugin {
     static id = "tableOfContentOption";
     static dependencies = ["remove"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [TableOfContentOption, TableOfContentNavbarOption],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin_translate.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin_translate.js
@@ -4,6 +4,7 @@ import { applyFunDependOnSelectorAndExclude } from "@html_builder/plugins/utils"
 export class TranslateTableOfContentOptionPlugin extends Plugin {
     static id = "tableOfContentOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         normalize_handlers: this.normalize.bind(this),
         content_not_editable_selectors: [".s_table_of_content_navbar"],

--- a/addons/website/static/src/builder/plugins/options/timeline_list_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/timeline_list_option_plugin.js
@@ -21,6 +21,7 @@ export class DotColorOption extends BaseOptionComponent {
 
 class TimelineListOptionPlugin extends Plugin {
     static id = "timelineListOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             // TODO AGAU: alignment option sequence doesn't match master, must split template

--- a/addons/website/static/src/builder/plugins/options/timeline_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/timeline_option_plugin.js
@@ -32,6 +32,7 @@ export class DotColorOption extends BaseOptionComponent {
 
 class TimelineOptionPlugin extends Plugin {
     static id = "timelineOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(TIMELINE, TimelineOption),

--- a/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
@@ -8,6 +8,13 @@ import { CONDITIONAL_VISIBILITY, DEVICE_VISIBILITY } from "@website/builder/opti
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef {{
+ *      saveAttribute: string;
+ *      attributeName: string;
+ *      callWith: "code" | "name" | "value" | "id";
+ * }[]} visibility_selector_parameters
+ */
 export const DEVICE_VISIBILITY_OPTION_SELECTOR = "section .row > div";
 
 export class DeviceVisibilityOption extends BaseOptionComponent {
@@ -20,6 +27,7 @@ export class DeviceVisibilityOption extends BaseOptionComponent {
 class VisibilityOptionPlugin extends Plugin {
     static id = "visibilityOption";
     static dependencies = ["visibility", "websiteSession"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(CONDITIONAL_VISIBILITY, VisibilityOption),

--- a/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
@@ -56,6 +56,7 @@ export class WebsiteBackgroundOnlyBGImageOption extends BaseWebsiteBackgroundOpt
 class WebsiteBackgroundOptionPlugin extends Plugin {
     static id = "websiteOption";
     carouselApplyTo = ":scope > .carousel:not(.s_carousel_cards)";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(SNIPPET_SPECIFIC_BEFORE, WebsiteBackgroundCarouselOption),

--- a/addons/website/static/src/builder/plugins/options/website_info_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_info_option_plugin.js
@@ -13,6 +13,7 @@ export class InfoPageOption extends BaseOptionComponent {
 
 class WebsiteInfoPageOption extends Plugin {
     static id = "websiteInfoPageOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [InfoPageOption],
     };

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -9,6 +9,15 @@ import { TopMenuVisibilityOption } from "./website_page_config_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef { Object } WebsitePageConfigOptionShared
+ * @property { WebsitePageConfigOptionPlugin['setDirty'] } setDirty
+ * @property { WebsitePageConfigOptionPlugin['setFooterVisible'] } setFooterVisible
+ * @property { WebsitePageConfigOptionPlugin['getVisibilityItem'] } getVisibilityItem
+ * @property { WebsitePageConfigOptionPlugin['getFooterVisibility'] } getFooterVisibility
+ * @property { WebsitePageConfigOptionPlugin['doesPageOptionExist'] } doesPageOptionExist
+ */
+
 export const TOP_MENU_VISIBILITY = after(HEADER_TEMPLATE);
 export const HIDE_FOOTER = after(FOOTER_COPYRIGHT);
 
@@ -30,6 +39,7 @@ class WebsitePageConfigOptionPlugin extends Plugin {
         "getFooterVisibility",
         "doesPageOptionExist",
     ];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             SetWebsiteHeaderVisibilityAction,

--- a/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
@@ -2,11 +2,18 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 
+/**
+ * @typedef { Object } PopupVisibilityShared
+ * @property { PopupVisibilityPlugin['onTargetHide'] } onTargetHide
+ * @property { PopupVisibilityPlugin['onTargetShow'] } onTargetShow
+ */
+
 export class PopupVisibilityPlugin extends Plugin {
     static id = "popupVisibilityPlugin";
     static dependencies = ["visibility", "history"];
     static shared = ["onTargetShow", "onTargetHide"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         target_show: this.onTargetShow.bind(this),
         target_hide: this.onTargetHide.bind(this),

--- a/addons/website/static/src/builder/plugins/save_translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/save_translation_plugin.js
@@ -6,6 +6,7 @@ export class SaveTranslationPlugin extends Plugin {
     static id = "saveTranslation";
     static dependencies = ["websiteSavePlugin"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         save_elements_overrides: withSequence(20, this.saveTranslationElements.bind(this)),
     };

--- a/addons/website/static/src/builder/plugins/setup_editor_plugin.js
+++ b/addons/website/static/src/builder/plugins/setup_editor_plugin.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 
 export class WebsiteSetupEditorPlugin extends Plugin {
     static id = "website.setup_editor_plugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         snippet_preview_dialog_bundles: ["web.assets_frontend"],
     };

--- a/addons/website/static/src/builder/plugins/size_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/size_option_plugin.js
@@ -11,6 +11,7 @@ export class SizeOption extends BaseOptionComponent {
 
 class SizeOptionPlugin extends Plugin {
     static id = "sizeOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(after(BLOCK_ALIGN), SizeOption)],
     };

--- a/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
+++ b/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
@@ -7,6 +7,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 class SnippetsPowerboxPlugin extends Plugin {
     static id = "alert";
     static dependencies = ["dom", "history"];
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         user_commands: [
             {

--- a/addons/website/static/src/builder/plugins/switchable_views_plugin.js
+++ b/addons/website/static/src/builder/plugins/switchable_views_plugin.js
@@ -3,15 +3,24 @@ import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { SwitchableViews } from "./switchable_views";
 
+/**
+ * @typedef { Object } SwitchableViewsShared
+ * @property { SwitchableViewsPlugin['getSwitchableRelatedViews'] } getSwitchableRelatedViews
+ */
+
 export class SwitchableViewsPlugin extends Plugin {
     static id = "switchableViews";
     static dependencies = ["customizeWebsite"];
     static shared = ["getSwitchableRelatedViews"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [SwitchableViews],
     };
 
+    /**
+     * @returns {Promise<[]>}
+     */
     getSwitchableRelatedViews() {
         if (!this.prom) {
             const viewKey = this.document.querySelector("html").dataset.viewXmlid;

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -21,6 +21,15 @@ import { CustomizeWebsiteVariableAction } from "../customize_website_plugin";
 import { EditHeadBodyDialog } from "@website/components/edit_head_body_dialog/edit_head_body_dialog";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
+/**
+ * @typedef { Object } ThemeTabShared
+ * @property { ThemeTabPlugin['buildGray'] } buildGray
+ * @property { ThemeTabPlugin['getGrays'] } getGrays
+ * @property { ThemeTabPlugin['getGrayParams'] } getGrayParams
+ * @property { ThemeTabPlugin['setGrays'] } setGrays
+ * @property { ThemeTabPlugin['setGrayParams'] } setGrayParams
+ */
+
 export const GRAY_PARAMS = {
     EXTRA_SATURATION: "gray-extra-saturation",
     HUE: "gray-hue",
@@ -43,6 +52,7 @@ export class ThemeTabPlugin extends Plugin {
     grayParams = {};
     grays = reactive({});
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             CustomizeGrayAction,

--- a/addons/website/static/src/builder/plugins/timeline_images_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/timeline_images_option_plugin.js
@@ -21,6 +21,7 @@ export class DotColorOption extends BaseOptionComponent {
 
 class TimelineImagesOptionPlugin extends Plugin {
     static id = "timelineImagesOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
             withSequence(BEGIN, TimelineImagesOption),

--- a/addons/website/static/src/builder/plugins/translate_announcement_scroll_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_announcement_scroll_plugin.js
@@ -6,6 +6,7 @@ export class TranslateAnnouncementScrollPlugin extends Plugin {
     static id = "translateAnnouncementScroll";
     static dependencies = ["history"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         mark_translatable_nodes: this.listenToAnnouncementScrollClick.bind(this),
     };

--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 
 export class TranslateLinkInlinePlugin extends Plugin {
     static id = "translateLinkInline";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         create_link_handlers: (linkEl) => linkEl.classList.add("o_translate_inline"),
     };

--- a/addons/website/static/src/builder/plugins/translate_setup_editor_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_setup_editor_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 
 export class TranslateSetupEditorPlugin extends Plugin {
     static id = "translate_setup_editor_plugin";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         o_editable_selectors: "[data-oe-model][data-oe-translation-source-sha]",
     };

--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -9,6 +9,10 @@ import {
 } from "../translation_components/translatorInfoDialog";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef {((editableEls: HTMLElement[]) => void)[]} mark_translatable_nodes
+ */
+
 export const translationAttributeSelector =
     '[placeholder*="data-oe-translation-source-sha="], ' +
     '[title*="data-oe-translation-source-sha="], ' +
@@ -50,6 +54,7 @@ export class TranslationPlugin extends Plugin {
     static id = "translation";
     static dependencies = ["history"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         get_dirty_els: this.getDirtyTranslations.bind(this),

--- a/addons/website/static/src/builder/plugins/translation_tab/customize_translation_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_tab/customize_translation_tab_plugin.js
@@ -9,6 +9,11 @@ import { uniqueId } from "@web/core/utils/functions";
 import { TranslateWebpageOption } from "./translate_webpage_option";
 
 /**
+ * @typedef { Object } CustomizeTranslationTabShared
+ * @property { CustomizeTranslationTabPlugin['getTranslationState'] } getTranslationState
+ */
+
+/**
  * Action to translate the entire webpage using AI.
  */
 class TranslateToAction extends BuilderAction {
@@ -241,6 +246,7 @@ export class CustomizeTranslationTabPlugin extends Plugin {
         isTranslating: false,
     });
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_actions: {
             TranslateToAction,

--- a/addons/website/static/src/builder/plugins/vertical_alignment_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/vertical_alignment_option_plugin.js
@@ -13,6 +13,7 @@ export class WebsiteVerticalAlignmentOption extends BaseVerticalAlignmentOption 
 
 class VerticalAlignmentOptionPlugin extends Plugin {
     static id = "websiteVerticalAlignmentOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(BOX_BORDER_SHADOW, WebsiteVerticalAlignmentOption)],
     };

--- a/addons/website/static/src/builder/plugins/website_save_plugin.js
+++ b/addons/website/static/src/builder/plugins/website_save_plugin.js
@@ -2,10 +2,16 @@ import { escapeTextNodes } from "@html_builder/utils/escaping";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 
+/**
+ * @typedef { Object } WebsiteSaveShared
+ * @property { WebsiteSavePlugin['saveView'] } saveView
+ */
+
 export class WebsiteSavePlugin extends Plugin {
     static id = "websiteSavePlugin";
     static shared = ["saveView"];
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         save_element_handlers: this.saveView.bind(this),
     };

--- a/addons/website/static/src/builder/plugins/website_session_plugin.js
+++ b/addons/website/static/src/builder/plugins/website_session_plugin.js
@@ -1,6 +1,11 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 
+/**
+ * @typedef { Object } WebsiteSessionShared
+ * @property { WebsiteSessionPlugin['getSession'] } getSession
+ */
+
 export class WebsiteSessionPlugin extends Plugin {
     static id = "websiteSession";
     static shared = ["getSession"];

--- a/addons/website/static/src/builder/plugins/website_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/website_visibility_plugin.js
@@ -6,6 +6,7 @@ import { VisibilityOption } from "./options/visibility_option";
 export class WebsiteVisibilityPlugin extends Plugin {
     static id = "websiteVisibilityPlugin";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         system_classes: ["o_conditional_hidden"],
         target_show: this.onTargetShow.bind(this),

--- a/addons/website/static/src/core/website_cookies_service.js
+++ b/addons/website/static/src/core/website_cookies_service.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { EventBus } from "@website/utils/misc";
 
-registry.category("services").add("website_cookies", {
+export const websiteCookiesService = {
     dependencies: ["public.interactions"],
     start(env, deps) {
         const bus = new EventBus();
@@ -26,4 +26,6 @@ registry.category("services").add("website_cookies", {
 
         return { bus, manageIframeSrc };
     },
-});
+};
+
+registry.category("services").add("website_cookies", websiteCookiesService);

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -46,7 +46,7 @@ export function buildEditableInteractions(builders) {
     return result;
 }
 
-registry.category("services").add("website_edit", {
+export const websiteEditService = {
     dependencies: ["public.interactions"],
     start(env, { ["public.interactions"]: publicInteractions }) {
         let editableInteractions = null;
@@ -313,7 +313,8 @@ registry.category("services").add("website_edit", {
 
         return websiteEditService;
     },
-});
+};
+registry.category("services").add("website_edit", websiteEditService);
 
 // Patch PublicRoot.
 

--- a/addons/website/static/src/core/website_map_service.js
+++ b/addons/website/static/src/core/website_map_service.js
@@ -5,7 +5,7 @@ import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { markup } from "@odoo/owl";
 
-registry.category("services").add("website_map", {
+export const websiteMapService = {
     dependencies: ["public.interactions", "notification"],
     start(env, deps) {
         const publicInteractions = deps["public.interactions"];
@@ -137,4 +137,6 @@ registry.category("services").add("website_map", {
             },
         };
     },
-});
+};
+
+registry.category("services").add("website_map", websiteMapService);

--- a/addons/website/static/src/core/website_menus_service.js
+++ b/addons/website/static/src/core/website_menus_service.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
 
-registry.category("services").add("website_menus", {
+export const websiteMenusService = {
     start() {
         const updateCallbacks = new Set();
         return {
@@ -16,4 +16,6 @@ registry.category("services").add("website_menus", {
             },
         };
     },
-});
+};
+
+registry.category("services").add("website_menus", websiteMenusService);

--- a/addons/website/static/src/core/website_page_service.js
+++ b/addons/website/static/src/core/website_page_service.js
@@ -2,7 +2,7 @@ import { jsToPyLocale } from "@web/core/l10n/utils";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
 
-registry.category("services").add("website_page", {
+export const websitePageService = {
     start() {
         const htmlEl = document.querySelector("html");
         // TODO this is duplicated in website_service.js at least... to share
@@ -21,4 +21,6 @@ registry.category("services").add("website_page", {
             },
         };
     },
-});
+};
+
+registry.category("services").add("website_page", websitePageService);

--- a/addons/website_blog/static/src/@types/plugins.d.ts
+++ b/addons/website_blog/static/src/@types/plugins.d.ts
@@ -1,0 +1,7 @@
+declare module "plugins" {
+    import { DynamicSnippetBlogPostsOptionShared } from "../website_builder/dynamic_snippet_blog_posts_option_plugin";
+
+    interface SharedMethods {
+        dynamicSnippetBlogPostsOption: DynamicSnippetBlogPostsOptionShared;
+    }
+}

--- a/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
@@ -13,6 +13,7 @@ export class BlogPageOption extends BaseOptionComponent {
 
 export class BlogPageOptionPlugin extends Plugin {
     static id = "blogPageOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [BlogPageOption],
     };

--- a/addons/website_blog/static/src/website_builder/blog_post_page_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_post_page_option_plugin.js
@@ -13,6 +13,7 @@ export class BlogPostPageOption extends BaseOptionComponent {
 
 export class BlogPostPageOptionPlugin extends Plugin {
     static id = "blogPostPageOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [BlogPostPageOption],
     };

--- a/addons/website_blog/static/src/website_builder/blog_post_tags_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_post_tags_option_plugin.js
@@ -4,6 +4,7 @@ import { BlogPostTagsOption } from "./blog_post_tags_option";
 
 class BlogPostTagsOptionPlugin extends Plugin {
     static id = "blogPostTagsOption";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [BlogPostTagsOption],
     };

--- a/addons/website_blog/static/src/website_builder/blog_searchbar_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_searchbar_option_plugin.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 class BlogSearchbarOptionPlugin extends Plugin {
     static id = "blogSearchbarOption";
 
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         searchbar_option_order_by_items: [
             {

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
@@ -7,11 +7,18 @@ import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 import { DynamicSnippetBlogPostsOption } from "./dynamic_snippet_blog_posts_option";
 
+/**
+ * @typedef { Object } DynamicSnippetBlogPostsOptionShared
+ * @property { DynamicSnippetBlogPostsOptionPlugin['fetchBlogs'] } fetchBlogs
+ * @property { DynamicSnippetBlogPostsOptionPlugin['getModelNameFilter'] } getModelNameFilter
+ */
+
 class DynamicSnippetBlogPostsOptionPlugin extends Plugin {
     static id = "dynamicSnippetBlogPostsOption";
     static dependencies = ["dynamicSnippetOption"];
     static shared = ["fetchBlogs", "getModelNameFilter"];
     modelNameFilter = "blog.post";
+    /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: withSequence(DYNAMIC_SNIPPET, DynamicSnippetBlogPostsOption),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),


### PR DESCRIPTION
*: html_editor, web, website

The goal of this PR is to enable IntelliSense autocompletion like so (examples in codium):

## Registry / Services
`registry`:
<img width="647" height="99" alt="image" src="https://github.com/user-attachments/assets/a3ee6bb4-3b7f-4c8b-bc0d-e0c6f12178e6" />

`services`
<img width="988" height="111" alt="image" src="https://github.com/user-attachments/assets/6277189f-e2cb-4fc5-8b82-693382cf23ea" />

## Plugins

`shared` methods:
<img width="960" height="141" alt="image" src="https://github.com/user-attachments/assets/b7237b66-2f64-424d-8ce4-9edfac5b148c" />
<img width="1091" height="152" alt="image" src="https://github.com/user-attachments/assets/18650490-a16c-4aa4-887f-a5b00aa076dd" />

`resources`:
<img width="893" height="270" alt="image" src="https://github.com/user-attachments/assets/908ad7ff-4ccd-4fad-82c1-60deb98c53ab" />

`getResource`:
<img width="598" height="261" alt="image" src="https://github.com/user-attachments/assets/56800a2d-5f59-4e4a-8da5-fc87673170b6" />

`dispatchTo` with expected arguments:
<img width="803" height="293" alt="image" src="https://github.com/user-attachments/assets/3a37e8c9-ead6-4245-9904-350d11446162" />


task-5249231