### PR TITLE
[FIX] stock{, _picking_batch}: Hide column for invisible fields

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -114,8 +114,8 @@
                            decoration-muted="state == 'draft'"
                            decoration-success="state == 'done'"
                            decoration-warning="state not in ('draft','cancel','done','assigned')"/>
-                    <field name="activity_exception_decoration" widget="activity_exception"/>
-                    <field name="json_popover" widget="stock_rescheduling_popover" nolabel="1" invisible="not json_popover"/>
+                    <field name="activity_exception_decoration" widget="activity_exception" column_invisible="True"/>
+                    <field name="json_popover" widget="stock_rescheduling_popover" nolabel="1" invisible="not json_popover" column_invisible="True"/>
                 </tree>
             </field>
         </record>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -144,7 +144,7 @@
                 <field name="picking_type_id" readonly="state != 'draft'"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="state" widget="badge" decoration-success="state == 'done'" decoration-info="state in ('draft', 'in_progress')" decoration-danger="state == 'cancel'"/>
-                <field name="activity_exception_decoration" widget="activity_exception"/>
+                <field name="activity_exception_decoration" widget="activity_exception" column_invisible="True"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Issue: Blank, unused columns showed in Deliveries and Batch Transfers.
Repro Steps:
	Open Deliveries and see a right-side gap .
	Open Batch Transfers list and see a right-side gap.
	Open a Batch Transfer details shows left-side gap.

Cause:
	Rows were hidden, but their table columns stayed visible, so space was still reserved.

Fix:
	Deliveries: hide the rescheduling popover column and the activity indicator column at the column level.
	Batch Transfers list: hide the activity indicator column at the column level.
	Batch Transfer Detailed: hide the three quality-check button columns at the column level when the batch has no checks to do (keep row-level visibility when shown).

opw-5167229

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
