### PR TITLE
[FIX] hw_drivers: certificate retro compatibility

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from cryptography.x509 import Certificate
 from functools import wraps
-import platform
 import requests
 
 from . import server_logger
@@ -34,7 +32,3 @@ def set_user_agent(func):
 
 requests.get = set_user_agent(_get)
 requests.post = set_user_agent(_post)
-
-# Ensure cryptography compatibility with python < 3.13
-if platform.system() == 'Linux' and float(tools.helpers.get_version()[1:8]) < 2025.10:
-    Certificate.not_valid_after_utc = Certificate.not_valid_after


### PR DESCRIPTION
To avoid a deprecation warning on `x509.Certificate`, we switched from `not_valid_after` to `not_valid_after_utc`, and patched the newer version to point to the previous one if the iot box was before a certain version.

However this patch wasn't working properly as the certificate object isn't patchable (not python type).
We now call the specific method depending on the version everytime we need this attribute.

