### PR TITLE
[FIX] crm: preserve lead contact names on partner auto-assignment

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -666,12 +666,16 @@ class Lead(models.Model):
         return values
 
     def _prepare_contact_name_from_partner(self, partner):
+        if not partner:
+            return {'contact_name': self.contact_name}
         contact_name = False if partner.is_company else partner.name
         return {'contact_name': contact_name or self.contact_name}
 
     def _prepare_partner_name_from_partner(self, partner):
         """ Company name: name of partner parent (if set) or name of partner
         (if company) or company_name of partner (if not a company). """
+        if not partner:
+            return {'partner_name': self.partner_name}
         partner_name = partner.parent_id.name
         if not partner_name and partner.is_company:
             partner_name = partner.name


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a lead with manually entered contact_name and partner_name fields sends an email through a template, the _message_post_after_hook method automatically assigns a partner_id based on the email address. This triggers the computed fields _compute_contact_name and _compute_partner_name, which overwrite the manually entered values with data from the partner record, causing data loss.

Current behavior before PR:

1. User creates a lead with contact_name="person1", partner_name="company1", and email_from="person1@company1.com"
2. User sends an email template from the lead
3. System automatically finds/creates a partner and assigns it to partner_id
4. The _compute_contact_name and _compute_partner_name methods are triggered
5. Bug: Manual values are overwritten with partner data (e.g., contact_name changes from "person1" to "company1" if the partner is a company)

Desired behavior after PR is merged:

1. User creates a lead with contact_name="person1", partner_name="company1", and email_from="person1@company1.com"
2. User sends an email template from the lead
3. System automatically finds/creates a partner and assigns it to partner_id
4. The _compute_contact_name and _compute_partner_name methods are triggered
5. Fixed: Manual values are preserved when partner data is empty or missing (e.g., contact_name remains "person1")

Video with the problem: https://drive.google.com/file/d/1R0z6Rfni5J9b4iWpUxqKzyOvMIYjjMgA/view

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
