### PR TITLE
[FIX] sale: do not magically delete orders

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -98,14 +98,3 @@ class ResPartner(models.Model):
                 fields.Date.context_today(self)
             )
             partner.commercial_partner_id.credit_to_invoice += credit_company_currency
-
-    def unlink(self):
-        # Unlink draft/cancelled SO so that the partner can be removed from database
-        self.env['sale.order'].sudo().search([
-            ('state', 'in', ['draft', 'cancel']),
-            '|', '|',
-            ('partner_id', 'in', self.ids),
-            ('partner_invoice_id', 'in', self.ids),
-            ('partner_shipping_id', 'in', self.ids),
-        ]).unlink()
-        return super().unlink()


### PR DESCRIPTION
Versions
--------
- 17.0

Steps
-----
1. Create a new partner;
2. add an invoice and/or delivery address;
3. create a draft sales order for the partner;
4. unlink the invoice or delivery address.

Issue
-----
The draft order was magically deleted.

Cause
-----
An `unlink` override deletes any draft/cancelled orders linked to the address.

This behavior was removed for version 18.0+ via 7ad89d892f36, but is still present in 17.0.

Solution
--------
Backport 7ad89d892f36

opw-5220488
