### PR TITLE
[REF] mail, *: simplify code of message confirm delete slightly

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -2,7 +2,6 @@ import { AttachmentList } from "@mail/core/common/attachment_list";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
 import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
-import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { NavigableList } from "@mail/core/common/navigable_list";
 import { MAIL_PLUGINS, MAIL_SMALL_UI_PLUGINS } from "@mail/core/common/plugin/plugin_sets";
 import { useSuggestion } from "@mail/core/common/suggestion_hook";
@@ -808,14 +807,7 @@ export class Composer extends Component {
                 })
             );
         } else {
-            this.env.services.dialog.add(MessageConfirmDialog, {
-                message: composer.message,
-                onConfirm: () =>
-                    this.message.remove({
-                        removeFromThread: this.shouldHideFromMessageListOnDelete,
-                    }),
-                prompt: _t("Are you sure you want to bid farewell to this message forever?"),
-            });
+            composer.message.showDeleteConfirm(this);
         }
         this.suggestion?.clearRawMentions();
     }
@@ -944,9 +936,5 @@ export class Composer extends Component {
         if (Number.isInteger(config.replyToMessageId)) {
             composer.replyToMessage = this.store["mail.message"].insert(config.replyToMessageId);
         }
-    }
-
-    get shouldHideFromMessageListOnDelete() {
-        return false;
     }
 }

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -488,10 +488,6 @@ export class Message extends Component {
             { context: this }
         );
     }
-
-    get shouldHideFromMessageListOnDelete() {
-        return false;
-    }
 }
 
 discussComponentRegistry.add("Message", Message);

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -3,8 +3,6 @@ import { toRaw } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
 import { registry } from "@web/core/registry";
-import { discussComponentRegistry } from "./discuss_component_registry";
-import { Deferred } from "@web/core/utils/concurrency";
 import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
@@ -141,25 +139,7 @@ registerMessageAction("delete", {
     condition: ({ message }) => message.deletable,
     icon: "fa fa-trash",
     name: _t("Delete"),
-    onSelected: async ({ message: msg, owner, store }) => {
-        const message = toRaw(msg);
-        const def = new Deferred();
-        store.env.services.dialog.add(
-            discussComponentRegistry.get("MessageConfirmDialog"),
-            {
-                message,
-                prompt: _t("Are you sure you want to bid farewell to this message forever?"),
-                onConfirm: () => {
-                    def.resolve(true);
-                    message.remove({
-                        removeFromThread: owner.shouldHideFromMessageListOnDelete,
-                    });
-                },
-            },
-            { context: owner, onClose: () => def.resolve(false) }
-        );
-        return def;
-    },
+    onSelected: ({ message, owner }) => toRaw(message).showDeleteConfirm(owner),
     sequence: 120,
     tags: ACTION_TAGS.DANGER,
 });

--- a/addons/mail/static/src/core/common/message_confirm_dialog.js
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.js
@@ -18,9 +18,8 @@ export class MessageConfirmDialog extends Component {
     ];
     static defaultProps = {
         confirmColor: "btn-primary",
-        confirmText: _t("Delete"),
+        confirmText: _t("Confirm"),
         size: "xl",
-        title: _t("Send this message to the great trash can in the sky?"),
     };
     static template = "mail.MessageConfirmDialog";
 

--- a/addons/portal/static/src/chatter/frontend/composer_patch.js
+++ b/addons/portal/static/src/chatter/frontend/composer_patch.js
@@ -6,8 +6,4 @@ patch(Composer.prototype, {
     get showComposerAvatar() {
         return super.showComposerAvatar || (this.compact && this.props.composer.portalComment);
     },
-
-    get shouldHideFromMessageListOnDelete() {
-        return this.env.inFrontendPortalChatter || super.shouldHideFromMessageListOnDelete;
-    },
 });

--- a/addons/portal/static/src/chatter/frontend/message_model_patch.js
+++ b/addons/portal/static/src/chatter/frontend/message_model_patch.js
@@ -9,4 +9,7 @@ patch(Message.prototype, {
         }
         return result;
     },
+    shouldHideFromMessageListOnDelete(env) {
+        return env.inFrontendPortalChatter || super.shouldHideFromMessageListOnDelete(...arguments);
+    },
 });

--- a/addons/portal/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal/static/src/chatter/frontend/message_patch.js
@@ -12,8 +12,4 @@ patch(Message.prototype, {
         }
         return super.authorAvatarUrl;
     },
-
-    get shouldHideFromMessageListOnDelete() {
-        return this.env.inFrontendPortalChatter || super.shouldHideFromMessageListOnDelete;
-    },
 });

--- a/addons/project/static/src/project_sharing/chatter/composer_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/composer_patch.js
@@ -24,8 +24,4 @@ patch(Composer.prototype, {
         }
         return super.allowUpload;
     },
-
-    get shouldHideFromMessageListOnDelete() {
-        return true;
-    }
 });

--- a/addons/project/static/src/project_sharing/chatter/message_model_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/message_model_patch.js
@@ -1,0 +1,8 @@
+import { patch } from "@web/core/utils/patch";
+import { Message } from "@mail/core/common/message_model";
+
+patch(Message.prototype, {
+    shouldHideFromMessageListOnDelete(env) {
+        return env.projectSharingId || super.shouldHideFromMessageListOnDelete(...arguments);
+    },
+});

--- a/addons/project/static/src/project_sharing/chatter/message_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/message_patch.js
@@ -1,9 +1,0 @@
-import { Message } from "@mail/core/common/message";
-
-import { patch } from "@web/core/utils/patch";
-
-patch(Message.prototype, {
-    get shouldHideFromMessageListOnDelete() {
-        return true;
-    },
-});


### PR DESCRIPTION
- Share code of message deletion with `msg.showDeleteConfirm()`
- MessageConfirmDialog props are more neutral
- patch `shouldHideFromMessageListOnDelete` once per module

https://github.com/odoo/enterprise/pull/98793