### PR TITLE
19.0 fix contact import recruitment access

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -12,7 +12,7 @@ from collections import defaultdict, OrderedDict
 from werkzeug.exceptions import InternalServerError
 
 from odoo import http
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, AccessError
 from odoo.http import content_disposition, request
 from odoo.tools import osutil
 
@@ -320,10 +320,15 @@ class Export(http.Controller):
                 field_to_get = Model._field_to_sql(Model._table, definition_record, self_subquery)
                 domain_definition.append(('id', 'in', self_subquery.subselect(field_to_get)))
 
-            definition_records = target_model.search_fetch(
-                domain_definition, [definition_record_field, 'display_name'],
-                order='id',  # Avoid complex order
-            )
+            try:
+                definition_records = target_model.search_fetch(
+                    domain_definition, [definition_record_field, 'display_name'],
+                    order='id',  # Avoid complex order
+                )
+
+            except AccessError:
+                # Skip property fields from models the user cannot access
+                continue
 
             for record in definition_records:
                 for definition in record[definition_record_field]:

--- a/doc/cla/individual/emiliano-gandini-outeda.md
+++ b/doc/cla/individual/emiliano-gandini-outeda.md
@@ -1,0 +1,11 @@
+Uruguay, 2025-11-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Emiliano Gandini Outeda emiliano.outeda@gmail.com https://github.com/emiliano-gandini-outeda


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes #234103  
Importing contacts can fail with an AccessError if the system tries to
read property definitions from `hr.job` while the user lacks access to
Recruitment.

Current behavior before PR:
The import process crashes with an "AccessError" and the contacts are not imported.

Desired behavior after PR is merged:
Contact import completes normally. Property definitions that cannot be
accessed are safely skipped.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
