### PR TITLE
[IMP] base: mark database delete button danger

### DIFF
--- a/addons/web/static/src/public/database_manager.qweb.html
+++ b/addons/web/static/src/public/database_manager.qweb.html
@@ -256,7 +256,7 @@
                             </div>
                         </div>
                         <div class="modal-footer">
-                            <input type="submit" value="Delete" class="btn btn-primary float-end"/>
+                            <input type="submit" value="Delete" class="btn btn-danger float-end"/>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Make the two delete buttons both danger.

**Current behavior before PR:**
<img width="1776" height="956" alt="截图 2025-11-04 10-32-01" src="https://github.com/user-attachments/assets/f007959d-b952-40d3-9433-273eb478a6c3" />

**Desired behavior after PR is merged:**
<img width="1776" height="956" alt="截图 2025-11-04 10-31-31" src="https://github.com/user-attachments/assets/4a6c19dc-5a2a-4e2a-985b-10817cdafe4e" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
