### PR TITLE
[FIX] web: reverse search pattern to match reversed field strings in export dialog

### DIFF
--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -374,8 +374,10 @@ export class ExportDataDialog extends Component {
     }
 
     lookup(value) {
+        // Reverse the pattern to match the reversed field.string
+        const reversedPattern = value.split("/").reverse().join("/");
         let lookupResult = fuzzyLookup(
-            value,
+            reversedPattern,
             Object.values(this.knownFields),
             // because fuzzyLookup gives an higher score if the string starts with the pattern,
             // reversing the string makes the search more reliable in this context


### PR DESCRIPTION
The export dialog reverses field.string to prioritize field names over parent paths
in fuzzy search scoring. However, the search pattern was not reversed, causing
mismatches when searching with display names like "Order Lines/Product".

Before: pattern "Order Lines/Product" searched in reversed string "Product/Order Lines"
        → character order mismatch → no results

After:  both pattern and string are reversed → proper matching

This fix ensures searching by display names (e.g., "Order Lines/Product") works
as expected, while technical IDs (e.g., "order_line/product_id") continue to work
in debug mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
