### PR TITLE
[FIX] account: prevent error when adding an attachment after saving email template

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -245,6 +245,8 @@ class AccountMoveSendWizard(models.TransientModel):
     @api.depends('template_id')
     def _compute_model(self):
         for wizard in self:
+            if wizard.model:
+                continue
             wizard.model = self.env.context.get('active_model')
 
     # Similar of mail.compose.message


### PR DESCRIPTION
Currently, an error occurs when trying to add an attachment after saving an
invoice email as a template in the `Send wizard`.

**Steps to produce:**
- Install the `account` module.
- Create a new invoice, fill in all required details, then `confirm` and click `Send`.
- Click the `three-dot (⋮)` menu and select `Save as Template`, enter a name,
  and save the template.
- Try to add an attachment.

**Error:**
`AttributeError: 'account.move.send.wizard' object has no attribute '_mail_post_access'`
`AttributeError: 'account.move.send.wizard' object has no attribute '_get_thread_with_access'`

Root **cause:**
At [1], the code sets a new `template_id` when the template is saved. This
triggers `_compute_model()` at [2], which updates the model field to
`account.move.send.wizard` instead of `account.move`, using the `active_model`
context, causing the `error`.

**Fix:**
This commit ensures that after saving a mail template, the wizard retains the
correct model, same as [3], and prevents the attachment upload error.

[1]:
https://github.com/odoo/odoo/blob/5c6afcbffb49803a03e3a384ed60de68093dca04/addons/account/wizard/account_move_send_wizard.py#L296

[2]:
https://github.com/odoo/odoo/blob/5c6afcbffb49803a03e3a384ed60de68093dca04/addons/account/wizard/account_move_send_wizard.py#L244-L248

[3]:
https://github.com/odoo/odoo/blob/5c6afcbffb49803a03e3a384ed60de68093dca04/addons/mail/wizard/mail_compose_message.py#L380-L389

sentry-6987172677