### PR TITLE
[FIX] bus: implement application level connection checks

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -50,6 +50,7 @@ const logger = new Logger("bus_websocket_worker");
 export class WebsocketWorker {
     INITIAL_RECONNECT_DELAY = 1000;
     RECONNECT_JITTER = 1000;
+    CONNECTION_CHECK_DELAY = 60_000;
 
     constructor(name) {
         this.name = name;
@@ -352,6 +353,7 @@ export class WebsocketWorker {
      * closed.
      */
     _onWebsocketClose({ code, reason }) {
+        clearInterval(this._connectionCheckInterval);
         this._logDebug("_onWebsocketClose", code, reason);
         this._updateState(WORKER_STATE.DISCONNECTED);
         this.lastChannelSubscription = null;
@@ -399,6 +401,7 @@ export class WebsocketWorker {
      * @param {MessageEvent} messageEv
      */
     _onWebsocketMessage(messageEv) {
+        this._restartConnectionCheckInterval();
         const notifications = JSON.parse(messageEv.data);
         this._logDebug("_onWebsocketMessage", notifications);
         this.lastNotificationId = notifications[notifications.length - 1].id;
@@ -439,6 +442,27 @@ export class WebsocketWorker {
             this.messageWaitQueue.forEach((msg) => this.websocket.send(msg));
             this.messageWaitQueue = [];
         });
+        this._restartConnectionCheckInterval();
+    }
+
+    /**
+     * Sends a custom application-level message to perform a connection check
+     * on the WebSocket.
+     *
+     * Browsers rely on the OS's TCP mechanism, which can take minutes or
+     * hours to detect a dead connection. Sending data triggers an immediate
+     * I/O operation, quickly revealing any network-level failure. This must be
+     * implemented at the application level because the browser WebSocket API
+     * does not expose the built-in ping/pong mechanism.
+     */
+    _restartConnectionCheckInterval() {
+        clearInterval(this._connectionCheckInterval);
+        this._connectionCheckInterval = setInterval(() => {
+            if (this._isWebsocketConnected()) {
+                this.websocket.send(new Uint8Array([0x00]));
+                this._logDebug("connection_checked");
+            }
+        }, this.CONNECTION_CHECK_DELAY);
     }
 
     /**
@@ -478,6 +502,7 @@ export class WebsocketWorker {
             } else {
                 this.firstSubscribeDeferred.then(() => this.websocket.send(payload));
             }
+            this._restartConnectionCheckInterval();
         }
     }
 

--- a/addons/bus/static/tests/mock_websocket.js
+++ b/addons/bus/static/tests/mock_websocket.js
@@ -92,6 +92,17 @@ patch(MockServer.prototype, {
 patch(WebsocketWorker.prototype, {
     INITIAL_RECONNECT_DELAY: 0,
     RECONNECT_JITTER: 5,
+    // `runAllTimers` advances time based on the longest registered timeout.
+    // Some tests rely on the fragile assumption that time won’t advance too much.
+    // Disable the interval until those tests are rewritten to be more robust.
+    enableCheckInterval: false,
+
+    _restartConnectionCheckInterval() {
+        if (this.enableCheckInterval) {
+            super._restartConnectionCheckInterval(...arguments);
+        }
+    },
+
     _sendToServer(message) {
         const { env } = MockServer;
         if (!env) {

--- a/addons/bus/static/tests/websocket_worker.test.js
+++ b/addons/bus/static/tests/websocket_worker.test.js
@@ -1,5 +1,5 @@
 import { getWebSocketWorker } from "@bus/../tests/mock_websocket";
-import { describe, expect, test } from "@odoo/hoot";
+import { advanceTime, describe, expect, test } from "@odoo/hoot";
 import { runAllTimers } from "@odoo/hoot-dom";
 import {
     asyncStep,
@@ -104,4 +104,49 @@ test("disconnect event is sent when stopping the worker", async () => {
     worker._stop();
     await runAllTimers();
     await expect.waitForSteps(["broadcast disconnect"]);
+});
+
+test("check connection health during inactivity", async () => {
+    const ogSocket = window.WebSocket;
+    let waitingForCheck = true;
+    patchWithCleanup(window, {
+        WebSocket: function () {
+            const ws = new ogSocket(...arguments);
+            ws.send = (message) => {
+                if (waitingForCheck && message instanceof Uint8Array) {
+                    expect.step("check_connection_health_sent");
+                    waitingForCheck = false;
+                }
+            };
+            return ws;
+        },
+    });
+    const worker = await startWebSocketWorker((type) => {
+        if (type === "connect") {
+            expect.step(`broadcast ${type}`);
+        }
+    });
+    patchWithCleanup(worker, {
+        enableCheckInterval: true,
+        _restartConnectionCheckInterval() {
+            expect.step("_restartConnectionCheckInterval");
+            super._restartConnectionCheckInterval();
+        },
+        _sendToServer(payload) {
+            if (payload.event_name === "foo") {
+                super._sendToServer(payload);
+            }
+        },
+    });
+    await expect.waitForSteps(["broadcast connect", "_restartConnectionCheckInterval"]);
+    worker.websocket.dispatchEvent(
+        new MessageEvent("message", {
+            data: JSON.stringify([{ id: 70, message: { type: "foo" } }]),
+        })
+    );
+    await expect.waitForSteps(["_restartConnectionCheckInterval"]);
+    worker._sendToServer({ event_name: "foo" });
+    await expect.waitForSteps(["_restartConnectionCheckInterval"]);
+    await advanceTime(worker.CONNECTION_CHECK_DELAY + 1000);
+    await expect.waitForSteps(["check_connection_health_sent"]);
 });

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -958,7 +958,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "saas-18.3-6"
+    _VERSION = "saas-18.3-7"
 
     @classmethod
     def websocket_allowed(cls, request):
@@ -1101,6 +1101,9 @@ class WebsocketConnectionHandler:
             # worker version.
             websocket.close(CloseCode.CLEAN, "OUTDATED_VERSION")
         for message in websocket.get_messages():
+            if message == b'\x00':
+                # Ignore internal sentinel message used to detect dead/idle connections.
+                continue
             with WebsocketRequest(db, httprequest, websocket) as req:
                 try:
                     req.serve_websocket_message(message)


### PR DESCRIPTION
When a TCP connection is not closed cleanly, it can take minutes to detect a closed WebSocket connection. During this time, no messages are received. This can happen in slow or unstable network conditions.

Browsers do not expose WebSocket ping/pong mechanisms. To detect dead connections quickly, periodic application level messages are sent if no messages were either sent or received within a minute.

This approach ensures quicker detection compared to relying on the OS TCP timeout, which is typically set to a high value.

X-original-commit: d043e12

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
