### PR TITLE
[FIX] hr: add activity filters to employee contract templates

### DIFF
--- a/addons/hr/views/hr_version_views.xml
+++ b/addons/hr/views/hr_version_views.xml
@@ -82,6 +82,13 @@
                 <filter string="Contract End Date" name="contract_date_end" date="contract_date_end"/>
                 <separator />
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
+                <filter invisible="1" string="Late Activities" name="activities_overdue"
+                    domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
+                    help="Show all records whose next activity date is past"/>
+                <filter invisible="1" string="Today Activities" name="activities_today"
+                    domain="[('my_activity_date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
+                <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
+                    domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
 
                 <filter string="Employee" name="group_by_employee" domain="[]" context="{'group_by': 'employee_id'}"/>
                 <separator />


### PR DESCRIPTION
The contract template’s activity view incorrectly displays all contracts, 
instead of only those with assigned activities.

**Steps to reproduce this issue:**
1) Install the hr module.
2) Open Employees → Employees → Contract Templates. 
3) Create multiple contract templates and add an activity to one of them. 
4) Open the activities from the Activities (top right corner).

**Issue:**
You will end up in the all contract templates list, with no filters applied.

**Cause:**
When the user clicks on the activities, a default search filter is added in the context, 
which is then applied to the view.

But in the contract template, we don't have any search filters for the activities. 
Therefore, it renders all contract records.

**Solution:**
Add the activity search filters for the contract template records.

opw-5209691
