### PR TITLE
[FIX] website: Make menu inherit header font-size

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -423,6 +423,8 @@ $-navbar-mobile-bg-color: o-color('menu-custom') or o-color('menu');
         }
 
         .accordion-button {
+            font-size: inherit;
+
             &:not(.collapsed) {
                 @if $-navbar-mobile-bg-color != null {
                     background-color: shade-color($-navbar-mobile-bg-color, 5%);


### PR DESCRIPTION
Steps to reproduce:
===================
- Create a menu and a submenu
- Change the header template to the hamburger menu
- Update the navbar format ->The format of the submenu's parent is not updated.

Cause:
======
The menu in the hamburger layout uses the `.accordion-button` class, which applies a fixed base font size defined here: https://github.com/odoo/odoo/blob/ebb250d3b56970c09ffb5ebefef38f97c622c33d/addons/web/static/lib/bootstrap/scss/_accordion.scss#L37 This prevents the submenu text from inheriting the updated header font-size.

Solution:
=========
Allow the `.accordion-button` font size to inherit from its parent. This ensures that submenu text correctly follows the header's font-size setting.

opw-5223664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
