### PR TITLE
[IMP] core: -t alias for --test-tags and --stop alias for --stop-after-init

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -420,7 +420,7 @@ class configmanager:
                               "- replica: simulate a deployment with readonly replica "
                               "- werkzeug: open a html debugger on http request error "
                               "- xml: read views from the source code, and not the db ")
-        group.add_option("--stop-after-init", action="store_true", dest="stop_after_init", my_default=False, file_exportable=False, file_loadable=False,
+        group.add_option("--stop", "--stop-after-init", action="store_true", dest="stop_after_init", my_default=False, file_exportable=False, file_loadable=False,
                          help="stop the server after its initialization")
         group.add_option("--osv-memory-count-limit", dest="osv_memory_count_limit", my_default=0,
                          help="Force a limit on the maximum number of records kept in the virtual "

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -274,7 +274,7 @@ class configmanager:
                          help="Launch a python test file.")
         group.add_option("--test-enable", dest='test_enable', action="store_true", file_loadable=False,
                          help="Enable unit tests. Implies --stop-after-init")
-        group.add_option("--test-tags", dest="test_tags", file_loadable=False,
+        group.add_option("-t", "--test-tags", dest="test_tags", file_loadable=False,
                          help="Comma-separated list of specs to filter which tests to execute. Enable unit tests if set. "
                          "A filter spec has the format: [-][tag][/module][:class][.method][[params]] "
                          "The '-' specifies if we want to include or exclude tests matching this spec. "


### PR DESCRIPTION
**[IMP] core: --stop alias for --stop-after-init**
**[IMP] core: -t alias for --test-tags**

Let's merge them in master first. My end goal would be to backport them to 16/17, along with [[IMP] config: stop after init after tests](odoo/odoo#178948)