### PR TITLE
[FIX] account_peppol: Fix writes in batch in Peppol verification

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -221,8 +221,10 @@ class ResPartner(models.Model):
             self.account_peppol_is_endpoint_valid = False
         else:
             edi_identification = f'{self.peppol_eas}:{self.peppol_endpoint}'.lower()
-            self.account_peppol_validity_last_check = fields.Date.context_today(self)
-            self.account_peppol_is_endpoint_valid = bool(self._check_peppol_participant_exists(edi_identification, ubl_cii_format=self.ubl_cii_format))
+            self.write({
+                'account_peppol_validity_last_check': fields.Date.context_today(self),
+                'account_peppol_is_endpoint_valid': bool(self._check_peppol_participant_exists(edi_identification, ubl_cii_format=self.ubl_cii_format)),
+            })
 
             if (
                 not self.account_peppol_is_endpoint_valid
@@ -231,7 +233,9 @@ class ResPartner(models.Model):
                 inverse_eas = '9925' if self.peppol_eas == '0208' else '0208'
                 inverse_endpoint = f'BE{self.peppol_endpoint}' if self.peppol_eas == '0208' else self.peppol_endpoint[2:]
                 if self._check_peppol_participant_exists(f'{inverse_eas}:{inverse_endpoint}', ubl_cii_format=self.ubl_cii_format):
-                    self.peppol_eas = inverse_eas
-                    self.peppol_endpoint = inverse_endpoint
-                    self.account_peppol_is_endpoint_valid = True
+                    self.write({
+                        'peppol_eas': inverse_eas,
+                        'peppol_endpoint': inverse_endpoint,
+                        'account_peppol_is_endpoint_valid': True,
+                    })
         return False


### PR DESCRIPTION
In some cases, when doing two consequent writes instead of one batch, the ORM will trigger the dependencies needlessly, and it can end up to discrepancies like: EAS=0208, endpoint=BE... which lead to a validation error.

opw-5228670
opw-5225590
opw-5228716
opw-5229057
opw-5232276
