### PR TITLE
[IMP] website: link state field to country field in form builder

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_field_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_field_option.js
@@ -96,6 +96,14 @@ export class FormFieldOption extends BaseOptionComponent {
             };
         });
 
+        this.canLinkStateToCountry = useDomState((el) => {
+            const formEl = el.closest("form");
+            const hasCountryField = !!formEl.querySelector(
+                ".s_website_form_input[name='country_id']"
+            );
+            return { value: getFieldName(el) === "state_id" && hasCountryField };
+        });
+
         onWillStart(async () => {
             const el = this.env.getEditingElement();
             const fieldOptionData = await loadFieldOptionData(el);

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -159,6 +159,10 @@
             <BuilderButton title.translate="Right" actionValue="'right'" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>
         </BuilderButtonGroup>
     </BuilderRow>
+    <BuilderRow label.translate="Link to country">
+        <BuilderCheckbox action="'linkStateToCountry'" t-if="this.canLinkStateToCountry.value"
+            id="'link_state_to_country_opt'" applyTo="'.s_website_form_input'"/>
+    </BuilderRow>
     <BuilderRow label.translate="Description">
         <BuilderCheckbox action="'toggleDescription'" preview="false"/>
     </BuilderRow>
@@ -212,7 +216,7 @@
             applyWithUnit="false"
         />
     </BuilderRow>
-    <BuilderRow t-if="state.valueList">
+    <BuilderRow t-if="state.valueList and (!(this.domState.fieldName === 'state_id' and isActiveItem('link_state_to_country_opt')))">
         <div class="d-flex flex-column w-100">
             <p class="hb-row-label mb-0 flex-grow-0 flex-shrink-0 flex-basis-auto">
                 <t t-out="state.valueList.title" />

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -1430,18 +1430,7 @@ export class SetFormCustomFieldValueListAction extends BuilderAction {
         return this.dependencies.websiteFormOption.prepareFields(context);
     }
     apply({ editingElement: fieldEl, value, loadResult: fields }) {
-        let valueList = JSON.parse(value);
-        if (getSelect(fieldEl)) {
-            valueList = valueList.filter((value) => value.id !== "" || value.display_name !== "");
-            const hasDefault = valueList.some((value) => value.selected);
-            if (valueList.length && !hasDefault) {
-                valueList.unshift({
-                    id: "",
-                    display_name: "",
-                    selected: true,
-                });
-            }
-        }
+        const valueList = JSON.parse(value);
         const field = getActiveField(fieldEl, { fields });
         field.records = valueList;
         this.dependencies.websiteFormOption.replaceField(fieldEl, field, fields);

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -284,6 +284,11 @@ export function setActiveProperties(fieldEl, field) {
     field.modelRequired = classList.contains("s_website_form_model_required");
     field.hidden = classList.contains("s_website_form_field_hidden");
     field.formatInfo = getFieldFormat(fieldEl);
+    // this is needed to link states to the country
+    if (field.name === "state_id") {
+        field.linkStateToCountry =
+            fieldEl.querySelector(".s_website_form_input").dataset.linkStateToCountry !== "false";
+    }
 }
 
 /**
@@ -501,6 +506,24 @@ export function getModelName(formEl) {
     return formEl.dataset.model_name || "mail.mail";
 }
 
+export function getFormCacheKey(formEl) {
+    // Combine model and fields into cache key.
+    const model = getModelName(formEl);
+    const propertyOrigins = {};
+    const parts = [model];
+    for (const hiddenInputEl of [...formEl.querySelectorAll("input[type=hidden]")].sort(
+        (firstEl, secondEl) => firstEl.name.localeCompare(secondEl.name)
+    )) {
+        // Pushing using the name order to avoid being impacted by the
+        // order of hidden fields within the DOM.
+        parts.push(hiddenInputEl.name);
+        parts.push(hiddenInputEl.value);
+        propertyOrigins[hiddenInputEl.name] = hiddenInputEl.value;
+    }
+    const cacheKey = parts.join("/");
+    return { cacheKey, model, propertyOrigins };
+}
+
 export function getListItems(fieldEl) {
     const selectEl = getSelect(fieldEl);
     const multipleInputsEl = getMultipleInputs(fieldEl);
@@ -512,11 +535,15 @@ export function getListItems(fieldEl) {
     }
     return options.map((opt) => {
         const name = selectEl ? opt : opt.nextElementSibling;
-        return {
+        const res = {
             id: isSmallInteger(opt.value) ? parseInt(opt.value) : opt.value,
             display_name: name.textContent.trim(),
             selected: selectEl ? opt.selected : opt.checked,
         };
+        if (opt.dataset.countryId) {
+            res.country_id = [parseInt(opt.dataset.countryId), ""];
+        }
+        return res;
     });
 }
 

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -122,6 +122,18 @@ export function renderField(field, resetId = false) {
     if (!field.id) {
         field.id = generateHTMLId();
     }
+    if (field.records && (field.type === "many2one" || field.type === "selection")) {
+        const hasDefault =
+            field.records[0]?.["display_name"] === "" ||
+            field.records.some((value) => value.selected);
+        if (!hasDefault) {
+            field.records.unshift({
+                id: "",
+                display_name: "",
+                selected: true,
+            });
+        }
+    }
     const params = { field: { ...field } };
     if (["url", "email", "tel"].includes(field.type)) {
         params.field.inputType = field.type;

--- a/addons/website/static/src/interactions/state_form_field.js
+++ b/addons/website/static/src/interactions/state_form_field.js
@@ -1,0 +1,81 @@
+import { registry } from "@web/core/registry";
+import { renderToMarkup } from "@web/core/utils/render";
+import { Interaction } from "@web/public/interaction";
+
+export class StateFormField extends Interaction {
+    static selector =
+        ".s_website_form:has([name='country_id']) .s_website_form_input[data-link-state-to-country='true']";
+    dynamicSelectors = {
+        ...this.dynamicSelectors,
+        _countryField: () =>
+            this.el
+                .closest(".s_website_form")
+                .querySelector(".s_website_form_input[name='country_id']"),
+    };
+    dynamicContent = {
+        _root: {
+            "t-on-change": this.onStateFieldChange,
+            "t-out": this.getStateOptions,
+        },
+        _countryField: {
+            "t-on-change": this.onCountryFieldChange,
+        },
+    };
+
+    setup() {
+        // Cloning ensures we keep a detached copy
+        this.allOptions = Array.from(this.el.querySelectorAll("option")).map((opt) => {
+            opt.removeAttribute("selected");
+            return opt.cloneNode(true);
+        });
+
+        this.countryField = this.el
+            .closest("form")
+            .querySelector(".s_website_form_input[name='country_id']");
+        this.selectedCountryId =
+            this.countryField.value || this.countryField.querySelector("[selected]")?.value || "";
+
+        this.availableCountriesIds = Array.from(this.countryField.querySelectorAll("option")).map(
+            (opt) => opt.value
+        );
+    }
+
+    onCountryFieldChange() {
+        this.selectedCountryId = this.countryField.value;
+    }
+
+    onStateFieldChange() {
+        this.selectedStateId = this.el.value;
+        if (!this.selectedStateId) {
+            return;
+        }
+        this.selectedCountryId =
+            Array.from(this.el.options).find((option) => option.value === this.selectedStateId)
+                ?.dataset.countryId || "";
+        this.countryField.value = this.selectedCountryId;
+    }
+
+    getStateOptions() {
+        const optionsToRender = this.allOptions.filter(
+            (option) =>
+                (!this.selectedCountryId &&
+                    this.availableCountriesIds.includes(option.dataset.countryId)) ||
+                !option.value ||
+                option.dataset.countryId === this.selectedCountryId
+        );
+
+        // disable the field if there's no valid option to select
+        this.el.disabled = optionsToRender.length <= 1 && !optionsToRender[0]?.value;
+
+        return renderToMarkup(
+            "website.form_state_input_field",
+            {
+                optionsToRender,
+                selectedStateId: this.selectedStateId,
+            },
+            this.el
+        );
+    }
+}
+
+registry.category("public.interactions").add("website.state_form_field", StateFormField);

--- a/addons/website/static/src/interactions/state_form_field.xml
+++ b/addons/website/static/src/interactions/state_form_field.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.form_state_input_field">
+    <t t-foreach="optionsToRender" t-as="option" t-key="option_index">
+        <option t-att-id="option.id" t-att-value="option.value"
+            t-att-data-country-id="option.dataset.countryId" t-out="option.innerHTML"
+            t-attf-selected="{{option.value === selectedStateId ? 'selected' : undefined}}" />
+    </t>
+</t>
+
+</templates>

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -51,7 +51,17 @@ export class Form extends Interaction {
         },
         // Do not disable inputs that are required for the model.
         ".s_website_form_field:not(.s_website_form_model_required) .s_website_form_input": {
-            "t-att-disabled": (el) => !this.isInputVisible(el) || undefined,
+            "t-att-disabled": (el) => {
+                if (!this.isInputVisible(el)) {
+                    this.disabledInputEls.add(el);
+                    return true;
+                }
+                if (el.disabled && !this.disabledInputEls.has(el)) {
+                    return true;
+                }
+
+                this.disabledInputEls.delete(el);
+            },
         },
         ".s_website_form_datetime, .o_website_form_datetime, .s_website_form_date, .o_website_form_date":
             {
@@ -69,6 +79,7 @@ export class Form extends Interaction {
         this.disabledStates = new Map();
         this.visibilityFunctionByFieldEl = new Map();
         this.visibilityFunctionByFieldName = new Map();
+        this.disabledInputEls = new Set();
         this.inputEls = this.el.querySelectorAll(
             ".s_website_form_field.s_website_form_field_hidden_if .s_website_form_input"
         );

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -279,9 +279,15 @@
         <!-- Generic one2many -->
         <t t-if="field.relation !== 'ir.attachment'">
             <t t-call="website.form_field">
-                <select class="form-select s_website_form_input" t-att-name="field.name" t-att-required="field.required || field.modelRequired || None" t-att-id="field.id">
+                <select class="form-select s_website_form_input" t-att-name="field.name"
+                    t-att-required="field.required || field.modelRequired || None" t-att-id="field.id"
+                    t-attf-data-link-state-to-country="{{ field.name == 'state_id' and field.linkStateToCountry ? 'true' : 'false' }}">
                     <t t-foreach="field.records" t-as="record" t-key="record_index">
-                        <option t-out="record.display_name" t-att-id="field.id + record_index" t-att-value="record.id" t-att="{selected: record.selected and 'selected' or None}"/>
+                        <option t-out="record.display_name" t-att-id="field.id + record_index" t-att-value="record.id"
+                            t-att="{
+                                selected: record.selected and 'selected' or None,
+                                'data-country-id': field.name == 'state_id' and (record.country_id and record.country_id[0]) or None
+                            }" />
                     </t>
                 </select>
             </t>

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -435,3 +435,77 @@ test("Last list entry cannot be removed", async () => {
     await contains(".options-container .builder_list_add_item").click();
     expect(".options-container .builder_list_remove_item").toHaveCount(2);
 });
+
+test("Can link states to a country", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(
+        `<section class="s_website_form"><form data-model_name="mail.mail">
+            <div data-name="Country" class="s_website_form_field s_website_form_custom" data-type="many2one">
+                <div>
+                    <label class="s_website_form_label" for="country">
+                        <span class="s_website_form_label_content">Country</span>
+                    </label>
+                    <div>
+                        <select class="form-select s_website_form_input" name="country_id" id="country">
+                            <option value=""></option>
+                            <option value="1" selected="selected">Country 1 (A)</option>
+                            <option value="2">Country 2 (B)</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div data-name="State" class="s_website_form_field s_website_form_custom" data-type="many2one">
+                <div>
+                    <label class="s_website_form_label" for="state">
+                        <span class="s_website_form_label_content">State</span>
+                    </label>
+                    <div>
+                        <select class="form-select s_website_form_input" name="state_id" id="state">
+                            <option value=""></option>
+                            <option data-country-id="1" value="s1">State 1 (A)</option>
+                            <option data-country-id="2" value="s2">State 2 (B)</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </form></section>`
+    );
+    await contains(":iframe select[name='state_id']").click();
+    expect(".options-container .hb-row [data-action-id='linkStateToCountry']").toHaveCount(1);
+    expect(
+        ".options-container .hb-row [data-action-id='linkStateToCountry'] input"
+    ).not.toBeChecked();
+    expect(".options-container .hb-row p:contains('Option List')").toHaveCount(1);
+
+    await contains(
+        ".options-container .hb-row [data-action-id='linkStateToCountry'] input"
+    ).click();
+
+    expect(".options-container .hb-row [data-action-id='linkStateToCountry'] input").toBeChecked();
+    expect(".options-container .hb-row :contains('Option List')").toHaveCount(0);
+    expect(":iframe select[name='state_id']").toHaveAttribute("data-link-state-to-country", "true");
+});
+
+test("Shouldn't have the 'Link to country' option if there's no country field", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(
+        `<section class="s_website_form"><form data-model_name="mail.mail">
+            <div data-name="State" class="s_website_form_field s_website_form_custom" data-type="many2one">
+                <div>
+                    <label class="s_website_form_label" for="state">
+                        <span class="s_website_form_label_content">State</span>
+                    </label>
+                    <div>
+                        <select class="form-select s_website_form_input" name="state_id" id="state">
+                            <option value=""></option>
+                            <option data-country-id="1" value="s1">State 1 (A)</option>
+                            <option data-country-id="2" value="s2">State 2 (B)</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </form></section>`
+    );
+    await contains(":iframe select[name='state_id']").click();
+    expect(".options-container .hb-row[data-action-id='linkStateToCountry']").toHaveCount(0);
+});

--- a/addons/website/static/tests/interactions/state_form_field.test.js
+++ b/addons/website/static/tests/interactions/state_form_field.test.js
@@ -84,3 +84,18 @@ test("Country selected should be updated when changing state", async () => {
     await animationFrame();
     expect(".s_website_form_input[name='country_id']").toHaveValue("2");
 });
+
+test("When the selected country has no states, the state field should be disabled", async () => {
+    const { core } = await startInteractions(formEl);
+
+    expect(core.interactions).toHaveLength(1);
+    const countryField = queryOne(".s_website_form_input[name='country_id']");
+
+    expect(".s_website_form_input[name='state_id']").not.toHaveAttribute("disabled", "disabled");
+
+    countryField.value = "3";
+    countryField.dispatchEvent(new Event("change"));
+    await animationFrame();
+
+    expect(".s_website_form_input[name='state_id']").toHaveAttribute("disabled");
+});

--- a/addons/website/static/tests/interactions/state_form_field.test.js
+++ b/addons/website/static/tests/interactions/state_form_field.test.js
@@ -1,0 +1,86 @@
+import { animationFrame, describe, expect, queryAll, queryOne, test } from "@odoo/hoot";
+import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
+
+setupInteractionWhiteList("website.state_form_field");
+
+describe.current.tags("interaction_dev");
+
+const formEl = `<section class="s_website_form"><form data-model_name="mail.mail">
+        <div data-name="Country" class="s_website_form_field s_website_form_custom" data-type="many2one">
+            <div>
+                <label class="s_website_form_label" for="country">
+                    <span class="s_website_form_label_content">Country</span>
+                </label>
+                <div>
+                    <select class="form-select s_website_form_input" name="country_id" id="country">
+                        <option value=""></option>
+                        <option value="1" selected="selected">Country 1 (A)</option>
+                        <option value="2">Country 2 (B)</option>
+                        <option value="3">Country 3 (C)</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div data-name="State" class="s_website_form_field s_website_form_custom" data-type="many2one">
+            <div>
+                <label class="s_website_form_label" for="state">
+                    <span class="s_website_form_label_content">State</span>
+                </label>
+                <div>
+                    <select class="form-select s_website_form_input" data-link-state-to-country="true" name="state_id" id="state">
+                        <option value=""></option>
+                        <option data-country-id="1" value="s1">State 1 (A)</option>
+                        <option data-country-id="2" value="s2">State 2 (B)</option>
+                        <option data-country-id="2" value="s3">State 3 (B)</option>
+                        <option data-country-id="1" value="s4">State 4 (A)</option>
+                        <option data-country-id="2" value="s5">State 5 (B)</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </form></section>`;
+
+test("States are linked to the selected country", async () => {
+    const { core } = await startInteractions(formEl);
+
+    expect(core.interactions).toHaveLength(1);
+
+    expect(".s_website_form_input[name='country_id']").toHaveValue("1");
+    expect(".s_website_form_input[name='state_id'] > option").toHaveCount(3);
+    expect(
+        queryAll(".s_website_form_input[name='state_id'] > option").every(
+            (option) => !option.value || option.dataset.countryId === "1"
+        )
+    ).toBe(true);
+
+    const countryField = queryOne(".s_website_form_input[name='country_id']");
+    countryField.value = "2";
+    countryField.dispatchEvent(new Event("change"));
+    await animationFrame();
+
+    expect(".s_website_form_input[name='state_id'] > option").toHaveCount(4);
+    expect(
+        queryAll(".s_website_form_input[name='state_id'] > option").every(
+            (option) => !option.value || option.dataset.countryId === "2"
+        )
+    ).toBe(true);
+});
+
+test("Country selected should be updated when changing state", async () => {
+    const { core } = await startInteractions(formEl);
+
+    expect(core.interactions).toHaveLength(1);
+    const countryField = queryOne(".s_website_form_input[name='country_id']");
+    const stateField = queryOne(".s_website_form_input[name='state_id']");
+
+    countryField.value = "";
+    countryField.dispatchEvent(new Event("change"));
+    await animationFrame();
+
+    expect(".s_website_form_input[name='country_id']").toHaveValue("");
+    expect(".s_website_form_input[name='state_id'] > option").toHaveCount(6);
+    stateField.value = "s5";
+    stateField.dispatchEvent(new Event("change"));
+    await animationFrame();
+    expect(".s_website_form_input[name='country_id']").toHaveValue("2");
+});


### PR DESCRIPTION
Before this commit, form state and country fields were independent of each other. So for example, when a user selected a country, the state field did not update to show only the states related to the selected country, and it displayed all states instead.

task-5038843