### PR TITLE
[FIX] website_sale: fix ribbon public access

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1057,7 +1057,7 @@ class ProductTemplate(models.Model):
         :rtype: `product.ribbon` recordset
         """
         variant = variant or self.product_variant_id
-        ribbon = variant.variant_ribbon_id or self.sudo().website_ribbon_id
+        ribbon = variant.sudo().variant_ribbon_id or self.sudo().website_ribbon_id
         if not ribbon:
             # The None check ensures that we do not recompute the ribbons when no ribbons were
             # previously found.

--- a/addons/website_sale/security/ir.model.access.csv
+++ b/addons/website_sale/security/ir.model.access.csv
@@ -21,7 +21,9 @@ access_product_pricelist_public_employee,product.pricelist.public,product.model_
 access_product_pricelist_item_public_public,product.pricelist.item.public,product.model_product_pricelist_item,base.group_public,1,0,0,0
 access_product_pricelist_item_public_portal,product.pricelist.item.public,product.model_product_pricelist_item,base.group_portal,1,0,0,0
 access_product_pricelist_item_public_employee,product.pricelist.item.public,product.model_product_pricelist_item,base.group_user,1,0,0,0
-access_product_ribbon_public,product.ribbon.public,website_sale.model_product_ribbon,base.group_user,1,0,0,0
+access_product_ribbon_public_public,product.ribbon.public,website_sale.model_product_ribbon,base.group_public,1,0,0,0
+access_product_ribbon_public_portal,product.ribbon.public,website_sale.model_product_ribbon,base.group_portal,1,0,0,0
+access_product_ribbon_public_employee,product.ribbon.public,website_sale.model_product_ribbon,base.group_user,1,0,0,0
 access_product_ribbon_sale_manager,product.ribbon.sale_manager,website_sale.model_product_ribbon,sales_team.group_sale_manager,1,1,1,1
 access_product_attribute_public_public,product.attribute public,product.model_product_attribute,base.group_public,1,0,0,0
 access_product_attribute_public_portal,product.attribute public,product.model_product_attribute,base.group_portal,1,0,0,0


### PR DESCRIPTION
### Issue:
An access error is shown on the website if ribbon is added to a product variant.

#### To reproduce:
1- Create a db with `website_sale` installed.
2- Activate product variant.
3- Create a product variant and publish it.
4- Add a ribbon to the variant.
5- Using public user, navigate to the website product page.

#### Cause:
This is caused due to not having proper access rights. On stable we can use both the csv modification and adding sudo env to have an easier view update without need to upgrade the module.
In master, we can keep the fix only in the csv file.

opw-5224552
