### PR TITLE
[FIX] hr_recruitment: use correct menu name

### DIFF
--- a/addons/hr_recruitment/models/ir_ui_menu.py
+++ b/addons/hr_recruitment/models/ir_ui_menu.py
@@ -10,7 +10,7 @@ class IrUiMenu(models.Model):
         res = super()._load_menus_blacklist()
         is_interviewer = self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer')
         is_user = self.env.user.has_group('hr_recruitment.group_hr_recruitment_user')
-        job_menu = self.env.ref('hr_recruitment.menu_hr_job', raise_if_not_found=False)
+        job_menu = self.env.ref('hr.menu_view_hr_job', raise_if_not_found=False)
         pos_menu = self.env.ref('hr_recruitment.menu_hr_job_position', raise_if_not_found=False)
         int_menu = self.env.ref('hr_recruitment.menu_hr_job_position_interviewer', raise_if_not_found=False)
         if job_menu and not is_interviewer:


### PR DESCRIPTION
used wrong name in this forward-port: 4e847de16a71cb03cb21e05c6d535f6abfae0287

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
