### PR TITLE
[FIX] mail: update guest name in member list when join using welcome page

### DIFF
--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -35,9 +35,9 @@ export class WelcomePage extends Component {
         }
     }
 
-    joinChannel() {
+    async joinChannel() {
         if (this.store.self.type === "guest") {
-            this.store.self.updateGuestName(this.state.userName.trim());
+            await this.store.self.updateGuestName(this.state.userName.trim());
         }
         browser.localStorage.setItem("discuss_call_preview_join_mute", !this.state.audioStream);
         browser.localStorage.setItem(


### PR DESCRIPTION

**Steps to Reproduce:**
- Login with Admin, start a meeting, open the member list.
- Join the meeting with a guest, using the invite link.
- Change the guest name from the welcome page.
- Admin member list doesn't show updated guest name.

**Current behavior before PR:**

Before this PR, the guest appeared as `Guest` in the member list 
even after updating their name on the welcome page.

**Desired behavior after PR is merged:**

This PR ensures the guest name is updated and displayed instantly 
upon joining, providing a smoother and more consistent experience.

task-[5062702](https://www.odoo.com/odoo/project/1519/tasks/5062702)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
