### PR TITLE
[FIX] base: don't filter out attachment fields with bypass access

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -598,6 +598,7 @@ class IrAttachment(models.Model):
         if (
             not self.env.context.get('skip_res_field_check')
             and not any(d.field_expr in ('id', 'res_field') for d in domain.iter_conditions())
+            and not bypass_access
         ):
             disable_binary_fields_attachments = True
             domain &= Domain('res_field', '=', False)

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1243,6 +1243,15 @@ class TestOrmAttachmentHost(models.Model):
         'test_orm.attachment', bypass_search_access=True,
     )
 
+    real_binary = fields.Binary(attachment=True)
+    real_attachment_ids = fields.One2many(
+        'ir.attachment', 'res_id', bypass_search_access=True,
+        domain=lambda self: [('res_model', '=', self._name)],
+    )
+    real_m2m_attachment_ids = fields.Many2many(
+        'ir.attachment', bypass_search_access=True,
+    )
+
 
 class DecimalPrecisionTest(models.Model):
     _name = 'decimal.precision.test'


### PR DESCRIPTION
### Issue:
The invoices supposed to be sent with follow-ups when the option `join_invoices` is tick are not sent.

### Steps to reproduce:
- Install "account_followup"
- Create a new partner
- Create an invoice for this partner with a due date in the past, confirm and send
- Go on the partner form view, under the "Accounting" it should be in the state "In need of action"
- Click "Send", the wizard pops up with the invoice attachment
- Click "Send", the message does have the invoice attachment, only the report

### Cause:
The attachment in linked to the wizard in database but when doing a read, the domain is appended with `'res_field', '=', False` by these lines:

https://github.com/odoo/odoo/blob/f8f72b15598576f5870e49879e96fc5c127a6100/odoo/addons/base/models/ir_attachment.py#L598-L603

But the invoices attachments have res_field set to `invoice_pdf_report_file` so they are filtered out.

The purpose of adding the new leaf to the domain is to filter out attachments that we are not searching for specifically. As they are linked to a specific field (`res_field`), if we don't search on this field, we are not supposed to see them.

With the `followup_manual_reminder` wizard, we are linking attachments having a `res_field` to `account_move.invoice_pdf_report_file` to a new field: `followup_manual_reminder.attachment_ids`. So `'res_field', '=', False` should not be added.

### Solution:
The problematic fields are all `Many2Many` fields to `ir.attachment` and 
since [this commit](https://github.com/odoo/enterprise/commit/fd4fcb1bd8764dbde1c8b3295623dd020c882a60) these fields have `bypass_search_access=True`.

So the fix consist of not adding the domain `'res_field', '=', False` when `bypass_access` is True.

opw-5164456