### PR TITLE
[FIX] web: datetimepicker_service: updateValueFromInputs

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -396,7 +396,7 @@ export const datetimePickerService = {
                         getInputs(),
                         ensureArray(pickerProps.value),
                         (el, currentValue) => {
-                            if (!el) {
+                            if (!el || el.tagName?.toLowerCase() !== "input") {
                                 return currentValue;
                             }
                             const [parsedValue, error] = safeConvert("parse", el.value);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7903,7 +7903,7 @@ test(`edit button does not trigger fold group`, async () => {
                 </groupby>
             </list>
         `,
-        groupBy: ['currency_id']
+        groupBy: ["currency_id"],
     });
     expect(`.o_group_open`).toHaveCount(0);
     await contains(`.o_group_header:eq(0)`).click();
@@ -19350,4 +19350,40 @@ test("scroll position is restored when coming back to list view", async () => {
     await animationFrame();
     expect(".o_list_renderer").toHaveCount(1);
     expect(".o_list_view").toHaveProperty("scrollTop", 200);
+});
+
+test.tags("desktop");
+test("multi_edit: must work for copy/paster or operation", async () => {
+    Foo._records[1].datetime = "1989-05-03 12:51:35";
+    Foo._records[2].datetime = "1987-11-13 12:12:34";
+    Foo._records[3].datetime = "2019-04-09 03:21:35";
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list multi_edit="1">
+                <field name="foo"/>
+                <field name="datetime"/>
+            </list>
+        `,
+    });
+
+    await contains(`.o_list_record_selector`).click();
+    await contains(`.o_data_cell[name=datetime]`).click();
+    await animationFrame();
+    await waitFor(`.o_datetime_picker`);
+    await contains(`input[data-field=datetime]`).edit("+125d", { confirm: "tab" });
+    expect(`tbody tr:eq(0) td[name=datetime]`).toHaveText("Jul 14, 11:30 AM");
+    await contains(`.modal button:contains(update)`).click();
+    expect(".modal").toHaveCount(0);
+    expect(queryAllTexts(`.o_data_cell`)).toEqual([
+        "yop",
+        "Jul 14, 11:30 AM",
+        "blip",
+        "Jul 14, 11:30 AM",
+        "gnap",
+        "Jul 14, 11:30 AM",
+        "blip",
+        "Jul 14, 11:30 AM",
+    ]);
 });


### PR DESCRIPTION
How to reproduce
================
Write an operation or calculation in datetime field like +1d or +=1d or copy/paste a value in field. As the focus is lost, button reappears in the field. Then, the getInputs method in useDateTimePicker hook must (as this name suggests it) return input elements.

The fix
=======
We filter on tagName === 'input' elements

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
