### PR TITLE
[FIX] stock_account, purchase_stock: prevent error when changing move line qty

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -863,3 +863,23 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
                 'debit': 0.0,
             },
         ])
+
+    def test_set_move_line_quantity_to_zero(self):
+        """Test set move line quantity to zero which not affect product standard price"""
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.test_product_order.id,
+            })],
+        })
+        po.button_confirm()
+
+        po.picking_ids.button_validate()
+        move_line = po.picking_ids.move_ids.move_line_ids
+        old_price = move_line.product_id.standard_price
+
+        move_line.quantity = 0
+
+        self.assertEqual(move_line.quantity, 0.0)
+        self.assertEqual(po.picking_ids.move_ids.quantity, 0.0)
+        self.assertEqual(move_line.product_id.standard_price, old_price)

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -217,7 +217,8 @@ class ProductProduct(models.Model):
             return self.standard_price
         if (product_value and last_in and product_value.date > last_in.date) or not last_in:
             return product_value.value
-        return last_in._get_value(at_date=date) / last_in._get_valued_qty()
+        valued_qty = last_in._get_valued_qty()
+        return last_in._get_value(at_date=date) / valued_qty if valued_qty else self.standard_price
 
     def _get_value_from_lots(self):
         lots = self.env['stock.lot'].search([


### PR DESCRIPTION
Currently an error occurs when user change the move line quantity.

Steps to Reproduce [video](https://drive.google.com/file/d/12r0DxsKZkvuVjoCsRgXlHJ23NpaqciV7/view?usp=drive_link):

 - Install the `purchase_stock` module.
 - Create a `product` with category: `Costing Method: FIFO`.
 - Create a `purchase order` and add the newly created product to it.
 - Click `Confirm Order`, then click on `Receipt` and `validate` it.
 - Click on `Moves`, open the record, set the `Quantity to zero`, and `save`.

`ZeroDivisionError: float division by zero`

This error occurs when a user confirms a purchase order, validates its picking, and changes the move line quantity to zero. It then tries to update the move line value and the product's standard price due to the FIFO costing method, but the valued quantity becomes zero from [1], which raises an error at [2].

This commit ensures that if the move line has a zero quantity, the product's standard price remains unchanged.

[1]- https://github.com/odoo/odoo/blob/f8f72b15598576f5870e49879e96fc5c127a6100/addons/stock_account/models/stock_move.py#L333-L343

[2]- https://github.com/odoo/odoo/blob/f8f72b15598576f5870e49879e96fc5c127a6100/addons/stock_account/models/product.py#L218

sentry-6993648057

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
