### PR TITLE
[FIX] mrp_account: failing test due to duration inverse change

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -814,7 +814,6 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
         })
         mo.action_confirm()
         workorder = mo.workorder_ids
-        workorder.button_start()
         workorder.duration = 60
         self.assertEqual(workorder._cal_cost(), 20)
         # Simulate missing finished moves


### PR DESCRIPTION
### Issue:
This is caused by changing the duration inverse in #233777.

### Cause:
Before #233777, in duration inverse, only sum of `time_ids` was taken into account to calculate the `duration`.
After that PR, `time_ids` with `get_working_duration` are also taken into account which cause this test fail.

runbot-233742