### PR TITLE
[FIX] sms, mass_mailing_sms: Improve sms factor error handeling

### DIFF
--- a/addons/mass_mailing_sms/models/mailing_trace.py
+++ b/addons/mass_mailing_sms/models/mailing_trace.py
@@ -34,6 +34,7 @@ class MailingTrace(models.Model):
         ('sms_registration_needed', 'Country-specific Registration Required'),
         ('sms_server', 'Server Error'),
         ('sms_acc', 'Unregistered Account'),
+        ('sms_to_moderate', 'Moderation'),
         # mass mode specific codes
         ('sms_blacklist', 'Blacklisted'),
         ('sms_duplicate', 'Duplicate'),

--- a/addons/sms/models/mail_notification.py
+++ b/addons/sms/models/mail_notification.py
@@ -29,6 +29,7 @@ class MailNotification(models.Model):
         ('sms_not_allowed', 'Not Allowed'),
         ('sms_not_delivered', 'Not Delivered'),
         ('sms_rejected', 'Rejected'),
+        ('sms_to_moderate', 'Moderation'),
     ])
 
     @api.depends('sms_id_int', 'notification_type')

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -24,13 +24,6 @@ class SmsSms(models.Model):
         'sent': 'pending',
         'delivered': 'sent',
     }
-    IAP_TO_SMS_FAILURE_TYPE = {  # TODO RIGR remove me in master
-        'insufficient_credit': 'sms_credit',
-        'wrong_number_format': 'sms_number_format',
-        'country_not_supported': 'sms_country_not_supported',
-        'server_error': 'sms_server',
-        'unregistered': 'sms_acc'
-    }
 
     BOUNCE_DELIVERY_ERRORS = {'sms_invalid_destination', 'sms_not_allowed', 'sms_rejected'}
     DELIVERY_ERRORS = {'sms_expired', 'sms_not_delivered', *BOUNCE_DELIVERY_ERRORS}

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -46,6 +46,7 @@ class SmsSms(models.Model):
         ('process', 'Processing'),
         ('pending', 'Sent'),
         ('sent', 'Delivered'),  # As for notifications and traces
+        ('to_moderate', 'Moderation'),
         ('error', 'Error'),
         ('canceled', 'Cancelled')
     ], 'SMS Status', readonly=True, copy=False, default='outgoing', required=True)
@@ -58,10 +59,12 @@ class SmsSms(models.Model):
         ('sms_credit', 'Insufficient Credit'),
         ('sms_server', 'Server Error'),
         ('sms_acc', 'Unregistered Account'),
+        ('sms_existing_account', 'Account already exist'),
         # mass mode specific codes, generated internally, not returned by IAP.
         ('sms_blacklist', 'Blacklisted'),
         ('sms_duplicate', 'Duplicate'),
         ('sms_optout', 'Opted Out'),
+        ('sms_to_moderate', 'Moderation'),
     ], copy=False)
     sms_tracker_id = fields.Many2one('sms.tracker', string='SMS trackers', compute='_compute_sms_tracker_id')
     to_delete = fields.Boolean(
@@ -224,7 +227,7 @@ class SmsSms(models.Model):
                 else:
                     sms_sudo.sms_tracker_id.with_context(sms_known_failure_reason=failure_reason)._action_update_from_provider_error(iap_state)
                 to_delete = {'to_delete': True} if unlink_failed else {}
-                sms_sudo.write({'state': 'error', 'failure_type': failure_type, **to_delete})
+                sms_sudo.write({'state': failure_type != 'sms_to_moderate' and 'error' or 'to_moderate', 'failure_type': failure_type, **to_delete})
 
         all_sms_sudo._handle_call_result_hook(results)
         all_sms_sudo.mail_message_id._notify_message_notification_update()

--- a/addons/sms/static/src/core/notification_model_patch.js
+++ b/addons/sms/static/src/core/notification_model_patch.js
@@ -30,6 +30,8 @@ const notificationPatch = {
                 return _t("Not Delivered");
             case "sms_rejected":
                 return _t("Rejected");
+            case "sms_to_moderate":
+                return _t("Moderation");
             default:
                 return super.failureMessage;
         }

--- a/addons/sms/tools/sms_api.py
+++ b/addons/sms/tools/sms_api.py
@@ -59,6 +59,7 @@ class SmsApi(SmsApiBase):  # TODO RIGR in master: rename SmsApi to SmsApiIAP, an
         'country_not_supported': 'sms_country_not_supported',
         'insufficient_credit': 'sms_credit',
         'unregistered': 'sms_acc',
+        'to_moderate': 'sms_to_moderate',
     }
 
     def __init__(self, env, account=None):

--- a/addons/sms/views/sms_sms_views.xml
+++ b/addons/sms/views/sms_sms_views.xml
@@ -10,7 +10,7 @@
                     <button name="send" string="Send Now" type="object" invisible="state != 'outgoing' or to_delete" class="oe_highlight"/>
                     <button name="action_set_outgoing" string="Retry" type="object" invisible="state not in ('error', 'canceled')"/>
                     <button name="action_set_canceled" string="Cancel" type="object" invisible="state not in ('error', 'outgoing')"/>
-                    <field name="state" widget="statusbar" statusbar_visible="outgoing,sent,error,canceled"/>
+                    <field name="state" widget="statusbar" statusbar_visible="outgoing,sent,to_moderate,error,canceled"/>
                 </header>
                 <sheet>
                     <group>
@@ -40,7 +40,7 @@
                 <field name="number"/>
                 <field name="partner_id"/>
                 <field name="failure_type"/>
-                <field name="state" widget="badge" decoration-info="state == 'outgoing'" decoration-muted="state == 'canceled'" decoration-success="state == 'sent'" decoration-danger="state == 'error'"/>
+                <field name="state" widget="badge" decoration-info="state in ('outgoing', 'to_moderate')" decoration-muted="state == 'canceled'" decoration-success="state == 'sent'" decoration-danger="state == 'error'"/>
                 <button name="send" string="Send Now" type="object" icon="fa-paper-plane" invisible="state != 'outgoing'"/>
                 <button name="action_set_outgoing" string="Retry" type="object" icon="fa-repeat" invisible="state not in ('error', 'canceled')"/>
                 <button name="action_set_canceled" string="Cancel" type="object" icon="fa-times-circle" invisible="state not in ('error', 'outgoing')"/>


### PR DESCRIPTION
Improve error handling with SmsFactor for moderated sms. Before this commit,
we were marking the moderated sms as rejected even though it was in moderation.
A moderated sms is not supposed to be rejected unless the moderation is refused.
So we should mark those sms as 'To Moderate' while waiting for the moderation
to be done.

Linked:https://github.com/odoo/iap-apps/pull/1258

task-5183197
