### PR TITLE
[CLN] website_*: clean the slots registration button

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -273,7 +273,6 @@ class WebsiteEventController(http.Controller):
             'google_url': lazy(lambda: urls.get('google_url')),
             'iCal_url': lazy(lambda: urls.get('iCal_url')),
             'registration_error_code': post.get('registration_error_code'),
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'website_visitor_timezone': request.env['website.visitor']._get_visitor_timezone(),
         }
 
@@ -530,7 +529,6 @@ class WebsiteEventController(http.Controller):
             'google_url': urls.get('google_url'),
             'iCal_url': urls.get('iCal_url'),
             'slot': slot,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'website_visitor_timezone': request.env['website.visitor']._get_visitor_timezone(),
         }
 

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -236,7 +236,7 @@
                 </small>
                 <div class="card bg-transparent py-3 px-2 px-md-3">
                     <!-- Up to the next 3 closest dates -->
-                    <t t-set="slots_to_preview" t-value="dict(list(slots.items())[:3])"/>
+                    <t t-set="slots_to_preview" t-value="dict(list(event.event_slot_ids._filter_open_slots().grouped('date').items())[:3])"/>
                     <t t-if="slots_to_preview">
                         <div class="row">
                             <div t-foreach="slots_to_preview" t-as="date" class="col d-flex flex-column align-items-start gap-1 pb-2">
@@ -710,6 +710,7 @@
                         </ul>
                     </nav>
                     <div class="o_wevent_slot_dates row px-2">
+                        <t t-set="slots" t-value="event.event_slot_ids._filter_open_slots().grouped('date')"/>
                         <div t-foreach="slots" t-as="date" t-attf-class="o_wevent_slot_date col col-sm-6 col-lg-4 px-3 pb-4">
                             <time t-out="date" class="text-nowrap pe-5 me-5" t-options="{'widget': 'date', 'format': 'full'}"/>
                             <div class="d-flex flex-wrap gap-2">

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -73,7 +73,6 @@ class WebsiteEventBoothController(WebsiteEventController):
             'event_booths': event_booths,
             'hide_sponsors': True,
             'redirect_url': werkzeug.urls.url_quote(request.httprequest.full_path),
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
         }
 
     @http.route('/event/<model("event.event"):event>/booth/confirm',
@@ -131,7 +130,6 @@ class WebsiteEventBoothController(WebsiteEventController):
             'main_object': event_sudo,
             'selected_booth_category_id': (chosen_booth_category or default_booth_category).id,
             'selected_booth_ids': booth_ids if booth_category_id == chosen_booth_category.id and booth_ids else False,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
         }
 
     def _prepare_booth_registration_values(self, event, kwargs):

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -105,7 +105,6 @@ class ExhibitorController(WebsiteEventController):
             # event information
             'event': event,
             'main_object': event,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'sponsor_categories': sponsor_categories,
             'hide_sponsors': True,
             # search information
@@ -162,7 +161,6 @@ class ExhibitorController(WebsiteEventController):
             # event information
             'event': event,
             'main_object': sponsor,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'sponsor': sponsor,
             'hide_sponsors': True,
             # sidebar

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -162,7 +162,6 @@ class EventTrackController(http.Controller):
             # event information
             'event': event,
             'main_object': event,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             # tracks display information
             'tracks': tracks_sudo,
             'tracks_by_day': tracks_by_day,
@@ -195,7 +194,6 @@ class EventTrackController(http.Controller):
             'event': event,
             'main_object': event,
             'seo_object': seo_object,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'tag': tag,
             'is_event_user': request.env.user.has_group('event.group_event_user'),
             'website_visitor_timezone': request.env['website.visitor']._get_visitor_timezone(),
@@ -385,7 +383,6 @@ class EventTrackController(http.Controller):
             # event information
             'event': event,
             'main_object': track,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'track': track,
             # sidebar
             'tracks_other': tracks_other,
@@ -467,7 +464,6 @@ class EventTrackController(http.Controller):
             'event': event,
             'main_object': event,
             'seo_object': event.track_proposal_menu_ids,
-            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
         })
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal/post'''], type='http', auth="public", methods=['POST'], website=True)

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -33,7 +33,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
 
     def _get_community_leaderboard_render_values(self, event, search_term, page):
         values = self._get_leaderboard(event, search_term)
-        values.update({'event': event, 'search': search_term, 'slots': event.event_slot_ids._filter_open_slots().grouped('date')})
+        values.update({'event': event, 'search': search_term})
 
         user_count = len(values['visitors'])
         if user_count:


### PR DESCRIPTION
* = event, event_booth, event_exhibitor, event_track, event_track_quiz

This PR cleans this fix (https://github.com/odoo/odoo/pull/226635). The open slots were filtered in each route displaying the slots modal. However, this solution makes the code difficult to maintain as the slots must be added in the return of the new routes, which is easy to forget. A better solution is to filter the slots once and for all inside the slots modal. That solution was not doable in stable as it required the update of the XML records.

Task-5083175
