### PR TITLE
[FIX] portal_rating: allow ios rating

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/composer_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/composer_patch.xml
@@ -3,13 +3,13 @@
     <t t-inherit="mail.Composer" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Composer-coreMain')]" position="before">
             <div t-if="env.displayRating and !message" class="o-mail-Composer-starCard d-flex">
-                <div class="o-mail-Composer-stars enabled" t-on-mouseleave="() => portalState.starValue = portalState.ratingValue">
+                <div class="o-mail-Composer-stars enabled" t-on-mouseleave="onMouseLeaveStar">
                     <t t-set="index" t-value="0" />
-                    <t t-foreach="Array(portalState.starValue)" t-as="num" t-key="num_index">
+                    <t t-foreach="Array(visibleRatingValue)" t-as="num" t-key="num_index">
                         <i class="fa fa-star" role="img" aria-label="Full star" t-att-index="index" t-on-mousemove="onMoveStar" t-on-click="onClickStar"/>
                         <t t-set="index" t-value="index + 1" />
                     </t>
-                    <t t-foreach="Array(5 - portalState.starValue)" t-as="num" t-key="num_index">
+                    <t t-foreach="Array(MAX_STAR_RATING - visibleRatingValue)" t-as="num" t-key="Array(visibleRatingValue) + num_index">
                         <i class="fa fa-star-o text-black-25" role="img" aria-label="Empty star" t-att-index="index" t-on-mousemove="onMoveStar" t-on-click="onClickStar"/>
                         <t t-set="index" t-value="index + 1" />
                     </t>


### PR DESCRIPTION
## Versions
18.0+

## Issue
On iOS devices, when submitting a product review with a custom star rating, the selected value would revert to the default (4 stars) before submission.

## Steps to reproduce
*On a laptop*
- Open Editor mode on a product eCommerce page:
  - Select any product element (e.g. click on the price);
  - Activate customer ratings and save.

*On a physical Apple mobile device (iPhone or iPad) or on an iOS emulator via XCode (only on MacOS)*
- Go to the product's eCommerce page:
  - Move down to the "Customer Reviews" section and un-toggle it:
    - Write down a review;
    - Click on any star rating but 4;
    - Send.

## Cause
`mouseleave` event is triggered before the rating is saved and resets the rating to the default 4-star one.

## Solution
Only trigger `mouseleave` event on devices handling them correctly and post the number of visible stars on the form.

opw-5142682