### PR TITLE
[FIX] point_of_sale: fix generic localization tour 

### DIFF
--- a/addons/point_of_sale/static/tests/tours/generic_tour.js
+++ b/addons/point_of_sale/static/tests/tours/generic_tour.js
@@ -2,6 +2,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
 import { GenericHooks } from "@point_of_sale/../tests/tours/utils/generic_hooks";
 import { registry } from "@web/core/registry";
 
@@ -19,13 +20,13 @@ registry.category("web_tour.tours").add("generic_localization_tour", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             GenericHooks.afterValidateHook(),
-            ProductScreen.closePos(),
-            Dialog.confirm("Close Register"),
             {
-                trigger: "button:contains(backend)",
-                run: "click",
-                expectUnloadPage: true,
+                timeout: 20000,
+                content: "receipt screen is shown",
+                trigger: ".pos .receipt-screen",
             },
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.isShown(),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_generic_localization.py
+++ b/addons/point_of_sale/tests/test_generic_localization.py
@@ -24,6 +24,4 @@ class TestGenericLocalization(TestPointOfSaleHttpCommon):
 
     def test_generic_localization(self):
         self.main_pos_config.open_ui()
-        current_session = self.main_pos_config.current_session_id
         self.start_pos_tour("generic_localization_tour", login="accountman")
-        self.assertEqual(current_session.state, 'closed')


### PR DESCRIPTION
backport of : https://github.com/odoo/odoo/pull/231884

Remove the closing of the PoS in the tour as it is really unstable and
fail a lot. It's mostly due to the fact that the PoS take a long time to
close with a lost of modules installed.
This will also make the tour faster.

runbot-233183