### PR TITLE
[FIX] website: fail test inde when you edit an image

### DIFF
--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -8,7 +8,7 @@ import { Tooltip } from "@web/core/tooltip/tooltip";
 
 export class MediaWebsitePlugin extends Plugin {
     static id = "media_website";
-    static dependencies = ["media", "selection", "builderOptions"];
+    static dependencies = ["media", "selection", "builderOptions", "operation"];
     static shared = ["replaceMedia"];
 
     resources = {
@@ -93,13 +93,15 @@ export class MediaWebsitePlugin extends Plugin {
     }
 
     /**
-     * Replaces the double-cliked media element.
+     * Replaces the double-clicked media element.
      *
      * @param {HTMLElement} mediaEl the media element to replace
      */
     async onDblClickEditableMedia(mediaEl) {
-        this.removeCurrentTooltip();
-        await this.replaceMedia(mediaEl);
+        this.dependencies.operation.next(async () => {
+            this.removeCurrentTooltip();
+            await this.replaceMedia(mediaEl);
+        });
     }
 
     /**

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, queryFirst, waitFor } from "@odoo/hoot-dom";
+import { queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { delay } from "@web/core/utils/concurrency";
@@ -8,13 +8,14 @@ import { testImg } from "./image_test_helpers";
 defineWebsiteModels();
 
 test("Should set a shape on an image", async () => {
-    const { getEditor } = await setupWebsiteBuilder(`
+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
     const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
@@ -52,7 +53,7 @@ test("Should set a shape on a GIF", async () => {
     >`;
 
     // Set up the website builder with the test GIF.
-    const { getEditor } = await setupWebsiteBuilder(`
+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testGif}
         </div>
@@ -61,6 +62,7 @@ test("Should set a shape on a GIF", async () => {
 
     // Click the GIF to activate the image options in the sidebar.
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     // Select and apply a shape.
     await contains("[data-label='Shape'] .dropdown").click();
@@ -107,6 +109,7 @@ test("Should change the shape color of an image", async () => {
         }
     );
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
@@ -157,7 +160,7 @@ test("Should change the shape color of an image", async () => {
     );
 });
 test("Should change the shape color of an image with a class color", async () => {
-    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
         `<div class="test-options-target">
             ${testImg}
         </div>`,
@@ -165,13 +168,12 @@ test("Should change the shape color of an image with a class color", async () =>
             loadIframeBundles: true,
         }
     );
-    const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
-    // ensure the shape action has been applied
-    await editor.shared.operation.next(() => {});
+    await waitSidebarUpdated();
 
     await waitFor(`[data-label="Colors"] .o_we_color_preview`);
 
@@ -218,38 +220,34 @@ test("Should change the shape color of an image with a class color", async () =>
     );
 });
 test("Should not show transform action on shape that cannot bet transformed", async () => {
-    const { getEditor } = await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
-    const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
-    // ensure the shape action has been applied
-    await editor.shared.operation.next(() => {});
-    await animationFrame();
-
+    await waitSidebarUpdated();
     expect(`[data-action-id="flipImageShape"]`).not.toHaveCount();
     expect(`[data-action-id="rotateImageShape"]`).not.toHaveCount();
 });
 describe("flip shape axis", () => {
     test("Should flip the shape X axis", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
@@ -264,19 +262,18 @@ describe("flip shape axis", () => {
         expect(`:iframe .test-options-target img`).toHaveAttribute("data-shape-flip", "x");
     });
     test("Should unflip the shape X axis", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
@@ -292,19 +289,18 @@ describe("flip shape axis", () => {
         expect(`:iframe .test-options-target img`).not.toHaveAttribute("data-shape-flip");
     });
     test("Should flip the shape Y axis", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
@@ -319,19 +315,18 @@ describe("flip shape axis", () => {
         expect(`:iframe .test-options-target img`).toHaveAttribute("data-shape-flip", "y");
     });
     test("Should flip the shape XY axis", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
@@ -349,19 +344,18 @@ describe("flip shape axis", () => {
 });
 describe("rotate shape", () => {
     test("Should rotate the shape to the left", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
-        const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         await waitFor(`[data-action-id="rotateImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
@@ -371,24 +365,22 @@ describe("rotate shape", () => {
 
         await contains(`[data-action-id="rotateImageShape"]:has(.fa-rotate-left)`).click();
         // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         expect(`:iframe .test-options-target img`).toHaveAttribute("data-shape-rotate", "270");
     });
     test("Should remove rotate data when there is no rotation", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-
+        await waitSidebarUpdated();
         await waitFor(`[data-action-id="rotateImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
@@ -404,18 +396,19 @@ describe("rotate shape", () => {
         expect(`:iframe .test-options-target img`).not.toHaveAttribute("data-shape-rotate");
     });
     test("Should rotate the shape to the right", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
+        await waitSidebarUpdated();
 
         await waitFor(`[data-action-id="rotateImageShape"]`);
 
@@ -432,35 +425,33 @@ describe("rotate shape", () => {
     });
 });
 test("Should not show animate speed if the shape is not animated", async () => {
-    const { getEditor } = await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
-    const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
-    // ensure the shape action has been applied
-    await editor.shared.operation.next(() => {});
-    await animationFrame();
-
+    await waitSidebarUpdated();
     expect(`[data-action-id="setImageShapeSpeed"]`).not.toHaveCount();
 });
 test("Should change the speed of an animated shape", async () => {
-    const { getEditor } = await setupWebsiteBuilder(`
+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
     const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
     // ensure the shape action has been applied
-    await editor.shared.operation.next(() => {});
+    await waitSidebarUpdated();
 
     const originalSrc = queryFirst(":iframe .test-options-target img").src;
 
@@ -480,46 +471,37 @@ test("Should change the speed of an animated shape", async () => {
 });
 describe("toggle ratio", () => {
     test("Should not be able to toggle the ratio of a pattern_wave_4", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
-        const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-        await animationFrame();
+        await waitSidebarUpdated();
 
         expect(`[data-action-id="toggleImageShapeRatio"]`).not.toHaveCount();
     });
     test("A shape with togglable ratio should be added cropped and crop when clicked", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
-        const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
         // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-        await animationFrame();
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
+        await waitSidebarUpdated();
         const croppedSrc = queryFirst(":iframe .test-options-target img").src;
 
         await contains(`[data-action-id="toggleImageShapeRatio"] input`).click();
-
-        // ensure the shape action has been applied
-        await editor.shared.operation.next(() => {});
-        await animationFrame();
-
+        await waitSidebarUpdated();
         expect(`:iframe .test-options-target img`).not.toHaveAttribute("src", croppedSrc);
     });
 });
@@ -532,6 +514,8 @@ test("Should reset crop when removing shape with ratio", async () => {
     `);
 
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
     await waitSidebarUpdated();

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -50,14 +50,18 @@ test("Double click on image and replace it", async () => {
             public: true,
         },
     ]);
-    await setupWebsiteBuilder(`<div><img class=a_nice_img src='${dummyBase64Img}'></div>`);
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<div><img class=a_nice_img src='${dummyBase64Img}'></div>`
+    );
     expect(".modal-content").toHaveCount(0);
     await dblclick(":iframe img.a_nice_img");
     await animationFrame();
     expect(".modal-content:contains(Select a media) .o_upload_media_button").toHaveCount(1);
     expect("div.o-tooltip").toHaveCount(0);
     await contains(".o_select_media_dialog img[title='logo']").click();
+    await waitSidebarUpdated();
     await waitForNone(".o_select_media_dialog");
+    expect(".o_select_media_dialog").toHaveCount(0);
     expect(":iframe img").toHaveClass("o_modified_image_to_save");
     expect(".options-container[data-container-title='Image']").toHaveCount(1);
 });
@@ -240,14 +244,14 @@ test("pasted/dropped images are converted to attachments on snippet save", async
 
 describe("Image format/optimize", () => {
     test("Should format an image to be 800px", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
         const editor = getEditor();
         await contains(":iframe .test-options-target img").click();
-
+        await waitSidebarUpdated();
         await contains("[data-label='Format'] .dropdown").click();
         await waitFor('[data-action-id="setImageFormat"]');
         queryAll(`[data-action-id="setImageFormat"]`)
@@ -264,7 +268,7 @@ describe("Image format/optimize", () => {
         expect(queryFirst("[data-label='Format'] .dropdown").textContent).toMatch(/800px/);
     });
     test("should set the quality of an image to 50", async () => {
-        const { getEditor } = await setupWebsiteBuilder(`
+        const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
@@ -273,8 +277,8 @@ describe("Image format/optimize", () => {
 
         const img = await waitFor(":iframe .test-options-target img");
         await contains(":iframe .test-options-target img").click();
-
-        const input = await waitFor('[data-action-id="setImageQuality"] input');
+        await waitSidebarUpdated();
+        const input = queryFirst('[data-action-id="setImageQuality"] input');
         input.value = 50;
         input.dispatchEvent(new Event("input"));
         await delay();

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -280,7 +280,11 @@ export async function setupWebsiteBuilder(
 
 async function openBuilderSidebar(editAssetsLoaded) {
     // The next line allow us to await asynchronous fetches and cache them before it is used
-    await Promise.all([getWebsiteSnippets(), loadBundle("website.website_builder_assets")]);
+    await Promise.all([
+        getWebsiteSnippets(),
+        loadBundle("website.website_builder_assets"),
+        loadBundle("html_editor.assets_image_cropper"),
+    ]);
 
     await click(".o-website-btn-custo-primary");
     await editAssetsLoaded;


### PR DESCRIPTION
The goal of this commit is to fix the indeterminate tests related
to image editing in the website builder.

Problem:
=====
Some tests related to image editing on the website fail in an indeterminate
manner. This test failure is related to the sidebar's async. When selecting
an image, the Image options need to fetch certain data (the original image, etc.).
The “html_editor.assets_image_cropper” bundle is also loaded. This loading
time can exceed 200 ms, causing the test to fail unpredictably.

Solution:
======
1.Preload the “html_editor.assets_image_cropper” bundle and store it in the cache.
2. Use `waitSidebarUpdated` when selecting an image.
   `waitSidebarUpdated`` will wait until all the data is loaded and
   the sidebar is updated. This solution is not optimal, but it will make
   all the tests deterministic.

The best solution:
=========
We should mock or preload all the data needed for the tests.
This change requires adapting the current production code to make it easily
patchable to mock, for example, “.text()” on a response to an image fetch.

Error: https://runbot.odoo.com/odoo/error/232956




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
