### PR TITLE
[IMP] orm: stop invalidating inverses of o2m fields

### DIFF
--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -5220,16 +5220,7 @@ class TestModifiedPerformance(TransactionCase):
                    "test_orm_modified_line"."create_date"
             FROM "test_orm_modified_line"
             WHERE "test_orm_modified_line"."id" IN %s
-        """, """
-            SELECT "test_orm_modified_line"."id",
-                   "test_orm_modified_line"."parent_id"
-            FROM "test_orm_modified_line"
-            WHERE "test_orm_modified_line"."id" IN %s
         """], flush=False):
-            # Two requests:
-            # - one for fetch modified_line_a_child_child data (invalidate just before)
-            # - one because modified_line_a_child.parent_id (invalidate just before because we invalidate inverse in `_invalidate_cache`,
-            # see TODO) -> We should change that
             self.modified_line_a_child_child.price = 4
         self.assertEqual(self.modified_line_a_child_child.total_price_quantity, 20)
         self.assertEqual(self.modified_line_a_child.total_price_quantity, 30)

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6111,7 +6111,10 @@ class BaseModel(metaclass=MetaModel):
         env = self.env
         for field in fields:
             field._invalidate_cache(env, ids)
-            # TODO VSC: used to remove the inverse of many_to_one from the cache, though we might not need it anymore
+            if field.type == 'one2many':
+                # skip invalidation of inverse for o2m fields
+                # (o2m is "computed" from m2o)
+                continue
             for invf in self.pool.field_inverses[field]:
                 self.env[invf.model_name].flush_model([invf.name])
                 invf._invalidate_cache(env)


### PR DESCRIPTION
Whe invalidating o2m_ids, we should not invalidate inverses as these can still be valid. When you invalidate a o2m, the m2o value should remain in cache as o2m is only based on it. For m2m relationships, invalidating the relation, invalidates both ends.

For example, in mail, `_invalidate_documents` will invalidate x2m files pointing to the created message. If we invalidate inverses, we will just invalidate res_id which just have been set.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
