### PR TITLE
[FIX] web: display the provided no content helper when no matching data

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -65,7 +65,7 @@
                 </t>
                 <t t-if="model.isReady and model.data">
 					<t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
-						<ActionHelper noContentHelp="props.noContentHelp" showRibbon="model.useSampleModel"/>
+						<ActionHelper noContentHelp="props.info.noContentHelp" showRibbon="model.useSampleModel"/>
                     </t>
                     <t t-if="model.data.exceeds">
                         <div class="alert alert-info text-center o_graph_alert" role="status">

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -1251,6 +1251,27 @@ test("no content helper after update", async () => {
     expect(".abc").toHaveCount(0);
 });
 
+test("display the provided no content helper when search has no matching data", async () => {
+    Foo._records = [];
+
+    await mountView({
+        type: "graph",
+        resModel: "foo",
+        noContentHelp: /* xml */ `
+            <p class="abc">This helper should be displayed</p>
+        `,
+    });
+
+    expect(".o_graph_canvas_container canvas").toHaveCount(1);
+    expect(".o_view_nocontent").toHaveCount(0);
+
+    await toggleSearchBarMenu();
+    await toggleMenuItem("color");
+
+    expect(".o_graph_canvas_container canvas").toHaveCount(0);
+    expect(".o_nocontent_help:contains(This helper should be displayed)").toHaveCount(1);
+});
+
 test("can reload with other group by", async () => {
     const view = await mountView({
         type: "graph",


### PR DESCRIPTION
Before this commit:
In the graph view, when performing a search that yields no matching data, the default no content helper is shown even if a custom no content helper has been provided for that action window.

After this commit:
The provided no content helper for the action window is displayed instead.

task-5136801

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
