### PR TITLE
[IMP] hr_holidays: Attached documents visibility

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -200,6 +200,7 @@ class HrLeave(models.Model):
         'ir.attachment', string="Attach File", compute='_compute_supported_attachment_ids',
         inverse='_inverse_supported_attachment_ids')
     supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids')
+    attachment_is_visible = fields.Boolean(compute='_compute_attachment_is_visible', compute_sudo=True)
     # UX fields
     work_entry_type_request_unit = fields.Selection(related='work_entry_type_id.request_unit', readonly=True)
     work_entry_type_support_document = fields.Boolean(related="work_entry_type_id.support_document")
@@ -718,6 +719,16 @@ class HrLeave(models.Model):
         for holiday in self:
             holiday.supported_attachment_ids = holiday.attachment_ids
             holiday.supported_attachment_ids_count = len(holiday.attachment_ids.ids)
+
+    @api.depends_context('uid')
+    @api.depends('work_entry_type_support_document')
+    def _compute_attachment_is_visible(self):
+        is_privileged_user = self.env.user.has_groups('hr_holidays.group_hr_holidays_user,hr_holidays.group_hr_holidays_manager')
+        for leave in self:
+            if leave.work_entry_type_support_document and (is_privileged_user or self.env.uid in (leave.user_id.id, leave.create_uid.id)):
+                leave.attachment_is_visible = True
+            else:
+                leave.attachment_is_visible = False
 
     @api.depends('employee_id', 'work_entry_type_id')
     def _compute_leaves(self):

--- a/addons/hr_holidays/static/src/components/hr_leave_chatter_patch/hr_leave_chatter_patch.js
+++ b/addons/hr_holidays/static/src/components/hr_leave_chatter_patch/hr_leave_chatter_patch.js
@@ -1,0 +1,31 @@
+import { patch } from "@web/core/utils/patch";
+import { Chatter } from "@mail/chatter/web_portal_project/chatter";
+import { useService } from "@web/core/utils/hooks";
+
+patch(Chatter.prototype, {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.applyConditionalAttachmentVisibility();
+    },
+
+     async applyConditionalAttachmentVisibility() {
+        try {
+            if (this.props.threadModel === "hr.leave" && this.props.threadId) {
+                const record = await this.orm.read(
+                    "hr.leave",
+                    [this.props.threadId],
+                    ["attachment_is_visible"]
+                );
+                const isVisible = record?.[0]?.attachment_is_visible;
+                if (!isVisible) {
+                    if (this.state.thread) {
+                        this.state.thread.attachments = [];
+                    }
+                }
+            }
+        } catch (error) {
+            console.warn("Failed to check attachment visibility:", error);
+        }
+    },
+});

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -299,7 +299,7 @@
                                     groups="hr_holidays.group_hr_holidays_user">
                                     Refuse
                                 </button>
-                                <button t-if="record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0 text-danger">
+                                <button t-if="record.attachment_is_visible and record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0 text-danger">
                                     <i class="fa fa-paperclip"> <field name="supported_attachment_ids_count" nolabel="1"/></i>
                                 </button>
                             </bottom>
@@ -452,7 +452,7 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//group[@name='attachments_relapse']" position="inside">
-                <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="state != 'confirm'" colspan="2"/>
+                <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="not attachment_is_visible or state != 'confirm'" colspan="2"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
. Conditionally display the attached time-off documents based on the viewer's rights

task-5232050

Description of the issue/feature this PR addresses: Conditionally display the attached time-off documents based on the viewer's security clearance.

Current behavior before PR: Non-privileged users with no time-off rights or privileges  currently have access to sensitive personal data (such as doctor's reports) attached to time-off requests, creating a security and privacy risk.

Desired behavior after PR is merged: Conditionally hides the attached document (certificate, doctor's note) on the time-off request, with of normal users



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
