### PR TITLE
[FIX] html_editor: fix traceback when coloring with selection on feff

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -54,8 +54,12 @@ import { closestScrollableY } from "@web/core/utils/scrolling";
  * @property {() => void} restore
  * @property {(callback: (cursor: Cursor) => void) => Cursors} update
  * @property {(node: Node, newNode: Node) => Cursors} remapNode
+ * @property {(newOffset: number) => Cursors} setAnchorOffset
+ * @property {(newOffset: number) => Cursors} setFocusOffset
  * @property {(node: Node, newOffset: number) => Cursors} setOffset
  * @property {(node: Node, shiftOffset: number) => Cursors} shiftOffset
+ * @property {{ node: Node, offset: number }} anchor
+ * @property {{ node: Node, offset: number }} focus
  */
 
 /**
@@ -661,6 +665,14 @@ export class SelectionPlugin extends Plugin {
                     }
                 });
             },
+            setAnchorOffset(newOffset) {
+                anchor.offset = newOffset;
+                return this;
+            },
+            setFocusOffset(newOffset) {
+                focus.offset = newOffset;
+                return this;
+            },
             setOffset(node, newOffset) {
                 return this.update((cursor) => {
                     if (cursor.node === node) {
@@ -675,6 +687,8 @@ export class SelectionPlugin extends Plugin {
                     }
                 });
             },
+            anchor,
+            focus,
         };
     }
 

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -26,6 +26,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { isBlock } from "@html_editor/utils/blocks";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { removeEmptyTextNodes } from "../../utils/dom";
+import { nodeSize } from "@html_editor/utils/position";
 
 const RGBA_OPACITY = 0.6;
 const HEX_OPACITY = "99";
@@ -341,6 +342,12 @@ export class ColorPlugin extends Plugin {
                         font = this.dependencies.split.splitAroundUntil(
                             selectedChildren,
                             splitnode
+                        );
+                        cursors.setAnchorOffset(
+                            Math.min(nodeSize(cursors.anchor.node), cursors.anchor.offset)
+                        );
+                        cursors.setFocusOffset(
+                            Math.min(nodeSize(cursors.focus.node), cursors.focus.offset)
                         );
                         if (isGradientBeingUpdated) {
                             const classRegex =

--- a/addons/html_editor/static/src/main/link/link.scss
+++ b/addons/html_editor/static/src/main/link/link.scss
@@ -24,4 +24,8 @@
             font-size: unset;
         }
     }
+    font[class^="text-o-"] a,
+    font[style*="color"] a {
+        color: inherit !important;
+    }
 }

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -676,6 +676,9 @@ test("Should properly apply color when selection on feff", async () => {
             </div>
         `)
     );
+    // Ensure the link inherited the font color.
+    const a = el.querySelector("a");
+    expect(getComputedStyle(a).color).toBe("rgb(255, 0, 0)");
 });
 
 test("should be able to remove color applied by 'text-*' classes (1)", async () => {


### PR DESCRIPTION
Problem:
When the user selects a link to color and the selection falls on a `feff` character, a traceback occurs.

Cause:
After commit 927f4b973932d14961c148e13473017651a60dc0, we preserve the selection at:
https://github.com/odoo/odoo/blob/bee7fc1f955c52a88b527ad9a2ddf0021529bbc7/addons/html_editor/static/src/main/font/color_plugin.js#L247-L247
and then call `getFonts()`, which internally uses
`this.dependencies.split.splitAroundUntil()`.

If the selection is on a `feff` node, `splitAroundUntil()` can clear those nodes because `splitElement()` inside it dispatches to `clean_handlers` with the selected element containing the `feff`. Since the preserved cursor offset refers to the node before the `feff` was removed, restoring it throws:
`The offset x is larger than the node's length (y).`

Solution:
After `splitAroundUntil()`, adjust the preserved cursor offsets if the nodes were mutated to ensure they remain valid.

Steps to reproduce:
It is difficult to reproduce manually, but the issue occurs when coloring a link with the selection on a `feff`.
A test case replicating the situation can be based on the original failing template in the customer’s database.

opw-4953943

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
