### PR TITLE
[FIX] base: display missing vat_label in contact warning before saving

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -432,6 +432,7 @@ class Partner(models.Model):
                 domain += [('id', '!=', partner_id), '!', ('id', 'child_of', partner_id)]
             partner.same_company_registry_partner_id = bool(partner.company_registry) and not partner.parent_id and Partner.search(domain, limit=1)
 
+    @api.depends('vat')
     @api.depends_context('company')
     def _compute_vat_label(self):
         self.vat_label = self.env.company.country_id.vat_label or _("Tax ID")


### PR DESCRIPTION
**Steps to reproduce:**
1. Login with the admin.
2. Open any contact with a VAT number and copy the VAT.
3. Create a new contact and paste the same VAT.
4. Observe the warning message shown before saving.

**Issue:**
- Just before saving, the `vat_label` value is missing in the warning message. After saving, the correct label (e.g., "Tax ID") is displayed.
<img width="914" height="79" alt="image" src="https://github.com/user-attachments/assets/bd46b8a2-c8e4-41e6-99f3-ae7bf293e4d0" />

**Cause:**
- The computed field `vat_label` only depended on the company context, which is not triggered when a VAT value is entered on a new record.

**Solution:**
- Added a dependency on the `vat` field to ensure `_compute_vat_label` is computed immediately when the VAT number is added, so the correct label appears in the pre-save warning as well.
<img width="789" height="59" alt="image" src="https://github.com/user-attachments/assets/822ebce3-9c9b-49d8-9127-2ecef239dfde" />


**opw-5226632**