### PR TITLE
[IMP] l10n_es_edi_verifactu: Alert banner resequence under veri*factu

### DIFF
--- a/addons/l10n_es_edi_verifactu/__manifest__.py
+++ b/addons/l10n_es_edi_verifactu/__manifest__.py
@@ -10,6 +10,7 @@
     'data': [
         'security/ir.model.access.csv',
         'wizard/account_move_reversal_views.xml',
+        'wizard/account_resequence_views.xml',
         'views/account_move_views.xml',
         'views/account_tax_views.xml',
         'views/certificate_certificate_views.xml',

--- a/addons/l10n_es_edi_verifactu/wizard/__init__.py
+++ b/addons/l10n_es_edi_verifactu/wizard/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move_reversal
+from . import account_resequence

--- a/addons/l10n_es_edi_verifactu/wizard/account_resequence.py
+++ b/addons/l10n_es_edi_verifactu/wizard/account_resequence.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class AccountResequenceWizard(models.TransientModel):
+    _inherit = 'account.resequence.wizard'
+
+    # Technical field to display (or not) banner in wizard
+    l10n_es_edi_verifactu_required_in_prod = fields.Boolean(compute='_compute_l10n_es_edi_verifactu_required_in_prod')
+
+    def _compute_l10n_es_edi_verifactu_required_in_prod(self):
+        for wizard in self:
+            wizard.l10n_es_edi_verifactu_required_in_prod = (
+                any(move.l10n_es_edi_verifactu_required for move in wizard.move_ids)
+                and any(not company.l10n_es_edi_verifactu_test_environment for company in wizard.move_ids.company_id)
+            )

--- a/addons/l10n_es_edi_verifactu/wizard/account_resequence_views.xml
+++ b/addons/l10n_es_edi_verifactu/wizard/account_resequence_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_account_resequence_inherit_l10n_es_edi_verifactu" model="ir.ui.view">
+            <field name="name">account.resequence.form.inherit.l10n_es_edi_verifactu</field>
+            <field name="model">account.resequence.wizard</field>
+            <field name="inherit_id" ref="account.account_resequence_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='sequence_number_reset']" position="after">
+                    <div class="alert alert-danger" role="alert" invisible="not l10n_es_edi_verifactu_required_in_prod">
+                        Al usar Veri*factu, el número de factura no puede modificarse sin alterar la integridad e
+                        inalterabilidad exigidas por los artículos 8 y 13 del RD 007/2023. Existe un alto riesgo de que
+                        la factura quede invalidada a efectos fiscales.
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
[IMP] l10n_es_edi_verifactu: Alert banner resequence under veri*factu

If Veri*Factu is enabled in production mode, display a banner if a user wants to resequence moves because that's illegal.

task-5187419