### PR TITLE
[IMP] add :text pseudo-class

### DIFF
--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -153,7 +153,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Check message has correct recipients",
-            trigger: ".o-mail-MessageNotificationPopover:contains('Not A Demo User\nJane')",
+            trigger: ".o-mail-MessageNotificationPopover:contains('Not A Demo User Jane')",
         },
         {
             content: "Check message contains the first attachment",

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -83,12 +83,12 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.clickControlButton("Guests"),
             {
                 content: `click numpad button: 1`,
-                trigger: ".modal div.numpad button:contains(/^1$/)",
+                trigger: ".modal div.numpad button:text(1)",
                 run: "click",
             },
             {
                 content: `click numpad button: 5`,
-                trigger: ".modal div.numpad button:contains(/^5$/)",
+                trigger: ".modal div.numpad button:text(5)",
                 run: "click",
             },
             NumberPopup.isShown("15"),
@@ -101,7 +101,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             },
             {
                 content: `click numpad button: 5`,
-                trigger: ".modal div.numpad button:contains(/^5$/)",
+                trigger: ".modal div.numpad button:text(5)",
                 run: "click",
             },
             NumberPopup.isShown("5"),

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -130,11 +130,11 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         },
     }, {
         content: "Click on Restore History btn to get back to the selected revision in the previous step",
-        trigger: ".modal button.btn-primary:contains(/^Restore history$/)",
+        trigger: ".modal button.btn-primary:text(Restore history)",
         run: "click",
     }, {
         content: "Verify the confirmation dialog is opened",
-        trigger: ".modal button.btn-primary:contains(/^Restore$/)",
+        trigger: ".modal button.btn-primary:text(Restore)",
         run: "click",
     }, {
         content: "Verify that the description contains the right text after the restore",
@@ -243,7 +243,7 @@ registry.category("web_tour.tours").add("project_task_last_history_steps_tour", 
         trigger: 'button:contains("/^Restore history$/")',
         run: "click",
     }, {
-        trigger: '.modal button.btn-primary:contains(/^Restore$/)',
+        trigger: '.modal button.btn-primary:text(Restore)',
         run: "click",
     },
         ...insertEditorContent("2"),

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -100,7 +100,7 @@ function selectAttribute(productName, attributeName, attributeValue, attributeTy
         case 'multi':
             return {
                 content: content,
-                trigger: `${ptalSelector}:has(label:contains(/^${attributeValue}$/)) input[type="checkbox"]`,
+                trigger: `${ptalSelector}:has(label:text(${attributeValue})) input[type="checkbox"]`,
                 run: "click",
             };
         case 'pills':

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -10,7 +10,7 @@ registry.category("web_tour.tours").add('sale_signature', {
     steps: () => [
     {
         content: "open the test SO",
-        trigger: 'a:contains(/^test SO$/)',
+        trigger: 'a:text(test SO)',
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -636,7 +636,7 @@ registry.category("web_tour.tours").add("base_automation.on_change_rule_creation
             run: "edit ir.ui.view",
         },
         {
-            trigger: ".ui-menu-item > a:contains(/^View$/)",
+            trigger: ".ui-menu-item > a:text(View)",
             run: "click",
         },
         {
@@ -648,7 +648,7 @@ registry.category("web_tour.tours").add("base_automation.on_change_rule_creation
             run: "edit Active",
         },
         {
-            trigger: ".ui-menu-item > a:contains(/^Active$/)",
+            trigger: ".ui-menu-item > a:text(Active)",
             run: "click",
         },
         ...stepUtils.saveForm(),

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -71,7 +71,7 @@ registerWebsitePreviewTour(
     () => [
         {
             content: "check that the view got fixed",
-            trigger: ":iframe p:contains(/^Test Page View$/)",
+            trigger: ":iframe p:text(Test Page View)",
         },
         {
             content: "check that the inherited COW view is still there (created during edit mode)",

--- a/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
@@ -469,12 +469,16 @@ describe(parseUrl(import.meta.url), () => {
             expectSelector(".title:eq('1')").toEqualNodes(".title", { index: 1 });
             expectSelector('.title:eq("1")').toEqualNodes(".title", { index: 1 });
 
-            // :contains (text)
+            // :contains
             expectSelector("main > .text:contains(ipsum)").toEqualNodes("p");
             expectSelector(".text:contains(/\\bL\\w+\\b\\sipsum/)").toEqualNodes("p");
             expectSelector(".text:contains(item)").toEqualNodes("li");
 
-            // :contains (value)
+            // :text
+            expectSelector(".text:text(item)").toEqualNodes("");
+            expectSelector(".text:text(first item)").toEqualNodes("li:first-of-type");
+
+            // :value
             expectSelector("input:value(john)").toEqualNodes("[name=name],[name=email]");
             expectSelector("input:value(john doe)").toEqualNodes("[name=name]");
             expectSelector("input:value('John Doe (JOD)')").toEqualNodes("[name=name]");
@@ -610,9 +614,9 @@ describe(parseUrl(import.meta.url), () => {
                     <div>PA4: PAV41</div>
                 </span>
             `);
-            expectSelector(
-                `span:contains("Matrix (PAV11, PAV22, PAV31)\nPA4: PAV41")`
-            ).toEqualNodes("span");
+            expectSelector(`span:contains("Matrix (PAV11, PAV22, PAV31) PA4: PAV41")`).toEqualNodes(
+                "span"
+            );
         });
 
         test(":has(...):first", async () => {
@@ -744,7 +748,7 @@ describe(parseUrl(import.meta.url), () => {
             `);
 
             expectSelector(
-                `.o_content:has(.o_field_widget[name=messages]):has(td:contains(/^bbb$/)):has(td:contains(/^\\[test_trigger\\] Mitchell Admin$/))`
+                `.o_content:has(.o_field_widget[name=messages]):has(td:text(bbb)):has(td:contains(/^\\[test_trigger\\] Mitchell Admin/))`
             ).toEqualNodes(".o_content");
         });
 

--- a/addons/web/static/tests/_framework/search_test_helpers.js
+++ b/addons/web/static/tests/_framework/search_test_helpers.js
@@ -113,14 +113,14 @@ export async function mountWithSearch(componentConstructor, searchProps = {}, co
  * @param {string} label
  */
 export async function toggleMenu(label) {
-    await contains(`button.o-dropdown:contains(/^${label}$/i)`).click();
+    await contains(`button.o-dropdown:text(${label})`).click();
 }
 
 /**
  * @param {string} label
  */
 export async function toggleMenuItem(label) {
-    const target = queryOne`.o_menu_item:contains(/^${label}$/i)`;
+    const target = queryOne`.o_menu_item:text(${label})`;
     if (target.classList.contains("dropdown-toggle")) {
         await contains(target).hover();
     } else {
@@ -133,8 +133,8 @@ export async function toggleMenuItem(label) {
  * @param {string} optionLabel
  */
 export async function toggleMenuItemOption(itemLabel, optionLabel) {
-    const { parentElement: root } = queryOne`.o_menu_item:contains(/^${itemLabel}$/i)`;
-    const target = queryOne(`.o_item_option:contains(/^${optionLabel}$/i)`, { root });
+    const { parentElement: root } = queryOne`.o_menu_item:text(${itemLabel})`;
+    const target = queryOne(`.o_item_option:text(${optionLabel})`, { root });
     if (target.classList.contains("dropdown-toggle")) {
         await contains(target).hover();
     } else {
@@ -146,7 +146,7 @@ export async function toggleMenuItemOption(itemLabel, optionLabel) {
  * @param {string} label
  */
 export function isItemSelected(label) {
-    return queryOne`.o_menu_item:contains(/^${label}$/i)`.classList.contains("selected");
+    return queryOne`.o_menu_item:text(${label})`.classList.contains("selected");
 }
 
 /**
@@ -154,10 +154,8 @@ export function isItemSelected(label) {
  * @param {string} optionLabel
  */
 export function isOptionSelected(itemLabel, optionLabel) {
-    const { parentElement: root } = queryOne`.o_menu_item:contains(/^${itemLabel}$/i)`;
-    return queryOne(`.o_item_option:contains(/^${optionLabel}$/i)`, { root }).classList.contains(
-        "selected"
-    );
+    const { parentElement: root } = queryOne`.o_menu_item:text(${itemLabel})`;
+    return queryOne(`.o_item_option:text(${optionLabel})`, { root }).classList.contains("selected");
 }
 
 export function getMenuItemTexts() {
@@ -217,7 +215,7 @@ export async function toggleFavoriteMenu() {
  */
 export async function deleteFavorite(text) {
     await ensureSearchBarMenu();
-    await contains(`.o_favorite_menu .o_menu_item:contains(/^${text}$/i) i.fa-trash-o`).click();
+    await contains(`.o_favorite_menu .o_menu_item:text(${text}) i.fa-trash-o`).click();
 }
 
 export async function toggleSaveFavorite() {
@@ -262,7 +260,7 @@ export function getFacetTexts() {
  */
 export async function removeFacet(label) {
     await ensureSearchView();
-    await contains(`.o_searchview_facet:contains(/^${label}$/i) .o_facet_remove`).click();
+    await contains(`.o_searchview_facet:text(${label}) .o_facet_remove`).click();
 }
 
 /**

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -26,7 +26,7 @@ import {
 import { resetDateFieldWidths } from "@web/views/list/column_width_hook";
 
 function getPickerCell(expr) {
-    return queryAll(`.o_datetime_picker .o_date_item_cell:contains(/^${expr}$/)`);
+    return queryAll(`.o_datetime_picker .o_date_item_cell:text(${expr})`);
 }
 
 class Partner extends models.Model {

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -343,8 +343,8 @@ test('StateSelectionField edited by the smart actions "Set kanban state as <stat
     expect(".o_status_red").toHaveCount(1);
     await press(["control", "k"]);
     await animationFrame();
-    expect(`.o_command:contains("Set kanban state as Normal\nALT + D")`).toHaveCount(1);
-    const doneItem = `.o_command:contains("Set kanban state as Done\nALT + G")`;
+    expect(`.o_command:contains("Set kanban state as Normal ALT + D")`).toHaveCount(1);
+    const doneItem = `.o_command:contains("Set kanban state as Done ALT + G")`;
     expect(doneItem).toHaveCount(1);
 
     await click(doneItem);
@@ -353,9 +353,9 @@ test('StateSelectionField edited by the smart actions "Set kanban state as <stat
 
     await press(["control", "k"]);
     await animationFrame();
-    expect(`.o_command:contains("Set kanban state as Normal\nALT + D")`).toHaveCount(1);
-    expect(`.o_command:contains("Set kanban state as Blocked\nALT + F")`).toHaveCount(1);
-    expect(`.o_command:contains("Set kanban state as Done\nALT + G")`).toHaveCount(0);
+    expect(`.o_command:contains("Set kanban state as Normal ALT + D")`).toHaveCount(1);
+    expect(`.o_command:contains("Set kanban state as Blocked ALT + F")`).toHaveCount(1);
+    expect(`.o_command:contains("Set kanban state as Done ALT + G")`).toHaveCount(0);
 });
 
 test("StateSelectionField uses legend_* fields", async () => {
@@ -513,7 +513,8 @@ test("StateSelectionField - hotkey handling when there are more than 3 options a
     await press(["control", "k"]);
     await animationFrame();
 
-    expect(".o_command#o_command_2").toHaveText("Set kanban state as Done\nALT + G", {
+    expect(".o_command#o_command_2").toHaveText("Set kanban state as Done ALT + G", {
+        inline: true,
         message: "hotkey and command are present",
     });
     expect(".o_command#o_command_4").toHaveText("Set kanban state as Martine", {

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -247,7 +247,7 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "Check body",
-    trigger: ":iframe body:not(:has(#wrap p font:first:contains(/^paragraphs <b>describing</b>$/)))",
+    trigger: ":iframe body:not(:has(#wrap p font:first:text(paragraphs <b>describing</b>)))",
 },
 ...clickOnEditAndWaitEditMode(),
 {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1135,7 +1135,7 @@ registerWebsitePreviewTour("website_form_editable_content", {
     },
     {
         content: "Check that the new text value was correctly set",
-        trigger: ":iframe section.s_website_form h5:contains(/^ABC$/)",
+        trigger: ":iframe section.s_website_form h5:text(ABC)",
     },
     {
         content: "Remove the dropped column",

--- a/addons/website_event/static/tests/tours/website_event_pages_seo.js
+++ b/addons/website_event/static/tests/tours/website_event_pages_seo.js
@@ -33,11 +33,11 @@ registry.category("web_tour.tours").add("website_event_pages_seo", {
             trigger: "body:not(:has(.modal))",
         },
         {
-            trigger: ":iframe head:has(title:contains(/^Hello, world!$/)):not(:visible)",
+            trigger: ":iframe head:has(title:text(Hello, world!)):not(:visible)",
         },
         {
             content: "Check that the page title is adapted, inside and outside the iframe",
-            trigger: "head:has(title:contains(/^Hello, world!$/)):not(:visible)",
+            trigger: "head:has(title:text(Hello, world!)):not(:visible)",
         },
     ],
 });

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -29,14 +29,14 @@ registerBackendAndFrontendTour("question", {
     run: "editor Test",
 },
 {
-    trigger: `.note-editable p:not(:contains(/^<br>$/))`,
+    trigger: `.note-editable p:not(:text(<br>))`,
 },
 {
     trigger: ".o_select_menu_toggler",
     content: _t("Insert tags related to your question."),
     tooltipPosition: "top",
     run: "click",
-}, 
+},
 {
     trigger: ".o_select_menu_sticky",
     run: "edit Test",
@@ -82,7 +82,7 @@ registerBackendAndFrontendTour("question", {
     run: "editor Test",
 },
 {
-    trigger: `.note-editable p:not(:contains(/^<br>$/))`,
+    trigger: `.note-editable p:not(:text(<br>))`,
 },
 {
     trigger: "button:contains(\"Post Answer\")",
@@ -90,7 +90,7 @@ registerBackendAndFrontendTour("question", {
     tooltipPosition: "bottom",
     run: "click",
     expectUnloadPage: true,
-}, 
+},
 {
     trigger: ".o_wforum_content_wrapper h3:contains(test)",
 },

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -103,7 +103,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
         },
         {
             content: "check that we landed on correct page with correct query strings",
-            trigger: ".s_title h1:contains(/^Contact us$/)",
+            trigger: ".s_title h1:text(Contact us)",
             run: function () {
                 const enc = c => encodeURIComponent(c).replace(/%20/g, '+');
                 const expectedUrl = `/contactus?utm_campaign=${enc(campaignValue)}&utm_source=${enc(sourceValue)}&utm_medium=${enc(mediumValue)}`;

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -35,25 +35,25 @@ export function assertCartAmounts({taxes = false, untaxed = false, total = false
     if (taxes) {
         steps.push({
             content: 'Check if the tax is correct',
-            trigger: `tr#order_total_taxes .oe_currency_value:contains(/^${taxes}$/)`,
+            trigger: `tr#order_total_taxes .oe_currency_value:text(${taxes})`,
         });
     }
     if (untaxed) {
         steps.push({
             content: 'Check if the tax is correct',
-            trigger: `tr#order_total_untaxed .oe_currency_value:contains(/^${untaxed}$/)`,
+            trigger: `tr#order_total_untaxed .oe_currency_value:text(${untaxed})`,
         });
     }
     if (total) {
         steps.push({
             content: 'Check if the tax is correct',
-            trigger: `tr#order_total .oe_currency_value:contains(/^${total}$/)`,
+            trigger: `tr#order_total .oe_currency_value:text(${total})`,
         });
     }
     if (delivery) {
         steps.push({
             content: 'Check if the tax is correct',
-            trigger: `tr#order_delivery .oe_currency_value:contains(/^${delivery}$/)`,
+            trigger: `tr#order_delivery .oe_currency_value:text(${delivery})`,
         });
     }
     return steps
@@ -121,7 +121,7 @@ export function goToCart({
 } = {}) {
     return {
         content: _t("Go to cart"),
-        trigger: `${backend ? ":iframe" : ""} a sup.my_cart_quantity:contains(/^${quantity}$/)`,
+        trigger: `${backend ? ":iframe" : ""} a sup.my_cart_quantity:text(${quantity})`,
         tooltipPosition: position,
         run: "click",
         expectUnloadPage,
@@ -242,7 +242,7 @@ export function searchProduct(productName, { select = false } = {}) {
     if (select) {
         steps.push({
             content: `Select ${productName}`,
-            trigger: `.oe_product_cart:first a:contains(/^${productName}$/i)`,
+            trigger: `.oe_product_cart:first a:text(${productName})`,
             run: "click",
             expectUnloadPage: true,
         });

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -48,7 +48,7 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
     timeout: 30000,
 },
 {
-    trigger: ":iframe .product_price .o_dirty .oe_currency_value:not(:contains(/^1.00$/))",
+    trigger: ":iframe .product_price .o_dirty .oe_currency_value:not(:text(1.00))",
 },
 {
     trigger: ":iframe #wrap img.product_detail_img",

--- a/addons/website_sale/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale/static/tests/tours/website_free_delivery.js
@@ -11,7 +11,7 @@ registry.category("web_tour.tours").add("check_free_delivery", {
         tourUtils.goToCart({ quantity: 1 }),
         tourUtils.goToCheckout(),
         {
-            trigger: "#o_delivery_methods label:contains(/^Delivery Now Free Over 10$/)",
+            trigger: "#o_delivery_methods label:text(Delivery Now Free Over 10)",
         },
         {
             content: "Check Free Delivery value to be zero",

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -22,7 +22,7 @@
     },
     {
         content: "Check b2b Tax-Excluded Prices",
-        trigger: ".product_price .oe_price .oe_currency_value:contains(/^79.00$/)",
+        trigger: ".product_price .oe_price .oe_currency_value:text(79.00)",
     },
     {
         content: "Click on add to cart",
@@ -299,7 +299,7 @@
     },
     {
         content: "Check b2c Tax-Included Prices",
-        trigger: ".product_price .oe_price .oe_currency_value:contains(/^90.85$/)",
+        trigger: ".product_price .oe_price .oe_currency_value:text(90.85)",
     },
     {
         content: "Click on add to cart",

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add('google_analytics_add_to_cart', {
     },
     {
         content: 'check add to cart event',
-        trigger: "a:has(.my_cart_quantity:contains(/^1$/))",
+        trigger: "a:has(.my_cart_quantity:text(1))",
         timeout: 25000,
     },
 ]});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
     steps: () => [
     {
         content: "select Test Product",
-        trigger: ".oe_product_cart a:contains(/^Test Product 2$/)",
+        trigger: ".oe_product_cart a:text(Test Product 2)",
         run: "click",
         expectUnloadPage: true,
     },
@@ -69,7 +69,7 @@ registry.category("web_tour.tours").add('test_09_pills_variant', {
     steps: () => [
     {
         content: "select Test Product",
-        trigger: ".oe_product_cart a:contains(/^Test Product 2$/)",
+        trigger: ".oe_product_cart a:text(Test Product 2)",
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -55,7 +55,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
     },
     {
         content: "click Send an Email",
-        trigger: "span:contains(/^Send an email$/)",
+        trigger: "span:text(Send an email)",
         run: "click",
     },
     {
@@ -79,7 +79,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
     },
     {
         content: "check the mail is sent, grab the recovery link, and logout",
-        trigger: ".o-mail-Message-body a:contains(/^Resume order$/)",
+        trigger: ".o-mail-Message-body a:text(Resume order)",
         run: function () {
             var link = queryOne('.o-mail-Message-body a:contains("Resume order")').getAttribute('href');
             browser.localStorage.setItem(recoveryLinkKey, link);

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -64,7 +64,7 @@ registerWebsitePreviewTour('shop_customize', {
         },
         {
             content: "check price is 750",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^750.00$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(750.00)",
         },
         {
             content: "switch to another variant",
@@ -73,7 +73,7 @@ registerWebsitePreviewTour('shop_customize', {
         },
         {
             content: "verify that price has changed when changing variant",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^800.40$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(800.40)",
         },
         ...clickOnEditAndWaitEditMode(),
         {
@@ -101,7 +101,7 @@ registerWebsitePreviewTour('shop_customize', {
         },
         {
             content: "check price is 750",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^750.00$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(750.00)",
         },
         {
             content: "switch to Aluminium variant",
@@ -110,7 +110,7 @@ registerWebsitePreviewTour('shop_customize', {
         },
         {
             content: "verify that price has changed when changing variant",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^800.40$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(800.40)",
         },
         {
             content: "switch back to Steel variant",
@@ -119,7 +119,7 @@ registerWebsitePreviewTour('shop_customize', {
         },
         {
             content: "check price is 750",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^750.00$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(750.00)",
         },
         {
             content: "click on 'Add to Cart' button",
@@ -128,7 +128,7 @@ registerWebsitePreviewTour('shop_customize', {
         },
         {
             content: "check quantity",
-            trigger: ":iframe .my_cart_quantity:contains(/^1$/),.o_extra_menu_items .fa-plus",
+            trigger: ":iframe .my_cart_quantity:text(1),.o_extra_menu_items .fa-plus",
         },
         goToCart({ backend: true, expectUnloadPage: false }),
         {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
@@ -13,7 +13,7 @@ registry.category("web_tour.tours").add('tour_shop_deleted_archived_variants', {
     },
     {
         content: "select Test Product 2",
-        trigger: ".oe_product_cart a:contains(/^Test Product 2$/)",
+        trigger: ".oe_product_cart a:text(Test Product 2)",
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add('tour_shop_dynamic_variants', {
     steps: () => [
     {
         content: "select Dynamic Product",
-        trigger: ".oe_product_cart a:contains(/^Dynamic Product$/)",
+        trigger: ".oe_product_cart a:text(Dynamic Product)",
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -59,7 +59,7 @@ registerWebsitePreviewTour('shop_list_view_b2c', {
         },
         {
             content: "check price is 825",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^825.00$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(825.00)",
         },
         {
             content: "switch to another variant",
@@ -68,7 +68,7 @@ registerWebsitePreviewTour('shop_list_view_b2c', {
         },
         {
             content: "verify that price has changed when changing variant",
-            trigger: ":iframe .product_price .oe_price .oe_currency_value:contains(/^880.44$/)",
+            trigger: ":iframe .product_price .oe_price .oe_currency_value:text(880.44)",
         },
         {
             content: "click on 'Add to Cart' button",
@@ -78,7 +78,7 @@ registerWebsitePreviewTour('shop_list_view_b2c', {
         goToCart({ backend: true, expectUnloadPage: false }),
         {
             content: "check price on /cart",
-            trigger: ":iframe #cart_products .oe_currency_value:contains(/^880.44$/)",
+            trigger: ":iframe #cart_products .oe_currency_value:text(880.44)",
         },
     ],
 );

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
     steps: () => [
     {
         content: "select Product",
-        trigger: ".oe_product_cart a:contains(/^Product Multi$/)",
+        trigger: ".oe_product_cart a:text(Product Multi)",
         run: "click",
         expectUnloadPage: true,
     },
@@ -68,7 +68,7 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value',
     steps: () => [
     {
         content: "select Product",
-        trigger: '.oe_product_cart a:contains(/^Burger$/)',
+        trigger: '.oe_product_cart a:text(Burger)',
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add('tour_shop_no_variant_attribute', {
     steps: () => [
     {
         content: "select Test Product 3",
-        trigger: ".oe_product_cart a:contains(/^Test Product 3$/)",
+        trigger: ".oe_product_cart a:text(Test Product 3)",
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add('shop_zoom', {
     steps: () => [
     {
         content: "select " + imageName,
-        trigger: `.oe_product_cart a:contains(/^${imageName}$/)`,
+        trigger: `.oe_product_cart a:text(${imageName})`,
         run: "click",
         expectUnloadPage: true,
     },

--- a/addons/website_sale_loyalty/static/tests/tours/test_update_shipping_after_discount.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_update_shipping_after_discount.js
@@ -48,11 +48,11 @@ registry.category('web_tour.tours').add('update_shipping_after_discount', {
         }),
         {
             content: "check discount code discount",
-            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):contains(/^- 50.00$/)',
+            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):text(- 50.00)',
         },
         {
             content: "check eWallet discount",
-            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):contains(/^- 55.00$/)',
+            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):text(- 55.00)',
         },
     ],
 });

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -63,11 +63,11 @@
         run: "click",
     }, {
         content: "select Admin",
-        trigger: 'tr:has(td:contains(/^Mitchell Admin$/)) .o_list_record_selector input[type="checkbox"]',
+        trigger: 'tr:has(td:text(Mitchell Admin)) .o_list_record_selector input[type="checkbox"]',
         run: "click",
     },
     {
-        trigger: 'tr:has(td:contains(/^Mitchell Admin$/)) .o_list_record_selector input[type="checkbox"]:checked',
+        trigger: 'tr:has(td:text(Mitchell Admin)) .o_list_record_selector input[type="checkbox"]:checked',
     },
     {
         content: "save selected participants",
@@ -75,7 +75,7 @@
         run: "click",
     },
     {
-        trigger: '.o_field_widget[name=participants] .o_data_cell:contains(/^Mitchell Admin$/)',
+        trigger: '.o_field_widget[name=participants] .o_data_cell:text(Mitchell Admin)',
     },
     ...stepUtils.saveForm(),
     { // add message a
@@ -124,7 +124,7 @@
     },
     { // change message b
         content: "edit message b",
-        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^b$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_cell:text(b)',
         run: "click",
     }, {
         content: "change the body",
@@ -164,11 +164,11 @@
         run: "click",
     }, {
         content: "select Demo User",
-        trigger: 'tr:has(td:contains(/^Marc Demo$/)) .o_list_record_selector input[type="checkbox"]',
+        trigger: 'tr:has(td:text(Marc Demo)) .o_list_record_selector input[type="checkbox"]',
         run: "click",
     },
     {
-        trigger: 'tr:has(td:contains(/^Marc Demo$/)) .o_list_record_selector input[type="checkbox"]:checked',
+        trigger: 'tr:has(td:text(Marc Demo)) .o_list_record_selector input[type="checkbox"]:checked',
     },
     {
         content: "save selected participants",
@@ -191,7 +191,7 @@
         trigger: '.o_content:has(.o_field_widget[name=messages] tbody .o_data_row:eq(2))',
     }, {
         content: "check data 2",
-        trigger: `.o_content:has(.o_field_widget[name=messages] tr:has(td:contains(/^bbb$/)):has(td:contains(/^\\[test_trigger\\] Mitchell Admin$/)))`,
+        trigger: `.o_content:has(.o_field_widget[name=messages] tr:has(td:text(bbb)):has(td:text([test_trigger] Mitchell Admin)))`,
     }, {
         content: "go to tab 3",
         trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
@@ -229,7 +229,7 @@
         run: "click",
     },
     {
-        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^d$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_cell:text(d)',
     },
     { // add message e
         content: "create new message e",
@@ -245,11 +245,11 @@
         run: "click",
     },
     {
-        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^e$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_cell:text(e)',
     },
     { // change message a
         content: "edit message a",
-        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^a$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_cell:text(a)',
         run: "click",
     }, {
         content: "change the body",
@@ -261,11 +261,11 @@
         run: "click",
     },
     {
-        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^aaa$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_cell:text(aaa)',
     },
     { // change message e
         content: "edit message e",
-        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^e$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_cell:text(e)',
         run: "click",
     }, {
         content: "open the many2one to select another user",
@@ -293,15 +293,15 @@
         trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger] Marc Demo:e)',
     }, { // remove
         content: "remove b",
-        trigger: '.o_field_widget[name=messages] .o_data_row:has(.o_data_cell:contains(/^bbb$/)) .o_list_record_remove',
+        trigger: '.o_field_widget[name=messages] .o_data_row:has(.o_data_cell:text(bbb)) .o_list_record_remove',
         run: "click",
     }, {
         content: "remove e",
-        trigger: '.o_field_widget[name=messages] .o_data_row:has(.o_data_cell:contains(/^e$/)) .o_list_record_remove',
+        trigger: '.o_field_widget[name=messages] .o_data_row:has(.o_data_cell:text(e)) .o_list_record_remove',
         run: "click",
     },
     {
-        trigger: 'body:not(:has(tr:has(td:contains(/^e$/))))',
+        trigger: 'body:not(:has(tr:has(td:text(e))))',
     },
     { // save
         content: "save discussion",
@@ -312,10 +312,10 @@
         trigger: '.o_content:not(:has(.o_field_widget[name=messages] tbody tr:has(.o_list_record_remove):eq(4)))',
     }, {
         content: "check data 5",
-        trigger: '.o_content:has(.o_field_widget[name=messages] tbody:has(tr td:contains(/^aaa$/)):has(tr td:contains(/^c$/)):has(tr td:contains(/^d$/)))',
+        trigger: '.o_content:has(.o_field_widget[name=messages] tbody:has(tr td:text(aaa)):has(tr td:text(c)):has(tr td:text(d)))',
     }, {
         content: "check data 6",
-        trigger: `.o_content:has(.o_field_widget[name=messages] tbody tr:has(td:contains(/^\\[test_trigger\\] Mitchell Admin$/)):has(td:contains(/^aaa$/)))`,
+        trigger: `.o_content:has(.o_field_widget[name=messages] tbody tr:has(td:text([test_trigger] Mitchell Admin)):has(td:text(aaa)))`,
     }, {
         content: "go to Participants",
         trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
@@ -333,7 +333,7 @@
         run: "click",
     },
     {
-        trigger: '.o_form_editable .o_field_widget[name=messages] tbody tr:has(td:contains(/^d$/))',
+        trigger: '.o_form_editable .o_field_widget[name=messages] tbody tr:has(td:text(d))',
     },
     { // add message ddd
         content: "create new message ddd",
@@ -370,7 +370,7 @@
         trigger: '.o_content:has(.o_field_widget[name=messages] .o_data_row:eq(3))',
     },
     {
-        trigger: '.o_field_widget[name=messages]:has(tr td:contains(/^ddd$/))',
+        trigger: '.o_field_widget[name=messages]:has(tr td:text(ddd))',
     },
     ...stepUtils.discardForm({ // cancel
         content: "cancel change",
@@ -466,7 +466,7 @@
         trigger: '.o_content:not(:has(.o_field_widget[name="message_concat"] textarea:value(Mitchell Admin:d)))',
     },
     {
-        trigger: 'body:not(:has(tr:has(td:contains(/^d$/))))',
+        trigger: 'body:not(:has(tr:has(td:text(d))))',
     },
     ...stepUtils.saveForm(),
     { // check saved data
@@ -536,11 +536,11 @@
         run:     "edit {generate_dummy_message} && click body",
     },
     {
-        trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:contains(/^13$/)',
+        trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:text(13)',
     },
     {
         content: "check new dummy message happened",
-        trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:contains(/^13$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:text(13)',
     }, {
         content: "check field not in embedded view received correctly",
         trigger: '.o_field_widget[name=messages] .o_data_row input[type="checkbox"]:checked',
@@ -557,11 +557,11 @@
         run:     "edit {generate_dummy_message} && click body",
     },
     {
-        trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:contains(/^22$/)',
+        trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:text(22)',
     },
     {
         content: "check update and new dummy message happened",
-        trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:contains(/^22$/)',
+        trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:text(22)',
     },
     ...stepUtils.discardForm(),
     ]});


### PR DESCRIPTION
This commit adds the ':text()' pseudo-class to the list of supported
pseudo-classes in Hoot selectors.

Its purpose is the same as ':contains()', with the specificity of being
an *exact* match instead of a *partial* one.

It effectively replaces ':contains(/^<expression>$/)' by
':text(<expression>)', improving the readability and making the
developer experience a bit nicer.

Enterprise: https://github.com/odoo/enterprise/pull/98772

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
