### PR TITLE
[FIX] hr_work_entry: fix context in work entry gantt view

### DIFF
--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -17,7 +17,7 @@ export class WorkEntryCalendarModel extends CalendarModel {
     async updateData(data) {
         const { start, end } = this.computeRange();
         await this.orm.call("hr.employee", "generate_work_entries", [
-            [this.meta.context.active_id],
+            [this.meta.context.default_employee_id],
             serializeDate(start),
             serializeDate(end),
         ]);

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.js
@@ -59,7 +59,7 @@ export class WorkEntryCalendarMultiSelectionButtons extends MultiSelectionButton
 
     makeValues(workEntryTypeId) {
         return {
-            employee_id: this.actionService.currentController.currentState.active_id,
+            employee_id: this.props.reactive.context.default_employee_id,
             duration: -1,
             work_entry_type_id: workEntryTypeId,
         };

--- a/addons/hr_work_entry/static/tests/work_entry_calendar_view.test.js
+++ b/addons/hr_work_entry/static/tests/work_entry_calendar_view.test.js
@@ -3,6 +3,7 @@ import { animationFrame, mockDate } from "@odoo/hoot-mock";
 import { findComponent, makeMockServer, mountView } from "@web/../tests/web_test_helpers";
 import { defineHrWorkEntryModels } from "@hr_work_entry/../tests/hr_work_entry_test_helpers";
 import { WorkEntryCalendarController } from "@hr_work_entry/views/work_entry_calendar/work_entry_calendar_controller";
+import { WorkEntryCalendarMultiSelectionButtons } from "@hr_work_entry/views/work_entry_calendar/work_entry_multi_selection_buttons";
 const { DateTime } = luxon;
 
 describe.current.tags("desktop");
@@ -52,5 +53,27 @@ test("Test work entry calendar without work entry type", async () => {
     await animationFrame();
     expect(".fc-event").toHaveCount(2, {
         message: "2 work entries should be displayed in the calendar view",
+    });
+});
+
+test("should use default_employee_id from context in work entry", async () => {
+    const defaultEmployeeId = 100;
+    const view = await mountView({
+        type: "calendar",
+        resModel: "hr.work.entry",
+        context: { default_employee_id: defaultEmployeeId },
+    });
+
+    const controller = findComponent(
+        view,
+        (component) => component instanceof WorkEntryCalendarMultiSelectionButtons
+    );
+    const workEntryTypeId = 1;
+    const values = controller.makeValues(workEntryTypeId);
+
+    expect(values).toEqual({
+        employee_id: defaultEmployeeId,
+        duration: -1,
+        work_entry_type_id: workEntryTypeId,
     });
 });


### PR DESCRIPTION
**Steps to reproduce:**
- Install the hr_payroll module.
- Open the form view of an employee with a running contract and click on the Payslip smart button.
- Create or open an existing payslip, then open the Work Entries from smart button.
- Click on any day cell and then click the Quick Replace button.

**Issue:**
Clicking the Quick Replace button (next to Set) triggers an error, 'Missing record' or 'Contract out of range.'

**Cause:**
The issue occurs due to an incorrect context being passed in the Gantt view (https://github.com/odoo/odoo/pull/223409). The view incorrectly passes the payslip ID instead of the employee ID.

**Fix:**
This PR updates the context to ensure the correct employee ID is passed to the Gantt view.

task-5219487
