### PR TITLE
[IMP] account: multiple embed files peppol

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -65,9 +65,18 @@ class AccountMoveSend(models.AbstractModel):
             'author_partner_id': get_setting('author_partner_id', from_cron=from_cron) or self.env.user.partner_id.id,
         }
         vals['invoice_edi_format'] = get_setting('invoice_edi_format', default_value=self._get_default_invoice_edi_format(move, sending_methods=vals['sending_methods']))
+        mail_template = get_setting('mail_template') or self._get_default_mail_template_id(move)
         if 'email' in vals['sending_methods']:
-            mail_template = get_setting('mail_template') or self._get_default_mail_template_id(move)
             mail_lang = get_setting('mail_lang') or self._get_default_mail_lang(move, mail_template)
+            vals.update({
+                'mail_template': mail_template,
+                'mail_lang': mail_lang,
+                'mail_body': get_setting('mail_body', default_value=self._get_default_mail_body(move, mail_template, mail_lang)),
+                'mail_subject': get_setting('mail_subject', default_value=self._get_default_mail_subject(move, mail_template, mail_lang)),
+                'mail_partner_ids': get_setting('mail_partner_ids', default_value=self._get_default_mail_partner_ids(move, mail_template, mail_lang).ids),
+            })
+        # Add mail attachments if sending methods support them
+        if self._display_attachments_widget(vals['invoice_edi_format'], vals['sending_methods']):
             mail_attachments_widget = self._get_default_mail_attachments_widget(
                 move,
                 mail_template,
@@ -75,14 +84,7 @@ class AccountMoveSend(models.AbstractModel):
                 extra_edis=vals['extra_edis'],
                 pdf_report=vals['pdf_report'],
             )
-            vals.update({
-                'mail_template': mail_template,
-                'mail_lang': mail_lang,
-                'mail_body': get_setting('mail_body', default_value=self._get_default_mail_body(move, mail_template, mail_lang)),
-                'mail_subject': get_setting('mail_subject', default_value=self._get_default_mail_subject(move, mail_template, mail_lang)),
-                'mail_partner_ids': get_setting('mail_partner_ids', default_value=self._get_default_mail_partner_ids(move, mail_template, mail_lang).ids),
-                'mail_attachments_widget': get_setting('mail_attachments_widget', default_value=mail_attachments_widget),
-            })
+            vals['mail_attachments_widget'] = get_setting('mail_attachments_widget', default_value=mail_attachments_widget)
         return vals
 
     # -------------------------------------------------------------------------
@@ -313,6 +315,10 @@ class AccountMoveSend(models.AbstractModel):
             return Markup("%s<ul>%s</ul>") % (error['error_title'], errors)
         else:
             return error
+
+    @api.model
+    def _display_attachments_widget(self, edi_format, sending_methods):
+        return 'email' in sending_methods
 
     # -------------------------------------------------------------------------
     # SENDING METHODS

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.js
@@ -22,7 +22,14 @@ export class MailAttachments extends Component {
     }
 
     getValue(){
-        return this.props.record.data[this.props.name] || [];
+        const attachments = this.props.record.data[this.props.name] || [];
+        const attachmentsNotSupported = this.props.record.data.attachments_not_supported || {};
+        for (const attachment of attachments) {
+            if (attachment.id && attachment.id in attachmentsNotSupported) {
+                attachment.tooltip = attachmentsNotSupported[attachment.id];
+            }
+        }
+        return attachments;
     }
 
     getUrl(attachmentId) {
@@ -31,6 +38,11 @@ export class MailAttachments extends Component {
 
     getExtension(file) {
         return file.name.replace(/^.*\./, "");
+    }
+
+    get iconsSupported() {
+        // Technical getter to display icons in view
+        return this.getValue().some(attachment => !!attachment.tooltip);
     }
 
     onFileUploaded(files) {

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.xml
@@ -36,6 +36,18 @@
         </xpath>
         <!-- Remove the mimetype on the second line. -->
         <xpath expr="//div[hasclass('caption', 'small')]" position="replace"/>
+        <!-- Set float left to add an icon on the right. -->
+        <xpath expr="//div[@name='attachment']" position="attributes">
+            <attribute name="t-attf-class"
+                       add="d-flex flex-row align-items-center gap-1 w-100 {{ iconsSupported ? 'float-start' : '' }}"
+                       separator=" "/>
+        </xpath>
+        <!-- Add Icon on the right of the Attachment -->
+        <xpath expr="//div[@name='attachment']" position="inside">
+            <div class="float-start" t-if="file.tooltip">
+                <i class="fa fa-fw o_button_icon fa-warning" t-att-data-tooltip="file.tooltip"></i>
+            </div>
+        </xpath>
     </t>
 
     <t t-name="account.mail_attachments">

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -694,6 +694,18 @@ class AccountTestInvoicingCommon(ProductCommon):
         )
 
     @classmethod
+    def _create_account_move_send_wizard_single(cls, move, **kwargs):
+        return cls.env['account.move.send.wizard']\
+            .with_context(active_model='account.move', active_ids=move.ids)\
+            .create(kwargs)
+
+    @classmethod
+    def _create_account_move_send_wizard_multi(cls, moves, **kwargs):
+        return cls.env['account.move.send.batch.wizard']\
+            .with_context(active_model='account.move', active_ids=moves.ids)\
+            .create(kwargs)
+
+    @classmethod
     def _reverse_invoice(cls, invoice, post=False, **reversal_args):
         reverse_action_values = (
             cls.env['account.move.reversal']

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -512,10 +512,10 @@ class TestAccountMoveSendCommon(AccountTestInvoicingCommon):
             )
 
     def create_send_and_print(self, invoices, **kwargs):
-        wizard_model = 'account.move.send.wizard' if len(invoices) == 1 else 'account.move.send.batch.wizard'
-        return self.env[wizard_model]\
-            .with_context(active_model='account.move', active_ids=invoices.ids)\
-            .create(kwargs)
+        if len(invoices) == 1:
+            return self._create_account_move_send_wizard_single(invoices, **kwargs)
+        else:
+            return self._create_account_move_send_wizard_multi(invoices, **kwargs)
 
     def _get_mail_message(self, move):
         return self.env['mail.message'].search([('model', '=', move._name), ('res_id', '=', move.id)], limit=1)

--- a/addons/account/wizard/account_move_send_wizard.xml
+++ b/addons/account/wizard/account_move_send_wizard.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <form>
                 <field name="move_id" invisible="1"/>
+                <field name="attachments_not_supported" invisible="1"/>
 
                 <!-- Warnings -->
                 <div class="m-0" id="alerts" invisible="not alerts">
@@ -49,19 +50,19 @@
                            widget="html_mail"/>
                     <group>
                         <group>
-                            <field name="mail_attachments_widget"
-                                   widget="mail_attachments"
-                                   string="Attach a file"
-                                   nolabel="1"
-                                   colspan="2"/>
-                        </group>
-                        <group>
                             <field name="mail_template_id"
                                    options="{'no_create': True, 'no_edit': True}"
                                    context="{'default_model': 'account.move'}"/>
                         </group>
                     </group>
                 </div>
+
+                <field name="mail_attachments_widget"
+                       widget="mail_attachments"
+                       string="Attach a file"
+                       nolabel="1"
+                       colspan="2"
+                       invisible="not display_attachments_widget"/>
 
                 <footer>
                     <button string="Send"

--- a/addons/account_edi_ubl_cii/__init__.py
+++ b/addons/account_edi_ubl_cii/__init__.py
@@ -1,4 +1,5 @@
 from . import models
+from . import wizard
 
 
 def uninstall_hook(env):

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -110,6 +110,18 @@ EAS_MAPPING = {
     'YT': {'0009': 'siret', '9957': 'vat', '0002': None},  # Mayotte
 }
 
+# -------------------------------------------------------------------------
+# SUPPORTED FILE TYPES FOR IMPORT
+# -------------------------------------------------------------------------
+SUPPORTED_FILE_TYPES = {
+    'application/pdf': '.pdf',
+    'application/vnd.oasis.opendocument.spreadsheet': '.ods',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+    'image/jpeg': '.jpeg',
+    'image/png': '.png',
+    'text/csv': '.csv',
+}
+
 
 class AccountEdiCommon(models.AbstractModel):
     _name = "account.edi.common"
@@ -368,33 +380,35 @@ class AccountEdiCommon(models.AbstractModel):
         return True
 
     def _import_attachments(self, invoice, tree):
-        # Import the embedded PDF in the xml if some are found
+        # Import the embedded documents in the xml if some are found
         attachments = self.env['ir.attachment']
         additional_docs = tree.findall('./{*}AdditionalDocumentReference')
         for document in additional_docs:
             attachment_name = document.find('{*}ID')
             attachment_data = document.find('{*}Attachment/{*}EmbeddedDocumentBinaryObject')
-            if attachment_name is not None \
-                    and attachment_data is not None \
-                    and attachment_data.attrib.get('mimeCode') == 'application/pdf':
+            if attachment_name is not None and attachment_data is not None:
+                mimetype = attachment_data.attrib.get('mimeCode')
+                if not (extension := SUPPORTED_FILE_TYPES.get(mimetype)):
+                    continue
                 text = attachment_data.text
                 # Normalize the name of the file : some e-fff emitters put the full path of the file
                 # (Windows or Linux style) and/or the name of the xml instead of the pdf.
-                # Get only the filename with a pdf extension.
-                name = (attachment_name.text or 'invoice').split('\\')[-1].split('/')[-1].split('.')[0] + '.pdf'
+                # Get only the filename with the right extension.
+                name = (attachment_name.text or 'invoice').split('\\')[-1].split('/')[-1].split('.')[0] + extension
                 attachment = self.env['ir.attachment'].create({
                     'name': name,
                     'res_id': invoice.id,
                     'res_model': 'account.move',
                     'datas': text + '=' * (len(text) % 3),  # Fix incorrect padding
                     'type': 'binary',
-                    'mimetype': 'application/pdf',
+                    'mimetype': mimetype,
                 })
                 # Upon receiving an email (containing an xml) with a configured alias to create invoice, the xml is
                 # set as the main_attachment. To be rendered in the form view, the pdf should be the main_attachment.
                 if invoice.message_main_attachment_id and \
                         invoice.message_main_attachment_id.name.endswith('.xml') and \
-                        'pdf' not in invoice.message_main_attachment_id.mimetype:
+                        'pdf' not in invoice.message_main_attachment_id.mimetype and \
+                        mimetype == 'application/pdf':
                     invoice._message_set_main_attachment_id(attachment, force=True, filter_xml=False)
                 attachments |= attachment
 

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -146,7 +146,12 @@ class ResPartner(models.Model):
     @api.model
     def _get_ubl_cii_formats_info(self):
         return {
-            'ubl_bis3': {'countries': list(PEPPOL_DEFAULT_COUNTRIES), 'on_peppol': True, 'sequence': 200},
+            'ubl_bis3': {
+                'countries': list(PEPPOL_DEFAULT_COUNTRIES),
+                'on_peppol': True,
+                'sequence': 200,
+                'embed_attachments': True,
+            },
             'xrechnung': {'countries': ['DE'], 'on_peppol': True},
             'ubl_a_nz': {'countries': ['NZ', 'AU'], 'on_peppol': False},  # Not yet available through Odoo's Access Point, although it's a Peppol valid format
             'nlcius': {'countries': ['NL'], 'on_peppol': True},

--- a/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
@@ -1,5 +1,9 @@
+from lxml import etree
+
 from odoo import Command
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.test_mimetypes.tests.test_guess_mimetypes import contents
 from odoo.tests import tagged
 from odoo.tools import misc
 
@@ -514,3 +518,57 @@ class TestUblBis3(AccountTestInvoicingCommon):
         invoice.action_post()
         self.env['account.move.send']._generate_and_send_invoices(invoice, sending_methods=['manual'])
         self._assert_invoice_ubl_file(invoice, 'bis3/test_unit_price_precision')
+
+    def test_send_and_print_extra_attachments(self):
+        self.setup_partner_as_be1(self.env.company.partner_id)
+        self.setup_partner_as_be2(self.partner_a)
+
+        tax_21 = self.percent_tax(21.0)
+        product = self._create_product(lst_price=100.0, taxes_id=tax_21)
+        invoice = self._create_invoice_one_line(
+            product_id=product,
+            partner_id=self.partner_a,
+            post=True,
+        )
+
+        # Supported
+        xlsx_attachment = self.env['ir.attachment'].create({
+            'name': 'xlsx attachment',
+            'raw': contents('xlsx'),
+            'mimetype': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        })
+        # Not supported
+        docx_attachment = self.env['ir.attachment'].create({
+            'name': 'docx attachment',
+            'raw': contents('docx'),
+            'mimetype': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        })
+        xml_attachment = self.env['ir.attachment'].create({
+            'name': 'xml attachment',
+            'raw': "<?xml version='1.0' encoding='UTF-8'?><test/>",
+            'mimetype': 'application/xml',
+        })
+        txt_attachment = self.env['ir.attachment'].create({
+            'name': 'txt attachment',
+            'raw': b'txt attachment'
+        })
+
+        wizard = self._create_account_move_send_wizard_single(invoice, sending_methods=['manual'])
+        wizard.mail_attachments_widget = wizard.mail_attachments_widget + [{
+            'id': attachment.id,
+            'name': attachment.name,
+            'mimetype': attachment.mimetype,
+            'placeholder': False,
+            'manual': True,
+        } for attachment in [xlsx_attachment, docx_attachment, xml_attachment, txt_attachment]]
+
+        wizard.action_send_and_print()
+
+        self.assertTrue(invoice.ubl_cii_xml_id)
+        tree = etree.fromstring(invoice.ubl_cii_xml_id.raw)
+
+        attachments_elements = tree.findall('./{*}AdditionalDocumentReference')
+
+        self.assertEqual(len(attachments_elements), 2)
+        self.assertEqual(attachments_elements[0].find('{*}ID').text, invoice.invoice_pdf_report_id.name)
+        self.assertEqual(attachments_elements[1].find('{*}ID').text, xlsx_attachment.name)

--- a/addons/account_edi_ubl_cii/wizard/__init__.py
+++ b/addons/account_edi_ubl_cii/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_send_wizard

--- a/addons/account_edi_ubl_cii/wizard/account_move_send_wizard.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send_wizard.py
@@ -1,0 +1,17 @@
+from odoo import _, api, models
+
+
+class AccountMoveSendWizard(models.TransientModel):
+    _inherit = 'account.move.send.wizard'
+
+    @api.depends('invoice_edi_format', 'mail_attachments_widget')
+    def _compute_attachments_not_supported(self):
+        for wizard in self:
+            _attachments_to_embed, attachments_not_supported = wizard._get_ubl_available_attachments(
+                wizard.mail_attachments_widget,
+                wizard.invoice_edi_format
+            )
+            wizard.attachments_not_supported = {
+                attachment.id: _("Unspported file type via %s", wizard.invoice_edi_format)
+                for attachment in attachments_not_supported
+            }

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -1,9 +1,11 @@
 from base64 import b64encode
 from datetime import timedelta
 
-from odoo import fields, models, _
+from odoo import _, fields, models
+
 from odoo.addons.account.models.company import PEPPOL_LIST
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
+
 
 class AccountMoveSend(models.AbstractModel):
     _inherit = 'account.move.send'
@@ -176,6 +178,10 @@ class AccountMoveSend(models.AbstractModel):
                     )
                     continue
 
+                if len(xml_file) > 64000000:
+                    invoice_data['error'] = _("Invoice %s is too big to send via peppol (64MB limit)", invoice.name)
+                    continue
+
                 receiver_identification = f"{partner.peppol_eas}:{partner.peppol_endpoint}"
                 params['documents'].append({
                     'filename': filename,
@@ -208,13 +214,33 @@ class AccountMoveSend(models.AbstractModel):
             else:
                 # the response only contains message uuids,
                 # so we have to rely on the order to connect peppol messages to account.move
-                invoices = self.env['account.move']
+                attachments_linked_message = _("The invoice has been sent to the Peppol Access Point. The following attachments were sent with the XML:")
+                attachments_not_linked_message = _("Some attachments could not be sent with the XML:")
                 for message, (invoice, invoice_data) in zip(response['messages'], invoices_data_peppol.items()):
                     invoice.peppol_message_uuid = message['message_uuid']
                     invoice.peppol_move_state = 'processing'
-                    invoices |= invoice
-                log_message = _('The document has been sent to the Peppol Access Point for processing')
-                invoices._message_log_batch(bodies={invoice.id: log_message for invoice in invoices})
+                    attachments_linked, attachments_not_linked = self._get_ubl_available_attachments(
+                        invoice_data['mail_attachments_widget'],
+                        invoice_data['invoice_edi_format']
+                    )
+                    if attachments_not_linked:
+                        invoice._message_log(body=attachments_not_linked_message, attachment_ids=attachments_not_linked.mapped('id'))
+
+                    base_attachments = [
+                        (invoice_data[key]['name'], invoice_data[key]['raw'])
+                        for key in ['pdf_attachment_values', 'ubl_cii_xml_attachment_values']
+                        if invoice_data.get(key)
+                    ]
+
+                    attachments_embedded = [
+                        (attachment.name, attachment.raw)
+                        for attachment in attachments_linked
+                    ] + base_attachments
+
+                    invoice.with_context(no_new_invoice=True).message_post(
+                        body=attachments_linked_message,
+                        attachments=attachments_embedded
+                    )
                 self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger(at=fields.Datetime.now() + timedelta(minutes=5))
 
         if self._can_commit():

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -241,7 +241,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
 
         wizard.sending_methods = ['peppol']
         wizard.action_send_and_print()
-        self.assertEqual(self._get_mail_message(move).preview, 'The document has been sent to the Peppol Access Point for processing')
+        self.assertEqual(self._get_mail_message(move).preview, 'The invoice has been sent to the Peppol Access Point. The following attachments were sent with the XML:')
 
     def test_send_peppol_alerts_not_valid_partner(self):
         move = self.create_move(self.invalid_partner)

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
@@ -27,7 +27,7 @@
 
 <t t-name="web.Many2ManyBinaryField.attachment_preview">
     <t t-set="editable" t-value="!props.readonly"/>
-    <div t-attf-class="o_attachment o_attachment_many2many #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
+    <div name="attachment" t-attf-class="o_attachment o_attachment_many2many #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
         <div class="o_attachment_wrap">
             <t t-set="ext" t-value="getExtension(file)"/>
             <t t-set="url" t-value="getUrl(file.id)"/>


### PR DESCRIPTION
[IMP] account: multiple embed files peppol

This commit allows user to send multiple attachments through peppol. The attachments will be embedded into the xml under the `AdditionalDocumentReference` tags

task-5103539

