### PR TITLE
[FIX] web: datetimepicker_service: updateValueFromInputs

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -35,13 +35,15 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
         {
             content: "Change Scheduled End",
             trigger: "button#schedule_end_0",
-            run() {
-                const input = document.querySelector("button#schedule_end_0");
-                input.value = luxon.DateTime
-                    .fromFormat(input.value, "MM/dd/yyyy hh:mm:ss a")
+            run: "click",
+        },
+        {
+            trigger: "input#schedule_end_0",
+            async run({ edit, anchor }) {
+                const value = luxon.DateTime.fromFormat(anchor.value, "MM/dd/yyyy hh:mm:ss a")
                     .plus({ hours: 1 })
                     .toFormat("MM/dd/yyyy hh:mm:ss a");
-                input.dispatchEvent(new Event("change"));
+                await edit(value);
             },
         },
         {

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -400,7 +400,7 @@ export const datetimePickerService = {
                         getInputs(),
                         ensureArray(pickerProps.value),
                         (el, currentValue) => {
-                            if (!el) {
+                            if (!el || el.tagName?.toLowerCase() !== "input") {
                                 return currentValue;
                             }
                             const [parsedValue, error] = safeConvert("parse", el.value);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7888,7 +7888,7 @@ test(`edit button does not trigger fold group`, async () => {
                 </groupby>
             </list>
         `,
-        groupBy: ['currency_id']
+        groupBy: ["currency_id"],
     });
     expect(`.o_group_open`).toHaveCount(0);
     await contains(`.o_group_header:eq(0)`).click();
@@ -19268,6 +19268,42 @@ test(`multi edition: many2many_tags add few tags in one time`, async () => {
     expect(`.modal .o_field_many2many_tags .badge:eq(0)`).toHaveText("Value 3", {
         message: "should have display_name in badge",
     });
+});
+
+test.tags("desktop");
+test("multi_edit: must work for copy/paster or operation", async () => {
+    Foo._records[1].datetime = "1989-05-03 12:51:35";
+    Foo._records[2].datetime = "1987-11-13 12:12:34";
+    Foo._records[3].datetime = "2019-04-09 03:21:35";
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list multi_edit="1">
+                <field name="foo"/>
+                <field name="datetime"/>
+            </list>
+        `,
+    });
+
+    await contains(`.o_list_record_selector`).click();
+    await contains(`.o_data_cell[name=datetime]`).click();
+    await animationFrame();
+    await waitFor(`.o_datetime_picker`);
+    await contains(`input[data-field=datetime]`).edit("+125d", { confirm: "tab" });
+    expect(`tbody tr:eq(0) td[name=datetime]`).toHaveText("Jul 14, 11:30 AM");
+    await contains(`.modal button:contains(update)`).click();
+    expect(".modal").toHaveCount(0);
+    expect(queryAllTexts(`.o_data_cell`)).toEqual([
+        "yop",
+        "Jul 14, 11:30 AM",
+        "blip",
+        "Jul 14, 11:30 AM",
+        "gnap",
+        "Jul 14, 11:30 AM",
+        "blip",
+        "Jul 14, 11:30 AM",
+    ]);
 });
 
 test.tags("mobile");


### PR DESCRIPTION
How to reproduce
================
Write an operation or calculation in datetime field like +1d or +=1d or copy/paste a value in field. As the focus is lost, button reappears in the field. Then, the getInputs method in useDateTimePicker hook must (as this name suggests it) return input elements.

The fix
=======
We filter on tagName === 'input' elements

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
