### PR TITLE
[FIX] resource: force intervals normalization

### DIFF
--- a/addons/resource/models/utils.py
+++ b/addons/resource/models/utils.py
@@ -162,7 +162,7 @@ class Intervals(object):
 
         # using 'self' and 'other' below forces normalization
         bounds1 = _boundaries(self, 'start', 'stop')
-        bounds2 = _boundaries(other, 'switch', 'switch')
+        bounds2 = _boundaries(Intervals(other), 'switch', 'switch')
 
         start = None                    # set by start/stop
         recs1 = None                    # set by start

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -91,6 +91,22 @@ class TestIntervals(TransactionCase):
             [(0, 5), (12, 13), (20, 22), (23, 24)],
         )
 
+    def test_intervals_normalization(self):
+        """
+        Test the merge operation between normalized Intervals
+        and unnormalized Intervals. It must return normalized
+        intervals.
+        """
+        # Simulating unnormalized Intervals. E.g: WorkIntervals
+        class Intervals2(Intervals):
+            def __init__(self, intervals=()):
+                self._items = intervals
+
+        A = Intervals(self.ints([(0, 10)]))
+        B = Intervals2(self.ints([(-5, 5), (5, 15)]))
+        C = A & B
+        self.assertEqual(len(C), 1)
+        self.assertEqual(list(C), self.ints([(0, 10)]))
 
 class TestErrors(TestResourceCommon):
     def setUp(self):


### PR DESCRIPTION
## The issue

Prior to this commit, the `other` parameter in the `_merge`
method could belong to a different class, not necessarily an
instance of `Intervals`.

https://github.com/odoo/odoo/blob/8c737601327acec1d83e1e5e3c6e66c9fd226339/addons/resource/models/utils.py#L158-L165

The comment indicates that normalization should be enforced; however, there
is no corresponding reference to it within the  `_boundaries` method.

https://github.com/odoo/odoo/blob/8c737601327acec1d83e1e5e3c6e66c9fd226339/addons/resource/models/utils.py#L48-L53

That normalization just happens in the `__init__`.

https://github.com/odoo/odoo/blob/8c737601327acec1d83e1e5e3c6e66c9fd226339/addons/resource/models/utils.py#L117-L132

## Example

For example, in Planning module, we perform operations between
`Intervals` and `WorkIntervals`.

The `WorkIntervals` class behaves differently from `Intervals`:
while `Intervals` uses disjoint closed intervals, `WorkIntervals`
uses disjoint semi-closed intervals.

## Side effects

During these operations, the `_merge` method was not normalizing
the `_items`, which caused inconsistencies and errors (when we are
merging two unormalized intervals `([0, 10], [10, 20])` with an empty
`others`).

## The fix

This commit ensures that the `other` parameter is normalized before
processing the `_merge` operation. The fix ensures that normalized
intervals are always produced after `_merge`, even when unnormalized
intervals are provided as input.

## Real case

That issue has been found in that ticket: 5184291