### PR TITLE
[FIX] website_forum: disable image size options relying on inline styles

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -151,6 +151,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     showHeading3: false,
                     showLink: hasFullEdit,
                     showImageEdit: hasFullEdit,
+                    showImageWidth: false,
                 },
                 recordInfo: {
                     context: self._getContext(),
@@ -160,6 +161,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 value: recordContent,
                 resizable: true,
                 userGeneratedContent: true,
+                disableTransform: true,
                 height: 350,
             };
             options.allowCommandLink = hasFullEdit;


### PR DESCRIPTION
Problem:
When creating a new forum post with an image set to "50%" or "25%" size, the post is saved with the original image size instead of the selected one.

Cause:
The `Post.content` field has `strip_style=True`, which removes any inline `style` attributes before saving. Since image size ratios were applied using `style="width: 50%"`, the width information was lost.

Solution:
Disable image size options that depend on inline `style` attributes, as they cannot be preserved when saving forum posts.

Steps to reproduce:
1. Go to Forum.
2. Create a new post.
3. Add an image and set its size to 50% or 25%.
4. Save the post — the image appears with its original size.

opw-5173917

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
