### PR TITLE
[FIX] account: Check if accounts on move lines have correct companies

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3934,6 +3934,15 @@ class AccountMove(models.Model):
             if move.line_ids.account_id.filtered(lambda account: account.deprecated) and not self._context.get('skip_account_deprecation_check'):
                 raise UserError(_("A line of this move is using a deprecated account, you cannot post it."))
 
+            account_companies = move.line_ids.account_id.company_id
+
+            if not ((move.journal_id.company_id.sudo().child_ids | move.journal_id.company_id) & account_companies == account_companies):
+                raise UserError(_(
+                    "The entry %s (id %s) is using accounts from a different company.",
+                    move.name,
+                    move.id
+                ))
+
         if soft:
             future_moves = self.filtered(lambda move: move.date > fields.Date.context_today(self))
             for move in future_moves:


### PR DESCRIPTION
**Steps to reproduce:**
- Create Company A and Company B
- Create an invoice on Company A with one line having an account in Company A.
- On the same invoice, change the company to Company B and change the journal to a journal of Company B.
- Save, then confirm the invoice.

**Issue:**
The invoice, now belonging to Company B, still has the same account from company A, and we are able to post it on the journal from company B.

**Solution:**
Adding a step to check if the companies are correct on the move lines before posting.

opw-5167958
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
