### PR TITLE
[FIX] mrp: fix postinventory of lot producing mo's

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1822,9 +1822,9 @@ class MrpProduction(models.Model):
             finish_moves = order.move_finished_ids.filtered(lambda m: m.product_id == order.product_id and m.state not in ('done', 'cancel'))
             # the finish move can already be completed by the workorder.
             for move in finish_moves:
-                move.quantity = order.product_uom_id.round(order.qty_producing - order.qty_produced, rounding_method='HALF-UP')
                 if move.has_tracking != 'none' and not move.lot_ids:
                     move.lot_ids = order.lot_producing_ids.ids
+                move.quantity = order.product_uom_id.round(order.qty_producing - order.qty_produced, rounding_method='HALF-UP')
                 extra_vals = order._prepare_finished_extra_vals()
                 if extra_vals:
                     move.move_line_ids.write(extra_vals)


### PR DESCRIPTION
For 'By Lots' manufactured products, producing more than requested gives the error "You need to supply a Lot/Serial Number for product...".

This occurs from within _post_inventory operations:
- update the finished move line with only the producing quantity
- create a new finished move line with the exceeding quantity & lot
- raise the warning under action_done because one move line has no lot

By inverting the updates ( setting the lot before setting the quantity ) we ensure the lot is correctly propagated.

task: 5232544

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
