### PR TITLE
[FIX] web: adjust bg color for search_panel on mobile

### DIFF
--- a/addons/web/static/src/search/search_panel/search_panel.scss
+++ b/addons/web/static/src/search/search_panel/search_panel.scss
@@ -78,3 +78,9 @@
         }
     }
 }
+
+.o_search_panel_section {
+    .o_popover > & .list-group {
+        --#{$prefix}list-group-bg: var(--#{$prefix}popover-bg);
+    }
+}


### PR DESCRIPTION
This commit adjusts the search_panel background color so it adapts correctly to both light and dark modes on mobile.
It only affects the "popover" use case.

task-5121027

Requires:
- https://github.com/odoo/enterprise/pull/98248



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
