### PR TITLE
[FIX] core: fix uninstallation for model extension

### DIFF
--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -4,10 +4,7 @@ from . import controllers
 from . import models
 from . import wizard
 
-import odoo
-from odoo import api, SUPERUSER_ID
 from odoo.http import request
-from functools import partial
 
 
 def uninstall_hook(env):
@@ -24,18 +21,6 @@ def uninstall_hook(env):
     # created by the user (not XML data). Same goes for @api.ondelete available
     # from 15.0 and above.
     env['website'].search([])._remove_attachments_on_website_unlink()
-
-    # Properly unlink website_id from ir.model.fields
-    def rem_website_id_null(dbname):
-        db_registry = odoo.modules.registry.Registry.new(dbname)
-        with db_registry.cursor() as cr:
-            env = api.Environment(cr, SUPERUSER_ID, {})
-            env['ir.model.fields'].search([
-                ('name', '=', 'website_id'),
-                ('model', '=', 'res.config.settings'),
-            ]).unlink()
-
-    env.cr.postcommit.add(partial(rem_website_id_null, env.cr.dbname))
 
 
 def post_init_hook(env):

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -17,6 +17,7 @@ import odoo.sql_db
 import odoo.tools.sql
 import odoo.tools.translate
 from odoo import api, tools
+from odoo.tools import OrderedSet
 
 from . import db as modules_db
 from .migration import MigrationManager
@@ -128,7 +129,7 @@ def load_module_graph(
     graph: ModuleGraph,
     update_module: bool = False,
     report: OdooTestResult | None = None,
-    models_to_check: set[str] | None = None,
+    models_to_check: OrderedSet[str] | None = None,
     install_demo: bool = True,
 ) -> None:
     """ Load, upgrade and install not loaded module nodes in the ``graph`` for ``env.registry``
@@ -141,7 +142,7 @@ def load_module_graph(
        :param install_demo: whether to attempt installing demo data for newly installed modules
     """
     if models_to_check is None:
-        models_to_check = set()
+        models_to_check = OrderedSet()
 
     registry = env.registry
     assert isinstance(env.cr, odoo.sql_db.Cursor), "Need for a real Cursor to load modules"
@@ -195,8 +196,8 @@ def load_module_graph(
 
         if needs_update:
             model_names = registry.descendants(model_names, '_inherit', '_inherits')
-            models_updated |= set(model_names)
-            models_to_check -= set(model_names)
+            models_updated |= model_names
+            models_to_check -= model_names
             registry._setup_models__(env.cr)
             registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
         elif package.state != 'to remove':
@@ -206,7 +207,11 @@ def load_module_graph(
             # e.g. adding required=True to an existing field, but the schema has not been
             # updated by this module because it's not marked as 'to upgrade/to install'.
             model_names = registry.descendants(model_names, '_inherit', '_inherits')
-            models_to_check |= set(model_names) & models_updated
+            models_to_check |= model_names & models_updated
+        elif update_module and package.state == 'to remove':
+            # For all model extented (with _inherit) in the package to uninstall, we need to
+            # update ir.model / ir.model.fields along side not-null SQL constrains.
+            models_to_check |= model_names
 
         if needs_update:
             # Can't put this line out of the loop: ir.module.module will be
@@ -346,6 +351,7 @@ def load_modules(
     upgrade_modules: Collection[str] = (),
     install_modules: Collection[str] = (),
     new_db_demo: bool = False,
+    models_to_check: OrderedSet[str] | None = None,
 ) -> None:
     """ Load the modules for a registry object that has just been created.  This
         function is part of Registry.new() and should not be used anywhere else.
@@ -356,9 +362,10 @@ def load_modules(
         :param install_modules: A collection of module names to install.
         :param new_db_demo: Whether to install demo data for new database. Defaults to ``False``
     """
-    initialize_sys_path()
+    if models_to_check is None:
+        models_to_check = OrderedSet()
 
-    models_to_check: set[str] = set()
+    initialize_sys_path()
 
     with registry.cursor() as cr:
         # prevent endless wait for locks on schema changes (during online
@@ -542,11 +549,8 @@ def load_modules(
                 cr.commit()
                 _logger.info('Reloading registry once more after uninstalling modules')
                 registry = Registry.new(
-                    cr.dbname, update_module=update_module
+                    cr.dbname, update_module=update_module, models_to_check=models_to_check,
                 )
-                cr.reset()
-                registry.check_tables_exist(cr)
-                cr.commit()
                 return
 
         # STEP 5.5: Verify extended fields on every model
@@ -561,7 +565,9 @@ def load_modules(
             cr.execute("""SELECT DISTINCT model FROM ir_model_fields WHERE state = 'manual'""")
             models_to_check.update(model_name for model_name, in cr.fetchall() if model_name in registry)
         if models_to_check:
-            registry.init_models(cr, list(models_to_check), {'models_to_check': True, 'update_custom_fields': True})
+            # Doesn't check models that didn't exist anymore, it might happen during uninstallation
+            models_to_check = [model for model in models_to_check if model in registry]
+            registry.init_models(cr, models_to_check, {'models_to_check': True, 'update_custom_fields': True})
 
         # STEP 6: verify custom views on every model
         if update_module:

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -132,6 +132,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         install_modules: Collection[str] = (),
         upgrade_modules: Collection[str] = (),
         new_db_demo: bool | None = None,
+        models_to_check: set[str] | None = None,
     ) -> Registry:
         """Create and return a new registry for the given database name.
 
@@ -172,6 +173,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     upgrade_modules=upgrade_modules,
                     install_modules=install_modules,
                     new_db_demo=new_db_demo,
+                    models_to_check=models_to_check,
                 )
             except Exception:
                 reset_modules_state(db_name)


### PR DESCRIPTION
When we uninstall a module, we never reflect impacted models or fields on ir.model or ir.model.fields. That can lead to an inconsistent state after uninstallation:

For example, the 'appointment_account_payment' module that makes `calendar_event_id` not required anymore. After uninstalling it, the ORM will complain that the not-null constraint doesn't exist ("Missing not-null constraint on appointment.answer.input.calendar_event_id"). Also, if we look at the `ir.model.fields` record for `calendar_event_id`, it shows that the field isn't required, but it should be required again (with the correct constraints too).

Add the information of impacted models for the 'to remove' modules, and force the new registry to call `init_models` on them. This will handle constraints and reflection on `ir.model`/`ir.model.fields`. We can then remove the call to `check_tables_exist` (see 3058ca4121048796c38aad78e3e4f5ffde3530f5) since `init_models` will do the job correctly for impacted models.

Also remove a part of the uninstall hook of website because it forces reloading the registry too soon (warning of missing not-null constraint) and the uninstallation manages the case genericly (remove correctly `ir.model.fields` record of `res.config.settings.website_id`)

runbot-error-233770

