### PR TITLE
[FIX] mail: reset chat hub position on chat window open

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -49,6 +49,7 @@ export class ChatHub extends Component {
             }
         });
         useMovable({
+            enable: () => this.chatHub.compact || !this.chatHub.opened.length,
             cursor: "grabbing",
             ref: this.ref,
             elements: ".o-mail-ChatHub-bubbles",
@@ -60,6 +61,9 @@ export class ChatHub extends Component {
             },
             onDragEnd: () => (this.position.isDragging = false),
             onDrop: this.onDrop.bind(this),
+        });
+        this.env.bus.addEventListener("ChatWindow:will-open", () => {
+            this.resetPosition();
         });
     }
 
@@ -122,6 +126,9 @@ export class ChatHub extends Component {
     expand() {
         this.chatHub.compact = false;
         this.more.isOpen = this.chatHub.folded.length > this.chatHub.maxFolded;
+        if (this.chatHub.opened.length > 0) {
+            this.resetPosition();
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -88,6 +88,7 @@ export class ChatWindow extends Record {
 
     async open({ focus = false, notifyState = true, jumpToNewMessage = false } = {}) {
         await this.store.chatHub.initPromise;
+        this.store.env.bus.trigger("ChatWindow:will-open");
         this.store.chatHub.folded.delete(this);
         this.store.chatHub.opened.delete(this);
         this.store.chatHub.opened.unshift(this);


### PR DESCRIPTION
Prior to this commit, moving the chat hub could cause newly opened chat windows to appear on top of it, rendering the hub invisible and unusable.

This commit fixes the issue by resetting the chat hub's position whenever a chat window opens and disabling its drag functionality while any chat window remains open.

task-5227499