### PR TITLE
[IMP] website_sale: automated optional and alternative products

### DIFF
--- a/addons/sale/data/product_demo.xml
+++ b/addons/sale/data/product_demo.xml
@@ -160,6 +160,15 @@
         <field name="image_1920" type="bytes" file="sale/static/img/floor_protection-image.jpg"/>
     </record>
 
+    <!-- Assign XMLID to automatically created product variant -->
+    <function model="ir.model.data" name="_update_xmlids">
+        <value model="base" eval="[{
+            'xml_id': 'sale.product_product_1_product_product',
+            'record': obj().env.ref('sale.product_product_1_product_template').product_variant_id,
+            'noupdate': True,
+        }]"/>
+    </function>
+
     <record id="product.product_product_4_product_template" model="product.template">
         <field name="optional_product_ids" eval="[Command.set([ref('product.product_product_11_product_template')])]"/>
     </record>

--- a/addons/website_sale/__init__.py
+++ b/addons/website_sale/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tools.sql import SQL
 
 from . import controllers, models, report
 
@@ -15,6 +16,23 @@ def _post_init_hook(env):  # noqa: RUF067
     existing_websites = env["website"].search([])
     for website in existing_websites:
         website._create_checkout_steps()
+
+    # suggest_optional_products is TRUE only if there are no optional products set
+    env.execute_query(
+        SQL(
+            """
+            UPDATE product_template
+               SET suggest_optional_products = TRUE
+             WHERE NOT EXISTS (
+                 SELECT 1
+                   FROM product_optional_rel r
+                  WHERE r.src_id = product_template.id
+                 )
+               AND sale_ok IS TRUE
+               AND is_published IS TRUE
+            """
+        )
+    )
 
 
 def uninstall_hook(env):  # noqa: RUF067

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -26,6 +26,7 @@
         "data/mail_template_data.xml",
         "data/data.xml",  # Needs mail_template_data
         "data/digest_data.xml",  # Needs mail_template_data
+        "data/ir_actions_server_data.xml",
         "data/ir_cron_data.xml",
         "data/product_ribbon_data.xml",
         "data/tour.xml",

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -927,6 +927,132 @@
             <field name="default_code">SERV_125890</field>
         </record>
 
+        <!-- Optional products automatic suggestion -->
+        <record id="website_sale_order_19" model="sale.order">
+            <field name="partner_id" ref="base.res_partner_3"/>
+            <field name="partner_invoice_id" ref="base.res_partner_address_25"/>
+            <field name="partner_shipping_id" ref="base.res_partner_address_25"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="website_id" ref="website.default_website"/>
+            <field name="team_id" ref="sales_team.salesteam_website_sales"/>
+            <field name="date_order" eval="datetime.now()"/>
+            <field name="state">sale</field>
+        </record>
+
+        <record id="website_sale_order_line_19" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_19"/>
+            <field name="product_id" ref="product.product_product_4e"/>  <!--Customizable Desk-->
+        </record>
+
+        <record id="website_sale_order_line_20" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_19"/>
+            <field name="product_id" ref="product.product_product_11b"/>  <!--Conference Chair-->
+        </record>
+
+        <record id="website_sale_order_line_21" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_19"/>
+            <field name="product_id" ref="sale.product_product_1_product_product"/>  <!--Chair floor protection-->
+        </record>
+
+        <record id="website_sale_order_line_22" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_19"/>
+            <field name="product_id" ref="website_sale.product_product_1"/>  <!--Warranty-->
+        </record>
+
+        <record id="website_sale_order_20" model="sale.order">
+            <field name="partner_id" ref="base.res_partner_3"/>
+            <field name="partner_invoice_id" ref="base.res_partner_address_25"/>
+            <field name="partner_shipping_id" ref="base.res_partner_address_25"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="website_id" ref="website.default_website"/>
+            <field name="team_id" ref="sales_team.salesteam_website_sales"/>
+            <field name="date_order" eval="datetime.now()"/>
+            <field name="state">sale</field>
+        </record>
+
+        <record id="website_sale_order_line_23" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_20"/>
+            <field name="product_id" ref="product.product_product_4e"/>  <!--Customizable Desk-->
+        </record>
+
+        <record id="website_sale_order_line_24" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_20"/>
+            <field name="product_id" ref="product.product_product_11b"/>  <!--Conference Chair-->
+        </record>
+
+        <record id="website_sale_order_line_25" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_20"/>
+            <field name="product_id" ref="sale.product_product_1_product_product"/>  <!--Chair floor protection-->
+        </record>
+
+        <record id="website_sale_order_line_26" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_20"/>
+            <field name="product_id" ref="website_sale.product_product_1"/>  <!--Warranty-->
+        </record>
+
+        <record id="website_sale_order_21" model="sale.order">
+            <field name="partner_id" ref="base.res_partner_3"/>
+            <field name="partner_invoice_id" ref="base.res_partner_address_25"/>
+            <field name="partner_shipping_id" ref="base.res_partner_address_25"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="website_id" ref="website.default_website"/>
+            <field name="team_id" ref="sales_team.salesteam_website_sales"/>
+            <field name="date_order" eval="datetime.now()"/>
+            <field name="state">sale</field>
+        </record>
+
+        <record id="website_sale_order_line_27" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_21"/>
+            <field name="product_id" ref="product.product_product_27"/>  <!--Drawer-->
+        </record>
+
+        <record id="website_sale_order_line_28" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_21"/>
+            <field name="product_id" ref="product.product_delivery_02"/>  <!--Office Lamp-->
+        </record>
+
+        <record id="website_sale_order_line_29" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_21"/>
+            <field name="product_id" ref="product.product_product_7"/>  <!--Storage Box-->
+        </record>
+
+        <record id="website_sale_order_line_30" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_21"/>
+            <field name="product_id" ref="product.desk_organizer"/>  <!--Desk Organizer-->
+        </record>
+
+        <record id="website_sale_order_22" model="sale.order">
+            <field name="partner_id" ref="base.res_partner_3"/>
+            <field name="partner_invoice_id" ref="base.res_partner_address_25"/>
+            <field name="partner_shipping_id" ref="base.res_partner_address_25"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="website_id" ref="website.default_website"/>
+            <field name="team_id" ref="sales_team.salesteam_website_sales"/>
+            <field name="date_order" eval="datetime.now()"/>
+            <field name="state">sale</field>
+        </record>
+
+        <record id="website_sale_order_line_31" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_22"/>
+            <field name="product_id" ref="product.product_product_27"/>  <!--Drawer-->
+        </record>
+
+        <record id="website_sale_order_line_32" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_22"/>
+            <field name="product_id" ref="product.product_delivery_02"/>  <!--Office Lamp-->
+        </record>
+
+        <record id="website_sale_order_line_33" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_22"/>
+            <field name="product_id" ref="product.product_product_7"/>  <!--Storage Box-->
+        </record>
+
+        <record id="website_sale_order_line_34" model="sale.order.line">
+            <field name="order_id" ref="website_sale_order_22"/>
+            <field name="product_id" ref="product.desk_organizer"/>  <!--Desk Organizer-->
+        </record>
+
+
         <record id="website_sale.product_1_attribute_3_value_2" model="product.template.attribute.value">
             <field name="price_extra">18.00</field>
         </record>

--- a/addons/website_sale/data/ir_actions_server_data.xml
+++ b/addons/website_sale/data/ir_actions_server_data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="action_update_suggested_products" model="ir.actions.server">
+        <field name="name">Update suggested products</field>
+        <field name="model_id" ref="website_sale.model_product_template"/>
+        <field name="binding_model_id" ref="website_sale.model_product_template"/>
+        <field name="binding_view_types">form,list</field>
+        <field
+            name="group_ids"
+            eval="[(4, ref('website_sale.group_automate_suggested_products'))]"
+        />
+        <field name="state">code</field>
+        <field name="code">records.action_update_suggested_products()</field>
+    </record>
+
+</odoo>

--- a/addons/website_sale/data/ir_cron_data.xml
+++ b/addons/website_sale/data/ir_cron_data.xml
@@ -18,4 +18,15 @@
         <field name="code">model._cron_send_order_rating_emails()</field>
         <field name="state">code</field>
     </record>
+
+    <record id="update_suggested_products_cron" model="ir.cron">
+        <field name="name">eCommerce: Update suggested products</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">weeks</field>
+        <field name="model_id" ref="model_product_template"/>
+        <field name="code">model._cron_update_suggested_products()</field>
+        <field name="active">False</field>
+        <field name="state">code</field>
+    </record>
+
 </odoo>

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+import random
 from collections import defaultdict
 
 from werkzeug import urls
@@ -8,7 +9,7 @@ from werkzeug import urls
 from odoo import _, api, fields, models
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.tools import float_is_zero, is_html_empty
+from odoo.tools import float_is_zero, is_html_empty, lazy
 from odoo.tools.sql import SQL, column_exists, create_column
 from odoo.tools.translate import adapt_translated_field_value, html_translate
 
@@ -79,24 +80,47 @@ class ProductTemplate(models.Model):
 
     alternative_product_ids = fields.Many2many(
         string="Alternative Products",
+        help="Suggest alternatives to your customer (upsell strategy)."
+        " Those products show up on the product page.",
         comodel_name="product.template",
         relation="product_alternative_rel",
         column1="src_id",
         column2="dest_id",
         check_company=True,
-        help="Suggest alternatives to your customer (upsell strategy)."
-        " Those products show up on the product page.",
     )
     accessory_product_ids = fields.Many2many(
         string="Accessory Products",
+        help="Accessories show up when the customer reviews the cart before payment"
+        " (cross-sell strategy).",
         comodel_name="product.product",
         relation="product_accessory_rel",
         column1="src_id",
         column2="dest_id",
         check_company=True,
-        help="Accessories show up when the customer reviews the cart before payment"
-        " (cross-sell strategy).",
     )
+    # Whether a cron should automatically fill optional products.
+    suggest_optional_products = fields.Boolean(
+        string="Suggest Optional Products",
+        compute="_compute_suggest_optional_products",
+        readonly=False,
+        store=True,
+    )
+    # Whether a cron should automatically fill accessory products.
+    suggest_accessory_products = fields.Boolean(
+        string="Suggest Accessory Products",
+        compute="_compute_suggest_accessory_products",
+        readonly=False,
+        store=True,
+    )
+    # Whether a cron should automatically fill alternative products.
+    suggest_alternative_products = fields.Boolean(
+        string="Suggest Alternative Products",
+        compute="_compute_suggest_alternative_products",
+        readonly=False,
+        store=True,
+    )
+    # Last update date of the optional, accessory and alternative products.
+    suggested_products_last_update = fields.Datetime(string="Last update of suggested products")
 
     website_size_x = fields.Integer(string="Size X", default=1)
     website_size_y = fields.Integer(string="Size Y", default=1)
@@ -193,6 +217,36 @@ class ProductTemplate(models.Model):
 
     # === COMPUTE METHODS ===#
 
+    @api.depends("optional_product_ids")
+    def _compute_suggest_optional_products(self):
+        if self._is_automate_suggested_product_feature_enabled():
+            # Disable auto-suggestion if the user manually sets optional_product_ids
+            self.suggest_optional_products = False
+        else:
+            for template in self:
+                # Maintain consistency for feature enablement: suggest only when empty
+                template.suggest_optional_products = not template.optional_product_ids
+
+    @api.depends("accessory_product_ids")
+    def _compute_suggest_accessory_products(self):
+        if self._is_automate_suggested_product_feature_enabled():
+            # Disable auto-suggestion if the user manually sets accessory_product_ids
+            self.suggest_accessory_products = False
+        else:
+            for template in self:
+                # Maintain consistency for feature enablement: suggest only when empty
+                template.suggest_accessory_products = not template.accessory_product_ids
+
+    @api.depends("alternative_product_ids")
+    def _compute_suggest_alternative_products(self):
+        if self._is_automate_suggested_product_feature_enabled():
+            # Disable auto-suggestion if the user manually sets alternative_product_ids
+            self.suggest_alternative_products = False
+        else:
+            for template in self:
+                # Maintain consistency for feature enablement: suggest only when empty
+                template.suggest_alternative_products = not template.alternative_product_ids
+
     @api.depends("is_published")
     def _compute_publish_date(self):
         """Set `publish_date` to the moment of (re-)publishing."""
@@ -212,6 +266,18 @@ class ProductTemplate(models.Model):
             )
 
     # === CRUD METHODS ===#
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        # Compute the suggest_x fields based on the m2m x now correctly saved
+        for record, vals in zip(records, vals_list):
+            record.write({
+                "suggest_optional_products": not vals.get("optional_product_ids"),
+                "suggest_accessory_products": not vals.get("accessory_product_ids"),
+                "suggest_alternative_products": not vals.get("alternative_product_ids"),
+            })
+        return records
 
     def write(self, vals):
         # Clear empty ecommerce description content to avoid side-effects on product pages
@@ -239,6 +305,198 @@ class ProductTemplate(models.Model):
     def _get_website_alternative_product(self):
         domain = self.env["website"].sale_product_domain()
         return self.alternative_product_ids.filtered_domain(domain)
+
+    def _cron_update_suggested_products(self, batch_size=100):
+        if not self._is_automate_suggested_product_feature_enabled():
+            return  # Skip the automation if the cron was activated without the feature.
+
+        products_domain = Domain([("sale_ok", "=", True), ("is_published", "=", True)])
+        cron_domain = products_domain & (
+            Domain("suggested_products_last_update", "<", "-12H")
+            | Domain("suggested_products_last_update", "=", False)
+        )
+        # Order by last update (desc) to ensure the cron processes all products over time,
+        # starting with those that haven't been updated recently
+        products_to_update = self.search(
+            cron_domain, order="suggested_products_last_update", limit=batch_size
+        )
+
+        remaining = (
+            len(products_to_update)
+            if len(products_to_update) < batch_size
+            else self.search_count(cron_domain)
+        )
+        self.env["ir.cron"]._commit_progress(remaining=remaining)
+        products_to_update._update_suggested_products()
+        self.env["ir.cron"]._commit_progress(processed=len(products_to_update))
+
+    def action_update_suggested_products(self):
+        # If called from the server action, reset the suggest_ fields
+        self.write({
+            "suggest_optional_products": True,
+            "suggest_accessory_products": True,
+            "suggest_alternative_products": True,
+        })
+        self._update_suggested_products()
+
+    def _update_suggested_products(self):
+        """Update the current product templates' optional, accessory, and alternative products.
+
+        Only salable and published product templates are considered. The heuristics to find
+        suggested products are as follows:
+        - Optional products: Up to 2 products bought together with the main product.
+        - Accessory products: Up to 1 product bought together with the main product.
+        - Alternative products: Up to 4 products sharing similar characteristics (attributes and
+          categories).
+
+        :rtype: None
+        """
+        for company, products in self.grouped("company_id").items():
+            products_by_categories = lazy(lambda: products._get_products_by_categories(company))
+            products_by_sales = lazy(lambda: products._get_products_by_sales(max_products=3))
+            with self.env.protecting(
+                [
+                    self._fields[fname]
+                    for fname in (
+                        "suggest_optional_products",
+                        "suggest_accessory_products",
+                        "suggest_alternative_products",
+                    )
+                ],
+                products,
+            ):  # Avoid recomputing the suggest_* fields when the value isn't set manually.
+                for product in products:
+                    if product.suggest_optional_products or product.suggest_accessory_products:
+                        optionals, accessories = product._get_suggested_optionals_and_accessories(
+                            products_by_sales, max_optionals=2
+                        )
+                        if product.suggest_optional_products:
+                            product.optional_product_ids = optionals
+                        if product.suggest_accessory_products:
+                            product.accessory_product_ids = accessories
+                    if product.suggest_alternative_products:
+                        product.alternative_product_ids = product._get_suggested_alternatives(
+                            products_by_categories, max_products=4
+                        )
+
+        self.suggested_products_last_update = self.env.cr.now()
+
+    @api.model
+    def _is_automate_suggested_product_feature_enabled(self):
+        return self.env["res.groups"]._is_feature_enabled(
+            "website_sale.group_automate_suggested_products"
+        )
+
+    def _get_products_by_sales(self, max_products):
+        """Get products that are bought together with the main product,
+        in at least 2 sale orders dated within 5 years.
+
+        rtype: dict[int, list[int]]
+        """
+        # Return the list of tuples (main_pt_id, recommended_pt_id)
+        # for any product.template sharing the conditions:
+        # - same order, dated from less than 5 years
+        # - active product, cheaper than the main product, not a combo item, not himself
+        result = self.env.execute_query(
+            SQL(
+                """
+                SELECT main_pt_id, recommended_pt_id
+                  FROM (SELECT pt.id  AS main_pt_id,
+                               pt2.id AS recommended_pt_id,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY pt.id
+                                       ORDER BY COUNT(DISTINCT so.id) DESC, RANDOM()
+                               )      AS rn
+                          FROM sale_order_line sol
+                          JOIN sale_order        so  ON so.id  = sol.order_id
+                          JOIN product_product   pp  ON pp.id  = sol.product_id
+                          JOIN product_template  pt  ON pt.id  = pp.product_tmpl_id
+                          JOIN sale_order_line   sol2 ON sol2.order_id = so.id AND sol2.id != sol.id
+                          JOIN product_product   pp2  ON pp2.id  = sol2.product_id
+                          JOIN product_template  pt2  ON pt2.id  = pp2.product_tmpl_id
+                         WHERE pt.id = ANY(%(pt_ids)s)
+                           AND so.state      = 'sale'
+                           AND so.date_order >= NOW() - INTERVAL '5 years'
+                           AND pt2.active    = TRUE
+                           AND pt2.sale_ok   = TRUE
+                           AND pt2.is_published = TRUE
+                           AND pt2.list_price < pt.list_price
+                           AND sol2.combo_item_id IS NULL
+                           AND pt2.id        != pt.id
+                         GROUP BY pt.id, pt2.id) ranked
+                 WHERE rn <= %(max_products)s
+                """,
+                pt_ids=list(self.ids),
+                max_products=max_products,
+            )
+        )
+        products_by_sales = defaultdict(list)
+        for main_id, recommended_id in result:
+            products_by_sales[main_id].append(recommended_id)
+
+        return products_by_sales
+
+    def _get_products_by_categories(self, company):
+        return dict(
+            self._read_group(
+                Domain([
+                    ("sale_ok", "=", True),
+                    ("is_published", "=", True),
+                    ("company_id", "=", company.id),
+                ]),
+                groupby=["public_categ_ids"],
+                aggregates=["id:recordset"],
+            )
+        )
+
+    def _get_suggested_optionals_and_accessories(self, products_by_sales, max_optionals):
+        """Get the records recommended as optional and accessory products for self."""
+        recommended_ids = products_by_sales.get(self.id, [])
+        optional_products_ids = recommended_ids[:max_optionals]
+        accessory_products_ids = recommended_ids[max_optionals:]  # last ones
+        optional_products = self.env["product.template"].browse(optional_products_ids)
+        accessory_products = (
+            self.env["product.template"].browse(accessory_products_ids).product_variant_ids
+        )
+        # Return one of the variant as accessory_product_ids requires a product.product
+        accessory_product = random.choice(accessory_products) if accessory_products else None
+        return optional_products, accessory_product
+
+    def _get_suggested_alternatives(self, products_by_categories, max_products):
+        """Get similar products based on the categories and attributes shared with self.
+        - Categories weight = 0.8, at least one category in common
+        - Attributes weight = 0.2.
+        """
+        scores = []
+        categories_a = set(self.public_categ_ids.ids)
+        attributes_a = set(self.attribute_line_ids.value_ids.ids)
+        # Limit to 1000 other products with at least one category in common (random order)
+        other_products_sharing_categories = self.env["product.template"]
+        for categ in self.public_categ_ids:
+            other_products_sharing_categories |= products_by_categories.get(categ)
+        other_products_sharing_categories = list(other_products_sharing_categories - self)
+        random.shuffle(other_products_sharing_categories)
+
+        for product_b in other_products_sharing_categories[:1000]:
+            categories_b = set(product_b.public_categ_ids.ids)
+            attributes_b = set(product_b.attribute_line_ids.value_ids.ids)
+            # Jaccard coefficient (A and B / A or B)
+            intersection_cat = categories_a & categories_b
+            union_cat = categories_a | categories_b
+            similar_categories = len(intersection_cat) / len(union_cat)
+            intersection_attr = attributes_a & attributes_b
+            union_attr = attributes_a | attributes_b
+            similar_attributes = len(intersection_attr) / len(union_attr) if union_attr else 0
+            score = 0.8 * similar_categories + 0.2 * similar_attributes
+
+            scores.append((product_b, score))
+
+        # Shuffle equal scores to avoid returning always the same top products
+        random.shuffle(scores)
+        scores = sorted(scores, key=lambda x: x[1], reverse=True)[:max_products]
+
+        # Return the product templates with the highest score
+        return self.env["product.template"].browse([p.id for p, score in scores])
 
     def _has_no_variant_attributes(self):
         """Return whether this `product.template` has at least one no_variant

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -19,6 +19,11 @@ class ResConfigSettings(models.TransientModel):
         implied_group="website_sale.group_product_feed",
         group="base.group_user",
     )
+    group_automate_suggested_products = fields.Boolean(
+        string="Automate suggested products",
+        implied_group="website_sale.group_automate_suggested_products",
+        group="website.group_website_restricted_editor",
+    )
 
     # Modules
     module_website_sale_autocomplete = fields.Boolean("Address Autocomplete")
@@ -88,6 +93,9 @@ class ResConfigSettings(models.TransientModel):
     # === CRUD METHODS === #
 
     def set_values(self):
+        had_group_asp = self.default_get(["group_automate_suggested_products"])[
+            "group_automate_suggested_products"
+        ]
         super().set_values()
         if self.website_id:
             website = self.with_context(website_id=self.website_id.id).website_id
@@ -100,6 +108,16 @@ class ResConfigSettings(models.TransientModel):
             view = self.env.ref("website_sale.product_comment", raise_if_not_found=False)
             if view and not view.active:
                 view.active = True
+
+        # Activate / deactivate the automation of suggested products
+        suggested_products_cron_sudo = self.sudo().env.ref(
+            "website_sale.update_suggested_products_cron"
+        )
+        if self.group_automate_suggested_products and not had_group_asp:  # Enable the feature
+            suggested_products_cron_sudo.active = True
+            suggested_products_cron_sudo._trigger()
+        elif not self.group_automate_suggested_products and had_group_asp:  # Disable the feature
+            suggested_products_cron_sudo.active = False
 
     # === ACTION METHODS === #
 

--- a/addons/website_sale/security/res_groups.xml
+++ b/addons/website_sale/security/res_groups.xml
@@ -6,6 +6,10 @@
         <field name="name">Comparison Price</field>
     </record>
 
+    <record id="group_automate_suggested_products" model="res.groups">
+        <field name="name">Automatically add optional, accessory and alternative products</field>
+    </record>
+
     <record id="group_product_feed" model="res.groups">
         <field name="name">Product Feed</field>
     </record>

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -38,6 +38,7 @@ from . import (
     test_show_compare_list_price,
     test_sitemap,
     test_snippets,
+    test_suggested_products,
     test_technical_page,
     test_website_editor,
     test_website_sale_checkout_steps,

--- a/addons/website_sale/tests/test_suggested_products.py
+++ b/addons/website_sale/tests/test_suggested_products.py
@@ -1,0 +1,167 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.base.tests.test_ir_cron import CronMixinCase
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSuggestedProducts(WebsiteSaleCommon, CronMixinCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Create product categories
+        cls.category_desks, cls.category_chairs = cls.env["product.public.category"].create([
+            {"name": "Desks"},
+            {"name": "Chairs"},
+        ])
+        # Create product templates
+        cls.template_desk = cls.env["product.template"].create({
+            "name": "Desk",
+            "list_price": 100,
+            "public_categ_ids": [Command.link(cls.category_desks.id)],
+            "is_published": True,
+        })
+        cls.template_chair = cls.env["product.template"].create({
+            "name": "Chair",
+            "list_price": 50,
+            "public_categ_ids": [Command.link(cls.category_chairs.id)],
+            "is_published": True,
+        })
+        cls.template_combo_desk_chair = cls.env["product.template"].create({
+            "name": "Desk + Chair",
+            "public_categ_ids": [
+                Command.link(cls.category_desks.id),
+                Command.link(cls.category_chairs.id),
+            ],
+            "is_published": True,
+        })
+        # Create sale orders
+        cls.so_1 = cls.env["sale.order"].create({
+            "partner_id": cls.partner.id,
+            "order_line": [
+                Command.create({"product_id": cls.template_desk.product_variant_id.id}),
+                Command.create({"product_id": cls.template_chair.product_variant_id.id}),
+            ],
+            "state": "sale",
+        })
+        cls.so_2 = cls.env["sale.order"].create({
+            "partner_id": cls.partner.id,
+            "order_line": [
+                Command.create({"product_id": cls.template_desk.product_variant_id.id}),
+                Command.create({"product_id": cls.template_chair.product_variant_id.id}),
+            ],
+            "state": "sale",
+        })
+        # Enable the suggested products feature
+        cls.env["res.config.settings"].create({
+            "group_automate_suggested_products": True
+        }).set_values()
+
+    def test_suggested_products_do_not_erase_existing_content_on_creation(self):
+        """Test that suggested products are not set on product creation if the fields are filled."""
+        self.product_with_alternatives = self.env["product.template"].create([
+            {
+                "name": "Product with alternatives",
+                "alternative_product_ids": [Command.link(self.template_chair.id)],
+            }
+        ])
+        self.assertFalse(self.product_with_alternatives.suggest_alternative_products)
+        self.product_without_alternatives = self.env["product.template"].create([
+            {"name": "Product without alternatives"}
+        ])
+        self.assertTrue(self.product_without_alternatives.suggest_alternative_products)
+
+    def test_activate_automate_suggested_products_settings_triggers_cron(self):
+        """Activating the website settings automatically triggers the cron
+        updating the optional and alternative products."""
+        # Disable the suggested products feature
+        self.env["res.config.settings"].create({
+            "group_automate_suggested_products": False
+        }).set_values()
+        suggested_products_cron = self.env.ref("website_sale.update_suggested_products_cron")
+        with self.capture_triggers(
+            "website_sale.update_suggested_products_cron"
+        ) as captured_triggers:
+            # Enable the suggested products feature
+            self.env["res.config.settings"].create({
+                "group_automate_suggested_products": True
+            }).set_values()
+        self.assertTrue(suggested_products_cron.active)
+        # Assert that a trigger was created
+        self.assertTrue(captured_triggers.records)
+
+    def test_update_suggested_products_sets_alternative_products(self):
+        """_update_suggested_products fills alternative products based on shared categories."""
+        tested_products = self.template_desk | self.template_chair | self.template_combo_desk_chair
+        # Update suggested products on tested_products
+        tested_products._update_suggested_products()
+        self.assertEqual(self.template_desk.alternative_product_ids, self.template_combo_desk_chair)
+        self.assertEqual(
+            self.template_chair.alternative_product_ids, self.template_combo_desk_chair
+        )
+        chair_and_desk = self.template_chair | self.template_desk
+        self.assertEqual(self.template_combo_desk_chair.alternative_product_ids, chair_and_desk)
+
+    def test_update_suggested_products_sets_optional_products(self):
+        """Test that _update_suggested_products fills optional products based on sales history."""
+        # Update suggested products for template_desk
+        self.template_desk._update_suggested_products()
+        self.assertEqual(self.template_desk.optional_product_ids, self.template_chair)
+
+    def test_cron_write_preserves_automation(self):
+        """Test that writing from cron context doesn't disable the automation flags."""
+        self.template_desk.suggest_alternative_products = True
+        self.template_desk.suggest_optional_products = True
+        # Write from cron
+        with self.enter_registry_test_mode(), self.env.registry.cursor() as cr:
+            env = self.env(context={"cron_id": 1}, cr=cr)
+            self.env["product.template"].with_env(env)._cron_update_suggested_products()
+        self.assertTrue(self.template_desk.suggest_alternative_products)
+        self.assertTrue(self.template_desk.suggest_optional_products)
+
+    def test_manual_write_disables_automation(self):
+        """Test that manually writing disables the automation flags."""
+        # Ensure the automation is set for template_desk
+        self.template_desk.suggest_alternative_products = True
+        self.template_desk.suggest_optional_products = True
+        # Manually set alternative and optional products
+        self.template_desk.write({
+            "alternative_product_ids": [Command.link(self.template_chair.id)],
+            "optional_product_ids": [Command.link(self.template_chair.id)],
+        })
+        self.assertFalse(self.template_desk.suggest_alternative_products)
+        self.assertFalse(self.template_desk.suggest_optional_products)
+
+    def test_action_reenables_automation(self):
+        """Test that calling _update_suggested_products from the action re-enables automation."""
+        self.template_desk.suggest_alternative_products = False
+        self.template_desk.suggest_optional_products = False
+        # Call from action
+        self.template_desk.action_update_suggested_products()
+        self.assertTrue(self.template_desk.suggest_alternative_products)
+        self.assertTrue(self.template_desk.suggest_optional_products)
+
+    def test_cron_only_updates_outdated_products(self):
+        """Test that cron only updates products not updated within the last 12 hours."""
+        now = self.env.cr.now()
+        recent_date = now - relativedelta(hours=6)
+        old_date = now - relativedelta(hours=13)
+        self.template_desk.suggested_products_last_update = recent_date
+        self.template_chair.suggested_products_last_update = old_date
+        with patch.object(fields.Datetime, "now", return_value=now):
+            with self.enter_registry_test_mode(), self.env.registry.cursor() as cr:
+                env = self.env(context={"cron_id": 1}, cr=cr)
+                self.env["product.template"].with_env(env)._cron_update_suggested_products()
+        # template_desk should not be updated (recently updated)
+        self.assertEqual(self.template_desk.suggested_products_last_update, recent_date)
+        # template_chair should be updated
+        self.assertNotEqual(self.template_chair.suggested_products_last_update, old_date)

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -108,6 +108,12 @@
                     <field name="group_product_price_comparison"/>
                 </setting>
                 <setting
+                    help="Automatically add optional, accessory, and alternative products."
+                    info="This setting is shared across all companies."
+                >
+                    <field name="group_automate_suggested_products"/>
+                </setting>
+                <setting
                     string="Product Reference Price"
                     id="ecom_uom_price_option_setting"
                     help="Add a reference price per UoM on products (e.g $/kg), in addition to the


### PR DESCRIPTION
Adding a new setting allowing to automatically fill:
- alternative products based on shared categories and attributes
- optional and accessory products based on sales history

task-4819590