### PR TITLE
[PERF] stock: don't perform quant_tasks when unpacking empty packs

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1649,10 +1649,11 @@ class QuantPackage(models.Model):
     def unpack(self):
         if not self.quant_ids:
             return
+        quants = self.quant_ids
         self.quant_ids.move_quants(message=_("Quantities unpacked"), unpack=True)
         # Quant clean-up, mostly to avoid multiple quants of the same product. For example, unpack
         # 2 packages of 50, then reserve 100 => a quant of -50 is created at transfer validation.
-        self.quant_ids._quant_tasks()
+        quants._quant_tasks()
 
     def action_view_picking(self):
         action = self.env["ir.actions.actions"]._for_xml_id("stock.action_picking_tree_all")

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1647,6 +1647,8 @@ class QuantPackage(models.Model):
         return super().write(vals)
 
     def unpack(self):
+        if not self.quant_ids:
+            return
         self.quant_ids.move_quants(message=_("Quantities unpacked"), unpack=True)
         # Quant clean-up, mostly to avoid multiple quants of the same product. For example, unpack
         # 2 packages of 50, then reserve 100 => a quant of -50 is created at transfer validation.


### PR DESCRIPTION
For an empty package the  `quant_tasks` function will be executed without restriction of scope and can potentially slow the user request intensly.
And if there is no quants in the package the tasks are not necessary.

After the unpacking of the quants they are not in the package anymore.
Causing the call to quant_tasks to be done on an empty recordset.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
