### PR TITLE
[FIX] hw_drivers: cert_end_date offset-aware

### DIFF
--- a/addons/hw_drivers/tools/certificate.py
+++ b/addons/hw_drivers/tools/certificate.py
@@ -55,12 +55,14 @@ def get_certificate_end_date():
     # Ensure cryptography compatibility with python < 3.13
     if platform.system() == 'Linux' and float(get_version()[1:8]) < 2025.10:
         cert_end_date = cert.not_valid_after
+        now = datetime.datetime.now()
     else:
         cert_end_date = cert.not_valid_after_utc
+        now = datetime.datetime.now(datetime.timezone.utc)
 
     if (
         common_name == 'OdooTempIoTBoxCertificate'
-        or datetime.datetime.now() > cert_end_date - datetime.timedelta(days=10)
+        or now > cert_end_date - datetime.timedelta(days=10)
     ):
         _logger.debug("SSL certificate '%s' must be updated.", common_name)
         return None


### PR DESCRIPTION
Before this commit, datetime.now() was compared to cert.not_valid_after_utc, leading to an error because we compare offset-naive and offset-aware datetimes

After this commit, we set an offset-aware datetime.now() if we use not_valid_after_utc

Issue introduced in #234005

opw-5237595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
