### PR TITLE
[FIX] project: prevent error when mail sent to alias

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1676,13 +1676,13 @@ class ProjectTask(models.Model):
         )
         partners = self.env['res.partner'].concat(*matched_partners)
         unresolved_emails = set(sanitized_email_dict) - set(partners.mapped("email"))
-        unmatched_partner_emails = [sanitized_email_dict.get(email) for email in unresolved_emails]
         if project_id:
             project = self.env["project.project"].browse(project_id)
             project_alias_address = project.alias_name + "@" + project.alias_domain_id.name
-            # Removing project alias from unmatched_partner_emails as this will be added to cc_mail address and when
+            # Removing project alias from unresolved_emails as this will be added to cc_mail address and when
             # a mail is sent unnecessary partner is created in the name of project_alias
-            unmatched_partner_emails.remove(project_alias_address)
+            unresolved_emails.discard(project_alias_address)
+        unmatched_partner_emails = [sanitized_email_dict.get(email) for email in unresolved_emails]
 
         users = partners.user_ids
         internal_user_ids = users.filtered(lambda u: not u.share).ids


### PR DESCRIPTION
**Steps to reproduce**
- Set an alias on a project, e.g. `my-project@my-domain.com`
- Send an email to this alias, with the `To` part including a display name (default in most clients).
e.g. `To: MyProject <my-project@my-domain.com>`
- Issue: the task is not created because of a traceback `ValueError: list.remove(x): x not in list`

**Change**
The values in the dict returned by `_mail_cc_sanitized_raw_dict` can be more than just an email, so use the keys instead. Note: use `discard` instead of `remove` to avoid error if for some reason a partner has the same mail as the alias.

opw-5176607