### PR TITLE
[FIX] payment: disable boleto tokenization

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -683,7 +683,7 @@
         <field name="sequence">1000</field>
         <field name="active">False</field>
         <field name="image" type="base64" file="payment/static/img/boleto.png"/>
-        <field name="support_tokenization">True</field>
+        <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund"></field>
         <field name="supported_country_ids"


### PR DESCRIPTION
## Versions
17.0+

## Issue
Boleto is an offline, one-time-use payment method and cannot be tokenized with most payment providers (e.g., Adyen: https://docs.adyen.com/payment-methods/boleto-bancario/, Nuvei: https://www.nuvei.com/apm/boleto).

## Exception
Stripe allows a form of tokenization by storing the customer's billing information and regenerating a new Boleto for each payment (cf. https://docs.stripe.com/payments/boleto). Technically, the Boleto itself is not reusable — Stripe simulates tokenization by associating customer info with new Boleto transactions.

## Fix
To maintain consistent behavior and avoid provider-specific edge cases, tokenization is disabled for Boleto payments globally.

opw-5156718