### PR TITLE
[FIX] website_sale: fix target ProductsListPageOption

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_list_page_option.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.js
@@ -5,6 +5,7 @@ import { products_sort_mapping } from "@website_sale/website_builder/shared";
 export class ProductsListPageOption extends BaseOptionComponent {
     static template = "website_sale.ProductsListPageOption";
     static selector = "main:has(#o_wsale_container)";
+    static applyTo = "#o_wsale_container";
     static title = _t("Products Page");
     static groups = ["website.group_website_designer"];
     static editableOnly = false;


### PR DESCRIPTION
In PR https://github.com/odoo/odoo/pull/233696, we forgot to add an applyTo to keep the same target's option.
This commit will fix the issue by adding the missing applyTo.

