### PR TITLE
[FIX] web: fix `<SearchBarMenu>` flickering icon

### DIFF
--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.scss
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.scss
@@ -16,8 +16,15 @@ $o-search-bar-menu-max-width: calc(100vw - #{map-get($spacers, 3) * 2 });
         white-space: nowrap;
     }
 
-    .o_favorite_item:hover i {
-        display: block !important;
+    .o_favorite_item {
+        &:hover {
+            --show-on-hover: visible;
+        }
+
+        i {
+            display: block !important;
+            visibility: var(--show-on-hover, hidden);
+        }
     }
 
     @include media-breakpoint-up(lg) {


### PR DESCRIPTION
This PR fixes an issue related to the edit favourite filter icon.

Prior to this PR, the edit favourite filter icon used `d-none` by default and `display: block` on hover.

Since `display: none` removes the element from the layout, the parent popover resized on hover, causing a flickering effect. This did not occur for filters with short labels (which had enough room for the icon) or for long labels (where the label was truncated).

To prevent the flickering, the icon now uses `visibility: hidden/visible`, which keeps its space in the layout and avoids layout shifts.


https://github.com/user-attachments/assets/5308c11e-8706-403c-80e3-fc05ab37a61d



task-5237493

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
