### PR TITLE
[IMP] mail: add sequence in discuss category

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -80,6 +80,7 @@ For more specific needs, you may also assign custom-defined actions
         'views/mail_mail_views.xml',
         'views/mail_followers_views.xml',
         'views/mail_ice_server_views.xml',
+        'views/discuss_category_views.xml',
         'views/discuss_channel_member_views.xml',
         'views/discuss_channel_rtc_session_views.xml',
         'views/mail_link_preview_views.xml',

--- a/addons/mail/models/discuss/discuss_category.py
+++ b/addons/mail/models/discuss/discuss_category.py
@@ -11,16 +11,20 @@ class DiscussCategory(models.Model):
     _description = "Discussion Category"
     _inherit = ["bus.sync.mixin"]
 
+    def _default_sequence(self):
+        return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
+
     # description
     name = fields.Char("Name", required=True)
     channel_ids = fields.One2many("discuss.channel", "discuss_category_id", string="Channels")
+    sequence = fields.Integer("Sequence", default=_default_sequence)
 
     # constraints
     _name_unique = models.Constraint("UNIQUE(name)", "The category name must be unique")
 
     def _sync_field_names(self):
         res = super()._sync_field_names()
-        res[None] += ["name"]
+        res[None] += ["name", "sequence"]
         return res
 
     def _bus_channel(self):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -467,7 +467,8 @@ class DiscussChannel(models.Model):
         res = super()._sync_field_names()
         res[None] += [
             Store.Attr("avatar_cache_key", predicate=is_channel_or_group),
-            Store.One("discuss_category_id", ["name"], sudo=True),  # sudo: discuss.category - reading name is acceptable
+            # sudo: discuss.category - guests can read categories of accessible channels
+            Store.One("discuss_category_id", ["name", "sequence"], sudo=True),
             "channel_type",
             "create_uid",
             "default_display_mode",
@@ -1191,7 +1192,8 @@ class DiscussChannel(models.Model):
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         res = [
             Store.Attr("avatar_cache_key", predicate=is_channel_or_group),
-            Store.One("discuss_category_id", ["name"], sudo=True),  # sudo: discuss.category - reading name is acceptable
+            # sudo: discuss.category - guests can read categories of accessible channels
+            Store.One("discuss_category_id", ["name", "sequence"], sudo=True),
             "channel_type",
             "create_uid",
             Store.Many(

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_model_patch.js
@@ -9,10 +9,24 @@ const discussAppPatch = {
         super.setup(...arguments);
         this.allCategories = fields.Many("DiscussAppCategory", {
             inverse: "app",
-            sort: (c1, c2) =>
-                c1.sequence !== c2.sequence
-                    ? c1.sequence - c2.sequence
-                    : c1.name.localeCompare(c2.name),
+            sort: (c1, c2) => {
+                // Favorites category always first
+                if (c1.id === "favorites" || c2.id === "favorites") {
+                    return c1.id === "favorites" ? -1 : 1;
+                }
+                // Categories linked to discuss.category come before others
+                const c1HasDiscussCategory = !!c1.discussCategoryAsAppCategory;
+                const c2HasDiscussCategory = !!c2.discussCategoryAsAppCategory;
+                if (c1HasDiscussCategory !== c2HasDiscussCategory) {
+                    return c1HasDiscussCategory ? -1 : 1;
+                }
+                // Finally sort by sequence then name if they are both linked or both not linked to discuss.category
+                const c1Sequence = c1.discussCategoryAsAppCategory?.sequence ?? c1.sequence;
+                const c2Sequence = c2.discussCategoryAsAppCategory?.sequence ?? c2.sequence;
+                return c1Sequence !== c2Sequence
+                    ? c1Sequence - c2Sequence
+                    : c1.name.localeCompare(c2.name);
+            },
         });
         this.channelCategory = fields.One("DiscussAppCategory", {
             compute() {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_category_model.js
@@ -21,6 +21,8 @@ export class DiscussCategory extends Record {
     id;
     /** @type {string} */
     name;
+    /** @type {number} */
+    sequence;
 
     delete() {
         this.appCategory?.delete();

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -56,17 +56,17 @@ test("Display discuss categories", async () => {
     await contains(".o-mail-DiscussSidebarCategory", { text: "rd" });
     await contains(".o-mail-DiscussSidebarCategory", { text: "services" });
     await contains(".o-mail-DiscussSidebarChannel", {
-        text: "general",
-        after: [".o-mail-DiscussSidebarCategory", { text: "Channels" }],
-        before: [".o-mail-DiscussSidebarCategory", { text: "rd" }],
-    });
-    await contains(".o-mail-DiscussSidebarChannel", {
         text: "rd-Discuss",
         after: [".o-mail-DiscussSidebarCategory", { text: "rd" }],
         before: [".o-mail-DiscussSidebarCategory", { text: "services" }],
     });
     await contains(".o-mail-DiscussSidebarChannel", {
         text: "office",
+        after: [".o-mail-DiscussSidebarCategory", { text: "rd" }],
+        before: [".o-mail-DiscussSidebarCategory", { text: "Channels" }],
+    });
+    await contains(".o-mail-DiscussSidebarChannel", {
+        text: "general",
         after: [".o-mail-DiscussSidebarCategory", { text: "services" }],
     });
 });

--- a/addons/mail/views/discuss_category_views.xml
+++ b/addons/mail/views/discuss_category_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="discuss_category_view_tree" model="ir.ui.view">
+            <field name="name">discuss.category.list</field>
+            <field name="model">discuss.category</field>
+            <field name="arch" type="xml">
+                <list string="Discuss Categories" editable="bottom" sample="1">
+                    <field name="sequence" widget="handle"/>
+                    <field name="name" placeholder="e.g. Service"/>
+                    <field name="channel_ids" widget="many2many_tags" domain="[('discuss_category_id', '=', False), ('channel_type', '=', 'channel')]"/>
+                </list>
+            </field>
+        </record>
+
+        <record id="discuss_category_view_form" model="ir.ui.view">
+            <field name="name">discuss.category.form</field>
+            <field name="model">discuss.category</field>
+            <field name="arch" type="xml">
+                <form string="Discuss Categories">
+                    <sheet>
+                        <group>
+                            <field name="name" placeholder="e.g. Service"/>
+                            <field name="channel_ids" widget="many2many_tags" domain="[('discuss_category_id', '=', False), ('channel_type', '=', 'channel')]"/>
+                            <field name="sequence"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="discuss_category_settings_action" model="ir.actions.act_window">
+            <field name="name">Discuss Categories</field>
+            <field name="res_model">discuss.category</field>
+            <field name="view_mode">list,form</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No discuss category found. Let's create one!
+                </p><p>
+                    Use discuss categories to organize the channels.
+                </p>
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -40,6 +40,12 @@
         action="mail.discuss_call_settings_action"
         sequence="5"
     />
+    <menuitem name="Categories"
+        id="mail.menu_discuss_category"
+        parent="mail.menu_configuration"
+        action="mail.discuss_category_settings_action"
+        sequence="10"
+    />
     <menuitem name="Canned Responses"
         id="mail.menu_canned_responses"
         parent="mail.menu_configuration"


### PR DESCRIPTION
Add a sequence field to the discuss category model to allow for ordering of categories.

Add a menu item to access discuss categories from the Discuss configuration menu.

Add views to category configuration, including a list view with drag-and-drop reordering based on the sequence field.

task-5227503

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
