### PR TITLE
Rename 'o_editable' class

### DIFF
--- a/addons/html_builder/models/ir_ui_view.py
+++ b/addons/html_builder/models/ir_ui_view.py
@@ -197,9 +197,6 @@ class IrUiView(models.Model):
         :return: a new mapping of attributes -> value
         """
         attributes = {k: v for k, v in attributes if k not in EDITING_ATTRIBUTES}
-        if 'class' in attributes:
-            classes = attributes['class'].split()
-            attributes['class'] = ' '.join([c for c in classes if c != 'o_savable'])
         if attributes.get('contenteditable') == 'true':
             del attributes['contenteditable']
         return attributes

--- a/addons/html_builder/models/ir_ui_view.py
+++ b/addons/html_builder/models/ir_ui_view.py
@@ -199,7 +199,7 @@ class IrUiView(models.Model):
         attributes = {k: v for k, v in attributes if k not in EDITING_ATTRIBUTES}
         if 'class' in attributes:
             classes = attributes['class'].split()
-            attributes['class'] = ' '.join([c for c in classes if c != 'o_editable'])
+            attributes['class'] = ' '.join([c for c in classes if c != 'o_savable'])
         if attributes.get('contenteditable') == 'true':
             del attributes['contenteditable']
         return attributes

--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -14,7 +14,7 @@ declare module "plugins" {
     import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
     import { empty_node_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
     import { after_save_handlers, before_save_handlers, get_dirty_els, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
-    import { after_setup_editor_handlers, before_setup_editor_handlers, o_editable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
+    import { after_setup_editor_handlers, before_setup_editor_handlers, savable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
     import { target_hide, target_show, VisibilityShared } from "@html_builder/core/visibility_plugin";
     import { default_shape_handlers, post_compute_shape_listeners } from "@html_builder/plugins/image/image_shape_option_plugin";
     import { background_filter_target_providers, get_target_element_providers, on_bg_image_hide_handlers } from "@html_builder/plugins/background_option/background_image_option_plugin";
@@ -139,7 +139,7 @@ declare module "plugins" {
         lower_panel_entries: lower_panel_entries;
         mark_color_level_selector_params: mark_color_level_selector_params;
         no_parent_containers: no_parent_containers;
-        o_editable_selectors: o_editable_selectors;
+        savable_selectors: savable_selectors;
         /** @deprecated */
         patch_builder_options: {
             target_name: string,

--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -13,7 +13,7 @@ declare module "plugins" {
     import { OperationShared } from "@html_builder/core/operation_plugin";
     import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
     import { empty_node_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
-    import { after_save_handlers, before_save_handlers, get_dirty_els, savable_selectors, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
+    import { after_save_handlers, before_save_handlers, get_dirty_els, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
     import { after_setup_editor_handlers, before_setup_editor_handlers, o_editable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
     import { target_hide, target_show, VisibilityShared } from "@html_builder/core/visibility_plugin";
     import { default_shape_handlers, post_compute_shape_listeners } from "@html_builder/plugins/image/image_shape_option_plugin";
@@ -147,7 +147,6 @@ declare module "plugins" {
             method: "replace" | "add" | "remove",
             value: CSSSelector,
         }[];
-        savable_selectors: savable_selectors;
         so_content_addition_selector: so_content_addition_selector;
         so_snippet_addition_selector: so_snippet_addition_selector;
         snippet_preview_dialog_bundles: snippet_preview_dialog_bundles;

--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -21,7 +21,7 @@ export class BuilderContentEditablePlugin extends Plugin {
             "section > .o_container_small",
             "section > .container",
             "section > .container-fluid",
-            ".o_editable",
+            ".o_savable",
         ],
         valid_contenteditable_predicates: this.isValidContentEditable.bind(this),
         content_editable_providers: this.getContentEditableEls.bind(this),
@@ -58,7 +58,7 @@ export class BuilderContentEditablePlugin extends Plugin {
         };
         return (
             !contentEditableEl.matches("input, [data-oe-readonly]") &&
-            contentEditableEl.closest(".o_editable") &&
+            contentEditableEl.closest(".o_savable") &&
             !isDescendantOfNotEditableNotSnippet(contentEditableEl)
         );
     }

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -204,7 +204,7 @@ export class BuilderOptionsPlugin extends Plugin {
      */
     checkElement(el, { editableOnly = true, exclude = "" }) {
         // Unless specified otherwise, the element should be in an editable.
-        if (editableOnly && !(el.closest(".o_editable") || el.closest(".o_editable_attribute"))) {
+        if (editableOnly && !(el.closest(".o_savable") || el.closest(".o_editable_attribute"))) {
             return false;
         }
         // Check that the element is not to be excluded.

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -204,7 +204,7 @@ export class BuilderOptionsPlugin extends Plugin {
      */
     checkElement(el, { editableOnly = true, exclude = "" }) {
         // Unless specified otherwise, the element should be in an editable.
-        if (editableOnly && !(el.closest(".o_savable") || el.closest(".o_editable_attribute"))) {
+        if (editableOnly && !(el.closest(".o_savable") || el.closest(".o_savable_attribute"))) {
             return false;
         }
         // Check that the element is not to be excluded.

--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -25,7 +25,7 @@ export class DisableSnippetsPlugin extends Plugin {
 
         // TODO only for website ?
         // TODO improve to add case when "+" menu appears (resize event ?)
-        const editableDropdownEls = this.editable.querySelectorAll(".dropdown-menu.o_editable");
+        const editableDropdownEls = this.editable.querySelectorAll(".dropdown-menu.o_savable");
         editableDropdownEls.forEach((dropdownEl) => {
             const dropdownToggleEl = dropdownEl.parentNode.querySelector(".dropdown-toggle");
             this.addDomListener(dropdownToggleEl, "shown.bs.dropdown", this._disableSnippets);
@@ -46,7 +46,7 @@ export class DisableSnippetsPlugin extends Plugin {
      * TODO: trigger the computation in the situation that needs it.
      */
     disableUndroppableSnippets() {
-        const editableAreaEls = this.dependencies.setup_editor_plugin.getEditableAreas();
+        const editableAreaEls = this.dependencies.setup_editor_plugin.getSavableAreas();
         const rootEl = this.dependencies.dropzone.getDropRootElement();
         const dropAreasBySelector = this.getDropAreas(editableAreaEls, rootEl);
 

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -77,7 +77,7 @@ export class DropZonePlugin extends Plugin {
             return openModalEl;
         }
         const openDropdownEl = this.editable.querySelector(
-            ".o_editable.dropdown-menu.show, .dropdown-menu.show .o_editable.dropdown-menu"
+            ".o_savable.dropdown-menu.show, .dropdown-menu.show .o_savable.dropdown-menu"
         );
         if (openDropdownEl) {
             return openDropdownEl;
@@ -106,7 +106,7 @@ export class DropZonePlugin extends Plugin {
         const selectorExcludeAncestor = [];
         const selectorLockedWithin = [];
 
-        const editableAreaEls = this.dependencies.setup_editor_plugin.getEditableAreas();
+        const editableAreaEls = this.dependencies.setup_editor_plugin.getSavableAreas();
         const rootEl = this.getDropRootElement();
         this.dropzoneSelectors.forEach((dropzoneSelector) => {
             const {

--- a/addons/html_builder/static/src/core/editor.edit.scss
+++ b/addons/html_builder/static/src/core/editor.edit.scss
@@ -32,7 +32,7 @@ $-editor-messages-margin-x: 2%;
 
 // This style block is about the "editor message" which highlights the areas
 // where the user can drag & drop snippets.
-.o_editable {
+.o_savable {
     // Summernote did not Support for placeholder text, guess who else does not...
     &[placeholder]:not(:focus) {
         &:empty:before,
@@ -119,7 +119,7 @@ $-editor-messages-margin-x: 2%;
 }
 
 .css_non_editable_mode_hidden,
-.o_editable .media_iframe_video .css_editable_mode_display {
+.o_savable .media_iframe_video .css_editable_mode_display {
     display: block !important;
 }
 

--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -97,7 +97,7 @@ export class MediaWebsitePlugin extends Plugin {
     async replaceMedia(mediaEl) {
         const sel = this.dependencies.selection.getEditableSelection();
         const editableEl =
-            closestElement(mediaEl || sel.startContainer, ".o_editable") || this.editable;
+            closestElement(mediaEl || sel.startContainer, ".o_savable") || this.editable;
         await this.dependencies.media.openMediaDialog({ node: mediaEl }, editableEl);
     }
 

--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -134,9 +134,9 @@ export class RemovePlugin extends Plugin {
             "prev"
         );
         const nextSiblingEl = this.dependencies.visibility.getVisibleSibling(toRemoveEl, "next");
-        if (parentEl.matches(".o_editable:not(body)")) {
-            // If we target the editable, we want to reset the selection to the
-            // body. If the editable has options, we do not want to show them.
+        if (parentEl.matches(".o_savable:not(body)")) {
+            // If we target the savable, we want to reset the selection to the
+            // body. If the savable has options, we do not want to show them.
             parentEl = parentEl.closest("body");
         }
 

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -24,8 +24,6 @@ import { uniqueId } from "@web/core/utils/functions";
  * @typedef {((cleanedEls: HTMLElement[]) => Promise<boolean>)[]} save_elements_overrides
  *
  * @typedef {(() => HTMLElement[] | NodeList)[]} get_dirty_els
- *
- * @typedef {CSSSelector[]} savable_selectors
  */
 
 export class SavePlugin extends Plugin {
@@ -38,11 +36,6 @@ export class SavePlugin extends Plugin {
         handleNewRecords: this.handleMutations.bind(this),
         start_edition_handlers: this.startObserving.bind(this),
         // Resource definitions:
-        savable_selectors: [
-            "#wrapwrap .oe_structure[data-oe-xpath][data-oe-id]",
-            "#wrapwrap [data-oe-field]:not([data-oe-sanitize-prevent-edition])",
-            "#wrapwrap .s_cover[data-res-model]",
-        ],
         clean_for_save_handlers: [
             // ({root}) => {
             //     clean DOM before save (leaving edit mode)
@@ -57,7 +50,6 @@ export class SavePlugin extends Plugin {
 
     setup() {
         this.canObserve = false;
-        this.savableSelector = this.getResource("savable_selectors").join(", ");
     }
 
     async save({ shouldSkipAfterSaveHandlers = async () => true } = {}) {
@@ -149,7 +141,7 @@ export class SavePlugin extends Plugin {
             if (!targetEl) {
                 continue;
             }
-            const savableEl = targetEl.closest(this.savableSelector);
+            const savableEl = targetEl.closest(".o_savable");
             if (
                 !savableEl ||
                 savableEl.classList.contains("o_dirty") ||

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -1,10 +1,11 @@
 import { Plugin } from "@html_editor/plugin";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
 
 /**
  * @typedef { Object } SetupEditorShared
- * @property { SetupEditorPlugin['getEditableAreas'] } getEditableAreas
+ * @property { SetupEditorPlugin['getSavableAreas'] } getSavableAreas
  */
 
 /**
@@ -16,24 +17,29 @@ import { _t } from "@web/core/l10n/translation";
 
 export class SetupEditorPlugin extends Plugin {
     static id = "setup_editor_plugin";
-    static shared = ["getEditableAreas"];
+    static shared = ["getSavableAreas"];
     /** @type {import("plugins").BuilderResources} */
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
-        closest_savable_providers: withSequence(10, (el) => el.closest(".o_editable")),
+        closest_savable_providers: withSequence(10, (el) => el.closest(".o_savable")),
         o_editable_selectors: "[data-oe-model]",
-        unremovable_node_predicates: (node) => node.classList?.contains("o_editable"),
+        unremovable_node_predicates: (node) => node.classList?.contains("o_savable"),
     };
 
     setup() {
+        for (const savableEl of selectElements(this.editable, ".o_editable")) {
+            // Remove potential `o_editable` class from elements (that is there
+            // due to wrong templates for example).
+            savableEl.classList.remove("o_editable");
+        }
         const welcomeMessageEl = this.editable.querySelector(
             "#wrap .o_homepage_editor_welcome_message"
         );
         welcomeMessageEl?.remove();
         this.dispatchTo("before_setup_editor_handlers");
-        let editableEls = this.getEditableElements(
-            this.getResource("o_editable_selectors").join(", ")
-        )
+        const editableSelectors = this.getResource("o_editable_selectors").join(", ");
+        const editableEls = [...this.editable.querySelectorAll(editableSelectors)]
+            .filter((el) => !el.closest(".o_not_editable"))
             .filter((el) => !el.matches("link, script"))
             .filter((el) => !el.hasAttribute("data-oe-readonly"))
             .filter(
@@ -45,38 +51,32 @@ export class SetupEditorPlugin extends Plugin {
             .filter((el) => !el.classList.contains("oe_snippet_editor"))
             .filter((el) => !el.matches("hr, br, input, textarea"))
             .filter((el) => !el.hasAttribute("data-oe-sanitize-prevent-edition"));
-        editableEls.concat(Array.from(this.editable.querySelectorAll(".o_editable")));
-        editableEls.forEach((el) => el.classList.add("o_editable"));
+        for (const editableEl of editableEls) {
+            editableEl.classList.add("o_savable");
+        }
         if (this.delegateTo("after_setup_editor_handlers")) {
             return;
         }
 
         // Add automatic editor message on the editables where we can drag and
         // drop elements.
-        editableEls = this.getEditableElements('.oe_structure.oe_empty, [data-oe-type="html"]');
-        editableEls.forEach((el) => {
+        const dragAndDropSavableEls = [
+            ...this.editable.querySelectorAll(
+                '.o_savable.oe_structure.oe_empty, .o_savable[data-oe-type="html"]'
+            ),
+        ];
+        for (const el of dragAndDropSavableEls) {
             if (!el.hasAttribute("data-editor-message")) {
                 el.setAttribute("data-editor-message-default", true);
                 el.setAttribute("data-editor-message", _t("DRAG BUILDING BLOCKS HERE"));
             }
-        });
-    }
-
-    getEditableElements(selector) {
-        const editableEls = [...this.editable.querySelectorAll(selector)]
-            .filter((el) => !el.matches(".o_not_editable"))
-            .filter((el) => {
-                const parent = el.closest(".o_editable, .o_not_editable");
-                return !parent || parent.matches(".o_editable");
-            });
-        return editableEls;
+        }
     }
 
     cleanForSave({ root }) {
-        root.classList.remove("o_editable");
-        root.querySelectorAll(".o_editable").forEach((el) => {
-            el.classList.remove("o_editable");
-        });
+        for (const savableEl of selectElements(root, ".o_savable")) {
+            savableEl.classList.remove("o_savable");
+        }
 
         [root, ...root.querySelectorAll("[data-editor-message]")].forEach((el) => {
             el.removeAttribute("data-editor-message");
@@ -85,18 +85,14 @@ export class SetupEditorPlugin extends Plugin {
     }
 
     /**
-     * Gets all the editable elements contained in the given root element (or
-     * the editable if none is specified), including this element.
+     * Gets all the savable elements contained in the given root element (or the
+     * editable if none is specified), including this element.
      *
      * @param {HTMLElement|undefined} rootEl
      * @returns {Array<HTMLElement}
      */
-    getEditableAreas(rootEl) {
+    getSavableAreas(rootEl) {
         const editableEl = rootEl || this.editable;
-        const editablesAreaEls = [...editableEl.querySelectorAll(".o_editable")];
-        if (editableEl.matches(".o_editable")) {
-            editablesAreaEls.unshift(editableEl);
-        }
-        return editablesAreaEls;
+        return [...selectElements(editableEl, ".o_savable")];
     }
 }

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -12,7 +12,7 @@ import { _t } from "@web/core/l10n/translation";
  * @typedef {(() => void | true)[]} after_setup_editor_handlers
  * @typedef {(() => void)[]} before_setup_editor_handlers
  *
- * @typedef {CSSSelector[]} o_editable_selectors
+ * @typedef {CSSSelector[]} savable_selectors
  */
 
 export class SetupEditorPlugin extends Plugin {
@@ -22,7 +22,7 @@ export class SetupEditorPlugin extends Plugin {
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         closest_savable_providers: withSequence(10, (el) => el.closest(".o_savable")),
-        o_editable_selectors: "[data-oe-model]",
+        savable_selectors: "[data-oe-model]",
         unremovable_node_predicates: (node) => node.classList?.contains("o_savable"),
     };
 
@@ -37,8 +37,8 @@ export class SetupEditorPlugin extends Plugin {
         );
         welcomeMessageEl?.remove();
         this.dispatchTo("before_setup_editor_handlers");
-        const editableSelectors = this.getResource("o_editable_selectors").join(", ");
-        const editableEls = [...this.editable.querySelectorAll(editableSelectors)]
+        const savableSelectors = this.getResource("savable_selectors").join(", ");
+        const savableEls = [...this.editable.querySelectorAll(savableSelectors)]
             .filter((el) => !el.closest(".o_not_editable"))
             .filter((el) => !el.matches("link, script"))
             .filter((el) => !el.hasAttribute("data-oe-readonly"))
@@ -51,8 +51,8 @@ export class SetupEditorPlugin extends Plugin {
             .filter((el) => !el.classList.contains("oe_snippet_editor"))
             .filter((el) => !el.matches("hr, br, input, textarea"))
             .filter((el) => !el.hasAttribute("data-oe-sanitize-prevent-edition"));
-        for (const editableEl of editableEls) {
-            editableEl.classList.add("o_savable");
+        for (const savableEl of savableEls) {
+            savableEl.classList.add("o_savable");
         }
         if (this.delegateTo("after_setup_editor_handlers")) {
             return;

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -219,7 +219,7 @@ export class BlockTab extends Component {
             let scrollingElement =
                 this.shared.dropzone.getDropRootElement() ||
                 getScrollingElement(this.document) ||
-                this.editable.querySelector(".o_editable");
+                this.editable.querySelector(".o_savable");
             if (!isScrollableY(scrollingElement)) {
                 scrollingElement =
                     closestScrollableY(this.document.defaultView.frameElement) ?? scrollingElement;

--- a/addons/html_builder/static/src/utils/utils.js
+++ b/addons/html_builder/static/src/utils/utils.js
@@ -159,7 +159,7 @@ export function isEditable(node) {
             if (currentNode.className.includes("o_not_editable")) {
                 return false;
             }
-            if (currentNode.className.includes("o_editable")) {
+            if (currentNode.className.includes("o_savable")) {
                 return true;
             }
         }

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -313,7 +313,7 @@ export function isBackgroundImageAttribute(attribute) {
  *
  * TODO: the name of this function is voluntarily bad to reflect the fact that
  * this system should be improved. The combination of o_not_editable,
- * o_editable, getContentEditableAreas, getReadOnlyAreas and other concepts
+ * o_savable, getContentEditableAreas, getReadOnlyAreas and other concepts
  * related to what should be editable or not should be reviewed.
  *
  * @returns {boolean}
@@ -326,7 +326,7 @@ export function shouldEditableMediaBeEditable(mediaEl) {
     // This case is complex and the solution to support it is not
     // perfect: we mark those media with a class and check that they
     // are descendant of a savable.
-    return mediaEl.parentElement && mediaEl.parentElement.closest(".o_editable");
+    return mediaEl.parentElement && mediaEl.parentElement.closest(".o_savable");
 }
 /**
  * Returns the label of a link element.

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -588,7 +588,7 @@ test("An option should only appear if its target is inside an editable area, unl
         `<div class="content">
             <div class="test-target test-not-editable">NOT IN EDITABLE</div>
         </div>
-        <div class="content o_editable">
+        <div class="content o_savable">
             <div class="test-target test-editable">IN EDITABLE</div>
         </div>`
     );

--- a/addons/html_builder/static/tests/editor.test.js
+++ b/addons/html_builder/static/tests/editor.test.js
@@ -277,8 +277,8 @@ describe("font types", () => {
         expect(editor.editable.querySelector("p")).toHaveClass("small");
     });
 
-    test("Should not be able to change tag of `o_editable` element", async () => {
-        const { getEditor } = await setupHTMLBuilder(`<h1 class="o_editable">abcd</h1>`);
+    test("Should not be able to change tag of `o_savable` element", async () => {
+        const { getEditor } = await setupHTMLBuilder(`<h1 class="o_savable">abcd</h1>`);
         const editor = getEditor();
         const h1 = editor.editable.querySelector("h1");
         setSelection({ anchorNode: h1, anchorOffset: 0, focusOffset: 1 });

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -279,9 +279,9 @@ export async function setupHTMLBuilder(
         setup() {
             super.setup();
             _resolve();
-            editableContent = this.getEditableElements(
-                '.oe_structure.oe_empty, [data-oe-type="html"]'
-            )[0];
+            editableContent = this.editable.querySelector(
+                '.o_savable.oe_structure.oe_empty, .o_savable[data-oe-type="html"]'
+            );
         },
     });
 

--- a/addons/html_builder/static/tests/section_contenteditable.test.js
+++ b/addons/html_builder/static/tests/section_contenteditable.test.js
@@ -3,7 +3,7 @@ import { expect, test, describe } from "@odoo/hoot";
 
 describe.current.tags("desktop");
 
-test("section with containers should not be contenteditable, but there containers should, unless outside o_editable", async () => {
+test("section with containers should not be contenteditable, but there containers should, unless outside o_savable", async () => {
     await setupHTMLBuilder(
         `<section><div class="container"><span class="inside">in</span></div></section>`,
         {

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -563,7 +563,7 @@ export class DomPlugin extends Plugin {
     /**
      * Determines if a block element can be safely retagged.
      *
-     * Certain blocks (like 'o_editable') should not be retagged because doing so
+     * Certain blocks (like 'o_savable') should not be retagged because doing so
      * will recreate the block, potentially causing issues. This function checks
      * if retagging a block is safe.
      *

--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -124,7 +124,7 @@ pre {
 
 /* ----- GENERIC LAYOUTING HELPERS ---- */
 /* table */
-#wrapwrap, .o_editable {
+#wrapwrap {
     // Only style editor-made tables (shop/portal/... tables are not supposed to
     // use table-bordered...)
     table.table.table-bordered {

--- a/addons/html_editor/static/tests/field.test.js
+++ b/addons/html_editor/static/tests/field.test.js
@@ -8,7 +8,7 @@ describe("monetary field", () => {
         await testEditor({
             contentBefore: unformat(`
                 <p>
-                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">
+                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]">
                         $&nbsp;
                         <span class="oe_currency_value">[]</span>
                     </span>
@@ -17,7 +17,7 @@ describe("monetary field", () => {
             stepFunction: deleteBackward,
             contentAfter: unformat(`
                 <p>
-                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">
+                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]">
                         $&nbsp;
                         <span class="oe_currency_value">[]</span>
                     </span>

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -293,7 +293,7 @@ class CardCampaign(models.Model):
 <style id="design-element"></style>
 <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
 <div class="row">
-<div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable theme_selection_done">
+<div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure theme_selection_done">
 
 <div class="s_text_block o_mail_snippet_general pt24 pb24" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text">
     <div class="container s_allow_columns">

--- a/addons/mass_mailing/demo/mailing_mailing.xml
+++ b/addons/mass_mailing/demo/mailing_mailing.xml
@@ -23,7 +23,7 @@
 <div class="o_layout o_default_theme oe_unremovable oe_unmovable" data-name="Mailing">
     <div class="container o_mail_wrapper oe_unremovable oe_unmovable" style="border-collapse:collapse;">
         <div class="row">
-            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable" style="text-align:left;width:100%;">
+            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure" style="text-align:left;width:100%;">
                 <div class="o_mail_block_header_logo" data-snippet="s_mail_block_header_logo">
                     <div class="o_mail_snippet_general" style="margin:0px auto 0px auto;background-color:rgb(255, 255, 255);max-width:600px;width:100%;">
                         <div class="container o_mail_h_padding" style="padding:0 20px 0 20px;width:100%;border-collapse:separate;">

--- a/addons/mass_mailing/static/src/builder/plugins/mass_mailing_setup_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/mass_mailing_setup_plugin.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 export class MassMailingSetupPlugin extends Plugin {
     static id = "mass_mailing_setup_plugin";
     resources = {
-        o_editable_selectors: ".o_mail_wrapper_td",
+        savable_selectors: ".o_mail_wrapper_td",
         snippet_preview_dialog_bundles: [
             "mass_mailing.assets_iframe_style",
             "mass_mailing.iframe_add_dialog",

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -68,7 +68,7 @@ class Mailing extends models.Model {
                 <div data_name="Mailing" class="o_layout oe_unremovable oe_unmovable o_empty_theme">
                     <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
                         <div class="row">
-                            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable oe_empty" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true">
+                            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_savable oe_empty" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true">
                                 This element <t t-out="'should be inline'"/>
                             </div>
                         </div>

--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -21,7 +21,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
     run: "click",
 }, {
     content: 'wait for the editor to be rendered',
-    trigger: '[name="body_arch"] :iframe .o_editable[data-editor-message="DRAG BUILDING BLOCKS HERE"]',
+    trigger: '[name="body_arch"] :iframe .o_savable[data-editor-message="DRAG BUILDING BLOCKS HERE"]',
 }, {
     trigger: '.o_snippet[name="Headings"] button',
     content: 'Click the "Headings" snippet category to drop a snippet in the editor',
@@ -35,7 +35,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
     trigger: 'body:not(:has(.o_we_ongoing_insertion))',
 }, {
     content: 'verify that the title was inserted properly in the editor',
-    trigger: '[name="body_arch"] :iframe .o_editable h1',
+    trigger: '[name="body_arch"] :iframe .o_savable h1',
 }, {
     trigger: 'button.o_form_button_save',
     run: "click",
@@ -44,7 +44,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
     trigger: 'label.o_field_invalid',
 }, {
     content: 'verify that the edited mailing body was not lost during the failed save',
-    trigger: '[name="body_arch"] :iframe .o_editable h1',
+    trigger: '[name="body_arch"] :iframe .o_savable h1',
 }, {
     trigger: 'input#subject_0',
     run: "edit TestFromTour",
@@ -54,5 +54,5 @@ registry.category("web_tour.tours").add('mailing_editor', {
 },
 ...stepUtils.saveForm(),
 {
-    trigger: ':iframe .o_editable',
+    trigger: ':iframe .o_savable',
 }]});

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
             run: "click",
         },
         {
-            trigger: '[name="body_arch"] :iframe .o_editable h1',
+            trigger: '[name="body_arch"] :iframe .o_savable h1',
             content: 'Verify that the title was inserted properly in the editor',
         },
         ...stepUtils.discardForm(),

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
@@ -41,7 +41,7 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
     { // necessary to wait for the cursor to be placed in the first p
       // and to avoid leaving the page before the selection is added
         content: "Wait for template selection event to be over.",
-        trigger: ":iframe .odoo-editor-editable .o_editable",
+        trigger: ":iframe .odoo-editor-editable .o_savable",
         run: "click",
     },
     {

--- a/addons/mass_mailing_crm/demo/mailing_mailing.xml
+++ b/addons/mass_mailing_crm/demo/mailing_mailing.xml
@@ -14,7 +14,7 @@
         <field name="reply_to_mode">new</field>
         <field name="reply_to">{{ object.company_id.email }}</field>
         <field name="body_arch" type="html">
-<div class="oe_structure o_editable">
+<div class="oe_structure o_mail_wrapper_td">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 24px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>

--- a/addons/mass_mailing_sale/demo/mailing_mailing.xml
+++ b/addons/mass_mailing_sale/demo/mailing_mailing.xml
@@ -14,7 +14,7 @@
         <field name="reply_to_mode">new</field>
         <field name="reply_to">{{ object.company_id.email }}</field>
         <field name="body_arch" type="html">
-<div class="oe_structure o_editable">
+<div class="oe_structure o_mail_wrapper_td">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 24px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -188,7 +188,7 @@ registerWebsitePreviewTour(
         ...clickOnEditAndWaitEditMode(),
         {
             content: "Footer should not be be editable for restricted user",
-            trigger: ":iframe :has(.o_editable) footer:not(.o_editable):not(:has(.o_editable))",
+            trigger: ":iframe :has(.o_savable) footer:not(.o_savable):not(:has(.o_savable))",
         },
         ...clickOnSave(),
     ]

--- a/addons/test_website/static/tests/tours/translation.js
+++ b/addons/test_website/static/tests/tours/translation.js
@@ -145,7 +145,7 @@ function singleLanguage() {
         ...clickOnEditAndWaitEditMode(),
         {
             content: "Edit template text",
-            trigger: ":iframe main p.o_editable[data-oe-field='arch'][contenteditable='true']",
+            trigger: ":iframe main p.o_savable[data-oe-field='arch'][contenteditable='true']",
             run: "editor Modified Text",
         },
         ...clickOnSave("bottom", 50000, false),
@@ -392,7 +392,7 @@ function multiLanguage(mainLanguage, secondLanguage) {
         ...clickOnEditAndWaitEditMode(),
         {
             content: "Edit template text",
-            trigger: ":iframe main p.o_editable[contenteditable='true']",
+            trigger: ":iframe main p.o_savable[contenteditable='true']",
             run: "editor Modified View",
         },
         ...clickOnSave("bottom", 50000, false),
@@ -428,7 +428,7 @@ function multiLanguage(mainLanguage, secondLanguage) {
         ...clickOnEditAndWaitEditMode(),
         {
             content: "Edit template text",
-            trigger: ":iframe main p.o_editable[data-oe-field='arch'][contenteditable='true']",
+            trigger: ":iframe main p.o_savable[data-oe-field='arch'][contenteditable='true']",
             run: "editor Even more modified Text",
         },
         ...clickOnSave("bottom", 50000, false),

--- a/addons/website/static/src/builder/plugins/options/countdown_option.edit.scss
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.edit.scss
@@ -1,5 +1,5 @@
 // s_countdown preview classes
-.o_editable .s_countdown {
+.o_savable .s_countdown {
     &.s_countdown_enable_preview {
         &.hide-countdown .s_countdown_canvas_wrapper, &.hide-countdown .s_countdown_inline_wrapper {
             display: none !important;

--- a/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
@@ -17,7 +17,7 @@ class CoverPropertiesOptionPlugin extends Plugin {
             SetCoverBackgroundAction,
             MarkCoverPropertiesToBeSavedAction,
         },
-        savable_selectors: "#wrapwrap .o_record_cover_container[data-res-model]",
+        o_savable_selectors: "#wrapwrap .o_record_cover_container[data-res-model]",
         before_save_handlers: this.savePendingBackgroundImage.bind(this),
         save_element_handlers: this.saveCoverProperties.bind(this),
     };

--- a/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
@@ -17,7 +17,7 @@ class CoverPropertiesOptionPlugin extends Plugin {
             SetCoverBackgroundAction,
             MarkCoverPropertiesToBeSavedAction,
         },
-        o_savable_selectors: "#wrapwrap .o_record_cover_container[data-res-model]",
+        savable_selectors: "#wrapwrap .o_record_cover_container[data-res-model]",
         before_save_handlers: this.savePendingBackgroundImage.bind(this),
         save_element_handlers: this.saveCoverProperties.bind(this),
     };

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -43,7 +43,7 @@ export class MegaMenuOptionPlugin extends Plugin {
             // menu itself.
             const classes = [...megaMenuEl.classList].filter(
                 (megaMenuClass) =>
-                    !["dropdown-menu", "o_mega_menu", "o_editable"].includes(megaMenuClass)
+                    !["dropdown-menu", "o_mega_menu", "o_savable"].includes(megaMenuClass)
             );
 
             proms.push(

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -99,8 +99,7 @@ export class MoveBlockAction extends BuilderAction {
             : value === "currentPage";
     }
     apply({ editingElement, value }) {
-        const selector =
-            value === "allPages" ? "#o_shared_blocks" : "main .oe_structure.o_editable";
+        const selector = value === "allPages" ? "#o_shared_blocks" : "main .oe_structure.o_savable";
         const whereEl = this.editable.querySelector(selector);
         const popupEl = editingElement.closest(".s_popup");
         whereEl.insertAdjacentElement("afterbegin", popupEl);

--- a/addons/website/static/src/builder/plugins/translation/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation/translation_plugin.js
@@ -36,10 +36,10 @@ function findOEditable(containerEl) {
     const isOEditable = (node) => {
         // Ideally, we should entirely rely on the contenteditable mechanism.
         // The problem is that the translatable attributes are not branded DOM
-        // nodes hence the o_editable_attribute hack.
+        // nodes hence the o_savable_attribute hack.
         if (
             node.isContentEditable ||
-            (node.classList.contains("o_editable_attribute") &&
+            (node.classList.contains("o_savable_attribute") &&
                 (!node.closest(".o_not_editable") || node.classList.contains("o_editable_media")))
         ) {
             return true;
@@ -63,10 +63,10 @@ export class TranslationPlugin extends Plugin {
                 this.services.website.pageDocument
             );
             for (const translationSavableEl of translationSavableEls) {
-                translationSavableEl.classList.add("o_editable_attribute");
+                translationSavableEl.classList.add("o_savable_attribute");
             }
             // Apply data-oe-readonly on wrapping editor
-            const editableElSelector = ".o_savable, .o_editable_attribute";
+            const editableElSelector = ".o_savable, .o_savable_attribute";
             const editableEls = [
                 ...this.services.website.pageDocument.querySelectorAll(".o_savable"),
             ];
@@ -81,7 +81,7 @@ export class TranslationPlugin extends Plugin {
         start_edition_handlers: withSequence(5, () => {
             this.prepareTranslation();
         }),
-        system_classes: ["o_editable_attribute"],
+        system_classes: ["o_savable_attribute"],
     };
 
     setup() {
@@ -138,7 +138,7 @@ export class TranslationPlugin extends Plugin {
             this.handleToC(translateEl);
         }
         const savableInsideNotEditableEls = this.editable.querySelectorAll(
-            ".o_not_editable .o_savable, .o_not_editable .o_editable_attribute"
+            ".o_not_editable .o_savable, .o_not_editable .o_savable_attribute"
         );
         for (const savableInsideNotEditableEl of savableInsideNotEditableEls) {
             this.addDomListener(savableInsideNotEditableEl, "click", showNotification);
@@ -342,8 +342,8 @@ export class TranslationPlugin extends Plugin {
     }
 
     cleanForSave({ root }) {
-        root.querySelectorAll(".o_editable_attribute").forEach((el) => {
-            el.classList.remove("o_editable_attribute");
+        root.querySelectorAll(".o_savable_attribute").forEach((el) => {
+            el.classList.remove("o_savable_attribute");
         });
         // Remove the `.o_translation_select` temporary element
         const optionsEl = root.querySelector(".o_translation_select");

--- a/addons/website/static/src/builder/plugins/translation/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation/translation_plugin.js
@@ -66,14 +66,14 @@ export class TranslationPlugin extends Plugin {
                 translationSavableEl.classList.add("o_editable_attribute");
             }
             // Apply data-oe-readonly on wrapping editor
-            const editableElSelector = ".o_editable, .o_editable_attribute";
+            const editableElSelector = ".o_savable, .o_editable_attribute";
             const editableEls = [
-                ...this.services.website.pageDocument.querySelectorAll(".o_editable"),
+                ...this.services.website.pageDocument.querySelectorAll(".o_savable"),
             ];
             for (const editableEl of editableEls) {
                 if (editableEl.querySelector(editableElSelector)) {
                     editableEl.setAttribute("data-oe-readonly", "true");
-                    editableEl.classList.remove("o_editable");
+                    editableEl.classList.remove("o_savable");
                 }
             }
             return true;
@@ -106,7 +106,7 @@ export class TranslationPlugin extends Plugin {
         const menuEls = this.websiteService.pageDocument.querySelectorAll(".dropdown-menu");
         for (const menuEl of menuEls) {
             this.addDomListener(menuEl, "click", (ev) => {
-                const editableEl = ev.target.closest(".o_editable");
+                const editableEl = ev.target.closest(".o_savable");
                 if (editableEl && menuEl.contains(editableEl)) {
                     ev.stopPropagation();
                     ev.preventDefault();
@@ -138,7 +138,7 @@ export class TranslationPlugin extends Plugin {
             this.handleToC(translateEl);
         }
         const savableInsideNotEditableEls = this.editable.querySelectorAll(
-            ".o_not_editable .o_editable, .o_not_editable .o_editable_attribute"
+            ".o_not_editable .o_savable, .o_not_editable .o_editable_attribute"
         );
         for (const savableInsideNotEditableEl of savableInsideNotEditableEls) {
             this.addDomListener(savableInsideNotEditableEl, "click", showNotification);

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -36,7 +36,7 @@ $-editor-messages-margin-x: 2%;
     }
 }
 
-.o_editable {
+.o_savable {
     &:not(:empty), &[data-oe-type] {
         &:not([data-oe-model="ir.ui.view"]):not([data-oe-type="html"]):not(.o_editable_no_shadow):not([data-oe-type="image"]):hover,
         &.o_editable_date_field_linked {
@@ -158,7 +158,7 @@ $-editor-messages-margin-x: 2%;
 }
 
 .editor_enable .css_non_editable_mode_hidden,
-.o_editable .media_iframe_video .css_editable_mode_display {
+.o_savable .media_iframe_video .css_editable_mode_display {
     display: block!important;
 }
 
@@ -187,7 +187,7 @@ $-editor-messages-margin-x: 2%;
 }
 
 // fontawesome
-#wrap.o_editable .fa {
+#wrap.o_savable .fa {
     cursor: pointer;
 }
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -302,7 +302,7 @@ body {
 }
 
 // We don't want the area to be visible in edit mode when we edit the popup that
-// is shared on all pages, otherwise the .o_editable area has a minimum height
+// is shared on all pages, otherwise the .o_savable area has a minimum height
 // when it is focused.
 #o_shared_blocks {
     min-height: 0px;

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -361,7 +361,7 @@ test("The overlay buttons should only appear for elements in editable areas, unl
         `<div class="content">
             <div class="test-not-editable">NOT IN EDITABLE</div>
         </div>
-        <div class="content o_editable">
+        <div class="content o_savable">
             <div class="test-editable">IN EDITABLE</div>
         </div>`
     );

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -46,7 +46,7 @@ test("basic save", async () => {
         '<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch"><h1 class="title">H1ello</h1></div>'
     );
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
-    expect(":iframe #wrap").not.toHaveClass("o_editable");
+    expect(":iframe #wrap").not.toHaveClass("o_savable");
     expect(":iframe #wrap .title:contains('H1ello')").toHaveCount(1);
 });
 
@@ -59,7 +59,7 @@ test("nothing to save", async () => {
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     expect(resultSave.length).toBe(0);
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
-    expect(":iframe #wrap").not.toHaveClass("o_editable");
+    expect(":iframe #wrap").not.toHaveClass("o_savable");
     expect(":iframe #wrap .title:contains('Hello')").toHaveCount(1);
 });
 
@@ -96,7 +96,7 @@ test("discard modified elements", async () => {
     await contains(".o-snippets-top-actions button[data-action='cancel']").click();
     await contains(".modal-content button.btn-primary").click();
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
-    expect(":iframe #wrap").not.toHaveClass("o_editable");
+    expect(":iframe #wrap").not.toHaveClass("o_savable");
     expect(":iframe #wrap .title:contains('Hello')").toHaveCount(1);
 });
 
@@ -109,7 +109,7 @@ test("discard without any modifications", async () => {
     await setupWebsiteBuilder(exampleContent);
     await contains(".o-snippets-top-actions button[data-action='cancel']").click();
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
-    expect(":iframe #wrap").not.toHaveClass("o_editable");
+    expect(":iframe #wrap").not.toHaveClass("o_savable");
     expect(":iframe #wrap .title:contains('Hello')").toHaveCount(1);
 });
 
@@ -283,7 +283,7 @@ test("Drag and drop from sidebar should only mark the concerned elements as dirt
     await dragUtils.drop(getDragHelper());
     await waitForEndOfOperation();
     expect(":iframe .s_dummy_snippet_2 p").toHaveCount(2);
-    expect(":iframe .view.o_editable").toHaveClass("o_dirty");
+    expect(":iframe .view.o_savable").toHaveClass("o_dirty");
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
     expect(":iframe .o_dirty").toHaveCount(1);
     // Undo
@@ -299,7 +299,7 @@ test("Drag and drop from sidebar should only mark the concerned elements as dirt
     await dragUtils.drop(getDragHelper());
     await waitForEndOfOperation();
     expect(":iframe .s_dummy_snippet_1 p").toHaveCount(2);
-    expect(":iframe .view.o_editable").not.toHaveClass("o_dirty");
+    expect(":iframe .view.o_savable").not.toHaveClass("o_dirty");
     expect(":iframe #wrap").toHaveClass("o_dirty");
     expect(":iframe .o_dirty").toHaveCount(1);
     // Undo
@@ -365,8 +365,8 @@ test("Drag and drop from the page should only mark the concerned elements as dir
     await waitForEndOfOperation();
     expect(":iframe .s_dummy_snippet_1 .s_alert:nth-child(1)").toHaveCount(1);
     expect(":iframe #wrap").toHaveClass("o_dirty");
-    expect(":iframe .view_1.o_editable").not.toHaveClass("o_dirty");
-    expect(":iframe .view_2.o_editable").not.toHaveClass("o_dirty");
+    expect(":iframe .view_1.o_savable").not.toHaveClass("o_dirty");
+    expect(":iframe .view_2.o_savable").not.toHaveClass("o_dirty");
     expect(":iframe .o_dirty").toHaveCount(1);
     // Undo
     await contains(".o-website-builder_sidebar .fa-undo").click();
@@ -382,8 +382,8 @@ test("Drag and drop from the page should only mark the concerned elements as dir
     await waitForEndOfOperation();
     expect(":iframe .s_dummy_snippet_3 .s_alert:nth-child(1)").toHaveCount(1);
     expect(":iframe #wrap").toHaveClass("o_dirty");
-    expect(":iframe .view_1.o_editable").not.toHaveClass("o_dirty");
-    expect(":iframe .view_2.o_editable").toHaveClass("o_dirty");
+    expect(":iframe .view_1.o_savable").not.toHaveClass("o_dirty");
+    expect(":iframe .view_2.o_savable").toHaveClass("o_dirty");
     expect(":iframe .o_dirty").toHaveCount(2);
     // Undo
     await contains(".o-website-builder_sidebar .fa-undo").click();

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -583,3 +583,21 @@ test("attempt to prevent closing window with unsaved changes", async () => {
     deferSave.resolve();
     await expect.waitForSteps(["save - end"]);
 });
+
+test("Modifying an element inside '.o_not_editable' should not mark this element as 'dirty'", async () => {
+    // An example of such a situation is a change of the blog author that makes
+    // a change of the author avatar accordingly.
+    addOption({
+        selector: ".test",
+        template: xml`<BuilderButton classAction="'x'"/>`,
+        editableOnly: false,
+    });
+    await setupWebsiteBuilder(`
+        <div class="o_not_editable" data-oe-model="model" data-oe-id="1" data-oe-field="field">
+            <p class="test">Test</p>
+        </div>
+    `);
+    await contains(`:iframe .test`).click();
+    await contains("[data-class-action='x']").click();
+    expect(":iframe [data-oe-model='model']").not.toHaveClass("o_dirty");
+});

--- a/addons/website/static/tests/builder/setup_html_builder.test.js
+++ b/addons/website/static/tests/builder/setup_html_builder.test.js
@@ -9,7 +9,7 @@ defineWebsiteModels();
 
 test("setup of the editable elements", async () => {
     await setupWebsiteBuilder('<h1 class="title">Hello</h1>');
-    expect(":iframe #wrap").toHaveClass("o_editable");
+    expect(":iframe #wrap").toHaveClass("o_savable");
 });
 
 test("history back", async () => {

--- a/addons/website/static/tests/builder/snippets_menu.test.js
+++ b/addons/website/static/tests/builder/snippets_menu.test.js
@@ -71,23 +71,23 @@ test("undo and redo buttons", async () => {
     expect(".o_menu_systray .o-website-btn-custo-primary").toHaveCount(1);
     await openBuilderSidebar();
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
-    expect(":iframe #wrap").toHaveClass("o_editable");
+    expect(":iframe #wrap").toHaveClass("o_savable");
     const editor = getEditor();
     const editableContent = getEditableContent();
     setContent(editableContent, "<p> Text[] </p>");
     await insertText(editor, "a");
     expect(editor.editable).toHaveInnerHTML(
-        '<div id="wrap" class="oe_structure oe_empty o_editable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Texta </p> </div>'
+        '<div id="wrap" class="oe_structure oe_empty o_savable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Texta </p> </div>'
     );
     await animationFrame();
     await click(".o-snippets-menu button.fa-undo");
     await animationFrame();
     expect(editor.editable).toHaveInnerHTML(
-        '<div id="wrap" class="oe_structure oe_empty o_editable" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Text </p> </div>'
+        '<div id="wrap" class="oe_structure oe_empty o_savable" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Text </p> </div>'
     );
     await click(".o-snippets-menu button.fa-repeat");
     expect(editor.editable).toHaveInnerHTML(
-        '<div id="wrap" class="oe_structure oe_empty o_editable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Texta </p> </div>'
+        '<div id="wrap" class="oe_structure oe_empty o_savable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Texta </p> </div>'
     );
 });
 

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -123,7 +123,7 @@ test("translate field", async () => {
     });
     const editor = getEditor();
     await contains(".modal .btn:contains(Ok, never show me this again)").click();
-    expect(":iframe [data-oe-model='test']").toHaveClass("o_editable");
+    expect(":iframe [data-oe-model='test']").toHaveClass("o_savable");
     setSelection({ anchorNode: queryOne(":iframe #sectionId"), anchorOffset: 0 });
     await insertText(editor, "New");
     await contains(".o-snippets-top-actions button:contains(Save)").click();
@@ -139,7 +139,7 @@ test("Translate link of a mega menu", async () => {
                 <section>
                     <div class="container s_allow_columns">
                         <a href="#" class="nav-link d-inline">
-                            <span data-oe-model="ir.ui.view" data-oe-id="526" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="123" class="o_editable translate_branding">
+                            <span data-oe-model="ir.ui.view" data-oe-id="526" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="123" class="translate_branding">
                                 Hello
                             </span>
                         </a>
@@ -168,9 +168,9 @@ test("cascade of [data-oe-model] in translation", async () => {
             })}</section></div>
         `,
     });
-    expect(":iframe [data-oe-model='test']").not.toHaveClass("o_editable");
+    expect(":iframe [data-oe-model='test']").not.toHaveClass("o_savable");
     expect(":iframe .container").not.toHaveAttribute("contenteditable");
-    expect(":iframe .container span.o_editable").toHaveAttribute("contenteditable", "true");
+    expect(":iframe .container span.o_savable").toHaveAttribute("contenteditable", "true");
 });
 
 test("404 page in translate mode", async () => {
@@ -200,7 +200,7 @@ test("translate attribute", async () => {
     onRpc("ir.ui.view", "save", ({ args }) => true);
     await setupSidebarBuilderForTranslation({
         websiteContent: `
-            <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto rounded o_editable" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
+            <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto rounded" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
         `,
     });
     await contains(".modal .btn:contains(Ok, never show me this again)").click();
@@ -213,12 +213,12 @@ test("translate attribute", async () => {
 });
 
 test("translate attribute history", async () => {
-    const { getEditableContent } = await setupSidebarBuilderForTranslation({
+    const { getEditor } = await setupSidebarBuilderForTranslation({
         websiteContent: `
             <img src="/web/image/website.s_text_image_default_image" class="img img-fluid" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
         `,
     });
-    const editable = getEditableContent();
+    const wrapEl = getEditor().editable.querySelector("#wrap");
     await contains(".modal .btn:contains(Ok, never show me this again)").click();
     await contains(":iframe img").click();
     await contains(".modal .modal-body input").edit("titre");
@@ -227,9 +227,9 @@ test("translate attribute history", async () => {
         `<img src="/web/image/website.s_text_image_default_image" class="img img-fluid o_editable_attribute o_translatable_attribute${
             translated ? " oe_translated" : ""
         }" loading="lazy" title="${titleName}" style="" data-oe-translation-state="to_translate"></img>`;
-    expect(editable).toHaveInnerHTML(getImg({ titleName: "titre", translated: true }));
+    expect(wrapEl).toHaveInnerHTML(getImg({ titleName: "titre", translated: true }));
     await contains(".o-snippets-menu button.fa-undo").click();
-    expect(editable).toHaveInnerHTML(getImg({ titleName: "title", translated: false }));
+    expect(wrapEl).toHaveInnerHTML(getImg({ titleName: "title", translated: false }));
     await contains(":iframe img").click();
     expect(".modal .modal-body input").toHaveValue("title");
 });
@@ -239,12 +239,12 @@ test("translate select", async () => {
         websiteContent: `
             <div class="row s_col_no_resize s_col_no_bgcolor">
                 <label class="col-form-label col-sm-auto s_website_form_label">
-                    <span data-oe-model="ir.ui.view" data-oe-id="544" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="sourceSha" class="o_editable">
+                    <span data-oe-model="ir.ui.view" data-oe-id="544" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="sourceSha">
                         <span class="s_website_form_label_content">Custom Text</span>
                     </span>
                     </label>
                 <div class="col-sm">
-                    <span data-oe-model="ir.ui.view" data-oe-id="544" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="sourceSha" class="o_editable">
+                    <span data-oe-model="ir.ui.view" data-oe-id="544" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="sourceSha">
                         <select class="form-select s_website_form_input" name="Custom Text" id="oojm1tjo6m19">
                             <option id="optionId1" value="Option 1">Option 1</option>
                             <option id="optionId2" value="Option 2">Option 2</option>
@@ -366,7 +366,7 @@ test("'Translate to' button should be visible in translate mode", async () => {
     expectElementCount("button[data-action-id='translateWebpageAI']", 1);
     await contains("button[data-action-id='translateWebpageAI']").click();
     await animationFrame();
-    expect(":iframe .o_editable").toHaveText("Bonjour");
+    expect(":iframe .o_savable").toHaveText("Bonjour");
 });
 
 test("trying to translate an element inside a .o_not_editable should add a notification", async () => {
@@ -396,7 +396,7 @@ test("trying to translate an attribute of an image inside a .o_not_editable shou
     await setupSidebarBuilderForTranslation({
         websiteContent: `
             <div class="o_not_editable">
-                <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto rounded o_editable" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
+                <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto rounded" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
             <div/>
         `,
     });
@@ -440,7 +440,7 @@ function getTranslateEditable({
         <main>
             <div class="container s_allow_columns${containerEditable ? "" : " o_not_editable"}">
                 <p>
-                    <span data-oe-model="ir.ui.view" data-oe-id="${oeId}" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="${sourceSha}" class="o_editable translate_branding">${inWrap}</span>
+                    <span data-oe-model="ir.ui.view" data-oe-id="${oeId}" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="${sourceSha}" class="translate_branding">${inWrap}</span>
                 </p>
             </div>
         </main>`;

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -224,7 +224,7 @@ test("translate attribute history", async () => {
     await contains(".modal .modal-body input").edit("titre");
     await contains(".modal .btn:contains(Ok)").click();
     const getImg = ({ titleName, translated }) =>
-        `<img src="/web/image/website.s_text_image_default_image" class="img img-fluid o_editable_attribute o_translatable_attribute${
+        `<img src="/web/image/website.s_text_image_default_image" class="img img-fluid o_savable_attribute o_translatable_attribute${
             translated ? " oe_translated" : ""
         }" loading="lazy" title="${titleName}" style="" data-oe-translation-state="to_translate"></img>`;
     expect(wrapEl).toHaveInnerHTML(getImg({ titleName: "titre", translated: true }));

--- a/addons/website/static/tests/builder/website_builder/cookies_bar_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/cookies_bar_option.test.js
@@ -11,7 +11,7 @@ import {
 defineWebsiteModels();
 
 const cookiesBarTemplate = `
-    <div id="website_cookies_bar" class="s_popup o_snippet_invisible o_no_save o_editable o_dirty" data-name="Cookies Bar" data-vcss="001" data-oe-id="1328" data-oe-xpath="/data/xpath/div" data-oe-model="ir.ui.view" data-oe-field="arch" contenteditable="true" data-invisible="1">
+    <div id="website_cookies_bar" class="s_popup o_snippet_invisible o_no_save o_savable o_dirty" data-name="Cookies Bar" data-vcss="001" data-oe-id="1328" data-oe-xpath="/data/xpath/div" data-oe-model="ir.ui.view" data-oe-field="arch" contenteditable="true" data-invisible="1">
         <div class="modal s_popup_bottom s_popup_no_backdrop o_cookies_discrete modal_shown show" data-show-after="500" data-display="afterDelay" data-consents-duration="999" data-bs-focus="false" data-bs-backdrop="false" data-bs-keyboard="false" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
             <div class="modal-dialog d-flex s_popup_size_full">
                 <div class="modal-content oe_structure">

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -233,9 +233,9 @@ export async function setupWebsiteBuilder(
     patchWithCleanup(SetupEditorPlugin.prototype, {
         setup() {
             super.setup();
-            editableContent = this.getEditableElements(
-                '.oe_structure.oe_empty, [data-oe-type="html"]'
-            )[0];
+            editableContent = this.editable.querySelector(
+                '.o_savable.oe_structure.oe_empty, .o_savable[data-oe-type="html"]'
+            );
         },
     });
 

--- a/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
+++ b/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
@@ -16,7 +16,7 @@ registerWebsitePreviewTour(
     },
     () => [
         ...clickOnSnippet(
-            ".s_title.custom[data-oe-model][data-oe-id][data-oe-field][data-oe-xpath]"
+            ".s_title.o_savable.custom[data-oe-model][data-oe-id][data-oe-field][data-oe-xpath]"
         ),
         changeOption("Block", ".oe_snippet_save"),
         goBackToBlocks(),
@@ -39,7 +39,7 @@ registerWebsitePreviewTour(
         {
             content: "Check that the custom snippet does not have branding",
             trigger:
-                ":iframe #wrap .s_title.custom:not([data-oe-model]):not([data-oe-id]):not([data-oe-field]):not([data-oe-xpath])",
+                ":iframe #wrap .s_title.custom:not([data-oe-model]):not([data-oe-id]):not([data-oe-field]):not([data-oe-xpath]):not(.o_savable)",
         },
     ]
 );

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -19,7 +19,7 @@ registerWebsitePreviewTour(
         }),
         {
             content: "Edit s_popup snippet",
-            trigger: ':iframe #wrap.o_editable [data-snippet="s_popup"] .row > div', // Click deep in the snippet structure
+            trigger: ':iframe #wrap.o_savable [data-snippet="s_popup"] .row > div', // Click deep in the snippet structure
             run: "click",
         },
         {
@@ -35,7 +35,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Edit s_popup snippet(2)",
-            trigger: ':iframe #wrap.o_editable [data-snippet="s_popup"] h2',
+            trigger: ':iframe #wrap.o_savable [data-snippet="s_popup"] h2',
             run: function () {
                 // Simulating pressing enter.
                 const anchor = this.anchor;
@@ -60,7 +60,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Check the s_popup was removed",
-            trigger: ":iframe #wrap.o_editable:not(:has([data-snippet='s_popup']))",
+            trigger: ":iframe #wrap.o_savable:not(:has([data-snippet='s_popup']))",
         },
         // Test that undoing dropping the snippet removes the invisible elements
         // panel.
@@ -80,7 +80,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Check that the s_popup was removed.",
-            trigger: ':iframe #wrap.o_editable:not(:has([data-snippet="s_popup"]))',
+            trigger: ':iframe #wrap.o_savable:not(:has([data-snippet="s_popup"]))',
         },
         {
             content: "The invisible elements panel should also be removed.",

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -152,7 +152,7 @@ registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
             ...insertSnippet({ id: "s_text_image", name: "Text - Image", groupName: "Content" }),
             {
                 content: "Click on s_text_image snippet",
-                trigger: ":iframe #wrap.o_editable [data-snippet='s_text_image']",
+                trigger: ":iframe #wrap.o_savable [data-snippet='s_text_image']",
                 run: "click",
             },
             {

--- a/addons/website_blog/static/src/website_builder/author_avatar_many2one_plugin.js
+++ b/addons/website_blog/static/src/website_builder/author_avatar_many2one_plugin.js
@@ -17,11 +17,6 @@ patch(Many2OneAction.prototype, {
                 `[data-oe-model="blog.post"][data-oe-id="${oeId}"][data-oe-field="author_avatar"]`
             )) {
                 node.querySelector("img").src = `/web/image/res.partner/${id}/avatar_1024`;
-                // We do not want to save it to the server
-                // TODO: a more general approach for editing records that are used at different parts of the page
-                this.dependencies.history.ignoreDOMMutations(() => {
-                    node.classList.remove("o_dirty");
-                });
             }
         }
     },

--- a/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
@@ -16,6 +16,7 @@ export class BlogPageOptionPlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [BlogPageOption],
+        content_not_editable_selectors: [".o_list_cover"],
     };
 }
 

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -163,7 +163,7 @@
         <t t-set="record" t-value="data['_record']"/>
         <div class="card h-100">
             <a class="text-decoration-none text-reset" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">
-                <div class="s_blog_posts_post_cover o_not_editable card-img-top ratio ratio-16x9">
+                <div class="s_blog_posts_post_cover card-img-top ratio ratio-16x9">
                     <t t-call="website.record_cover">
                         <t t-set="_record" t-value="record"/>
                         <t t-set="additionnal_classes" t-value="'position-absolute w-100 h-100 bg-600 o_snippet_not_selectable'"/>

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -142,14 +142,15 @@
 <!-- ======   Template: Post Author   ==========================================
 ============================================================================ -->
 <template id="post_author">
-    <div t-attf-class="o_not_editable align-items-center position-relative #{additionnal_classes or ''}">
+    <div t-attf-class="align-items-center position-relative #{additionnal_classes or ''}">
         <div t-if="blog_post.author_avatar"
              t-field="blog_post.author_avatar"
              style="line-height:1"
+             class="o_not_editable"
              t-options='{"widget": "image", "alt": "", "class": "rounded-circle " + "o_wblog_author_avatar me-1" if hide_date else  "o_wblog_author_avatar_date me-2"}' />
         <div t-att-class="not hide_date and 'small fw-bold'" style="line-height:1">
             <span t-if="editable" t-field="blog_post.author_id" t-options='{ "widget": "contact", "fields": ["name"]}'/>
-            <span t-else="" t-out="blog_post.author_name"/>
+            <span t-else="" class="o_not_editable" t-out="blog_post.author_name"/>
             <t t-if="not hide_date">
                 <small t-if="blog_post.published_date" t-field="blog_post.published_date" t-options="{'format': 'long', 'date_only': 'true'}"/>
                 <small t-elif="blog_post.publish_on" t-field="blog_post.publish_on" t-options="{'format': 'long', 'date_only': 'true'}"/>

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -199,10 +199,10 @@ according to the enabled options.
 
         <t t-call="website.record_cover">
             <t t-set="_record" t-value="blog_post"/>
-            <t t-set="additionnal_classes" t-value="'o_list_cover o_not_editable ' + (not opt_blog_cards_design and ' rounded overflow-hidden shadow mb-3' or '')"/>
+            <t t-set="additionnal_classes" t-value="'o_list_cover ' + (not opt_blog_cards_design and ' rounded overflow-hidden shadow mb-3' or '')"/>
 
             <t t-if="is_view_active('website_blog.opt_posts_loop_show_author')" t-call="website_blog.post_author">
-                <t t-set="additionnal_classes" t-value="'o_wblog_post_list_author o_list_cover d-flex text-white w-100 o_not_editable ' + ('p-3 h5 m-0' if opt_blog_list_view else 'px-2 pb-2 pt-3') "/>
+                <t t-set="additionnal_classes" t-value="'o_wblog_post_list_author o_list_cover d-flex text-white w-100 ' + ('p-3 h5 m-0' if opt_blog_list_view else 'px-2 pb-2 pt-3') "/>
                 <t t-set="hide_date" t-value="True"/>
             </t>
         </t>

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -9,7 +9,7 @@ registerWebsitePreviewTour('website_crm_pre_tour', {
     edition: true,
 }, () => [{
     content: "Select contact form",
-    trigger: ":iframe #wrap.o_editable section.s_website_form",
+    trigger: ":iframe #wrap.o_savable section.s_website_form",
     run: "click",
 },
 {

--- a/addons/website_profile/static/src/scss/website_profile.scss
+++ b/addons/website_profile/static/src/scss/website_profile.scss
@@ -133,7 +133,7 @@ $owprofile-color-bg: mix($body-bg, #efeff4);
         h4 {
             width: 60%;
             // only apply ellipsis when in non-edit mode, that way the editor can see the full value
-            &:not(.o_editable) {
+            &:not(.o_savable) {
                 @include o-text-overflow();
             }
             margin-bottom: 0 !important;

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1688,7 +1688,7 @@ $-product-radius-map: (
         cursor: zoom-in;
     }
 
-    .o_editable img[data-zoom] {
+    .o_savable img[data-zoom] {
         cursor: pointer;
     }
 }

--- a/addons/website_sale/static/tests/builder/product_page_option.test.js
+++ b/addons/website_sale/static/tests/builder/product_page_option.test.js
@@ -51,7 +51,7 @@ test("Product page options", async () => {
                             <div id="o-carousel-product">
                                 <div class="carousel-item h-100 text-center active o_colored_level" style="min-height: 693px;">
                                     <div name="o_img_with_max_suggested_width"
-                                        class="d-flex align-items-start justify-content-center h-100 oe_unmovable o_editable"
+                                        class="d-flex align-items-start justify-content-center h-100 oe_unmovable"
                                         data-oe-xpath="/t[1]/div[2]/div[1]" data-oe-model="product.product" data-oe-id="13"
                                         data-oe-field="image_1920" data-oe-type="image"
                                         data-oe-expression="product_image.image_1920" contenteditable="false">
@@ -60,7 +60,7 @@ test("Product page options", async () => {
                                 </div>
                                 <div class="carousel-item h-100 text-center active o_colored_level" style="min-height: 693px;">
                                     <div name="o_img_with_max_suggested_width"
-                                        class="d-flex align-items-start justify-content-center h-100 oe_unmovable o_editable"
+                                        class="d-flex align-items-start justify-content-center h-100 oe_unmovable"
                                         data-oe-xpath="/t[1]/div[2]/div[1]" data-oe-model="product.product" data-oe-id="14"
                                         data-oe-field="image_1920" data-oe-type="image"
                                         data-oe-expression="product_image.image_1920" contenteditable="false">


### PR DESCRIPTION
[IMP] html_builder, *: rename the o_editable class by o_savable
*: html_editor, marketing_cards, mass_mailing, mass_mailing_crm,
mass_mailing_sale, test_website, website, website_crm, website_profile,
website_sale

The goal of this commit is to rename the `o_editable` class by
`o_savable` in order to reduce confusion about its role. This system
class is added on savable area (area with the branding) by the editor
when entering in edit mode and is removed when leaving the edit mode.
The class has also been renamed to avoid confusion with
`.o_not_editable`: while `.o_not_editable` is a class that a user can
add on templates to mark a zone as non editable
(`[contenteditable=false]` is added on those nodes when entering in edit
mode), `.o_savable` is a system class that concerns savability (not only
editability) and should not be added on templates as it is entirely
managed by the editor.

The class has also been removed from `html_editor` templates used on
tests as this class is managed by `html_builder` (`html_editor` should
be agnostic of this class).

It has also been removed from elements on templates that already have
the `o_mail_wrapper_td` class. As `o_mail_wrapper_td` is defined in the
`o_editable_selectors` resource, elements with this class will receive
the `o_savable` class when entering in edit mode.

task-5248483

------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] html_builder, *: remove 'savable_selectors' resource
*: website, website_blog

The goal of this commit is to remove the `savable_selectors` resource.
This resource was used to identify the element on which to add the
`o_dirty` class when a modification was applied. This resource is
useless and we should rather use the `o_savable` class to identify those
elements. Indeed, more checks are done before adding the `o_savable`
class on an element (check that the element is not `[data-oe-readonly]`,
check that it is not inside an `.o_not_editable` element etc...). That
being done, few templates had to be adapted;
- In `website_blog.post_cover_image`: `.o_not_editable` has been removed
from the `additional_classes` to be added on the `website.record_cover`
template as we want the `[data-res-model]` element to be a savable
element (elements that are `.o_not_editable` or are inside
`.o_not_editable` are not considered as savable elements). Instead, the
`.o_list_cover` selector is added in the
`content_not_editable_selectors`. Thanks to it,
`[contenteditable='false']` is added on the element so the user can not
directly edit it (add text or make the toolbar appear) but it is saved
when options modify its content.
- In `website_blog.post_author`: `.o_not_editable` is moved from the
parent `div` to the "avatar" `div` as we want the author to be saved
when it is changed by the options. Note that `author_id` is a `many2one`
that will be marked as `contenteditable=false`. `post_date` is a
`datetime` field that will be marked as `contenteditable=false`.
- `website_blog.dynamic_filter_template_blog_post_card`: the useless
`.o_not_editable` has been removed as the template is used in
`website.s_dynamic_snippet_template` that contains itself the
`o_not_editable` class.

task-5248483


------------------------------------------------------------------------------------------------------------------------------------------------------


[IMP] html_builder, *: rename resource and class
*: mass_mailing, website

As the `o_editable` class has been renamed into `o_savable`, this commit
renames the `o_editable_attribute` class by `o_savable_attribute` and
the `o_editable_selectors` resource by `savable_selectors`.

task-5248483

------------------------------------------------------------------------------------------------------------------------------------------------------

[REM] html_builder, website: avoid removing nonexistant class
This commit removes the useless remove of the `o_savable` class from
elements when saving a custom snippet or "oe structures" (introduced by
[1]). Indeed, since the [website refactoring], this class (previously
`o_editable`) is already removed at the clean for save.

[website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[1]: https://github.com/odoo/odoo/commit/4625cb2fefa0e105031e9e76b16cef756d7b9322

task-5248483


