### PR TITLE
[FIX] analytic: close analytic distribution widget on window click

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -663,7 +663,8 @@ export class AnalyticDistribution extends Component {
         ];
         if (this.isDropdownOpen
             && !this.widgetRef.el.contains(ev.target)
-            && !ev.target.closest(selectors.join(","))
+            && (!ev.target.closest(selectors.join(",")) ||
+                document.querySelector(".modal:not(.o_inactive_modal)").contains(this.widgetRef.el))
             && !ev.target.isSameNode(document.documentElement)
            ) {
             this.forceCloseEditor();


### PR DESCRIPTION
**Issue**
When editing a line on the reco widget, close and keep change on analytic widget on unfocus

**Steps to Reproduce**
1. Activate Analytic Accounting
2. Go on the Bank Reconciliation Widget
3. Edit a line
4. Change the Analytic Distribution.
5. Click elsewhere. 
6. The Analytic Widget should close and keep the changes. (as it does on invoices)

**Fix**
Properly detect the condition for closing the widget.

task-5232476