### PR TITLE
[FIX] *: replace `btn-default` for `btn-secondary`

### DIFF
--- a/addons/portal/wizard/portal_share_views.xml
+++ b/addons/portal/wizard/portal_share_views.xml
@@ -15,7 +15,7 @@
                 </group>
                 <footer>
                     <button string="Send" name="action_send_mail" invisible="access_warning != ''" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-default" special="cancel" data-hotkey="x" />
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>
         </field>

--- a/addons/project/wizard/project_task_share_wizard_views.xml
+++ b/addons/project/wizard/project_task_share_wizard_views.xml
@@ -7,8 +7,8 @@
         <field name="inherit_id" ref="portal.portal_share_wizard"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//button[hasclass('btn-default')]" position="replace">
-                <button string="Discard" class="btn-default" special="cancel" data-hotkey="x" />
+            <xpath expr="//button[hasclass('btn-secondary')]" position="replace">
+                <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
             </xpath>
             <xpath expr="//button[hasclass('btn-primary')]" position="attributes">
                 <attribute name="invisible">project_privacy_visibility in ['invited_users', 'followers']</attribute>

--- a/addons/stock/wizard/stock_rules_report_views.xml
+++ b/addons/stock/wizard/stock_rules_report_views.xml
@@ -21,7 +21,7 @@
                         type="object"
                         data-hotkey="q"
                         class="btn-primary"/>
-                    <button string="Cancel" class="btn-default" special="cancel" data-hotkey="x"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/website/wizard/blocked_third_party_domains.xml
+++ b/addons/website/wizard/blocked_third_party_domains.xml
@@ -19,7 +19,7 @@
             </p>
             <footer>
                 <button string="Save" name="action_save" type="object" class="oe_highlight" data-hotkey="q"/>
-                <button string="Cancel" class="btn btn-default" special="cancel" data-hotkey="x"/>
+                <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
             </footer>
         </form>
     </field>

--- a/addons/website/wizard/website_robots.xml
+++ b/addons/website/wizard/website_robots.xml
@@ -18,7 +18,7 @@
                 </small>
                 <footer>
                     <button string="Save" name="action_save" type="object" class="oe_highlight" data-hotkey="q"/>
-                    <button string="Cancel" class="btn btn-default" special="cancel" data-hotkey="x"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -20,12 +20,12 @@ according to the enabled options.
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                 <span class="me-1">Show:</span>
                 <div class="btn-group btn-group-sm">
-                    <a t-attf-class="btn #{state == 'published' and 'btn-success' or 'btn-default bg-white border'}"
+                    <a t-attf-class="btn #{state == 'published' and 'btn-success' or 'bg-white border'}"
                        t-attf-href="#{state == 'published' and blog_url(state='') or blog_url(state='published')}">
                         <i t-attf-class="fa me-1 #{state == 'published' and 'fa-check-square-o' or 'fa-square-o'}"/>
                         Published (<t t-out="state_info['published']" />)
                     </a>
-                    <a t-attf-class="btn #{state == 'unpublished' and 'btn-success' or 'btn-default bg-white border'}"
+                    <a t-attf-class="btn #{state == 'unpublished' and 'btn-success' or 'bg-white border'}"
                        t-attf-href="#{state == 'unpublished' and blog_url(state='') or blog_url(state='unpublished')}">
                         <i t-attf-class="fa me-1 #{state == 'unpublished' and 'fa-check-square-o' or 'fa-square-o'}"/>
                         Unpublished (<t t-out="state_info['unpublished']" />)

--- a/addons/website_forum/static/tests/interactions/website_forum_spam.test.js
+++ b/addons/website_forum/static/tests/interactions/website_forum_spam.test.js
@@ -22,7 +22,7 @@ const template = (options = {}) => `
                 </div>
                 <div class="modal-footer justify-content-start">
                     <button type="button" class="btn btn-primary o_wforum_mark_spam">Mark as spam</button>
-                    <a class="btn btn-sm btn-default o_wforum_select_all_spam" href="#" type="button">Select All</a>
+                    <a class="btn btn-light o_wforum_select_all_spam" href="#" type="button">Select All</a>
                 </div>
             </div>
         </div>
@@ -92,7 +92,7 @@ test("select all checkboxes", async () => {
                     </div>
                     <div class="modal-footer justify-content-start">
                         <button type="button" class="btn btn-primary o_wforum_mark_spam">Mark as spam</button>
-                        <a class="btn btn-sm btn-default o_wforum_select_all_spam" href="#" type="button">Select All</a>
+                        <a class="btn btn-light o_wforum_select_all_spam" href="#" type="button">Select All</a>
                     </div>
                 </div>
             </div>

--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -133,7 +133,7 @@
                     </div>
                     <div class="modal-footer justify-content-start">
                         <button type="button" class="btn btn-primary o_wforum_mark_spam">Mark as spam</button>
-                        <a class="btn btn-sm btn-default o_wforum_select_all_spam" href="#" type="button">Select All</a>
+                        <a class="btn btn-light o_wforum_select_all_spam" href="#" type="button">Select All</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
*: portal,project,stock,website,website_blog,website_forum

`btn-default` doesn't exist anymore, this is a dead utility class. This commit changes it for `btn-secondary` in the backend and `btn-light` in the frontend.

Note: In blog the buttons didn't work with btn-light, thus we keep the bg-white and its border. (Also I didn't manage to access the alert without removing the conditions, so maybe dead code?)

[task-5236550](https://www.odoo.com/web#id=5236550&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)

Enteprise PR:  https://github.com/odoo/enterprise/pull/98817



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
