### PR TITLE
[FIX] stock: apply putaway rules when different uom on move

### DIFF
--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -425,7 +425,7 @@ class StockPackage(models.Model):
 
         grouped_ops = {}
         for k, g in groupby(move_lines, key=_keys_groupby):
-            grouped_ops[k] = sum(self.env['stock.move.line'].concat(*g).mapped('quantity'))
+            grouped_ops[k] = sum(self.env['stock.move.line'].concat(*g).mapped('quantity_product_uom'))
 
         return all(float_is_zero(grouped_quants.get(key, 0) - grouped_ops.get(key, 0), precision_digits=precision_digits) for key in grouped_quants) \
            and all(float_is_zero(grouped_ops.get(key, 0) - grouped_quants.get(key, 0), precision_digits=precision_digits) for key in grouped_ops)

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -960,6 +960,7 @@ class TestPacking(TestPackingCommon):
         self.env.user.write({'group_ids': [(4, self.env.ref('stock.group_stock_multi_locations').id)]})
         # Required for `result_package_id` to be visible in the view
         self.env.user.write({'group_ids': [(4, self.env.ref('stock.group_tracking_lot').id)]})
+        pack_of_6 = self.env.ref('uom.product_uom_pack_6')
 
         package_01, package_02 = self.env['stock.package'].create([{
             'name': 'Pallet %s' % i,
@@ -970,7 +971,7 @@ class TestPacking(TestPackingCommon):
         # so the pallet capacity constraint should be the effective one
         stor_category = self.env['stock.storage.category'].create({
             'name': 'Super Storage Category',
-            'max_weight': 100,
+            'max_weight': 60,
             'package_capacity_ids': [(0, 0, {
                 'package_type_id': self.pack_type_pallet.id,
                 'quantity': 1,
@@ -1003,8 +1004,8 @@ class TestPacking(TestPackingCommon):
         })
         self.env['stock.move'].create({
             'product_id': self.productA.id,
-            'product_uom': self.productA.uom_id.id,
-            'product_uom_qty': 100.0,
+            'product_uom': pack_of_6.id,
+            'product_uom_qty': 10.0,
             'picking_id': receipt_picking.id,
             'location_id': receipt_picking.location_id.id,
             'location_dest_id': receipt_picking.location_dest_id.id,
@@ -1015,10 +1016,10 @@ class TestPacking(TestPackingCommon):
         # one with 51 x P (to easy the debugging in case of trouble)
         move_form = Form(receipt_picking.move_ids, view="stock.view_stock_move_operations")
         with move_form.move_line_ids.edit(0) as line:
-            line.quantity = 49
+            line.quantity = 4
             line.result_package_id = package_01
         with move_form.move_line_ids.new() as line:
-            line.quantity = 51
+            line.quantity = 6
             line.result_package_id = package_02
         move_form.save()
         receipt_picking.move_ids.picked = True
@@ -1027,20 +1028,20 @@ class TestPacking(TestPackingCommon):
         # We are in two-steps receipt -> check the internal picking
         internal_picking = self.env['stock.picking'].search([], order='id desc', limit=1)
         self.assertRecordValues(internal_picking.move_line_ids, [
-            {'quantity': 51, 'result_package_id': package_02.id, 'location_dest_id': sub_loc_01.id},
-            {'quantity': 49, 'result_package_id': package_01.id, 'location_dest_id': sub_loc_02.id},
+            {'quantity': 6, 'result_package_id': package_02.id, 'location_dest_id': sub_loc_01.id},
+            {'quantity': 4, 'result_package_id': package_01.id, 'location_dest_id': sub_loc_02.id},
         ])
 
         # Change the constraints of the storage category:
         # max 75kg (so 75 x P) and max 2 pallet -> this time, the weight
         # constraint should be the effective one
-        stor_category.max_weight = 75
+        stor_category.max_weight = 45
         stor_category.package_capacity_ids.quantity = 2
         internal_picking.do_unreserve()
         internal_picking.action_assign()
         self.assertRecordValues(internal_picking.move_line_ids, [
-            {'quantity': 51, 'result_package_id': package_02.id, 'location_dest_id': sub_loc_01.id},
-            {'quantity': 49, 'result_package_id': package_01.id, 'location_dest_id': sub_loc_02.id},
+            {'quantity': 6, 'result_package_id': package_02.id, 'location_dest_id': sub_loc_01.id},
+            {'quantity': 4, 'result_package_id': package_01.id, 'location_dest_id': sub_loc_02.id},
         ])
 
     def test_pack_in_receipt_two_step_multi_putaway_03(self):
@@ -2137,3 +2138,28 @@ class TestPackagePropagation(TestPackingCommon):
             {'name': 'p2', 'parent_package_id': packages[1].id, 'package_dest_id': False},
             {'name': 'p3', 'parent_package_id': packages[2].id, 'package_dest_id': False},
         ])
+
+    def test_package_propagation_different_uom(self):
+        supplier_location = self.env.ref('stock.stock_location_suppliers')
+        self.warehouse.in_type_id.set_package_type = False
+        self.warehouse.reception_steps = "two_steps"
+        pack_of_6 = self.env.ref('uom.product_uom_pack_6')
+        self.productA.uom_ids = [Command.link(pack_of_6.id)]
+
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.in_type_id.id,
+            'location_id': supplier_location.id,
+            'location_dest_id': self.warehouse.wh_input_stock_loc_id.id,
+            'move_ids': [Command.create({
+                'product_id': self.productA.id,
+                'product_uom_qty': 2.0,
+                'product_uom': self.productA.uom_ids.id,
+                'location_id': supplier_location.id,
+                'location_dest_id': self.warehouse.wh_input_stock_loc_id.id,
+            })]
+        })
+        receipt.action_confirm()
+        receipt.action_put_in_pack()
+        receipt.button_validate()
+        in_stock_move = receipt.move_ids.move_dest_ids
+        self.assertEqual(in_stock_move.package_ids, receipt.move_ids.package_ids)


### PR DESCRIPTION
**Problem:**
the stock putaway rules do not apply
when the uom on the move is different
than the base uom of the product

**Steps to reproduce:**
- set the warehouse incoming shipment as 'two steps'
- enable the 'packages' setting
- navigate to 'Operation Types' and select Receipts
- check the 'set package type' box
- create a storable product
- in the sales tab add 'pack of 6' to the packagings
- navigate to 'package types' and create a new one
- navigate to 'storage categories' and create a new one
- In the 'capacity by pacakge' tab set a limit by package to 1 quantity of your new pacakge type
- open 'warhouse management/locations' and create a new one
- set the parent location to stock and the storage category to your new storage category
- open 'putaway rules' and create a new one
- set the 'store to' field as your new loc
- set the 'when product arrives in' field to stock
- set the 'product' field to your product
- create a new receipt for your product
- set the demand as 4 and the unit as 'pack of 6'
- mark as to do
- change the quantity to 2 and click on put in pack
- in the 'package type' field of the widget enter your new package type
- set the quantity to 4 and click on put in pack
- in the 'package type' field of the widget enter your new package type
- validate the picking
- click on next transfer
- validate the picking
- click on the moves smart button

**Current behavior:**
- both moves are going to your new location

**Expected behavior:**
- as there is a one package limit for this package type only the first move should be going
there

**Cause of the issue:**
The problem comes from the fact that there is no
destination package (result_package_id) on the
move lines of the second pick.
As a consequence the limits regarding packages
can not apply.

Here is why there is no result_package_id on those move lines :
when assigning the new move, action_assign
calls check_entire_pack().
https://github.com/odoo/odoo/blob/96264f88e6ea2dc61ba6c546f9f1a03d49df55ea/addons/stock/models/stock_move.py#L2013 There, before writing the 'result_package_id'
field of the move lines, the method calls
check_move_lines_map_quant_package inside the
if statement.
https://github.com/odoo/odoo/blob/96264f88e6ea2dc61ba6c546f9f1a03d49df55ea/addons/stock/models/stock_picking.py#L1301-L1305 This results in a call to _check_move_lines_map_quant.
Inside _check_move_lines_map_quant, when building
the grouped_ops dictionnary, the quantity of the
move line is expressed in the uom of the line
(here pack of 6) so it will be 2.
Whereas in grouped_quants the quantity used is expressed
in the uom of the quant (here unit) so it will be 12.    https://github.com/odoo/odoo/blob/96264f88e6ea2dc61ba6c546f9f1a03d49df55ea/addons/stock/models/stock_package.py#L403
As a consequence the diff in the float_is_zero
will not be null and the return value will be False.
    https://github.com/odoo/odoo/blob/96264f88e6ea2dc61ba6c546f9f1a03d49df55ea/addons/stock/models/stock_package.py#L405-L406

opw-5154168
