### PR TITLE
[FIX] website,ir_http.py: slug normalized to NFC

### DIFF
--- a/addons/website/tests/test_converter.py
+++ b/addons/website/tests/test_converter.py
@@ -119,6 +119,18 @@ class TestTitleToSlug(BaseCase):
             self._slugify("_-__   -- -mi-dd-le- -- _ _-_- - ")
         )
 
+    def test_normalized_composed(self):
+        self.assertEqual(
+            '\N{HANGUL SYLLABLE GA}',
+            self._slugify('\N{HANGUL SYLLABLE GA}')
+        )
+
+    def test_normalized_decomposed(self):
+        self.assertEqual(
+            '\N{HANGUL SYLLABLE GA}',
+            self._slugify('\N{HANGUL CHOSEONG KIYEOK}\N{HANGUL JUNGSEONG A}')
+        )
+
     def test_all(self):
         self.assertEqual(
             "do-you-know-馬丁娜-a-la-海灘",

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -156,12 +156,10 @@ class IrHttp(models.AbstractModel):
         uni = unicodedata.normalize('NFKD', value)
         slugified_segments = []
         for slug in re.split('-|_| ', uni):
-            slug = re.sub(r'([^\w-])+', '', slug)
-            slug = re.sub(r'--+', '-', slug)
-            slug = slug.strip('-')
+            slug = re.sub(r'([^\w])+', '', slug)
             if slug:
                 slugified_segments.append(slug.lower())
-        slugified_str = '-'.join(slugified_segments)
+        slugified_str = unicodedata.normalize('NFC', '-'.join(slugified_segments))
         return slugified_str[:max_length]
 
     @classmethod


### PR DESCRIPTION
Scenario:

- create a page with url "가" (\N{HANGUL SYLLABLE GA})

then in safari: copy the url to open it in a new tab => a 404 error is shown
in all browser: go to /가 writing it manually => a 404 error is shown

Cause:

We decompose the unicode combination to remove diacritics, but never
recompose them, so we save the slug
\N{HANGUL CHOSEONG KIYEOK}\N{HANGUL JUNGSEONG A} (NFD normalization)
instead of \N{HANGUL SYLLABLE GA} (NFC normalization). Those appear
exactly the same, but when typing you would usually use the NFC one.

Comparing other software, they usually convert NFD to NFC but not the
other way.

When you use the address bar in safari, the URL is normalized with NFC
so you can't type or copy paste a NFKD path to get to it (and can only
get to it by link).

But the issue still exists for other browser where you will usually
manually type NFC and not NFKD.

This is not reproduced, but this could also have effect with search motor
that would normalize link content.

Fix:

When creating slug, normalize to NFC after the removal of diacritics.

opw-5184532

__pr note:__

the original ticket also reported about removal of diacritical mark in Vietnamese and Japanese, but this seems a more of a feature for master change since we have had "éléphant" becomes "elephant" since forever.

other services that allow unicode in path (such as wordpress, wix) seems to just keep the diacritics and normalize to NFC even if the input was in NFD.

for NFD / NFC explanation: https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize