### PR TITLE
[FIX] mail: fix tests that waste 3 seconds to pass assertion

### DIFF
--- a/addons/im_livechat/static/tests/visitor_disconnection.test.js
+++ b/addons/im_livechat/static/tests/visitor_disconnection.test.js
@@ -7,7 +7,7 @@ import {
     startServer,
     click,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, test, waitFor } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
 import { Store } from "@mail/core/common/store_service";
 import { Thread } from "@mail/core/common/thread";
@@ -54,19 +54,19 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
         guest_id: guestId,
         im_status: "offline",
     });
-    await contains(".o-livechat-VisitorDisconnected", {
-        text: "Visitor is disconnected since 1:00 PM",
-    });
+    await waitFor(
+        ".o-livechat-VisitorDisconnected:contains(/^Visitor is disconnected since 1:00 PM$/)"
+    );
     mockDate("2025-01-02 12:00:00", +1);
     await click("button[title*='Fold']");
     await click(".o-mail-ChatBubble");
-    await contains(".o-livechat-VisitorDisconnected", {
-        text: "Visitor is disconnected since yesterday at 1:00 PM",
-    });
+    await waitFor(
+        ".o-livechat-VisitorDisconnected:contains(/^Visitor is disconnected since yesterday at 1:00 PM$/)"
+    );
     mockDate("2025-01-05 12:00:00", +1);
     await click("button[title*='Fold']");
     await click(".o-mail-ChatBubble");
-    await contains(".o-livechat-VisitorDisconnected", { text: `Visitor is disconnected` });
+    await waitFor(".o-livechat-VisitorDisconnected:contains(/^Visitor is disconnected$/)");
     pyEnv["bus.bus"]._sendone(guestId, "bus.bus/im_status_updated", {
         partner_id: false,
         guest_id: guestId,

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -19,7 +19,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test, waitFor } from "@odoo/hoot";
 import { press, queryFirst, queryValue } from "@odoo/hoot-dom";
 import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
 import {
@@ -978,5 +978,5 @@ test("Update unread counter when receiving new message", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-discuss-badge", { text: "2" });
+    await waitFor(".o-discuss-badge:contains(/^2$/)");
 });


### PR DESCRIPTION
Some tests were passing but took 3 seconds to pass an `await contains()`. These contains have been replaced by `waitFor()`, which is more aggressively checking presence in DOM with an interval.