### PR TITLE
[IMP] {purchase}_mrp: allow deletion of components linked to child MOs

### DIFF
--- a/addons/mrp/data/mail_templates.xml
+++ b/addons/mrp/data/mail_templates.xml
@@ -2,28 +2,48 @@
 <odoo>
     <template id="exception_on_mo">
         <div class="alert alert-warning" role="alert">
-            Exception(s) occurred on the manufacturing order(s):
+            <t t-if="exception_on_picking">
+                Exception(s) occurred on the picking:
+            </t>
+            <t t-else="">
+                Exception(s) occurred on the manufacturing order(s):
+            </t>
             <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="production_order.id"><t t-out="production_order.name"/></a>.
             Manual actions may be needed.
             <div class="mt16">
                 <p>Exception(s):</p>
-                <ul t-foreach="order_exceptions.items()" t-as="order_exception">
-                    <li>
-                        <t t-set="move_raw_id" t-value="order_exception[0]"/>
-                        <t t-set="exception" t-value="order_exception[1]"/>
-                        <t t-set="order" t-value="exception[0]"/>
-                        <t t-set="new_qty" t-value="exception[1][0]"/>
-                        <t t-set="old_qty" t-value="exception[1][1]"/>
-                            <t t-set="uom" t-value="move_raw_id.uom_id if 'uom_id' in move_raw_id else move_raw_id.uom_id"/>
+                <ul>
+                    <t t-if="exception_on_picking">
+                        <t t-set="move" t-value="moves_information[0][0]"/>
+                        <t t-set="qty" t-value="moves_information[0][1][1]"/>
+                        <li>
+                            <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="production_order.id">
+                                <t t-out="production_order.name"/>
+                            </a>:
+                            <t t-out="qty"/> <t t-out="move.uom_id.name"/> of <t t-out="move.product_id.display_name"/>
+                            unlinked from the source manufacturing order
+                        </li>
+                    </t>
+                    <t t-else="" t-foreach="order_exceptions.items()" t-as="order_exception">
+                        <li>
+                            <t t-set="move_raw_id" t-value="order_exception[0]"/>
+                            <t t-set="exception" t-value="order_exception[1]"/>
+                            <t t-set="new_qty" t-value="exception[1][0]"/>
+                            <t t-set="old_qty" t-value="exception[1][1]"/>
+                            <t t-set="uom" t-value="move_raw_id.uom_id"/>
                             <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="production_order.id"><t t-out="production_order.name"/></a>:
                             <t t-out="new_qty"/> <t t-out="uom.name"/> of <t t-out="move_raw_id.product_id.name"/>
-                            <t t-if="cancel">
+                            <t t-if="is_child_mo_unlink">
+                                unlinked from the source manufacturing order
+                            </t>
+                            <t t-elif="cancel">
                                 cancelled
                             </t>
-                            <t t-if="not cancel">
+                            <t t-else="">
                                 ordered instead of <t t-out="old_qty"/> <t t-out="uom.name"/>
                             </t>
-                      </li>
+                        </li>
+                    </t>
                 </ul>
             </div>
             <div class="mt16" t-if="not cancel and impacted_pickings">

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -598,7 +598,13 @@ class MrpProduction(models.Model):
         for production in self:
             if not production.state or not production.uom_id or not (production.id or production._origin.id):
                 production.state = 'draft'
-            elif production.state == 'cancel' or (production.move_finished_ids and all(move.state == 'cancel' for move in production.move_finished_ids)):
+            elif (
+                production.state == 'cancel'
+                or (
+                    (moves := production.move_finished_ids | production.move_raw_ids)
+                    and all(move.state == 'cancel' for move in moves)
+                )
+            ):
                 production.state = 'cancel'
             elif (
                 production.state == 'done'
@@ -2566,9 +2572,18 @@ class MrpProduction(models.Model):
         def _render_note_exception_quantity_mo(rendering_context):
             visited_objects = []
             order_exceptions = {}
+            context = self.env.context
+            exception_on_picking = context.get('exception_on_picking')
             for exception in rendering_context:
+                if exception_on_picking:
+                    order_exceptions.update(exception)
+                    continue
                 order_exception, visited = exception
-                order_exceptions.update(order_exception)
+                valid_visited = [moves for moves in visited if moves]
+                if valid_visited:
+                    order_exceptions.update({moves[0]: order_exception[moves[0]] for moves in valid_visited})
+                else:
+                    order_exceptions.update(order_exception)
                 visited_objects += visited
             visited_objects = [sm for sm in visited_objects if sm._name == 'stock.move']
             impacted_object = []
@@ -2580,8 +2595,12 @@ class MrpProduction(models.Model):
                 'production_order': self,
                 'order_exceptions': order_exceptions,
                 'impacted_object': impacted_object,
-                'cancel': cancel
+                'cancel': cancel,
+                'is_child_mo_unlink': context.get('is_child_mo_unlink'),
+                'exception_on_picking': exception_on_picking,
             }
+            if exception_on_picking:
+                values['moves_information'] = [(move, info[1]) for move, info in order_exceptions.items()]
             return self.env['ir.qweb']._render('mrp.exception_on_mo', values)
 
         self.env['stock.picking']._log_activity(_render_note_exception_quantity_mo, documents)

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -592,7 +592,13 @@ class MrpProduction(models.Model):
         for production in self:
             if not production.state or not production.uom_id or not (production.id or production._origin.id):
                 production.state = 'draft'
-            elif production.state == 'cancel' or (production.move_finished_ids and all(move.state == 'cancel' for move in production.move_finished_ids)):
+            elif (
+                production.state == 'cancel'
+                or (
+                    (production.move_finished_ids | production.move_raw_ids)
+                    and all(move.state == 'cancel' for move in (production.move_finished_ids | production.move_raw_ids))
+                )
+            ):
                 production.state = 'cancel'
             elif (
                 production.state == 'done'
@@ -2543,7 +2549,12 @@ class MrpProduction(models.Model):
         def _render_note_exception_quantity_mo(rendering_context):
             visited_objects = []
             order_exceptions = {}
+            context = self.env.context
+            exception_on_picking = context.get('exception_on_picking')
             for exception in rendering_context:
+                if exception_on_picking:
+                    order_exceptions.update(exception)
+                    continue
                 order_exception, visited = exception
                 order_exceptions.update(order_exception)
                 visited_objects += visited
@@ -2557,8 +2568,12 @@ class MrpProduction(models.Model):
                 'production_order': self,
                 'order_exceptions': order_exceptions,
                 'impacted_object': impacted_object,
-                'cancel': cancel
+                'cancel': cancel,
+                'is_child_mo_unlink': context.get('is_child_mo_unlink'),
+                'exception_on_picking': exception_on_picking,
             }
+            if exception_on_picking:
+                values['moves_information'] = [(move, info[1]) for move, info in order_exceptions.items()]
             return self.env['ir.qweb']._render('mrp.exception_on_mo', values)
 
         self.env['stock.picking']._log_activity(_render_note_exception_quantity_mo, documents)

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -221,6 +221,44 @@ class StockMove(models.Model):
             if move.raw_material_production_id and move.uom_id.compare(move.quantity, 0) < 0:
                 raise ValidationError(_("Please enter a positive quantity."))
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_if_draft_or_cancel(self):
+        component_moves = self.filtered(lambda m: m.state != 'draft' and (m.raw_material_production_id or m.created_production_id))
+        if not component_moves:
+            return super()._unlink_if_draft_or_cancel()
+
+        def _unlink_child_mos(move, parent_mo, child_mos):
+            for child_mo in child_mos:
+                finished_move = child_mo.move_finished_ids.filtered(lambda m: m.product_id == child_mo.product_id)
+                documents = {(child_mo, parent_mo.user_id): [({finished_move: (child_mo, (finished_move.product_uom_qty, 0))}, [])]}
+                parent_mo.with_context(is_child_mo_unlink=True)._log_manufacture_exception(documents)
+                move.production_group_id.child_ids = [Command.unlink(child_mo.production_group_id.id)]
+
+        move_to_check = self.env['stock.move']
+        for move in component_moves:
+            parent_mo = move.raw_material_production_id
+            pickings = move.move_orig_ids.picking_id.filtered(lambda p: p.state != 'done' and p.move_ids - move.move_orig_ids)
+            if pickings:
+                documents = {(picking, picking.user_id): [{move: (parent_mo, (0, move.product_uom_qty))}] for picking in pickings}
+                parent_mo.with_context(exception_on_picking=True)._log_manufacture_exception(documents)
+            child_mos = move.move_orig_ids.production_id or move.move_orig_ids.created_production_id
+            if not child_mos and move.warehouse_id.manufacture_steps != 'mrp_one_step' and parent_mo.mrp_production_child_count:
+                child_mos = self.env['mrp.production'].search([
+                    ('production_group_id', 'in', move.production_group_id.child_ids.ids),
+                    ('product_id', '=', move.product_id.id),
+                    ('state', '!=', 'done'),
+                ])
+            if child_mos or (parent_mo and move.move_orig_ids):
+                if child_mos and parent_mo:
+                    _unlink_child_mos(move, parent_mo, child_mos)
+                moves_to_unlink = move | move.move_orig_ids
+                moves_to_unlink.move_orig_ids = [Command.unlink(m) for m in moves_to_unlink.ids]
+                moves_to_unlink.filtered(lambda move: move.state != 'done').unlink()
+            else:
+                move_to_check |= move
+            pickings.filtered(lambda p: not p.move_ids).unlink()
+        return super(StockMove, move_to_check)._unlink_if_draft_or_cancel()
+
     @api.model_create_multi
     def create(self, vals_list):
         """ Enforce consistent values (i.e. match _get_move_raw_values/_get_move_finished_values) for:

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -222,6 +222,44 @@ class StockMove(models.Model):
             if move.raw_material_production_id and move.uom_id.compare(move.quantity, 0) < 0:
                 raise ValidationError(_("Please enter a positive quantity."))
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_if_draft_or_cancel(self):
+        component_moves = self.filtered(lambda m: m.state != 'draft' and (m.raw_material_production_id or m.created_production_id))
+        if not component_moves:
+            return super()._unlink_if_draft_or_cancel()
+
+        def _unlink_child_mos(move, parent_mo, child_mos):
+            for child_mo in child_mos:
+                finished_move = child_mo.move_finished_ids.filtered(lambda m: m.product_id == child_mo.product_id)
+                documents = {(child_mo, parent_mo.user_id): [({finished_move: (child_mo, (finished_move.product_uom_qty, 0))}, [])]}
+                parent_mo.with_context(is_child_mo_unlink=True)._log_manufacture_exception(documents)
+                move.production_group_id.child_ids = [Command.unlink(child_mo.production_group_id.id)]
+
+        move_to_check = self.env['stock.move']
+        for move in component_moves:
+            parent_mo = move.raw_material_production_id
+            pickings = move.move_orig_ids.picking_id.filtered(lambda p: p.state != 'done' and p.move_ids - move.move_orig_ids)
+            if pickings:
+                documents = {(picking, picking.user_id): [{move: (parent_mo, (0, move.product_uom_qty))}] for picking in pickings}
+                parent_mo.with_context(exception_on_picking=True)._log_manufacture_exception(documents)
+            child_mos = move.move_orig_ids.production_id or move.move_orig_ids.created_production_id
+            if not child_mos and move.warehouse_id.manufacture_steps != 'mrp_one_step' and parent_mo.mrp_production_child_count:
+                child_mos = self.env['mrp.production'].search([
+                    ('production_group_id', 'in', move.production_group_id.child_ids.ids),
+                    ('product_id', '=', move.product_id.id),
+                    ('state', '!=', 'done'),
+                ])
+            if child_mos or (parent_mo and move.move_orig_ids):
+                if child_mos and parent_mo:
+                    _unlink_child_mos(move, parent_mo, child_mos)
+                moves_to_keep = child_mos.move_finished_ids if child_mos else self.env['stock.move']
+                moves_to_unlink = move | (move.move_orig_ids - moves_to_keep)
+                move.write({'move_orig_ids': [Command.clear()]})
+                moves_to_unlink.filtered(lambda m: m.state != 'done').unlink()
+            else:
+                move_to_check |= move
+        return super(StockMove, move_to_check)._unlink_if_draft_or_cancel()
+
     @api.model_create_multi
     def create(self, vals_list):
         """ Enforce consistent values (i.e. match _get_move_raw_values/_get_move_finished_values) for:

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models, fields
-from odoo.tools.float_utils import float_is_zero, float_round
-from odoo.exceptions import UserError
+from odoo import Command, api, models
 
 
 class StockMove(models.Model):
@@ -50,3 +48,11 @@ class StockMove(models.Model):
             if kit_bom:
                 return line._compute_kit_quantities_from_moves(line.move_ids - self, kit_bom)
         return super()._get_qty_received_without_self()
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_if_draft_or_cancel(self):
+        for move in self.filtered(lambda m: m.raw_material_production_id):
+            purchase_moves = move.move_orig_ids.filtered(lambda m: m.purchase_line_id)
+            if purchase_moves:
+                move.move_orig_ids = [Command.unlink(m.id) for m in purchase_moves]
+        return super()._unlink_if_draft_or_cancel()

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
-from odoo.exceptions import UserError
+from odoo import Command, api, models
 from odoo.tools import float_compare
 
 
@@ -67,3 +66,23 @@ class StockMove(models.Model):
             if kit_bom:
                 return line._compute_kit_quantities_from_moves(line.move_ids - self, kit_bom)
         return super()._get_qty_received_without_self()
+
+    def _get_upstream_documents_and_responsibles(self, visited):
+        docs = super()._get_upstream_documents_and_responsibles(visited)
+        for po_line in self.created_purchase_line_ids:
+            if po_line.state not in ('done', 'cancel'):
+                docs.extend(po_line._get_upstream_documents_and_responsibles(visited))
+        return docs
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_if_draft_or_cancel(self):
+        for move in self.filtered(lambda m: m.raw_material_production_id):
+            purchase_moves = move.move_orig_ids.filtered(lambda m: m.purchase_line_id)
+            if purchase_moves:
+                move.move_orig_ids = [Command.unlink(m.id) for m in purchase_moves]
+            purchase_lines = (move | move.move_orig_ids).created_purchase_line_ids
+            for po_line in purchase_lines:
+                po = po_line.order_id
+                documents = {(po, po.user_id): [({po_line: (move, (move.product_uom_qty, 0))}, [])]}
+                move.raw_material_production_id.with_context(is_child_mo_unlink=True)._log_manufacture_exception(documents)
+        return super()._unlink_if_draft_or_cancel()


### PR DESCRIPTION
Currently, users encounter an error ("You cannot delete moves linked to another
operation") when attempting to delete a component that has generated a child
manufacturing order (MO) through a Make To Order (MTO) flow. A similar
limitation exists in 2-step and 3-step manufacturing flows, where component
moves are linked to their corresponding transfers.

In practice, users may need to remove such components based on operational
requirements. This change allows the deletion of components even when they are
linked to downstream documents.

- When a component linked to a child MO is deleted, the related child MO is
  automatically unlinked from the parent MO, and an exception is logged on the
  child MO to preserve traceability.

- In 2-step and 3-step manufacturing flows, when a related transfer is not in a
  done state, deleting a component will also remove the corresponding move from
  the transfer and log an exception on the transfer to maintain traceability.
  If all component moves are removed from the transfer, the transfer itself is
  automatically deleted to preserve inventory consistency.

- This update properly breaks MTO and transfer links when the corresponding
  component is removed, preventing inconsistencies and avoiding user confusion.
  Now users can safely delete components even if they have generated child MOs
  or are linked to intermediate transfers.

Task ID: 5226878