### PR TITLE
[FIX] mrp_subcontracting: allow qty edit for tracked non-subcontracted products

### DIFF
--- a/addons/mrp_subcontracting/views/stock_picking_views.xml
+++ b/addons/mrp_subcontracting/views/stock_picking_views.xml
@@ -11,9 +11,6 @@
                         type="object" class="oe_stat_button" icon="fa-sitemap"
                         invisible="not show_subcontracting_details_visible"/>
             </xpath>
-            <xpath expr="//field[@name='move_ids']/list//field[@name='quantity']" position="attributes">
-                <attribute name="readonly" separator="or" add="has_tracking != 'none'"/>
-            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Issue Before This Commit:
-----
- When subcontracting was enabled, users were unable to edit the quantity of
traceable products directly on transfer lines, even if those products were not
part of any subcontracting flow. This causes unnecessary limitations in normal
warehouse operations.

Steps to Reproduce:
-----
- Install the `mrp_subcontracting` module.
- Create a transfer containing a traceable product (lot/serial tracked).
- Confirm the transfer (_Mark as Todo_).
- Try to edit the quantity directly on the transfer line.
- Notice that the field is non-editable, even though the transfer is not part of
a subcontracting process.

Cause of the Issue:
-----
- The quantity field was made globally read-only for tracked products in this
[`PR`](https://github.com/odoo/odoo/pull/220383/files#diff-a5b7491ccd078355b6edcbc19b7f85e3847c65c4f953457dd5e668e86299119cR18-R20).

With This Commit:
-----
- Users can now edit quantities of traceable products on transfer lines when
they are not used in subcontracting.
- This helps streamline regular transfer operations by allowing quick quantity
adjustments without affecting subcontracting flows.

Task - 5169885