### PR TITLE
[FIX] stock_account: prevent type mismatch error on valuation report

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -143,7 +143,7 @@ class ProductProduct(models.Model):
         self.company_currency_id = company_id.currency_id
 
         for product in self:
-            at_date = fields.Datetime.to_datetime(product.env.context.get('to_date'))
+            at_date = product.env.context.get('to_date')
             if at_date:
                 product = product.with_context(at_date=at_date)
             qty_available = product.sudo(False)._with_valuation_context().qty_available


### PR DESCRIPTION
Currently, an error occurs when a user attempts to access the stock valuation report for a date beyond today.

**Steps to produce:**
- Install `stock_account`, `purchase_stock`, `accountant`.
- Go to settings, set `Inventory Cost Method` to Average Cost(AVCO) and Turn on `Lots and Serial Numbers`.
- Go to Products and create a new one with name `test`, set `Track Inventory` - `by lots`.
- Open RFQs, Create a new one with test product and Click `Confirm Order` > Click `Receive`.
- Set the Lot name by clicking the `Details` button on the move lines.
- Click `Validate`, go to `Purchase > Orders > Purchase Orders`.
- Select the currently made Purchase Order (It will be in the `Waiting Bills` state) and Click on the `Create bills` Button, Confirm it (it should be in the paid state now).
- Now go to `Accountant > Review > Inventory Evaluation` and select and date ahead of today, the error will occur.

**Error:**
`TypeError: can't compare datetime.datetime to datetime.date`

**Cause:**
- The error occurs because of recent commit [PR] where at [1] `at_date` is typecasted from `datetime.date` to `datetime.datetime` but at [2] `aml_date` comes as `datetime.date` and this causes the error.

**Solution:**
- Now we don't convert `at_date` to datetime.datetime format.
- Also, at [here] we do the same.

[PR]: https://github.com/odoo/odoo/pull/227567
[here]: https://github.com/odoo/odoo/pull/231358
[1] https://github.com/odoo/odoo/blob/9d1b12410d868db64774d4ad37eb88be921f65b0/addons/stock_account/models/product.py#L146
[2] https://github.com/odoo/odoo/blob/9d1b12410d868db64774d4ad37eb88be921f65b0/addons/purchase_stock/models/stock_move.py#L157

**sentry-6998126753**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
