### PR TITLE
[FIX] html_editor: splitElement should not lose element reference

### DIFF
--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -168,9 +168,8 @@ export class SplitPlugin extends Plugin {
     }
 
     /**
-     * Split the given element at the given offset. The element will be removed in
-     * the process so caution is advised in dealing with its reference. Returns a
-     * tuple containing the new elements on both sides of the split.
+     * Split the given element at the given offset. Returns a tuple containing
+     * the new elements on both sides of the split.
      *
      * @param {HTMLElement} element
      * @param {number} offset
@@ -178,17 +177,12 @@ export class SplitPlugin extends Plugin {
      */
     splitElement(element, offset) {
         /** @type {HTMLElement} **/
-        const firstPart = element.cloneNode();
-        /** @type {HTMLElement} **/
         const secondPart = element.cloneNode();
-        element.before(firstPart);
-        element.after(secondPart);
         const children = childNodes(element);
-        firstPart.append(...children.slice(0, offset));
         secondPart.append(...children.slice(offset));
-        element.remove();
-        this.dispatchTo("after_split_element_handlers", { firstPart, secondPart });
-        return [firstPart, secondPart];
+        element.after(secondPart);
+        this.dispatchTo("after_split_element_handlers", { element, secondPart });
+        return [element, secondPart];
     }
 
     /**

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -944,6 +944,7 @@ export class LinkPlugin extends Plugin {
         }
         const startBlock = closestBlock(startLink);
         const endBlock = closestBlock(endLink);
+        const multipleLinks = startLink !== endLink;
         if (
             startLink &&
             startLink.isConnected &&
@@ -962,7 +963,8 @@ export class LinkPlugin extends Plugin {
             endLink &&
             endLink.isConnected &&
             endLink.parentElement.isContentEditable &&
-            !this.isUnremovable(endLink)
+            !this.isUnremovable(endLink) &&
+            multipleLinks
         ) {
             focusNode = this.dependencies.split.splitAroundUntil(focusNode, endLink);
             focusOffset = direction === DIRECTIONS.RIGHT ? nodeSize(focusNode) : 0;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
