### PR TITLE
[IMP] point_of_sale: improve hoot data and sync logic

### DIFF
--- a/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
@@ -1,4 +1,4 @@
-import { models } from "@web/../tests/web_test_helpers";
+import { models, Command } from "@web/../tests/web_test_helpers";
 
 export class PosOrder extends models.ServerModel {
     _name = "pos.order";
@@ -32,12 +32,46 @@ export class PosOrder extends models.ServerModel {
     sync_from_ui(data) {
         const orderIds = [];
         for (const record of data) {
+            const record_uuid_mapping = record.relations_uuid_mapping || {};
+            delete record.relations_uuid_mapping;
             if (record.id) {
                 this.write([record.id], record);
                 orderIds.push(record.id);
             } else {
                 const id = this.create(record);
                 orderIds.push(id);
+            }
+            for (const [modelName, mapping] of Object.entries(record_uuid_mapping)) {
+                // Search for owner records by UUID
+                const ownerRecords = this.env[modelName].search_read(
+                    [["uuid", "in", Object.keys(mapping)]],
+                    ["id", "uuid"]
+                );
+                for (const [uuid, fields] of Object.entries(mapping)) {
+                    for (const [name, uuids] of Object.entries(fields)) {
+                        const field = this.env[modelName]._fields[name];
+                        if (["one2many", "many2many"].includes(field.type)) {
+                            // Get all related records by uuids
+                            const relatedRecords = this.env[field.relation].search_read(
+                                [["uuid", "in", uuids]],
+                                ["id", "uuid"]
+                            );
+                            const ownerRecord = ownerRecords.find((r) => r.uuid === uuid);
+                            if (ownerRecord) {
+                                this.env[modelName].write([ownerRecord.id], {
+                                    [name]: relatedRecords.map((r) => Command.link(r.id)),
+                                });
+                            }
+                        } else {
+                            // single record relation (many2one)
+                            const record = this.env[field.relation].search([["uuid", "=", uuids]]);
+                            const ownerRecord = ownerRecords.find((r) => r.uuid === uuid);
+                            if (ownerRecord && record) {
+                                this.env[modelName].write([ownerRecord.id], { [name]: record[0] });
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/addons/point_of_sale/static/tests/unit/data/product_product.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/product_product.data.js
@@ -16,6 +16,7 @@ export class ProductProduct extends models.ServerModel {
             "product_tag_ids",
             "default_code",
             "standard_price",
+            "pos_categ_ids",
         ];
     }
 
@@ -31,6 +32,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [1],
         },
         {
             id: 5,
@@ -43,6 +45,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [2],
         },
         {
             id: 6,
@@ -55,6 +58,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [2],
         },
         {
             id: 7,
@@ -67,6 +71,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [],
         },
         {
             id: 8,
@@ -79,6 +84,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [],
         },
         {
             id: 9,
@@ -91,6 +97,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [],
         },
         {
             id: 10,
@@ -103,6 +110,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [],
         },
         {
             id: 11,
@@ -115,6 +123,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [],
         },
         {
             id: 12,
@@ -127,6 +136,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [4],
         },
         {
             id: 13,
@@ -139,6 +149,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [5],
         },
         {
             id: 14,
@@ -151,6 +162,7 @@ export class ProductProduct extends models.ServerModel {
             default_code: false,
             product_template_attribute_value_ids: [],
             product_template_variant_value_ids: [],
+            pos_categ_ids: [4],
         },
     ];
 }


### PR DESCRIPTION
In this commit:
---
- Improved `sync_from_ui` function to support record UUID-based relational mapping.
- Added `pos_categ_ids` field in product data for better category linkage in tests.

task-5225193

Related PR:
- https://github.com/odoo/enterprise/pull/98849

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
