### PR TITLE
[FIX] mail: adapt the start message for meeting chats

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1227,6 +1227,11 @@ class DiscussChannel(models.Model):
             Store.Attr("avatar_cache_key", predicate=is_channel_or_group),
             "channel_type",
             "create_uid",
+            Store.Attr(
+                "create_date",
+                predicate=lambda channel: channel.default_display_mode == "video_full_screen"
+                and channel.channel_type == "group",
+            ),
             Store.Many(
                 "channel_member_ids",
                 only_data=True,

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -701,10 +701,8 @@ export class Thread extends Component {
                 channelName: this.props.thread.name,
             });
         }
-        if (this.props.thread.channel_type === "channel") {
-            return _t("This is the start of %(conversationName)s group", {
-                conversationName: this.props.thread.displayName,
-            });
+        if (this.props.thread.channel_type === "group") {
+            return _t("This is the start this conversation.");
         }
         return _t("This is the start of your direct chat with %(userName)s", {
             userName: this.props.thread.displayName,

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MeetingChat">
-        <ActionPanel t-if="thread" title.translate="Chat" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
+        <ActionPanel t-if="thread" title.translate="In call messages" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
             <Thread thread="thread" jumpPresent="state.jumpPresent"/>
             <t t-call="mail.ChatWindow.memberTyping"/>
             <Composer

--- a/addons/mail/static/src/discuss/call/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/message_model_patch.js
@@ -1,0 +1,22 @@
+import { Message } from "@mail/core/common/message_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Message} */
+const messagePatch = {
+    get notificationHidden() {
+        const meetingThread =
+            this.thread?.model === "discuss.channel" &&
+            this.thread.channel_type === "group" &&
+            this.thread.default_display_mode === "video_full_screen";
+        const meetingViewActive =
+            meetingThread &&
+            this.store?.meetingViewOpened &&
+            this.store.discuss?.thread?.eq(this.thread);
+        if (meetingViewActive && this.notificationType === "call") {
+            return true;
+        }
+        return super.notificationHidden;
+    },
+};
+patch(Message.prototype, messagePatch);


### PR DESCRIPTION
Previously, the start message and thread name for group-type channels included
the participant’s name. In the context of meetings created using the
“New Meeting” button, this was misleading, as it made the group appear like a
direct chat in the meeting view.

This commit updates the behavior to use “Meeting – MM/DD/YYYY, HH:MM AM/PM”” as both the
thread name and the start message when the group is created using the
"New Meeting" button, providing a clearer indication that the conversation
represents a meeting rather than a direct discussion.


Before / After

<img width="376" height="945" alt="image" src="https://github.com/user-attachments/assets/75bb5cb9-208e-4b14-98a2-b779e7fb38dc" />  
<img width="376" height="944" alt="image" src="https://github.com/user-attachments/assets/fd3bce85-6a8e-44c4-a54a-09ebb6408e4e" />


Part of: 5190261