### PR TITLE
[FIX] stock_landed_costs: open form view directly if only one landed cost exists

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -41,11 +41,13 @@ class AccountMove(models.Model):
 
     def action_view_landed_costs(self):
         self.ensure_one()
-        action = self.env["ir.actions.actions"]._for_xml_id("stock_landed_costs.action_stock_landed_cost")
-        domain = [('id', 'in', self.landed_costs_ids.ids)]
-        context = dict(self.env.context, default_vendor_bill_id=self.id)
-        views = [(self.env.ref('stock_landed_costs.view_stock_landed_cost_tree2').id, 'list'), (False, 'form'), (False, 'kanban')]
-        return dict(action, domain=domain, context=context, views=views)
+
+        views = [(False, 'form')] if len(self.landed_costs_ids) == 1 else [
+            (self.env.ref('stock_landed_costs.view_stock_landed_cost_tree2').id, 'list'), (False, 'form'), (False, 'kanban')
+        ]
+        return self.landed_costs_ids.with_context(
+            default_vendor_bill_id=self.id
+        )._get_records_action(name=self.env._("Landed Costs"), views=views)
 
     def _update_order_line_info(self, product_id, quantity, **kwargs):
         price_unit = super()._update_order_line_info(product_id, quantity, **kwargs)


### PR DESCRIPTION
## Before this commit:
When a user clicked the Landed Costs smart button on a vendor bill, even if there was only a single landed cost, the system opened the list view first. The user then had to click again to open the form view, which was unnecessary and inconvenient.

## After this commit:
The system now opens the landed cost form view directly if only one record exists, avoiding the unnecessary step of displaying the list view.

> Task-5231913


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
