### PR TITLE
[FIX] product: prevent text overflow in product attribute kanban card

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -653,7 +653,7 @@ action = {
                     <t t-name="card" class="p-0">
                     <!-- TODO : not getting border when select record -->
                         <div class="d-flex flex-grow-1 m-2">
-                            <div class="p-2 pt-1 d-flex flex-column m-0"
+                            <div class="p-2 pt-1 d-flex flex-column m-0 w-100"
                                     t-attf-id="product-{{record.id.raw_value}}">
                                 <div class="d-flex">
                                     <field class="mt-1 me-1"


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to Products > Create a new product.
2. Add or create a new attribute and set a long text value.
3. Go to Sales > Open any quotation.
4. In the sale order line, click on "Catalog" and search for the created product.

**Issue:**
- The attribute value text overflows outside the product card in the kanban view, causing layout misalignment and making the UI look broken.
<img width="509" height="157" alt="image" src="https://github.com/user-attachments/assets/a2af2c6d-9265-451c-9d1e-526df8487841" />

**Cause:**
- The inner `<div>` containing the attribute text did not have a width constraint, causing it to exceed the container width when the text length was large.

**Solution:**
Added the Bootstrap class `w-100` to the <div> element to ensure the content fits within the parent container and wraps properly inside the card.
<img width="322" height="166" alt="image" src="https://github.com/user-attachments/assets/5ba82207-7f52-4f9e-b400-e4ab4e79f0a0" />


**opw-5222002**