### PR TITLE
[FIX] pos_restaurant: fix printing the self order receipt

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -105,7 +105,7 @@ patch(PosStore.prototype, {
     async sendOrderInPreparation(order, opts = {}) {
         let categoryCount = [];
         if (!opts.cancelled) {
-            categoryCount = this.categoryCount;
+            categoryCount = this.getCategoryCount(order);
         }
         const result = await super.sendOrderInPreparation(order, opts);
 
@@ -411,7 +411,10 @@ patch(PosStore.prototype, {
         }
     },
     get categoryCount() {
-        const orderChanges = this.getOrderChanges();
+        return this.getCategoryCount();
+    },
+    getCategoryCount(order = this.getOrder()) {
+        const orderChanges = this.getOrderChanges(order);
         const linesChanges = orderChanges.orderlines;
 
         const categories = Object.values(linesChanges).reduce((acc, curr) => {
@@ -442,12 +445,11 @@ patch(PosStore.prototype, {
             categories["noteUpdate"] = { count: nbNoteChange, name: _t("Note") };
         }
         // Only send modeUpdate if there's already an older mode in progress.
-        const currentOrder = this.getOrder();
         if (
             orderChanges.modeUpdate &&
-            Object.keys(currentOrder.last_order_preparation_change.lines).length
+            Object.keys(order.last_order_preparation_change.lines).length
         ) {
-            const displayName = _t(currentOrder.preset_id?.name);
+            const displayName = _t(order.preset_id?.name);
             categories["modeUpdate"] = { count: 1, name: displayName };
         }
 

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -276,18 +276,37 @@ describe("restaurant pos_store.js", () => {
         });
     });
 
-    test("categoryCount", async () => {
-        const store = await setupPosEnv();
-        const order = await getFilledOrder(store);
-        order.lines[0].note = '[{"text":"Test Note","colorIndex":0}]';
-        order.lines[1].note = '[{"text":"Test 1","colorIndex":0},{"text":"Test 2","colorIndex":0}]';
-        order.general_customer_note = '[{"text":"General Note","colorIndex":0}]';
-        const changes = store.categoryCount;
-        expect(changes).toEqual([
-            { count: 3, name: "Category 1" },
-            { count: 2, name: "Category 2" },
-            { count: 1, name: "Message" },
-        ]);
+    describe("categoryCount", () => {
+        test("Normal flow", async () => {
+            const store = await setupPosEnv();
+            const order = await getFilledOrder(store);
+            order.lines[0].note = '[{"text":"Test Note","colorIndex":0}]';
+            order.lines[1].note =
+                '[{"text":"Test 1","colorIndex":0},{"text":"Test 2","colorIndex":0}]';
+            order.general_customer_note = '[{"text":"General Note","colorIndex":0}]';
+            const changes = store.categoryCount;
+            expect(changes).toEqual([
+                { count: 3, name: "Category 1" },
+                { count: 2, name: "Category 2" },
+                { count: 1, name: "Message" },
+            ]);
+        });
+
+        test("Unselected order", async () => {
+            const store = await setupPosEnv();
+            const order = await getFilledOrder(store);
+            order.general_customer_note = '[{"text":"General Note","colorIndex":0}]';
+            store.selectedOrderUuid = null;
+            // without a selected order, `categoryCount` throws
+            expect(() => store.categoryCount).toThrow();
+            // explicitly specify the order to compute the changes for
+            const changes = store.getCategoryCount(order);
+            expect(changes).toEqual([
+                { count: 3, name: "Category 1" },
+                { count: 2, name: "Category 2" },
+                { count: 1, name: "Message" },
+            ]);
+        });
     });
 
     test("getDefaultSearchDetails", async () => {


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. For restaurant, enable self order, and set an online payment method
2. From self order, make an order. The receipt should be automatically
   printed in PoS.

Observation -> The receipt is not printed. No warnings or anything.

Reasons
-------
`sendOrderInPreparation` is called with the online `order`, however,
intelally, it was calling the getter `categoryCount` which uses the
current active order in PoS which is `undefined`, and not the passed
online `order`.

Fix
---
We introduce a method `getCategoryCount` which is identical to the
getter `categoryCount` but it can be passed an `order` argument to
compute for an order different than the default order `getOrder()`.

Bug discovered while working on ticket 5190993.
opw-5263885