### PR TITLE
[FIX] stock_picking_batch: keep responsible

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -225,6 +225,7 @@ class StockPicking(models.Model):
                 return new_batch
 
         # If nothing was found after those two steps, then create a batch with the current picking alone
+        new_batch_data['user_id'] = self.user_id.id
         new_batch = self.env['stock.picking.batch'].sudo().create(new_batch_data)
         if self.picking_type_id.batch_auto_confirm:
             new_batch.action_confirm()

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -458,6 +458,7 @@ class TestBatchPicking(TransactionCase):
         self.assertTrue(picking_out_3.batch_id)
         self.assertEqual(picking_out_1.batch_id.id, picking_out_3.batch_id.id)
         self.assertTrue(picking_out_2.batch_id)
+        self.assertTrue(picking_out_2.user_id == picking_out_2.batch_id.user_id == self.env.user)
         self.assertNotEqual(picking_out_2.batch_id.id, picking_out_1.batch_id.id)
         # If Picking 1 is validated without Picking 3, Picking 1 should be removed from the batch
         picking_out_1.move_ids.write({'quantity': 10, 'picked': True})


### PR DESCRIPTION
## Issue
When auto-batching a picking create a new batch, the picking's responsible is lost when the picking is added to the batch.

## How to reproduce
1. Enable auto-batch for receipt operation type (by partner for example)
2. Create a new picking and assign a responsible;
3. Confirm the picking -> It's automatically added to a new batch and the picking's responsible is lost.

## Explanation
When a picking is added to a batch, the batch's responsible is assigned as the picking responsible which is totally wanted. The issue here is a new batch is created without a responsible and thus, `False` is assigned as the picking's responsible when the picking is added to the batch.

## Fix
To fix that, if a batch is created by a single picking, the picking's responsible is the batch responsible.

**Enterprise PR:** odoo/enterprise#96657