### PR TITLE
[IMP] web: search properties type

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -94,13 +94,14 @@
         </div>
         <DropdownItem
             t-if="!choice.isGroup"
-            onSelected="() => this.onItemSelected(choice.value)"
-            class="getItemClass(choice) + ' text-wrap'"
+            closingMode="choice.enabled ? 'all' : 'none'"
+            onSelected="() => choice.enabled and this.onItemSelected(choice.value)"
+            class="this.getItemClass(choice)"
             attrs="{ 'data-choice-index': choice_index }"
         >
             <t t-if="props.slots and props.slots.choice" t-slot="choice" data="choice"/>
             <t t-else="">
-                <div t-esc="choice.label || choice.value" />
+                <div t-out="choice.label" />
             </t>
         </DropdownItem>
     </t>

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -1,19 +1,19 @@
-import { _t } from "@web/core/l10n/translation";
-import { PropertyValue } from "./property_value";
+import { Component, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
 import { CheckBox } from "@web/core/checkbox/checkbox";
-import { DomainSelector } from "@web/core/domain_selector/domain_selector";
 import { Domain } from "@web/core/domain";
+import { DomainSelector } from "@web/core/domain_selector/domain_selector";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
 import { ModelSelector } from "@web/core/model_selector/model_selector";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { useOwnedDialogs, useService } from "@web/core/utils/hooks";
+import { uuid } from "@web/core/utils/strings";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
-import { useService, useOwnedDialogs } from "@web/core/utils/hooks";
+import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 import { PropertyDefinitionSelection } from "./property_definition_selection";
 import { PropertyTags } from "./property_tags";
-import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
-import { uuid } from "@web/core/utils/strings";
-
-import { Component, useState, onWillUpdateProps, useEffect, useRef } from "@odoo/owl";
+import { PropertyValue } from "./property_value";
 
 export const PROPERTIES_INFO = {
     char: {
@@ -92,6 +92,7 @@ export class PropertyDefinition extends Component {
         ModelSelector,
         PropertyDefinitionSelection,
         PropertyTags,
+        SelectMenu,
     };
     static props = {
         fieldName: { type: String },
@@ -170,7 +171,16 @@ export class PropertyDefinition extends Component {
      * @returns {array}
      */
     get availablePropertyTypes() {
-        return Object.entries(PROPERTIES_INFO).map(([key, { label }]) => [key, label]);
+        const defaultCurrencyField = this.defaultCurrencyField;
+        return Object.entries(PROPERTIES_INFO).map(([value, { label }]) => {
+            const isEnabled = value !== "monetary" || !!defaultCurrencyField;
+            return {
+                enabled: isEnabled,
+                label,
+                tooltip: isEnabled ? "" : _t("Not possible to create monetary field because there is no currency on current model."),
+                value,
+            };
+        });
     }
 
     get currencyFields() {

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -41,38 +41,19 @@
                                 t-attf-src="/web/static/src/views/fields/properties/icons/{{state.propertyDefinition.type}}.png"/>
                             <span t-out="state.typeLabel"/>
                         </div>
-                        <Dropdown t-else="" menuClass="'o_field_property_definition_type_menu'">
-                            <button class="btn btn-link d-flex p-0 w-100" t-att-title="state.typeLabel">
-                                <div class="o_input_dropdown w-100 o_field_property_dropdown">
-                                    <img t-attf-src="/web/static/src/views/fields/properties/icons/{{state.propertyDefinition.type}}.png"
-                                        class="position-relative z-1 me-n4"/>
-                                    <input type="text" class="dropdown text-start w-100 o_input py-1 align-middle ms-1"
-                                        t-att-id="getUniqueDomID('type')"
-                                        t-att-value="state.typeLabel" readonly=""/>
-                                    <span class="o_dropdown_button" />
-                                </div>
-                            </button>
-                            <t t-set-slot="content">
-                                <t t-foreach="availablePropertyTypes" t-as="option" t-key="option[0]">
-                                    <t t-if="option[0] === 'monetary' and !this.defaultCurrencyField">
-                                        <DropdownItem closingMode="'none'">
-                                            <div class="d-flex align-items-center text-muted" data-tooltip="Not possible to create monetary field because there is no currency on current model.">
-                                                <img class="me-2" t-attf-src="/web/static/src/views/fields/properties/icons/{{option[0]}}.png"/>
-                                                <span t-out="option[1]"/>
-                                            </div>
-                                        </DropdownItem>
+                        <t t-else="">
+                            <div class="d-flex align-items-center">
+                                <img class="o_avatar me-1" t-attf-src="/web/static/src/views/fields/properties/icons/{{this.state.propertyDefinition.type}}.png" style="--Avatar-size: 20px;"/>
+                                <SelectMenu autoSort="false" choices="this.availablePropertyTypes" id="this.getUniqueDomID('type')" menuClass="'o_field_property_definition_type_menu'" onSelect.bind="this.onPropertyTypeChange" required="true" togglerClass="'ps-1'" value="this.state.propertyDefinition.type">
+                                    <t t-set-slot="choice" t-slot-scope="choiceScope">
+                                        <div class="d-flex align-items-center" t-att-data-tooltip="choiceScope.data.tooltip">
+                                            <img class="o_avatar me-2" t-attf-src="/web/static/src/views/fields/properties/icons/{{choiceScope.data.value}}.png" style="--Avatar-size: 20px;"/>
+                                            <span t-out="choiceScope.data.label"/>
+                                        </div>
                                     </t>
-                                    <t t-else="">
-                                        <DropdownItem onSelected.bind="() => this.onPropertyTypeChange(option[0])">
-                                            <div class="d-flex align-items-center">
-                                                <img class="me-2" t-attf-src="/web/static/src/views/fields/properties/icons/{{option[0]}}.png"/>
-                                                <span t-out="option[1]"/>
-                                            </div>
-                                        </DropdownItem>
-                                    </t>
-                                </t>
-                            </t>
-                        </Dropdown>
+                                </SelectMenu>
+                            </div>
+                        </t>
                     </div>
                 </div>
                 <!-- Add / remove selection labels -->

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1,6 +1,5 @@
-import { expect, test } from "@odoo/hoot";
+import { animationFrame, expect, runAllTimers, test } from "@odoo/hoot";
 import { click, edit, press, queryAllTexts, queryOne, queryAll } from "@odoo/hoot-dom";
-import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
 import {
     contains,
@@ -1158,10 +1157,8 @@ test("Groups can be member of sections", async () => {
     expect(queryAllTexts(".o_select_menu_group")).toEqual([
         "Group A",
         "Subgroup 2",
-        "Group B",
-        "Subgroup 1B",
     ]);
-    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Option 2.I", "Option B.2"]);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Option 2.I"]);
 });
 
 test("Can add custom data to choices", async () => {
@@ -1352,4 +1349,19 @@ test("Space bar key opens the dropdown", async () => {
     await animationFrame();
     expect(".o_select_menu_menu").toHaveCount(1);
     expect(".o_select_menu_input").toHaveValue("World");
+});
+
+test("Disabled choice", async () => {
+    class ParentWithDisabledChoice extends Parent {
+        setup() {
+            super.setup();
+            this.choices[0].enabled = false;
+        }
+    }
+
+    await mountSingleApp(ParentWithDisabledChoice);
+    await click(".o_select_menu_toggler");
+    await animationFrame();
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Hello", "World"]);
+    expect(".o_select_menu_item:eq(0)").toHaveClass("text-muted");
 });


### PR DESCRIPTION
This commit replaces the property definition type dropdown by a select menu. It allows searching the property type in the input.
The select menu now highlights the searched text in the option labels and supports odoomark.

task-5226604