### PR TITLE
[IMP] http: mark session non-dirty after saving

### DIFF
--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -408,6 +408,13 @@ class TestSessionStore(HttpCaseWithUserDemo):
             session_from_store = odoo.http.root.session_store.get(session)
             self.assertNotEqual(session, session_from_store.sid, "the old session as been removed")
 
+    def test05_session_not_dirty_after_save(self):
+        session = self.authenticate('admin', 'admin')
+        session.touch()
+        self.assertTrue(session.is_dirty)
+        odoo.http.root.session_store.save(session)
+        self.assertFalse(session.is_dirty)
+
 
 # HttpCase because session rotation needs to be tested on the file store instead of memory store
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -54,6 +54,7 @@ class MemorySessionStore(SessionStore):
 
     def save(self, session):
         self.store[session.sid] = session
+        session.is_dirty = False
 
     def delete(self, session):
         self.store.pop(session.sid, None)


### PR DESCRIPTION
Before this commit, when a session was saved (or at least when an attempt was made to save it), it was always marked as dirty. However, after this save logic, the session continued to be dirty.

This commit marks the session as non-dirty after saving. This behaviour is more consistent given that the data is on disk. There is no longer any reason to re-save as long as the session has not been touched.