### PR TITLE
[FIX] mail: unwanted screen share warning in discuss call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -879,7 +879,11 @@ export class Rtc extends Record {
         } else if (microphone) {
             errorMessage = _t("Microphone access blocked. Enable in browser settings.");
         } else if (screen) {
-            errorMessage = _t("Screen sharing access blocked. Enable in browser settings.");
+            errorMessage = _t(
+                "Unable to start screen sharing. Please verify your browser permissions and try again."
+            );
+        } else {
+            return;
         }
         this.notification.add(errorMessage, { type: "warning" });
     }
@@ -2022,10 +2026,10 @@ export class Rtc extends Record {
                 }
                 this.soundEffectsService.play("screen-sharing");
             }
-        } catch {
+        } catch (e) {
             this.showMediaUnavailableWarning({
                 camera: type === "camera",
-                screen: type === "screen",
+                screen: type === "screen" && e.name !== "NotAllowedError",
             });
             stopVideo();
             return;


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
A warning notification appears even when the user simply cancels the screen selection modal during a discuss call.

**Current behavior before PR:**
A warning notification is displayed when the user cancels the screen selection modal instead of proceeding with screen sharing.

**Desired behavior after PR is merged:**
The screen-sharing warning is no longer triggered when canceling the screen selection modal, preventing unnecessary notifications and improving the user experience during calls.

**Before**
![Before](https://github.com/user-attachments/assets/484a6253-8f32-4e15-b470-5ab682ba773e)


**After**
![After](https://github.com/user-attachments/assets/5254bf27-ef4a-46c7-be1b-8b8d4f7362a0)


part of - [5227387](https://www.odoo.com/odoo/project/1519/tasks/5227387)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
