### PR TITLE
[FIX] website_sale: remove unnecessary tour step

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -36,13 +36,11 @@ const removeImg = [
         trigger: ".o_customize_tab [data-container-title='Image'] button[data-action-id='removeMedia']",
         run: "click",
     },
+    // If the snippet editor is not visible, the remove process is considered as
+    // finished.
     {
         content: "Check that the snippet editor is not visible",
         trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
-    },
-    {
-        content: "Wait until the the image removal is saved",
-        trigger: ':iframe #o-carousel-product div:not(.o_dirty) > img',
     },
 ];
 

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -11,7 +11,7 @@ from odoo.tests import HttpCase, tagged
 from odoo.addons.website.tests.common import HttpCaseWithWebsiteUser
 
 
-def _create_image(color: int | str = 0, dims=(1920, 1080), format='JPEG'):
+def _create_image(color='black', dims=(1920, 1080), format='JPEG'):
     f = io.BytesIO()
     Image.new('RGB', dims, color).save(f, format)  # type: ignore
     f.seek(0)


### PR DESCRIPTION
Before #234150, the `remove_product_image_*` tours occasionally failed due to the incorrect assumption that removing an image from the DOM was immediately saved in the database. A fix was introduced by adding a final tour step to ensure that the asynchronous DOM save was completed before exiting the tour.

This fix was later forward-ported to 18.4 with
bb6825760095df30a3559bcbf69cfa17bf383654. However, in 18.4, the website editor framework was improved with the introduction of the `BuilderAction` class. The migration to this new framework already resolved the issues with the `remove_product_image_*` tours, rendering the fix in #234150 unnecessary.

This commit reverts part of that fix by removing the final tour step while retaining some improvements in the Python code.

