### PR TITLE
[IMP] core: cleanup codes for monetary field a little

### DIFF
--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1053,33 +1053,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             for record in records:
                 self.check_monetary(record, amount, currency, 'multi write(amount)')
 
-    def test_20_monetary_opw_2223134(self):
-        """ test monetary fields with cache override """
-        model = self.env['test_orm.monetary_order']
-        currency = self.env.ref('base.USD')
-
-        def check(value):
-            self.assertEqual(record.total, value)
-            self.env.flush_all()
-            self.cr.execute('SELECT total FROM test_orm_monetary_order WHERE id=%s', [record.id])
-            [total] = self.cr.fetchone()
-            self.assertEqual(total, value)
-
-        # create, and compute amount
-        record = model.create({
-            'currency_id': currency.id,
-            'line_ids': [Command.create({'subtotal': 1.0})],
-        })
-        check(1.0)
-
-        # delete and add a line: the deletion of the line clears the cache, then
-        # the recomputation of 'total' must prefetch record.currency_id without
-        # screwing up the new value in cache
-        record.write({
-            'line_ids': [Command.delete(record.line_ids.id), Command.create({'subtotal': 1.0})],
-        })
-        check(1.0)
-
     def test_20_monetary_related(self):
         """ test value rounding with related currency """
         currency = self.env.ref('base.USD')

--- a/odoo/orm/fields_numeric.py
+++ b/odoo/orm/fields_numeric.py
@@ -227,9 +227,9 @@ class Monetary(Field[float]):
             currency = dummy[currency_field_name]
         else:
             # Note: this is wrong if 'record' is several records with different
-            # currencies, which is functional nonsense and should not happen
-            # BEWARE: do not prefetch other fields, because 'value' may be in
-            # cache, and would be overridden by the value read from database!
+            # currencies, which is functional nonsense and should not happen.
+            # sudo and only fetch the currency record in case the user doesn't
+            # have the read permission of the currency field.
             currency = record[:1].sudo().with_context(prefetch_fields=False)[currency_field_name]
             currency = currency.with_env(record.env)
 
@@ -244,9 +244,9 @@ class Monetary(Field[float]):
         if value and validate:
             # FIXME @rco-odoo: currency may not be already initialized if it is
             # a function or related field!
-            # BEWARE: do not prefetch other fields, because 'value' may be in
-            # cache, and would be overridden by the value read from database!
             currency_field = self.get_currency_field(record)
+            # sudo and only fetch the currency record in case the user doesn't
+            # have the read permission of the currency field.
             currency = record.sudo().with_context(prefetch_fields=False)[currency_field]
             if len(currency) > 1:
                 raise ValueError("Got multiple currencies while assigning values of monetary field %s" % str(self))


### PR DESCRIPTION
### [IMP] core: remove unnecessary prefetch for monetary

prefetch=False is not necessary in the latest fetch strategy which won't
update the cache if it is already filled.
sudo is not necessary we can raise the access error if the user doesn't
have read permission of the currency field.


### [IMP] core: avoid rounding value from the cache

According to the comment, the method is for https://github.com/odoo/odoo/pull/177200, but in
https://github.com/odoo/odoo/pull/177200, we rounded the value of the argument but not the value
from the cache. The code logic is actually changed in https://github.com/odoo/odoo/pull/204796
when migrating the code from environments.py to fields_numeric.py.

After re-analyzing the code, we think it is not needed to re-round the
``cache_value`` of the argument for each ``record[currency_field]``,
since we expect it is already arounded before calling the this method,
and all records should have the same ``record[currency_field]``. So we
can drop the outdated comment.

Rounding ``value`` from the cache is a logic added in https://github.com/odoo/odoo/pull/204796.
The idea was to avoid modifying value in cache like 1.000000000000001
to 1.00 and marking it dirty when the ronding digits for decimal places
is 2.

We decide to drop the logic because:
1. code is less and simpler
2. the number of extra queries to fix unrounded values are acceptable
3. can have better data consistency
4. less space usage for each database raw
5. allow to users to fix and get better exported data
   a. database value is 1.000000000000001
   b. export reocrd data (value is not rounded when exporting)
   c. csv value: '1.000000000000001'
   d. fix the value to '1.00'
   e. import record data from csv
   f. export record data again
   g. csv value: '1.00'


### [IMP] core: more accurate cache value for monetary

For monetary fields, in ``convert_to_cache``, when ``currency`` is
available, convert the ``round``ed float value to str like
``convert_to_column_insert`` and then convert it back to float, which
mimics the type converting from python variable to postgresql database
and then back to python variable.So that even if the ``round`` method
is not perfect, we can still promise the new cache value will be ``==``
to the value fetched from the database after flushing.

for example, the
rounded value is ``99.99000000000001``  # assume the ``round`` is not perfect
float_repr value is ``'99.99'``
database value is ``'99.99'::numeric``
fetched value would be ``float('99.99')``

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
