### PR TITLE
[FIX] website_forum: fix navigation spacing issue

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -138,7 +138,7 @@
                 </div>
             </div>
         </div>
-        <div t-foreach="posts_ids" t-as="question" class="post_to_validate card mb-3">
+        <div t-foreach="posts_ids" t-as="question" class="post_to_validate card mt-2 mb-3">
             <div class="card-header">
                 <div class="row align-items-baseline">
                     <h6 class="col-md-2 mb-0">


### PR DESCRIPTION
This commit fixes an issue in the `website_forum` moderation panel introduced by Commit [^1], which aimed to make navigation across the front-end more consistent.

| Master | This PR |
|--------|--------|
| <img width="1011" height="218" alt="image" src="https://github.com/user-attachments/assets/ee4a7d4a-538c-4373-a942-9fcfdf8d8ddc" /> | <img width="995" height="260" alt="image" src="https://github.com/user-attachments/assets/2fc04c24-d9a8-4036-993c-b0f28d49f982" /> | 

To do so, some utility classes handling padding were removed. However, there are corner cases where these classes were actually needed, which is the case on this screen, to ensure that the button rendered next to the breadcrumb does not stick to the card below.

task-5240823

[^1]: https://github.com/odoo/odoo/commit/bb5b7cfa284a55e6dd3a5deb4870bcfae28033af

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
