### PR TITLE
[FIX] website: prevent traceback when clicking on Bento block

### DIFF
--- a/addons/website/static/src/builder/plugins/options/bento_border_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/bento_border_option_plugin.js
@@ -4,10 +4,13 @@ import { withSequence } from "@html_editor/utils/resource";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
+import { ShadowOption } from "@html_builder/plugins/shadow_option";
 
 export class BentoBorderOption extends BaseOptionComponent {
     static template = "html_builder.BentoBorderOption";
     static selector = ".s_bento_banner section[data-name='Card'], .s_bento_block_card";
+    static components = { BorderConfigurator, ShadowOption };
 }
 
 class BentoBorderOptionPlugin extends Plugin {


### PR DESCRIPTION
Steps to reproduce:
===================
1- Go to Website → Add a Bento block.
2- Click on the block.
→ A traceback occurs.

Cause:
======
The Bento Border XML references `BorderConfigurator` and `ShadowOption`, but these components were never registered in the `BentoBorderOption` definition.
https://github.com/odoo/odoo/blob/43654a2a967cb330d65ae0d163a3436462c12c8c/addons/website/static/src/builder/plugins/options/bento_border_option.xml#L8

Solution:
=========
Register BorderConfigurator and ShadowOption as components of BentoBorderOption to ensure proper initialization.

opw-5234406

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
