### PR TITLE
[FIX] mail: ensure activity user is assigned when created via automation rule

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -420,6 +420,8 @@ class IrActionsServer(models.Model):
                 # if x2m field, assign to the first user found
                 # (same behavior as Field.traverse_related)
                 vals['user_id'] = user.ids[0]
+            else:
+                vals['user_id'] = self.env.user.id
             record.activity_schedule(**vals)
         return False
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install base_automation, sale_management, and stock.
- Create an automation rule for the Transfer model (stock.picking) that creates an activity 
when the state is set to Ready.
   - User type → Dynamic user (based on record)
   - User field → Responsible
- Confirm a Sale Order and open the related delivery.
- Move delivery to the Ready state.
- Notice that the created activity has no assigned user.

**Issue:**
- The activity is created without a user_id.

**Cause:**
- Since user_id is no longer a required field on mail.activity, when creating an activity through automation, 
if the related record (e.g., stock.picking) does not have a responsible user, and activity type dose not have 
`default_user_id  the user_id` remains unset.

https://github.com/odoo/odoo/blob/7ced429ff54c9670f2ff1b1866ecfb01f49ad50d/addons/mail/models/mail_activity_mixin.py#L408-L409

- Previously, the creation logic would fall back to using either a default user from the activity type 
or the current environment user (env.uid). This fallback no longer occurs in all cases.

https://github.com/odoo/odoo/blob/279504268e1c4b57f26543db1c7da9a709fea350/addons/mail/models/mail_activity_mixin.py#L401-L402

**Solution:**
- If no user_id is determined (either from the record or activity type), explicitly assign
the current logged-in user (env.user) as the activity’s responsible user during creation.
- This ensures that every activity created through automation has a valid assignee

opw - 5213520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
