### PR TITLE
[FIX] pos_{,restaurant}: traceback when reopening register default preset takeout

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
@@ -29,7 +29,7 @@ export class LoginScreen extends Component {
                 ? this.pos.previousScreen
                 : this.pos.defaultPage;
         const order = this.pos.getOrder();
-        if (!order) {
+        if (!order && selectedScreen.page === "ProductScreen") {
             this.pos.addNewOrder();
         }
         const params =

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -617,6 +617,16 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_open_register_with_preset_takeaway", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("5"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("RestaurantPresetEatInTour", {
     steps: () =>
         [

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -616,6 +616,8 @@ class TestFrontend(TestFrontendCommon):
             'resource_calendar_id': resource_calendar
         })
         self.start_pos_tour('test_preset_timing_restaurant')
+        self.main_pos_config.write({'default_preset_id': self.preset_takeaway.id})
+        self.start_pos_tour('test_open_register_with_preset_takeaway')
 
     def test_restaurant_preset_eatin_tour(self):
         self.pos_config.write({


### PR DESCRIPTION
STEPS TO REPRODUCE:
--------
1. Set default preset as Takeout in configuration.
2. Open a register than Close the register.
3. Reopen the register.
4. Observe traceback.

CAUSE:
-----------------
LoginScreen created an order before the ProductScreen was loaded causing preset 
logic to access undefined order data.

FIX:
-----------------------------
Create a new order only when the selected screen is ProductScreen:
 
Task-5237713
