### PR TITLE
[FIX] mrp: fix wrong units on product moves

### DIFF
--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2797,6 +2797,23 @@ class TestBoM(TestMrpCommon):
         mo = mo_form.save()
         self.assertEqual(mo.workorder_ids.operation_id, kit_bom.operation_ids.filtered(lambda op: op.bom_product_template_attribute_value_ids == blue))
 
+    def test_correct_bom_final_product_unit(self):
+        """
+        Checks if the Final product (tracked by lot) is manufactured with the correct unit.
+        """
+        final_product = self.env['product.product'].create(dict({'is_storable': True}, name="Product to manufacture"))
+        final_product.tracking = 'lot'
+        # Create MO.with a different UOM
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = final_product
+        mo_form.product_qty = 1
+        mo_form.product_uom_id = self.uom_dozen
+        mo = mo_form.save()
+        mo.action_confirm()
+        mo.button_mark_done()
+        self.assertEqual(mo.finished_move_line_ids.product_uom_id, self.uom_dozen)
+
+
 @tagged('-at_install', 'post_install')
 class TestTourBoM(HttpCase):
     @classmethod

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -619,7 +619,7 @@ Please change the quantity done or the rounding precision in your settings.""",
                         move_line = mls_without_lots[:1]
                         move_lines_commands.append(Command.update(move_line.id, {
                             'lot_id': lot.id,
-                            'product_uom_id': move.product_id.uom_id.id,
+                            'product_uom_id': move.product_id.uom_id.id if move.product_id.tracking == 'serial' else move.product_uom.id,
                             'quantity': 1 if move.product_id.tracking == 'serial' else move.quantity,
                         }))
                         mls_without_lots -= move_line


### PR DESCRIPTION
**Steps to reproduce:** 
- Create a bill of material for a product tracked by lot
- Modify the uom on the bill of material for that final product to 'pack of 6' 
- add any component that you like  
- Create a manufacturing order for the final product 
- Generate a lot number and validate the production order

**Issue:**
The unit for the final product is incorrect.

Task: 5232897



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
