### PR TITLE
[FIX] pos_restaurant: tb when printing prep changes without selected order

### DIFF
--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -288,6 +288,22 @@ describe("restaurant pos_store.js", () => {
             { count: 2, name: "Category 2" },
             { count: 1, name: "Message" },
         ]);
+        // when order is not selected
+        store.selectedOrderUuid = false;
+        expect(store.categoryCount).toBeEmpty();
+    });
+
+    test("_computeCategoryCount", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        expect(store._computeCategoryCount()).toEqual([
+            { count: 3, name: "Category 1" },
+            { count: 2, name: "Category 2" },
+        ]);
+        expect(store._computeCategoryCount(order)).toEqual([
+            { count: 3, name: "Category 1" },
+            { count: 2, name: "Category 2" },
+        ]);
     });
 
     test("getDefaultSearchDetails", async () => {


### PR DESCRIPTION
Steps to reproduce:
- Set up UrbanPiper and a preparation printer in the restaurant.
- Open the Ticket Screen from the Floor Screen.
- Accept an UrbanPiper order.

Issue:
- Traceback occurs when sending the order for preparation if no order is currently selected in the POS service.

Fix:
- Prevent error during preparation printing when no order is selected.

----
Remove redundant `modeUpdate` logic from `categoryCount` computation


Task-5241128