### PR TITLE
[FIX] mail: add 100ms ticks for contains 3 seconds timeout

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -532,6 +532,7 @@ afterEach(() => (hasUsedContainsPositively = false));
  * @property {boolean} [visible] if provided, the found element(s) must be (in)visible
  */
 class Contains {
+    timeoutCount = 0;
     /**
      * @param {string} selector
      * @param {ContainsOptions} [options={}]
@@ -599,6 +600,18 @@ class Contains {
         this.executeError = undefined;
     }
 
+    setTickTimeout() {
+        this.timer = setTimeout(() => {
+            this.timeoutCount++;
+            const res = this.runOnce(`Timeout of ${this.timeoutCount * 0.1} seconds`, {
+                crashOnFail: this.timeoutCount > 29,
+            });
+            if (!res) {
+                this.setTickTimeout();
+            }
+        }, 100);
+    }
+
     /**
      * Starts this contains check, either immediately resolving if there is a
      * match, or registering appropriate listeners and waiting until there is a
@@ -617,10 +630,7 @@ class Contains {
         this.onFocus = () => this.runOnce("after focus");
         this.onScroll = () => this.runOnce("after scroll");
         if (!this.runOnce("immediately")) {
-            this.timer = setTimeout(
-                () => this.runOnce("Timeout of 3 seconds", { crashOnFail: true }),
-                3000
-            );
+            this.setTickTimeout();
             this.observer = new MutationObserver((mutations) => {
                 try {
                     this.runOnce("after mutations");


### PR DESCRIPTION
Before this commit, contains had 3 seconds timeout to make a final runOnce.

Some tests could be longer than necessary due to:
- change not observed by DOM mutation, e.g. `:focus` in selector
- some selectors are sometimes not properly observed by mutation somehow, like discuss badges.

This commit adds 100ms ticks to re-check selector, and the 3 seconds timeout now happens with calling the ticks 30 times.