### PR TITLE
[IMP] point_of_sale: add backdrop props to Dialog component

### DIFF
--- a/addons/point_of_sale/static/src/app/components/dialog/dialog.js
+++ b/addons/point_of_sale/static/src/app/components/dialog/dialog.js
@@ -1,0 +1,28 @@
+import { Dialog } from "@web/core/dialog/dialog";
+import { patch } from "@web/core/utils/patch";
+
+patch(Dialog, {
+    props: {
+        ...Dialog.props,
+        backdrop: { type: Boolean, optional: true },
+        closeOnBodyButtonClick: { type: Boolean, optional: true },
+    },
+    defaultProps: { ...Dialog.defaultProps, backdrop: false, closeOnBodyButtonClick: false },
+});
+
+patch(Dialog.prototype, {
+    onClick(event) {
+        // Click outside the modal content
+        if (this.props.backdrop && event.target === this.modalRef.el) {
+            this.dismiss();
+        }
+        // Click on a button inside the modal body or on an element with the 'close-dialog' class
+        else if (
+            (this.props.closeOnBodyButtonClick &&
+                event.target.closest(".modal-body button:not(.prevent-close-dialog)")) ||
+            event.target.closest(".close-dialog")
+        ) {
+            this.data.close();
+        }
+    },
+});

--- a/addons/point_of_sale/static/src/app/components/dialog/dialog.xml
+++ b/addons/point_of_sale/static/src/app/components/dialog/dialog.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
+  <t t-name="point_of_sale.Dialog" t-inherit="web.Dialog" t-inherit-mode="extension">
+    <xpath expr="//div[hasclass('modal')]" position="attributes">
+      <attribute name="t-on-click">onClick</attribute>
+    </xpath>
+  </t>
+
   <t t-name="point_of_sale.Dialog" t-inherit="web.ConfirmationDialog" t-inherit-mode="extension">
     <xpath expr="//Dialog" position="attributes">
       <attribute name="contentClass">'o_confirmation_dialog ' + (props.contentClass || '')</attribute>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -21,7 +21,6 @@ export class ControlButtons extends Component {
     static props = {
         showRemainingButtons: { type: Boolean, optional: true },
         onClickMore: { type: Function, optional: true },
-        close: { type: Function, optional: true },
     };
     static defaultProps = {
         showRemainingButtons: false,
@@ -156,7 +155,4 @@ export class ControlButtons extends Component {
 export class ControlButtonsPopup extends Component {
     static components = { Dialog, ControlButtons };
     static template = "point_of_sale.ControlButtonsPopup";
-    static props = {
-        close: Function,
-    };
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -48,14 +48,14 @@
                     <i class="fa fa-outdent" role="img" aria-label="Break combo" title="Brean combo" /> Break combo
                 </button>
                 <button t-if="this.pos.cashier._role != 'minimal'" t-att-class="buttonClass" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
-                    <i class="fa fa-trash me-1" role="img" /> Cancel Order 
+                    <i class="fa fa-trash me-1" role="img" /> Cancel Order
                 </button>
             </div>
         </t>
     </t>
     <t t-name="point_of_sale.ControlButtonsPopup">
-        <Dialog bodyClass="'d-flex flex-column'" footer="false" title.translate="Actions" t-on-click="props.close">
-            <ControlButtons showRemainingButtons="true" close="props.close"/>
+        <Dialog bodyClass="'d-flex flex-column'" footer="false" title.translate="Actions" backdrop="true" closeOnBodyButtonClick="true">
+            <ControlButtons showRemainingButtons="true" />
         </Dialog>
     </t>
 </templates>


### PR DESCRIPTION
Task: [#5223006](https://www.odoo.com/odoo/project/1737/tasks/5223006)

---

Before this commit, clicking a disabled button inside the Control Buttons popup would close the dialog.
Disabled buttons should not trigger any action — including closing the popup.

To fix this, a new prop `backdrop` was added to the `Dialog` component to allow closing the dialog when clicking outside of it.
Another prop, `closeOnBodyButtonClick`, was also added to close the dialog when clicking on a button within the dialog body.

These props are used in the `ControlButtonsPopup` so that the dialog still closes when clicking outside of it or on an active button, but not when clicking on a disabled button.