### PR TITLE
[FIX] website: avoid mutating the plugin list in test helper addPlugin

### DIFF
--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -300,8 +300,7 @@ export function addPlugin(...Plugin) {
     patchWithCleanup(WebsiteBuilder.prototype, {
         get builderProps() {
             const props = super.builderProps;
-            props.Plugins.push(...Plugin);
-            return props;
+            return { ...props, Plugins: [...props.Plugins, ...Plugin] };
         },
     });
 }


### PR DESCRIPTION
The commit 25c602cff4db3f191434ab608ccdc51fa1ac75fb changed the internal of `addPlugin`, but did not follow the good practice of not mutating anything in a getter. In this commit, we instead create a mutated copy.

task-5176469