### PR TITLE
[IMP] web: add discuss type def generation to pre commit hook

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -1,11 +1,4 @@
 declare module "models" {
-    export interface DiscussApp {
-        defaultLivechatCategory: DiscussAppCategory;
-        livechats: DiscussChannel[];
-    }
-    export interface DiscussAppCategory {
-        livechat_channel_id: LivechatChannel;
-    }
     export interface DiscussChannel {
         appAsLivechats: DiscussApp;
     }

--- a/addons/im_livechat/static/src/core/public_web/discuss_app/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/@types/models.d.ts
@@ -1,0 +1,9 @@
+declare module "models" {
+    export interface DiscussApp {
+        defaultLivechatCategory: DiscussAppCategory;
+        livechats: DiscussChannel[];
+    }
+    export interface DiscussAppCategory {
+        livechat_channel_id: LivechatChannel;
+    }
+}

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -1,12 +1,7 @@
 declare module "models" {
-    import { DiscussApp as DiscussAppClass } from "@mail/core/public_web/discuss_app/discuss_app_model";
-
-    export interface DiscussApp extends DiscussAppClass {}
-
     export interface Store {
         action_discuss_id: number|undefined;
         discuss: DiscussApp;
-        DiscussApp: StaticMailRecord<DiscussApp, typeof DiscussAppClass>;
     }
     export interface Thread {
         askLeaveConfirmation: (body: string) => Promise<void>;
@@ -16,9 +11,5 @@ declare module "models" {
         setActiveURL: () => void;
         setAsDiscussThread: (pushState: boolean) => void;
         unpin: () => Promise<void>;
-    }
-
-    export interface Models {
-        DiscussApp: DiscussApp;
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_app/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/discuss_app/@types/models.d.ts
@@ -1,0 +1,13 @@
+declare module "models" {
+    import { DiscussApp as DiscussAppClass } from "@mail/core/public_web/discuss_app/discuss_app_model";
+
+    export interface DiscussApp extends DiscussAppClass {}
+
+    export interface Store {
+        DiscussApp: StaticMailRecord<DiscussApp, typeof DiscussAppClass>;
+    }
+
+    export interface Models {
+        DiscussApp: DiscussApp;
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -9,6 +9,7 @@ declare module "models" {
         channelMembers: ChannelMember[];
     }
     export interface Message {
+        channel_id: DiscussChannel;
         channelMemberHaveSeen: Readonly<ChannelMember[]>;
         hasEveryoneSeen: boolean|undefined;
         hasNewMessageSeparator: boolean;
@@ -36,6 +37,7 @@ declare module "models" {
     }
     export interface Thread {
         _computeOfflineMembers: () => ChannelMember[];
+        allow_invite_by_email: Readonly<boolean>;
         allowCalls: Readonly<boolean>;
         allowDescription: Readonly<boolean>;
         allowedToLeaveChannelTypes: Readonly<string[]>;
@@ -61,7 +63,6 @@ declare module "models" {
         firstUnreadMessage: Message;
         group_ids: ResGroups[];
         hasMemberList: Readonly<boolean>;
-        hasOtherMembersTyping: boolean;
         hasSeenFeature: boolean;
         hasSelfAsMember: Readonly<boolean>;
         invitationLink: Readonly<unknown|string>;
@@ -72,6 +73,7 @@ declare module "models" {
         lastMessageSeenByAllId: undefined|number;
         lastSelfMessageSeenByEveryone: Message;
         leaveChannel: () => Promise<void>;
+        leaveChannelRpc: () => void;
         markAsFetched: () => Promise<void>;
         markedAsUnread: boolean;
         markingAsRead: boolean;
@@ -83,7 +85,6 @@ declare module "models" {
         notifyDescriptionToServer: (description: unknown) => Promise<unknown>;
         offlineMembers: ChannelMember[];
         onlineMembers: ChannelMember[];
-        otherTypingMembers: ChannelMember[];
         rename: (name: string) => Promise<void>;
         scrollUnread: boolean;
         self_member_id: ChannelMember;
@@ -91,7 +92,6 @@ declare module "models" {
         showUnreadBanner: Readonly<boolean>;
         toggleBusSubscription: boolean;
         typesAllowingCalls: Readonly<string[]>;
-        typingMembers: ChannelMember[];
         unknownMembersCount: Readonly<number>;
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -1,26 +1,22 @@
 declare module "models" {
-    import { DiscussAppCategory as DiscussAppCategoryClass } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+    import { DiscussCategory as DiscussCategoryClass } from "@mail/discuss/core/public_web/discuss_category_model";
 
-    export interface DiscussAppCategory extends DiscussAppCategoryClass {}
+    export interface DiscussCategory extends DiscussCategoryClass {}
 
-    export interface DiscussApp {
-        allCategories: DiscussAppCategory[];
-        channelCategory: DiscussAppCategory;
-        chatCategory: DiscussAppCategory;
-        computeChatCategory: () => object;
-        unreadChannels: Thread[];
+    export interface DiscussChannel {
+        discuss_category_id: DiscussCategory;
     }
     export interface Message {
         linkedSubChannel: Thread;
     }
     export interface Store {
         channels: ReturnType<Store['makeCachedFetchData']>;
-        DiscussAppCategory: StaticMailRecord<DiscussAppCategory, typeof DiscussAppCategoryClass>;
+        "discuss.category": StaticMailRecord<DiscussCategory, typeof DiscussCategoryClass>;
         fetchSsearchConversationsSequential: () => Promise<any>;
         searchConversations: (searchValue: string) => Promise<void>;
     }
     export interface Thread {
-        _computeDiscussAppCategory: () => undefined|unknown;
+        _computeDiscussAppCategory: () => unknown;
         appAsUnreadChannels: DiscussApp;
         categoryAsThreadWithCounter: DiscussAppCategory;
         createSubChannel: (param0: { initialMessage: Message, name: string }) => Promise<void>;
@@ -37,6 +33,6 @@ declare module "models" {
     }
 
     export interface Models {
-        DiscussAppCategory: DiscussAppCategory;
+        "discuss.category": DiscussCategory;
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/@types/models.d.ts
@@ -1,0 +1,21 @@
+declare module "models" {
+    import { DiscussAppCategory as DiscussAppCategoryClass } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+
+    export interface DiscussAppCategory extends DiscussAppCategoryClass {}
+
+    export interface DiscussApp {
+        allCategories: DiscussAppCategory[];
+        channelCategory: DiscussAppCategory;
+        chatCategory: DiscussAppCategory;
+        computeChatCategory: () => object;
+        favoriteCategory: DiscussAppCategory;
+        unreadChannels: Thread[];
+    }
+    export interface Store {
+        DiscussAppCategory: StaticMailRecord<DiscussAppCategory, typeof DiscussAppCategoryClass>;
+    }
+
+    export interface Models {
+        DiscussAppCategory: DiscussAppCategory;
+    }
+}

--- a/addons/web/tooling/_package.json
+++ b/addons/web/tooling/_package.json
@@ -11,6 +11,7 @@
         "format-diff": "echo '{\"extends\": [\"plugin:diff/diff\"]}' | eslint --fix --resolve-plugins-relative-to . -c /dev/stdin '**/*.js'"
     },
     "devDependencies": {
+        "discuss_pre_commit": "^1.0.34",
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-diff": "^2.0.1",
@@ -25,7 +26,9 @@
     },
     "lint-staged": {
         "*.js": [
-            "eslint --fix"
+            "eslint --fix",
+            "npx discuss-pre-commit-type-gen -f",
+            "git add '**/*.d.ts'"
         ]
     },
     "engines": {


### PR DESCRIPTION
Discuss uses a script to generate type definitions for its models. However, running it on each PR is cumbersome, which can lead to outdated type definitions.

This commit adds the script to the web pre-commit hook. The script runs only when Discuss related modules are modified.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
