### PR TITLE
[FIX] crm,mail: suggested recipient values not used in full composer

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2062,7 +2062,7 @@ class Lead(models.Model):
             name_from_email = name_emails[0][0] if name_emails else False
             if name_from_email:
                 continue  # already containing name + email
-            name_from_email = self.partner_name or self.contact_name
+            name_from_email = self.contact_name or self.partner_name
             emails_normalized = tools.email_normalize_all(email)
             email_normalized = emails_normalized[0] if emails_normalized else False
             if email.lower() == self.email_from.lower() or (email_normalized and self.email_normalized == email_normalized):

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -43,6 +43,10 @@ class ThreadController(http.Controller):
 
     @http.route("/mail/partner/from_email", methods=["POST"], type="json", auth="user")
     def mail_thread_partner_from_email(self, emails, additional_values=None):
+        additional_values = {
+            email_normalize(email, strict=False) or email: values
+            for email, values in (additional_values if additional_values else {}).items()
+        }
         partners = [
             {"id": partner.id, "name": partner.name, "email": partner.email}
             for partner in request.env["res.partner"]._find_or_create_from_emails(emails, additional_values)


### PR DESCRIPTION
When a partner is created from suggested recipients for the composer, values suggested for its creation are not used.
Whereas they should be used, just like is the case when sending a message from the small composer.

We just need to normalize the emails from the "additional values" dict on the server.
As was done in [1] for the post route (small composer).

Additionally the suggested recipient for leads is updated to use the contact name if available, to match suggested recipient values which defaults to assuming we are creating an individual (not a company)

task-5241064

[1]: https://github.com/odoo/odoo/commit/67c5a61b09e199430a48aa15a899ac05c761ad6a
