### PR TITLE
[FIX] spreadsheet: Fix css overrides

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss
@@ -20,16 +20,23 @@
 }
 
 .o-sidePanel {
+    --o-spreadsheet-input-border-color: #D8DADD;
     .o_input {
         color: #111827;
-        border-color: #D8DADD;
+        border-color: var(--o-spreadsheet-input-border-color);
         &::placeholder {
             opacity: 0.5;
         }
     }
 
-    .o_required_modifier {
-        .o-input {
+    .o_field_invalid, .o_missing_field{
+        .o-input, .o_input {
+            border-color: var(--o-input-border-color);
+        }
+    }
+
+    .o_required_modifier:not(.o_field_invalid):not(.o_missing_field) {
+        .o_input {
             border-color: #111827;
         }
     }


### PR DESCRIPTION
Following the style revamp of the o-spreadsheet lib, we introduced a class o-input (differs from odoo o_input) in order to avoid collision with the odoo classes which tend to be altered in dark mode which spreadsheet does not support.

However, we still relied on the default behaviour of odoo classes to mark specific inputs as invalid or missing.

This commit ensures that missing/invalid are always marked as such while make preventing the dark mode to break the default layout.

Task-4878174

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
