### PR TITLE
[FIX] point_of_sale: correctly compute dynamic product prices

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -599,7 +599,7 @@ export class PosStore extends Reactive {
             attribute_value_ids: attributeLinesValues.map((values) => values[0].id),
             attribute_custom_values: [],
             price_extra: attributeLinesValues
-                .filter((attr) => attr[0].attribute_id.create_variant !== "always")
+                .filter((attr) => attr[0].attribute_id.create_variant === "no_variant")
                 .reduce((acc, values) => acc + values[0].price_extra, 0),
             quantity: 1,
         };
@@ -720,7 +720,8 @@ export class PosStore extends Reactive {
                                 const attr =
                                     this.data.models["product.template.attribute.value"].get(a);
                                 return (
-                                    attr.is_custom || attr.attribute_id.create_variant !== "always"
+                                    attr.is_custom ||
+                                    attr.attribute_id.create_variant === "no_variant"
                                 );
                             }
                             return true;
@@ -749,7 +750,7 @@ export class PosStore extends Reactive {
         } else if (values.product_id.product_template_variant_value_ids.length > 0) {
             // Verify price extra of variant products
             const priceExtra = values.product_id.product_template_variant_value_ids
-                .filter((attr) => attr.attribute_id.create_variant !== "always")
+                .filter((attr) => attr.attribute_id.create_variant === "no_variant")
                 .reduce((acc, attr) => acc + attr.price_extra, 0);
             values.price_extra += priceExtra;
         }

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -158,7 +158,7 @@ export class ProductConfiguratorPopup extends Component {
                 attribute_custom_values[valueIds[0]] = custom_value;
             }
             const attr = this.pos.data.models["product.template.attribute.value"].get(valueIds[0]);
-            if (attr && attr.attribute_id.create_variant !== "always") {
+            if (attr && attr.attribute_id.create_variant === "no_variant") {
                 price_extra += extra;
             }
         });

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -773,3 +773,20 @@ registry.category("web_tour.tours").add("test_product_ref_displayed", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_dynamic_product_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Dynamic Product"),
+            ProductConfiguratorPopup.pickRadio("Dynamic Value 1"),
+            Chrome.clickBtn("Add"),
+            ProductScreen.selectedOrderlineHas("Dynamic Product (Dynamic Value 1)", "1.0", "10.00"),
+            ProductScreen.clickDisplayedProduct("Dynamic Product"),
+            ProductConfiguratorPopup.pickRadio("Dynamic Value 2"),
+            Chrome.clickBtn("Add"),
+            ProductScreen.selectedOrderlineHas("Dynamic Product (Dynamic Value 2)", "1.0", "20.00"),
+            Chrome.endTour(),
+        ].flat(),
+});


### PR DESCRIPTION
Before this commit, if a product had dynamic attributes with extra prices, those extra prices were computed twice, resulting in incorrect total prices.

opw-5187405

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
