### PR TITLE
[FIX] sale_project: set allocated hours on task creation

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -275,7 +275,7 @@ class SaleOrderLine(models.Model):
     def _timesheet_create_task_prepare_values(self, project):
         self.ensure_one()
         allocated_hours = 0.0
-        if self.product_id.service_type not in ['milestones', 'manual']:
+        if self.product_id.service_type != 'milestones':
             allocated_hours = self._convert_qty_company_hours(self.company_id)
         sale_line_name_parts = self.name.split('\n')
         products_inside_template_line_with_name = self.order_id.sale_order_template_id.sale_order_template_line_ids.filtered(

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1329,3 +1329,18 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         so.action_confirm()
         self.assertFalse(self.product_order_service2.project_id.task_ids)
         self.assertFalse(sol.task_id)
+
+    def test_allocated_hours_manual_delivery_service(self):
+        """
+        Test that allocated_hours match the quantity ordered on creation
+        when the service product has 'delivered_manual' service policy.
+        """
+        self.product_service_delivered_manual.service_tracking = 'task_in_project'
+        so = self.env['sale.order'].create({'partner_id': self.partner.id})
+        sol = self.env['sale.order.line'].create({
+            'order_id': so.id,
+            'product_id': self.product_service_delivered_manual.id,
+            'product_uom_qty': 10,
+        })
+        so.action_confirm()
+        self.assertEqual(sol.task_id.allocated_hours, 10, "The allocated hours should be 10.")


### PR DESCRIPTION
To reproduce:
=============
- Create service product with `service_tracking = task_in_project` and `service_type = manual`
- Create a SO with this product and set quantity on the line
- Confirm the SO
- check the created task, allocated hours is 0.0 instead of the quantity of the SO line

Problem:
========
When creating tasks from SO lines, allocated hours is initialized to 0 then computed based on the SOL quantity except when the product's service_type is 'milestones' or 'manual'.

Solution:
=========
Following the logic in `write` method of `sale.order.line`, the allocated hours should be set to the SOL quantity.

opw-5153467
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
