### PR TITLE
[FIX] iot_drivers: no event returned for 'status' printer action

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -147,6 +147,8 @@ class PrinterDriver(PrinterDriverBase):
 
         commands = self.RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
         if self.escpos_device:
+            if not self.check_printer_status():
+                return
             try:
                 with EscposIO(self.escpos_device) as dev:
                     dev.printer.set(align='center', double_height=True, double_width=True)
@@ -154,6 +156,7 @@ class PrinterDriver(PrinterDriverBase):
                     dev.printer.set_with_default(align='center', double_height=False, double_width=False)
                     dev.writelines(body.decode())
                     dev.printer.qr(f"http://{helpers.get_ip()}", size=6)
+                self.send_status(status='success')
                 return
             except (escpos.exceptions.Error, OSError, AssertionError):
                 _logger.warning("Failed to print QR status receipt, falling back to simple receipt")


### PR DESCRIPTION
**Steps to reproduce:**
1. Connect a receipt printer to an IoT box, and pair the IoT box with Odoo.
2. In the device form for the receipt printer, click the 'Test' button.

**Expected behaviour:**
- Status receipt is printed and a 'Test page printed' notification is shown on the screen.

**Actual behaviour:**
- Status receipt is printed but no notification is shown on the screen.

In odoo/odoo#229731, a QR code was added to the test status receipt printer action. This was achieved by directly sending commands to the printer with the `escpos` library, bypassing the `print_raw` method.

However, by bypassing the `print_raw` method it also bypassed the status events that are normally sent to inform the Odoo user of the outcome of the print.

This commit adds back these events to the receipt test print action.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
