### PR TITLE
[FIX] mail: can search and jump to messages in mailboxes

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -259,7 +259,7 @@ export function useMessageHighlight(duration = 2000) {
          * @param {import("models").Thread} thread
          */
         async highlightMessage(message, thread) {
-            if (thread.notEq(message.originThread)) {
+            if (thread.model !== "mail.box" && thread.notEq(message.originThread)) {
                 return;
             }
             await threadService.loadAround(thread, message.id);

--- a/addons/mail/static/tests/discuss/search_discuss_tests.js
+++ b/addons/mail/static/tests/discuss/search_discuss_tests.js
@@ -130,6 +130,8 @@ QUnit.test("Search a message in history", async () => {
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
+    await click(".o-mail-SearchMessagesPanel .o-mail-MessageCard-jump");
+    await contains(".o-mail-Thread .o-mail-Message.o-highlighted");
 });
 
 QUnit.test("Should close the search panel when search button is clicked again", async () => {


### PR DESCRIPTION
Before this commit, we could not jump to messages in mailboxes.

This happens because the `useMessageHighlight()` hook prevented jumping to messages in thread that were not their origin thread.

This commit fixes the issue by removing this limitation specifically for mailboxes.

opw-4948798
opw-5087102