### PR TITLE
[IMP] calendar: limit previous events sync

### DIFF
--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -33,18 +33,11 @@ class GoogleCalendarService():
         if event_id:
             url += f"/{event_id}"
         headers = {'Content-type': 'application/json'}
-        params = {'access_token': token}
-        if sync_token:
-            params['syncToken'] = sync_token
-        else:
-            # full sync, limit to a range of 1y in past to 1y in the futur by default
-            ICP = self.google_service.env['ir.config_parameter'].sudo()
-            day_range = ICP.get_int('google_calendar.sync.range_days') or 365
-            _logger.info("Full cal sync, restricting to %s days range", day_range)
-            lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)
-            upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)
-            params['timeMin'] = lower_bound.isoformat() + 'Z'  # Z = UTC (RFC3339)
-            params['timeMax'] = upper_bound.isoformat() + 'Z'  # Z = UTC (RFC3339)
+        params = {
+            'access_token': token,
+            'timeMin': fields.Datetime.now().isoformat() + 'Z',  # Z = UTC (RFC3339)
+            'timeMax': fields.Datetime.add(fields.Datetime.now(), days=30).isoformat() + 'Z',  # Z = UTC (RFC3339)
+        }
         try:
             status, data, time = self.google_service._do_request(url, params, headers, method='GET', timeout=timeout)
         except requests.HTTPError as e:


### PR DESCRIPTION
The spec must be clarified.

About the google_calendar.sync.range_days config_parameter : https://github.com/odoo/odoo/commit/30f4be4889968e89ce4c81e454b7de1758c03491

Task-5150937