### PR TITLE
[FIX] test_lint: Index lint Many2one inverse for inherited fields

### DIFF
--- a/odoo/addons/test_lint/tests/test_index.py
+++ b/odoo/addons/test_lint/tests/test_index.py
@@ -70,7 +70,7 @@ class TestIndex(common.TransactionCase):
             for field in model._fields.values():
                 if field.type == 'one2many' and field.inverse_name:
                     comodel = self.env[field.comodel_name]
-                    inverse_field = comodel._fields.get(field.inverse_name)
+                    inverse_field = comodel._fields.get(field.inverse_name).base_field
                     if inverse_field and not ignore(field, inverse_field):
                         fields_to_index.add(f"{inverse_field} (inverse of {field})")
         if fields_to_index:


### PR DESCRIPTION
Many2one fields that originated from an `inherits` model were not linted for indexing if they were an inverse to a One2many field, because those fields on the inverse model have `store=False`. The Many2one field that needs to be indexed is the one on the delegated model.

This commit fixes this by always getting the `base_field` for the inverse field - if it's an inherited field, it will use the source field; if not, it will use the field itself.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
