### PR TITLE
[FIX] point_of_sale: assign partner correctly on picking creation

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1693,7 +1693,7 @@ class PosOrderLine(models.Model):
             'date_deadline': date_deadline,
             'route_ids': self.order_id.config_id.route_id,
             'warehouse_id': self.order_id.config_id.warehouse_id or False,
-            'partner_id': self.order_id.partner_id.id,
+            'partner': self.order_id.partner_id,
             'product_description_variants': self.full_product_name,
             'company_id': self.order_id.company_id,
             'reference_ids': self.order_id.stock_reference_ids,


### PR DESCRIPTION
in this commit:
- The partner was not being set on pickings due to a recent change in the stock module. Previously, the `partner_id` was derived from the `group_id`, but it is now taken directly from the values. We updated the values to ensure the correct partner is passed.


reference PR: [212679](https://github.com/odoo/odoo/pull/212679/files#diff-a8e268c29293c3896cc7bf77c5a0809a394ffe929388180b6e96cce485177956L331)

runbot-232733
