### PR TITLE
[FIX] mail: correct z-index stacking for dialogs in mobile chat windows

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -10,11 +10,7 @@
     &.o-mobile {
         margin-right: $o-mail-ChatHub-bubblesMargin + 5px;
         --mail-ChatHub-bubbles-bottomLift: 35px;
-
-        body:has(.o-mail-Discuss):not(:has(.o-mail-ChatWindow)) &, body:has(.o-mail-MessagingMenu):not(:has(.o-mail-ChatWindow)) &  {
-            --mail-ChatHub-bubbles-bottomLift: 65px;
-            z-index: $zindex-modal + 5;
-        }
+        z-index: $o-mail-NavigableList-zIndex - 1;
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -6,6 +6,9 @@
         --border-opacity: .15;
         height: Min(95vh, $o-mail-ChatWindow-width * 15 / 9)
     }
+    &.o-mobile {
+        z-index: $zindex-sticky - 2 !important;
+    }
     outline: none;
 }
 


### PR DESCRIPTION
**Purpose of this PR :**

- Before this PR, dialogs triggered by message actions were rendered beneath the chat window in mobile view due to incorrect `z-index` hierarchy. This created a confusing UX where users had no visual feedback, only discovering the hidden dialog after minimizing the chat window.

- This PR adjusts the `z-index` values to ensure dialogs are properly elevated above the chat window layer, restoring the expected stacking context and enabling direct interaction with modal dialogs.

**Current behavior before PR:**  

[before_z.webm](https://github.com/user-attachments/assets/8063633f-6de7-4874-9884-963f4d223587)

**Desired behavior after PR is merged:**

[after_z.webm](https://github.com/user-attachments/assets/5674a953-8308-4469-907d-311a0d5a3f94)

Backport of https://github.com/odoo/odoo/pull/235852
task-[5208322](https://www.odoo.com/odoo/project/1519/tasks/5208322)