### PR TITLE
[FIX] attachment_indexation: fix import find_spec()

### DIFF
--- a/addons/attachment_indexation/models/ir_attachment.py
+++ b/addons/attachment_indexation/models/ir_attachment.py
@@ -13,7 +13,7 @@ from odoo.tools.lru import LRU
 
 _logger = logging.getLogger(__name__)
 
-if not importlib.util.find_spec('pdfminer.high_level'):
+if not (importlib.util.find_spec('pdfminer') and importlib.util.find_spec('pdfminer.high_level')):
     _logger.warning("Attachment indexation of PDF documents is unavailable because the 'pdfminer.six' Python library cannot be found on the system. "
                     "You may install it from https://pypi.org/project/pdfminer.six/ (e.g. `pip3 install pdfminer.six`)")
 


### PR DESCRIPTION
The call to `importlib.util.find_spec('pdfminer.high_level')` introduced by https://github.com/odoo/odoo/pull/230123 crashes when the module is not available.  One has to check for `'pdfminer'` first, and then `'pdfminer.high_level'`.