### PR TITLE
[FIX] test_lint: TestDocstring panics when checking types

### DIFF
--- a/odoo/addons/test_lint/tests/test_docstring.py
+++ b/odoo/addons/test_lint/tests/test_docstring.py
@@ -235,7 +235,7 @@ class TestDocstring(BaseCase):
         sign_rtype = signature.return_annotation
 
         if sign_rtype != signature.empty and doc_rtype != signature.empty:
-            self.assertEqual(sign_rtype, doc_rtype)
+            self.assertEqual(self._stringify_annotation(sign_rtype), doc_rtype)
 
         try:
             m = "the docstring is documenting non-existing parameters"
@@ -258,6 +258,9 @@ class TestDocstring(BaseCase):
         for param, doc_type in doc_types.items():
             sign_type = sign_types.get(param, signature.empty)
             if sign_type != signature.empty:
-                if isinstance(sign_type, type):
-                    sign_type = sign_type.__name__
-                self.assertEqual(sign_type, doc_type)
+                self.assertEqual(self._stringify_annotation(sign_type), doc_type)
+
+    def _stringify_annotation(self, sign_type):
+        if isinstance(sign_type, type):
+            sign_type = sign_type.__name__
+        return str(sign_type)


### PR DESCRIPTION
This commit fixes a bug in `TestDocstring` when a method has type hint specified both in the docstring and as a type hint.

Example:
```
def example(a: list[int]) -> int:
    """
    :param list[int] a: a list
    :rtype: int
    """
    return len(a)
```

the `_test_docstring_params` method will break twice:
- the `rtype` check raises `AssertionError: <class 'int'> != 'int'`
- the `type` check raises `AssertionError: list[int] != 'list[int]'`


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
