### PR TITLE
[IMP] base: fetch fields from cache for stable data

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -62,7 +62,7 @@ class ProductTemplate(models.Model):
                 product_template.categ_id.with_company(
                     product_template.company_id
                 ).property_cost_method
-                or (product_template.company_id or self.env.company).cost_method
+                or (product_template.company_id or self.env.company).sudo().cost_method
             )
 
     @api.depends_context('company')

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -19,7 +19,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #   - search website_rewrite (_get_rewrites) sometimes occurs depending on the routing cache
         #   - insert res_device_log
         #   - _xmlid_lookup (_get_public_users)
-        #   - fetch website (_get_cached_values)
+        #   - fetch website (_cached_data)
         #   - _get ir_config_parameter (_pre_dispatch website_sale)
         #   4 _message_fetch:
         #       2 _search_needaction:

--- a/addons/test_website/tests/test_session.py
+++ b/addons/test_website/tests/test_session.py
@@ -49,7 +49,7 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
         self.assertEqual(res.status_code, 303)
         self.assertTrue(res.next.path_url.startswith("/web/login/totp"))
 
-    def test_04_ensure_website_get_cached_values_can_be_called(self):
+    def test_04_ensure_website_cached_data_can_be_called(self):
         session = self.authenticate('admin', 'admin')
 
         # Force a browser language that is not installed
@@ -57,8 +57,8 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
         http.root.session_store.save(session)
 
         # Disable cache in order to make sure that values would be fetched at any time
-        get_cached_values_without_cache = Website._get_cached_values.__cache__.method
-        with patch.object(Website, '_get_cached_values',
+        get_cached_values_without_cache = Website._cached_data.__cache__.method
+        with patch.object(Website, '_cached_data',
                           side_effect=get_cached_values_without_cache, autospec=True):
 
             # ensure that permissions on logout are OK

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -295,10 +295,10 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 50  # To increase this number you must ask the permission to al
+        query_count = 49  # To increase this number you must ask the permission to al
         queries = {
             'orm_signaling_registry': 1,
-            'website': 2,
+            'website': 1,
             'res_company': 2,
             'product_pricelist': 4,
             'product_template': 6,

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -102,7 +102,7 @@ class Website(Home):
         Most DBs will just have a website.page with '/' as URL and keep the
         homepage_url setting empty.
         """
-        homepage_url = request.website._get_cached('homepage_url')
+        homepage_url = request.website.homepage_url
         if homepage_url and homepage_url != '/':
             request.reroute(homepage_url)
 

--- a/addons/website/models/html_text_processor.py
+++ b/addons/website/models/html_text_processor.py
@@ -42,7 +42,7 @@ class WebsiteHTMLTextProcessor(models.AbstractModel):
         )
 
     def _get_processing_cache(self, cache_key):
-        """Get cached data from context, similar to website._get_cached() pattern
+        """Get cached data from context.
         :param cache_key: Key to get cached data from context
         :return: Cached data from context
         :rtype: dict

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -163,7 +163,7 @@ class IrHttp(models.AbstractModel):
         public_users = super()._get_public_users()
         website = request.env(user=SUPERUSER_ID)['website'].with_context(lang='en_US').get_current_website()  # sudo
         if website:
-            public_users.append(website._get_cached('user_id'))
+            public_users.append(website.user_id.id)
         return public_users
 
     @classmethod
@@ -174,7 +174,7 @@ class IrHttp(models.AbstractModel):
         if not request.session.uid:
             website = request.env(user=SUPERUSER_ID)['website'].with_context(lang='en_US').get_current_website()  # sudo
             if website:
-                request.update_env(user=website._get_cached('user_id'))
+                request.update_env(user=website.user_id.id)
 
         if not request.env.uid:
             super()._auth_method_public()
@@ -247,8 +247,8 @@ class IrHttp(models.AbstractModel):
         # propagate to the global context of the tab. If the company of
         # the website is not in the allowed companies of the user, set
         # the main company of the user.
-        website_company_id = website._get_cached('company_id')
-        if user.id == website._get_cached('user_id'):
+        website_company_id = website.company_id.id
+        if user == website.user_id:
             # avoid a read on res_company_user_rel in case of public user
             allowed_company_ids = [website_company_id]
         elif website_company_id in user._get_company_ids():
@@ -285,7 +285,7 @@ class IrHttp(models.AbstractModel):
     def _get_default_lang(cls):
         if getattr(request, 'is_frontend', True):
             website = request.env['website'].sudo().get_current_website()
-            return request.env['res.lang']._get_data(id=website._get_cached('default_lang_id'))
+            return request.env['res.lang']._get_data(id=website.default_lang_id.id)
         return super()._get_default_lang()
 
     @classmethod
@@ -413,7 +413,7 @@ class IrHttp(models.AbstractModel):
         if request.env.user.has_group('website.group_website_restricted_editor'):
             session_info.update({
                 'website_id': request.website.id,
-                'website_company_id': request.website._get_cached('company_id'),
+                'website_company_id': request.website.company_id.id,
             })
         session_info['bundle_params']['website_id'] = request.website.id
         return session_info

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -90,7 +90,7 @@ class IrQweb(models.AbstractModel):
         values.update(dict(
             website=current_website,
             is_view_active=lazy(lambda: current_website.is_view_active),
-            res_company=lazy(request.env['res.company'].browse(current_website._get_cached('company_id')).sudo),
+            res_company=lazy(current_website.company_id.sudo),
             translatable=translatable,
             editable=editable,
         ))

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -332,13 +332,11 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'website_page': 1,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
-            'website': 1,
-            # Check if website.cookies_bar is active
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 5, select_tables_perf, nocache=True)
-        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 5)
+        self._check_url_hot_query(self.page.url, 4, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 4)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -167,7 +167,7 @@
             <t t-foreach="frontend_languages.values()" t-as="lg">
         <link rel="alternate" t-att-hreflang="lg.hreflang" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, canonical_domain=canonical_domain)"/>
             </t>
-        <link rel="alternate" hreflang="x-default" t-att-href="url_localized(lang_code=website.env['res.lang']._get_data(id=website._get_cached('default_lang_id')).code, canonical_domain=canonical_domain)"/>
+        <link rel="alternate" hreflang="x-default" t-att-href="url_localized(lang_code=website.default_lang_id.code, canonical_domain=canonical_domain)"/>
         </t>
         <link rel="canonical" t-att-href="website._get_canonical_url()"/>
         <!-- TODO: Once we have style in DB, add this preconnect only if a
@@ -189,7 +189,7 @@
     </xpath>
 
     <xpath expr="//t[@t-set='body_classname']" position="after">
-        <t t-set="default_lang_code" t-value="website.env['res.lang']._get_data(id=website._get_cached('default_lang_id')).code"/>
+        <t t-set="default_lang_code" t-value="website.default_lang_id.code"/>
         <t t-set="mainobject_url" t-value="main_object.with_context(lang=default_lang_code).website_url if main_object and 'website_url' in main_object else ''"/>
         <t t-set="mainobject_url" t-value="mainobject_url.split('?')[0].split('#')[0]"/>
         <t t-set="mainobject_url" t-value="'_home' if mainobject_url == '/' else mainobject_url"/>

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -409,7 +409,7 @@ class IrHttp(models.AbstractModel):
     def _get_translations_for_webclient(self, modules, lang):
         if not lang:
             lang = self.env.context.get("lang")
-        lang_data = self.env['res.lang']._get_data(code=lang)
+        lang_data = self.env['res.lang'].sudo()._lang_get(lang)
         lang_params = {
             "name": lang_data.name,
             "code": lang_data.code,

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2803,7 +2803,7 @@ class IrQweb(models.AbstractModel):
         If debug=assets, the assets will be regenerated when a file which composes them has been modified.
         Else, the assets will be generated only once and then stored in cache.
         """
-        rtl = self.env['res.lang'].sudo()._get_data(code=(self.env.lang or self.env.user.lang)).direction == 'rtl'
+        rtl = self.env['res.lang'].sudo()._lang_get(code=(self.env.lang or self.env.user.lang)).direction == 'rtl'
         assets_params = self.env['ir.asset']._get_asset_params() # website_id
         debug_assets = debug and 'assets' in debug
 

--- a/odoo/addons/base/tests/test_res_lang.py
+++ b/odoo/addons/base/tests/test_res_lang.py
@@ -72,7 +72,7 @@ class test_res_lang(TransactionCase):
         dummy_data = ResLang._get_data(id=0)
 
         # test __eq__
-        self.env.registry.clear_cache()
+        self.env.registry.clear_cache('stable')
         self.assertEqual(ResLang._get_data(id=fr_id), fr_data)
         self.assertEqual(ResLang._get_data(id=0), dummy_data)
 
@@ -87,19 +87,22 @@ class test_res_lang(TransactionCase):
         # test dict conversion
         self.assertEqual(
             dict(ResLang._get_data(id=fr_id)),
-            ResLang.browse(fr_id).read(ResLang.CACHED_FIELDS)[0]
+            ResLang.browse(fr_id).read(ResLang._cached_data_fields)[0]
         )
         self.assertEqual(
             dict(ResLang._get_data(id=0)),
-            dict.fromkeys(ResLang.CACHED_FIELDS, False)
+            dict.fromkeys(ResLang._cached_data_fields, False) | {'id': False}
         )
 
         # test performance
         self.env.cache.clear()
-        self.env.registry.clear_cache()
+        self.env.registry.clear_cache('stable')
         # 1 query for res_lang +
         # 1 query for ir_attachment to compute `flag_image_url`
         with self.assertQueryCount(2):
+            # get cached field value for an active language
+            self.assertEqual(ResLang.browse(en_id).url_code, en_url_code)
+        with self.assertQueryCount(0):
             # get cached field value for an active language
             self.assertEqual(ResLang._get_data(code='en_US').url_code, en_url_code)
             # get another cached field value for another active language

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -814,7 +814,7 @@ class TestTranslationWrite(TransactionCase):
 
         langs = self.env['res.lang'].get_installed()
         self.assertEqual([('nl_NL', 'Dutch / Nederlands'), ('en_US', 'English (US)'), ('fr_FR', 'French / Français')], langs,
-                         "Test did not started with expected languages")
+                         "Test did not start with expected languages")
 
         belgium = self.env.ref('base.be')
         # vat_label is translatable and not required

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -20,6 +20,7 @@ from odoo.orm.models import (
     to_record_ids,
 )
 from odoo.orm.model_classes import is_model_class, is_model_definition
+from odoo.orm.models_cached import CachedModel
 from odoo.orm.models_transient import TransientModel
 from odoo.orm.query import Query, TableSQL
 from odoo.orm.table_objects import Constraint, Index, UniqueIndex

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -311,7 +311,7 @@ class Environment(Mapping[str, "BaseModel"]):
     def lang(self) -> str | None:
         """Return the current language code."""
         lang = self.context.get('lang')
-        if lang and lang != 'en_US' and not self['res.lang']._get_data(code=lang):
+        if lang and lang != 'en_US' and not self['res.lang']._lang_get(lang):
             # cannot translate here because we do not have a valid language
             raise UserError(f'Invalid language code: {lang}')  # pylint: disable=missing-gettext
         return lang or None

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -312,7 +312,7 @@ class BaseString(Field[str | typing.Literal[False]]):
             clean_records = records.filtered(lambda rec: rec.id not in dirty_ids)
             clean_records.invalidate_recordset([self.name])
             self._update_cache(records, cache_value, dirty=True)
-            if lang != 'en_US' and not records.env['res.lang']._get_data(code='en_US'):
+            if lang != 'en_US' and not records.env['res.lang']._lang_get('en_US'):
                 # if 'en_US' is not active, we always write en_US to make sure value_en is meaningful
                 self._update_cache(records.with_context(lang='en_US'), cache_value, dirty=True)
             return
@@ -377,7 +377,7 @@ class BaseString(Field[str | typing.Literal[False]]):
                 new_store_translations = new_translations
             new_store_translations[lang] = cache_value
 
-            if not records.env['res.lang']._get_data(code='en_US'):
+            if not records.env['res.lang']._lang_get('en_US'):
                 new_store_translations['en_US'] = cache_value
                 new_store_translations.pop('_en_US', None)
             new_translations_list.append(new_store_translations)

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -439,6 +439,10 @@ class BaseModel(metaclass=MetaModel):
     _fold_name: str = 'fold'         #: field to determine folded groups in kanban views
 
     _clear_cache_name: str = ''      # cache to clear on create/write/update
+    _clear_cache_on_fields: Iterable[str] | None = None
+    """the fields that trigger invalidation of cache named ``_clear_cache_name``,
+    ``None`` meaning all fields
+    """
 
     _translate: bool = True           # False disables translations export for this model (Old API) TODO deprecate/remove
     _check_company_auto: bool = False
@@ -3735,8 +3739,8 @@ class BaseModel(metaclass=MetaModel):
 
             # invalidate the cache
             if real_recs and (cache_name := self._clear_cache_name) and (
-                not hasattr(self, '_clear_cache_on_fields')
-                or not self._clear_cache_on_fields.isdisjoint(vals)
+                self._clear_cache_on_fields is None
+                or not vals.keys().isdisjoint(self._clear_cache_on_fields)
             ):
                 self.env.registry.clear_cache(cache_name)
 

--- a/odoo/orm/models_cached.py
+++ b/odoo/orm/models_cached.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import frozendict, ormcache
+
+from .models import Model
+
+
+class CachedModel(Model):
+    """ The abstract model 'ir.cached.data' is used as a mixin to provide a stable
+    cache for some fields of the model's records.  It uses the cache named
+    ``'stable'`` and automatically invalidates it based on ``_clear_cache_name``.
+    """
+    _register: bool = False  # not visible in ORM registry, meant to be Python-inherited only
+
+    _clear_cache_name = 'stable'
+
+    _cached_data_domain = []
+    """domain of the records to cache"""
+
+    _cached_data_fields: tuple[str] = ()
+    """the fields to cache for the records to cache. Please promise all these
+    fields don't depend on other models and context and are not translated."""
+
+    @property
+    def _clear_cache_on_fields(self):
+        return self._cached_data_fields
+
+    @ormcache(cache='stable')
+    def _cached_data(self) -> frozendict:
+        """ Return the cached values for all records that satisfy ``_cached_data_domain``.
+        The result is a mapping where keys are field names (including field ``id``)
+        and values are tuples of cached values.
+        """
+        fnames = self._cached_data_fields
+        assert fnames, "missing fields to cache"
+        records = self.sudo().with_context({'active_test': False}).search_fetch(
+            self._cached_data_domain, fnames, order='id')
+
+        # each field is mapped to a tuple
+        result = {'id': records._ids}
+        for fname in fnames:
+            field = self._fields[fname]
+            if field.compute and not field.store:
+                records.mapped(fname)  # fill the cache for computed field
+            result[fname] = tuple(map(field._get_cache(records.env).__getitem__, records.ids))
+        return frozendict(result)
+
+    def _fetch_field(self, field):
+        if any(self._ids) and field.name in self._cached_data_fields:
+            self._check_field_access(field, 'read')
+            data = self._cached_data()
+            field._insert_cache(self.browse(data['id']), data[field.name])
+            data_ids = set(data['id'])
+            if all(record_id in data_ids for record_id in self._ids):
+                self.check_access('read')
+                return
+        super()._fetch_field(field)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Some data is very commonly used and we have cached functions that return some data for them. We take this one step further to fill the transaction cache with the cached data.
We do this for: *res_lang, res_currency, res_country, res_company*. Companies was not in stable cache yet, but change very little; for example, a lot of record rules check `parent_id` or we get the currency of the company.

Current behavior before PR:
If we read a field that is not in transaction cache, a database query is done.
`env.ref('base.lang_en').code` will always query the database.

Desired behavior after PR is merged:
If we read a field that is not in transaction cache, if that field is cached data, then just fill the transaction cache from the ormcache.
`env.ref('base.lang_en').code` if cache is filled, just fill the transaction cache.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
