### PR TITLE
[IMP] l10n_tr*: add partner demo data with VAT exception

### DIFF
--- a/addons/l10n_tr/demo/demo_company.xml
+++ b/addons/l10n_tr/demo/demo_company.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="base.partner_demo_company_tr" model="res.partner" forcecreate="1">
+    <record id="base.partner_demo_company_tr" model="res.partner" context="{'no_vat_validation': True}" forcecreate="1">
         <field name="name">TR Company</field>
-        <field name="vat">3297552117</field>
+        <field name="vat">1234567801</field>
         <field name="street">3281. Cadde</field>
+        <field name="street2">Mavişehir Sokak, 5. Kat</field>
         <field name="city">İç Anadolu Bölgesi</field>
         <field name="country_id" ref="base.tr"/>
         <field name="state_id" ref="base.state_tr_81"/>
@@ -12,6 +13,51 @@
         <field name="email">info@company.trexample.com</field>
         <field name="website">www.trexample.com</field>
         <field name="is_company" eval="True"/>
+        <field name="ref">Düzce Vergi Dairesi Müdürlüğü</field>
+    </record>
+
+    <record id="l10n_tr_res_partner_1" model="res.partner" context="{'no_vat_validation': True}">
+        <field name="name">Başhisar Elektronik ve Hizmetler A.Ş.</field>
+        <field name="is_company">1</field>
+        <field name="vat">1234567802</field>
+        <field name="street">Üçhisar Mahallesi</field>
+        <field name="street2">Kaya Sokak No: 15</field>
+        <field name="city">Ürgüp</field>
+        <field name="country_id" ref="base.tr"/>
+        <field name="state_id" ref="base.state_tr_50"/>
+        <field name="zip">50240</field>
+        <field name="phone">+90 509 987 12 34</field>
+        <field name="email">demo.elektronik@company.trexample.com</field>
+        <field name="website">http://www.demo-elektronik-example.com</field>
+        <field name="ref">Nevşehir Vergi Dairesi Müdürlüğü</field>
+    </record>
+
+    <record id="l10n_tr_res_partner_2" model="res.partner">
+        <field name="name">T.C. Sağlık Bakanlığı – Konak Belediyesi Başkanlığı</field>
+        <field name="vat">42451934800</field>
+        <field name="street">Atatürk Caddesi</field>
+        <field name="street2">Konak Sokak, No: 45</field>
+        <field name="city">Konak Belediyesi</field>
+        <field name="country_id" ref="base.tr"/>
+        <field name="state_id" ref="base.state_tr_35"/>
+        <field name="zip">35100</field>
+        <field name="phone">+90 500 987 56 00</field>
+        <field name="email">kamu@gmail.trexample.com</field>
+        <field name="website">http://www.kamu-example.com</field>
+        <field name="ref">İzmir Vergi Dairesi Başkanlığı</field>
+    </record>
+
+    <record id="l10n_tr_res_partner_3" model="res.partner" context="{'no_vat_validation': True}">
+        <field name="name">Ayşe Yılmaz</field>
+        <field name="vat">02098712345</field>
+        <field name="street">İstiklal Caddesi No: 50</field>
+        <field name="street2">Daire: 7, Kat: 3</field>
+        <field name="city">Beyoğlu</field>
+        <field name="country_id" ref="base.tr"/>
+        <field name="state_id" ref="base.state_tr_34"/>
+        <field name="zip">34000</field>
+        <field name="phone">+90 599 987 56 00</field>
+        <field name="email">ayseyilmaz@trexample.com</field>
     </record>
 
     <record id="base.demo_company_tr" model="res.company" forcecreate="1">

--- a/addons/l10n_tr_nilvera_einvoice/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__manifest__.py
@@ -11,6 +11,9 @@ For sending and receiving electronic invoices to Nilvera.
         'data/res_partner_category_data.xml',
         'views/account_move_views.xml',
     ],
+    'demo': [
+        'demo/demo_company.xml',
+    ],
     'auto_install': ['l10n_tr_nilvera'],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/l10n_tr_nilvera_einvoice/demo/demo_company.xml
+++ b/addons/l10n_tr_nilvera_einvoice/demo/demo_company.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="partner_demo_company_tr_tag" model="res.partner.category">
+        <field name="name">0-123456780100019</field>
+        <field name="parent_id" ref="l10n_tr_nilvera_einvoice.res_partner_category_mersisno"/>
+        <field name="color" eval="3"/>
+    </record>
+
+    <record id="l10n_tr_res_partner_1_tag" model="res.partner.category">
+        <field name="name">0-123456780200020</field>
+        <field name="parent_id" ref="l10n_tr_nilvera_einvoice.res_partner_category_mersisno"/>
+        <field name="color" eval="4"/>
+    </record>
+
+    <record id="l10n_tr_res_partner_2_tag" model="res.partner.category">
+        <field name="name">0-424519348000017</field>
+        <field name="parent_id" ref="l10n_tr_nilvera_einvoice.res_partner_category_mersisno"/>
+        <field name="color" eval="5"/>
+    </record>
+
+    <record id="base.partner_demo_company_tr" model="res.partner">
+        <field eval="[Command.set([ref('partner_demo_company_tr_tag')])]" name="category_id"/>
+    </record>
+
+    <record id="l10n_tr.l10n_tr_res_partner_1" model="res.partner">
+        <field eval="[Command.set([ref('l10n_tr_res_partner_1_tag')])]" name="category_id"/>
+    </record>
+
+    <record id="l10n_tr.l10n_tr_res_partner_2" model="res.partner">
+        <field eval="[Command.set([ref('l10n_tr_res_partner_2_tag')])]" name="category_id"/>
+    </record>
+</odoo>

--- a/addons/l10n_tr_nilvera_einvoice_extended/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/__manifest__.py
@@ -26,6 +26,9 @@ Features include:
         'views/product_views.xml',
         'views/res_config_settings_views.xml',
     ],
+    'demo': [
+        'demo/demo_company.xml',
+    ],
     'auto_install': ['l10n_tr_nilvera_einvoice'],
     'installable': True,
     'post_init_hook': '_l10n_tr_nilvera_einvoice_extended_post_init',

--- a/addons/l10n_tr_nilvera_einvoice_extended/demo/demo_company.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/demo/demo_company.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="base.partner_demo_company_tr" model="res.partner">
+        <field name="l10n_tr_tax_office_id" ref="l10n_tr_nilvera_einvoice_extended.l10n_tr_nilvera_einvoice_extended_tax_office_1045"></field>
+    </record>
+
+    <record id="l10n_tr.l10n_tr_res_partner_1" model="res.partner">
+        <field name="l10n_tr_tax_office_id" ref="l10n_tr_nilvera_einvoice_extended.l10n_tr_nilvera_einvoice_extended_tax_office_763"></field>
+    </record>
+
+    <record id="l10n_tr.l10n_tr_res_partner_2" model="res.partner">
+        <field name="l10n_tr_tax_office_id" ref="l10n_tr_nilvera_einvoice_extended.l10n_tr_nilvera_einvoice_extended_tax_office_545"></field>
+    </record>
+</odoo>


### PR DESCRIPTION
The purpose of adding this demo data is to simplify the setup for the demo and test scenarios of Turkish E-Invoice workflows, which currently require a lengthy and manual configuration process.

**Techincal**:
Added demo data with `no_vat_validation` as they do not support the tr VAT format, but are required for test purposes.
These numbers are given by Nilvera.

task-5116372