### PR TITLE
[REF] hr: remove `hr.job.allowed_user_ids`

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -33,8 +33,6 @@ class HrJob(models.Model):
         help="The Recruiter will be the default value for all Applicants in this job \
             position. The Recruiter is automatically added to all meetings with the Applicant.",
     )
-    # TODO (master): remove the field `allowed_user_ids`.
-    allowed_user_ids = fields.Many2many('res.users', compute='_compute_allowed_user_ids', readonly=True)
     department_id = fields.Many2one('hr.department', string='Department', check_company=True, tracking=True, index='btree_not_null')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, tracking=True)
     contract_type_id = fields.Many2one('hr.contract.type', string='Contract Type', tracking=True)
@@ -55,28 +53,6 @@ class HrJob(models.Model):
         for job in self:
             job.no_of_employee = result.get(job.id, 0)
             job.expected_employees = result.get(job.id, 0) + job.no_of_recruitment
-
-    @api.depends("company_id")
-    def _compute_allowed_user_ids(self):
-        company_ids = self.mapped("company_id.id")
-        domain = [("share", "=", False)]
-        if company_ids:
-            domain += [("company_ids", "in", company_ids)]
-
-        users_by_company = dict(
-            self.env["res.users"]._read_group(
-                domain=domain,
-                groupby=["company_id"],
-                aggregates=["id:recordset"],
-            ),
-        )
-
-        all_users = self.env["res.users"]
-        for users in users_by_company.values():
-            all_users |= users
-
-        for job in self:
-            job.allowed_user_ids = users_by_company.get(job.company_id, all_users)
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Following odoo/odoo@278216a81c84f12010c6050379973953348aeb61, the field `hr.job.allowed_user_ids` has been deprecated.

This commits removes the field itself, as it shouldn't be required anymore.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
