### PR TITLE
[FIX] mail, im_livechat: prevent notification when invited to meeting

### DIFF
--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -267,6 +267,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         "type": "discuss.channel/joined",
                         "payload": {
                             "channel_id": discuss_channel.id,
+                            "invite_to_rtc_call": False,
                             "data": channel_data_join,
                             "invited_by_user_id": self.env.user.id,
                         },

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -606,6 +606,7 @@ class DiscussChannel(models.Model):
             for member in new_members:
                 payload = {
                     "channel_id": member.channel_id.id,
+                    "invite_to_rtc_call": invite_to_rtc_call,
                     "data": Store(bus_channel=member._bus_channel())
                     .add(member.channel_id)
                     .add(member, "unpin_dt")

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -15,14 +15,24 @@ export class DiscussCorePublicWeb {
         this.busService = services.bus_service;
         this.notificationService = services.notification;
         this.busService.subscribe("discuss.channel/joined", async (payload) => {
-            const { data, channel_id, invited_by_user_id: invitedByUserId } = payload;
+            const {
+                data,
+                channel_id,
+                invited_by_user_id: invitedByUserId,
+                invite_to_rtc_call: inviteToRtcCall,
+            } = payload;
             this.store.insert(data);
             await this.store.fetchChannel(channel_id);
             const thread = this.store["mail.thread"].get({
                 id: channel_id,
                 model: "discuss.channel",
             });
-            if (thread && invitedByUserId && invitedByUserId !== this.store.self_user?.id) {
+            if (
+                !inviteToRtcCall &&
+                thread &&
+                invitedByUserId &&
+                invitedByUserId !== this.store.self_user?.id
+            ) {
                 this.notificationService.add(
                     _t("You have been invited to #%s", thread.displayName),
                     { type: "info" }


### PR DESCRIPTION
Before this PR, when inviting someone to a meeting, they received both a call invitation card and a channel invited notification, which was redundant. This change removes the duplicate notification, keeping only the call invitation card for clarity.

<img width="613" height="200" alt="image" src="https://github.com/user-attachments/assets/dd525c84-4ee4-4961-88e5-a17cf3938785" />


part of task- [5227387](https://www.odoo.com/odoo/project/1519/tasks/5227387)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
