### PR TITLE
[FIX] purchase_stock: prevent error when making replenishment with Buy route

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -260,7 +260,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_default_supplier(self):
         self.ensure_one()
-        if self.show_supplier:
+        if self.show_supplier and self.product_id:
             return self._get_default_rule()._get_matching_supplier(
                 self.product_id, self.qty_to_order, self.product_uom, self.company_id, {}
             )
@@ -304,7 +304,7 @@ class StockWarehouseOrderpoint(models.Model):
     def _get_replenishment_multiple_alternative(self, qty_to_order):
         self.ensure_one()
         routes = self.effective_route_id or self.product_id.route_ids
-        if not any(r.action == 'buy' for r in routes.rule_ids):
+        if not (self.product_id and any(r.action == 'buy' for r in routes.rule_ids)):
             return super()._get_replenishment_multiple_alternative(qty_to_order)
         planned_date = self._get_orderpoint_procurement_date()
         global_horizon_days = self.get_horizon_days()

--- a/addons/purchase_stock/static/tests/tours/product_replenishment.js
+++ b/addons/purchase_stock/static/tests/tours/product_replenishment.js
@@ -1,0 +1,63 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_product_replenishment", {
+    steps: () => [
+        // Show Route column
+        {
+            content: "Open line fields list",
+            trigger: ".o_optional_columns_dropdown_toggle",
+            run: "click",
+        },
+        {
+            content: "Show route column",
+            trigger: '.o-dropdown-item input[name="route_id"]',
+            run: async ({ anchor }) => {
+                // We need this condition because `route_id` field is hidden by
+                // default except if `purchase_mrp` is installed.
+                if (!anchor.checked) {
+                    anchor.click();
+                }
+            },
+        },
+        {
+            content: "Close line fields list",
+            trigger: ".o_optional_columns_dropdown_toggle",
+            run: "click",
+        },
+        // Create reordering rule for product 'Book Shelf'
+        {
+            content: "Click New Button",
+            trigger: 'button:contains("New")',
+            run: "click",
+        },
+        {
+            content: "Select Buy Route",
+            trigger: '.o_selected_row .o_list_many2one[name="route_id"] input',
+            run: "edit Buy",
+        },
+        {
+            content: "Valid Route",
+            trigger: '.ui-menu-item-wrapper:contains("Buy")',
+            run: "click",
+        },
+        {
+            content: "Select Product",
+            trigger: '.o_selected_row .o_list_many2one[name="product_id"] input',
+            run: "edit Book Shelf",
+        },
+        {
+            content: "Valid Product",
+            trigger: '.ui-menu-item-wrapper:contains("Book Shelf")',
+            run: "click",
+        },
+        {
+            content: "Save the Rule",
+            trigger: 'button:contains("Save")',
+            run: "click",
+        },
+        {
+            content: "Wait for the reordering rule to be added",
+            trigger: '.o_data_row td:contains("Book Shelf")',
+        },
+    ],
+});

--- a/addons/purchase_stock/tests/__init__.py
+++ b/addons/purchase_stock/tests/__init__.py
@@ -22,6 +22,7 @@ from . import test_purchase_stock_report
 from . import test_reordering_rule
 from . import test_replenish_wizard
 from . import test_routes
+from . import test_stock_orderpoint
 from . import test_stockvaluation
 from . import test_supplier
 from . import test_uninstall

--- a/addons/purchase_stock/tests/test_stock_orderpoint.py
+++ b/addons/purchase_stock/tests/test_stock_orderpoint.py
@@ -1,0 +1,19 @@
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestStockWarehouseOrderpoint(HttpCase):
+
+    def test_product_replenishment(self):
+        product = self.env['product.product'].create({
+            'name': 'Book Shelf',
+            'lst_price': 1750.00,
+            'is_storable': True,
+            'purchase_ok': True,
+        })
+        self.assertFalse(product.orderpoint_ids)
+
+        self.start_tour("/odoo/replenishment", "test_product_replenishment", login='admin')
+
+        self.assertEqual(len(product.orderpoint_ids), 1)
+        self.assertEqual(product.orderpoint_ids[0].route_id.name, 'Buy')


### PR DESCRIPTION
Currently, an error is produced when creating a new replenishment record for using the **Buy** route.

**Steps to Reproduce:**
1. Install `purchase_stock` module with demo data.
2. Inventory > Operations > Replenishment.
3. Make **Route** field visible in the list.
3. Click **New**, and select the **"Buy"** in Route.

**Error:**
`TypeError - combine() argument 1 must be datetime.date, not bool`

**Cause:**
The method `_get_orderpoint_procurement_date()` expects a valid lead horizon date but receives a boolean value when the product is not set. This leads to a traceback during the computation.

**Fix:**
The commit handles the replenishment computation when a product is not defined. As a result, creating a replenishment with the "Buy" route works correctly even when the product is not defined.

sentry-6928858334