### PR TITLE
[FIX] stock: prevent error when location is unset in stock quant form view

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -589,6 +589,9 @@ class StockQuant(models.Model):
     def _compute_display_name(self):
         """name that will be displayed in the detailed operation"""
         for record in self:
+            if not record.ids:
+                record.display_name = ''
+                continue
             name = [record.location_id.display_name]
             if record.lot_id:
                 name.append(record.lot_id.name)


### PR DESCRIPTION
Currently, an error is produced when accessing the stock quant form view without a location set.

**Steps to Reproduce:**
1. Install the Inventory module.
2. Create a product with tracking enabled (By Unique Serial Number).
3. Click **"Update Quantity"** (opens list view).
4. Click **New**, click View on the unsaved record (opens form view).
5. Remove the Location field.

**Error:**
`TypeError - sequence item 0: expected str instance, bool found`

**Cause:**
In the display name computation at [1], the system attempts to join name parts where one of them can be `False` if the location is not set.

**Fix:**
Before generating the display name, it now checks whether the record is saved (record.ids). If the record is unsaved (no ID), it sets an empty `display_name` and skips the name-joining logic.

[1] - https://github.com/odoo/odoo/blob/16e889bf5885c4d827b8c2c5dce102f98aad689f/addons/stock/models/stock_quant.py#L599

sentry-6717759358