### PR TITLE
[FIX] discuss: increase the ping tolerance for rtc sessions

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -157,4 +157,4 @@ class MailRtcSession(models.Model):
 
     @api.model
     def _inactive_rtc_session_domain(self):
-        return [('write_date', '<', fields.Datetime.now() - relativedelta(minutes=1))]
+        return [('write_date', '<', fields.Datetime.now() - relativedelta(minutes=1, seconds=15))]


### PR DESCRIPTION
Before this commit, the ping to keep rtc sessions alive was done
every 30 seconds and had a 1 minute timeframe to successfully ping,
which meant that missing a single ping would drop the rtc session.

This commit increases the timeframe to 1 minutes and 15 seconds so that
one ping can be missed.

This can help preventing disconnections when the Odoo server is
slow, as calls can work fine without a stable connection to the odoo
server (since P2P and SFU connections are independent from Odoo once
the connections are initialized).

task-5177246