### PR TITLE
[FIX] hr_attendance: merge computes and optimize _update_overtime

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -801,8 +801,3 @@ class TestHrAttendanceOvertime(TransactionCase):
             'check_out': datetime(2023, 1, 4, 18, 0)
         })
         self.assertEqual(attendance.validated_overtime_hours, previous, "Extra hours shouldn't be recomputed")
-
-        # Changing check out should recompute extra hours
-        with Form(attendance) as attendance_form:
-            attendance_form.check_out = datetime(2023, 1, 2, 19, 15)
-        self.assertAlmostEqual(attendance.validated_overtime_hours, 2.25, 2)


### PR DESCRIPTION
Before this commit:

Intermediate values `__set__` on `overtime_hours` for records outside of `self` would trigger the compute of `validated_overtime_hours` and persist in the database with this value.

Additionally, `_update_overtime` would recompute the fields for all the affected employees' attendance records, which is unnecessary when the functions `create`, `write`, and `unlink` operate within a certain timeframe of records.

After this commit:
`validated_overtime_hours`  is computed with `overtime_hours` in a merged function, and it does not overwrite values set by the user.
`_update_overtime` now recomputes the attendances in its time scope instead of the global recompute for all affected employees' attendance

opw-4946761
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
