### PR TITLE
[IMP] hr_recruitment: Add matching to talent applications

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -200,21 +200,8 @@ class HrApplicant(models.Model):
         if not indirectly_linked:
             return
 
-        all_emails = {a.email_normalized for a in indirectly_linked if a.email_normalized}
-        all_phones = {a.partner_phone_sanitized for a in indirectly_linked if a.partner_phone_sanitized}
-        all_linkedins = {a.linkedin_profile for a in indirectly_linked if a.linkedin_profile}
-
-        epl_domain = Domain.FALSE
-        if all_emails:
-            epl_domain |= Domain("email_normalized", "in", list(all_emails))
-        if all_phones:
-            epl_domain |= Domain("partner_phone_sanitized", "in", list(all_phones))
-        if all_linkedins:
-            epl_domain |= Domain("linkedin_profile", "in", list(all_linkedins))
-
-        pool_domain = Domain(["|", ("talent_pool_ids", "!=", False), ("pool_applicant_id", "!=", False)])
-        domain = pool_domain & epl_domain
-        in_pool_applicants = self.env["hr.applicant"].with_context(active_test=True).search(domain)
+        domain = self._get_similar_applicants_domain() & Domain(["|", ("talent_pool_ids", "!=", False), ("pool_applicant_id", "!=", False)])
+        in_pool_applicants = self.env["hr.applicant"].with_context(active_test=False).search(domain)
 
         in_pool_emails = defaultdict(int)
         in_pool_phones = defaultdict(int)
@@ -318,9 +305,7 @@ class HrApplicant(models.Model):
             if applicant.pool_applicant_id:
                 related_ids.update(pool_applicant_map.get(applicant.pool_applicant_id, set()))
 
-            count = len(related_ids)
-
-            applicant.application_count = max(0, count)
+            applicant.application_count = len(related_ids)
 
     @api.depends("talent_pool_ids")
     def _compute_is_pool(self):
@@ -329,7 +314,7 @@ class HrApplicant(models.Model):
 
     def _get_similar_applicants_domain(self, ignore_talent=False, only_talent=False):
         """
-        This method returns a domain for the applicants whitch match with the
+        This method returns a domain for the applicants which match with the
         current applicant according to email_from, partner_phone or linkedin_profile.
         Thus, search on the domain will return the current applicant as well
         if any of the following fields are filled.
@@ -382,21 +367,8 @@ class HrApplicant(models.Model):
         if not indirect:
             return
 
-        all_emails = {a.email_normalized for a in indirect if a.email_normalized}
-        all_phones = {a.partner_phone_sanitized for a in indirect if a.partner_phone_sanitized}
-        all_linkedins = {a.linkedin_profile for a in indirect if a.linkedin_profile}
-
-        epl_domain = Domain.FALSE
-        if all_emails:
-            epl_domain |= Domain("email_normalized", "in", list(all_emails))
-        if all_phones:
-            epl_domain |= Domain("partner_phone_sanitized", "in", list(all_phones))
-        if all_linkedins:
-            epl_domain |= Domain("linkedin_profile", "in", list(all_linkedins))
-
-        pool_domain = Domain(["|", ("talent_pool_ids", "!=", False), ("pool_applicant_id", "!=", False)])
-        domain = pool_domain & epl_domain
-        in_pool_applicants = self.env["hr.applicant"].with_context(active_test=True).search(domain)
+        domain = self._get_similar_applicants_domain() & Domain(["|", ("talent_pool_ids", "!=", False), ("pool_applicant_id", "!=", False)])
+        in_pool_applicants = self.env["hr.applicant"].with_context(active_test=False).search(domain)
         in_pool_data = {"emails": set(), "phones": set(), "linkedins": set()}
 
         for applicant in in_pool_applicants:
@@ -881,14 +853,13 @@ class HrApplicant(models.Model):
 
     def action_job_add_applicants(self):
         return {
-            "name": _("Create Applications"),
+            "name": _("Apply to Jobs"),
             "type": "ir.actions.act_window",
             "res_model": "job.add.applicants",
             "target": "new",
             "views": [[False, "form"]],
             "context": {
                 "is_modal": True,
-                "dialog_size": "medium",
                 "default_applicant_ids": self.ids
                 or self.env.context.get("default_applicant_ids"),
             },

--- a/addons/hr_recruitment/static/src/scss/job_add_applicants.scss
+++ b/addons/hr_recruitment/static/src/scss/job_add_applicants.scss
@@ -1,0 +1,6 @@
+.o_job_add_applicants {
+    .o_form_nosheet {
+        padding-top: 8px !important;
+        padding-bottom: 0px !important;
+    }
+}

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -96,7 +96,11 @@
                 <button string="Refuse" name="archive_applicant" type="object" invisible="not active or is_pool_applicant" data-hotkey="d"/>
                 <button string="Restore" name="action_unarchive" type="object" invisible="active" data-hotkey="x"/>
                 <field name="stage_id" widget="rotting_statusbar_duration" options="{'clickable': '1'}" invisible="(not active and not employee_id) or is_pool_applicant"/>
-                <button string="Create Applications" name="action_job_add_applicants" type="object" invisible="not is_pool_applicant"/>
+                <button string="Apply to Jobs"
+                        name="action_job_add_applicants"
+                        type="object"
+                        invisible="not is_pool_applicant"
+                />
                 <button string="Add to Pool" name="action_talent_pool_add_applicants" type="object" invisible="is_pool_applicant or is_applicant_in_pool"/>
             </header>
             <sheet>
@@ -730,5 +734,13 @@
         <field name="context">{'default_res_model': 'hr.applicant', 'default_res_ids': active_ids}</field>
         <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="binding_view_types">list,kanban</field>
+    </record>
+    <record id="action_job_add_applicants" model="ir.actions.server">
+        <field name="name">Apply to Jobs</field>
+        <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
+        <field name="state">code</field>
+        <field name="code">action = records.action_job_add_applicants()</field>
+        <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
+        <field name="binding_view_types">form</field>
     </record>
 </odoo>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -423,10 +423,10 @@
         <field name="inherit_id" ref="hr.view_hr_job_tree"/>
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="department_id"/>
+                <field name="department_id" optional="hide"/>
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                 <field name="open_application_count" string="Open Applications" groups="hr_recruitment.group_hr_recruitment_interviewer" optional="hide"/>
-                <field name="no_of_recruitment" optional="hide"/>
+                <field name="no_of_recruitment"/>
             </field>
             <field name="no_of_employee" position="after">
                 <field name="expected_employees" optional="hide"

--- a/addons/hr_recruitment/wizard/job_add_applicants_views.xml
+++ b/addons/hr_recruitment/wizard/job_add_applicants_views.xml
@@ -4,14 +4,27 @@
         <field name="name">job.add.applicants.view.form</field>
         <field name="model">job.add.applicants</field>
         <field name="arch" type="xml">
-            <form string="Add Applicants to Pool">
+            <form string="Add Applicants to Pool" class="o_job_add_applicants">
                 <group>
-                    <field name="job_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" placeholder="Move to..."/>
+                    <p class="text-muted">
+                        Duplicates this Applicant/Talent profile for the selected Job Position(s) 
+                    </p>
+                </group>
+                <div class="my-3"/>
+                <group>
+                    <field
+                        name="job_ids"
+                        widget="many2many_tags"
+                        options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"
+                        placeholder="Add to New Job"
+                        domain="[('id', 'not in', context.get('active_applicant_job_ids', []))]"
+                        context="{'show_matching_score_in_name': True}"
+                    />
                 </group>
                 <footer>
                     <button
                         name="action_add_applicants_to_job"
-                        string="Create Applications"
+                        string="Apply"
                         type="object"
                         class="btn-primary"
                         data-hotkey="q"

--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -133,6 +133,20 @@ class HrApplicant(models.Model):
                 mapped_commands.append(command)
         return mapped_commands
 
+    def action_job_add_applicants(self):
+        res = super().action_job_add_applicants()
+        if len(self.ids) == 1:
+            res["context"]["active_applicant_skill_ids"] = self.skill_ids.ids
+            res["context"]["active_applicant_id"] = self.id
+            applicant_job_ids = self.job_id
+            if self.pool_applicant_id:
+                applicant_job_ids += self.pool_applicant_id.linked_applicant_ids.job_id
+            else:
+                domain = self._get_similar_applicants_domain()
+                applicant_job_ids += self.env["hr.applicant"].search(domain).job_id
+            res["context"]["active_applicant_job_ids"] = applicant_job_ids.ids
+        return res
+
     def action_add_to_job(self):
         self.with_context(just_moved=True).write(
             {

--- a/addons/hr_recruitment_skills/models/hr_job.py
+++ b/addons/hr_recruitment_skills/models/hr_job.py
@@ -10,38 +10,38 @@ class HrJob(models.Model):
 
     applicant_matching_score = fields.Float(string="Matching Score(%)", compute="_compute_applicant_matching_score",
         groups="hr_recruitment.group_hr_recruitment_interviewer")
+    matching_applicant_skill_ids = fields.Many2many(string="Matching Skills", comodel_name='hr.skill',
+        compute="_compute_applicant_matching_score", groups="hr_recruitment.group_hr_recruitment_interviewer")
+    missing_applicant_skill_ids = fields.Many2many(string="Missing Skills", comodel_name='hr.skill',
+        compute="_compute_applicant_matching_score", groups="hr_recruitment.group_hr_recruitment_interviewer")
 
     @api.depends_context("active_applicant_id")
     def _compute_applicant_matching_score(self):
-        active_applicant_id = self.env.context.get("active_applicant_id")
-        if not active_applicant_id:
-            for job in self:
-                job.applicant_matching_score = False
-            return
+        active_applicant_id = self.env.context.get("active_applicant_id", [])
 
         applicant = self.env["hr.applicant"].browse(active_applicant_id)
-        for job in self:
-            if not job.job_skill_ids:
-                job.applicant_matching_score = False
-                continue
-            job_skills = job.job_skill_ids
-            job_degree = job.expected_degree.score * 100
-            job_total = sum(job.job_skill_ids.mapped("level_progress")) + job_degree
-            job_skill_map = {js.skill_id.id: js.level_progress for js in job_skills}
+        applicant_skill_map = {a.skill_id.id: a.level_progress for a in applicant.current_applicant_skill_ids}
 
-            matching_applicant_skills = applicant.current_applicant_skill_ids.filtered(
-                lambda a: a.skill_id.id in job_skill_map,
-            )
+        for job in self:
+            if not active_applicant_id or not job.job_skill_ids:
+                job.applicant_matching_score = False
+                job.matching_applicant_skill_ids = False
+                job.missing_applicant_skill_ids = False
+                continue
+
+            job_degree = job.expected_degree.score * 100
+            job_total = job_degree
             applicant_degree = applicant.type_id.score * 100 if job_degree > 1 else 0
-            applicant_total = (
-                sum(
-                    min(skill.level_progress, job_skill_map[skill.skill_id.id] * 2)
-                    for skill in matching_applicant_skills
-                )
-                + applicant_degree
-            )
+            applicant_total = applicant_degree
+            for skill in job.job_skill_ids:
+                job_total += skill.level_progress
+                applicant_total += min(applicant_skill_map.get(skill.skill_id.id, 0), skill.level_progress * 2)
 
             job.applicant_matching_score = applicant_total / job_total * 100
+            job.matching_applicant_skill_ids = job.skill_ids.filtered(
+                lambda js: js.id in applicant_skill_map,
+            )
+            job.missing_applicant_skill_ids = job.skill_ids - job.matching_applicant_skill_ids
 
     def action_search_matching_applicants(self):
         self.ensure_one()
@@ -75,3 +75,22 @@ class HrJob(models.Model):
             'help': Markup("<p class='o_view_nocontent_empty_folder'>%s</p><p>%s</p>") % (help_message_1, help_message_2),
         })
         return action
+
+    def _compute_display_name(self):
+        super()._compute_display_name()
+        if self.env.context.get("show_matching_score_in_name", False):
+            for job in self:
+                if job.applicant_matching_score:
+                    name = f"{job.display_name or job.name} \t --{job.applicant_matching_score:.0f}%--"
+                    job.display_name = name.strip()
+
+    @api.model
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        if self.env.context.get('show_matching_score_in_name'):
+            records = self.search_fetch(
+                domain=[('id', 'not in', self.env.context.get('active_applicant_job_ids', []))],
+                field_names=['display_name'],
+            )
+            records = records.sorted(lambda a: (a.no_of_recruitment > 0, a.applicant_matching_score), reverse=True)[:limit]
+            return [(r.id, r.display_name) for r in records]
+        return super().name_search(name, domain, operator, limit)

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -33,24 +33,14 @@
                                 <!-- empty group to align matching and missing skills below the job position matching widget -->
                             </group>
                             <group>
-                                <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="is_pool_applicant"/>
+                                <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="is_pool_applicant"/>
                             </group>
                         </group>
                     </div>
                 </page>
             </notebook>
         </field>
-    </record>
-
-    <record id="action_find_matching_job" model="ir.actions.act_window">
-        <field name="name">Matching Positions</field>
-        <field name="res_model">hr.job</field>
-        <field name="view_mode">list</field>
-        <field name="target">current</field>
-        <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
-        <field name="binding_view_types">form</field>
-        <field name="context">{'active_applicant_id': active_id,}</field>
     </record>
 
     <record id="hr_applicant_view_search_bis" model="ir.ui.view">

--- a/addons/hr_recruitment_skills/views/hr_job_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_job_views.xml
@@ -5,10 +5,13 @@
         <field name="model">hr.job</field>
         <field name="inherit_id" ref="hr_recruitment.hr_job_view_tree_inherit"/>
         <field name="arch" type="xml">
-            <field name="department_id" position="after">
-                <field name="applicant_matching_score" widget="progressbar"
-                    groups="hr_recruitment.group_hr_recruitment_interviewer"
-                    invisible="not applicant_matching_score" column_invisible="not context.get('active_applicant_id')"/>
+            <field name="open_application_count" position="before">
+                <field name="applicant_matching_score" string="Matching" widget="progressbar" options="{'overflow_class': 'bg-success'}"
+                    column_invisible="not context.get('active_applicant_id') and not context.get('active_applicant_skill_ids')"/>
+                <field name="matching_applicant_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"
+                    column_invisible="not context.get('active_applicant_skill_ids')"/>
+                <field name="missing_applicant_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"
+                    column_invisible="not context.get('active_applicant_skill_ids')"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This commit adds general improvements to the `hr.applicant`, `hr.job`, and `job.add.applicant` views.

- On `job.add.applicant`, show for each job application the `applicant_matching_score` for the current applicant.
- In `view_hr_job_tree` hid unnecessary fields and added matching fields.

task-5184168

