### PR TITLE
[FIX] web: calendar: dummy catchall props for Calendar components

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -108,7 +108,7 @@ export class CalendarCommonRenderer extends Component {
             slotLabelFormat: is24HourFormat() ? HOUR_FORMATS[24] : HOUR_FORMATS[12],
             snapDuration: { minutes: 15 },
             timeZone: luxon.Settings.defaultZone.name,
-            timeGridEventMinHeight : 15,
+            timeGridEventMinHeight: 15,
             unselectAuto: false,
             weekLabel: this.props.model.scale === "month" && this.env.isSmall ? "" : _t("Week"),
             weekends: this.props.isWeekendVisible,
@@ -351,6 +351,7 @@ export class CalendarCommonRenderer extends Component {
         });
     }
 }
+CalendarCommonRenderer.props = ["*"];
 CalendarCommonRenderer.components = {
     Popover: CalendarCommonPopover,
 };

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -373,6 +373,7 @@ export class CalendarController extends Component {
         browser.localStorage.setItem("calendar.isWeekendVisible", this.state.isWeekendVisible);
     }
 }
+CalendarController.props = ["*"];
 CalendarController.components = {
     DatePicker: DateTimePicker,
     FilterPanel: CalendarFilterPanel,

--- a/addons/web/static/src/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_renderer.js
@@ -28,6 +28,7 @@ export class CalendarRenderer extends Component {
         };
     }
 }
+CalendarRenderer.props = ["*"];
 CalendarRenderer.components = {
     day: CalendarCommonRenderer,
     week: CalendarCommonRenderer,

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -182,7 +182,7 @@ export class CalendarFilterPanel extends Component {
         this.props.model.createFilter(fieldName, filterValue);
     }
 }
-
+CalendarFilterPanel.props = ["*"];
 CalendarFilterPanel.components = {
     AutoComplete,
     Transition,


### PR DESCRIPTION
Some Components used by the calendar view did not have props set, which triggered warnings on the runbot. This has been corrected in saas-17.2 with odoo/odoo@dd583fd670e0ee03b04711780bad2429b18a0788

In the meantime, to avoid warnings, we just set props = ["*"] to avoid breaking the component's API

related PR for which the runbot warns: https://github.com/odoo/enterprise/pull/98903

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
