### PR TITLE
[IMP] web,calendar: add attendee partner popover

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.js
@@ -1,11 +1,11 @@
-import { Component } from "@odoo/owl";
-import { registry } from "@web/core/registry";
-import {
-    Many2ManyTagsAvatarField,
-    many2ManyTagsAvatarField,
-} from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
-import { useSpecialData } from "@web/views/fields/relational_utils";
+import { AvatarTag } from "@web/core/tags_list/avatar_tag";
 import { ConnectionLostError } from "@web/core/network/rpc";
+import {
+    Many2ManyTagsAvatarUserField,
+    many2ManyTagsAvatarUserField,
+} from "@mail/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field";
+import { registry } from "@web/core/registry";
+import { useSpecialData } from "@web/views/fields/relational_utils";
 
 const ICON_BY_STATUS = {
     accepted: "fa-check",
@@ -13,16 +13,21 @@ const ICON_BY_STATUS = {
     tentative: "fa-question",
 };
 
-export class AttendeeTag extends Component {
+export class AttendeeTag extends AvatarTag {
     static template = "calendar.AttendeeTag";
-    static props = ["imageUrl", "isUnavailable?", "noEmail?", "onDelete?", "status?", "text", "tooltip"];
+    static props = {
+        ...AvatarTag.props,
+        isUnavailable: { type: Boolean, optional: true },
+        noEmail: { type: Boolean, optional: true },
+        status: { type: String, optional: true },
+    };
 
     get statusIcon() {
         return ICON_BY_STATUS[this.props.status];
     }
 }
 
-export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
+export class Many2ManyAttendee extends Many2ManyTagsAvatarUserField {
     static template = "calendar.Many2ManyAttendee";
     static components = {
         ...super.components,
@@ -56,6 +61,7 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
             text: tag.text,
             tooltip: tag.tooltip,
             imageUrl: tag.imageUrl,
+            onAvatarClick: tag.onAvatarClick,
             onDelete: tag.onDelete,
         };
 
@@ -103,7 +109,7 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
 }
 
 export const many2ManyAttendee = {
-    ...many2ManyTagsAvatarField,
+    ...many2ManyTagsAvatarUserField,
     component: Many2ManyAttendee,
     additionalClasses: ["o_field_many2many_tags_avatar", "w-100"],
 };

--- a/addons/calendar/static/src/views/fields/many2many_attendee.scss
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.scss
@@ -3,6 +3,11 @@
 
     position: relative;
 
+    img:hover {
+        cursor: context-menu;
+        outline: $border-width solid $o-action;
+    }
+
     .attendee_tag_status {
         @include o-position-absolute($bottom: -0.375em, $right: -0.375em);
         aspect-ratio: 1;

--- a/addons/calendar/static/src/views/fields/many2many_attendee.xml
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.xml
@@ -9,24 +9,20 @@
         </xpath>
     </t>
 
-    <t t-name="calendar.AttendeeTag">
-        <span class="o_tag position-relative d-inline-flex align-items-center user-select-none mw-100 opacity-trigger-hover" tabindex="-1" t-att-data-tooltip="this.props.tooltip" t-att-aria-label="this.props.tooltip">
+    <t t-name="calendar.AttendeeTag" t-inherit="web.AvatarTag" t-inherit-mode="primary">
+        <xpath expr="//img[hasclass('o_avatar')]" position="replace">
             <div class="o_attendee_tags_list">
-                <img class="o_avatar o_m2m_avatar position-relative rounded" t-att-src="this.props.imageUrl"/>
+                <img class="o_avatar o_m2m_avatar position-relative rounded" t-att-src="this.props.imageUrl" t-on-click="this.onAvatarClick"/>
                 <div t-if="this.statusIcon" class="attendee_tag_status fa fa-fw rounded-circle" t-att-class="this.statusIcon" t-attf-class="o_attendee_status_{{this.props.status}}"/>
             </div>
-            <div class="o_tag_badge_text position-relative ms-1" t-out="this.props.text"/>
-            <div t-if="this.props.isUnavailable" data-tooltip="unavailable" class="ms-1">
+        </xpath>
+        <xpath expr="//div[hasclass('o_tag_badge_text')]" position="after">
+            <div t-if="this.props.isUnavailable" data-tooltip="Unavailable" class="ms-1">
                 <i class="fa fa-moon-o position-relative" role="img"/>
             </div>
-            <div t-if="this.props.noEmail" data-tooltip="no email" class="ms-1">
+            <div t-if="this.props.noEmail" data-tooltip="No email" class="ms-1">
                 <i class="fa fa-exclamation-triangle position-relative" role="img"/>
             </div>
-            <t t-if="this.props.onDelete">
-                <a class="o_delete d-flex align-items-center opacity-100-hover btn btn-link position-relative py-0 px-1 text-danger opacity-0" href="#" tabindex="0" aria-label="Delete" data-tooltip="Delete" t-on-click.stop.prevent="() => this.props.onDelete()">
-                    <i class="oi oi-close align-text-top"/>
-                </a>
-            </t>
-        </span>
+        </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
@@ -21,6 +21,10 @@
     @media screen  and (max-width: 480px) {
         max-width: 90vw;
     }
+
+    .o_card_user_infos a:focus-visible {
+        outline: none;
+    }
 }
 
 .o_popover:has(.o_card_avatar) {

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -1542,6 +1542,29 @@ test(`render popover`, async () => {
         `.o_cw_popover .o_cw_popover_fields_secondary .list-group-item:eq(1) span.fw-bold`
     ).toHaveText("Partner");
 
+    await animationFrame();
+    await runAllTimers(); // Wait for popover reposition by position hook
+    // Fully visible
+    const popover = document.querySelector(`.o_cw_popover`).getBoundingClientRect();
+    expect(
+        popover.top >= 0 &&
+            popover.left >= 0 &&
+            popover.bottom <= window.innerHeight &&
+            popover.right <= window.innerWidth
+    ).toBe(true);
+    // Displayed nearby its targeted full calendar event
+    const popoverTarget = document
+        .querySelector(`.fc-event[data-event-id='2']`)
+        .getBoundingClientRect();
+    expect(
+        Math.min(
+            Math.abs(popover.top - popoverTarget.bottom),
+            Math.abs(popover.bottom - popoverTarget.top),
+            Math.abs(popover.left - popoverTarget.right),
+            Math.abs(popover.right - popoverTarget.left)
+        ) < 30
+    ).toBe(true);
+
     await contains(`.o_cw_popover .o_cw_popover_close`).click();
     expect(`.o_cw_popover`).toHaveCount(0);
 });


### PR DESCRIPTION
Adding a partner popover with the attendee info when clicking on
the attendee avatar in the calendar popover.
The popover includes its name, email, phone, a link to its profile
and a direct access to open a discuss chat.

NB: This partner popover can't be opened from the PoS to prevent access
to sensible information and only make necessary information available
(cf enterprise PR).

Also adding some tests for the calendar popover to make sure it's correctly rendered,
fully visible and correctly displayed near its targeted full calendar event.

Task-5153118