### PR TITLE
[IMP] html_builder, mass_mailing, website: add mass_mailing favorite snippets

### DIFF
--- a/addons/html_builder/models/__init__.py
+++ b/addons/html_builder/models/__init__.py
@@ -1,1 +1,2 @@
 from . import ir_qweb
+from . import ir_ui_view

--- a/addons/html_builder/models/ir_ui_view.py
+++ b/addons/html_builder/models/ir_ui_view.py
@@ -1,0 +1,217 @@
+import uuid
+from lxml import etree, html
+
+from odoo import api, models
+from odoo.addons.base.models.ir_ui_view import MOVABLE_BRANDING
+from odoo.fields import Domain
+
+EDITING_ATTRIBUTES = MOVABLE_BRANDING + [
+    'data-oe-type',
+    'data-oe-expression',
+    'data-oe-translation-id',
+    'data-note-id'
+]
+
+
+class IrUiView(models.Model):
+    _inherit = "ir.ui.view"
+
+    @api.model
+    def delete_snippet(self, view_id, template_key):
+        snippet_view = self.browse(view_id)
+        key = snippet_view.key.split('.')[1]
+        custom_key = self._get_snippet_addition_view_key(template_key, key)
+        snippet_addition_view = self.search([('key', '=', custom_key)])
+        (snippet_addition_view | snippet_view).unlink()
+
+    @api.model
+    def rename_snippet(self, name, view_id, template_key):
+        snippet_view = self.browse(view_id)
+        key = snippet_view.key.split('.')[1]
+        custom_key = self._get_snippet_addition_view_key(template_key, key)
+        snippet_addition_view = self.search([('key', '=', custom_key)])
+        if snippet_addition_view:
+            snippet_addition_view.name = name + ' Block'
+        snippet_view.name = name
+
+    @api.model
+    def save_snippet(self, name, arch, template_key, snippet_key, thumbnail_url):
+        """
+        Saves a new snippet arch so that it appears with the given name when
+        using the given snippets template.
+
+        :param name: the name of the snippet to save
+        :param arch: the html structure of the snippet to save
+        :param template_key: the key of the view regrouping all snippets in
+            which the snippet to save is meant to appear
+        :param snippet_key: the key (without module part) to identify
+            the snippet from which the snippet to save originates
+        :param thumbnail_url: the url of the thumbnail to use when displaying
+            the snippet to save
+        """
+        app_name = template_key.split('.')[0]
+        snippet_key = '%s_%s' % (snippet_key, uuid.uuid4().hex)
+        full_snippet_key = '%s.%s' % (app_name, snippet_key)
+
+        used_names = self.env['ir.ui.view'].search(self._get_used_names_domain(name)).mapped("name")
+        name = self._find_available_name(name, used_names)
+
+        # html to xml to add '/' at the end of self closing tags like br, ...
+        arch_tree = html.fromstring(arch)
+        attributes = self._get_cleaned_non_editing_attributes(arch_tree.attrib.items())
+        for attr in arch_tree.attrib:
+            if attr in attributes:
+                arch_tree.attrib[attr] = attributes[attr]
+            else:
+                del arch_tree.attrib[attr]
+        xml_arch = etree.tostring(arch_tree, encoding='utf-8')
+        new_snippet_view_values = {
+            'name': name,
+            'key': full_snippet_key,
+            'type': 'qweb',
+            'arch': xml_arch,
+        }
+        new_snippet_view_values.update(self._snippet_save_view_values_hook())
+        custom_snippet_view = self.create(new_snippet_view_values)
+        model = self.env.context.get('model')
+        field = self.env.context.get('field')
+        if field == 'arch':
+            # Special case for `arch` which is a kind of related (through a
+            # compute) to `arch_db` but which is hosting XML/HTML content while
+            # being a char field.. Which is then messing around with the
+            # `get_translation_dictionary` call, returning XML instead of
+            # strings
+            field = 'arch_db'
+        res_id = self.env.context.get('resId')
+        if model and field and res_id:
+            self._copy_field_terms_translations(
+                self.env[model].browse(int(res_id)),
+                field,
+                custom_snippet_view,
+                'arch_db',
+            )
+
+        custom_section = self.search([('key', '=', template_key)])
+        snippet_addition_view_values = {
+            'name': name + ' Block',
+            'key': self._get_snippet_addition_view_key(template_key, snippet_key),
+            'inherit_id': custom_section.id,
+            'type': 'qweb',
+            'arch': """
+                <data inherit_id="%s">
+                    <xpath expr="//snippets[@id='snippet_custom']" position="inside">
+                        <t t-snippet="%s" t-thumbnail="%s"/>
+                    </xpath>
+                </data>
+            """ % (template_key, full_snippet_key, thumbnail_url),
+        }
+        snippet_addition_view_values.update(self._snippet_save_view_values_hook())
+        self.create(snippet_addition_view_values)
+        return name
+
+    @api.model
+    def _copy_field_terms_translations(self, records_from, name_field_from, record_to, name_field_to):
+        """ Copy model terms translations from ``records_from.name_field_from``
+        to ``record_to.name_field_to`` for all activated languages if the term
+        in ``record_to.name_field_to`` is untranslated (the term matches the
+        one in the current language).
+
+        For instance, copy the translations of a
+        ``product.template.html_description`` field to a ``ir.ui.view.arch_db``
+        field.
+
+        The method takes care of read and write access of both records/fields.
+        """
+        record_to.check_access('write')
+        field_from = records_from._fields[name_field_from]
+        field_to = record_to._fields[name_field_to]
+        record_to._check_field_access(field_to, 'write')
+
+        error_callable_msg = "'translate' property of field %r is not callable"
+        if not callable(field_from.translate):
+            raise TypeError(error_callable_msg % field_from)
+        if not callable(field_to.translate):
+            raise TypeError(error_callable_msg % field_to)
+        if not field_to.store:
+            raise ValueError("Field %r is not stored" % field_to)
+
+        # This will also implicitly check for `read` access rights
+        if not record_to[name_field_to] or not any(records_from.mapped(name_field_from)):
+            return
+
+        lang_env = self.env.lang or 'en_US'
+        langs = {lang for lang, _ in self.env['res.lang'].get_installed()}
+
+        # 1. Get translations
+        records_from.flush_model([name_field_from])
+        existing_translation_dictionary = field_to.get_translation_dictionary(
+            record_to[name_field_to],
+            {lang: record_to.with_context(prefetch_langs=True, lang=lang)[name_field_to] for lang in langs if lang != lang_env}
+        )
+        extra_translation_dictionary = {}
+        for record_from in records_from:
+            extra_translation_dictionary.update(field_from.get_translation_dictionary(
+                record_from[name_field_from],
+                {lang: record_from.with_context(prefetch_langs=True, lang=lang)[name_field_from] for lang in langs if lang != lang_env}
+            ))
+        for term, extra_translation_values in extra_translation_dictionary.items():
+            existing_translation_values = existing_translation_dictionary.setdefault(term, {})
+            # Update only default translation values that aren't customized by the user.
+            for lang, extra_translation in extra_translation_values.items():
+                if existing_translation_values.get(lang, term) == term:
+                    existing_translation_values[lang] = extra_translation
+        translation_dictionary = existing_translation_dictionary
+
+        # The `en_US` jsonb value should always be set, even if english is not
+        # installed. If we don't do this, the custom snippet `arch_db` will only
+        # have a `fr_BE` key but no `en_US` key.
+        langs.add('en_US')
+
+        # 2. Set translations
+        new_value = {
+            lang: field_to.translate(lambda term: translation_dictionary.get(term, {}).get(lang), record_to[name_field_to])
+            for lang in langs
+        }
+        record_to.env.cache.update_raw(record_to, field_to, [new_value], dirty=True)
+        # Call `write` to trigger compute etc (`modified()`)
+        record_to[name_field_to] = new_value[lang_env]
+
+    @api.model
+    def _find_available_name(self, name, used_names):
+        attempt = 1
+        candidate_name = name
+        while candidate_name in used_names:
+            attempt += 1
+            candidate_name = f"{name} ({attempt})"
+        return candidate_name
+
+    def _get_cleaned_non_editing_attributes(self, attributes):
+        """
+        Returns a new mapping of attributes -> value without the parts that are
+        not meant to be saved (branding, editing classes, ...). Note that
+        classes are meant to be cleaned on the client side before saving as
+        mostly linked to the related options (so we are not supposed to know
+        which to remove here).
+
+        :param attributes: a mapping of attributes -> value
+        :return: a new mapping of attributes -> value
+        """
+        attributes = {k: v for k, v in attributes if k not in EDITING_ATTRIBUTES}
+        if 'class' in attributes:
+            classes = attributes['class'].split()
+            attributes['class'] = ' '.join([c for c in classes if c != 'o_editable'])
+        if attributes.get('contenteditable') == 'true':
+            del attributes['contenteditable']
+        return attributes
+
+    @api.model
+    def _get_snippet_addition_view_key(self, template_key, key):
+        return '%s.%s' % (template_key, key)
+
+    @api.model
+    def _get_used_names_domain(self, name):
+        return Domain('name', '=like', '%s%%' % name)
+
+    @api.model
+    def _snippet_save_view_values_hook(self):
+        return {}

--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -79,6 +79,9 @@ export class SaveSnippetPlugin extends Plugin {
             this.wrapWithBeforeAfterSaveHandlers.bind(this)
         );
         if (savedName) {
+            if (this.delegateTo("custom_snippets_notification_handlers", savedName)) {
+                return;
+            }
             const message = _t(
                 "Saved as %s. Find it in your snippets.",
                 markup`<strong>${savedName}</strong>`

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -24,11 +24,11 @@
                 </div>
                 <div t-if="snippet.isCustom" class="d-grid mt-2 mx-5 gap-2 d-md-flex justify-content-md-end o_custom_snippet_edit">
                     <span class="w-100" t-esc="snippet.title"></span>
-                    <button class="o_btn_reset me-md-2" t-on-click="() => this.onClickRename(snippet)">
+                    <button class="o_btn_reset me-md-2" t-on-click="() => this.onClickRename(snippet)" title="Rename">
                         <span class="visually-hidden" t-esc="getRenameBtnLabel(snippet.title)"/>
                         <span class="fa fa-pencil"/>
                     </button>
-                    <button class="o_btn_reset" t-on-click="() => this.onClickDelete(snippet)">
+                    <button class="o_btn_reset" t-on-click="() => this.onClickDelete(snippet)" title="Remove">
                         <span class="visually-hidden" t-esc="getDeleteBtnLabel(snippet.title)"/>
                         <span class="fa fa-trash"/>
                     </button>

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
@@ -6,6 +6,8 @@ import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/backend/plugin_sets";
 import { registry } from "@web/core/registry";
 import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
 import { OptionsContainerWithSnippetVersionControl } from "./options/options_container";
+import { massMailingSnippetModelPatch } from "./snippet_model_patch";
+import { useService } from "@web/core/utils/hooks";
 
 class CustomizeTabWithSnippetVersionControl extends CustomizeTab {
     static components = {
@@ -30,6 +32,14 @@ export class MassMailingBuilder extends Component {
         toggleFullScreen: { type: Function },
     };
 
+    setup() {
+        this.snippetsService = useService("html_builder.snippets");
+        this.snippetsService.patchSnippetModel(
+            this.props.builderProps.snippetsName,
+            massMailingSnippetModelPatch
+        );
+    }
+
     get builderProps() {
         const builderProps = Object.assign({}, this.props.builderProps);
         const massMailingPlugins = [
@@ -39,7 +49,6 @@ export class MassMailingBuilder extends Component {
         const pluginsToRemove = [
             "BuilderFontPlugin", // Makes call to Google API (can't be used for emails)
             "SavePlugin",
-            "SaveSnippetPlugin",
             "AnchorPlugin",
             "ColorUIPlugin",
             "EmbeddedFilePlugin",

--- a/addons/mass_mailing/static/src/builder/plugins/save_snippet_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/save_snippet_plugin.js
@@ -1,0 +1,27 @@
+import { Plugin } from "@html_editor/plugin";
+import { markup } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+class SaveSnippetPlugin extends Plugin {
+    static id = "mass_mailing.SaveSnippetPlugin";
+    resources = {
+        custom_snippets_notification_handlers: this.handleCustomSnippetNotification.bind(this),
+    };
+
+    handleCustomSnippetNotification(savedName) {
+        if (this.config.getRecordInfo().resModel !== "mailing.mailing") {
+            return false;
+        }
+        const message = _t(
+            "Your custom snippet was successfully saved as %s. Find it in your custom snippets collection.",
+            markup`<strong>${savedName}</strong>`
+        );
+        this.closeNotification = this.services.notification.add(message, {
+            type: "success",
+            autocloseDelay: 10000,
+        });
+        return true;
+    }
+}
+registry.category("mass_mailing-plugins").add(SaveSnippetPlugin.id, SaveSnippetPlugin);

--- a/addons/mass_mailing/static/src/builder/snippet_model_patch.js
+++ b/addons/mass_mailing/static/src/builder/snippet_model_patch.js
@@ -1,0 +1,13 @@
+export const massMailingSnippetModelPatch = {
+    cleanSnippetForSave(snippetCopyEl, cleanForSaveHandlers) {
+        super.cleanSnippetForSave(snippetCopyEl, cleanForSaveHandlers);
+        const dynamicPlaceholders = snippetCopyEl.querySelectorAll("t[t-out]");
+        dynamicPlaceholders.forEach((placeholderEl) => {
+            const placeholderString =
+                placeholderEl.innerText || placeholderEl.getAttribute("t-out");
+            placeholderEl.before(placeholderString);
+            placeholderEl.remove();
+        });
+        snippetCopyEl.removeAttribute("data-filter-domain");
+    },
+};

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -35,6 +35,7 @@
     <t id="default_snippets">
         <t t-set="company_id" t-value="res_company"/>
         <snippets id="snippet_groups" string="Categories">
+            <t snippet-group="custom" t-snippet="mass_mailing.s_snippet_group" string="Custom" t-thumbnail="/mass_mailing/static/src/img/snippets_thumbs/s_media_list.svg"/>
             <t snippet-group="headers" t-snippet="mass_mailing.s_snippet_group" string="Headers" t-thumbnail="/mass_mailing/static/src/img/snippets_thumbs/s_alert.svg"/>
             <t snippet-group="footers" t-snippet="mass_mailing.s_snippet_group" string="Footers" t-thumbnail="/mass_mailing/static/src/img/snippets_thumbs/block_footer_social.png"/>
             <t snippet-group="images" t-snippet="mass_mailing.s_snippet_group" string="Images" t-thumbnail="/mass_mailing/static/src/img/snippets_thumbs/s_picture.svg"/>

--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -42,11 +42,6 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Confirm reload",
-            trigger: ".modal-dialog button:contains('Save')",
-            run: "click",
-        },
-        {
             content: "Click on the block tab",
             trigger: ".o-snippets-tabs button[data-name='blocks']",
             run: "click",

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -11,16 +11,8 @@ from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, MissingError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.addons.base.models.ir_ui_view import MOVABLE_BRANDING
 
 _logger = logging.getLogger(__name__)
-
-EDITING_ATTRIBUTES = MOVABLE_BRANDING + [
-    'data-oe-type',
-    'data-oe-expression',
-    'data-oe-translation-id',
-    'data-note-id'
-]
 
 
 class IrUiView(models.Model):
@@ -482,25 +474,6 @@ class IrUiView(models.Model):
     # Save from html
     # ------------------------------------------------------
 
-    def _get_cleaned_non_editing_attributes(self, attributes):
-        """
-        Returns a new mapping of attributes -> value without the parts that are
-        not meant to be saved (branding, editing classes, ...). Note that
-        classes are meant to be cleaned on the client side before saving as
-        mostly linked to the related options (so we are not supposed to know
-        which to remove here).
-
-        :param attributes: a mapping of attributes -> value
-        :return: a new mapping of attributes -> value
-        """
-        attributes = {k: v for k, v in attributes if k not in EDITING_ATTRIBUTES}
-        if 'class' in attributes:
-            classes = attributes['class'].split()
-            attributes['class'] = ' '.join([c for c in classes if c != 'o_editable'])
-        if attributes.get('contenteditable') == 'true':
-            del attributes['contenteditable']
-        return attributes
-
     @api.model
     def extract_embedded_fields(self, arch):
         return arch.xpath('//*[@data-oe-model != "ir.ui.view"]')
@@ -587,73 +560,6 @@ class IrUiView(models.Model):
             custom_snippet_view = self.search([('name', '=', custom_snippet_name)], limit=1)
             if custom_snippet_view:
                 self._copy_field_terms_translations(custom_snippet_view, 'arch_db', record, html_field)
-
-    @api.model
-    def _copy_field_terms_translations(self, records_from, name_field_from, record_to, name_field_to):
-        """ Copy model terms translations from ``records_from.name_field_from``
-        to ``record_to.name_field_to`` for all activated languages if the term
-        in ``record_to.name_field_to`` is untranslated (the term matches the
-        one in the current language).
-
-        For instance, copy the translations of a
-        ``product.template.html_description`` field to a ``ir.ui.view.arch_db``
-        field.
-
-        The method takes care of read and write access of both records/fields.
-        """
-        record_to.check_access('write')
-        field_from = records_from._fields[name_field_from]
-        field_to = record_to._fields[name_field_to]
-        record_to._check_field_access(field_to, 'write')
-
-        error_callable_msg = "'translate' property of field %r is not callable"
-        if not callable(field_from.translate):
-            raise TypeError(error_callable_msg % field_from)
-        if not callable(field_to.translate):
-            raise TypeError(error_callable_msg % field_to)
-        if not field_to.store:
-            raise ValueError("Field %r is not stored" % field_to)
-
-        # This will also implicitly check for `read` access rights
-        if not record_to[name_field_to] or not any(records_from.mapped(name_field_from)):
-            return
-
-        lang_env = self.env.lang or 'en_US'
-        langs = {lang for lang, _ in self.env['res.lang'].get_installed()}
-
-        # 1. Get translations
-        records_from.flush_model([name_field_from])
-        existing_translation_dictionary = field_to.get_translation_dictionary(
-            record_to[name_field_to],
-            {lang: record_to.with_context(prefetch_langs=True, lang=lang)[name_field_to] for lang in langs if lang != lang_env}
-        )
-        extra_translation_dictionary = {}
-        for record_from in records_from:
-            extra_translation_dictionary.update(field_from.get_translation_dictionary(
-                record_from[name_field_from],
-                {lang: record_from.with_context(prefetch_langs=True, lang=lang)[name_field_from] for lang in langs if lang != lang_env}
-            ))
-        for term, extra_translation_values in extra_translation_dictionary.items():
-            existing_translation_values = existing_translation_dictionary.setdefault(term, {})
-            # Update only default translation values that aren't customized by the user.
-            for lang, extra_translation in extra_translation_values.items():
-                if existing_translation_values.get(lang, term) == term:
-                    existing_translation_values[lang] = extra_translation
-        translation_dictionary = existing_translation_dictionary
-
-        # The `en_US` jsonb value should always be set, even if english is not
-        # installed. If we don't do this, the custom snippet `arch_db` will only
-        # have a `fr_BE` key but no `en_US` key.
-        langs.add('en_US')
-
-        # 2. Set translations
-        new_value = {
-            lang: field_to.translate(lambda term: translation_dictionary.get(term, {}).get(lang), record_to[name_field_to])
-            for lang in langs
-        }
-        record_to.env.cache.update_raw(record_to, field_to, [new_value], dirty=True)
-        # Call `write` to trigger compute etc (`modified()`)
-        record_to[name_field_to] = new_value[lang_env]
 
     @api.model
     def _are_archs_equal(self, arch1, arch2):
@@ -814,109 +720,10 @@ class IrUiView(models.Model):
     def _get_snippet_addition_view_key(self, template_key, key):
         return '%s.%s' % (template_key, key)
 
-    def _find_available_name(self, name, used_names):
-        attempt = 1
-        candidate_name = name
-        while candidate_name in used_names:
-            attempt += 1
-            candidate_name = f"{name} ({attempt})"
-        return candidate_name
-
-    @api.model
-    def save_snippet(self, name, arch, template_key, snippet_key, thumbnail_url):
-        """
-        Saves a new snippet arch so that it appears with the given name when
-        using the given snippets template.
-
-        :param name: the name of the snippet to save
-        :param arch: the html structure of the snippet to save
-        :param template_key: the key of the view regrouping all snippets in
-            which the snippet to save is meant to appear
-        :param snippet_key: the key (without module part) to identify
-            the snippet from which the snippet to save originates
-        :param thumbnail_url: the url of the thumbnail to use when displaying
-            the snippet to save
-        """
-        app_name = template_key.split('.')[0]
-        snippet_key = '%s_%s' % (snippet_key, uuid.uuid4().hex)
-        full_snippet_key = '%s.%s' % (app_name, snippet_key)
-
-        # find available name
+    def _get_used_names_domain(self, name):
+        used_names_domain = super()._get_used_names_domain(name)
         current_website = self.env['website'].browse(self.env.context.get('website_id'))
-        website_domain = Domain(current_website.website_domain())
-        used_names = self.search(Domain('name', '=like', '%s%%' % name) & website_domain).mapped('name')
-        name = self._find_available_name(name, used_names)
-
-        # html to xml to add '/' at the end of self closing tags like br, ...
-        arch_tree = html.fromstring(arch)
-        attributes = self._get_cleaned_non_editing_attributes(arch_tree.attrib.items())
-        for attr in arch_tree.attrib:
-            if attr in attributes:
-                arch_tree.attrib[attr] = attributes[attr]
-            else:
-                del arch_tree.attrib[attr]
-        xml_arch = etree.tostring(arch_tree, encoding='utf-8')
-        new_snippet_view_values = {
-            'name': name,
-            'key': full_snippet_key,
-            'type': 'qweb',
-            'arch': xml_arch,
-        }
-        new_snippet_view_values.update(self._snippet_save_view_values_hook())
-        custom_snippet_view = self.create(new_snippet_view_values)
-        model = self.env.context.get('model')
-        field = self.env.context.get('field')
-        if field == 'arch':
-            # Special case for `arch` which is a kind of related (through a
-            # compute) to `arch_db` but which is hosting XML/HTML content while
-            # being a char field.. Which is then messing around with the
-            # `get_translation_dictionary` call, returning XML instead of
-            # strings
-            field = 'arch_db'
-        res_id = self.env.context.get('resId')
-        if model and field and res_id:
-            self._copy_field_terms_translations(
-                self.env[model].browse(int(res_id)),
-                field,
-                custom_snippet_view,
-                'arch_db',
-            )
-
-        custom_section = self.search([('key', '=', template_key)])
-        snippet_addition_view_values = {
-            'name': name + ' Block',
-            'key': self._get_snippet_addition_view_key(template_key, snippet_key),
-            'inherit_id': custom_section.id,
-            'type': 'qweb',
-            'arch': """
-                <data inherit_id="%s">
-                    <xpath expr="//snippets[@id='snippet_custom']" position="inside">
-                        <t t-snippet="%s" t-thumbnail="%s"/>
-                    </xpath>
-                </data>
-            """ % (template_key, full_snippet_key, thumbnail_url),
-        }
-        snippet_addition_view_values.update(self._snippet_save_view_values_hook())
-        self.create(snippet_addition_view_values)
-        return name
-
-    @api.model
-    def rename_snippet(self, name, view_id, template_key):
-        snippet_view = self.browse(view_id)
-        key = snippet_view.key.split('.')[1]
-        custom_key = self._get_snippet_addition_view_key(template_key, key)
-        snippet_addition_view = self.search([('key', '=', custom_key)])
-        if snippet_addition_view:
-            snippet_addition_view.name = name + ' Block'
-        snippet_view.name = name
-
-    @api.model
-    def delete_snippet(self, view_id, template_key):
-        snippet_view = self.browse(view_id)
-        key = snippet_view.key.split('.')[1]
-        custom_key = self._get_snippet_addition_view_key(template_key, key)
-        snippet_addition_view = self.search([('key', '=', custom_key)])
-        (snippet_addition_view | snippet_view).unlink()
+        return used_names_domain & Domain(current_website.website_domain())
 
     # --------------------------------------------------------------------------
     # Languages

--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -1,11 +1,8 @@
-import { SnippetModel } from "@html_builder/snippets/snippet_service";
 import { applyTextHighlight } from "@website/js/highlight_utils";
 import { registry } from "@web/core/registry";
-import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-patch(SnippetModel.prototype, {
+export const websiteSnippetModelPatch = {
     /**
      * @override
      */
@@ -34,142 +31,22 @@ patch(SnippetModel.prototype, {
         }
         return label;
     },
-
-    /**
-     * @override
-     */
-    async deleteCustomSnippet(snippet) {
-        return new Promise((resolve) => {
-            const message = _t(
-                "Are you sure you want to remove %(snippetName)s from your list of Custom Blocks?\nThis action is permanent and will affect all users across the website.", {
-                snippetName: snippet.title
-            });
-            this.dialog.add(
-                ConfirmationDialog,
-                {
-                    title: _t("Delete Custom Block"),
-                    body: message,
-                    confirm: async () => {
-                        const isInnerContent =
-                            this.snippetsByCategory.snippet_custom_content.includes(snippet);
-                        const snippetCustom = isInnerContent
-                            ? this.snippetsByCategory.snippet_custom_content
-                            : this.snippetsByCategory.snippet_custom;
-                        const index = snippetCustom.findIndex((s) => s.id === snippet.id);
-                        if (index > -1) {
-                            snippetCustom.splice(index, 1);
-                        }
-                        await this.orm.call("ir.ui.view", "delete_snippet", [], {
-                            view_id: snippet.viewId,
-                            template_key: this.snippetsName,
-                        });
-                    },
-                    cancel: () => {},
-                    confirmLabel: _t("Delete Block"),
-                    cancelLabel: _t("Keep it"),
-                },
-                {
-                    onClose: resolve,
-                }
-            );
+    cleanSnippetForSave(snippetCopyEl, cleanForSaveHandlers) {
+        const rootEl = snippetCopyEl.matches(".s_popup")
+            ? snippetCopyEl.firstElementChild
+            : snippetCopyEl;
+        super.cleanSnippetForSave(rootEl, cleanForSaveHandlers);
+    },
+    getContext(snippetEl) {
+        const context = super.getContext(...arguments);
+        const editableParentEl = snippetEl.closest("[data-oe-model][data-oe-field][data-oe-id]");
+        return Object.assign(context, {
+            model: editableParentEl.dataset.oeModel,
+            field: editableParentEl.dataset.oeField,
+            resId: editableParentEl.dataset.oeId,
         });
     },
-
-    /**
-     * @override
-     */
-    async renameCustomSnippet(snippet, newName) {
-        if (newName === snippet.title) {
-            return;
-        }
-        snippet.title = newName;
-        for (const snippetEl of this.snippetsDocument.body.querySelectorAll(
-            `snippets#snippet_custom > [data-oe-snippet-key = ${snippet.key}]`
-        )) {
-            snippetEl.setAttribute("name", newName);
-            snippetEl.children[0].dataset["name"] = newName;
-        }
-        await this.orm.call("ir.ui.view", "rename_snippet", [], {
-            name: newName,
-            view_id: snippet.viewId,
-            template_key: this.snippetsName,
-        });
-    },
-
-    /**
-     * @override
-     */
-    saveSnippet(
-        snippetEl,
-        cleanForSaveHandlers,
-        wrapWithSaveSnippetHandlers = (_, callback) => callback()
-    ) {
-        return new Promise((resolve) => {
-            this.dialog.add(
-                ConfirmationDialog,
-                {
-                    title: _t("Create a custom snippet"),
-                    body: _t("Do you want to save this snippet as a custom one?"),
-                    confirmLabel: _t("Save"),
-                    cancel: () => resolve(false),
-                    confirm: async () => {
-                        const isButton = snippetEl.matches("a.btn");
-                        const snippetKey = isButton ? "s_button" : snippetEl.dataset.snippet;
-                        const thumbnailURL = this.getSnippetThumbnailURL(snippetKey);
-
-                        const snippetCopyEl = await wrapWithSaveSnippetHandlers(snippetEl, () =>
-                            snippetEl.cloneNode(true)
-                        );
-
-                        // "CleanForSave" the snippet copy (only its children in
-                        // the case of a popup, or it will be saved as invisible
-                        // and will not be visible in the "add snippet" dialog).
-                        const rootEl = snippetEl.matches(".s_popup")
-                            ? snippetCopyEl.firstElementChild
-                            : snippetCopyEl;
-                        cleanForSaveHandlers.forEach((handler) => handler({ root: rootEl }));
-
-                        const defaultSnippetName = isButton
-                            ? _t("Custom Button")
-                            : _t("Custom %s", snippetEl.dataset.name);
-                        snippetCopyEl.classList.add("s_custom_snippet");
-                        delete snippetCopyEl.dataset.name;
-                        if (isButton) {
-                            snippetCopyEl.classList.remove("mb-2");
-                            snippetCopyEl.classList.add(
-                                "o_snippet_drop_in_only",
-                                "s_custom_button"
-                            );
-                        }
-
-                        const editableParentEl = snippetEl.closest(
-                            "[data-oe-model][data-oe-field][data-oe-id]"
-                        );
-                        const context = {
-                            ...this.context,
-                            model: editableParentEl.dataset.oeModel,
-                            field: editableParentEl.dataset.oeField,
-                            resId: editableParentEl.dataset.oeId,
-                        };
-                        const savedName = await this.orm.call("ir.ui.view", "save_snippet", [], {
-                            name: defaultSnippetName,
-                            arch: snippetCopyEl.outerHTML,
-                            template_key: this.snippetsName,
-                            snippet_key: snippetKey,
-                            thumbnail_url: thumbnailURL,
-                            context,
-                        });
-
-                        // Reload the snippets so the sidebar is up to date.
-                        await this.reload();
-                        resolve(savedName);
-                    },
-                },
-                { onClose: () => resolve(false) }
-            );
-        });
-    },
-});
+};
 
 registry
     .category("html_builder.snippetsPreprocessor")

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -44,6 +44,7 @@ import { CustomizeTranslationTab } from "@website/builder/plugins/translation_ta
 import { CustomizeTranslationTabPlugin } from "./plugins/translation_tab/customize_translation_tab_plugin";
 import { WebsiteSavePlugin } from "@website/builder/plugins/website_save_plugin";
 import { Plugin } from "@html_editor/plugin";
+import { websiteSnippetModelPatch } from "./snippet_model";
 
 const TRANSLATION_PLUGINS = [
     BuilderOptionsTranslationPlugin,
@@ -96,6 +97,11 @@ export class WebsiteBuilder extends Component {
     setup() {
         this.websiteService = useService("website");
         this.dialog = useService("dialog");
+        this.snippetsService = useService("html_builder.snippets");
+        this.snippetsService.patchSnippetModel(
+            this.props.builderProps.snippetsName,
+            websiteSnippetModelPatch
+        );
         useSetupAction({
             beforeUnload: (ev) => this.onBeforeUnload(ev),
             beforeLeave: () => this.onBeforeLeave(),

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -157,12 +157,10 @@ test("Use the sidebar 'save snippet' buttons", async () => {
 
     // Save the snippets.
     await contains(saveButtonSelector).click();
-    await contains(".o_dialog .btn:contains('Save')").click();
     expect(".o_notification_manager .o_notification_content").toHaveCount(1);
     await contains(".o_notification_manager .o_notification_close").click();
 
     await contains(saveSectionSelector).click();
-    await contains(".o_dialog .btn:contains('Save')").click();
     expect(".o_notification_manager .o_notification_content").toHaveCount(1);
 
     // Check that the custom sections appeared.

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -234,7 +234,6 @@ test("pasted/dropped images are converted to attachments on snippet save", async
     // Save snippet of section 1 and check if its image has been saved as attachment
     await contains(":iframe [test-id='1']").click();
     await contains("button.oe_snippet_save").click();
-    await contains(".modal button:contains(Save)").click();
     await expect.waitForSteps(["add_data image-1.png", "save snippet"]);
 
     // Save and check if image of section 2 has been saved as attachment

--- a/addons/website/static/tests/builder/snippet_custom.test.js
+++ b/addons/website/static/tests/builder/snippet_custom.test.js
@@ -129,7 +129,6 @@ test("thumbnails are displayed on custom inner snippets even if they have the sa
     );
     await contains(":iframe .s_test").click();
     await contains("div[data-container-title='test'] button.oe_snippet_save").click();
-    await contains(".modal-dialog button.btn-primary").click();
     await contains("button[data-name='blocks']").click();
     expect("div.o_snippet[name='Custom test'] div.o_snippet_thumbnail_img").toHaveStyle({
         "background-image": /url\(.*s_countdown/,

--- a/addons/website/static/tests/tours/custom_popup_snippet.js
+++ b/addons/website/static/tests/tours/custom_popup_snippet.js
@@ -25,11 +25,6 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "confirm and reload custom snippet",
-            trigger: ".modal-footer > .btn.btn-primary",
-            run: "click",
-        },
-        {
             content: "Hide the popup",
             trigger: ".o_we_invisible_entry i",
             run: "click",

--- a/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
+++ b/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
@@ -19,11 +19,6 @@ registerWebsitePreviewTour(
             ".s_title.custom[data-oe-model][data-oe-id][data-oe-field][data-oe-xpath]"
         ),
         changeOption("Block", ".oe_snippet_save"),
-        {
-            content: "Confirm modal",
-            trigger: ".modal-footer .btn-primary",
-            run: "click",
-        },
         goBackToBlocks(),
         {
             content: "Wait for the custom category to appear in the panel",


### PR DESCRIPTION
### html_builder, website: move generic save_snippet

This commit moves all the generic parts of the save snippet process to
html_builder. These are necessary for the addition of the process to
mass_mailing, as some parts of it required website to work.

Now, the SaveSnippetPlugin can be used in any context as the relevant website
parts of the code were moved back to website.
We also introduced a new helper to patch a specific SnippetModel Object, as the
original patch was applied to the prototype. Thereby affecting models unrelated
to website, e.g. `mass_mailing`.
Now, only the object linked to website will be impacted by the website patch.

### mass_mailing: add favorite snippets

This commit adds the possibility for users to add snippets as favorite so
that they can be used later on as it was the case in website.

This commit also adds all the adjustments necessary so that the plugin works as
intended.

task-5126148

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
