### PR TITLE
[FIX] account: preserve manually-set journal on bank statements witho…

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -179,7 +179,8 @@ class AccountBankStatement(models.Model):
     @api.depends('line_ids.journal_id')
     def _compute_journal_id(self):
         for statement in self:
-            statement.journal_id = statement.line_ids.journal_id
+            if statement.line_ids:
+                statement.journal_id = statement.line_ids.journal_id
 
     @api.depends('balance_end', 'balance_end_real', 'line_ids.amount', 'line_ids.state')
     def _compute_is_complete(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This closes #233990 

Creating a bank statement with `journal_id` but no `line_ids` results in
`journal_id` being overwritten to `False`. This happens because
`_compute_journal_id` always assigns `statement.line_ids.journal_id`, which is
`False` when no lines exist.

Current behavior before PR:

- When a statement is created without any `line_ids`, the manually provided `journal_id` is lost.
- The computed field overwrites the field to `False`, even though the user intentionally set a value.

Desired behavior after PR is merged:
- if the statement has `line_ids`, `journal_id` continues to be derived from them (existing intended behavior).
- If the statement has no `line_ids`, the manually-defined `journal_id` is preserved and not overwritten.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
