### PR TITLE
[FIX] stock: base forecast on qty_done rather than demand for done moves

### DIFF
--- a/addons/stock/tests/test_report_stock_quantity.py
+++ b/addons/stock/tests/test_report_stock_quantity.py
@@ -324,3 +324,22 @@ class TestReportStockQuantity(tests.TransactionCase):
         ):
             qty = get_inv_qty_at_date(product.id, date)
             self.assertEqual(qty, expected_qties)
+
+    def test_transfer_where_qty_done_differs_from_demand(self):
+        """
+        Verify that available quantities are correctly computed at different past dates
+        when the qty_done of a transfer differs from the demand.
+        """
+        today = self.move1.date
+        self.move2._action_cancel()
+        product = self.product1
+        with freeze_time(today):
+            self.move1.write({'quantity': 40.0, 'picked': True})
+            self.move1._action_done()
+            self.assertRecordValues(product, [{'qty_available': 40.0}])
+        report = self.env['report.stock.quantity']._read_group(
+            [('date', '>=', today - timedelta(days=1)), ('date', '<=', today), ('product_id', '=', product.id), ('state', '=', 'forecast')],
+            ['date:day', 'product_id'],
+            ['product_qty:sum'])
+        forecast_report = [qty for __, __, qty in report]
+        self.assertEqual(forecast_report, [0, 40])


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product
- Create a receipt for 100 units of that product
- Mark as to do, set the quantity to 50 and validate without backorder
- Go to your product form > Forecast
#### > The forecast displays a quantity of -50 for every date in the past

### Cause of the issue:

The part of the report query relying on done moves is based on the `prodcut_uom_qty` of the move and hence on its demand. However, when the move is 'done' only its quantity should be relevant.

#### Note:

The same issue happen if you receive more than the demand. That is:
- Mark as to do, set the quantity to 150 and validate without backorder
- Go to your product form > Forecast
#### > The forecast displays a quantity of 50 for every date in the past

The issue did not happen prior to 17.0 because validating a move for a quantity that differs from the demand would:
- in case quantity < product_uom_qty: split the move in 2: one done move where the demand matches the quantity and one cancelled move with the remaining demand.
- in case quantity > product_uom_qty: the demand of the move was updated to match the quantity of the move.

This has been changed in f9867a5fa572a15fb89c49c61e569427d6388cbc now, validating a move for a quantity that differs from the demand will keep the demand intact.

opw-5152570

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
