### PR TITLE
[FIX] account: accrual menu dependency

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -32,6 +32,7 @@
             <menuitem id="account_audit_control_menu" name="Control" sequence="20" groups="account.group_account_readonly">
                 <menuitem id="menu_action_account_moves_all" action="action_account_moves_all" groups="account.group_account_readonly" sequence="6"/>
             </menuitem>
+            <menuitem id="account_accruals_menu" name="Sales / Purchases" sequence="59"/>
             <menuitem id="account_logs_menu" name="Logs" sequence="60"/>
         </menuitem>
         <menuitem id="menu_finance_reports" name="Reporting" sequence="20" groups="account.group_account_readonly,account.group_account_invoice">


### PR DESCRIPTION
The PR odoo/enterprise#97151 introduces a miss-match between module dependency (new modules depend of `account_accountant`) and by records used as parent menu (defined in `account_report`.) `account_report` depends of `account_accountant` and is in auto-install which means by installing modules there is no issue, but in config where `account_accountant` is installed and then `account_report` is uninstalled, it causes issue.

To fix that, a new menu item is created in `account` and will be used by accrual menu item as parent menu.

**Enterprise PR:** https://github.com/odoo/enterprise/pull/98914