### PR TITLE
[FIX] hr_homeworking_calendar: fix events order

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -27,7 +27,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
                     if(event2.extendedProps.worklocation){
                         return 1;
                     } else {
-                        return event1.title.localeCompare(event2.title);
+                        return event1.start < event2.start ? -1 : 1;
                     }
                 }
             },


### PR DESCRIPTION
Purpose
=======
Fix the events ordering in the calendar month view.

Specification
=============
When comparing 2 events, if none of them has a work location the events are ordered following their title, in alphabetical order. This is wrong, the events should be ordered following their start time to keep a chronological order in the month view.

Task-5407656


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
