### PR TITLE
[FIX] account: avoid constraint error on equity_unaffected with archived companies

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -32,8 +32,11 @@ class AccountAccount(models.Model):
 
     @api.constrains('account_type')
     def _check_account_type_unique_current_year_earning(self):
-        result = self.with_context(active_test=False)._read_group(
-            domain=[('account_type', '=', 'equity_unaffected')],
+        result = self._read_group(
+            domain=[
+                ("account_type", "=", "equity_unaffected"),
+                ("company_ids.active", "=", True),
+            ],
             groupby=['company_ids'],
             aggregates=['id:recordset'],
             having=[('__count', '>', 1)],


### PR DESCRIPTION

When a company linked to an account is archived, it is filtered out from the `company_ids` many2many field due to the default `active=True` filter. As a result, `_read_group(groupby=['company_ids'])` groups such accounts under `False`, leading to a false-positive constraint error.

Add `('company_ids.active', '=', True)` to the domain in `_check_account_type_unique_current_year_earning` to consider only active companies.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
