### PR TITLE
[FIX] website: fix many2one form fields with zero records

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -130,7 +130,7 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Selection type">
-        <BuilderSelect t-if="isExistingFieldSelectType"
+        <BuilderSelect t-if="isExistingFieldSelectType and state.valueList"
             id="'existing_field_select_type_opt'" preview="false" action="'existingFieldSelectType'"
         >
             <BuilderSelectItem actionValue="'many2one'">Dropdown List</BuilderSelectItem>

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -282,7 +282,17 @@
         <!-- Generic one2many -->
         <t t-if="field.relation !== 'ir.attachment'">
             <t t-call="website.form_field">
-                <select class="form-select s_website_form_input" t-att-name="field.name" t-att-required="field.required || field.modelRequired || None" t-att-id="field.id">
+                <t t-if="!field.records || field.records.length === 0">
+                    <input
+                        class="form-control s_website_form_input"
+                        t-att-name="field.name"
+                        t-att-value="undefined"
+                        t-att-required="field.required || field.modelRequired || None"
+                        placeholder="No matching record!"
+                        disabled=""
+                    />
+                </t>
+                <select t-else="" class="form-select s_website_form_input" t-att-name="field.name" t-att-required="field.required || field.modelRequired || None" t-att-id="field.id">
                     <t t-foreach="field.records" t-as="record" t-key="record_index">
                         <option t-esc="record.display_name" t-att-id="field.id + record_index" t-att-value="record.id" t-att="{selected: record.selected and 'selected' or None}"/>
                     </t>


### PR DESCRIPTION
With the [website builder refactor], the code was not robust in case there were no records for a many2one field in a form.

Steps to reproduce:
- Open website builder on a form in a new database
- Set action "Send an email"
- Add a field with type "Alias Domain" ("Option List" must be empty)
- Change "Selection type" to "Radio"
- Bug: crash

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-5238496