### PR TITLE
[FIX] base: prevent traceback when merging malformed pdfs

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -704,7 +704,10 @@ class IrActionsReport(models.Model):
                 raise UserError(_("Odoo is unable to merge the generated PDFs."))
         result_stream = io.BytesIO()
         streams.append(result_stream)
-        writer.write(result_stream)
+        try:
+            writer.write(result_stream)
+        except PdfReadError:
+            raise UserError(_("Odoo is unable to merge the generated PDFs."))
         return result_stream
 
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):


### PR DESCRIPTION
Currently some PDFs cause error in PyPDF (Version 1 and 2) and cannot be merged.

Steps to reproduce:

- Create 2+ Bills with specific PDF (example found in ticket)
- From Bills list view, select both and click Download > Original bills

Issue:

Traceback will raise
`PyPDF2.errors.PdfReadError: Can't read object stream: Stream has ended unexpectedly`
Thsi occurs because the version of PyPDF currently in use (2.12.1) cannot recover when working an odd PDF file having wrong length markers.

This commit will add a nice error explaining to user what's going on.

opw-5142961