### PR TITLE
[FIX] purchase: correct 'Warnings' filter domain

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -457,7 +457,7 @@
                         domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
-                        domain="[('activity_exception_decoration', '!=', False)]"/>
+                        domain="[('activity_exception_decoration', 'in', ('warning','danger'))]"/>
                     <group expand="0" string="Group By">
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Buyer" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>
@@ -495,7 +495,7 @@
                         domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
-                        domain="[('activity_exception_decoration', '!=', False)]"/>
+                        domain="[('activity_exception_decoration', 'in', ('warning','danger'))]"/>
                     <group expand="0" string="Group By">
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Buyer" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>


### PR DESCRIPTION
Steps to reproduce:
- Purchases > Requests for Quotation
- Ensure you have some POs with:
  - No activities
  - Only normal activities
  - At least one exception activity (type with Decoration Type = Alert or Error, unarchive “Exception” in Activity Types if needed)
- Apply the “Warnings” filter
- Before this change:
  - POs with no activities incorrectly appear under “Warnings”
  - Inverting the filter shows the expected POs with exception activities

Cause of the issue:
- The "Warnings" filter domain relied on a negative operator on the exception decoration field:
https://github.com/odoo/odoo/blob/cebc2acbd0e4d2373e0d1f96bcd291bf70be3a03/addons/purchase/views/purchase_views.xml#L459-L460
- `activity_exception_decoration` is a computed selection set to 'warning' or 'danger' when an exception activity exists:
https://github.com/odoo/odoo/blob/cebc2acbd0e4d2373e0d1f96bcd291bf70be3a03/addons/mail/models/mail_activity_mixin.py#L89-L91
- In 17.0, the search method simply forwards the operator to the decoration type of the linked activities:
https://github.com/odoo/odoo/blob/cebc2acbd0e4d2373e0d1f96bcd291bf70be3a03/addons/mail/models/mail_activity_mixin.py#L120-L121
With ('activity_exception_decoration', '!=', False) this becomes ('activity_ids.activity_type_id.decoration_type', '!=', False), i.e. it relies on a negative operator on the decoration type instead of explicitly matching the exception values. This makes the domain more fragile than an explicit condition on 'warning'/'danger', even though the UI semantics expect “Warning” only when activity_exception_decoration is set.

Why this was not intended:
- The field is truthy only when exception activities exist, a filter named “Warnings” should select exactly those records.
- The negative-operator domain includes records with no activities due to how `!=` works on relational fields, contradicting that semantics.

opw-5177277
