### PR TITLE
[FIX] web: close picker after selecting value in datepicker

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -202,14 +202,17 @@ export class DateTimeField extends Component {
         this.startDate = useRef("start-date");
         this.endDate = useRef("end-date");
 
-        useEffect(() => {
-            [this.startDate, this.endDate].forEach((ref, index) => {
-                if (ref.el?.getAttribute("data-field") === this.picker.activeInput) {
-                    ref.el.focus();
-                    this.openPicker(index);
-                }
-            });
-        });
+        useEffect(
+            () => {
+                [this.startDate, this.endDate].forEach((ref, index) => {
+                    if (ref.el?.getAttribute("data-field") === this.picker.activeInput) {
+                        ref.el.focus();
+                        this.openPicker(index);
+                    }
+                });
+            },
+            () => [this.startDate.el?.tagName, this.endDate.el?.tagName, this.picker.activeInput]
+        );
 
         onWillRender(() => this.triggerIsDirty());
 


### PR DESCRIPTION
Before this commit, the date picker would reopen after selecting a value. This was caused by `activeInput` being reset after the close, which took time when the `onChange` RPC was slow. As a result, `useEffect` was triggered before `activeInput` had been reset, causing the picker to reopen.

To fix this, we've reduced the number of `useEffect` calls. It will no longer be triggered when the input value changes.

Steps to reproduce:
- Open Customer Invoice
- Set the invoice date => the picker will stay instead of being closed.

Note that this is a date field with an onChange

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
