### PR TITLE
[IMP] mail: open message actions with right-click on message

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -11,11 +11,13 @@
                 role="group"
                 t-att-aria-label="messageTypeText"
                 t-on-click="onClick"
+                t-on-contextmenu="onContextMenu"
                 t-on-mouseenter="onMouseenter"
                 t-on-mouseleave="onMouseleave"
                 t-ref="root"
                 t-if="message.exists()"
             >
+                <MessageContextMenu anchorRef="rightClickAnchor" dropdownState="rightClickDropdownState" message="message" thread="props.thread"/>
                 <div class="o-mail-Message-jumpTarget position-absolute top-0 pe-none"/>
                 <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1 m-n2"><t t-call="mail.Message.actions"/></div>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0 bg-inherit">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -35,14 +35,15 @@ registerMessageAction("reaction", {
         action: messageActionsRegistry.get("reaction"),
         messageActive: owner.isActive,
     }),
-    componentCondition: () => !isMobileOS(),
+    componentCondition: ({ owner }) => !isMobileOS() && !owner.isMessageContextMenu,
     condition: ({ message, thread }) => message.canAddReaction(thread),
     icon: "oi oi-smile-add",
     name: _t("Add a Reaction"),
     onSelected({ owner }) {
-        return owner.reactionPicker.open({
-            el: owner.root?.el?.querySelector(`[name="${this.id}"]`),
-        });
+        const anchorEl = owner.isMessageContextMenu
+            ? owner.anchor.el
+            : owner.root?.el?.querySelector(`[name="${this.id}"]`);
+        return owner.reactionPicker.open({ el: anchorEl });
     },
     setup: ({ message, owner, thread }) =>
         (owner.reactionPicker = useEmojiPicker(undefined, {

--- a/addons/mail/static/src/core/common/message_context_menu.js
+++ b/addons/mail/static/src/core/common/message_context_menu.js
@@ -1,0 +1,23 @@
+import { Component, useRef } from "@odoo/owl";
+import { useForwardRefToParent, useService } from "@web/core/utils/hooks";
+import { ActionList } from "./action_list";
+import { useMessageActions } from "./message_actions";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+
+export class MessageContextMenu extends Component {
+    static template = "mail.MessageContextMenu";
+    static components = { ActionList, Dropdown };
+    static props = ["anchorRef", "dropdownState", "message", "thread?"];
+
+    setup() {
+        super.setup();
+        useForwardRefToParent("anchorRef");
+        this.store = useService("mail.store");
+        this.anchor = useRef("anchorRef");
+        this.isMessageContextMenu = true;
+        this.messageActions = useMessageActions({
+            message: () => this.props.message,
+            thread: () => this.props.thread,
+        });
+    }
+}

--- a/addons/mail/static/src/core/common/message_context_menu.xml
+++ b/addons/mail/static/src/core/common/message_context_menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="mail.MessageContextMenu">
+    <Dropdown state="props.dropdownState" manual="true" menuClass="store.discussDropdownMenuClass(this)" position="'right-start'">
+        <span class="d-flex position-fixed z-1" t-ref="anchorRef"/>
+        <t t-set-slot="content">
+            <ActionList actions="messageActions.actions" dropdown="true"/>
+        </t>
+    </Dropdown>
+</t>
+
+</templates>

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -2,7 +2,7 @@ import { DateSection } from "@mail/core/common/date_section";
 import { Message } from "@mail/core/common/message";
 import { NotificationMessage } from "./notification_message";
 import { Record } from "@mail/model/export";
-import { useChildRefs, useVisible } from "@mail/utils/common/hooks";
+import { useChildRefs, useMessageSelection, useVisible } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -137,6 +137,7 @@ export class Thread extends Component {
             },
             { ready: false }
         );
+        this.messageSelection = useMessageSelection();
         this.presentThresholdState = useVisible("present-treshold", () =>
             this.updateShowJumpPresent()
         );

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -29,6 +29,7 @@
                         asCard="props.thread.model === 'mail.box'"
                         className="getMessageClassName(msg)"
                         message="msg"
+                        messageSelection="messageSelection"
                         messageRefs="messageRefs"
                         previousMessage="prevMsg"
                         squashed="isSquashed(msg, prevMsg)"

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -401,6 +401,10 @@ export function useMessageScrolling(duration = 2000) {
     return state;
 }
 
+export function useMessageSelection() {
+    return useState({ messageId: undefined });
+}
+
 export function useMicrophoneVolume() {
     let isClosed = false;
     let audioTrack = null;


### PR DESCRIPTION
With this commit, right-click on message in desktop now opens a dropdown with message actions with anchor as the cursor position that initiated the right click.

This makes it easier to make an action on a message, as we don't necessarily have to reach the dedicated buttons, and the dropdown with right-click opens at position of cursor.

<img width="471" height="650" alt="Screenshot 2025-11-05 at 18 38 40" src="https://github.com/user-attachments/assets/5099f7a6-cfc5-4b3f-bebd-64fc0c32c3fa" />
