### PR TITLE
[PERF] account: speed up _compute_amount

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -956,6 +956,15 @@ class AccountMove(models.Model):
         'line_ids.full_reconcile_id',
         'state')
     def _compute_amount(self):
+        self.line_ids.fetch([
+            'debit',
+            'balance',
+            'amount_currency',
+            'amount_residual',
+            'amount_residual_currency',
+            'display_type',
+            'tax_repartition_line_id'
+        ])
         for move in self:
             total_untaxed, total_untaxed_currency = 0.0, 0.0
             total_tax, total_tax_currency = 0.0, 0.0


### PR DESCRIPTION
Currently performance on `_compute_amount()` is bottlenecked by `__get__()` calls on fields on `line_ids`. We tackle this bottleneck by warming the cache with `fetch()`

Benchmark on reconciling 2 account moves with ~70k lines each
|          |Total Time|Allocated Memory|Queries|
|----------|----------|----------------|-------|
|Before    |43.23s    |2GB             |993    |
|After     |18.60s    |1GB             |693    |

opw-5098543