### PR TITLE
[FIX] mrp: Allow picked sml to be unlinked

### DIFF
--- a/addons/mrp/models/stock_scrap.py
+++ b/addons/mrp/models/stock_scrap.py
@@ -79,6 +79,15 @@ class StockScrap(models.Model):
     def _should_check_available_qty(self):
         return super()._should_check_available_qty() or self.product_is_kit
 
+    def do_scrap(self):
+        self._check_company()
+        domain = [
+            ('move_id.raw_material_production_id', 'in', self.mapped('production_id').ids),
+            ('lot_id', 'in', self.mapped('lot_id').ids),
+        ]
+        self.env['stock.move.line'].search(domain).picked = False
+        return super().do_scrap()
+
     def do_replenish(self, values=False):
         self.ensure_one()
         values = values or {}


### PR DESCRIPTION
Step to reproduce:
- Install MRP.
- Set up a warehouse for a 3-step manufacturing process.
- Create 2 products: serial number (SN) tracking and Lot with lot tracking.
- For the SN product, create a BOM requiring Lot as a component (2 Lot for 1 SN)
- Add  few  lots (2 qty in each lot)  for Lot for in hand quantity
- Create an MO for the SN product (2 qty).
- Two transfers are created. Validate the one for pre-production (ready state).
- In the MO, validated lots (2 lots) are assigned.
- Mass produce the SN. The move is picked.
- Scrap the MO-1 for lot 1 (2 qty), mark should replenish.

Observation:
- A transfer is created for pre-production but does nothing when validated.
- The "Check Availability" button does not work as expected.

Cause:
- when scrapping the move in production, the linked move_line are picked by
mass production, hence the linked lots are not considered for reservation.
i.e. if a move line is picked somehow(here, by mass producing), and then if we
scrap a move, the linked line with that lot is not unlinked.

Fix:
- when scrapping a move in production, we unpick the related move line, so it
will be considered for availability checks.

opw-5213272

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
