### PR TITLE
[FIX] l10n_din5008_sale: fix missing line numbers in sale order report

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -274,6 +274,12 @@
                     <th name="th_position" class="text-start">Position</th>
                 </t>
             </xpath>
+            <!-- Insert Empty Column for Position Numbers to Handle Section Misalignment -->
+            <xpath expr="//td[@name='line_name_td']" position="after">
+                <t t-if="o.company_id.has_position_column">
+                    <td/>
+                </t>
+            </xpath>
 
             <xpath expr="//table[@name='invoice_line_table']/tbody//t[1]" position="before">
                 <t t-if="o.company_id.has_position_column">

--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -105,7 +105,7 @@
                 <t t-set="line_number" t-value="1"/>
             </t>
         </xpath>
-        <xpath expr="//table/tbody//tr[1]//td[1]" position="before">
+        <xpath expr="//td[@name='td_product_name']" position="before">
             <t t-if="doc.company_id.has_position_column">
                <td class="text-start" t-esc="line_number"/>
                 <t t-set="line_number" t-value="line_number+1"/>

--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -100,6 +100,12 @@
                 <th name="th_position" class="text-start">Position</th>
             </t>
         </xpath>
+        <!-- Insert Empty Column for Position Numbers to Handle Section Misalignment -->
+        <xpath expr="//td[@name='td_section_name']" position="after">
+            <t t-if="doc.company_id.has_position_column">
+               <td/>
+            </t>
+        </xpath>
         <xpath expr="//table/tbody" position="before">
             <t t-if="doc.company_id.has_position_column">
                 <t t-set="line_number" t-value="1"/>


### PR DESCRIPTION
**BUG 1:**
----

**Steps to reproduce:**
- Install `sale_management` and `l10n_de` modules with demo data.
- Set the company to a DE company
- From setting activate `Show Position Column in Reports` option
- Create a sale order with multiple products and add some section lines
- Notice that the sequence number only appears on section lines, not on product lines

**Issue:**
- Line numbers are coming to section line instead of product lines in the sale order report.

**Cause:**
- Issue occurs form this [Commit](https://github.com/odoo/odoo/pull/224219/commits/10d349f07ab1852141945775e4acdd26a83670dc)
- The `Xpath` used in the inherited template no longer matches due to changes in the base report structure, 
resulting in numbering being applied only to section lines.

**Solution:**
- Update the `Xpath` expression to correctly target the updated template structure 
so that sequence numbers are displayed for all sale order lines.

<details>
    <summary>Click here to see the results:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/75089f85-e942-487d-b097-813fb3fbae59" />
    After:
   <img src="https://github.com/user-attachments/assets/3049f390-8aff-4493-9030-a0416b925d25" />

</details>

---

**BUG 2:**
----

**Steps to reproduce:**
- Install `sale_management` and `l10n_de` modules with demo data.
- Set the company to a DE company
- From setting activate `Show Position Column in Reports` option
- Create an invoice with multiple products and add some section lines
and print invoice
- Notice that the alignment of the section is misplaced.

**Issue:**
- Notice that the alignment of the section is misplaced — the amount should be
on the right side, below the “Amount” column.
- The same issue occurs in the Sale Order as well.

**Cause:**
- Added one extra column ‘Position’ in the line, but the section doesn’t have it
causing misalignment between the line and section.

**Solution:**
- Added an XPath for the empty column to resolve the position misalignment issue

<details>
    <summary>Click here to see the results:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/522b0f2c-c18f-4457-aad1-7edc9b23754a" />
    After:
   <img src="https://github.com/user-attachments/assets/cc771b3c-80d4-4746-8d7e-ad7c57321b32" />

</details>

---

opw - 5147198

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
