### PR TITLE
[IMP] website_sale: restrict uom per website

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -205,7 +205,7 @@ class ProductPricelist(models.Model):
             suitable_rule = self.env['product.pricelist.item']
 
             # If no uom is specified, fallback on the product uom
-            quantity_uom = uom or product.uom_id
+            quantity_uom = uom or product._get_main_uom()
 
             for rule in rules:
                 if rule._is_applicable_for(product, quantity, uom=quantity_uom, **kwargs):

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -1272,3 +1272,6 @@ class ProductProduct(models.Model):
 
     def _get_available_uoms(self):
         return self.product_tmpl_id._get_available_uoms() | self.extra_uom_ids
+
+    def _get_main_uom(self):
+        return self.product_tmpl_id._get_main_uom()

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -1266,12 +1266,14 @@ class ProductProduct(models.Model):
     def _has_multiple_uoms(self):
         if self.type == 'combo':
             return False
-        return self.env['res.groups']._is_feature_enabled('uom.group_uom') and len(
-            self._get_available_uoms()
-        ) > 1
+        return len(self._get_available_uoms()) > 1
 
     def _get_available_uoms(self):
-        return self.product_tmpl_id._get_available_uoms() | self.extra_uom_ids
+        res = self.product_tmpl_id._get_available_uoms()
+        if self.env["res.groups"]._is_feature_enabled("uom.group_uom"):
+            # Multi-uom disabled, only main product uom matters.
+            return res | self.extra_uom_ids
+        return res
 
     def _get_main_uom(self):
         return self.product_tmpl_id._get_main_uom()

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1718,6 +1718,14 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         return self.uom_id | self.uom_ids
 
+    def _get_main_uom(self):
+        """Return the default uom configured on the product.
+
+        :returns: the main uom of the product
+        :rtype: `uom.uom` recordset
+        """
+        return self.uom_id
+
     ###################
     # DEMO DATA SETUP #
     ###################

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1708,14 +1708,15 @@ class ProductTemplate(models.Model):
     def _has_multiple_uoms(self) -> bool:
         if self.type == 'combo':
             return False
-        return self.env['res.groups']._is_feature_enabled('uom.group_uom') and len(
-            self._get_available_uoms()
-        ) > 1
+        return len(self._get_available_uoms()) > 1
 
     def _get_available_uoms(self):
         if not self:
             return self.env['uom.uom']
         self.ensure_one()
+        if not self.env['res.groups']._is_feature_enabled('uom.group_uom'):
+            # Multi-uom disabled, only main product uom matters.
+            return self.uom_id
         return self.uom_id | self.uom_ids
 
     def _get_main_uom(self):

--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -295,7 +295,7 @@ class SaleProductConfiguratorController(Controller):
         """
         uom = (
             product_uom_id and request.env["uom.uom"].browse(product_uom_id)
-        ) or product_template.uom_id
+        ) or product_template._get_main_uom()
         product = product_template._get_variant_for_combination(combination)
         attribute_exclusions = product_template._get_attribute_exclusions(
             combination_ids=combination.ids

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -347,6 +347,10 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             query_count += 3
             queries['product_template_attribute_value'] += 3
 
+        if self.env['res.groups']._is_feature_enabled('uom.group_uom'):
+            query_count += 1
+            queries['uom_uom'] = 1
+
         # To increase the query count you must ask the permission to al
         return query_count, queries
 
@@ -377,6 +381,10 @@ class TestWebsiteAllPerformanceShop(TestWebsiteAllPerformance):
         query_count += 2
         queries['account_tax'] += 1
         queries['account_account_tag'] += 1
+
+        if self.env['res.groups']._is_feature_enabled('uom.group_uom'):
+            query_count += 1
+            queries['uom_uom'] += 1
 
         if self._has_demo_data():
             query_count += 2

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -936,6 +936,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "category": category,
             'original_category': original_category,
             "combination_info": combination_info,
+            "has_available_uoms": len(product._get_available_uoms()) > 0,
             "keep": keep,
             "main_object": product,
             "product": product,

--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -71,7 +71,11 @@ class WebsiteSaleVariantController(Controller):
 
         combination_info["packaging_selector"] = request.env["ir.ui.view"]._render_template(
             "website_sale.product_packaging_selector",
-            values={"product": product_template, "product_variant": product},
+            values={
+                "product": product_template,
+                "product_variant": product,
+                "combination_info": combination_info,
+            },
         )
 
         return combination_info

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -81,6 +81,8 @@ class ProductProduct(models.Model):
         self.ensure_one()
         if not self.filtered_domain(self.env["website"]._product_domain()):
             return False
+        if not self._get_available_uoms():
+            return False
         website = self.env["website"].get_current_website()
         return not (
             website.prevent_sale
@@ -229,3 +231,45 @@ class ProductProduct(models.Model):
         """
         self.ensure_one()
         return self.env["website"].image_url(self, "image_1024")
+
+    def _has_multiple_uoms(self) -> bool:
+        """Check if the product has multiple available uoms for the current website.
+
+        :return: True if the product has multiple available uoms for the current website
+                 or if the default uom is not available
+        """
+        res = super()._has_multiple_uoms()
+        if res:
+            return res
+        if self.env.context.get("website_id") and self.type != "combo":
+            uoms = self._get_available_uoms()
+            if uoms:
+                return self.uom_id not in uoms
+        return res
+
+    def _get_available_uoms(self):
+        """Return a recordset of uoms configured for the product that are available for the current
+        website.
+
+        :returns: uoms available on the product for the current website.
+        :rtype: recordset of `uom.uom`
+        """
+        all_uoms = super()._get_available_uoms()
+        if self.env["res.groups"]._is_feature_enabled("uom.group_uom") and self.env.context.get(
+            "website_id"
+        ):
+            return all_uoms - self.env["website"].get_current_website().restricted_uom_ids
+        return all_uoms
+
+    def _get_main_uom(self):
+        """Return the main uom for the product.
+        The main uom is always the first available uom on the current website, if no uom is
+        available, the default uom configured on the product is considered as the main uom.
+
+        :returns: the main uom of the product
+        :rtype: `uom.uom` recordset
+        """
+        self.ensure_one()
+        if self.env.context.get("website_id"):
+            return self._get_available_uoms()[:1] or self.uom_id
+        return super()._get_main_uom()

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -382,7 +382,7 @@ class ProductTemplate(models.Model):
                     product=template,
                     quantity=1.0,
                     date=date,
-                    uom=template.uom_id,
+                    uom=template._get_main_uom(),
                     currency=currency,
                 )
                 if currency.compare_amounts(pricelist_base_price, pricelist_price) == 1:
@@ -469,7 +469,7 @@ class ProductTemplate(models.Model):
 
         combination = combination or self.env["product.template.attribute.value"]
         website = request.website.with_context(self.env.context)
-        uom = self.env["uom.uom"].browse(uom_id) or self.uom_id
+        uom = self.env["uom.uom"].browse(uom_id) or self._get_main_uom()
 
         if not product_id and not combination and not only_template:
             combination = self._get_first_possible_combination()
@@ -982,6 +982,8 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         if not self.filtered_domain(self.env["website"]._product_domain()):
             return False
+        if not self._get_available_uoms():
+            return False
         website = self.env["website"].get_current_website()
         return not (
             website.prevent_sale
@@ -1143,3 +1145,45 @@ class ProductTemplate(models.Model):
         self.ensure_one()
 
         return bool(self.valid_product_template_attribute_line_ids)
+
+    def _has_multiple_uoms(self) -> bool:
+        """Check if the product has multiple available uoms for the current website.
+
+        :return: True if the product has multiple available uoms for the current website
+                 or if the default uom is not available
+        """
+        res = super()._has_multiple_uoms()
+        if res:
+            return res
+        if self.env.context.get("website_id") and self.type != "combo":
+            uoms = self._get_available_uoms()
+            if uoms:
+                return self.uom_id not in uoms
+        return res
+
+    def _get_available_uoms(self):
+        """Return a recordset of uoms configured for the product that are available for the current
+        website.
+
+        :returns: uoms available on the product for the current website.
+        :rtype: recordset of `uom.uom`
+        """
+        all_uoms = super()._get_available_uoms()
+        if self.env["res.groups"]._is_feature_enabled("uom.group_uom") and self.env.context.get(
+            "website_id"
+        ):
+            return all_uoms - self.env["website"].get_current_website().restricted_uom_ids
+        return all_uoms
+
+    def _get_main_uom(self):
+        """Return the main uom for the product.
+        The main uom is always the first available uom on the current website, if no uom is
+        available, the default uom configured on the product is considered as the main uom.
+
+        :returns: the main uom of the product
+        :rtype: `uom.uom` recordset
+        """
+        self.ensure_one()
+        if self.env.context.get("website_id"):
+            return self._get_available_uoms()[:1] or self.uom_id
+        return super()._get_main_uom()

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -54,6 +54,9 @@ class ResConfigSettings(models.TransientModel):
     rating_email_template_id = fields.Many2one(
         related="website_id.rating_email_template_id", readonly=False
     )
+    restricted_uom_ids = fields.Many2many(
+        related="website_id.restricted_uom_ids", readonly=False
+    )
 
     # Additional settings
     account_on_checkout = fields.Selection(

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -378,7 +378,7 @@ class SaleOrder(models.Model):
         self = self.with_company(self.company_id)
 
         if not uom_id:
-            uom_id = self.env["product.product"].browse(product_id).uom_id.id  # type: ignore
+            uom_id = self.env["product.product"].browse(product_id)._get_main_uom().id  # type: ignore
         if existing_sol := self._cart_find_product_line(product_id, uom_id=uom_id, **kwargs)[:1]:
             # If a matching line is found, update the existing line instead.
             return self._cart_update_line_quantity(

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -272,6 +272,7 @@ class Website(models.Model):
         domain=[("model", "=", "sale.order")],
         default=_default_confirmation_email_template,
     )
+    restricted_uom_ids = fields.Many2many(string="Restrict Packagings", comodel_name="uom.uom")
 
     # === COMPUTE METHODS ===#
 

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -668,7 +668,7 @@ export class ProductPage extends Interaction {
             }
         });
 
-        this._toggleDisable(parent, isCombinationPossible);
+        this._toggleDisable(parent, isCombinationPossible && this.el.dataset.hasAvailableUoms);
 
         // Only update the images, tags and packaging selector if the product has changed.
         if (!combination.no_product_change) {

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -22,7 +22,7 @@
         <t t-set="is_50_pc" t-value="website.product_page_image_width == '50_pc'"/>
 
         <t t-call="website.layout" additional_title="product.name">
-            <div id="wrap" class="o_wsale_product_page">
+            <div id="wrap" class="o_wsale_product_page" t-att-data-has-available-uoms="has_available_uoms">
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" data-editor-message.translate="Drag blocks here to add them on all products"/>
                 <section id="product_detail"
                          t-attf-class="oe_website_sale mt-1 mt-lg-2 mb-5 #{'discount'
@@ -475,8 +475,9 @@
                         data-bs-toggle="buttons"
                     >
                         <t t-set="product_uoms" t-value="product_variant._get_available_uoms()"/>
+                        <t t-set="main_uom" t-value="product._get_main_uom()"/>
                         <t t-foreach="product_uoms" t-as="uom">
-                            <t t-set="is_main_uom" t-value="uom.id == product.uom_id.id"/>
+                            <t t-set="is_main_uom" t-value="uom.id == main_uom.id"/>
                             <li t-attf-class="o_packaging_button o_variant_pills border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if is_main_uom else ''}">
                                 <input
                                     class="position-absolute opacity-0 cursor-pointer"

--- a/addons/website_sale/tests/test_product_template.py
+++ b/addons/website_sale/tests/test_product_template.py
@@ -137,3 +137,51 @@ class TestWebsiteSaleProductTemplate(WebsiteSaleCommon):
             date=Date.from_string("2020-01-01"),
         )
         self.assertAlmostEqual(result["price"], expected_price, places=2)
+
+    def test_get_available_uoms_no_restrictions(self):
+        self._enable_uom()
+        template = self.product.product_tmpl_id
+        template.uom_ids = [self.uom_dozen.id, self.uom_ton.id]
+
+        uoms = template.with_context({'website_id': self.website.id})._get_available_uoms()
+
+        self.assertEqual(len(uoms), 3)
+
+    def test_get_available_uoms_restricted_additional_uom(self):
+        self._enable_uom()
+        template = self.product.product_tmpl_id
+        template.uom_ids = [self.uom_dozen.id, self.uom_ton.id]
+        self.website.restricted_uom_ids = [self.uom_dozen.id]
+
+        uoms = template.with_context({'website_id': self.website.id})._get_available_uoms()
+
+        self.assertEqual(len(uoms), 2)
+        self.assertTrue(self.uom_dozen not in uoms)
+
+    def test_has_multiple_uoms_restricted_main_uom(self):
+        self._enable_uom()
+        template = self.product.product_tmpl_id
+        template.uom_ids = [self.uom_dozen.id]
+        self.website.restricted_uom_ids = [template.uom_id.id]
+
+        result = template.with_context({'website_id': self.website.id})._has_multiple_uoms()
+        uoms = template.with_context({'website_id': self.website.id})._get_available_uoms()
+        main_uom = template.with_context({'website_id': self.website.id})._get_main_uom()
+
+        self.assertEqual(len(uoms), 1)
+        self.assertTrue(result)
+        self.assertEqual(main_uom, self.uom_dozen)
+
+    def test_has_multiple_uoms_restricted_additional_uom(self):
+        self._enable_uom()
+        template = self.product.product_tmpl_id
+        template.uom_ids = [self.uom_dozen.id]
+        self.website.restricted_uom_ids = [self.uom_dozen.id]
+
+        result = template.with_context({'website_id': self.website.id})._has_multiple_uoms()
+        uoms = template.with_context({'website_id': self.website.id})._get_available_uoms()
+        main_uom = template.with_context({'website_id': self.website.id})._get_main_uom()
+
+        self.assertEqual(len(uoms), 1)
+        self.assertFalse(result)
+        self.assertEqual(main_uom, template.uom_id)

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -282,6 +282,13 @@
                 >
                     <field name="module_website_sale_collect"/>
                 </setting>
+                <setting
+                    id="restrict_packagings_setting"
+                    help="Prevent from selling the specified packagings"
+                    invisible="not group_uom"
+                >
+                    <field name="restricted_uom_ids" widget="many2many_tags"/>
+                </setting>
             </block>
             <setting id="google_analytics_setting" position="after">
                 <setting


### PR DESCRIPTION
**Purpose**
Packaging restriction per website can be interesting for B2B/B2C segmentation.

**Specification**
- Add a websites field on units of measure
- Filter available packagings on the shop's product page.

Task-5238106

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
