### PR TITLE
[FIX] point_of_sale: load missing fields widgets

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -137,6 +137,10 @@
             'bus/static/src/workers/*',
             'iot_base/static/src/network_utils/*',
             'iot_base/static/src/device_controller.js',
+            "account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.*",
+            "product/static/src/product_name_and_description/*",
+            "account/static/src/components/many2x_tax_tags/many2x_tax_tags.js",
+            'pos_enterprise/static/src/backend/components/fields/duration_field.*',
         ],
 
         # Main PoS assets, they are loaded in the PoS UI


### PR DESCRIPTION
Steps to reproduce
------------------
1. In PoS, make a normak order and pay it
2. Go to the "Orders", filter by "Paid"
3. Select the order of step 1 and click "Details"

Observed behavior -> Warnings in the console about missing widgets.

Fix
---
We add those missing widgets to point_of_sale/__manifest__.py

opw-5181965