### PR TITLE
[IMP] Group image transformation options

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.xml
@@ -74,7 +74,7 @@
                 computedOutput="this.toRatio" />
         </BuilderRow>
 
-        <BuilderRow label.translate="Stretch" level="1" t-if="this.state.togglableRatio" preview="false">
+        <BuilderRow label.translate="Stretch" level="1" t-if="this.state.togglableRatio" preview="false" tooltip.translate="Will remove the crop factor">
             <BuilderCheckbox action="'toggleImageShapeRatio'" />
         </BuilderRow>
     </t>

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -2,6 +2,18 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageToolOption">
+    <t t-if="!state.isGridMode and !state.isSocialMediaImg">
+        <MediaSizeOption level="1"/>
+    </t>
+    <BuilderRow label.translate="Transform" level="1" preview="false">
+        <div class="btn-group o-hb-button-group">
+            <BuilderButton title.translate="Crop image" action="'cropImage'" icon="'fa-crop'" id="'cropImage'" />
+            <BuilderButton title.translate="Reset crop" action="'resetCrop'" t-if="this.isActiveItem('cropImage')" icon="'oi-close'" className="'btn-danger-color-hover rounded-start-0 m-0 py-0 flex-grow-0'" />
+        </div>
+        <ImageTransformOption t-if="!state.isImageAnimated and !state.isSocialMediaImg" />
+    </BuilderRow>
+    <ImageFilterOption level="1"/>
+    <ImageFormatOption level="1"/>
     <t t-if="!state.isSocialMediaImg">
         <ImageShapeOption />
         <BuilderRow label.translate="Description"
@@ -18,18 +30,6 @@
                 placeholder.translate="Title tag" />
         </BuilderRow>
     </t>
-    <BuilderRow label.translate="Transform" preview="false">
-        <div class="btn-group o-hb-button-group">
-            <BuilderButton title.translate="Crop image" action="'cropImage'" icon="'fa-crop'" id="'cropImage'" />
-            <BuilderButton title.translate="Reset crop" action="'resetCrop'" t-if="this.isActiveItem('cropImage')" icon="'oi-close'" className="'btn-danger-color-hover rounded-start-0 m-0 py-0 flex-grow-0'" />
-        </div>
-        <ImageTransformOption t-if="!state.isImageAnimated and !state.isSocialMediaImg" />
-    </BuilderRow>
-    <ImageFilterOption />
-    <t t-if="!state.isGridMode and !state.isSocialMediaImg">
-        <MediaSizeOption/>
-    </t>
-    <ImageFormatOption />
 </t>
 
 <t t-name="html_builder.ImageAndFaOption">

--- a/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
@@ -18,7 +18,7 @@ class TransformImageAction extends BuilderAction {
     static id = "transformImage";
     static dependencies = ["history"];
     isApplied({ editingElement }) {
-        return editingElement.matches(`[style*="transform"]`);
+        return editingElement.matches(`[style*="transform"], [style*="width"], [style*="height"]`);
     }
     async apply({
         editingElement,

--- a/addons/html_builder/static/src/plugins/image/media_size_option.js
+++ b/addons/html_builder/static/src/plugins/image/media_size_option.js
@@ -2,4 +2,10 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class MediaSizeOption extends BaseOptionComponent {
     static template = "html_builder.MediaSizeOption";
+    static props = {
+        level: { type: Number, optional: true },
+    };
+    static defaultProps = {
+        level: 0,
+    };
 }

--- a/addons/html_builder/static/src/plugins/image/media_size_option.xml
+++ b/addons/html_builder/static/src/plugins/image/media_size_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.MediaSizeOption">
-    <BuilderRow label.translate="Size">
+    <BuilderRow label.translate="Size" level="this.props.level">
         <div style="width: 45%;">
             <BuilderRange
                 action="'mediaSizeSlider'"

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -214,6 +214,13 @@ export class ImagePlugin extends Plugin {
         selectionchange_handlers: this.updateImageParams.bind(this),
         post_undo_handlers: this.updateImageParams.bind(this),
         post_redo_handlers: this.updateImageParams.bind(this),
+        on_media_dialog_saved_handlers: async (elements) => {
+            for (const element of elements) {
+                if (element && element.tagName === "IMG") {
+                    this.resetImageTransformation(element, { addStep: false });
+                }
+            }
+        },
 
         /** Providers */
         paste_media_url_command_providers: this.getCommandForImageUrlPaste.bind(this),
@@ -380,14 +387,16 @@ export class ImagePlugin extends Plugin {
         this.dependencies.history.addStep();
     }
 
-    resetImageTransformation(image) {
+    resetImageTransformation(image, { addStep = true } = {}) {
         image.setAttribute(
             "style",
             (image.getAttribute("style") || "").replace(/[^;]*transform[\w:]*;?/g, "")
         );
         image.style.removeProperty("width");
         image.style.removeProperty("height");
-        this.dependencies.history.addStep();
+        if (addStep) {
+            this.dependencies.history.addStep();
+        }
     }
 
     getImageTransformProps() {


### PR DESCRIPTION
This PR reorganizes the image transformation options into a single group, making the interface more intuitive. It also correctly resets the image transformations once an image has been replaced.

Task: [5214095](https://www.odoo.com/odoo/project/974/tasks/5214095)
