### PR TITLE
[FIX] pos_hr : An TB occurs at opening and closing 

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -161,7 +161,7 @@ export default class IndexedDB {
         return results;
     }
 
-    getNewTransaction(dbStore) {
+    async getNewTransaction(dbStore) {
         try {
             if (!this.db) {
                 return false;
@@ -177,6 +177,17 @@ export default class IndexedDB {
                 `Error creating transaction: ${e.message}`,
                 CONSOLE_COLOR
             );
+            try {
+                await this.reset();
+                window.location.reload();
+            } catch (err) {
+                logPosMessage(
+                    "IndexedDB",
+                    "getNewTransaction",
+                    `Reset failed: ${err}`,
+                    CONSOLE_COLOR
+                );
+            }
             return false;
         }
     }


### PR DESCRIPTION
Before this fix, a traceback occurred on the frontend when switching from a POS configuration without the “Log in with employees” option enabled to one that had it enabled. 

Steps to reproduce :
1. Open a PoS without "Log In With Employees" option activated
2. Close Register and go to the backend
3. Enable the "Log in with employees option" for this PoS and set some users
4. Re-open the PoS with a user and close it
5. A TB occured

This traceback occurred because the IndexedDB did not include the "hr.employee" module required by the "Log in with employees" option. The fix was to delete the IndexedDB when the error is caught and refresh the page to trigger the IndexedDB upgrade process.

task: 5223393

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
