### PR TITLE
[FIX] l10n_sa_edi: use commercial partner to decide whether to use cl…

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -29,7 +29,12 @@ class AccountMove(models.Model):
         :return:
         """
         self.ensure_one()
-        return self.partner_id.company_type == 'person'
+
+        return (
+            self.partner_id.commercial_partner_id.company_type == "person"
+            if self.partner_id.commercial_partner_id
+            else self.partner_id.company_type == "person"
+        )
 
     @api.depends('amount_total_signed', 'amount_tax_signed', 'l10n_sa_confirmation_datetime', 'company_id',
                  'company_id.vat', 'journal_id', 'journal_id.l10n_sa_production_csid_json', 'edi_document_ids',


### PR DESCRIPTION
…earance or reporting api

When sending an invoice to ZATCA, if the contact is an individual, the invoice is sent through the reporting API, and if the contact is a company, the invoice is sent through the clearance API.

As of now, if the contact has a parent company, the invoice is sent through the report api. However, we need to make sure that in this case, the invoice goes through the clearance api.

The fix introduced simply checks the partner_id.commercial_partner_id to decide whether the invoice is a simplified invoice (i.e. through the reporting api) or not.

Task-5085142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
