### PR TITLE
[FIX] pos_hr : An TB occurs at opening and closing without any details

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -11,22 +11,24 @@ import { browser } from "@web/core/browser/browser";
 import { ConnectionLostError, rpc, RPCError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { logPosMessage } from "../utils/pretty_console_log";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 const { DateTime } = luxon;
 const CONSOLE_COLOR = "#28ffeb";
 
 export class PosData extends Reactive {
     static modelToLoad = []; // When empty all models are loaded
-    static serviceDependencies = ["orm", "bus_service"];
+    static serviceDependencies = ["orm", "bus_service", "dialog"];
 
     constructor() {
         super();
         this.ready = this.setup(...arguments).then(() => this);
     }
 
-    async setup(env, { orm, bus_service }) {
+    async setup(env, { orm, bus_service, dialog }) {
         this.orm = orm;
         this.bus = bus_service;
+        this.dialog = dialog;
         this.relations = [];
         this.custom = {};
         this.syncInProgress = false;
@@ -135,51 +137,78 @@ export class PosData extends Reactive {
     }
 
     async initIndexedDB(relations) {
-        // This method initializes indexedDB with all models loaded into the PoS. The default key is ID.
-        // But some models have another key configured in data_service_options.js. These models are
-        // generally those that can be created in the frontend.
         const allModelNames = Array.from(
             new Set([...Object.keys(relations), ...Object.keys(this.opts.databaseTable)])
         );
+
         const models = allModelNames.map((model) => {
             const key = this.opts.databaseTable[model]?.key || "id";
             return [key, model];
         });
 
-        return new Promise((resolve) => {
-            this.indexedDB = new IndexedDB(this.databaseName, false, models, resolve);
-        });
+        const result = await new Promise(
+            (resolve) => new IndexedDB(this.databaseName, false, models, resolve)
+        );
+        this.indexedDB = result.instance;
+
+        if (!result.success && result.timeout) {
+            //TODO display a dialog for other IndexedDB init errors?
+            this.dialog.add(AlertDialog, {
+                title: _t("IndexedDB Initialization error"),
+                body: _t(
+                    "The IndexedDB database is taking too long to initialize. This may be due to a corrupted IndexedDB database. " +
+                        "We recommend you to clear your browser's IndexedDB for this site and reload the Point of Sale."
+                ),
+                confirmLabel: _t("Clear cache"),
+                cancelLabel: _t("Continue"),
+                cancel: () => {},
+                confirm: async () => {
+                    await this.resetIndexedDB();
+                    window.location.reload();
+                },
+            });
+        }
     }
 
     async synchronizeLocalDataInIndexedDB() {
         // This methods will synchronize local data and state in indexedDB. This methods is mostly
         // used with models like pos.order, pos.order.line, pos.payment etc. These models are created
         // in the frontend and are not loaded from the backend.
-        const modelsParams = Object.entries(this.opts.databaseTable);
-        for (const [model, params] of modelsParams) {
-            const put = [];
-            const remove = [];
-            const data = this.models[model].getAll();
+        try {
+            const modelsParams = Object.entries(this.opts.databaseTable);
+            for (const [model, params] of modelsParams) {
+                const put = [];
+                const remove = [];
+                const data = this.models[model].getAll();
 
-            for (const record of data) {
-                const isToRemove = params.condition(record);
+                for (const record of data) {
+                    const isToRemove = params.condition(record);
 
-                if (isToRemove === undefined || isToRemove === true) {
-                    if (record[params.key]) {
-                        remove.push(record[params.key]);
+                    if (isToRemove === undefined || isToRemove === true) {
+                        if (record[params.key]) {
+                            remove.push(record[params.key]);
+                        }
+                    } else {
+                        put.push(record.serializeForIndexedDB());
                     }
-                } else {
-                    put.push(record.serializeForIndexedDB());
+                }
+
+                if (remove.length) {
+                    await this.indexedDB.delete(model, remove);
+                }
+
+                if (put.length) {
+                    await this.indexedDB.create(model, put);
                 }
             }
-
-            if (remove.length) {
-                await this.indexedDB.delete(model, remove);
-            }
-
-            if (put.length) {
-                await this.indexedDB.create(model, put);
-            }
+        } catch (error) {
+            logPosMessage(
+                "DataService",
+                "synchronizeLocalDataInIndexedDB",
+                "Error while synchronizing server data in indexedDB.",
+                CONSOLE_COLOR,
+                [error]
+            );
         }
     }
 
@@ -209,6 +238,10 @@ export class PosData extends Reactive {
     }
 
     async getLocalDataFromIndexedDB() {
+        if (!this.indexedDB) {
+            return {};
+        }
+
         // Used to retrieve models containing states from the indexedDB.
         // This method will load the records directly via loadData.
         const models = Object.keys(this.opts.databaseTable);
@@ -237,6 +270,10 @@ export class PosData extends Reactive {
     }
 
     async getCachedServerDataFromIndexedDB() {
+        if (!this.indexedDB) {
+            return {};
+        }
+
         // Used to load models that have not yet been loaded into related_models.
         // These models have been sent to the indexedDB directly after the RPC load_data.
         const data = await this.indexedDB.readAll();

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -276,9 +276,36 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async initServerData() {
-        await this.processServerData();
-        this.data.connectWebSocket("CLOSING_SESSION", this.closingSessionNotification.bind(this));
-        return await this.afterProcessServerData();
+        try {
+            await this.processServerData();
+            this.data.connectWebSocket(
+                "CLOSING_SESSION",
+                this.closingSessionNotification.bind(this)
+            );
+            return await this.afterProcessServerData();
+        } catch (error) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Error"),
+                body: _t(
+                    "Failed to initialize the application. This is often caused by outdated cached data.\nWould you like to clear the cache and reload?"
+                ),
+                confirmLabel: _t("Clear cache"),
+                cancelLabel: _t("Continue"),
+                cancel: () => {},
+                confirm: () => this.reloadData(true),
+                dismiss: () => this.reloadData(true),
+            });
+
+            logPosMessage(
+                "Store",
+                "initServerData",
+                "Error while initializing server data",
+                CONSOLE_COLOR,
+                error
+            );
+
+            return false;
+        }
     }
 
     async closingSessionNotification(data) {

--- a/addons/point_of_sale/static/tests/unit/tools/indexed_db.test.js
+++ b/addons/point_of_sale/static/tests/unit/tools/indexed_db.test.js
@@ -1,0 +1,41 @@
+import { expect, test } from "@odoo/hoot";
+import IndexedDB from "@point_of_sale/app/models/utils/indexed_db";
+
+test("Test indexedDB upgrade", async () => {
+    window.indexedDB.deleteDatabase("unit-test-db");
+    const store = [["id", "model1"]];
+    const initDb = async (stores) =>
+        new Promise((resolve) => new IndexedDB("unit-test-db", false, stores, resolve));
+
+    {
+        const result = await initDb(store);
+        expect(result.success).toBe(true);
+        expect(Array.from(result.instance.db.objectStoreNames)).toEqual(["model1"]);
+        result.instance.db.close();
+    }
+
+    {
+        store.push(["id", "model2"]);
+        const result = await initDb(store);
+        expect(result.success).toBe(true);
+        expect(Array.from(result.instance.db.objectStoreNames)).toEqual(["model1", "model2"]);
+        result.instance.db.close();
+    }
+
+    {
+        store.splice(1, 1); // remove model1
+        const result = await initDb(store);
+        expect(result.success).toBe(true);
+        expect(Array.from(result.instance.db.objectStoreNames)).toEqual(["model1"]);
+        result.instance.db.close();
+    }
+
+    {
+        const result = await initDb(store);
+        expect(result.success).toBe(true);
+        expect(Array.from(result.instance.db.objectStoreNames)).toEqual(["model1"]);
+        result.instance.db.close();
+    }
+
+    window.indexedDB.deleteDatabase("unit-test-db");
+});

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -36,6 +36,9 @@ patch(PosStore.prototype, {
             .filter((order) => order.is_reward_line && !order.reward_id)
             .map((line) => line.delete());
         await super.afterProcessServerData(...arguments);
+        if (this.selectedOrderUuid) {
+            this.updateRewards();
+        }
     },
     async updateOrder(order) {
         // Read value to trigger effect
@@ -636,12 +639,6 @@ patch(PosStore.prototype, {
 
                 reward.delete();
             }
-        }
-    },
-    async initServerData() {
-        await super.initServerData(...arguments);
-        if (this.selectedOrderUuid) {
-            this.updateRewards();
         }
     },
     /**


### PR DESCRIPTION
Before this fix, a traceback occurred on the frontend when switching from a POS configuration without the “Log in with employees” option enabled to one that had it enabled.

Steps to reproduce :
1. Open a PoS without "Log In With Employees" option activated
2. Close Register and go to the backend
3. Enable the "Log in with employees option" for this PoS and set some users
4. Re-open the PoS with a user and close it
5. A TB occured

This traceback occurred because the IndexedDB did not include the "hr.employee" module required by the "Log in with employees" option.

The fix was to upgrade the IndexedDB if a module is missing.

task: 5223393

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
