### PR TITLE
[FIX] mail: prevent max call stack error in messaging menu

### DIFF
--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -46,11 +46,6 @@ export class Persona extends Record {
     /** @type {string} */
     phone;
     debouncedSetImStatus;
-    displayName = fields.Attr(undefined, {
-        compute() {
-            return this._computeDisplayName();
-        },
-    });
     main_user_id = fields.One("res.users");
     monitorPresence = fields.Attr(false, {
         compute() {
@@ -117,6 +112,16 @@ export class Persona extends Record {
     write_date = fields.Datetime();
     group_ids = fields.Many("res.groups", { inverse: "personas" });
 
+    /**
+     * @deprecated
+     *
+     * `store.menuThreads` uses this field to filter threads based on search
+     * terms. For each computation, the `menuThread` field is marked as needing a
+     * recompute, which can lead to excessive recursion—sometimes even exceeding the
+     * call stack size. This computation is simple enough that it doesn’t need a
+     * compute and has been replaced by a getter. To override the display name
+     * computation, override the displayName getter.
+     */
     _computeDisplayName() {
         return this.name;
     }
@@ -147,6 +152,10 @@ export class Persona extends Record {
             });
         }
         return this.store.DEFAULT_AVATAR;
+    }
+
+    get displayName() {
+        return this._computeDisplayName();
     }
 
     searchChat() {


### PR DESCRIPTION
Accessing the chat tab in the messaging menu with many chats causes a max call stack error.

Threads in the messaging menu rely on the `menuThreads` store field, which depends on `thread.displayName`.
- Thread display name is a getter which accesses `correspondent.name`, a computed field.
- Accessing `thread.displayName` in a loop repeatedly triggers recomputation of `menuThreads`, eventually reaching max call stack size.
- Additionally, `menuThreads` computation is inefficient due to sorting and reactive proxy access.

To solve this issue:
- Update `menuThreads` to use the inverse relation instead of a complex compute.
- Debounce the array sort so it executes only once when the relation is fully filled.

task-4794325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
