### PR TITLE
[FIX] event_product: ensure tickets have correct service tracking

### DIFF
--- a/addons/event_product/models/product_product.py
+++ b/addons/event_product/models/product_product.py
@@ -1,7 +1,18 @@
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class Product(models.Model):
     _inherit = 'product.product'
 
     event_ticket_ids = fields.One2many('event.event.ticket', 'product_id', string='Event Tickets')
+
+    @api.constrains('event_ticket_ids', 'service_tracking')
+    def _check_event_ticket_service_tracking(self):
+        if any(product.service_tracking != 'event' for product in self if product.event_ticket_ids):
+            service_tracking = self.fields_get(['service_tracking'], ['string', 'selection'])['service_tracking']
+            raise ValidationError(_(
+                'Products linked to an event ticket must have "%(tracking)s" set to "%(event)s".',
+                tracking=service_tracking['string'],
+                event=dict(service_tracking['selection'])['event'],
+            ))

--- a/addons/event_product/tests/__init__.py
+++ b/addons/event_product/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_event_product

--- a/addons/event_product/tests/test_event_product.py
+++ b/addons/event_product/tests/test_event_product.py
@@ -1,0 +1,23 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.event_product.tests.common import TestEventProductCommon
+
+
+@tagged('post_install', '-at_install')
+class TestEventProduct(TestEventProductCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.test_event = cls.env['event.event'].create({
+            'name': "TestEventProduct",
+            'event_type_id': cls.event_type_tickets.id,
+        })
+
+    def test_ensure_event_service_tracking(self):
+        with self.assertRaises(ValidationError):
+            self.event_product.service_tracking = 'no'
+        with self.assertRaises(ValidationError):
+            self.event_product.type = 'consu'


### PR DESCRIPTION
Steps
-----
1. Have `sale_renting` but not `sale_stock_renting` installed;
2. create an event with a ticket;
3. make the ticket's product rentable;
4. change ticket's product type to Goods;
5. publish the event to website;
6. register for the event via website;
7. go to payment.

Issue
-----
> AttributeError: 'bool' object has no attribute 'tzinfo'

Cause
-----
By making it a rental product, it creates a rental order, but as registering for an event via website doesn't have any way to add rental dates, rental lines cannot be processed & rendered as expected.

Solution
--------
Prevent users from changing the `service_tracking` away from `'event'` by adding an `api.constrains` to `product.product` on `service_tracking` and `event_ticket_ids`.

opw-5207045