### PR TITLE
[FIX] crm: handle lead stage change when created in a won stage

### DIFF
--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -292,6 +292,16 @@ class TestCRMLead(TestCrmCommon):
 
     @users('user_sales_manager')
     def test_crm_lead_date_closed(self):
+        # ensure a lead created directly in a won stage gets a date_closed
+        lead_in_won = self.env['crm.lead'].create({
+            'name': 'Created in Won',
+            'type': 'opportunity',
+            'stage_id': self.stage_team1_won.id,
+            'expected_revenue': 123.45,
+        })
+        # date_closed must be set at creation when stage is won
+        self.assertTrue(lead_in_won.date_closed, "Lead created in a won stage must have date_closed set")
+        self.assertIsInstance(lead_in_won.date_closed, datetime)
         # Test for one won lead
         stage_team1_won2 = self.env['crm.stage'].create({
             'name': 'Won2',
@@ -299,6 +309,10 @@ class TestCRMLead(TestCrmCommon):
             'team_ids': [self.sales_team_1.id],
             'is_won': True,
         })
+        old_date_closed = lead_in_won.date_closed
+        with freeze_time('2020-02-02 18:00'):
+            lead_in_won.stage_id = stage_team1_won2
+        self.assertEqual(lead_in_won.date_closed, old_date_closed, 'Moving between won stages should not change existing date_closed')
         won_lead = self.lead_team_1_won.with_env(self.env)
         other_lead = self.lead_1.with_env(self.env)
         old_date_closed = won_lead.date_closed


### PR DESCRIPTION
Currently, if a lead is created in a won stage and later moved to another won stage, an error can occur.

Steps to Reproduce:
1) Install CRM without Demo.
2) Create 3 leads.
3) Navigate to CRM>Configuration>Stages and make **new** and **Qualified** stage
   to won stage.
4) Now generate a new lead. and then change the system time and increase 1 hour.
5) Now move the lead to the Qualified stage.

Error:
`TypeError: unsupported operand type(s) for -: 'bool' and 'datetime.datetime'`

Root Cause:
When a lead is created in a stage marked as won, its `date_closed` will be `False`. Updating that lead to another won stage triggers the condtion at [1] which performs check that performs `self.date_closed - self.create_date`. Because `date_closed` value is `False`, the subtraction raises an error.

FIX:
This fix makes sure below cases are handled:
- Make sure that `date_closed` value exists before comparing it with `create_date`
- Make sure that cases at [2] doesn't fails when lead is created in the won stage
  with some `expected revenue`.

[1]- https://github.com/odoo/odoo/blob/fad692777e90f3c91f91d2a91e706f8bdb64a08a/addons/crm/models/crm_lead.py#L1241-L1243
[2]- https://github.com/odoo/odoo/blob/25ec485082545f3bd8a92606b2cf4d9bcaf0185c/addons/crm/models/crm_lead.py#L1228-L1235

Note: This commit handles cases mentioned in [this commit](https://github.com/odoo/odoo/commit/d1b71f9bf04a9e1cc09941c34e444451ebdddb85)

sentry-6993496031,7026119584

Note:
I tried to add a test case, but was unable to do so since it is a small use case. I feel it will be bit overkill to add a test here.
[test branch](https://runbot.odoo.com/runbot/bundle/190-sentry-6993496031-crm-typeerror-test-path-413099)

