### PR TITLE
[IMP] mail: show 'is typing' on group chats

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_app/sidebar/channel_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/sidebar/channel_patch.js
@@ -1,0 +1,8 @@
+import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel";
+import { patch } from "@web/core/utils/patch";
+
+patch(DiscussSidebarChannel.prototype, {
+    get showThreadIcon() {
+        return this.channel.channel_type === "livechat" || super.showThreadIcon;
+    },
+});

--- a/addons/im_livechat/static/src/embed/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/discuss_channel_model_patch.js
@@ -35,5 +35,8 @@ const discussChannelPatch = {
     get hasAttachmentPanel() {
         return this.channel_type !== "livechat" && super.hasAttachmentPanel;
     },
+    get showImStatus() {
+        return (this.channel_type === "livechat" && this.correspondent) || super.showImStatus;
+    },
 };
 patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -81,9 +81,6 @@ export class ChatBubble extends Component {
     }
 
     get showImStatus() {
-        return (
-            this.channel.correspondent?.im_status &&
-            this.channel.correspondent.im_status !== "offline"
-        );
+        return this.channel.showImStatus;
     }
 }

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -77,10 +77,6 @@ export class ChatWindow extends Component {
         return this.props.chatWindow.channel;
     }
 
-    get showImStatus() {
-        return this.channel.channel_type === "chat" && this.channel.correspondent;
-    }
-
     get attClass() {
         return {
             "w-100 h-100 o-mobile": this.ui.isSmall,

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -56,7 +56,7 @@
 }
 
 .o-mail-ChatWindow-imStatus {
-    bottom: 2px;
+    bottom: -1px;
     right: -2px;
 }
 

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -88,7 +88,7 @@
         'ps-2': !hasActionsMenu,
     }" name="threadAvatar">
         <img class="rounded-3 object-fit-cover" t-att-src="channel.parent_channel_id?.avatarUrl ?? channel.avatarUrl" alt="Channel Image"/>
-        <ImStatus t-if="showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="channel.correspondent" size="'sm'"/>
+        <ImStatus t-if="channel.showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="channel.correspondent" size="'sm'" withIsTyping="false"/>
     </div>
     <t t-if="channel.parent_channel_id">
         <span class="fw-bold small o-mx-0_5 opacity-75 opacity-100-hover cursor-pointer o-hover-text-underline rounded fs-6" t-esc="channel.parent_channel_id.displayName" title="Open Channel" t-ref="parentChannel" t-on-click.stop="() => this.channel.parent_channel_id.open({ focus: true })"/>

--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -2,12 +2,24 @@ import { Component } from "@odoo/owl";
 import { Typing } from "@mail/discuss/typing/common/typing";
 
 export class ImStatus extends Component {
-    static props = ["persona?", "className?", "style?", "member?", "slots?", "size?"];
+    static props = [
+        "persona?",
+        "className?",
+        "style?",
+        "member?",
+        "slots?",
+        "size?",
+        "withIsTyping?",
+    ];
     static template = "mail.ImStatus";
-    static defaultProps = { className: "", style: "", size: "lg" };
+    static defaultProps = { className: "", style: "", size: "lg", withIsTyping: true };
     static components = { Typing };
 
     get persona() {
         return this.props.persona ?? this.props.member?.persona;
+    }
+
+    get showTypingIndicator() {
+        return this.props.withIsTyping && this.props.member?.isTyping;
     }
 }

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -5,8 +5,8 @@
         <div class="o-mail-ImStatus d-flex justify-content-center flex-shrink-0 align-items-center bg-white bg-opacity-100" t-attf-class="{{ props.className }}" t-att-style="props.style" t-att-class="{
             'o-md': props.size === 'md' or props.size === 'medium',
             'o-sm': props.size === 'sm' or props.size === 'small',
-            'rounded-circle': !props.member?.isTyping,
-            'rounded-pill': props.member?.isTyping,
+            'rounded-circle': !showTypingIndicator,
+            'rounded-pill': showTypingIndicator,
         }">
             <span class="d-flex flex-column" t-att-class="{
                 'smaller': props.size === 'md' or props.size === 'medium',
@@ -14,7 +14,7 @@
             }">
                 <t t-slot="pre_icon"/>
                 <t name="icon">
-                    <t t-if="(!props.member or !props.member.isTyping) and persona">
+                    <t t-if="(!props.member or !showTypingIndicator) and persona">
                         <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                         <i t-elif="persona.im_status === 'away'" class="fa fa-adjust o-yellow" title="Idle" role="img" aria-label="User is idle"/>
                         <i t-elif="persona.im_status === 'busy'" class="fa fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
@@ -22,7 +22,7 @@
                         <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                         <i t-else="" class="fa fa-question-circle opacity-75" title="No IM status available"/>
                     </t>
-                    <div t-if="props.member?.isTyping" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }">
+                    <div t-if="showTypingIndicator" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }">
                         <div class="bg-success rounded-pill" style="padding: 3px;">
                             <Typing member="props.member" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
                         </div>

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -5,8 +5,10 @@
         <div class="o-mail-ThreadIcon d-flex justify-content-center flex-shrink-0" t-att-class="props.className">
             <t t-set="largeClass" t-value="props.size === 'large' ? 'fa-lg' : ''"/>
             <t t-if="props.thread.channel?.channel_type === 'channel'">
-                <div t-if="props.thread.group_public_id" class="fa fa-fw fa-hashtag" t-att-class="largeClass" t-att-title="props.thread.accessRestrictedToGroupText"/>
-                <div t-else="" class="fa fa-fw fa-globe" t-att-class="largeClass" title="Public Channel"/>
+                <div t-if="!props.thread.group_public_id" class="fa fa-fw fa-globe" t-att-class="largeClass" title="Public Channel"/>
+            </t>
+            <t t-elif="props.thread.channel?.channel_type === 'group'">
+                <t name="group"/>
             </t>
             <t t-elif="props.thread.channel?.channel_type?.includes('chat') and correspondent">
                 <t name="chat">
@@ -18,7 +20,6 @@
                     </t>
                 </t>
             </t>
-            <div t-elif="props.thread.channel?.channel_type === 'group'" class="o-mail-ThreadIcon oi fa-fw oi-users" t-att-class="largeClass" title="Grouped Chat"/>
             <t t-elif="props.thread.model === 'mail.box'">
                 <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="largeClass"/>
                 <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="largeClass"/>

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -60,10 +60,6 @@ export class DiscussContent extends Component {
         return this.props.thread || this.store.discuss.thread;
     }
 
-    get showImStatus() {
-        return this.thread.channel?.channel_type === "chat";
-    }
-
     get showThreadAvatar() {
         return ["channel", "group", "chat"].includes(this.thread.channel?.channel_type);
     }

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -15,7 +15,7 @@
                             </a>
                         </t>
                     </FileUploader>
-                    <ImStatus t-if="thread.correspondent and showImStatus" className="'o-mail-DiscussContent-headerImStatus position-absolute'" member="thread.correspondent"/>
+                    <ImStatus t-if="thread.channel?.showImStatus" className="'o-mail-DiscussContent-headerImStatus position-absolute'" member="thread.correspondent" size="'sm'" withIsTyping="false"/>
                 </div>
                 <t t-else="">
                     <ThreadIcon className="'align-self-center fs-3 my-2 opacity-75'" size="'large'" thread="thread"/>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -256,6 +256,12 @@ export class DiscussChannel extends Record {
     });
     /** @type {"loaded"|"loading"|"error"|undefined} */
     pinnedMessagesState = undefined;
+    get showImStatus() {
+        return (
+            (this.channel_type === "chat" && this.correspondent) ||
+            (this.channel_type === "group" && this.hasOtherMembersTyping)
+        );
+    }
     sub_channel_ids = fields.Many("discuss.channel", {
         inverse: "parent_channel_id",
         sort: (a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -134,6 +134,14 @@ export class DiscussSidebarChannel extends Component {
         );
     }
 
+    get showThreadIcon() {
+        return (
+            this.channel.channel_type === "chat" ||
+            (this.channel.channel_type === "channel" && !this.channel.group_public_id) ||
+            (this.channel.channel_type === "group" && this.channel.hasOtherMembersTyping)
+        );
+    }
+
     get isSelfOrThreadActive() {
         return (
             this.channel.discussAppAsThread ||

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -33,7 +33,7 @@
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': store.discuss.isSidebarCompact, 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : channel.displayName">
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" style="width:26px;height:26px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded-2 object-fit-cover" t-att-class="threadAvatarAttClass" t-att-src="channel.avatarUrl" alt="Thread Image"/>
-                    <ThreadIcon t-if="channel.channel_type?.includes('chat') or (channel.channel_type === 'channel' and !channel.group_public_id)" thread="channel.thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+                    <ThreadIcon t-if="showThreadIcon" thread="channel.thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                 </div>
                 <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate text-start lh-sm opacity-trigger-hove flex-grow-1" t-att-class="itemNameAttClass">
                     <t t-esc="channel.displayName"/>

--- a/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.ThreadIcon" t-inherit-mode="extension">
-        <xpath expr="//t[@name='chat']" position="replace">
-            <div t-if="props.thread.channel.hasOtherMembersTyping" class="bg-inherit rounded-pill" style="padding: 1px;">
-                <div class="bg-success rounded-pill" style="padding: 3px;">
-                    <Typing channel="props.thread.channel" size="props.size" displayText="false" />
-                </div>
-            </div>
+        <xpath expr="//*[@name='group']" position="replace">
+            <t t-if="props.thread.channel.hasOtherMembersTyping" t-call="mail.ThreadIcon.typing"/>
             <t t-else="">$0</t>
         </xpath>
+        <xpath expr="//t[@name='chat']" position="replace">
+            <t t-if="props.thread.channel.hasOtherMembersTyping" t-call="mail.ThreadIcon.typing"/>
+            <t t-else="">$0</t>
+        </xpath>
+    </t>
+    <t t-name="mail.ThreadIcon.typing">
+        <div t-if="props.thread.channel.hasOtherMembersTyping" class="bg-inherit rounded-pill" style="padding: 1px;">
+            <div class="bg-success rounded-pill" style="padding: 3px;">
+                <Typing channel="props.thread.channel" size="props.size" displayText="false" />
+            </div>
+        </div>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/typing/typing.test.js
+++ b/addons/mail/static/tests/discuss/typing/typing.test.js
@@ -686,7 +686,7 @@ test("[text composer] chat: correspondent is typing in chat window", async () =>
             is_typing: true,
         })
     );
-    await contains("[title='Demo is typing...']", { count: 2 }); // icon in header & text above composer
+    await contains("[title='Demo is typing...']");
     // simulate receive typing notification from demo "no longer is typing"
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -725,7 +725,7 @@ test("chat: correspondent is typing in chat window", async () => {
             is_typing: true,
         })
     );
-    await contains("[title='Demo is typing...']", { count: 2 });
+    await contains("[title='Demo is typing...']");
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
             channel_id: channelId,

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2574,3 +2574,28 @@ test("do not show control panel without breadcrumbs", async () => {
     await contains(".o-mail-Discuss");
     await contains(".o_control_panel .breadcrumb", { text: serverState.partnerName });
 });
+
+test("Show typing icon on group chat in sidebar", async () => {
+    const pyEnv = await startServer();
+    const marcPid = pyEnv["res.partner"].create({ name: "Marc Demo" });
+    const marcUid = pyEnv["res.users"].create({ partner_id: marcPid, name: "Marc Demo" });
+    const groupChatId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: marcPid }),
+        ],
+        channel_type: "group",
+    });
+    await start();
+    await openDiscuss(groupChatId);
+    // simulate receive typing notification from Marc Demo "is typing"
+    withUser(marcUid, () =>
+        rpc("/discuss/channel/notify_typing", {
+            is_typing: true,
+            channel_id: groupChatId,
+        })
+    );
+    await contains(
+        ".o-mail-DiscussSidebar-item .o-discuss-Typing-icon[title='Marc Demo is typing...']"
+    );
+});

--- a/addons/website_livechat/static/src/web/discuss_content_patch.js
+++ b/addons/website_livechat/static/src/web/discuss_content_patch.js
@@ -9,7 +9,4 @@ patch(DiscussContent.prototype, {
     get showThreadAvatar() {
         return this.isLivechatChannel || super.showThreadAvatar;
     },
-    get showImStatus() {
-        return this.isLivechatChannel || super.showImStatus;
-    },
 });


### PR DESCRIPTION
This commit adds "is typing" icon on group chats in discuss sidebar and chat bubble.

This helps seeing that a group chat is still active after seeing a recent message and jumping to another conversation in the mean time.

This commit also removes showing of is typing in IM status of discuss app header and chat window header, as this is redundant with "is typing" close to composer.

<img width="1277" height="1000" alt="Screenshot 2025-12-17 at 14 13 43" src="https://github.com/user-attachments/assets/bed81e2c-bbad-4191-8a92-bdb8f39ccbdd" />

Task-5402098