### PR TITLE
[FIX] pos_self_order: display correct product prices based on pricelist

### DIFF
--- a/addons/point_of_sale/static/tests/unit/data/product_pricelist.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/product_pricelist.data.js
@@ -20,5 +20,11 @@ export class ProductPricelist extends models.ServerModel {
             display_name: "Test Pricelist B (USD)",
             item_ids: [1],
         },
+        {
+            id: 3,
+            name: "Test Pricelist 90%",
+            display_name: "Test Pricelist 90% (USD)",
+            item_ids: [2],
+        },
     ];
 }

--- a/addons/point_of_sale/static/tests/unit/data/product_pricelist_item.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/product_pricelist_item.data.js
@@ -50,5 +50,14 @@ export class ProductPricelistItem extends models.ServerModel {
             categ_id: false,
             min_quantity: 0.0,
         },
+        {
+            id: 2,
+            base: "list_price",
+            company_id: 250,
+            compute_price: "percentage",
+            currency_id: 1,
+            pricelist_id: 3,
+            percent_price: 90.0,
+        },
     ];
 }

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -830,9 +830,7 @@ export class SelfOrder extends Reactive {
     }
 
     getProductPriceInfo(productTemplate, product) {
-        const pricelist = this.config.use_presets
-            ? this.currentOrder.preset_id?.pricelist_id
-            : this.config.pricelist_id;
+        const pricelist = this.currentOrder.preset_id?.pricelist_id || this.config.pricelist_id;
         const price = productTemplate.getPrice(pricelist, 1, 0, false, product);
 
         if (!product) {
@@ -842,9 +840,10 @@ export class SelfOrder extends Reactive {
         // Taxes computation.
         const order = this.currentOrder;
         const taxesData = product.getTaxDetails({
-            price_unit: price,
-            quantity: 1,
-            fiscalPosition: order?.fiscal_position_id || false,
+            overridedValues: {
+                price,
+                fiscalPosition: order?.fiscal_position_id || false,
+            },
         });
         return { pricelist_price: price, ...taxesData };
     }

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -141,6 +141,30 @@ test("verifyCart", async () => {
     }
 });
 
+test("getProductPriceInfo", async () => {
+    const store = await setupSelfPosEnv();
+    const order = await getFilledSelfOrder(store);
+
+    const models = store.models;
+    const product5 = models["product.template"].get(5);
+    const pricelist = models["product.pricelist"].get(3);
+    const inPreset = models["pos.preset"].get(1);
+    const outPreset = store.models["pos.preset"].get(2);
+
+    expect(store.getProductPriceInfo(product5).pricelist_price).toBe(100);
+
+    store.config.pricelist_id = pricelist;
+    expect(store.getProductPriceInfo(product5).pricelist_price).toBe(10);
+
+    order.setPreset(outPreset);
+    expect(store.getProductPriceInfo(product5).pricelist_price).toBe(10);
+
+    pricelist.item_ids[0].percent_price = 80;
+    inPreset.pricelist_id = pricelist;
+    order.setPreset(inPreset);
+    expect(store.getProductPriceInfo(product5).pricelist_price).toBe(20);
+});
+
 describe("addToCart", () => {
     test("simple flow", async () => {
         const store = await setupSelfPosEnv();


### PR DESCRIPTION
### before this commit:
- Product cards displayed the product’s sale price instead of the price computed from the applied pricelist, even though the order total reflected the correct discounted amount.
- When a preset was enabled, the pricelist was applied only if it is explicitly set on the preset.

### after this commit:
- Product cards now show prices according to the active pricelist rules.
- When the preset is enabled without a pricelist, the default POS pricelist is applied automatically.

task-5236959

