### PR TITLE
[FIX] account: incorrect vendor bill payment state on deleting payment

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2123,7 +2123,7 @@ class AccountMove(models.Model):
         for move in self:
             move.next_payment_date = min([line.payment_date for line in move.line_ids.filtered(lambda l: l.payment_date and not l.reconciled)], default=False)
 
-    @api.depends('line_ids.matched_debit_ids', 'line_ids.matched_credit_ids', 'matched_payment_ids')
+    @api.depends('line_ids.matched_debit_ids', 'line_ids.matched_credit_ids', 'matched_payment_ids', 'matched_payment_ids.state')
     def _compute_reconciled_payment_ids(self):
         ''' Retrieve the payments reconciled to the invoices through the reconciliation (account.partial.reconcile) '''
         self.env['account.payment'].flush_model(fnames=['move_id'])


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install the Accounting module.
2. Create and confirm a Vendor Bill.
3. Click on Pay and create a payment for the bill.
4. Open the created payment using the smart button.
5. Delete the payment or click on Reset to Draft.


Observation:
-------------------------
1. On deleting the payment:
The Vendor Bill still shows the "In Payment" status even after the payment is
deleted.
2. On resetting the payment to draft:
The Vendor Bill also remains in the "In Payment" status instead of reverting to
"Not Paid".

This behavior is not observed for customer invoices, where the payment state
updates correctly in both cases.


Issue:
-------------------------
1. Delete case:
In the `unlink` method,
https://github.com/odoo/odoo/blob/b991f766e28dc71f8627fdfbf2d59589d9707d3a/addons/account/models/account_payment.py#L938-L945
the `linked_invoices` variable only includes invoices that are reconciled
(i.e., their journal items are matched). Since the Vendor Bill is not yet
reconciled, it is excluded from recomputation. Hence, its `payment_state`
remains unchanged.

2. Reset to draft case:
In the `_compute_payment_state` method,
https://github.com/odoo/odoo/blob/b991f766e28dc71f8627fdfbf2d59589d9707d3a/addons/account/models/account_move.py#L1162-L1163
the compute depends on the state of reconciled payments. However, since these
payments are not reconciled, the compute method is not triggered, and the
payment state remains outdated.


Solution:
-------------------------
Added `matched_payment_ids.state` in the depends of the
`_compute_reconciled_payment_ids` method to ensure it recomputes correctly when
payment state changes on setting payment to draft or deleting payment

Ticket [link](https://www.odoo.com/odoo/project.task/5208772)
opw-5208772