### PR TITLE
[IMP] html_editor, test_website: revamp image upload progress toast design

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.js
@@ -11,6 +11,7 @@ export class ProgressBar extends Component {
         name: String,
         size: { type: String, optional: true },
         errorMessage: { type: String, optional: true },
+        mimetype: { type: String, optional: true },
     };
     static defaultProps = {
         progress: 0,
@@ -18,6 +19,7 @@ export class ProgressBar extends Component {
         uploaded: false,
         size: "",
         errorMessage: "",
+        mimetype: "",
     };
 
     get errorMessage() {

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.scss
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.scss
@@ -1,26 +1,11 @@
 .o_upload_progress_toast {
-    font-size: 16px;
-
-    .o_we_progressbar:last-child {
-        hr {
-            display: none;
-        }
+    .progress {
+        --progress-height: .3rem;
+        --progress-border-radius: .25rem;
     }
 }
 
-$o-notification-max-width-sm: calc(400px - 3rem);
-$button-width: 3rem;
-
-.editor_notification_manager {
-    width: calc(100% - #{$button-width});
-    @include media-breakpoint-up(sm) {
-        width: calc(#{$o-notification-max-width-sm} + #{$button-width});
-    }
-}
-
-.editor_notification_body {
-    width: calc(100% - #{$button-width});
-    @include media-breakpoint-up(sm) {
-        width: $o-notification-max-width-sm;
-    }
+.o_notification_illustration, .o_notification_indicator {
+    width: map-get($spacers, 4) + map-get($spacers, 3);
+    aspect-ratio: 1;
 }

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
@@ -1,36 +1,45 @@
 <templates id="template" xml:space="preserve">
 <t t-name="html_editor.ProgressBar">
-    <small class="text-info d-flex align-items-center me-2">
-        <span t-if="!props.hasError and !props.uploaded"><i class="fa fa-circle-o-notch fa-spin me-2"/></span>
-        <span class="fst-italic fw-bold text-truncate flex-grow-1 me-2" t-esc="props.name"/>
-        <span class="fw-bold text-nowrap" t-esc="props.size"/>
-    </small>
-    <small t-if="props.uploaded or props.hasError" class="d-flex align-items-center mt-1">
-        <span t-if="props.uploaded" class="text-success"><i class="fa fa-check my-1 me-1"/> File has been uploaded</span>
-        <span t-else="" class="text-danger"><i class="oi oi-close float-start my-1 me-1"/> <span class="o_we_error_text" t-esc="errorMessage"/></span>
-    </small>
-    <div t-else="" class="progress mt-2">
-        <div class="progress-bar bg-info progress-bar-striped progress-bar-animated" role="progressbar" t-attf-style="width: {{this.progress}}%;" aria-label="Progress bar"><span t-esc="this.progress + '%'"/></div>
+    <span class="o_notification_illustration d-flex align-items-center justify-content-center flex-shrink-0 rounded-1 bg-200 bg-opacity-50">
+        <span
+            class="o_image w-50 user-select-none"
+            t-att-title="props.name" t-att-data-mimetype="props.mimetype"/>
+    </span>
+    <div class="w-100 overflow-hidden">
+        <span class="d-flex align-items-baseline gap-1">
+            <small class="flex-grow-1 text-truncate" t-esc="props.name"/>
+            <span class="o_notification_size text-nowrap text-600" t-esc="props.size"/>
+        </span>
+        <div class="progress mt-1 w-100">
+            <div t-attf-class="progress-bar progress-bar-animated {{props.uploaded ? 'bg-success' : 'bg-info'}}" role="progressbar" t-attf-style="width: {{this.progress}}%;" aria-label="Progress bar"></div>
+        </div>
+        <small t-if="props.hasError" class="text-danger fw-bold" t-esc="errorMessage"/>
     </div>
-    <hr/>
+    <div class="o_notification_indicator d-flex align-items-center justify-content-center pt-2">
+        <i t-if="!props.hasError and !props.uploaded" class="fa fa-circle-o-notch fa-spin fs-4"/>
+        <span t-if="props.uploaded" class="o_notification_indicator_success d-flex align-items-center justify-content-center p-1 rounded-5 text-bg-success smaller">
+            <i class="fa fa-check"/>
+        </span>
+        <i t-if="props.hasError" class="fa fa-exclamation-triangle fs-4 text-danger"/>
+    </div>
 </t>
 
 <t t-name="html_editor.UploadProgressToast">
     <div class="editor_notification_manager o_notification_manager o_upload_progress_toast">
-        <div t-if="state.isVisible" class="o_notification position-relative show fade mb-2 border border-info bg-white d-flex justify-content-between" role="alert" aria-live="assertive" aria-atomic="true">
+        <div t-if="state.isVisible" class="o_notification show fade mb-2 border p-1 bg-white rounded shadow-lg" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="editor_notification_body o_notification_body ps-2 py-2">
-                <div class="me-auto o_notification_content">
-                    <div t-foreach="state.files" t-as="file" t-key="file" class="o_we_progressbar">
+                <div class="me-auto o_notification_content d-flex flex-column gap-3 p-1">
+                    <div t-foreach="state.files" t-as="file" t-key="file" class="o_we_progressbar d-flex align-items-center gap-2">
                         <ProgressBar progress="file_value.progress"
                             errorMessage="file_value.errorMessage"
                             hasError="file_value.hasError"
                             name="file_value.name"
                             uploaded="file_value.uploaded"
-                            size="file_value.size"/>
+                            size="file_value.size"
+                            mimetype="file_value.mimetype"/>
                     </div>
                 </div>
             </div>
-            <button type="button" class="btn btn-close o_notification_close p-2" aria-label="Close" t-on-click="props.close"/>
         </div>
     </div>
 </t>

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -88,6 +88,7 @@ export const uploadService = {
                         id,
                         name: file.name,
                         size: fileSize,
+                        mimetype: file.type,
                     });
                 }
 

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -114,15 +114,15 @@ registerWebsitePreviewTour(
         },
         {
             content: "check upload progress bar is correctly shown (2)",
-            trigger: ".o_we_progressbar:contains('image.webp'):contains('File has been uploaded')",
+            trigger: ".o_we_progressbar:contains('image.webp') .o_notification_indicator_success",
         },
         {
             content: "check upload progress bar is correctly shown (3)",
-            trigger: ".o_we_progressbar:contains('image.png'):contains('File has been uploaded')",
+            trigger: ".o_we_progressbar:contains('image.png') .o_notification_indicator_success",
         },
         {
             content: "check upload progress bar is correctly shown (4)",
-            trigger: ".o_we_progressbar:contains('image.jpeg'):contains('File has been uploaded')",
+            trigger: ".o_we_progressbar:contains('image.jpeg') .o_notification_indicator_success",
         },
         {
             trigger: ".o_notification",
@@ -138,11 +138,6 @@ registerWebsitePreviewTour(
                     );
                 }
             },
-        },
-        {
-            content: "close notification",
-            trigger: ".o_notification_close",
-            run: "click",
         },
         {
             content: "close media dialog",
@@ -193,7 +188,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "the upload progress toast was updated",
-            trigger: ".o_we_progressbar:contains('image.png'):contains('File has been uploaded')",
+            trigger: ".o_we_progressbar:contains('image.png') .o_notification_indicator_success",
         },
         {
             content:
@@ -276,16 +271,13 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ".o_notification_close",
-        },
-        {
             content: "check that the upload progress bar is correctly shown",
             // ensure it is there so we are sure next step actually test something
-            trigger: ".o_we_progressbar:contains('fox'):contains('File has been uploaded')",
+            trigger: ".o_we_progressbar:contains('fox') .o_notification_indicator_success",
         },
         {
             content: "notification should close after 3 seconds",
-            trigger: "body:not(:has(.o_notification_close))",
+            trigger: "body:not(:has(.o_we_progressbar))",
             run: "click",
         },
         {


### PR DESCRIPTION
This PR refines the design of the image upload progress toast by:
- removing the unnecessary informational color
- adding an illustration representing the mimetype
- making the progress bar less prominent
- removing the success message — the icon is enough
- balancing the content layout
- removing the close button, which makes it look like the upload can be
canceled

task-5226553


| Before | After |
|--------|--------|
| <img width="424" height="467" alt="file-upload-before" src="https://github.com/user-attachments/assets/77bd25ad-2628-4c14-9337-70f8839c6767" /> | <img width="456" height="411" alt="Screenshot 2025-11-17 at 08 28 06" src="https://github.com/user-attachments/assets/8d2d677e-0e29-46d0-b6ea-c085f1677bfd" /> |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
