### PR TITLE
[ADD] l10n_es_edi_verifactu: add certificate dependency

### DIFF
--- a/addons/l10n_es_edi_verifactu/__manifest__.py
+++ b/addons/l10n_es_edi_verifactu/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Accounting/Localizations/EDI',
     'summary': "Module for sending Spanish Veri*Factu XML to the AEAT",
     'website': "https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/spain.html#veri-factu",
-    'depends': ['l10n_es'],
+    'depends': ['l10n_es', 'certificate'],
     'data': [
         'security/ir.model.access.csv',
         'wizard/account_move_reversal_views.xml',


### PR DESCRIPTION
Starting from version `18.0`, the module `l10n_es_edi_verifactu` is dependent to `certificate` because of moving the model `l10n_es_edi_verifactu.certificate` into standard model `certificate.certificate`[^1].

On the other side when we install the module `l10n_es_edi_verifactu` then the `certificate` is beiung installed because:

1. (dependency)[^2] --> l10n_es
2. (auto install)[^3] --> l10n_es_edi_facturae
3. (dependency)[^4] --> certificate

But we can uninstall the `certificate` while having `l10n_es_edi_verifactu`. It will make the db unusable with this traceback if we uninstall `certificate`:

```
Traceback (most recent call last):
  File "/home/odoo/.local/lib/python3.10/site-packages/werkzeug/serving.py", line 319, in run_wsgi
    execute(self.server.app)
  File "/home/odoo/.local/lib/python3.10/site-packages/werkzeug/serving.py", line 316, in execute
    application_iter.close()  # type: ignore
  File "/home/odoo/.local/lib/python3.10/site-packages/werkzeug/wsgi.py", line 466, in close
    callback()
  File "/home/odoo/.local/lib/python3.10/site-packages/werkzeug/wrappers/response.py", line 439, in close
    func()
  File "/home/odoo/src/odoo/18.0/addons/bus/websocket.py", line 916, in <lambda>
    response.call_on_close(lambda: cls._serve_forever(
  File "/home/odoo/src/odoo/18.0/addons/bus/websocket.py", line 1030, in _serve_forever
    for message in websocket.get_messages():
  File "/home/odoo/src/odoo/18.0/addons/bus/websocket.py", line 322, in get_messages
    self._handle_transport_error(exc)
  File "/home/odoo/src/odoo/18.0/addons/bus/websocket.py", line 625, in _handle_transport_error
    registry = Registry(self._session.db)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 108, in __new__
    return cls.new(db_name)
  File "<decorator-gen-13>", line 2, in new

  File "/home/odoo/src/odoo/18.0/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 129, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 195, in load_module_graph
    model_names = registry.load(env.cr, package)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 302, in load
    model = cls._build_model(self, cr)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 736, in _build_model
    raise TypeError("Model %r does not exist in registry." % name)
TypeError: Model 'certificate.certificate' does not exist in registry. - - -

```

[^1]: https://github.com/odoo/odoo/pull/219953
[^2]: https://github.com/odoo/odoo/blob/b991f766e28dc71f8627fdfbf2d59589d9707d3a/addons/l10n_es_edi_verifactu/__manifest__.py#L9
[^3]: https://github.com/odoo/odoo/blob/b991f766e28dc71f8627fdfbf2d59589d9707d3a/addons/l10n_es_edi_facturae/__manifest__.py#L41
[^4]: https://github.com/odoo/odoo/blob/b991f766e28dc71f8627fdfbf2d59589d9707d3a/addons/l10n_es_edi_facturae/__manifest__.py#L16

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
