### PR TITLE
[FIX] stock_account: enable Inventory at date for non-standard product

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import deque
+from datetime import datetime
 
 from odoo import api, Command, fields, models, _
+from odoo.fields import Date
 from odoo.tools.float_utils import float_round, float_is_zero, float_compare
 from odoo.exceptions import UserError
 
@@ -149,6 +151,10 @@ class StockMove(models.Model):
         valuation_data = super()._get_value_from_account_move(quantity, at_date=at_date)
         if not self.purchase_line_id:
             return valuation_data
+
+        if isinstance(at_date, datetime):
+            # Since aml.date are Date, we don't need the extra precision here.
+            at_date = Date.to_date(at_date)
 
         aml_quantity = 0
         value = 0


### PR DESCRIPTION
Steps to reproduce:
- Create a product
- Set a category using 'avco' valuation
- Create a purchase order for that product, with some quantity and unit price
- Validate the receipt
- Bill the purchase order
- Go to Inventory > Reporting > Stock
- Use 'Inventory at Date' with today's date

Issue:
A traceback appears, as the wizard sends a datetime for `at_date` context. However, we compare it later on with `account.move.line.date`, which is a date and will cause a faulty comparison between two different types.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
