### PR TITLE
[FIX] iot_box_image: remove aiortc version for windows

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -3,7 +3,7 @@ gatt; sys_platform == "linux" and "rpi" in platform_release
 /home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux" and "rpi" in platform_release
 
 # The following requirements are needed only on Windows Virtual IoT:
-aiortc==1.4.0; sys_platform == "win32"
+aiortc; sys_platform == "win32"
 ghostscript==0.7; sys_platform == "win32"
 decorator; sys_platform == "win32"
 


### PR DESCRIPTION
Forcing aiortc version to 1.4.0 on windows made it impossible to install, we then removed the marker to install the latest.