### PR TITLE
[FIX] mrp{,_account}: display correct value overview MO comp oth…

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -220,6 +220,8 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
         }
 
     def _get_unit_cost(self, move):
+        """ Returns the unit cost of the move expressed in the UOM of the move
+        """
         if not move:
             return 0.0
         return move.product_id.uom_id._compute_price(move.product_id.standard_price, move.product_uom)

--- a/addons/mrp_account/report/mrp_report_mo_overview.py
+++ b/addons/mrp_account/report/mrp_report_mo_overview.py
@@ -9,5 +9,6 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
 
     def _get_unit_cost(self, move):
         if move.state == 'done':
-            return move._get_price_unit()
+            price_unit = move._get_price_unit()
+            return move.product_id.uom_id._compute_price(price_unit, move.product_uom)
         return super()._get_unit_cost(move)

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -826,3 +826,45 @@ class TestMrpAccountMove(TestStockValuationCommon):
         mo._post_inventory()
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
+
+    def test_mo_overview_comp_different_uom(self):
+        """ Test that the overview takes into account the uom of the component in the price computation
+        """
+        product_chocolate = self.env['product.product'].create({
+            'name': 'Chocolate',
+            'is_storable': True,
+            'uom_id': self.env.ref('uom.product_uom_kgm').id,
+            'standard_price': 40,
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product_chocolate.id,
+            'inventory_quantity': 20,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+        })
+        product_chococake = self.env['product.product'].create({
+            'name': 'Choco Cake',
+            'is_storable': True,
+        })
+
+        self.env['mrp.bom'].create({
+            'product_id': product_chococake.id,
+            'product_tmpl_id': product_chococake.product_tmpl_id.id,
+            'product_uom_id': product_chococake.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({'product_id': product_chocolate.id, 'product_qty': 100, 'product_uom_id': self.env.ref('uom.product_uom_gram').id}),
+            ],
+        })
+        mo = self.env['mrp.production'].create({
+            'name': 'MO',
+            'product_qty': 1.0,
+            'product_id': product_chococake.id,
+        })
+
+        mo.action_confirm()
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 4)
+        mo.button_mark_done()
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 4)


### PR DESCRIPTION
…er uom

**Problem:**
The overview of a produced MO does not take into account the uom of the component for the valuation

**Steps to reproduce:**
- Create a storable product (the comp)
- set the uom as L and the cost as 40$ per L
- set an on hand quantity
- Create a storable product (the final product)
- Create a bom for this final product using 100 ml of the comp
- Create, confirm and produce a MO for the final product
- click on the overview smart button

**Current behavior:**
the real cost is 4000$ (100*40)

**Expected behavior:**
it should be 4 (0.1 * 40)

**fix**
A fix was first introduced in this PR https://github.com/odoo/odoo/pull/230585.
But it was closed because this PR had already fixed https://github.com/odoo/odoo/pull/232364. 
However since this PR the issue is back https://github.com/odoo/odoo/pull/232872.

Here is the explanation of the new fix :
Inside _get_component_real_cost
_get_unit_cost returns the unit cost of the move
expressed for 1 unit of the uom of the product (which
is correct).
But quantity is expressed in the uom of the move
so we need to convert it in the uom of the product. https://github.com/odoo/odoo/blob/2ba4998b470236feee3a1636bf6d1807c74eac3a/addons/mrp/report/mrp_report_mo_overview.py#L583-L586