### PR TITLE
[FIX] web: remove sample data ribbon from action helper

### DIFF
--- a/addons/web/static/src/views/action_helper.js
+++ b/addons/web/static/src/views/action_helper.js
@@ -1,12 +1,8 @@
 import { Component } from "@odoo/owl";
-import { Widget } from "@web/views/widgets/widget";
-import { RibbonWidget } from "@web/views/widgets/ribbon/ribbon";
 
 export class ActionHelper extends Component {
     static template = "web.ActionHelper";
-    static components = { Widget, RibbonWidget };
     static props = {
-        showRibbon: { type: Boolean, optional: true, default: false },
         noContentHelp: { type: String, optional: true },
     };
 

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -65,7 +65,7 @@
                 </t>
                 <t t-if="model.isReady and model.data">
 					<t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
-						<ActionHelper noContentHelp="props.noContentHelp" showRibbon="model.useSampleModel"/>
+						<ActionHelper noContentHelp="props.noContentHelp"/>
                     </t>
                     <t t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate" />
                 </t>

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -115,7 +115,7 @@
                 <div t-foreach="[,,,,,,]" t-as="i" t-key="i_index" class="o_kanban_record o_kanban_ghost flex-grow-1 flex-md-shrink-1 flex-shrink-0 my-0" />
             </t>
 	    <t t-if="showNoContentHelper">
-			<ActionHelper noContentHelp="props.noContentHelp" showRibbon="props.list.model.useSampleModel"/>
+			<ActionHelper noContentHelp="props.noContentHelp"/>
 	    </t>
         </div>
     </t>

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -9,7 +9,7 @@
             t-ref="root"
         >
             <t t-if="showNoContentHelper">
-    			<ActionHelper noContentHelp="props.noContentHelp" showRibbon="props.list.model.useSampleModel"/>
+    			<ActionHelper noContentHelp="props.noContentHelp"/>
             </t>
             <table t-attf-class="o_list_table table table-sm table-hover position-relative mb-0 {{props.list.isGrouped ? 'o_list_table_grouped' : 'o_list_table_ungrouped table-striped'}}" t-ref="table">
                 <thead>

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -32,7 +32,7 @@
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
 				<t t-if="model.isReady and displayNoContent">
-    				<ActionHelper noContentHelp="props.info.noContentHelp" showRibbon="model.useSampleModel"/>
+    				<ActionHelper noContentHelp="props.info.noContentHelp"/>
                 </t>
                 <t t-if="model.isReady" t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate"/>
             </Layout>


### PR DESCRIPTION
This commit fully removes the use of the sample data ribbon from the action helper.

Following #233205.