### PR TITLE
[FIX] mail: user notification in messaging menu opens inbox

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -338,7 +338,9 @@ export class Thread extends Record {
     /** @type {integer|null} */
     highlightMessage = Record.one("Message", {
         onAdd(msg) {
-            msg.thread = this;
+            if (!msg.thread) {
+                msg.thread = this;
+            }
         },
     });
     /** @type {String|undefined} */

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -34,8 +34,13 @@ export class MessagingMenu extends Component {
         useExternalListener(window, "keydown", this.onKeydown, true);
     }
 
-    onClickThread(isMarkAsRead, thread) {
+    onClickThread(isMarkAsRead, thread, message) {
         if (!isMarkAsRead) {
+            if (message?.needaction && message.message_type === "user_notification") {
+                this.store.inbox.highlightMessage = message;
+                this.openDiscussion(this.store.inbox);
+                return;
+            }
             this.openDiscussion(thread);
             return;
         }

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -18,7 +18,7 @@
                     iconSrc="thread.avatarUrl"
                     hasMarkAsReadButton="thread.isUnread"
                     muted="thread.mute_until_dt ? 2 : !thread.isUnread ? 1 : 0"
-                    onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
+                    onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread, message)"
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
                     onSwipeLeft="hasTouch() and thread.canUnpin ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                     nameMaxLine="1"

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -54,6 +54,18 @@ patch(Thread.prototype, {
         if (this.model === "discuss.channel" && !this.selfMember) {
             this.store.env.services["bus_service"].addChannel(this.busChannel);
         }
+        if (this.model === "mail.box") {
+            if (this.store.discuss.isActive) {
+                this.setAsDiscussThread();
+            } else {
+                this.store.env.services.action.doAction({
+                    context: { active_id: `mail.box_${this.id}` },
+                    tag: "mail.action_discuss",
+                    type: "ir.actions.client",
+                });
+            }
+            return;
+        }
         if (!this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
             this.openChatWindow(options);
             return;

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1315,3 +1315,25 @@ test("failure is removed from messaging menu when message is deleted", async () 
     pyEnv["mail.message"].unlink([messageId]);
     await contains(".o-mail-NotificationItem", { count: 0 });
 });
+
+test("user notification from inbox redirect to discuss inbox", async () => {
+    const pyEnv = await startServer();
+    const messageId = pyEnv["mail.message"].create({
+        body: "Hello world!",
+        message_type: "user_notification",
+        model: "res.partner",
+        needaction: true,
+        res_id: serverState.partnerId,
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem .o-mail-NotificationItem-text:text('You: Hello world!')");
+    await contains(".o-mail-Discuss-threadName[title='Inbox']");
+    await contains(".o-mail-Message.o-highlighted .o-mail-Message-body:text('Hello world!')");
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Install `Data Cleaning` app
- Activate notification in Odoo in the admin user profile
- Create a few duplicate contacts
- Go the the "Data Merge: Find Duplicate Records" scheduled action
- Run the action manually
- You should see new notifications telling you that they found potential duplicates
- In the top right MessaginMenu click on the notification, it opens a chatter
- Try to send a message in the chat window
- Traceback : `AttributeError: 'data_merge.model' object has no attribute '_get_thread_with_access'`

**Issue:**
The model doesn't inherit `mail.thread` so it uses `self.env['mail.thread']` directly to send notification:
```
self.env['mail.thread'].sudo().message_notify(
    ...
    model=self._name,
    notify_author=True,
    partner_ids=partner_ids,
    res_id=self.id,
)
```
But when sending the information with the `model` and `res_id` parameters the newly created `Store` uses `self.add("mail.thread", {"id": data.id, "model": data._name, **values})` and the message is assigned to a non-existing thread in the frontend.

**Fix:**
Explicitly check if the message is a `user_notification` and redirect the user to the discuss inbox if it's the case by reapplyng part of https://github.com/odoo/odoo/commit/b3be992c57dc5e412a127d05fc50b059814523aa

opw-5101510

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
