### PR TITLE
[FIX] pos_hr: show a notification when a cashier can not access backend

### DIFF
--- a/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.js
+++ b/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.js
@@ -59,6 +59,14 @@ patch(LoginScreen.prototype, {
             if (employee && employee.user_id?.id === this.pos.user.id) {
                 super.clickBack();
                 return;
+            } else if (employee) {
+                this.pos.notification.add(
+                    _t(
+                        "Only the cashier linked to the logged-in user (%s) can proceed to the Backend.",
+                        this.pos.user.name
+                    ),
+                    { type: "danger" }
+                );
             }
         }
     },


### PR DESCRIPTION
After this commit, when attempting to close a POS session, if the logged-in employee is not selected, a notification will inform the user. This prevents confusion.

opw-5244818

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
