### PR TITLE
[IMP] payment_mercado_pago: enable OAuth for Mercado Pago

### DIFF
--- a/addons/payment_mercado_pago/const.py
+++ b/addons/payment_mercado_pago/const.py
@@ -15,45 +15,23 @@ WEBHOOK_ROUTE = '/payment/mercado_pago/webhook'
 # The countries supported by Mercado Pago.
 SUPPORTED_COUNTRIES = {
     'AR',
-    'BO',
     'BR',
     'CL',
     'CO',
-    'CR',
-    'DO',
-    'EC',
-    'GT',
-    'HN',
     'MX',
-    'NI',
-    'PA',
-    'PY',
     'PE',
-    'SV',
     'UY',
-    'VE',
 }
 
 # Mapping of country codes to corresponding currency codes.
 CURRENCY_MAPPING = {
     'AR': 'ARS',  # Argentina - Argentine Peso
-    'BO': 'BOB',  # Bolivia - Boliviano
     'BR': 'BRL',  # Brazil - Brazilian Real
     'CL': 'CLP',  # Chile - Chilean Peso
     'CO': 'COP',  # Colombia - Colombian Peso
-    'CR': 'CRC',  # Costa Rica - Costa Rican Colón
-    'DO': 'DOP',  # Dominican Republic - Dominican Peso
-    'EC': 'USD',  # Ecuador - United States Dollar
-    'GT': 'GTQ',  # Guatemala - Guatemalan Quetzal
-    'HN': 'HNL',  # Honduras - Honduran Lempira
     'MX': 'MXN',  # Mexico - Mexican Peso
-    'NI': 'NIO',  # Nicaragua - Nicaraguan Córdoba
-    'PA': 'PAB',  # Panama - Panamanian Balboa (also uses USD)
-    'PY': 'PYG',  # Paraguay - Paraguayan Guaraní
     'PE': 'PEN',  # Peru - Peruvian Sol
-    'SV': 'USD',  # El Salvador - United States Dollar
     'UY': 'UYU',  # Uruguay - Uruguayan Peso
-    'VE': 'VES'   # Venezuela - Venezuelan Bolívar
 }
 
 # Set of currencies where Mercado Pago's minor units deviates from the ISO 4217 standard.

--- a/addons/payment_mercado_pago/const.py
+++ b/addons/payment_mercado_pago/const.py
@@ -5,7 +5,7 @@ from odoo.tools import LazyTranslate
 
 _lt = LazyTranslate(__name__)
 
-PROXY_URL = 'https://mercadopago.api.odoo.com/api/mercado_pago/1'
+PROXY_URL = 'https://mercadopago.api.odoo.com/api/mercado_pago'
 
 PAYMENT_RETURN_ROUTE = '/payment/mercado_pago/return'
 OAUTH_RETURN_ROUTE = '/payment/mercado_pago/oauth/return'

--- a/addons/payment_mercado_pago/controllers/onboarding.py
+++ b/addons/payment_mercado_pago/controllers/onboarding.py
@@ -82,5 +82,7 @@ class MercadoPagoOnboardingController(Controller):
             'is_published': True,
             'allow_tokenization': True,
         })
+        # Set the currency to the one compatible with the seller account.
+        provider_sudo._inverse_mercado_pago_account_country_id()
 
         return request.redirect(redirect_url)

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -81,7 +81,7 @@ class PaymentProvider(models.Model):
 
     def _compute_mercado_pago_is_oauth_supported(self):
         """Return current state of OAuth support by Odoo. To be removed in future versions."""
-        self.mercado_pago_is_oauth_supported = False
+        self.mercado_pago_is_oauth_supported = True
 
     # === CONSTRAINT METHODS === #
 

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -85,6 +85,21 @@ class PaymentProvider(models.Model):
 
     # === CONSTRAINT METHODS === #
 
+    @api.constrains('available_currency_ids')
+    def _check_currency_is_supported(self):
+        for provider in self.filtered(lambda p: p.code == 'mercado_pago'):
+            account_country = provider.mercado_pago_account_country_id
+            account_currency = const.CURRENCY_MAPPING.get(account_country.code)
+            if not account_country:
+                continue
+            if (
+                len(provider.available_currency_ids) != 1
+                or provider.available_currency_ids.name != account_currency
+            ):
+                raise ValidationError(
+                    _("Only the currency %s is available for this account.", account_currency)
+                )
+
     @api.constrains('state', 'mercado_pago_access_token')
     def _check_mercado_pago_credentials_are_set_before_enabling(self):
         """Check that the Mercado Pago credentials are valid when the provider is enabled.

--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -128,6 +128,7 @@ class PaymentTransaction(models.Model):
         return {
             'external_reference': self.reference,
             'notification_url': webhook_url,
+            'statement_descriptor': self.company_id.name,
         }
 
     def _send_payment_request(self):
@@ -145,9 +146,16 @@ class PaymentTransaction(models.Model):
         response_content = self._send_api_request(
             'POST', '/v1/card_tokens', data={'card_id': self.token_id.provider_ref}
         )
-
+        data = self._mercado_pago_prepare_base_request_payload()
         # Send the payment request to Mercado Pago.
-        data = {
+        data.update({
+            'additional_info': {
+                'items': [{
+                    'title': self.reference,
+                    'quantity': 1,
+                    'unit_price': self._mercado_pago_convert_amount(),
+                }],
+            },
             'transaction_amount': self._mercado_pago_convert_amount(),
             'token': response_content['id'],
             'installments': 1,
@@ -155,7 +163,7 @@ class PaymentTransaction(models.Model):
                 'type': 'customer',
                 'id': self.token_id.mercado_pago_customer_id,
             },
-        }
+        })
         response_content = self._send_api_request(
             'POST',
             endpoint='/v1/payments',
@@ -269,6 +277,9 @@ class PaymentTransaction(models.Model):
         """Override of `payment` to return token data based on payment data."""
         if self.provider_code != 'mercado_pago':
             return super()._extract_token_values(payment_data)
+
+        if not payment_data.get('token'):
+            return {}
 
         # Fetch the customer id or create a new one.
         email_data = {'email': payment_data['payer']['email']}

--- a/addons/payment_mercado_pago/tests/test_payment_transaction.py
+++ b/addons/payment_mercado_pago/tests/test_payment_transaction.py
@@ -24,6 +24,7 @@ class TestPaymentTransaction(MercadoPagoCommon, PaymentHttpCommon):
         self.assertDictEqual(request_payload, {
             'external_reference': tx.reference,
             'notification_url': f'{webhook_url}/{sanitized_reference}',
+            'statement_descriptor': tx.company_id.name,
             'auto_return': 'all',
             'back_urls': {
                 'failure': return_url,

--- a/addons/payment_mercado_pago/views/payment_provider_views.xml
+++ b/addons/payment_mercado_pago/views/payment_provider_views.xml
@@ -63,6 +63,13 @@
                     />
                 </div>
             </group>
+            <field name="available_currency_ids" position="attributes">
+                <attribute
+                    name="readonly"
+                    separator="or"
+                    add="(code == 'mercado_pago' and mercado_pago_public_key)"
+                />
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
OAuth is enabled for Mercado Pago, which also allows enabling
tokenization.

Not supported countries were added to the list of countries which
would result in an error when user in one of the unsupported countries
would try to go through OAuth.