### PR TITLE
[IMP] web, *: Make the logout route POST only

### DIFF
--- a/addons/auth_timeout/static/src/services/check_identity/check_identity.js
+++ b/addons/auth_timeout/static/src/services/check_identity/check_identity.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { redirect } from "@web/core/utils/urls";
 import { session } from "@web/session";
+import { post } from "@web/core/network/http_service";
 
 import * as passkeyLib from "@auth_passkey/../lib/simplewebauthn";
 
@@ -154,8 +155,9 @@ export class CheckIdentityDialog extends Component {
         this.formProps = {
             close: this.props.close,
         };
-        this.env.dialogData.dismiss = () => {
-            redirect("/web/session/logout");
+        this.env.dialogData.dismiss = async () => {
+            const url = await post('/web/session/logout', { csrf_token: odoo.csrf_token }, "url");
+            redirect(url);
         };
     }
 }

--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -135,7 +135,13 @@ class TestTOTP(TestTOTPMixin, HttpCase):
         user.
         """
         self.start_tour('/odoo', 'totp_tour_setup', login='test_user')
-        self.url_open('/web/session/logout')
+        self.url_open(
+            '/web/session/logout',
+            method='POST',
+            data={
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )
 
         headers = {
             "Content-Type": "application/json",

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -125,7 +125,13 @@ class TestWebsocketCaryall(WebsocketCase):
         new_test_user(self.env, login='test_user', password='Password!1')
         user_session = self.authenticate('test_user', 'Password!1')
         websocket = self.websocket_connect(cookie=f'session_id={user_session.sid};')
-        self.url_open('/web/session/logout')
+        self.url_open(
+            '/web/session/logout',
+            method='POST',
+            data={
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )
         # The session with whom the websocket connected has been
         # deleted. WebSocket should disconnect in order for the
         # session to be updated.
@@ -137,7 +143,13 @@ class TestWebsocketCaryall(WebsocketCase):
         user_session = self.authenticate('test_user', 'Password!1')
         websocket = self.websocket_connect(cookie=f'session_id={user_session.sid};')
         self.subscribe(websocket, ['channel1'], self.env['bus.bus']._bus_last_id())
-        self.url_open('/web/session/logout')
+        self.url_open(
+            '/web/session/logout',
+            method='POST',
+            data={
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )
         # Simulate postgres notify. The session with whom the websocket
         # connected has been deleted. WebSocket should be closed without
         # receiving the message.

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import http
 from odoo.tests import tagged, JsonRpcException
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
@@ -57,7 +58,12 @@ class TestWebsocketController(HttpCaseWithUserDemo):
             'last': 0,
             'is_first_poll': True,
         })
-        self.url_open('/web/session/logout')
+        self.url_open('/web/session/logout',
+            method='POST',
+            data={
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )
         # rpc with outdated session should lead to error.
         with self.assertRaises(JsonRpcException, msg='odoo.http.SessionExpiredException'):
             self.make_jsonrpc_request('/websocket/peek_notifications', {

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -106,9 +106,12 @@
                     <i class="fa fa-fw fa-th me-1 small text-primary-emphasis"/> Apps
                 </a>
                 <div id="o_logout_divider" class="dropdown-divider"/>
-                <a t-attf-href="/web/session/logout?redirect=/" role="menuitem" id="o_logout" class="dropdown-item ps-3">
-                    <i class="fa fa-fw fa-sign-out me-1 small text-primary-emphasis"/> Logout
-                </a>
+                <form method="POST" action="/web/session/logout" role="menuitem" class="dropdown-item p-0">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <button id="o_logout" type="submit" class="btn w-100 ps-3 text-start">
+                        <i class="fa fa-fw fa-sign-out small text-primary-emphasis"/> Logout
+                    </button>
+                </form>
             </div>
         </li>
     </template>

--- a/addons/test_website/tests/test_session.py
+++ b/addons/test_website/tests/test_session.py
@@ -62,7 +62,13 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
                           side_effect=get_cached_values_without_cache, autospec=True):
 
             # ensure that permissions on logout are OK
-            res = self.url_open('/web/session/logout')
+            res = self.url_open(
+                '/web/session/logout',
+                method='POST',
+                data={
+                    "csrf_token": http.Request.csrf_token(self),
+                },
+            )
             self.assertEqual(res.status_code, 200)
 
     def test_branding_cache(self):

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -85,7 +85,7 @@ class Session(http.Controller):
     def destroy(self):
         request.session.logout()
 
-    @http.route('/web/session/logout', type='http', auth='none', readonly=True)
+    @http.route('/web/session/logout', type='http', auth='none', methods=['POST'], readonly=True)
     def logout(self, redirect='/odoo'):
         request.session.logout(keep_db=True)
         return request.redirect(redirect, 303)

--- a/addons/web/static/src/core/network/http_service.js
+++ b/addons/web/static/src/core/network/http_service.js
@@ -36,6 +36,9 @@ export async function post(route, params = {}, readMethod = "json") {
         method: "POST",
     });
     checkResponseStatus(response);
+    if ( readMethod === "url" ) {
+        return response.url;
+    }
     return response[readMethod]();
 }
 

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -6,6 +6,8 @@ import { user } from "@web/core/user";
 import { session } from "@web/session";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
+import { post } from "@web/core/network/http_service";
+import { redirect } from "@web/core/utils/urls";
 
 function supportItem(env) {
     const url = session.support_url;
@@ -125,10 +127,10 @@ function logOutItem(env) {
         type: "item",
         id: "logout",
         description: _t("Log out"),
-        href: `${browser.location.origin}${route}`,
-        callback: () => {
+        callback: async () => {
             browser.navigator.serviceWorker?.controller?.postMessage("user_logout");
-            browser.location.href = route;
+            const url = await post(route, { csrf_token: odoo.csrf_token }, "url");
+            redirect(url);
         },
         sequence: 70,
     };

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -191,7 +191,12 @@
                     You are logged in.
                 </p>
                 <div t-attf-class="clearfix oe_login_buttons text-center mb-1 pt-3">
-                    <a class="btn btn-primary" href="/web/session/logout">Log out</a>
+                    <form method="POST" action="/web/session/logout" class="text-center">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                        <button type="submit" class="btn btn-primary">
+                            Logout
+                        </button>
+                    </form>
                 </div>
             </div>
         </t>

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
             run: "click",
         },
         {
-            trigger: "a:contains(Logout)",
+            trigger: "button:contains(Logout)",
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_livechat/tests/test_website_visitor.py
+++ b/addons/website_livechat/tests/test_website_visitor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import Command, fields
+from odoo import Command, fields, http
 from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTestsCommon
 from odoo.tests import new_test_user, tagged
 from odoo.exceptions import AccessError
@@ -94,7 +94,13 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
         channel_2._close_livechat_session()
 
         # After logout, a new visitor is created and reassigned to the original session
-        self.url_open("/web/session/logout")
+        self.url_open(
+            "/web/session/logout",
+            method='POST',
+            data={
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )
         self.url_open(self.tracked_page.url)
         visitor_3 = self._get_last_visitor()
         self.assertEqual(channel_1.livechat_visitor_id, visitor_3)

--- a/addons/website_sale/static/tests/tours/cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/cart_recovery.js
@@ -1,6 +1,7 @@
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { redirect } from "@web/core/utils/urls";
+import { post } from "@web/core/network/http_service";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 var orderIdKey = 'website_sale.tour_shop_cart_recovery.orderId';
@@ -14,10 +15,12 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
         {
             content: "check product is in cart, get cart id, logout, go to login",
             trigger: 'div:has(a>h6:contains("Acoustic Bloc Screens"))',
-            run: function () {
+            run: async function () {
                 const orderId = document.querySelector(".my_cart_quantity").dataset["orderId"];
                 browser.localStorage.setItem(orderIdKey, orderId);
-                redirect("/web/session/logout?redirect=/web/login");
+
+                const url = await post('/web/session/logout?redirect=/web/login', { csrf_token: odoo.csrf_token }, "url");
+                redirect(url);
             },
             expectUnloadPage: true,
         },
@@ -78,10 +81,12 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
         {
             content: "check the mail is sent, grab the recovery link, and logout",
             trigger: ".o-mail-Message-body a:contains(/^Resume order$/)",
-            run({ queryOne }) {
+            async run({ queryOne }) {
                 var link = queryOne('.o-mail-Message-body a:contains("Resume order")').getAttribute('href');
                 browser.localStorage.setItem(recoveryLinkKey, link);
-                redirect("/web/session/logout?redirect=/");
+
+                const url = await post('/web/session/logout?redirect=/', { csrf_token: odoo.csrf_token }, "url");
+                redirect(url);
             },
             expectUnloadPage: true,
         },

--- a/addons/website_sale/static/tests/tours/complete_flow.js
+++ b/addons/website_sale/static/tests/tours/complete_flow.js
@@ -1,5 +1,7 @@
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
+import { redirect } from "@web/core/utils/urls";
+import { post } from "@web/core/network/http_service";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('website_sale.complete_flow_1', {
@@ -263,8 +265,9 @@ registry.category("web_tour.tours").add('website_sale.complete_flow_1', {
                         kwargs: {},
                     });
                 });
-                def2.then(function () {
-                    window.location.href = '/web/session/logout?redirect=/shop?search=Storage Box Test';
+                def2.then(async function () {
+                    const url = await post('/web/session/logout?redirect=/shop?search=Storage Box Test', { csrf_token: odoo.csrf_token }, "url");
+                    redirect(url);
                 });
             },
             expectUnloadPage: true,

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -229,7 +229,14 @@ class TestHttpSession(TestHttpBase):
     def test_session09_logout(self):
         sid = self.authenticate('admin', 'admin').sid
         self.assertTrue(odoo.http.root.session_store.get(sid), "session should exist")
-        self.url_open('/web/session/logout', allow_redirects=False).raise_for_status()
+        self.url_open(
+            '/web/session/logout',
+            method='POST',
+            data={
+                "csrf_token": odoo.http.Request.csrf_token(self),
+            },
+            allow_redirects=False
+        ).raise_for_status()
         self.assertFalse(odoo.http.root.session_store.get(sid), "session should not exist")
 
     def test_session10_explicit_session(self):
@@ -237,7 +244,13 @@ class TestHttpSession(TestHttpBase):
         admin_session = self.authenticate('admin', 'admin')
         with self.assertLogs('odoo.http') as capture:
             qs = urlencode({'debug': 1, 'session_id': forged_sid})
-            self.url_open(f'/web/session/logout?{qs}').raise_for_status()
+            self.url_open(
+                f'/web/session/logout?{qs}',
+                method='POST',
+                data={
+                    "csrf_token": odoo.http.Request.csrf_token(self),
+                },
+            ).raise_for_status()
         self.assertEqual(len(capture.output), 1)
         self.assertRegex(capture.output[0],
             r"^WARNING:odoo.http:<function odoo\.addons\.\w+\.controllers\.\w+\.logout> "


### PR DESCRIPTION
* = auth_timeout, auth_totp, bus, portal, test_website, website,
website_livechat, website_sale, test_http

Currently, it is possible to trick and send an image containg 
'/web/session/logout' embedded in the chatter. Anytime, the image gets
loaded, the user gets disconnected which can be pretty annoying.

To avoid such behavior, we made to logout route POST only.

task-5245320

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
