### PR TITLE
[FIX] account_peppol: remove useless code

### DIFF
--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -167,12 +167,3 @@ class AccountInvoiceSend(models.TransientModel):
 
         if not tools.config['test_enable'] and not modules.module.current_test:
             self._cr.commit()
-
-        error_messages = {
-            invoice.id: invoice_data.get('error')
-            for invoice, invoice_data in invoices_data.items()
-            if invoice_data.get('error')}
-        invoices._message_log_batch(bodies=error_messages)
-
-        if not tools.config['test_enable'] and not modules.module.current_test:
-            self._cr.commit()


### PR DESCRIPTION
In the line

`invoices._message_log_batch(bodies=error_messages)`

the variable `invoices` can be undefined because of the flow where its defined.

This highlighted a bigger problem where several lines of code were not supposed to be there.

opw-5245788

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
