### PR TITLE
[FIX] payment: allow branch companies to use parent's payment providers

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -16,6 +16,7 @@ class PaymentProvider(models.Model):
     _description = 'Payment Provider'
     _order = 'module_state, state desc, sequence, name'
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
 
     def _valid_field_parameter(self, field, name):
         return name == 'required_if_provider' or super()._valid_field_parameter(field, name)

--- a/addons/payment/tests/test_payment_provider.py
+++ b/addons/payment/tests/test_payment_provider.py
@@ -247,6 +247,17 @@ class TestPaymentProvider(PaymentCommon):
         )
         self.assertNotIn(self.provider, compatible_providers)
 
+    def test_provider_compatible_with_branch_companies(self):
+        """ Test that the provider is compatible when it used for a branch company. """
+        branch_company = self.env['res.company'].create({
+            'name': "Branch Company",
+            'parent_id': self.provider.company_id.id,
+        })
+        compatible_providers = self.provider._get_compatible_providers(
+            branch_company.id, self.partner.id, self.amount,
+        )
+        self.assertIn(self.provider, compatible_providers)
+
     def test_validation_currency_is_supported(self):
         """ Test that only currencies supported by both the provider and the payment method can be
         used in validation operations. """


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a published payment provider;
2. create a branch company;
3. create a sales order in branch company;
4. enable online payment for sales order;
5. open sales order in portal view;
6. attempt to pay.

Issue
-----
No compatible payment providers found.

Cause
-----
The `payment.provider._check_company_domain` is set to the default exact match, so when it's used in `_get_compatible_payment_providers`, it's unable to find any providers for the branch company.

Solution
--------
Set `_check_company_domain` to `check_company_domain_parent_of`.

opw-5214269