### PR TITLE
[FIX] stock_account: create correct out svl lot 0 standard price

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -274,7 +274,7 @@ will update the cost of every lot/serial number in stock."),
         # Quantity is negative for out valuation layers.
         quantity = -1 * quantity
         cost = self.standard_price
-        if lot and lot.standard_price:
+        if lot and lot.sudo().stock_valuation_layer_ids:
             cost = lot.standard_price
         vals = {
             'product_id': self.id,

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -841,3 +841,10 @@ class TestLotValuation(TestStockValuationCommon):
         move.move_line_ids[1].lot_id = False
         move._action_done()
         self.assertEqual(move.quantity, 2)
+
+    def test_lot_svl_zero_standard_price(self):
+        self.product1.standard_price = 0
+        self._make_in_move(self.product1, 10, 0, lot_ids=[self.lot1])
+        self._make_in_move(self.product1, 10, 10, lot_ids=[self.lot2])
+        out_move = self._make_out_move(self.product1, 1, lot_ids=[self.lot1])
+        self.assertEqual(out_move.stock_valuation_layer_ids[0].value, 0)


### PR DESCRIPTION
**Problem:**
when selling a product valued by lot
and chosing a lot with a value of 0
the average value of the product
is used instead of 0.

**Steps to reproduce:**
- make sure your warehouse is in single step receipt and delivery
- create a product tracked by lot and valued by lot
- set the category as avco
- create a PO for a quantity of 10 and a unit price of 10
- confirm and open the receipt
- open the stock move widget on the stock move
- write "lot A" in the lot column and save
- validate
- create a PO for a quantity of 10 and a unit price of 0
- confirm and open the receipt
- open the stock move widget on the stock move
- write "lot B" in the lot column and save
- validate
- create a quotation for 1 quantity of your product
- confirm
- open the delivery
- open the stock move widget on the stock move
- in the 'pick from' column enter lot B and save
- validate
- open the valuation smart button

**Current behavior:**
the value of the stock valuation layer is -5

**Expected behavior:**
it should be 0

**Cause of the issue:**
Inside _prepare_out_svl_vals
lot.standard_price is 0 so the if condition
is false and we don't use the price of the lot
https://github.com/odoo/odoo/blob/cd2a241182cf56fc36d03df9f0afdcea30f682d2/addons/stock_account/models/product.py#L277

**fix:**
    deleting the lot.standard_price condition
    is not possible because when the lot is created
    at delivery it has no standard_price and in this
    case we want to use the standard_price of the
    product.
    (see test https://github.com/odoo/odoo/blob/d3835668349d466ed4ba27c9eacdbd3339f2ac37/addons/stock_account/tests/test_lot_valuation.py#L58)

opw-5077671
