### PR TITLE
[FIX] point_of_sale: compute combo price correctly with no free item

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -9,7 +9,7 @@ export const computeComboItems = (
 ) => {
     const comboItems = [];
     const parentLstPrice = parentProduct.getPrice(pricelist, 1, 0, false, parentProduct);
-    const originalTotal = childLineConf.reduce((acc, conf) => {
+    let originalTotal = childLineConf.reduce((acc, conf) => {
         const originalPrice = conf.combo_item_id.combo_id.base_price * conf.qty;
         return acc + originalPrice;
     }, 0);
@@ -32,6 +32,7 @@ export const computeComboItems = (
         remainingTotal -= priceUnit * conf.qty;
         if (conf === childLineConf[childLineConf.length - 1]) {
             priceUnit += remainingTotal;
+            remainingTotal = 0;
         }
         const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(
             (id) => productTemplateAttributeValueById[id]
@@ -48,10 +49,29 @@ export const computeComboItems = (
         });
     }
 
+    if (remainingTotal !== 0) {
+        originalTotal = childLineExtra.reduce((acc, conf) => {
+            const originalPrice = conf.combo_item_id.combo_id.base_price * conf.qty;
+            return acc + originalPrice;
+        }, 0);
+    }
+
     // Process extra child lines using combo 'base_price'
     for (const extra of childLineExtra) {
         const comboItem = extra.combo_item_id;
-        const priceUnit = ProductPrice.round(comboItem.combo_id.base_price);
+        const combo = comboItem.combo_id;
+        let priceUnit = ProductPrice.round(combo.base_price);
+        if (remainingTotal !== 0) {
+            const remaining = ProductPrice.round(
+                (combo.base_price * parentLstPrice) / originalTotal
+            );
+            priceUnit += remaining;
+            remainingTotal -= remaining * extra.qty;
+
+            if (comboItem.id == childLineExtra[childLineExtra.length - 1].combo_item_id.id) {
+                priceUnit += remainingTotal / extra.qty;
+            }
+        }
         const attribute_value_ids = extra.configuration?.attribute_value_ids.map(
             (id) => productTemplateAttributeValueById[id]
         );

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -262,3 +262,34 @@ registry.category("web_tour.tours").add("test_combo_item_image_not_display", {
             Dialog.confirm(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_combo_no_free_item", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            // Desk accessories combo
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 1"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 3"),
+            combo.checkTotal(`${10 * 3 + 2 + 40}.00`),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 5"),
+            combo.checkTotal(`${72 + 20 * 2 + 2}.00`),
+            combo.select("Combo Product 6"),
+            combo.select("Combo Product 7"),
+            combo.select("Combo Product 8"),
+            combo.checkTotal(`${114 + 30 * 3 + 5}.00`),
+            Dialog.confirm(),
+            inLeftSide([
+                ...ProductScreen.selectedOrderlineHasDirect("Office Combo", "1", "232.10"),
+            ]),
+            ProductScreen.totalAmountIs("232.10"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3293,6 +3293,17 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_different_currencies_correct_convertion', login="pos_user")
 
+    def test_combo_no_free_item(self):
+        """ Test a product combo with no free item allowed. """
+        setup_product_combo_items(self)
+        for combo_item in self.office_combo.combo_ids:
+            combo_item.write({
+                'qty_free': 0,
+                'qty_max': 5,
+            })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_combo_no_free_item')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
If a combo product is configured with no free item, the parent product's price was not computed in total correctly.

opw-5241225

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
