### PR TITLE
[FIX] pos_self_order: update docstring to correct attribute

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -338,7 +338,7 @@ class PosSelfOrderController(http.Controller):
         return amount_total, amount_untaxed
 
     # The first part will be the session_id of the order.
-    # The second part will be the table_id of the order.
+    # The second part will be the config_id of the order.
     # Last part the sequence number of the order.
     # INFO: This is allow a maximum of 999 tables and 9999 orders per table, so about ~1M orders per session.
     # Example: 'Self-Order 00001-001-0001'


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When calculating the order's `order_reference`, we'd use the order's `table.id` as the reference's middle constituent.
This was changed in 16.5 in [odoo/odoo:e512634935aa](https://github.com/odoo/odoo/pull/133902), from when on we used the order's `config.id` instead of its table - but the docstring was never updated to reflect the change. This commit fixes that.

**Current behavior before PR:**
Docstring referenced the table.id

**Desired behavior after PR is merged:**
Docstring references the config.id.
The whole pos_reference generation was revamped in [odoo/odoo:76336f6123a6](https://github.com/odoo/odoo/pull/183085) in 18.1, so this only affects versions 17.0 and 18.0.