### PR TITLE
[FIX] website: fix snippet dialog for rtl languages

### DIFF
--- a/addons/website/static/src/js/content/website_root_instance.js
+++ b/addons/website/static/src/js/content/website_root_instance.js
@@ -3,14 +3,24 @@
 import { createPublicRoot } from "@web/legacy/js/public/public_root";
 import lazyloader from "@web/legacy/js/public/lazyloader";
 import { WebsiteRoot } from "./website_root";
-import { loadBundle } from "@web/core/assets";
+import { loadCSS, loadJS } from "@web/core/assets";
 
 const prom = createPublicRoot(WebsiteRoot).then(async rootInstance => {
     // This data attribute is set by the WebsitePreview client action for a
     // restricted editor user.
     if (window.frameElement) {
         if (window.frameElement.dataset.loadWysiwyg === 'true') {
-            await loadBundle("website.assets_all_wysiwyg_inside");
+            // `getBundle` fetches the URL of the bundle by including
+            // `session.bundle_params` as search params. The `lang` search param
+            // in particular determines if the CSS bundles are fetch in their
+            // RTL version or not. 
+            // For `website.assets_all_wysiwyg_inside`, it needs to match the
+            // builder language direction and not the frontend one. Therefore we
+            // must use `getBundle` from outside the iframe.
+            const { getBundle } = window.parent.odoo.loader.modules.get("@web/core/assets");
+            await getBundle("website.assets_all_wysiwyg_inside").then(({ cssLibs, jsLibs }) =>
+                Promise.all([...cssLibs.map(loadCSS), ...jsLibs.map(loadJS)])
+            );
         }
         window.dispatchEvent(new CustomEvent('PUBLIC-ROOT-READY', {detail: {rootInstance}}));
     }

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -89,3 +89,31 @@ registerWebsitePreviewTour('snippet_translation_changing_lang', {
         trigger: ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
     },
 ]);
+registerWebsitePreviewTour(
+    "snippet_dialog_rtl",
+    {
+        url: "/",
+    },
+    () => [
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Select a category snippet to show the snippet dialog",
+            trigger: `#snippet_groups .oe_snippet.o_we_draggable[name="Intro"] .oe_snippet_thumbnail`,
+            run: "click",
+        },
+        {
+            content: "Check that the snippets preview is in rtl",
+            trigger: ".o_dialog :iframe .o_snippets_preview_row[style='direction: rtl;']",
+        },
+        {
+            content: "Check that web.assets_frontend CSS bundle is in rtl",
+            trigger:
+                ".o_dialog :iframe link[type='text/css'][href*='/web.assets_frontend.rtl']:not(:visible)",
+        },
+        {
+            content: "Check that website.assets_all_wysiwyg_inside CSS bundle is there but not in rtl",
+            trigger:
+                ".o_dialog :iframe link[type='text/css'][href*='/website.assets_all_wysiwyg_inside']:not([href*='/website.assets_all_wysiwyg_inside.rtl']):not(:visible)",
+        },
+    ],
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -250,6 +250,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'code': 'pa_GB',
             'iso_code': 'pa_GB',
             'url_code': 'pa_GB',
+            'direction': 'rtl',
         }, {
             'name': 'Fake User Lang',
             'code': 'fu_GB',
@@ -277,6 +278,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
 
         self.start_tour(f"/website/force/{website.id}", 'snippet_translation', login='admin')
         self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_changing_lang', login='admin')
+        self.start_tour(f"/website/force/{website.id}", 'snippet_dialog_rtl', login='admin')
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')


### PR DESCRIPTION
__Before this commit__:
1. Set a right-to-left language (e.g. arabic) as default language on the website
2. Open the website editor
3. Select an element of the page => The editor overlay border are not in the correct place
4. Open the snippet dialog => The snippets are not visible.

__Cause__:
Since [this commit][1], `lang` in `session.bundle_params` is (correctly) set to the `request.lang.code`.
Consequently, `website.assets_all_wysiwyg_inside` is fetched with the frontend language code in the `searchParams` which shouldn't be the case especially if the website language direction is not the same as the backend one.

__Description of the fix:__
The `getBundle` method from outside the iframe is used instead of the frontend one to retrieve the URL of the bundle that matches the language direction of the builder.

Backport and adapt the test from [this commit][2].

[1]: https://github.com/odoo/odoo/commit/e10852a45f10c55a833c33a51956e5f
[2]: https://github.com/odoo/odoo/commit/7bcd56c07852b77849b05184200c48a

task-5246916
opw-5214703