### PR TITLE
[FIX] account: remove sample data for account.move.line list view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -157,7 +157,7 @@
             <field name="model">account.move.line</field>
             <field eval="10" name="priority"/>
             <field name="arch" type="xml">
-                <list name="move_line_tree" string="Journal Items" decoration-info="parent_state == 'draft'" create="false" edit="true" expand="context.get('expand', False)" multi_edit="1" sample="1">
+                <list name="move_line_tree" string="Journal Items" decoration-info="parent_state == 'draft'" create="false" edit="true" expand="context.get('expand', False)" multi_edit="1">
                     <field name="move_id" column_invisible="True"/>
                     <field name="invoice_date" string="Invoice Date" optional="hide"/>
                     <field name="date" readonly="1"/>


### PR DESCRIPTION
Currently, when going into the "Journal Items" menu, if there's no data to display, some sample data are shown.
To reproduce: set a filter that won't match any journal item, set it as default filter and refresh the page.

It doesn't make sense to have sample data, as you cannot create journal items on the fly.

It is particularly confusing going to an accounting report like "Profit & Loss" and clicking on a "0.00" value.
As no journal item is present, the sample data are shown.

The fix is to remove the attribute `sample="1"` on the list.

no-task
