### PR TITLE
[FIX] stock{,_delivery}: properly compute weight with multi-level packs

### DIFF
--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -434,8 +434,16 @@ class StockPackage(models.Model):
         res = {}
         if picking_id:
             package_weights = defaultdict(float)
+            # If we check the weight of an ongoing package, we may need to check its current child dest as well to known their own weight.
+            children_by_dest_pack, all_pack_ids = self._get_all_children_package_dest_ids()
+            base_weight_per_package_group = self.env['stock.package']._read_group(
+                domain=[('id', 'in', all_pack_ids)],
+                groupby=['id', 'package_type_id.base_weight']
+            )
+            base_weight_per_package = {pack.id: weight for pack, weight in base_weight_per_package_group}
+
             res_groups = self.env['stock.move.line']._read_group(
-                [('result_package_id', 'child_of', self.ids), ('product_id', '!=', False), ('picking_id', '=', picking_id)],
+                [('result_package_id', 'in', all_pack_ids), ('product_id', '!=', False), ('picking_id', '=', picking_id)],
                 ['result_package_id', 'product_id', 'product_uom_id', 'quantity'],
                 ['__count'],
             )
@@ -449,7 +457,11 @@ class StockPackage(models.Model):
             weight = package.package_type_id.base_weight or 0.0
             if picking_id:
                 res[package] = weight + package_weights[package.id]
+                for child_id in children_by_dest_pack.get(package, []):
+                    res[package] += base_weight_per_package.get(child_id, 0) + package_weights.get(child_id, 0)
             else:
+                # Take the base_weight of every contained package, so we include package only containing packages
+                weight += sum(package.all_children_package_ids.mapped(lambda p: p.package_type_id.base_weight))
                 for quant in package.contained_quant_ids:
                     weight += quant.quantity * quant.product_id.weight
                 res[package] = weight

--- a/addons/stock_delivery/models/stock_package.py
+++ b/addons/stock_delivery/models/stock_package.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 class StockPackage(models.Model):
     _inherit = "stock.package"
 
-    @api.depends('quant_ids', 'package_type_id')
+    @api.depends('contained_quant_ids', 'package_type_id')
     def _compute_weight(self):
         packages_weight = self.sudo()._get_weight(self.env.context.get('picking_id'))
         for package in self:


### PR DESCRIPTION
When using multi-level packages, when the weight of the package is computed, the base weight of the package type is only counted for the top-level package, not for the children packages.

Task-5166120

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
