### PR TITLE
[FIX] account: Use company currency for analytic line creation.

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3216,7 +3216,7 @@ class AccountMoveLine(models.Model):
             distribution_on_each_plan = {}
             for account_ids, distribution in self.analytic_distribution.items():
                 line_values = self._prepare_analytic_distribution_line(float(distribution), account_ids, distribution_on_each_plan)
-                if not self.currency_id.is_zero(line_values.get('amount')):
+                if not self.company_currency_id.is_zero(line_values.get('amount')):
                     analytic_line_vals.append(line_values)
 
             self._round_analytic_distribution_line(analytic_line_vals)
@@ -3263,17 +3263,17 @@ class AccountMoveLine(models.Model):
 
         rounding_error = 0
         for line in analytic_lines_vals:
-            rounded_amount = self.currency_id.round(line['amount'])
+            rounded_amount = self.company_currency_id.round(line['amount'])
             rounding_error += rounded_amount - line['amount']
             line['amount'] = rounded_amount
 
         # distributing the rounding error
         for line in analytic_lines_vals:
-            if self.currency_id.is_zero(rounding_error):
+            if self.company_currency_id.is_zero(rounding_error):
                 break
             amt = max(
-                self.currency_id.rounding,
-                abs(self.currency_id.round(rounding_error / len(analytic_lines_vals)))
+                self.company_currency_id.rounding,
+                abs(self.company_currency_id.round(rounding_error / len(analytic_lines_vals)))
             )
             if rounding_error < 0.0:
                 line['amount'] += amt

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -124,6 +124,42 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
         out_invoice.button_draft()
         self.assertFalse(self.get_analytic_lines(out_invoice))
 
+    def test_analytic_lines_multicurrency(self):
+        '''Ensures analytic lines are created when the aml has a secondary currency set.'''
+        # set up second currency
+        self.env.ref('base.PYG').write({
+            'rounding': 1.0,
+            'active': True,
+            'rate_ids': [Command.create({
+                'company_rate': 100,
+                'name': '2017-01-01',
+            })]
+        })
+
+        out_invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2017-08-01',
+            'invoice_date': '2017-08-01',
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 2.00,
+                'analytic_distribution': {
+                    self.analytic_account_a.id: 100,
+                },
+                'currency_id': self.env.ref('base.PYG').id,
+            })],
+            'currency_id': self.env.ref('base.PYG').id,
+        }])
+
+        out_invoice.action_post()
+
+        # Will not show up if the wrong currency is used to round the amount.
+        self.assertRecordValues(self.get_analytic_lines(out_invoice), [{
+            'amount': 0.02,
+            self.default_plan._column_name(): self.analytic_account_a.id,
+        }])
+
     def test_analytic_lines_rounding(self):
         """ Ensures analytic lines rounding errors are spread across all lines, in such a way that summing them gives the right amount.
         For example, when distributing 100% of the the price, the sum of analytic lines should be exactly equal to the price. """


### PR DESCRIPTION
Analytic line values are determined by the balance of a journal item, not their amount_currency.

https://github.com/odoo/odoo/blob/8258ddf12ed6c0495628f7a480d1e2424e756540/addons/account/models/account_move_line.py#L3230-L3237

However, the journal item's currency is referenced when creating an analytic line. This can cause discrepancies when the journal item's currency has a different rounding factor (`rounding`).

[Ticket link](https://www.odoo.com/odoo/unassigned-tasks/5171681)
opw-5171681

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
