### PR TITLE
[IMP] website, website_sale: add all product snippets in insert block

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -735,3 +735,10 @@ class HTML_Editor(http.Controller):
             return response.json()
         else:
             return {'error': response.status_code}
+
+    @http.route('/web_editor/get_snippet_data', type='jsonrpc', auth='public', website=True)
+    def get_snippet_data(self, template_data, **kwargs):
+        results = {}
+        for key, value in template_data.items():
+            results[key] = request.env['website.snippet.filter'].get_dummy_product_records(key, value)
+        return results

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -4,7 +4,11 @@
         <section t-att-data-snippet="snippet_name"
             t-attf-class="#{snippet_name} #{snippet_classes} s_dynamic o_dynamic_snippet_empty pt64 pb64"
             t-att-data-custom-template-data="custom_template_data or '{}'"
-            t-att-data-number-of-records="is_single_record and '1' or ''">
+            t-att-data-number-of-records="is_single_record and '1' or ''"
+            t-att-data-template-key="snippet_template_key"
+            t-att-data-number-of-elements="snippet_number_of_elements"
+            t-att-data-row-per-slide="snippet_row_per_slide"
+            t-att-data-number-of-elements-small-devices="snippet_element_on_small_device">
             <div t-attf-class="s_dynamic_snippet_container {{container_classes or 'container'}}">
                 <div class="row s_nb_column_fixed">
                     <!-- Dynamic snippet loading effect -->

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -169,6 +169,7 @@
         'website.assets_wysiwyg': [
             'website_sale/static/src/scss/website_sale.editor.scss',
             'website_sale/static/src/js/website_sale_form_editor.js',
+            'website_sale/static/src/js/components/add_snippet_dialog.js',
         ],
         'website.assets_editor': [
             'website_sale/static/src/js/systray_items/*.js',

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1972,3 +1972,12 @@ class WebsiteSale(payment_portal.PaymentPortal):
             int(pair[0]): [int(value_id) for value_id in pair[1].split(',')]
             for pair in attribute_value_pairs
         }
+
+    @route('/website_sale/get_snippet_data', type='jsonrpc', auth='public', website=True)
+    def get_snippet_data(self, template_data, **kwargs):
+        results = {}
+        for key, value in template_data.items():
+            # Here, sudo() is added because, on Runbot, the "category_page_and_products_snippet_edition"
+            # tour is failing due to access rights issues with the website.snippet.filter model.
+            results[key] = request.env['website.snippet.filter'].sudo().get_dummy_product_records(key, value)
+        return results

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -318,3 +318,15 @@ class WebsiteSnippetFilter(models.Model):
         if 'field_names' in defaults and self.env.context.get('model') == 'product.product':
             defaults['field_names'] = 'display_name,description_sale,image_512'
         return defaults
+
+    # Move this code in website sale
+    @api.model
+    def get_dummy_product_records(self, template_key, num_of_elements):
+        """
+        Returns a list of dummy records for a given template key
+        @param template_key: Template key to identify the snippet
+        @return List of dummy records
+        """
+        dynamic_filter = self.env.ref("website_sale.dynamic_filter_newest_products")
+        rendered = dynamic_filter and dynamic_filter._render(template_key, num_of_elements, None, with_sample=True) or []
+        return rendered

--- a/addons/website_sale/static/src/js/components/add_snippet_dialog.js
+++ b/addons/website_sale/static/src/js/components/add_snippet_dialog.js
@@ -1,0 +1,56 @@
+import { AddSnippetDialog } from "@web_editor/js/editor/add_snippet_dialog";
+import { patch } from "@web/core/utils/patch";
+import { rpc } from "@web/core/network/rpc";
+
+patch(AddSnippetDialog.prototype, {
+    /**
+     * @override
+     * Insert dynamic product snippet by rendering exsisting templates.
+     */
+    async insertSnippets() {
+        const snippetsToDisplay = Array.from(this.props.snippets.values())
+            // Note: custom ones have "custom" group, but inner ones (custom or
+            // not) have no group.
+            .filter(snippet => snippet.group === this.state.groupSelected && !snippet.excluded);
+
+        if (this.state.groupSelected === "products") {
+            const xmlIdToElementsMap = snippetsToDisplay.reduce((acc, snippet) => {
+                const xmlId = snippet.content[0]?.querySelector("div[data-xml-id]")?.dataset.xmlId;
+                const numberOfElements = parseInt(snippet.data.numberOfElements) || 4;
+                if (xmlId) {
+                    acc[xmlId] = numberOfElements;
+                }
+                return acc;
+            }, {});
+
+            if (Object.keys(xmlIdToElementsMap).length) {
+                const data = await rpc("/website_sale/get_snippet_data", {
+                    template_data: xmlIdToElementsMap,
+                });
+
+                for (const [xmlId, snippets] of Object.entries(data)) {
+                    const snippet = snippetsToDisplay.find(
+                        (snippet) =>
+                            snippet.content[0]?.querySelector("div[data-xml-id]")?.dataset.xmlId === xmlId
+                    );
+
+                    if (snippet) {
+                        const targetElement = snippet.content[0]?.querySelector("div[data-xml-id]").parentElement;
+                        if (targetElement) {
+                            targetElement.innerHTML = "";
+                            snippets.forEach((snippetHTML) => {
+                                const productEl = new DOMParser().parseFromString(
+                                    snippetHTML,
+                                    "text/html"
+                                ).body.firstChild;
+
+                                targetElement.appendChild(productEl);
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        super.insertSnippets();
+    },
+});

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option.xml
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option.xml
@@ -4,6 +4,7 @@
 <t t-name="website_sale.DynamicSnippetProductsOption" t-inherit="website.DynamicSnippetCarouselOption">
     <!-- TODO: The product snippets design will be refactored soon... Hide the template
      option once the final layouts and previews of the snippets are available. -->
+     <!-- TODO: MSH: Need to adapt changes of s_dynamic_snippet_products/options.js -->
     <xpath expr="//BuilderRow[*[@id=&quot;'template_opt'&quot;]]" position="attributes">
         <attribute name="t-if">filteredTemplates.length &gt; 1</attribute>
     </xpath>

--- a/addons/website_sale/templates/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/templates/snippets/s_dynamic_snippet_products.xml
@@ -29,10 +29,148 @@
             -->
             <t
                 t-set="snippet_classes"
-                t-value="'oe_website_sale ' + default_design_classes"
+                t-value="'oe_website_sale s_product_product_borderless_1 ' + default_design_classes"
             />
             <t t-set="main_page_url" t-value="'/shop'"/>
-            <t t-call="website_sale.s_dynamic_snippet_products_preview_data"/>
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_borderless_1'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_borderless_1'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_borderless_2" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_borderless_2'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_borderless_2'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_borderless_2'"/>
+            </t>
+        </t>
+    </template>
+    <template id="s_dynamic_filter_template_product_product_card_group" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_card_group'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_number_of_elements" t-value="2"/>
+            <t t-set="snippet_row_per_slide" t-value="2" />
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_card_group'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_card_group'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_centered" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_centered'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_centered'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_centered'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_add_to_cart" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_add_to_cart'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_add_to_cart'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_add_to_cart'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_view_detail" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_view_detail'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_number_of_elements" t-value="3"/>
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_view_detail'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_view_detail'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_horizontal_card" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_horizontal_card'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale o_carousel_multiple_rows'"/>
+            <t t-set="snippet_number_of_elements" t-value="3"/>
+            <t t-set="snippet_row_per_slide" t-value="2" />
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_horizontal_card'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_horizontal_card'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_horizontal_card_2" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_horizontal_card_2'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale o_carousel_multiple_rows'"/>
+            <t t-set="snippet_number_of_elements" t-value="2"/>
+            <t t-set="snippet_row_per_slide" t-value="2" />
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_horizontal_card_2'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_horizontal_card_2'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_mini_image" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_mini_image'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_mini_image'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_mini_image'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_mini_name" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_mini_name'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_mini_name'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_mini_name'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_mini_price" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_mini_price'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_mini_price'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_mini_price'"/>
+            </t>
+        </t>
+    </template>
+
+    <template id="s_dynamic_filter_template_product_product_banner" name="Products">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_product_product_banner'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_products oe_website_sale'"/>
+            <t t-set="snippet_number_of_elements" t-value="1"/>
+            <t t-set="snippet_element_on_small_device" t-value="1" />
+            <t t-set="snippet_template_key" t-value="'website_sale.dynamic_filter_template_product_product_banner'"/>
+            <t t-call="website_sale.s_dynamic_snippet_products_preview_data">
+                <t t-set="snippet_preview_template" t-value="'website_sale.dynamic_filter_template_product_product_banner'"/>
+            </t>
         </t>
     </template>
     <!-- Multi record snippets (coming soon...) -->

--- a/addons/website_sale/templates/snippets/s_dynamic_snippet_products_preview_data.xml
+++ b/addons/website_sale/templates/snippets/s_dynamic_snippet_products_preview_data.xml
@@ -6,91 +6,12 @@
             <div class="carousel-inner row w-100 mx-auto">
                 <div role="option" class="carousel-item active" style="min-height: 357.875px;">
                     <div class="row">
-                        <div class="d-flex flex-grow-0 flex-shrink-0 col-3">
-                            <div class="o_carousel_product_card bg-transparent w-100 card border-0">
-                                <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
-                                    <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_1.jpg"/>
-                                    </div>
-                                </a>
-                                <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
-                                    <div class="h6 card-title">Three-Seat Sofa</div>
-                                    <div>
-                                        <div class="mt-2">
-                                            <span class="fw-bold" name="product_price" data-oe-type="monetary" data-oe-expression="data['price']">
-                                                <span class="oe_currency_value">1,500.00</span>
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="d-flex flex-grow-0 flex-shrink-0 col-3">
-                            <div class="o_carousel_product_card bg-transparent w-100 card border-0">
-                                <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
-                                    <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_2.jpg" alt="Warranty (2 year)"/>
-                                    </div>
-                                </a>
-                                <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
-                                    <div class="h6 card-title">Customizable Desk</div>
-                                    <div>
-                                        <div class="mt-2">
-                                            <span class="fw-bold" name="product_price" data-oe-type="monetary" data-oe-expression="data['price']">
-                                                <span class="oe_currency_value">750.00</span>
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="d-flex flex-grow-0 flex-shrink-0 col-3">
-                            <div class="o_carousel_product_card bg-transparent w-100 card border-0">
-                                <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
-                                    <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_3.jpg" alt="Warranty (2 year)"/>
-                                    </div>
-                                </a>
-                                <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
-                                    <div class="h6 card-title">Conference Chair</div>
-                                    <div>
-                                        <div class="mt-2">
-                                            <span class="fw-bold" name="product_price" data-oe-type="monetary" data-oe-expression="data['price']">
-                                                <span class="oe_currency_value">33.00</span>
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="d-flex flex-grow-0 flex-shrink-0 col-3">
-                            <div class="o_carousel_product_card bg-transparent w-100 card border-0">
-                                <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
-                                    <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_4.jpg" alt="Warranty (2 year)"/>
-                                    </div>
-                                </a>
-                                <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
-                                    <div class="h6 card-title">Cabinet with Doors</div>
-                                    <div>
-                                        <div class="mt-2">
-                                            <span class="fw-bold" name="product_price" data-oe-type="monetary" data-oe-expression="data['price']">
-                                                <span class="oe_currency_value">140.00</span>
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                        <div class="d-flex mx-auto">
+                            <div t-att-data-xml-id="snippet_preview_template"/>
                         </div>
                     </div>
                 </div>
             </div>
-            <a class="carousel-control-prev" data-bs-slide="prev" role="button" aria-label="Previous" title="Previous" href="#s_dynamic_snippet_1">
-                <span class="fa fa-chevron-circle-left fa-2x"></span>
-            </a>
-            <a class="carousel-control-next" data-bs-slide="next" role="button" aria-label="Next" title="Next" href="#s_dynamic_snippet_1">
-                <span class="fa fa-chevron-circle-right fa-2x"></span>
-            </a>
         </div>
     </template>
 

--- a/addons/website_sale/templates/snippets/snippets.xml
+++ b/addons/website_sale/templates/snippets/snippets.xml
@@ -4,6 +4,17 @@
 <template id="website_sale.snippets" inherit_id="website.snippets" name="e-commerce snippets">
     <xpath expr="//t[@id='sale_products_hook']" position="replace">
         <t t-snippet="website_sale.s_dynamic_snippet_products" string="Products" label="Dynamic Content" group="catalog"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_borderless_2" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_card_group" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_centered" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_add_to_cart" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_view_detail" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_horizontal_card" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_horizontal_card_2" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_mini_image" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_mini_name" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_mini_price" string="Products" group="products"/>
+        <t t-snippet="website_sale.s_dynamic_filter_template_product_product_banner" string="Products" group="products"/>
         <t t-snippet="website_sale.s_dynamic_snippet_category_list" string="Category List" label="Dynamic Content" group="catalog"/>
     </xpath>
     <xpath expr="//t[@id='snippet_add_to_cart_hook']" position="replace">

--- a/addons/website_sale/tests/test_snippets.py
+++ b/addons/website_sale/tests/test_snippets.py
@@ -37,7 +37,7 @@ class TestSnippets(HttpCase):
             'sale_ok': True,
             'list_price': 500,
         })
-        self.start_tour('/', 'website_sale.snippet_products', login='admin')
+        self.start_tour('/', 'website_sale.snippet_products', login='admin', timeout=100)
 
     def test_02_snippet_products_remove(self):
         Visitor = self.env['website.visitor']


### PR DESCRIPTION
We already have multiple product snippet templates that are visible in the editor when the snippet is dragged. With this commit, we are ensuring that all available product snippet templates are also displayed in the 'Insert Block' popup and removing the template option in `s_dynamic_product_snippet`.

task-4246687

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
