### PR TITLE
[FIX] hr_expense: fix approval datetime not updating correctly

### DIFF
--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -9,6 +9,7 @@ from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged, Form
 from odoo.tools.misc import format_date
+from datetime import datetime, timedelta
 
 
 @tagged('-at_install', 'post_install')
@@ -114,6 +115,12 @@ class TestExpenses(TestExpenseCommon):
             {'state': 'approved'},
             {'state': 'approved'},
         ])
+        # Check that approval_date is set to current datetime upon approval
+        self.assertAlmostEqual(
+            expense_sheets[0].approval_date,
+            datetime.now(),
+            delta=timedelta(seconds=5)
+        )
 
         # Generate a payment for 'company_account' (and its move(s)) and a vendor bill for 'own_account'
         expense_sheets.action_sheet_move_create()


### PR DESCRIPTION
**Steps to reproduce:**
- Install hr_expense and studio
- Open Expense Reports and add the `approval_date` field to the list view
- Create multiple new expenses, submit them, and approve each one
- Go back to the Expense Reports list — notice that all records show the same approval time

**Issue:**
- The `approval_date` field always shows the same time for all approvals, regardless of 
when each expense was approved.

**Cause:**
https://github.com/odoo/odoo/blob/b093786714e9e8567cf75abf78ac3d954a3d89b2/addons/hr_expense/models/hr_expense_sheet.py#L664-L668
- The field `approval_date` is a datetime field, but only the date was being set during approval,
causing all approvals to default to the same time.

**Solution:**
- Pass the current datetime (localized to the user’s timezone) instead of only the date when setting 
the approval date.

---

opw - 5134045

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
