### PR TITLE
[FIX] html_editor: fill copied empty list item

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -182,12 +182,19 @@ export class DomPlugin extends Plugin {
             !this.isEditionBoundary(selection.anchorNode);
 
         // Empty block must contain a br element to allow cursor placement.
+        const firstLeafNode = firstLeaf(container);
         if (
-            container.lastElementChild &&
-            isBlock(container.lastElementChild) &&
-            !container.lastElementChild.hasChildNodes()
+            isBlock(firstLeafNode) &&
+            !(closestElement(firstLeafNode, "[contenteditable]")?.contentEditable === "false")
         ) {
-            fillEmpty(container.lastElementChild);
+            fillEmpty(firstLeafNode);
+        }
+        const lastLeafNode = lastLeaf(container);
+        if (
+            isBlock(lastLeafNode) &&
+            !(closestElement(lastLeafNode, "[contenteditable]")?.contentEditable === "false")
+        ) {
+            fillEmpty(lastLeafNode);
         }
 
         // In case the html inserted is all contained in a single root <p> or <li>

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -448,7 +448,7 @@ describe("undo", () => {
 
     test("should work properly after undo and then redo", async () => {
         await testEditor({
-            contentBefore: "<p>[]</p>",
+            contentBefore: "<p>[]<br></p>",
             stepFunction: async (editor) => {
                 columnize(2)(editor);
                 undo(editor);
@@ -456,7 +456,7 @@ describe("undo", () => {
                 await insertText(editor, "x");
             },
             contentAfter:
-                columnsContainer(column(6, "<p>x[]</p>") + column(6, "<p><br></p>")) +
+                columnsContainer(column(6, "<p>x[]<br></p>") + column(6, "<p><br></p>")) +
                 "<p><br></p>",
         });
     });

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -164,6 +164,43 @@ describe("collapsed selection", () => {
         });
     });
 
+    test("should fill last empty list item", async () => {
+        await testEditor({
+            contentBefore: "<p>[]<br></p>",
+            stepFunction: async (editor) => {
+                editor.shared.dom.insert(
+                    parseHTML(editor.document, "<p>abc</p><ul><li></li></ul>")
+                );
+                editor.shared.history.addStep();
+            },
+            contentAfter: "<p>abc</p><ul><li>[]<br></li></ul>",
+        });
+    });
+
+    test("should fill first empty list item", async () => {
+        await testEditor({
+            contentBefore: "<p>[]<br></p>",
+            stepFunction: async (editor) => {
+                editor.shared.dom.insert(
+                    parseHTML(editor.document, "<ul><li></li></ul><p>abc</p>")
+                );
+                editor.shared.history.addStep();
+            },
+            contentAfter: "<ul><li><br></li></ul><p>abc[]</p>",
+        });
+    });
+
+    test("should fill first empty heading element", async () => {
+        await testEditor({
+            contentBefore: "<p>[]<br></p>",
+            stepFunction: async (editor) => {
+                editor.shared.dom.insert(parseHTML(editor.document, "<h1></h1><p>abc</p>"));
+                editor.shared.history.addStep();
+            },
+            contentAfter: "<h1><br></h1><p>abc[]</p>",
+        });
+    });
+
     test("never unwrap tables in breakable paragrap", async () => {
         // P elements' content can only be "phrasing" content
         // Adding a table within p is not possible
@@ -175,7 +212,7 @@ describe("collapsed selection", () => {
             parseHTML(editor.document, "<table><tbody><tr><td/></tr></tbody></table>")
         );
         expect(getContent(editor.editable)).toBe(
-            `<p>cont</p><table><tbody><tr><td></td></tr></tbody></table><p>[]ent</p>`
+            `<p>cont</p><table><tbody><tr><td><br></td></tr></tbody></table><p>[]ent</p>`
         );
     });
 
@@ -190,7 +227,7 @@ describe("collapsed selection", () => {
             parseHTML(editor.document, "<table><tbody><tr><td/></tr></tbody></table>")
         );
         expect(getContent(editor.editable)).toBe(
-            `<p class="oe_unbreakable">content[]</p><table><tbody><tr><td></td></tr></tbody></table>`
+            `<p class="oe_unbreakable">content</p><table><tbody><tr><td>[]<br></td></tr></tbody></table>`
         );
     });
 
@@ -208,7 +245,7 @@ describe("collapsed selection", () => {
             parseHTML(editor.document, "<table><tbody><tr><td/></tr></tbody></table>")
         );
         expect(getContent(editor.editable)).toBe(
-            `<div><p class="oe_unbreakable" contenteditable="true"><b class="oe_unbreakable">content[]</b><table><tbody><tr><td></td></tr></tbody></table></p></div>`
+            `<div><p class="oe_unbreakable" contenteditable="true"><b class="oe_unbreakable">content</b><table><tbody><tr><td>[]<br></td></tr></tbody></table></p></div>`
         );
     });
 


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Create a new paragraph, type some text.
- Create a numbered list below paragraph, type some text.
- Keep the cursor at the start of list text and select the above text
- Copy the selection and paste in a new paragraph.
- Backspace in pasted list is not working.

This happens because pasted list item is empty.

**Desired behavior after PR is merged:**

Now, copied empty list item is filled with `<br>`, as result backspace works properly.

task-5226511





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
