### PR TITLE
[FIX] pos_event: use partner details if not filled in

### DIFF
--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -40,3 +40,62 @@ registry.category("web_tour.tours").add("SellingEventInPos", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pos_event_registration_not_mandatory", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            // No customer, all information filled
+            ProductScreen.clickDisplayedProduct("Event regitration not mandatory"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            EventTourUtils.answerGlobalTextQuestion("Name", "Name 1"),
+            EventTourUtils.answerGlobalTextQuestion("Email", "1@test.com"),
+            Dialog.confirm(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+
+            // Customer given, all information filled
+            ProductScreen.clickDisplayedProduct("Event regitration not mandatory"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            EventTourUtils.answerGlobalTextQuestion("Name", "Name 2"),
+            EventTourUtils.answerGlobalTextQuestion("Email", "2@test.com"),
+            Dialog.confirm(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Event Parter"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+
+            // Customer given, partial information filled
+            ProductScreen.clickDisplayedProduct("Event regitration not mandatory"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            EventTourUtils.answerGlobalTextQuestion("Name", "Name 3"),
+            Dialog.confirm(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Event Parter"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+
+            // Customer given, partial information filled
+            ProductScreen.clickDisplayedProduct("Event regitration not mandatory"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            Dialog.confirm(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Event Parter"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/pos_event/static/tests/tours/utils/event_tour_utils.js
+++ b/addons/pos_event/static/tests/tours/utils/event_tour_utils.js
@@ -39,6 +39,16 @@ export function answerGlobalSelectQuestion(question, answer) {
     ];
 }
 
+export function answerGlobalTextQuestion(question, answer) {
+    return [
+        {
+            content: `Answer question ${question} with ${answer} for global`,
+            trigger: `.global_question:contains('${question}') input`,
+            run: `edit ${answer}`,
+        },
+    ];
+}
+
 export function pickTicket(name) {
     return [
         {


### PR DESCRIPTION
Currently, when a customer is set on the order and buys a event ticket, the information is not set as partner on the registration.

Steps to reproduce:
-------------------
* Create an event that asks for name but is not required
* Open pos and sell on ticket
* Do not put name info
* Select a customer for the order
* Validate order
* Check registrations
> Observation: The customer is not registered as the attendee

Why the fix:
------------
We compare the scenarios with the same flow but from website registrations.

On the website if there is no user registered:
- If information is not filled, nothing will be registered on the registration 
- If information is filled it will be used to populate attendee fields

If there is a user registered while on website:
- If no information is filled, attendee fields will be populated with the data from the connected user
- If information is filled, it will be used for attendee fields 
- If partial information is filled, it will be used for attendee fields but will also be completed with data coming from the connected user

To achieve the same behavior from the pos we first need to register the customer as the partner for the event.

During event creation we also remove values regarding attendee name, email, phone and company if they were not provided during the order. From the website they are not used during creation if they were not given by the customer. However, in the pos this information is present anyway (as empty string or False) as they are fields on the model "event.registration" and are still send to the backennd even if we remove the information here
https://github.com/odoo/odoo/blob/787621e44a9cef30469849929df267cae9e977f2/addons/pos_event/static/src/app/screens/product_screen/product_screen.js#L127

We do the fix server-side as a fix in the frontend would not be as straightforward. A customer might be on the order before selecting event ticket and it's easy but one might also add the customer after the ticket was selected.

opw-5137197