### PR TITLE
[FIX] iot_base: event listener requests not cancelling

### DIFF
--- a/addons/iot_base/static/src/network_utils/http.js
+++ b/addons/iot_base/static/src/network_utils/http.js
@@ -38,15 +38,17 @@ export function formatEndpoint(ip, route) {
  * @param params Parameters to send with the request (optional)
  * @param timeout Time before the request times out (default: 6000ms)
  * @param headers HTTP headers to send with the request (optional)
+ * @param abortSignal AbortSignal used to cancel the request early (optional)
  * @returns {Promise<any>}
  */
-export async function post(ip, route, params = {}, timeout = 6000, headers = {}) {
+export async function post(ip, route, params = {}, timeout = 6000, headers = {}, abortSignal = null) {
     const endpoint = formatEndpoint(ip, route);
+    const timeoutSignal = AbortSignal.timeout(timeout);
     const response = await browser.fetch(endpoint, {
         body: JSON.stringify({'params': params}),
         method: "POST",
         headers: {"Content-Type": "application/json", ...headers},
-        signal: AbortSignal.timeout(timeout),
+        signal: abortSignal ? AbortSignal.any([abortSignal, timeoutSignal]) : timeoutSignal,
     });
 
     return response.json();

--- a/addons/iot_base/static/src/network_utils/longpolling.js
+++ b/addons/iot_base/static/src/network_utils/longpolling.js
@@ -42,7 +42,7 @@ export class IoTLongpolling {
                 last_event: 0,
                 devices: {},
                 session_id: this._session_id,
-                rpc: false,
+                abortController: null,
             };
         }
         for (const device of devices) {
@@ -97,7 +97,7 @@ export class IoTLongpolling {
      */
     startPolling(iot_ip, fallback = true) {
         if (iot_ip) {
-            if (!this._listeners[iot_ip].rpc) {
+            if (!this._listeners[iot_ip].abortController) {
                 this._poll(iot_ip, fallback);
             }
         } else {
@@ -115,9 +115,9 @@ export class IoTLongpolling {
      * from listening on notifications on this channel.
      */
     stopPolling(iot_ip) {
-        if (this._listeners[iot_ip].rpc) {
-            this._listeners[iot_ip].rpc.abort();
-            this._listeners[iot_ip].rpc = false;
+        if (this._listeners[iot_ip].abortController) {
+            this._listeners[iot_ip].abortController.abort();
+            this._listeners[iot_ip].abortController = null;
         }
     }
 
@@ -139,16 +139,14 @@ export class IoTLongpolling {
      */
     async _rpcIoT(iot_ip, route, params, timeout = undefined, fallback = false, headers = undefined) {
         try {
-            const result = await post(iot_ip, route, params, timeout, headers);
+            const abortController = new AbortController();
 
             if (this._listeners[iot_ip] && route === this.pollRoute) {
-                this._listeners[iot_ip].rpc = result;
-                return this._listeners[iot_ip].rpc;
-            } else {
-                return result;
+                this._listeners[iot_ip].abortController = abortController;
             }
-        } catch {
-            if (!fallback) {
+            return await post(iot_ip, route, params, timeout, headers, abortController.signal);
+        } catch (error) {
+            if (!fallback && error?.name !== "AbortError") {
                 this._doWarnFail(iot_ip);
             }
             throw new Error("Longpolling action failed");
@@ -168,7 +166,7 @@ export class IoTLongpolling {
         this._rpcIoT(iot_ip, this.pollRoute, { listener: listener }, 60000, fallback).then(
             (result) => {
                 this._retries = 0;
-                this._listeners[iot_ip].rpc = false;
+                this._listeners[iot_ip].abortController = null;
                 const remainingDevices = Object.keys(this._listeners[iot_ip].devices || {});
                 if (result.result) {
                     if (this._session_id === result.result.session_id) {


### PR DESCRIPTION
Steps to reproduce:
1. Pair an IoT box
2. In the IoT form view, click on any device, then click back to return to the IoT form view.
3. Repeat this step multiple times. If you have devtools open, you can see a `/event` fetch request every time you open the device form.

Expected behaviour:
- When a new request is made, the previous request is cancelled.

Actual behaviour:
- The previous requests remain active, and eventually no further requests are possible due to browser limits.

This behaviour was broken when the longpolling was changed to use the `fetch` method instead of Odoo's `rpc` method. This commit restores the behaviour by using an `AbortController` instance which is aborted when `stopPolling` is called.

Manual Forward Port of Enterprise PR: https://github.com/odoo/enterprise/pull/98985

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
