### PR TITLE
[IMP] sale_stock: Allow salesman to access deliveries

### DIFF
--- a/addons/sale_stock/security/ir.model.access.csv
+++ b/addons/sale_stock/security/ir.model.access.csv
@@ -15,3 +15,4 @@ access_stock_location_sale_manager,stock.location sale manager,stock.model_stock
 access_stock_rule_salemanager,stock_rule salemanager,stock.model_stock_rule,sales_team.group_sale_manager,1,1,1,1
 access_stock_rule,stock.rule.flow,stock.model_stock_rule,sales_team.group_sale_salesman,1,0,0,0
 access_stock_package_type_salesman,stock_package_type salesman,stock.model_stock_package_type,sales_team.group_sale_salesman,1,0,0,0
+access_stock_lot_salesman,stock.lot salesman,stock.model_stock_lot,sales_team.group_sale_salesman,1,0,0,0

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -13,7 +13,7 @@
                     class="oe_stat_button"
                     icon="fa-truck"
                     invisible="delivery_count == 0"
-                    groups="stock.group_stock_user"
+                    groups="stock.group_stock_user,sales_team.group_sale_salesman"
                 >
                     <field name="delivery_count" widget="statinfo" string="Delivery"/>
                 </button>


### PR DESCRIPTION
**Purpose**
The delivery status on the SO is limited.
If there is a multistep delivery, there is no way for the salesman to know if the process has already started

**Specification**
Allow read access to deliveries for the salesperson of a SO

Task-4873914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
