### PR TITLE
[FIX] website, web_editor: Show text cover on mobile view

### DIFF
--- a/addons/web_editor/static/src/js/editor/drag_and_drop.js
+++ b/addons/web_editor/static/src/js/editor/drag_and_drop.js
@@ -74,6 +74,14 @@ export function useNativeDraggable(hookParams, initialParams) {
     // to the makeDraggableHook function. There should not be any need to add
     // the default selector class here.
     el.classList.add("o_draggable");
+    
+    // Temporary workaround for a background-image visibility bug in the stable.
+    // This code should be removed in the master branch.
+    const targetUrl = "/web/image/website.s_text_cover_default_image";
+
+    if (el.style.backgroundImage && el.style.backgroundImage.includes(targetUrl)) {
+        el.classList.remove("d-none");
+    }
     cleanupFunctions.push(() => el.classList.remove("o_draggable"));
 
     const draggableState = makeDraggableHook({ setupHooks, ...hookParams})(currentParams);

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -10,7 +10,7 @@
                     <p class="lead">Write one or two paragraphs describing your product, services or a specific feature. To be successful your content needs to be useful to your readers.</p>
                     <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
                 </div>
-                <div class="o_not_editable o_colored_level o_cc o_cc1 pt160 pb160 oe_img_bg col-lg-7 d-none d-md-block" style="background-image: url('/web/image/website.s_text_cover_default_image'); background-position: 100% 0;"/>
+                <div class="o_not_editable o_colored_level o_cc o_cc1 pt160 pb160 oe_img_bg col-lg-7 d-md-block" style="background-image: url('/web/image/website.s_text_cover_default_image'); background-position: 100% 0;"/>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Steps to reproduce:
===================
- Go to website and add a "text cover" snippet
- Zoom in on the page or switch to mobile view -> The cover's background image disappears

Cause:
======
A Bootstrap rule applied `d-md-block` to the cover image container on screens (specifically when width >= 768px, which can be removed by zooming).
https://github.com/odoo/odoo/blob/b093786714e9e8567cf75abf78ac3d954a3d89b2/addons/web/static/lib/bootstrap/dist/css/bootstrap.css#L8624 So `d-none` will be applied once d-md-block is removed.

Solution:
=========
Remove the `d-none` rule from this element to ensure the background image remains visible.
A workaround is included for non-updated views until master.

opw-5219747
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
