### PR TITLE
[FIX] Restricting Edit Access to Department

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -42,6 +42,33 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record id="hr_dept_manager_access_rule" model="ir.rule">
+        <field name="name">Department Access For Managers</field>
+        <field name="model_id" ref="model_hr_department"/>
+        <field name="domain_force">[
+            '|',
+            ('manager_id', 'in', user.employee_id.ids),
+            ('manager_id.is_subordinate', '=', True)
+        ]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+
+    </record>
+
+    <record id="hr_dept_hr_officer_access_rule" model="ir.rule">
+        <field name="name">Department Access For HR Officers</field>
+        <field name="model_id" ref="hr.model_hr_department"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
     <record id="hr_employee_public_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee_public"/>

--- a/addons/hr/security/ir.model.access.csv
+++ b/addons/hr/security/ir.model.access.csv
@@ -6,7 +6,7 @@ access_hr_employee_system_user,hr.employee system user,model_hr_employee,base.gr
 access_hr_employee_public_user,hr.employee_public,model_hr_employee_public,base.group_user,1,0,0,0
 access_hr_employee_resource_user,resource.resource.user,resource.model_resource_resource,group_hr_user,1,1,1,1
 access_hr_department_user,hr.department.user,model_hr_department,group_hr_user,1,1,1,1
-access_hr_department_employee,hr.department.employee,model_hr_department,base.group_user,1,0,0,0
+access_hr_department_employee,hr.department.employee,model_hr_department,base.group_user,1,1,0,0
 access_hr_job_user,hr.job user,model_hr_job,group_hr_user,1,1,1,1
 access_hr_job_employee,hr.job.employee,model_hr_job,base.group_user,1,0,0,0
 access_hr_employee_departure,access.hr.employee.departure,model_hr_employee_departure,hr.group_hr_user,1,1,1,1

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -184,8 +184,45 @@ class TestSelfAccessRights(TestHrCommon):
         # Searching user based on employee_id field should not raise bad query error
         self.env['res.users'].with_user(self.richard).search([('employee_id', 'ilike', 'Hubert')])
 
-    # Write hr.department
-    def testWriteDepartmentEmployee(self):
+    def test_user_can_edit_department_they_manage(self):
+        dept = self.env['hr.department'].create({
+            'name': 'Managed Dept',
+            'manager_id': self.richard_emp.id,
+        })
+
+        dept.with_user(self.richard).write({
+            'name': 'Renamed Managed Dept'
+        })
+
+        self.assertEqual(dept.name, 'Renamed Managed Dept')
+
+    def test_user_can_edit_department_managed_by_subordinate(self):
+        # Subordinate user
+        alice = new_test_user(
+            self.env,
+            login='alice',
+            groups='base.group_user',
+            name='Alice User',
+            email='alice@example.com'
+        )
+
+        alice_emp = self.env['hr.employee'].create({
+            'name': 'Alice',
+            'user_id': alice.id,
+            'parent_id': self.richard_emp.id,
+        })
+        dept = self.env['hr.department'].create({
+            'name': 'Subordinate Dept',
+            'manager_id': alice_emp.id,
+        })
+
+        dept.with_user(self.richard).write({
+            'name': 'Renamed Subordinate Dept'
+        })
+
+        self.assertEqual(dept.name, 'Renamed Subordinate Dept')
+
+    def test_user_cannot_create_nor_edit_random_department(self):
         with self.assertRaises(AccessError):
             self.env['hr.department'].with_user(self.richard).create({'name': 'New Dept'})
         dept = self.env['hr.department'].create({'name': 'New Dept'})


### PR DESCRIPTION
Before this commit:
any internal user could **edit** all departments

After this commit:
non-hr users can **edit**:
a) departments they manage
b) departments managed by one of their subordinates

Task-4948774