### PR TITLE
[FIX] bus: enforce websocket close timeout

### DIFF
--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -21,7 +21,6 @@ from ..websocket import (
     Frame,
     Opcode,
     TimeoutManager,
-    TimeoutReason,
     Websocket,
     WebsocketConnectionHandler,
 )
@@ -69,20 +68,18 @@ class TestWebsocketCaryall(WebsocketCase):
             # within TIMEOUT seconds, the connection should have timed out.
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
-            self.assertFalse(timeout_manager.has_timed_out())
+            self.assertFalse(timeout_manager.has_frame_response_timed_out())
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
-            self.assertTrue(timeout_manager.has_timed_out())
-            self.assertEqual(timeout_manager.timeout_reason, TimeoutReason.NO_RESPONSE)
+            self.assertTrue(timeout_manager.has_frame_response_timed_out())
 
             timeout_manager = TimeoutManager()
             # A CLOSE frame was just sent, if no close has been received
             # within TIMEOUT seconds, the connection should have timed out.
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.CLOSE))
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
-            self.assertFalse(timeout_manager.has_timed_out())
+            self.assertFalse(timeout_manager.has_frame_response_timed_out())
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
-            self.assertTrue(timeout_manager.has_timed_out())
-            self.assertEqual(timeout_manager.timeout_reason, TimeoutReason.NO_RESPONSE)
+            self.assertTrue(timeout_manager.has_frame_response_timed_out())
 
     def test_timeout_manager_overlapping_timeouts(self):
         with freeze_time('2022-08-19') as frozen_time:
@@ -91,16 +88,15 @@ class TestWebsocketCaryall(WebsocketCase):
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
             timeout_manager.acknowledge_frame_receipt(Frame(Opcode.PONG))
             frozen_time.tick(delta=timedelta(seconds=timeout_manager.TIMEOUT + 1))
-            self.assertTrue(timeout_manager.has_timed_out())
+            self.assertTrue(timeout_manager.has_frame_response_timed_out())
 
     def test_timeout_manager_keep_alive_timeout(self):
         with freeze_time('2022-08-19') as frozen_time:
             timeout_manager = TimeoutManager()
             frozen_time.tick(delta=timedelta(seconds=timeout_manager._keep_alive_timeout / 2))
-            self.assertFalse(timeout_manager.has_timed_out())
+            self.assertFalse(timeout_manager.has_keep_alive_timed_out())
             frozen_time.tick(delta=timedelta(seconds=timeout_manager._keep_alive_timeout / 2 + 1))
-            self.assertTrue(timeout_manager.has_timed_out())
-            self.assertEqual(timeout_manager.timeout_reason, TimeoutReason.KEEP_ALIVE)
+            self.assertTrue(timeout_manager.has_keep_alive_timed_out())
 
     def test_timeout_manager_reset_wait_for(self):
         with freeze_time('2022-08-19') as frozen_time:
@@ -109,13 +105,13 @@ class TestWebsocketCaryall(WebsocketCase):
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
             timeout_manager.acknowledge_frame_receipt(Frame(Opcode.PONG))
             frozen_time.tick(delta=timedelta(seconds=timeout_manager.TIMEOUT + 1))
-            self.assertFalse(timeout_manager.has_timed_out())
+            self.assertFalse(timeout_manager.has_frame_response_timed_out())
 
             # CLOSE frame
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.CLOSE))
             timeout_manager.acknowledge_frame_receipt(Frame(Opcode.CLOSE))
             frozen_time.tick(delta=timedelta(seconds=timeout_manager.TIMEOUT + 1))
-            self.assertFalse(timeout_manager.has_timed_out())
+            self.assertFalse(timeout_manager.has_frame_response_timed_out())
 
     def test_user_login(self):
         websocket = self.websocket_connect()
@@ -298,3 +294,36 @@ class TestWebsocketCaryall(WebsocketCase):
             ws.close(CloseCode.CLEAN)
             self.wait_remaining_websocket_connections()
             self.assertTrue(mock.called)
+
+    def test_websocket_terminates_after_closing_timeout(self):
+        orig_disconnect = Websocket.disconnect
+        orig_terminate = Websocket._terminate
+        disconnect_done_event = Event()
+        terminate_done_event = Event()
+
+        def disconnect_wrapper(self, code):
+            orig_disconnect(self, code)
+            disconnect_done_event.set()
+
+        def terminate_wrapper(self):
+            orig_terminate(self)
+            terminate_done_event.set()
+
+        with (
+            patch('odoo.addons.bus.websocket.TimeoutManager.KEEP_ALIVE_TIMEOUT', 0),
+            patch.object(Websocket, 'disconnect', disconnect_wrapper),
+            patch.object(Websocket, '_terminate', terminate_wrapper),
+            freeze_time('2022-08-19') as frozen_time,
+        ):
+            ws = self.websocket_connect(ping_after_connect=False)
+            ws.send(b'\x00')  # Wake up the WebSocket loop.
+            self.assertTrue(
+                disconnect_done_event.wait(timeout=5),
+                'Server should have initiated the closing handshake as the keep alive timeout is exceeded.',
+            )
+            frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT + 1))
+            ws.send(b'\x00')  # Wake up the WebSocket loop.
+            self.assertTrue(
+                terminate_done_event.wait(timeout=5),
+                'Server should have terminated the connection as it didn\'t receive any response.',
+            )

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -68,7 +68,6 @@ class TestWebsocketCaryall(WebsocketCase):
             # A PING frame was just sent, if no pong has been received
             # within TIMEOUT seconds, the connection should have timed out.
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
-            self.assertEqual(timeout_manager._awaited_opcode, Opcode.PONG)
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
             self.assertFalse(timeout_manager.has_timed_out())
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
@@ -79,12 +78,20 @@ class TestWebsocketCaryall(WebsocketCase):
             # A CLOSE frame was just sent, if no close has been received
             # within TIMEOUT seconds, the connection should have timed out.
             timeout_manager.acknowledge_frame_sent(Frame(Opcode.CLOSE))
-            self.assertEqual(timeout_manager._awaited_opcode, Opcode.CLOSE)
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
             self.assertFalse(timeout_manager.has_timed_out())
             frozen_time.tick(delta=timedelta(seconds=TimeoutManager.TIMEOUT / 2))
             self.assertTrue(timeout_manager.has_timed_out())
             self.assertEqual(timeout_manager.timeout_reason, TimeoutReason.NO_RESPONSE)
+
+    def test_timeout_manager_overlapping_timeouts(self):
+        with freeze_time('2022-08-19') as frozen_time:
+            timeout_manager = TimeoutManager()
+            timeout_manager.acknowledge_frame_sent(Frame(Opcode.CLOSE))
+            timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
+            timeout_manager.acknowledge_frame_receipt(Frame(Opcode.PONG))
+            frozen_time.tick(delta=timedelta(seconds=timeout_manager.TIMEOUT + 1))
+            self.assertTrue(timeout_manager.has_timed_out())
 
     def test_timeout_manager_keep_alive_timeout(self):
         with freeze_time('2022-08-19') as frozen_time:
@@ -96,18 +103,19 @@ class TestWebsocketCaryall(WebsocketCase):
             self.assertEqual(timeout_manager.timeout_reason, TimeoutReason.KEEP_ALIVE)
 
     def test_timeout_manager_reset_wait_for(self):
-        timeout_manager = TimeoutManager()
-        # PING frame
-        timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
-        self.assertEqual(timeout_manager._awaited_opcode, Opcode.PONG)
-        timeout_manager.acknowledge_frame_receipt(Frame(Opcode.PONG))
-        self.assertIsNone(timeout_manager._awaited_opcode)
+        with freeze_time('2022-08-19') as frozen_time:
+            timeout_manager = TimeoutManager()
+            # PING frame
+            timeout_manager.acknowledge_frame_sent(Frame(Opcode.PING))
+            timeout_manager.acknowledge_frame_receipt(Frame(Opcode.PONG))
+            frozen_time.tick(delta=timedelta(seconds=timeout_manager.TIMEOUT + 1))
+            self.assertFalse(timeout_manager.has_timed_out())
 
-        # CLOSE frame
-        timeout_manager.acknowledge_frame_sent(Frame(Opcode.CLOSE))
-        self.assertEqual(timeout_manager._awaited_opcode, Opcode.CLOSE)
-        timeout_manager.acknowledge_frame_receipt(Frame(Opcode.CLOSE))
-        self.assertIsNone(timeout_manager._awaited_opcode)
+            # CLOSE frame
+            timeout_manager.acknowledge_frame_sent(Frame(Opcode.CLOSE))
+            timeout_manager.acknowledge_frame_receipt(Frame(Opcode.CLOSE))
+            frozen_time.tick(delta=timedelta(seconds=timeout_manager.TIMEOUT + 1))
+            self.assertFalse(timeout_manager.has_timed_out())
 
     def test_user_login(self):
         websocket = self.websocket_connect()

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -175,7 +175,6 @@ HEARTBEAT_OP = {Opcode.PING, Opcode.PONG}
 VALID_CLOSE_CODES = {
     code for code in CloseCode if code is not CloseCode.ABNORMAL_CLOSURE
 }
-CLEAN_CLOSE_CODES = {CloseCode.CLEAN, CloseCode.GOING_AWAY, CloseCode.RESTART}
 RESERVED_CLOSE_CODES = range(3000, 5000)
 
 _XOR_TABLE = [bytes(a ^ b for a in range(256)) for b in range(256)]
@@ -219,11 +218,6 @@ class Websocket:
     # Maximum size for a message in bytes, whether it is sent as one
     # frame or many fragmented ones.
     MESSAGE_MAX_SIZE = 2 ** 20
-    # Proxies usually close a connection after 1 minute of inactivity.
-    # Therefore, a PING frame have to be sent if no frame is either sent
-    # or received within CONNECTION_TIMEOUT - 15 seconds.
-    CONNECTION_TIMEOUT = 60
-    INACTIVITY_TIMEOUT = CONNECTION_TIMEOUT - 15
     # How much time (in second) the history of last dispatched notifications is
     # kept in memory for each websocket.
     # To avoid duplicate notifications, we fetch them based on their ids.
@@ -298,17 +292,19 @@ class Websocket:
         while self.state is not ConnectionState.CLOSED:
             try:
                 readables = {
-                    selector_key[0].fileobj for selector_key in
-                    self.__selector.select(self.INACTIVITY_TIMEOUT)
+                    selector_key[0].fileobj
+                    for selector_key in self.__selector.select(TimeoutManager.TIMEOUT)
                 }
-                if self._timeout_manager.has_timed_out() and self.state is ConnectionState.OPEN:
-                    self.disconnect(
-                        CloseCode.ABNORMAL_CLOSURE
-                        if self._timeout_manager.timeout_reason is TimeoutReason.NO_RESPONSE
-                        else CloseCode.KEEP_ALIVE_TIMEOUT
-                    )
+                if (
+                    self._timeout_manager.has_keep_alive_timed_out()
+                    and self.state is ConnectionState.OPEN
+                ):
+                    self.disconnect(CloseCode.KEEP_ALIVE_TIMEOUT)
                     continue
-                if not readables:
+                if self._timeout_manager.has_frame_response_timed_out():
+                    self._terminate()
+                    continue
+                if not readables and self._timeout_manager.should_send_ping_frame():
                     self._send_ping_frame()
                     continue
                 if self.__notif_sock_r in readables:
@@ -715,39 +711,39 @@ class Websocket:
         self._send(notifications)
 
 
-class TimeoutReason(IntEnum):
-    KEEP_ALIVE = 0
-    NO_RESPONSE = 1
-
-
 class TimeoutManager:
     """
-    This class handles the Websocket timeouts. If no response to a
-    PING/CLOSE frame is received after `TIMEOUT` seconds or if the
-    connection is opened for more than `self._keep_alive_timeout` seconds,
-    the connection is considered to have timed out. To determine if the
-    connection has timed out, use the `has_timed_out` method.
+    Track WebSocket activity to determine when a response has timed out,
+    when a ping should be sent, and when the connection has exceeded its
+    keep-alive duration.
     """
     TIMEOUT = 15
     # Timeout specifying how many seconds the connection should be kept
     # alive.
     KEEP_ALIVE_TIMEOUT = int(config['websocket_keep_alive_timeout'])
+    # Proxies and NATs usually close a connection after 1 minute of inactivity.
+    # Therefore, a PING frame should be sent if the connection has been idle for
+    # a while. Since the selector can block for up to `TIMEOUT` seconds, the
+    # worst case delay is 55 seconds (`INACTIVITY_TIMEOUT` + `TIMEOUT`), which
+    # is enough to keep the connection alive.
+    CONNECTION_TIMEOUT = 60
+    INACTIVITY_TIMEOUT = CONNECTION_TIMEOUT - 20
 
     def __init__(self):
         super().__init__()
         # Maps an awaited response opcode (i.e. PONG, CLOSE) to the
         # time by which the response must be received.
         self._expiration_time_by_opcode = {}
-        # Time in which the connection was opened.
-        self._opened_at = time.time()
         # Custom keep alive timeout for each TimeoutManager to avoid multiple
         # connections timing out at the same time.
         self._keep_alive_timeout = (
             self.KEEP_ALIVE_TIMEOUT + random.uniform(0, self.KEEP_ALIVE_TIMEOUT / 2)
         )
-        self.timeout_reason = None
+        self._keep_alive_expiration_time = time.time() + self._keep_alive_timeout
+        self._next_ping_time = time.time() + self.INACTIVITY_TIMEOUT
 
     def acknowledge_frame_receipt(self, frame):
+        self._next_ping_time = time.time() + self.INACTIVITY_TIMEOUT
         self._expiration_time_by_opcode.pop(frame.opcode, None)
 
     def acknowledge_frame_sent(self, frame):
@@ -755,23 +751,30 @@ class TimeoutManager:
         Acknowledge a frame was sent. If this frame is a PING/CLOSE
         frame, start waiting for an answer.
         """
+        now = time.time()
+        self._next_ping_time = now + self.INACTIVITY_TIMEOUT
         if frame.opcode in (Opcode.PING, Opcode.CLOSE):
             self._expiration_time_by_opcode[
                 Opcode.PONG if frame.opcode is Opcode.PING else Opcode.CLOSE
-            ] = time.time() + self.TIMEOUT
+            ] = now + self.TIMEOUT
 
-    def has_timed_out(self):
+    def has_keep_alive_timed_out(self):
+        return time.time() >= self._keep_alive_expiration_time
+
+    def has_frame_response_timed_out(self):
         """
-        Determine whether the connection has timed out or not. The
-        connection times out when the answer to a CLOSE/PING frame
-        is not received within `TIMEOUT` seconds or if the connection
-        is opened for more than `self._keep_alive_timeout` seconds.
+        Check if any pending PING or CLOSE frame has been waiting for an answer
+        for at least `TIMEOUT` seconds.
         """
         now = time.time()
-        if now - self._opened_at >= self._keep_alive_timeout:
-            self.timeout_reason = TimeoutReason.KEEP_ALIVE
-            return True
         return any(now >= expiration for expiration in self._expiration_time_by_opcode.values())
+
+    def should_send_ping_frame(self):
+        return (
+            not self.has_frame_response_timed_out()
+            and not self.has_keep_alive_timed_out()
+            and time.time() >= self._next_ping_time
+        )
 
 
 # ------------------------------------------------------

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -731,7 +731,9 @@ class TimeoutManager:
 
     def __init__(self):
         super().__init__()
-        self._awaited_opcode = None
+        # Maps an awaited response opcode (i.e. PONG, CLOSE) to the
+        # time by which the response must be received.
+        self._expiration_time_by_opcode = {}
         # Time in which the connection was opened.
         self._opened_at = time.time()
         # Custom keep alive timeout for each TimeoutManager to avoid multiple
@@ -740,28 +742,19 @@ class TimeoutManager:
             self.KEEP_ALIVE_TIMEOUT + random.uniform(0, self.KEEP_ALIVE_TIMEOUT / 2)
         )
         self.timeout_reason = None
-        # Start time recorded when we started awaiting an answer to a
-        # PING/CLOSE frame.
-        self._waiting_start_time = None
 
     def acknowledge_frame_receipt(self, frame):
-        if self._awaited_opcode is frame.opcode:
-            self._awaited_opcode = None
-            self._waiting_start_time = None
+        self._expiration_time_by_opcode.pop(frame.opcode, None)
 
     def acknowledge_frame_sent(self, frame):
         """
         Acknowledge a frame was sent. If this frame is a PING/CLOSE
         frame, start waiting for an answer.
         """
-        if self.has_timed_out():
-            return
-        if frame.opcode is Opcode.PING:
-            self._awaited_opcode = Opcode.PONG
-        elif frame.opcode is Opcode.CLOSE:
-            self._awaited_opcode = Opcode.CLOSE
-        if self._awaited_opcode is not None:
-            self._waiting_start_time = time.time()
+        if frame.opcode in (Opcode.PING, Opcode.CLOSE):
+            self._expiration_time_by_opcode[
+                Opcode.PONG if frame.opcode is Opcode.PING else Opcode.CLOSE
+            ] = time.time() + self.TIMEOUT
 
     def has_timed_out(self):
         """
@@ -774,10 +767,7 @@ class TimeoutManager:
         if now - self._opened_at >= self._keep_alive_timeout:
             self.timeout_reason = TimeoutReason.KEEP_ALIVE
             return True
-        if self._awaited_opcode and now - self._waiting_start_time >= self.TIMEOUT:
-            self.timeout_reason = TimeoutReason.NO_RESPONSE
-            return True
-        return False
+        return any(now >= expiration for expiration in self._expiration_time_by_opcode.values())
 
 
 # ------------------------------------------------------

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -544,8 +544,9 @@ class Websocket:
             return
         self.state = ConnectionState.CLOSING
         self._close_sent = True
-        if frame.code not in CLEAN_CLOSE_CODES or self._close_received:
-            return self._terminate()
+        if frame.code is CloseCode.ABNORMAL_CLOSURE or self._close_received:
+            self._terminate()
+            return
         # After sending a control frame indicating the connection
         # should be closed, a peer does not send any further data.
         self.__selector.unregister(self.__notif_sock_r)
@@ -628,7 +629,10 @@ class Websocket:
                 _logger.warning("Bus operation aborted; registry has been reloaded")
             else:
                 _logger.error(exc, exc_info=True)
-        self.disconnect(code, reason)
+        if self.state is ConnectionState.OPEN:
+            self.disconnect(code, reason)
+        else:
+            self._terminate()
 
     def _limit_rate(self):
         """


### PR DESCRIPTION
This PR fixes several issues with WebSocket timeouts:

- Waiting for more than one response was not handled properly, resulting in missed timeouts.
- The closing handshake did not strictly follow the RFC when initiated on the server side (it closed without waiting for the other peer).
- Close timeouts were not enforced (the connection was not terminated when the other peer did not respond to the close frame).