### PR TITLE
[FIX] mail: can mention all group chat members inside its thread

### DIFF
--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -77,7 +77,7 @@ class ResPartner(models.Model):
         domain = expression.AND(
             [
                 self._get_mention_suggestions_domain(search),
-                [("channel_ids", "in", channel.id)],
+                [("channel_ids", "in", (channel.parent_channel_id | channel).ids)],
             ]
         )
         extra_domain = expression.AND([
@@ -94,7 +94,10 @@ class ResPartner(models.Model):
                 ]
             )
         partners = self._search_mention_suggestions(domain, limit, extra_domain)
-        members_domain = [("channel_id", "=", channel.id), ("partner_id", "in", partners.ids)]
+        members_domain = [
+            ("channel_id", "=", (channel.parent_channel_id | channel).ids),
+            ("partner_id", "in", partners.ids)
+        ]
         members = self.env["discuss.channel.member"].search(members_domain)
         member_fields = [
             Store.One("channel_id", [], as_thread=True, rename="thread"),

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -287,3 +287,25 @@ test("muted channel hides sub-thread unless channel is selected or thread has un
     );
     await contains(".o-mail-DiscussSidebar-item:contains('New Thread')");
 });
+
+test("can mention all group chat members inside its sub-thread", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Lilibeth" });
+    const groupChannelId = pyEnv["discuss.channel"].create({
+        name: "Our channel",
+        channel_type: "group",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    const groupSubChannelId = pyEnv["discuss.channel"].create({
+        name: "New Thread",
+        parent_channel_id: groupChannelId,
+        channel_member_ids: [Command.create({ partner_id: serverState.partnerId })],
+    });
+    await start();
+    await openDiscuss(groupSubChannelId);
+    await insertText(".o-mail-Composer-input", "@");
+    await contains(".o-mail-Composer-suggestion", { count: 2 });
+});

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -132,7 +132,7 @@ export class ResPartner extends webModels.ResPartner {
         );
         const store = new mailDataHelpers.Store();
         const memberIds = DiscussChannelMember.search([
-            ["channel_id", "=", channel_id],
+            ["channel_id", "in", [channel.id, channel.parent_channel_id]],
             ["partner_id", "in", partners],
         ]);
         const users = ResUsers.search([["partner_id", "in", partners]]).reduce((map, userId) => {
@@ -190,11 +190,12 @@ export class ResPartner extends webModels.ResPartner {
         const DiscussChannelMember = this.env["discuss.channel.member"];
         const ResUsers = this.env["res.users"];
 
+        const channel = this.env["discuss.channel"].browse(channel_id)[0];
         let partnerIds = [];
-        if (!domain?.length && channel_id) {
-            partnerIds = DiscussChannelMember.search([["channel_id", "=", channel_id]]).map(
-                (memberId) => DiscussChannelMember.browse(memberId)[0].partner_id
-            );
+        if (!domain?.length && channel) {
+            partnerIds = DiscussChannelMember.search([
+                ["channel_id", "in", [channel.id, channel.parent_channel_id]],
+            ]).map((memberId) => DiscussChannelMember.browse(memberId)[0].partner_id);
         } else {
             partnerIds = ResUsers.search(domain).map(
                 (userId) => ResUsers.browse(userId)[0].partner_id


### PR DESCRIPTION
Before this commit, when inside a thread of a group chat, it would not be possible to mention channel members that are not inside said thread.

Steps to reproduce:
1. Create group chat
2. Create a thread
3. Try to mention -> can only mention self

This commit fixes the issue by:
1. In the `get_mention_suggestions_from_channel`: correctly adding in the store all partners inside the parent channel
2. In the suggestion service: taking the `channel_member_ids` from the `parent_channel_id` when present

task-5233010