### PR TITLE
[FIX] website_sale{,_stock}: fix decimal quantity in ecommerce

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models
 from odoo.http import request
+from odoo.tools import float_round
 from odoo.tools.translate import html_translate
 
 from odoo.addons.website.models import ir_http
@@ -65,10 +66,12 @@ class ProductTemplate(models.Model):
         })
         if product_or_template.is_product_variant:
             product_sudo = product_or_template.sudo()
-            free_qty = product_sudo.uom_id._compute_quantity(
+            computed_qty = product_sudo.uom_id._compute_quantity(
                 website._get_product_available_qty(product_sudo),
                 to_unit=uom,
+                round=False,
             )
+            free_qty = float_round(computed_qty, precision_digits=0, rounding_method='DOWN')
             has_stock_notification = (
                 product_sudo._has_stock_notification(self.env.user.partner_id)
                 or (

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -2,6 +2,7 @@
 
 from odoo import models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_round
 
 
 class SaleOrder(models.Model):
@@ -29,7 +30,8 @@ class SaleOrder(models.Model):
 
             # Convert cart and available quantities to the requested uom
             product_qty_in_cart = product_uom._compute_quantity(product_qty_in_cart, uom)
-            available_qty = product_uom._compute_quantity(available_qty, uom)
+            available_qty = product_uom._compute_quantity(available_qty, uom, round=False)
+            available_qty = float_round(available_qty, precision_digits=0, rounding_method='DOWN')
 
             old_qty = order_line.product_uom_qty if order_line else 0
             added_qty = new_qty - old_qty


### PR DESCRIPTION
### Issue:
In ecommerce quantity can become decimal.

#### To reproduce:
1- Add a packaging `Pack of 6` to the product
2- Uncheck `continue selling`
3- Update in-stock quantity of the product to 9
4- In product shop page and increase the qty to 9
5- Change the packaging option to `Pack of 6`

Talked with PO about this issue.
There are no use cases in ecommerce where the quantity needs to be a decimal number.

We should round the quantity down, as in this instance where:
- In-stock quantity: 9
- Packaging: Pack of 6

The `free_qty` should be 1.

opw-5237233
