### PR TITLE
[FIX] mail: preserve partner mentions in composer

### DIFF
--- a/addons/mail/controllers/__init__.py
+++ b/addons/mail/controllers/__init__.py
@@ -8,6 +8,7 @@ from . import link_preview
 from . import mail
 from . import mailbox
 from . import message_reaction
+from . import res_partner
 from . import thread
 from . import webclient
 from . import webmanifest

--- a/addons/mail/controllers/res_partner.py
+++ b/addons/mail/controllers/res_partner.py
@@ -1,0 +1,43 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request
+from odoo.tools.misc import verify_limited_field_access_token
+
+from odoo.addons.mail.controllers.webclient import WebclientController
+from odoo.addons.mail.tools.discuss import Store
+
+
+class ResPartnerWebclientController(WebclientController):
+    """Override to add res.partner specific features."""
+
+    @classmethod
+    def _process_request_loop(self, store: Store, fetch_params):
+        """Override to add res.partner specific features."""
+        # aggregate of channels to return, to batch them in a single query when all the fetch params
+        # have been processed
+        request.update_context(partners=request.env["res.partner"], partners_no_fields=False)
+        super()._process_request_loop(store, fetch_params)
+        partners = request.env.context["partners"]
+        if partners and request.env.context["partners_no_fields"]:
+            store.add(partners, fields=["id"])
+
+    @classmethod
+    def _process_request_for_all(self, store: Store, name, params):
+        """Override to return channel as member and last messages."""
+        super()._process_request_for_all(store, name, params)
+        if name == "partners_no_fields":
+            partners = request.env["res.partner"].browse(params["partner_ids"])
+            partners.filtered(
+                lambda p: (
+                    (not request.env.user.share and p.has_access("read"))
+                    or (
+                        verify_limited_field_access_token(
+                            p,
+                            "id",
+                            params.get("partner_ids_mention_token", {}).get(str(p.id), ""),
+                            scope="mail.message_mention",
+                        )
+                    )
+                )
+            )
+            request.update_context(partners=partners, partners_no_fields=True)

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -360,6 +360,7 @@ export class Composer extends Component {
                 onFocusout: this.onFocusout.bind(this),
                 onInput: this.onInput.bind(this),
                 onKeydown: this.onKeydown.bind(this),
+                handleValidPartnerMention: this.handleValidPartnerMention.bind(this),
             },
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),
@@ -672,6 +673,13 @@ export class Composer extends Component {
         return markup`<div>${defaultBody}</div>`; // as to not wrap in <p> by html_sanitize
     }
 
+    async handleValidPartnerMention(partnerLinks) {
+        this.props.composer.mentionedPartners = [];
+        for (const partnerLink of partnerLinks) {
+            this.props.composer.mentionedPartners.push(this.store["res.partner"].get(Number(partnerLink.dataset.oeId)));
+        }
+    }
+
     clear() {
         this.props.composer.clear();
         browser.localStorage.removeItem(this.props.composer.localId);
@@ -905,6 +913,7 @@ export class Composer extends Component {
         const saveContentToLocalStorage = ({
             composerHtml,
             emailAddSignature,
+            partnerIdsMentionToken,
             replyToMessageId,
             fromFullComposer = composer.restoredFromFullComposer,
         }) => {
@@ -916,6 +925,9 @@ export class Composer extends Component {
                     JSON.stringify({
                         emailAddSignature,
                         replyToMessageId,
+                        partnerIdsMentionToken: Object.keys(partnerIdsMentionToken || {}).length
+                            ? partnerIdsMentionToken
+                            : undefined,
                         composerHtml: isMarkup(composerHtml)
                             ? ["markup", composerHtml]
                             : composerHtml,
@@ -930,16 +942,23 @@ export class Composer extends Component {
                     saveContentToLocalStorage({ ...args[0], fromFullComposer: true }),
             });
         } else {
+            const partner_ids_mention_token = {};
+            for (const partner of composer.mentionedPartners) {
+                if (partner?.mention_token) {
+                    partner_ids_mention_token[partner.id] = partner.mention_token;
+                }
+            }
             saveContentToLocalStorage({
                 composerHtml: composer.composerHtml,
                 emailAddSignature: true,
+                partnerIdsMentionToken: partner_ids_mention_token,
                 replyToMessageId: composer.replyToMessage?.id,
                 fromFullComposer: false,
             });
         }
     }
 
-    restoreContent() {
+    async restoreContent() {
         const composer = toRaw(this.props.composer);
         let config;
         try {
@@ -959,6 +978,19 @@ export class Composer extends Component {
         }
         if (Number.isInteger(config.replyToMessageId)) {
             composer.replyToMessage = this.store["mail.message"].insert(config.replyToMessageId);
+        }
+        if (Array.isArray(config.partnerIdsMentionToken)) {
+            await this.store.fetchStoreData("partners_no_fields", {
+                partner_ids: config.partnerIdsMentionToken.keys(),
+                partner_ids_mention_token: config.partnerIdsMentionToken,
+            });
+            for (const partnerId in config.partnerIdsMentionToken) {
+                const partner = this.store["res.partner"].get(partnerId);
+                if (!partner) {
+                    continue;
+                }
+                partner.mention_token = config.partnerIdsMentionToken[partnerId];
+            }
         }
     }
 

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -310,6 +310,7 @@ export class Composer extends Component {
                 onFocusout: this.onFocusout.bind(this),
                 onInput: this.onInput.bind(this),
                 onKeydown: this.onKeydown.bind(this),
+                handleValidPartnerMention: this.handleValidPartnerMention.bind(this),
             },
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),
@@ -687,6 +688,13 @@ export class Composer extends Component {
         return markup`<div>${defaultBody}</div>`; // as to not wrap in <p> by html_sanitize
     }
 
+    async handleValidPartnerMention(partnerLinks) {
+        this.props.composer.mentionedPartners = [];
+        for (const partnerLink of partnerLinks) {
+            this.props.composer.mentionedPartners.push(this.store["res.partner"].get(Number(partnerLink.dataset.oeId)));
+        }
+    }
+
     clear() {
         this.props.composer.clear();
         browser.localStorage.removeItem(this.props.composer.localId);
@@ -916,6 +924,7 @@ export class Composer extends Component {
         const saveContentToLocalStorage = ({
             composerHtml,
             emailAddSignature,
+            partnerIdsMentionToken,
             replyToMessageId,
         }) => {
             if (isHtmlEmpty(composerHtml)) {
@@ -926,6 +935,9 @@ export class Composer extends Component {
                     JSON.stringify({
                         emailAddSignature,
                         replyToMessageId,
+                        partnerIdsMentionToken: Object.keys(partnerIdsMentionToken || {}).length
+                            ? partnerIdsMentionToken
+                            : undefined,
                         composerHtml: isMarkup(composerHtml)
                             ? ["markup", composerHtml]
                             : composerHtml,
@@ -938,15 +950,22 @@ export class Composer extends Component {
                 onSaveContent: saveContentToLocalStorage,
             });
         } else {
+            const partner_ids_mention_token = {};
+            for (const partner of composer.mentionedPartners) {
+                if (partner?.mention_token) {
+                    partner_ids_mention_token[partner.id] = partner.mention_token;
+                }
+            }
             saveContentToLocalStorage({
                 composerHtml: composer.composerHtml,
                 emailAddSignature: true,
+                partnerIdsMentionToken: partner_ids_mention_token,
                 replyToMessageId: composer.replyToMessage?.id,
             });
         }
     }
 
-    restoreContent() {
+    async restoreContent() {
         const composer = toRaw(this.props.composer);
         let config;
         try {
@@ -963,6 +982,19 @@ export class Composer extends Component {
         }
         if (Number.isInteger(config.replyToMessageId)) {
             composer.replyToMessage = this.store["mail.message"].insert(config.replyToMessageId);
+        }
+        if (Array.isArray(config.partnerIdsMentionToken)) {
+            await this.store.fetchStoreData("partners_no_fields", {
+                partner_ids: config.partnerIdsMentionToken.keys(),
+                partner_ids_mention_token: config.partnerIdsMentionToken,
+            });
+            for (const partnerId in config.partnerIdsMentionToken) {
+                const partner = this.store["res.partner"].get(partnerId);
+                if (!partner) {
+                    continue;
+                }
+                partner.mention_token = config.partnerIdsMentionToken[partnerId];
+            }
         }
     }
 

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -10,7 +10,7 @@ import { withSequence } from "@html_editor/utils/resource";
  */
 export class MailComposerPlugin extends Plugin {
     static id = "mail_composer";
-    static dependencies = ["clipboard", "hint", "input", "selection"];
+    static dependencies = ["clipboard", "hint", "input", "mention_link", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
         bypass_paste_image_files: () => true,
@@ -35,6 +35,9 @@ export class MailComposerPlugin extends Plugin {
             }
         },
         input_handlers: this.config.composerPluginDependencies.onInput.bind(this),
+        valid_partner_mention_handlers: [
+            this.config.composerPluginDependencies.handleValidPartnerMention.bind(this),
+        ],
     };
 
     setup() {

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -28,7 +28,7 @@ const PRESERVED_CLASSNAMES = new Set(["o_mail_redirect", "o_channel_redirect", "
  */
 export class MailComposerPlugin extends Plugin {
     static id = "mail_composer";
-    static dependencies = ["clipboard", "dom", "hint", "history", "input", "selection"];
+    static dependencies = ["clipboard", "dom", "hint", "history", "input", "mention_link", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
         bypass_paste_image_files: () => true,
@@ -54,6 +54,9 @@ export class MailComposerPlugin extends Plugin {
             }
         },
         input_handlers: this.config.composerPluginDependencies.onInput.bind(this),
+        valid_partner_mention_handlers: [
+            this.config.composerPluginDependencies.handleValidPartnerMention.bind(this),
+        ],
     };
 
     setup() {

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -1,9 +1,9 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { generateThreadMentionElement } from "@mail/utils/common/format";
+import { generatePartnerMentionElement, generateThreadMentionElement } from "@mail/utils/common/format";
 
 export class MentionPlugin extends Plugin {
-    static id = "mention";
+    static id = "mention_link";
     static dependencies = ["baseContainer", "selection", "history"];
     resources = {
         is_node_editable_predicates: (node) => {
@@ -61,7 +61,9 @@ export class MentionPlugin extends Plugin {
             },
             {
                 selector: "a.o_mail_redirect",
-                checker: (el) => true,
+                checker: (el) => this.isValidPartnerMentionElement(el),
+                validMentionsHandler: (partnerLinks) =>
+                    this.handleValidPartnerMention(partnerLinks),
             },
             {
                 selector: "a.o-discuss-mention",
@@ -119,5 +121,35 @@ export class MentionPlugin extends Plugin {
             validChannelMention.getAttribute("href") === el.getAttribute("href") &&
             [...validChannelMention.classList].every((cls) => el.classList.contains(cls))
         );
+    }
+
+    async isValidPartnerMentionElement(el) {
+        if (el.dataset.oeModel !== "res.partner") {
+            return false;
+        }
+        const id = Number(el.dataset.oeId);
+        let partner = this.store["res.partner"].get(id);
+        if (!partner) {
+            await this.store.fetchStoreData("partners_no_fields", {
+                partner_ids: [id],
+            });
+            partner = this.store["res.partner"].get(id);
+        }
+        if (!partner) {
+            return false;
+        }
+        const validPartnerMention = generatePartnerMentionElement(partner);
+        return (
+            validPartnerMention.getAttribute("href") ===
+                el.getAttribute("href") &&
+            [...validPartnerMention.classList].every((cls) =>
+                el.classList.contains(cls),
+            )
+        );
+    }
+
+    handleValidPartnerMention(partnerLinks) {
+        const handlers = this.getResource("valid_partner_mention_handlers") || [];
+        handlers.forEach((handler) => handler(partnerLinks));
     }
 }


### PR DESCRIPTION
When a partner is mentioned in the mail composer, we linked internally to the composer. However, this will lost when we restore the composer content from local storage (e.g. after a page reload).

With the help of the mention plugin, we now listen to valid partner mentions and we update the composer mentioned partners accordingly. This fixes the issue when restoring the composer content from local storage.

task-5489812

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
