### PR TITLE
[FIX] iot_box_image: pip install error with new image

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -1,6 +1,6 @@
 # The following requirements are needed only on Raspberry Pi IoT:
 gatt; sys_platform == "linux" and "rpi" in platform_release
-/home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux" and "rpi" in platform_release
+/home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux" and "rpi" in platform_release and python_version <= '3.11'
 
 # The following requirements are needed only on Windows Virtual IoT:
 aiortc; sys_platform == "win32"


### PR DESCRIPTION
When checking out 19.0 from the new IoT box image running Python 3.13, there is an error when running `pip install`:

```
error: subprocess-exited-with-error

× Building wheel for cffi (pyproject.toml) did not run successfully.
```

This is due to it trying to install `aiortc` and all its dependencies via `pip` even though it is already installed via `apt`.

To fix this, we add a Python version check to the requirement, so that it will only be installed when using an old IoT box image.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
