### PR TITLE
[FIX] mail: ungroup 'Other Activities' for systray count

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -385,7 +385,7 @@ class ResUsers(models.Model):
             if activity.res_model:
                 activities_rec_groups[activity.res_model][activity.res_id] += activity
             else:
-                activities_rec_groups["mail.activity"][False] += activity
+                activities_rec_groups["mail.activity"][activity.id] += activity
         model_activity_states = {
             'mail.activity': {'overdue_count': 0, 'today_count': 0, 'planned_count': 0, 'total_count': 0}
         }
@@ -404,7 +404,7 @@ class ResUsers(models.Model):
                     allowed_company_ids=user_company_ids)._filtered_access('read')
             model_activity_states[model_name] = {'overdue_count': 0, 'today_count': 0, 'planned_count': 0, 'total_count': 0}
             for record_id, activities in activities_by_record.items():
-                if record_id in unallowed_records.ids or not record_id:
+                if record_id in unallowed_records.ids:
                     model_key = 'mail.activity'
                     activities_model_groups['mail.activity'] += activities
                 elif record_id in allowed_records.ids:
@@ -413,20 +413,14 @@ class ResUsers(models.Model):
                 elif record_id:
                     continue
 
-                # counter: record-based activities count as 1 (record is main)
-                # but free activities count as 'number of activities', each one
-                # is individual
-                count = 1 if (record_id and record_id in allowed_records.ids) else len(activities)
-                # update counters; note that "total" is actually the "todo" total
-                # not containing planned
                 if 'overdue' in activities.mapped('state'):
-                    model_activity_states[model_key]['overdue_count'] += count
-                    model_activity_states[model_key]['total_count'] += count
+                    model_activity_states[model_key]['overdue_count'] += 1
+                    model_activity_states[model_key]['total_count'] += 1
                 elif 'today' in activities.mapped('state'):
-                    model_activity_states[model_key]['today_count'] += count
-                    model_activity_states[model_key]['total_count'] += count
+                    model_activity_states[model_key]['today_count'] += 1
+                    model_activity_states[model_key]['total_count'] += 1
                 else:
-                    model_activity_states[model_key]['planned_count'] += count
+                    model_activity_states[model_key]['planned_count'] += 1
 
         model_ids = [self.env["ir.model"]._get_id(name) for name in activities_model_groups]
         user_activities = {}

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -416,7 +416,7 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
         with freeze_time(self.dt_reference):
             data = self.make_jsonrpc_request("/mail/data", {"fetch_params": ["systray_get_activities"]})
         for model_name, msg, exp_total, exp_today, exp_planned, exp_overdue in [
-            ('mail.activity', 'Free activities', 2, 2, 0, 0),
+            ('mail.activity', 'Free activities', 1, 1, 1, 0),
             (self.test_record._name, 'Archiving does not remove activities', 1, 1, 1, 0),
             (self.test_lead_records._name, 'Planned do not count in total', 1, 1, 1, 0),
         ]:
@@ -442,8 +442,8 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
                 self.assertEqual(planned_count, exp_planned)
                 self.assertEqual(overdue_count, exp_overdue)
         self.assertEqual(
-            data["Store"]["activityCounter"], 4,
-            '1 from lead (today), 2 from free (today), each activity=record-like, 1 from activity-test-model'
+            data["Store"]["activityCounter"], 3,
+            '1 from lead (today), 1 from free (today), 1 from activity-test-model'
         )
 
 


### PR DESCRIPTION
Activities without a resource model (displayed as "Other Activities") were previously grouped together.

This caused the counter logic, which splits activities into 'overdue', 'today', and 'planned', to fail. It would evaluate the entire group of activities and assign all of them to the first state it encountered (e.g., all 5 activities would be marked 'overdue' even if only 1 was).

This commit changes the grouping key for these "mail.activity" records so  that each "Other Activity" is processed individually, allowing its state to be correctly counted and displayed in the systray menu.

Task-5226403
