### PR TITLE
[FIX] point_of_sale: tax.group preceding_subtotal field not loaded

### DIFF
--- a/addons/point_of_sale/models/account_tax_group.py
+++ b/addons/point_of_sale/models/account_tax_group.py
@@ -12,4 +12,4 @@ class AccountTaxGroup(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'pos_receipt_label']
+        return ['id', 'name', 'pos_receipt_label', 'preceding_subtotal']


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The field preceding_subototal is not loaded in the PoS and as a result it is not shown / used on the receipts. It always shows
the default label, "Untaxed Amount".

Current behavior before PR:

Not showing the custom label in the receipt, i.e. always shows "Untaxed Amount"

Desired behavior after PR is merged:

Uses the field / label when it is configured on the tax.group




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
