### PR TITLE
[FIX] website: prevent error on missing attributes in embedded element

### DIFF
--- a/addons/website/static/src/snippets/s_embed_code/options.js
+++ b/addons/website/static/src/snippets/s_embed_code/options.js
@@ -21,12 +21,23 @@ class CodeEditorDialog extends Component {
     };
     setup() {
         this.dialog = useService("dialog");
-        this.state = useState({ value: this.props.value });
+        this.state = useState({ value: this.props.value, missingAttribute: false });
     }
     onCodeChange(newValue) {
         this.state.value = newValue;
     }
     onConfirm() {
+        const htmlContent = new DOMParser().parseFromString(this.state.value, "text/html");
+        const modelElements = htmlContent.querySelectorAll("[data-oe-model]");
+        for (const el of modelElements) {
+            if (!el.getAttribute("data-oe-field") || !el.getAttribute("data-oe-type")) {
+                this.state.missingAttribute = _t(
+                    "Missing 'data-oe-field' or 'data-oe-type' attributes in element:- %(element)s",
+                    { element: el.outerHTML }
+                );
+                return;
+            }
+        }
         this.props.confirm(this.state.value);
         this.props.close();
     }

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -237,6 +237,9 @@
                         theme="'monokai'"
                         onChange.bind="onCodeChange"
                         value="this.state.value"/>
+            <div t-if="this.state.missingAttribute" class="alert alert-danger mt-3">
+                <t t-esc="this.state.missingAttribute"/>
+            </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="onConfirm">Save</button>
                 <button class="btn" t-on-click="this.props.close">Discard</button>


### PR DESCRIPTION
Currently, an error occurs when saving a website page that contains an embedded 
element missing the `'data-oe-type'`, `'data-oe-field'`, or `both` attributes.

**Steps to produce:**
- Install the `website` module.
- Open the `Website` app and click `Edit`.
- Drag an `Embed Code` block and add one of the following examples: 
  `<span data-oe-field='name' data-oe-model='res.partner' />` 
             or 
  `<span data-oe-type='int' data-oe-model='res.partner' />`
- Try to `Save` it.

**Error:**
`TypeError: can only concatenate str (not 'NoneType') to str `
`KeyError: None`

**Root Cause:**
At [1], the code tries to concatenate `'ir.qweb.field.' + el.get('data-oe-type')`, 
but when `data-oe-type` is missing, `el.get('data-oe-type')` returns `None`, 
causing an `error`.

At [2], when the `data-oe-field` attribute is missing, the code 
tries to access `Model._fields[field]`, resulting in an `error`.

**Fix:**
This commit adds validation for missing attributes in the embedded 
element, ensuring a clear error message is raised instead of a crash.

[1]:
https://github.com/odoo/odoo/blob/4fca401148ed798b9c1d04674b44c3287ded5679/addons/web_editor/models/ir_ui_view.py#L67

[2]:
https://github.com/odoo/odoo/blob/4fca401148ed798b9c1d04674b44c3287ded5679/addons/web_editor/models/ir_ui_view.py#L71

sentry–6675421840