### PR TITLE
[FIX] account: Fix context for Journal Items on account.move

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1340,7 +1340,7 @@
                                        mode="list,kanban"
                                        context="{
                                            'default_move_type': context.get('default_move_type'),
-                                           'line_ids': line_ids,
+                                           'journal_line_ids': journal_line_ids,
                                            'journal_id': journal_id,
                                            'default_partner_id': commercial_partner_id,
                                            'default_currency_id': currency_id or company_currency_id,


### PR DESCRIPTION
The [commit](https://github.com/odoo/odoo/commit/6ed1e43b3f7d53c6a45fe24a1c68f8386e6adf8e) introduced the `journal_line_ids` field on `account.move` to hide sections and notes from the Journal Items tab.

However, the context for the Journal Items was not updated to reference this new field. It still referenced the previous `line_ids` field, which caused inconsistencies when the `onchange` method was triggered.

Specifically, this led to:
- The existing lines being lost during the `onchange` computation.
- Incorrect computation of the `debit` and `credit` fields when adding new lines, as the balance computation was prevented.

This commit updates the context to use `journal_line_ids` correctly, resolving the inconsistencies and restoring proper balance computation.

task-5241650

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
