### PR TITLE
[FIX] website: allow customizing style of several mega menu

### DIFF
--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -28,8 +28,10 @@ export class MegaMenuOptionPlugin extends Plugin {
     }
 
     async saveMegaMenuClasses() {
-        const megaMenuEl = this.editable.querySelector("[data-oe-field='mega_menu_content'");
-        if (megaMenuEl) {
+        const proms = [];
+        for (const megaMenuEl of this.editable.querySelectorAll(
+            "[data-oe-field='mega_menu_content']"
+        )) {
             // On top of saving the mega menu content like any other field
             // content, we must save the custom classes that were set on the
             // menu itself.
@@ -38,10 +40,13 @@ export class MegaMenuOptionPlugin extends Plugin {
                     !["dropdown-menu", "o_mega_menu", "o_editable"].includes(megaMenuClass)
             );
 
-            await this.services.orm.write("website.menu", [parseInt(megaMenuEl.dataset.oeId)], {
-                mega_menu_classes: classes.join(" "),
-            });
+            proms.push(
+                this.services.orm.write("website.menu", [parseInt(megaMenuEl.dataset.oeId)], {
+                    mega_menu_classes: classes.join(" "),
+                })
+            );
         }
+        await Promise.all(proms);
     }
 }
 

--- a/addons/website/static/tests/builder/mega_menu.test.js
+++ b/addons/website/static/tests/builder/mega_menu.test.js
@@ -1,0 +1,48 @@
+import { expect, test } from "@odoo/hoot";
+import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+
+defineWebsiteModels();
+
+test("Save several megamenu", async () => {
+    const savedMenus = new Set();
+
+    onRpc("ir.ui.view", "save", ({ args }) => true);
+    onRpc("website.menu", "write", ({ args: [[id], value] }) => {
+        expect(value).toEqual({ mega_menu_classes: "o_mega_menu_container_size" });
+        savedMenus.add(id);
+        expect.step(`save mega menu`);
+        return true;
+    });
+
+    await setupWebsiteBuilder("", {
+        headerContent: `
+            <div data-name="Mega Menu" data-oe-xpath="/t[1]/li[2]/div[1]" class="o_mega_menu" data-oe-model="website.menu" data-oe-id="1" data-oe-field="mega_menu_content" data-oe-type="html" data-oe-expression="submenu.mega_menu_content">
+                <section class="s_mega_menu_odoo_menu pt16 o_cc o_cc1">
+                    <div class="container">
+                        mega menu 1 content
+                    </div>
+                </section>
+            </div>
+            <div data-name="Mega Menu" data-oe-xpath="/t[1]/li[2]/div[1]" class="o_mega_menu" data-oe-model="website.menu" data-oe-id="2" data-oe-field="mega_menu_content" data-oe-type="html" data-oe-expression="submenu.mega_menu_content">
+                <section class="s_mega_menu_odoo_menu pt16 o_cc o_cc1">
+                    <div class="container">
+                        mega menu 2 content
+                    </div>
+                </section>
+            </div>
+        `,
+    });
+    await contains(":iframe [data-oe-id='1']").click();
+    await contains("[data-label=Size] button.dropdown").click();
+    await contains(".dropdown-item:contains(Narrow)").click();
+
+    await contains(":iframe [data-oe-id='2']").click();
+    await contains("[data-label=Size] button.dropdown").click();
+    await contains(".dropdown-item:contains(Narrow)").click();
+
+    await contains("[data-action=save]").click();
+
+    await expect.waitForSteps(["save mega menu", "save mega menu"]);
+    expect(savedMenus).toEqual(new Set([1, 2]), { message: "both menu have been saved" });
+});


### PR DESCRIPTION
The implementation of `save_handlers` for mega menus only saved the classes of the first mega menu found. Thus, customization of the "Size" of the second menu was not saved.

This commit change the handler to select all mega menus.

Steps to reproduce:
- Open website builder
- Create multiple mega menus
- Set "Size" to "Narrow" on each mega menu
- Save
- Bug: Only the first mega menu is narrow

task-5248206

Fixes #234222