### PR TITLE
[FIX] account: bill creation from mail alias

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -408,7 +408,7 @@ class AccountDocumentImportMixin(models.AbstractModel):
 
     def _should_attach_to_record(self, attachment):
         """ Indicate whether a given attachment should be displayed in the record's attachments. """
-        return not attachment.res_field and attachment.mimetype in {
+        return attachment and not attachment.res_field and attachment.mimetype in {
             'text/csv',
             'application/pdf',
             'application/vnd.ms-excel',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6547,8 +6547,15 @@ class AccountMove(models.Model):
         if self.env.context.get('from_alias'):
             # This is a newly-created invoice from a mail alias.
             # So dispatch the attachments into groups, and create a new invoice for each group beyond the first.
-            file_data_groups = self._group_files_data_into_groups_of_mixed_types(files_data)
+            valid_files_data = []
+            extra_files_data = []
+            for file_data in files_data:
+                if self._should_attach_to_record(file_data['attachment']) or file_data['xml_tree'] is not None:
+                    valid_files_data.append(file_data)
+                else:
+                    extra_files_data.append(file_data)
 
+            file_data_groups = self._group_files_data_into_groups_of_mixed_types(valid_files_data) or [[]]
             invoices = self
             if len(file_data_groups) > 1:
                 create_vals = (len(file_data_groups) - 1) * self.copy_data()
@@ -6556,9 +6563,8 @@ class AccountMove(models.Model):
 
             for invoice, file_data_group in zip(invoices, file_data_groups):
                 attachment_records = self._from_files_data(file_data_group)
-                invoice._fix_attachments_on_record(attachment_records)
-
                 if invoice == self:
+                    attachment_records |= self._from_files_data(extra_files_data)
                     new_message.attachment_ids = [Command.set(attachment_records.ids)]
                     message_values['attachment_ids'] = [Command.link(attachment.id) for attachment in attachment_records]
                     res = super()._message_post_after_hook(new_message, message_values)
@@ -6573,9 +6579,11 @@ class AccountMove(models.Model):
                         'attachment_ids': [Command.link(attachment.id) for attachment in attachment_records],
                     }
                     super(AccountMove, invoice)._message_post_after_hook(sub_new_message, sub_message_values)
+                invoice._fix_attachments_on_record(attachment_records)
 
             for invoice, file_data_group in zip(invoices, file_data_groups):
-                invoice._extend_with_attachments(file_data_group, new=True)
+                if file_data_group:
+                    invoice._extend_with_attachments(file_data_group, new=True)
 
             return res
 

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -589,6 +589,18 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             },
         )
 
+    def test_25_mail_alias_gifs(self):
+        self.assert_attachment_import(
+            origin='mail_alias',
+            attachments_vals=[self.gif1_vals, self.gif2_vals],
+            expected_invoices={
+                1: {
+                    'gif1.gif': {'on_message': True},
+                    'gif2.gif': {'on_message': True},
+                },
+            },
+        )
+
     def test_30_chatter_upload_pdf_and_xml(self):
         self.assert_attachment_import(
             origin='chatter_upload',
@@ -922,7 +934,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
                     'gif1.gif': {'on_message': True},
                     'gif2.gif': {'on_message': True},
                     'invoice1.pdf': {'on_invoice': True, 'on_message': True},
-                    'invoice1.xml': {'is_decoded': True, 'is_new': True, 'on_message': True}
+                    'invoice1.xml': {'is_decoded': True, 'is_new': True, 'on_message': True},
                 },
                 2: {
                     'invoice2.pdf': {'on_invoice': True, 'on_message': True},


### PR DESCRIPTION
Steps to reproduce:

- Set up email alias for Vendor Bill journal
- Send email with N images alias

Issue:

<N> Bills are created, in each one we will attempt to extract the image
content to enrich the bill.

Analysis:

This occurs because we split the attachment list into several groups,
each one creating a new invoice (except the first).
However we don't take into account if the attachments are actually
meaningful. In many cases this behavior will pollute the database
and waste iap credits.

This commit proposed to evaluate if in each group there is at least a
meaningful attachment before creating/extending an invoice

opw-5076315
[Ticket link](https://www.odoo.com/odoo/project/49/tasks/5076315)