### PR TITLE
[FIX] orm/fields_relational: Fix key error

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -64,6 +64,12 @@ class _Relational(Field[BaseModel]):
                     # a lot of missing records, just fetch that field
                     remaining = records[len(vals):]
                     remaining.fetch([self.name])
+                    # fetch does not raise MissingError, check value
+                    if record_id not in field_cache:
+                        raise MissingError("\n".join([
+                            env._("Record does not exist or has been deleted."),
+                            env._("(Record: %(record)s, User: %(user)s)", record=record_id, user=env.uid),
+                        ])) from None
                 else:
                     remaining = records.__class__(env, (record_id,), records._prefetch_ids)
                     super().__get__(remaining, owner)


### PR DESCRIPTION
**Issue:**

If no of records are [more](https://github.com/odoo/odoo/blob/f40203c0f3954d3c6be7d4234ee102cd903704b6/odoo/orm/fields_relational.py#L63) than the ``PREFETCH_MAX``.So, it just the fetch the data using ``fetch`` method. If records are less then that then it directly check from ORM and using ``__get__`` method. if record is missing it will raise missing error in that case otherwise records are more in that it directly assume that records are fetch and it directly check from field_cache which leads to key error and here in attachment scenerio code implementation they are expecting to have [missing error](https://github.com/odoo/odoo/blob/f40203c0f3954d3c6be7d4234ee102cd903704b6/odoo/addons/base/models/ir_attachment.py#L588)

 **To fix:**
 raising missing error

```
Traceback (most recent call last):
   File "/tmp/tmpbit0pj9c/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpbit0pj9c/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpbit0pj9c/migrations/base/tests/test_mock_crawl.py", line 430, in mock_act_window
    views = get_views(
   File "/home/odoo/src/odoo/19.0/addons/mail/models/mail_thread.py", line 463, in get_views
    res = super().get_views(views, options)
   File "/home/odoo/src/enterprise/19.0/web_studio/models/models.py", line 10, in get_views
    result = super().get_views(views, options=options)
   File "/home/odoo/src/enterprise/19.0/web_studio/models/ir_ui_view.py", line 52, in get_views
    return super().get_views(views, options)
   File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_ui_view.py", line 2935, in get_views
    result['models'][model] = {"fields": self.env[model].fields_get(
   File "/home/odoo/src/odoo/19.0/addons/stock/models/product.py", line 512, in fields_get
    res = super().fields_get(allfields, attributes)
   File "/home/odoo/src/enterprise/19.0/web_studio/models/ir_model.py", line 76, in fields_get
    return super().fields_get(allfields, attributes=attributes)
   File "/home/odoo/src/enterprise/19.0/ai_fields/models/models.py", line 47, in fields_get
    res = super().fields_get(allfields, attributes)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3360, in fields_get
    description = field.get_description(self.env, attributes=attributes)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 883, in get_description
    value = value(env)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 930, in _description_groupable
    model._read_group_groupby(model._table, groupby, query)
   File "/home/odoo/src/odoo/19.0/addons/mail/models/mail_activity_mixin.py", line 259, in _read_group_groupby
    return super()._read_group_groupby(alias, groupby_spec, query)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 2064, in _read_group_groupby
    coquery = comodel._search(codomain, bypass_access=field.bypass_search_access)
   File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_attachment.py", line 661, in _search
    return records._filtered_access('read')[offset:]._as_query(ordered)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4128, in _filtered_access
    if self and not self.env.su and (result := self._check_access(operation)):
   File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_attachment.py", line 544, in _check_access
    forbidden_res_model_id = set(self._inaccessible_comodel_records(model_ids, operation))
   File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_attachment.py", line 586, in _inaccessible_comodel_records
    records = records._filtered_access(operation)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4128, in _filtered_access
    if self and not self.env.su and (result := self._check_access(operation)):
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4152, in _check_access
    if domain and (forbidden := self - self.sudo().filtered_domain(domain)):
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6251, in filtered_domain
    predicate = Domain(domain)._as_predicate(self)
   File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 1079, in _as_predicate
    func = field.filter_function(records, field_expr, positive_operator, value)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields_relational.py", line 179, in filter_function
    corecords = getter(records)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields_relational.py", line 71, in __get__
    vals.append(field_cache[record_id])
 KeyError: 3
```

upg-3267511
opw-5246118

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
