### PR TITLE
[17.0][FIX] website_blog: variable referenced before assignment

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -101,6 +101,7 @@ class WebsiteBlog(http.Controller):
             elif state == "unpublished":
                 domain += ['|', ("website_published", "=", False), ("post_date", ">", fields.Datetime.now())]
         else:
+            published_count, unpublished_count = 0, 0
             domain += [("post_date", "<=", fields.Datetime.now())]
 
         use_cover = request.website.is_view_active('website_blog.opt_blog_cover_post')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Noticed this error in Sentry, considering the code is old the use case leading to this error is probably wrong but it's an easily fixable possible bug nonetheless
- local variable 'published_count' referenced before assignment
- local variable 'unpublished_count' referenced before assignment

Error on this line https://github.com/odoo/odoo/blob/cebc2acbd0e4d2373e0d1f96bcd291bf70be3a03/addons/website_blog/controllers/main.py#L171

Variables only assigned  inside this `if` https://github.com/odoo/odoo/blob/cebc2acbd0e4d2373e0d1f96bcd291bf70be3a03/addons/website_blog/controllers/main.py#L94-L104

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
