### PR TITLE
[IMP] mail: enhance WelcomePage for better pre-call experience

### DIFF
--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -1,15 +1,16 @@
 import { CallPreview } from "@mail/discuss/call/common/call_preview";
 
-import { Component, useState, useSubEnv } from "@odoo/owl";
+import { Component, useEffect, useState, useSubEnv } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
-import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 export class WelcomePage extends Component {
     static props = ["proceed?"];
     static template = "mail.WelcomePage";
     static components = { CallPreview };
+
+    cameraPermissionOnMountChecked = false;
 
     setup() {
         super.setup();
@@ -19,14 +20,34 @@ export class WelcomePage extends Component {
         this.rtc = useService("discuss.rtc");
         useSubEnv({ inWelcomePage: true });
         this.state = useState({
-            userName: this.store.self.name || _t("Guest"),
+            userName: this.store.self_user?.name || "",
+            activateCamera: 0,
+            activateMicrophone: 0,
             hasMicrophone: undefined,
             hasCamera: undefined,
         });
+        useEffect(
+            (showCallPreview, cameraPermission, microphonePermission) => {
+                if (!showCallPreview) {
+                    return;
+                }
+                if (cameraPermission === "prompt" && !this.cameraPermissionOnMountChecked) {
+                    this.rtc.showMediaPermissionDialog("camera");
+                }
+                if (cameraPermission === "granted") {
+                    this.state.activateCamera++;
+                }
+                if (microphonePermission === "granted") {
+                    this.state.activateMicrophone++;
+                }
+                this.cameraPermissionOnMountChecked = Boolean(cameraPermission);
+            },
+            () => [this.showCallPreview, this.rtc.cameraPermission, this.rtc.microphonePermission]
+        );
     }
 
     onKeydownInput(ev) {
-        if (ev.key === "Enter") {
+        if (ev.key === "Enter" && this.canJoin) {
             this.joinChannel();
         }
     }
@@ -43,8 +64,18 @@ export class WelcomePage extends Component {
         this.props.proceed?.();
     }
 
+    get canJoin() {
+        return (
+            this.store.self_user || (this.state.userName.trim() && this.state.userName.length <= 60)
+        );
+    }
+
     get noActiveParticipants() {
         return !this.store.discuss.thread.rtc_session_ids.length;
+    }
+
+    get showCallPreview() {
+        return this.store.discuss.thread.channel.default_display_mode === "video_full_screen";
     }
 
     /** @param {{ microphone?: boolean, camera?: boolean }} settings */

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -2,27 +2,27 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.WelcomePage">
-    <t t-set="showCallPreview" t-value="store.discuss.thread.channel.default_display_mode === 'video_full_screen'"/>
     <div class="o-mail-WelcomePage w-100 d-flex flex-column justify-content-md-center align-items-center bg-light p-3" style="min-height: 100dvh;">
         <h1 class="fw-light text-center">
-            <span t-if="this.store.discuss.thread.channel.default_display_mode === 'video_full_screen'">You've been invited to a meeting!</span>
+            <span t-if="showCallPreview">You've been invited to a meeting!</span>
             <span t-else="">You've been invited to a chat!</span>
         </h1>
         <h2 class="m-3 m-md-5" t-esc="store.companyName"/>
         <div class="w-100 d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
             <div t-if="showCallPreview" class="w-100 rounded-3 overflow-hidden" style="max-width: 640px;">
-                <CallPreview onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)"/>
+                <CallPreview activateCamera="state.activateCamera" activateMicrophone="state.activateMicrophone" onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)"/>
             </div>
             <div class="d-flex flex-column text-center justify-content-center">
-                <div class="d-flex flex-column gap-2" t-if="store.self_guest and !store.self_user">
-                    <label class="fs-4" >What's your name?</label>
-                    <input class="form-control mb-3 bg-white rounded" type="text" placeholder="Your name" t-model="state.userName" t-on-keydown="onKeydownInput"/>
+                <div class="d-flex flex-column" t-if="store.self_guest and !store.self_user">
+                    <label class="fs-4 mb-2">What's your name?</label>
+                    <input class="form-control bg-white rounded" type="text" name="guest_name" placeholder="Your name" t-model="state.userName" t-on-keydown="onKeydownInput"/>
+                    <small class="form-text text-end" t-att-class="{'text-danger': state.userName.length > 60}"><t t-out="state.userName.length"/>/60</small>
                 </div>
                 <div class="fs-3" t-if="store.self_user">
                     <p>Ready to join?</p>
                     <p t-if="showCallPreview and noActiveParticipants">No one else is here.</p>
                 </div>
-                <button class="d-flex btn btn-light rounded-pill align-items-center justify-content-center gap-3 px-4 fs-3" title="Join Channel" t-on-click="joinChannel">
+                <button class="d-flex btn btn-light rounded-pill align-items-center justify-content-center gap-3 px-4 fs-3" title="Join Channel" t-att-disabled="!canJoin" t-on-click="joinChannel">
                     <t t-if="showCallPreview" t-set="joinText">Join call</t>
                     <t t-else="" t-set="joinText">Join</t>
                     <span class="mb-0 text-success" t-esc="joinText"/>

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -12,6 +12,11 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
             },
         },
         {
+            content: "Fill in guest name",
+            trigger: "input[name='guest_name']",
+            run: "edit Guest",
+        },
+        {
             content: "Click join",
             trigger: "button[title='Join Channel']",
             run: "click",

--- a/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
@@ -3,6 +3,11 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("discuss_channel_call_public_tour.js", {
     steps: () => [
         {
+            content: "Close the video permission dialog",
+            trigger: ".o_dialog .modal-header .btn-close",
+            run: "click",
+        },
+        {
             content: "The call does not start on the welcome page",
             trigger: ".o-mail-WelcomePage",
             async run() {
@@ -12,6 +17,11 @@ registry.category("web_tour.tours").add("discuss_channel_call_public_tour.js", {
                     console.error("The call should not have started.");
                 }
             },
+        },
+        {
+            content: "Fill in guest name",
+            trigger: "input[name='guest_name']",
+            run: "edit Guest",
         },
         {
             content: "Click join",


### PR DESCRIPTION
This PR introduces several improvements to the call WelcomePage:

1. The “Guest” name field is now empty by default, requiring users to enter their name before joining. The input is limited to 60 characters.
2. If camera or microphone permissions were previously granted, they are automatically enabled on page load.
3. If permissions haven’t been granted or denied yet, a camera permission dialog is prompted when opening the page.

part of task-[5227387](https://www.odoo.com/odoo/project/1519/tasks/5227387)