### PR TITLE
[FIX] orm: attachment m2m link with res_field

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -106,6 +106,7 @@ class AccountBankStatement(models.Model):
         comodel_name='ir.attachment',
         string="Attachments",
         bypass_search_access=True,
+        context={'skip_res_field_check': True},
     )
 
     _journal_id_date_desc_id_desc_idx = models.Index("(journal_id, date DESC, id DESC)")

--- a/addons/fleet/wizard/fleet_vehicle_send_mail.py
+++ b/addons/fleet/wizard/fleet_vehicle_send_mail.py
@@ -16,6 +16,7 @@ class FleetVehicleSendMail(models.TransientModel):
         'wizard_id', 'attachment_id',
         string='Attachments',
         bypass_search_access=True,
+        context={'skip_res_field_check': True},
     )
 
     @api.depends('subject')

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -34,7 +34,9 @@ class ApplicantGetRefuseReason(models.TransientModel):
     duplicate_applicant_ids_domain = fields.Binary(compute="_compute_duplicate_applicant_ids_domain")
     attachment_ids = fields.Many2many(
         'ir.attachment', string='Attachments',
-        compute="_compute_from_template_id", readonly=False, store=True, bypass_search_access=True,
+        compute="_compute_from_template_id", readonly=False, store=True,
+        bypass_search_access=True,
+        context={'skip_res_field_check': True},
     )
     scheduled_date = fields.Char(
         'Scheduled Date',

--- a/addons/hr_recruitment/wizard/applicant_send_mail.py
+++ b/addons/hr_recruitment/wizard/applicant_send_mail.py
@@ -10,7 +10,7 @@ class ApplicantSendMail(models.TransientModel):
 
     applicant_ids = fields.Many2many('hr.applicant', string='Applications', required=True)
     author_id = fields.Many2one('res.partner', 'Author', required=True, default=lambda self: self.env.user.partner_id.id)
-    attachment_ids = fields.Many2many('ir.attachment', string='Attachments', readonly=False, store=True, bypass_search_access=True)
+    attachment_ids = fields.Many2many('ir.attachment', string='Attachments', readonly=False, store=True, bypass_search_access=True, context={'skip_res_field_check': True})
 
     @api.depends('subject')
     def _compute_render_model(self):

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -83,6 +83,7 @@ class MailActivity(models.Model):
         'activity_id', 'attachment_id',
         string='Attachments',
         bypass_search_access=True,
+        context={'skip_res_field_check': True},
     )
     # description
     user_id = fields.Many2one(

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -105,7 +105,10 @@ class MailMessage(models.Model):
     attachment_ids = fields.Many2many(
         'ir.attachment', 'message_attachment_rel',
         'message_id', 'attachment_id',
-        string='Attachments', bypass_search_access=True)
+        string='Attachments',
+        bypass_search_access=True,
+        context={'skip_res_field_check': True},
+    )
     parent_id = fields.Many2one(
         'mail.message', 'Parent Message', index='btree_not_null', ondelete='set null')
     child_ids = fields.One2many('mail.message', 'parent_id', 'Child Messages')

--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -38,7 +38,10 @@ class MailScheduledMessage(models.Model):
     attachment_ids = fields.Many2many(
         'ir.attachment', 'scheduled_message_attachment_rel',
         'scheduled_message_id', 'attachment_id',
-        string='Attachments', bypass_search_access=True)
+        string='Attachments',
+        bypass_search_access=True,
+        context={'skip_res_field_check': True},
+    )
     composition_comment_option = fields.Selection(
         [('reply_all', 'Reply-All'), ('forward', 'Forward')],
         string='Comment Options')  # mainly used for view in specific comment modes

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -75,6 +75,7 @@ class MailTemplate(models.Model):
         'email_template_id', 'attachment_id',
         string='Attachments',
         bypass_search_access=True,
+        context={'skip_res_field_check': True},
     )
     report_template_ids = fields.Many2many(
         'ir.actions.report', relation='mail_template_ir_actions_report_rel',

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -93,7 +93,10 @@ class MailComposeMessage(models.TransientModel):
     attachment_ids = fields.Many2many(
         'ir.attachment', 'mail_compose_message_ir_attachments_rel',
         'wizard_id', 'attachment_id', string='Attachments',
-        compute='_compute_attachment_ids', readonly=False, store=True, bypass_search_access=True)
+        compute='_compute_attachment_ids', readonly=False, store=True,
+        bypass_search_access=True,
+        context={'skip_res_field_check': True},
+    )
     email_layout_xmlid = fields.Char(
         'Email Notification Layout',
         compute='_compute_email_layout_xmlid', readonly=False, store=True,

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -118,7 +118,10 @@ class MailingMailing(models.Model):
     is_body_empty = fields.Boolean(compute="_compute_is_body_empty")
     attachment_ids = fields.Many2many(
         'ir.attachment', 'mass_mailing_ir_attachments_rel',
-        'mass_mailing_id', 'attachment_id', string='Attachments', bypass_search_access=True)
+        'mass_mailing_id', 'attachment_id', string='Attachments',
+        bypass_search_access=True,
+        context={'skip_res_field_check': True},
+    )
     keep_archives = fields.Boolean(string='Keep Archives')
     campaign_id = fields.Many2one('utm.campaign', string='UTM Campaign', index=True, ondelete='set null')
     medium_id = fields.Many2one(

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -26,7 +26,10 @@ class SurveyInvite(models.TransientModel):
     # composer content
     attachment_ids = fields.Many2many(
         'ir.attachment', 'survey_mail_compose_message_ir_attachments_rel', 'wizard_id', 'attachment_id',
-        string='Attachments', compute='_compute_attachment_ids', store=True, readonly=False, bypass_search_access=True)
+        string='Attachments', compute='_compute_attachment_ids', store=True, readonly=False,
+        bypass_search_access=True,
+        context={'skip_res_field_check': True},
+    )
     # origin
     author_id = fields.Many2one(
         'res.partner', 'Author', index=True,

--- a/addons/website_slides/wizard/slide_channel_invite.py
+++ b/addons/website_slides/wizard/slide_channel_invite.py
@@ -18,7 +18,8 @@ class SlideChannelInvite(models.TransientModel):
     _description = 'Channel Invitation Wizard'
 
     # composer content
-    attachment_ids = fields.Many2many('ir.attachment', string='Attachments', bypass_search_access=True)
+    attachment_ids = fields.Many2many('ir.attachment', string='Attachments',
+        bypass_search_access=True, context={'skip_res_field_check': True})
     send_email = fields.Boolean('Send Email', compute="_compute_send_email", readonly=False, store=True)
     # recipients
     partner_ids = fields.Many2many('res.partner', string='Recipients')

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -3,7 +3,7 @@ import logging
 
 from odoo import api, fields, models
 from odoo.exceptions import AccessError, ValidationError
-from odoo.fields import Command
+from odoo.fields import Command, Domain
 from odoo.tools import SQL
 from odoo.tools.float_utils import float_round
 from odoo.tools.translate import html_translate
@@ -1241,6 +1241,18 @@ class TestOrmAttachmentHost(models.Model):
     )
     m2m_attachment_ids = fields.Many2many(
         'test_orm.attachment', bypass_search_access=True,
+    )
+
+    real_binary = fields.Binary(attachment=True)
+    real_attachment_ids = fields.One2many(
+        'ir.attachment', 'res_id', bypass_search_access=True,
+        domain=lambda self: [('res_model', '=', self._name)],
+    )
+    real_m2m_attachment_ids = fields.Many2many(
+        'ir.attachment', bypass_search_access=True,
+        # this is needed to be able to link to attachments with res_field set
+        # see `IrAttachment._search` implementation
+        context={'skip_res_field_check': True},
     )
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Because `_search` is used, we need to set the context to ignore that added search filter.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
