### PR TITLE
[FIX] mail: call channel_fetched only once

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -139,3 +139,10 @@ class ChannelController(http.Controller):
             domain.append(["id", "<", before])
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
         return request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")._attachment_format()
+
+    @http.route("/discuss/channel/mark_as_fetched", methods=["POST"], type="json", auth="user")
+    def discuss_channel_mark_as_fetched(self, channel_id, last_message_id):
+        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        if not channel:
+            raise NotFound()
+        channel._channel_fetched(message_ids=[last_message_id])

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -146,8 +146,11 @@ export class ThreadService {
     /**
      * @param {import("models").Thread} thread
      */
-    async markAsFetched(thread) {
-        await this.orm.silent.call("discuss.channel", "channel_fetched", [[thread.id]]);
+    async markAsFetched(thread, messageId) {
+        await this.rpc("/discuss/channel/mark_as_fetched", {
+            channel_id: thread.id,
+            last_message_id: messageId,
+        });
     }
 
     getFetchRoute(thread) {

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -249,7 +249,7 @@ export class DiscussCoreCommon {
         ) {
             // disabled on non-channel threads and
             // on "channel" channels for performance reasons
-            this.threadService.markAsFetched(channel);
+            this.threadService.markAsFetched(channel, message.id);
         }
         if (
             !channel.loadNewer &&

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -72,6 +72,10 @@ patch(MockServer.prototype, {
             const { channel_id, known_member_ids } = args;
             return this._mockDiscussChannelloadOlderMembers([channel_id], known_member_ids);
         }
+        if (route === "/discuss/channel/mark_as_fetched") {
+            const { channel_id, last_message_id } = args;
+            return this._mockDiscussChannelChannelFetched(channel_id, [last_message_id]);
+        }
         if (route === "/mail/history/messages") {
             const { search_term, after, before, limit } = args;
             return this._mockRouteMailMessageHistory(search_term, after, before, limit);


### PR DESCRIPTION
Before this commit, each tab was sending a channel_fetched when receiving a new message. This would result in serialization error on the backend as well as performance reduction in case of high load of messages.

After this PR, only one tab will send the `channel_fetched` using the `multi_tab` service.

task-5180400


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
