### PR TITLE
[FIX] mail: Error when manually unregistering the ServiceWorker

### DIFF
--- a/addons/mail/static/src/webclient/web/webclient.js
+++ b/addons/mail/static/src/webclient/web/webclient.js
@@ -19,7 +19,9 @@ patch(WebClient.prototype, {
         this.orm = useService("orm");
         this.notification = useService("notification");
         if (this._canSendNativeNotification) {
-            this._subscribePush();
+            this.env.bus.addEventListener("WEB_CLIENT_READY", () => this._subscribePush(), {
+                once: true,
+            });
         }
         if (browser.navigator.permissions) {
             let notificationPerm;
@@ -55,6 +57,7 @@ patch(WebClient.prototype, {
      * @return {Promise<void>}
      */
     async _subscribePush(numberTry = 1) {
+        await this.serviceWorkerActivatedDeferred;
         const pushManager = await this.pushManager();
         if (!pushManager) {
             return;
@@ -125,6 +128,7 @@ patch(WebClient.prototype, {
      * @return {Promise<void>}
      */
     async _unsubscribePush() {
+        await this.serviceWorkerActivatedDeferred;
         const pushManager = await this.pushManager();
         if (!pushManager) {
             return;

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
+import { Deferred } from "@web/core/utils/concurrency";
 import { DebugMenu } from "@web/core/debug/debug_menu";
 import { localization } from "@web/core/l10n/localization";
 import { MainComponentsContainer } from "@web/core/main_components_container";
@@ -46,6 +47,7 @@ export class WebClient extends Component {
             this.env.bus.trigger("WEB_CLIENT_READY");
         });
         useExternalListener(window, "click", this.onGlobalClick, { capture: true });
+        this.serviceWorkerActivatedDeferred = new Deferred();
         onWillStart(this.registerServiceWorker);
     }
 
@@ -113,6 +115,19 @@ export class WebClient extends Component {
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker
                 .register("/web/service-worker.js", { scope: "/web" })
+                .then((registration) => {
+                    if (registration.active && registration.active.state === "activated") {
+                        this.serviceWorkerActivatedDeferred.resolve();
+                    } else {
+                        const sw =
+                            registration.installing || registration.waiting || registration.active;
+                        sw.addEventListener("statechange", (e) => {
+                            if (e.target.state === "activated") {
+                                this.serviceWorkerActivatedDeferred.resolve();
+                            }
+                        });
+                    }
+                })
                 .catch((error) => {
                     console.error("Service worker registration failed, error:", error);
                 });


### PR DESCRIPTION
When you manually unregister the ServiceWorker linked to your Odoo,
you may receive a notification "Failed to enable push notifications".
This occurs because the ServiceWorker associated with the previous
subscription is gone and the browser has lost the link between the
subscription and the Odoo instance.

To handle this case, we ensure waiting the activated state of the
registration of the service worker before subscribing to the web push
notification.

Steps to reproduce:

- In Odoo, enable push notifications.
- Inside another tab, go to the internal Chrome URL:
    chrome://serviceworker-internals/?devtools
- Unsubscribe the ServiceWorker linked to your Odoo instance.
- In the Odoo instance tab, press F5.
  => You will see an internal notification stating
  "Failed to enable push notifications" => BUG.