### PR TITLE
[IMP] l10n_sa,l10n_sa_edi_pos,l10n_ae: minor report improvements

### DIFF
--- a/addons/l10n_ae/i18n/ar.po
+++ b/addons/l10n_ae/i18n/ar.po
@@ -145,6 +145,11 @@ msgid "Simplified Tax Invoice"
 msgstr "فاتورة ضريبية مبسطة"
 
 #. module: l10n_ae
+#: model_terms:ir.ui.view,arch_db:l10n_ae.l10n_ae_report_invoice_document
+msgid "Tax Credit Note"
+msgstr "إشعار دائن ضريبي"
+
+#. module: l10n_ae
 #. odoo-python
 #: code:addons/l10n_ae/models/account_move.py:0
 msgid "Tax Invoice"

--- a/addons/l10n_ae/i18n/l10n_ae.pot
+++ b/addons/l10n_ae/i18n/l10n_ae.pot
@@ -146,6 +146,11 @@ msgid "Simplified Tax Invoice"
 msgstr ""
 
 #. module: l10n_ae
+#: model_terms:ir.ui.view,arch_db:l10n_ae.l10n_ae_report_invoice_document
+msgid "Tax Credit Note"
+msgstr ""
+
+#. module: l10n_ae
 #. odoo-python
 #: code:addons/l10n_ae/models/account_move.py:0
 msgid "Tax Invoice"

--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="l10n_ae_report_invoice_document" inherit_id="l10n_gcc_invoice.l10n_gcc_report_invoice_document" primary="True">
+        <!-- Titles -->
+        <t name="credit_note_title" position="replace">
+            <t name="credit_note_title">Tax Credit Note</t>
+        </t>
+        <t name="credit_note_title_ar" position="replace">
+            <t name="credit_note_title_ar">إشعار دائن ضريبي</t>
+        </t>
+        <t name="credit_note_title_en" position="replace">
+            <t name="credit_note_title_en">Tax Credit Note</t>
+        </t>
+        <!-- End Titles -->
         <!-- Invoice table -->
         <th name="th_taxes" position="after">
             <t t-if="display_taxes">

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -7,7 +7,8 @@
             <t t-if="o.company_id.country_id.code == 'SA' and o.is_sale_document() and not o._l10n_sa_is_legal() " t-set="custom_header_sa">
                 <div class="fw-bold text-center mt-2">
                     <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
-                    <h5>هذا المستند ليس مستنداً قانونياً</h5>
+                    <h5 t-if="display_in_en" t-translation="off">THIS IS NOT A LEGAL DOCUMENT</h5>
+                    <h5 t-if="display_in_ar" t-translation="off">هذا المستند ليس مستنداً قانونياً</h5>
                 </div>
                 <!-- To help with centering the previous div in flex justify between-->
                 <div t-if="is_html_empty(o.company_id.report_header)" class="col-1"/>

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -4,7 +4,7 @@
         <xpath expr="//img[hasclass('pos-receipt-qrcode')]" position="after">
             <div t-if="order.notLegal and order.isSACompany() and !order.isSettlement()" class="text-center mt-3">
                 <p>THIS IS NOT A LEGAL DOCUMENT</p>
-                <p>هذا المستند ليس مستنداً قانونياً</p>
+                <p t-if="order.config_id.l10n_gcc_dual_language_receipt">هذا المستند ليس مستنداً قانونياً</p>
             </div>
         </xpath>
     </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- add tax to credit not reports in l10n_ae
-adjusted arabic/english translations of 'this is not a legal document' to for the dual language option in settings

Current behavior before PR:
- tax wasn't printed before 'credit note' in l10n_ae
- this is not a legal document always printed in both languages.

Desired behavior after PR is merged:
- tax shows before 'credit note'
- this is not a legal document is printed in the language based on if the dual language setting is ticked.


task-5067998

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
