### PR TITLE
[IMP] product, website_sale: support pricelist rules on product packagings

### DIFF
--- a/addons/point_of_sale/models/product_pricelist.py
+++ b/addons/point_of_sale/models/product_pricelist.py
@@ -40,4 +40,4 @@ class ProductPricelistItem(models.Model):
     def _load_pos_data_fields(self, config):
         return ['product_tmpl_id', 'product_id', 'pricelist_id', 'price_surcharge', 'price_discount', 'price_round',
                 'price_min_margin', 'price_max_margin', 'company_id', 'currency_id', 'date_start', 'date_end', 'compute_price',
-                'fixed_price', 'percent_price', 'base_pricelist_id', 'base', 'categ_id', 'min_quantity']
+                'fixed_price', 'percent_price', 'base_pricelist_id', 'base', 'categ_id', 'min_quantity', 'uom_id']

--- a/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
@@ -101,7 +101,11 @@ export class ProductTemplateAccounting extends Base {
         const generalRulesIds = pricelist.getGeneralRulesIdsByCategories(this.parentCategories);
         const rules = this.models["product.pricelist.item"]
             .readMany([...productRulesSet, ...tmplRulesSet, ...generalRulesIds])
-            .filter((r) => !r.min_quantity || r.min_quantity <= quantity);
+            .filter(
+                (r) =>
+                    (!r.min_quantity || r.min_quantity <= quantity) &&
+                    (!r.uom_id || r.uom_id.id === product.uom_id.id)
+            );
 
         const rule = rules.length && rules[0];
         if (!rule) {

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -166,7 +166,8 @@ class ProductPricelist(models.Model):
         self, products, quantity, *, currency=None, uom=None, date=False, compute_price=True,
         **kwargs
     ):
-        """ Low-level method - Mono pricelist, multi products
+        """Low-level method - Mono pricelist, multi products.
+
         Returns: dict{product_id: (price, suitable_rule) for the given pricelist}
 
         Note: self and self.ensure_one()
@@ -196,26 +197,18 @@ class ProductPricelist(models.Model):
             # Used to fetch pricelist rules and currency rates
             date = fields.Datetime.now()
 
-        # Fetch all rules potentially matching specified products/templates/categories and date
-        rules = self._get_applicable_rules(products, date, **kwargs)
+        # Fetch all rules potentially matching specified products/templates/categories/uom and date
+        rules = self._get_applicable_rules(products, quantity, date, uom=uom, **kwargs)
 
         results = {}
         for product in products:
             suitable_rule = self.env['product.pricelist.item']
 
+            # If no uom is specified, fallback on the product uom
             quantity_uom = uom or product.uom_id
-            qty_to_consider = self._compute_qty_to_consider(
-                product,
-                quantity,
-                quantity_uom,
-                currency=currency,
-                date=date,
-                compute_price=compute_price,
-                **kwargs,
-            )
 
             for rule in rules:
-                if rule._is_applicable_for(product, qty_to_consider):
+                if rule._is_applicable_for(product, quantity, uom=quantity_uom, **kwargs):
                     suitable_rule = rule
                     break
 
@@ -232,16 +225,18 @@ class ProductPricelist(models.Model):
         return results
 
     # Split methods to ease (community) overrides
-    def _get_applicable_rules(self, products, date, **kwargs):
+    def _get_applicable_rules(self, products, quantity, date, *, uom=None, **kwargs):
         self and self.ensure_one()  # self is at most one record
         if not self:
             return self.env['product.pricelist.item']
 
         return self.env['product.pricelist.item'].search(
-            self._get_applicable_rules_domain(products=products, date=date, **kwargs)
+            self._get_applicable_rules_domain(
+                products=products, date=date, quantity=quantity, uom=uom, **kwargs
+            )
         )
 
-    def _get_applicable_rules_domain(self, products, date, **kwargs):
+    def _get_applicable_rules_domain(self, products, date, *, quantity=None, uom=None, **kwargs):
         self and self.ensure_one()  # self is at most one record
         if products._name == 'product.template':
             templates_domain = ('product_tmpl_id', 'in', products.ids)
@@ -250,7 +245,7 @@ class ProductPricelist(models.Model):
             templates_domain = ('product_tmpl_id', 'in', products.product_tmpl_id.ids)
             products_domain = ('product_id', 'in', products.ids)
 
-        return [
+        domain = [
             ('pricelist_id', '=', self.id),
             '|', ('categ_id', '=', False), ('categ_id', 'parent_of', products.categ_id.ids),
             '|', ('product_tmpl_id', '=', False), templates_domain,
@@ -259,13 +254,14 @@ class ProductPricelist(models.Model):
             '|', ('date_end', '=', False), ('date_end', '>=', date),
         ]
 
-    def _compute_qty_to_consider(self, product, quantity, uom, **_kwargs):
-        """Compute quantity in product UoM because the min quantity on pricelist rules are specified
-        w.r.t. product default UoM."""
-        product_uom = product.uom_id
-        if uom != product_uom:
-            return uom._compute_quantity(quantity, product_uom, raise_if_failure=False)
-        return quantity
+        if uom:
+            domain.extend(['|', ('uom_id', '=', False), ('uom_id', '=', uom.id)])
+        elif quantity:
+            # ONLY if no uom is given, pre-handle min_qty check as quantity will be in product uom
+            # already.
+            domain.extend(['|', ('min_quantity', '=', 0), ('min_quantity', '<=', quantity)])
+
+        return domain
 
     # Multi pricelists price|rule computation
     def _price_get(self, product, quantity, **kwargs):
@@ -414,3 +410,18 @@ class ProductPricelist(models.Model):
             'type': 'ir.actions.client',
             'tag': 'generate_pricelist_report',
         }
+
+    def _get_related_uoms(self, product):
+        """Return UoMs from applicable pricelist rules for the given product.
+
+        The method retrieves pricelist items matching the product and current date
+        using ``_get_applicable_rules_domain``, then filters out rules without a UoM.
+
+        :param product: Product template or product variant.
+        :return: UoMs defined on matching pricelist items.
+        :rtype: uom.uom
+        """
+        domain = self._get_applicable_rules_domain(product, fields.Datetime.now())
+        # filter out pricelist items without UoM
+        domain += [('uom_id', '!=', False)]
+        return self.env['product.pricelist.item'].search_fetch(domain, ['uom_id']).uom_id

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -69,6 +69,7 @@ class ProductPricelistItem(models.Model):
         required=True,
         help="Pricelist Item applicable on selected option")
 
+    # Product Related Fields
     categ_id = fields.Many2one(
         comodel_name='product.category',
         string="Category",
@@ -87,7 +88,10 @@ class ProductPricelistItem(models.Model):
         help="Specify a product if this rule only applies to one product. Keep empty otherwise.")
     product_uom_name = fields.Char(related='product_tmpl_id.uom_name')
     product_variant_count = fields.Integer(related='product_tmpl_id.product_variant_count')
+    uom_id = fields.Many2one(string="Packaging", comodel_name='uom.uom')
+    allowed_uom_ids = fields.Many2many('uom.uom', compute='_compute_allowed_uom_ids')
 
+    # Price Related Fields
     base = fields.Selection(
         selection=[
             ('list_price', 'Sales Price'),
@@ -157,7 +161,7 @@ class ProductPricelistItem(models.Model):
         compute='_compute_name',
         help="Explicit rule name for this pricelist line.")
     price = fields.Char(
-        string="Price",
+        string="Unit Price",
         compute='_compute_price_label',
         help="Explicit rule name for this pricelist line.")
     rule_tip = fields.Char(compute='_compute_rule_tip')
@@ -180,6 +184,11 @@ class ProductPricelistItem(models.Model):
                 or item.company_id.currency_id
                 or item.env.company.currency_id
             )
+
+    @api.depends('product_tmpl_id', 'product_tmpl_id.uom_id', 'product_tmpl_id.uom_ids')
+    def _compute_allowed_uom_ids(self):
+        for item in self:
+            item.allowed_uom_ids = item.product_tmpl_id.uom_id | item.product_tmpl_id.uom_ids
 
     @api.depends('applied_on', 'categ_id', 'product_tmpl_id', 'product_id')
     def _compute_name(self):
@@ -487,7 +496,7 @@ class ProductPricelistItem(models.Model):
             if applied_on == '3_global':
                 values.update({'product_id': None, 'product_tmpl_id': None, 'categ_id': None})
             elif applied_on == '2_product_category':
-                values.update({'product_id': None, 'product_tmpl_id': None})
+                values.update({'product_id': None, 'product_tmpl_id': None, 'uom_id': False})
             elif applied_on == '1_product':
                 values.update({'product_id': None, 'categ_id': None})
             elif applied_on == '0_product_variant':
@@ -501,7 +510,7 @@ class ProductPricelistItem(models.Model):
             if applied_on == '3_global':
                 vals.update({'product_id': None, 'product_tmpl_id': None, 'categ_id': None})
             elif applied_on == '2_product_category':
-                vals.update({'product_id': None, 'product_tmpl_id': None})
+                vals.update({'product_id': None, 'product_tmpl_id': None, 'uom_id': False})
             elif applied_on == '1_product':
                 vals.update({'product_id': None, 'categ_id': None})
             elif applied_on == '0_product_variant':
@@ -510,13 +519,15 @@ class ProductPricelistItem(models.Model):
 
     #=== BUSINESS METHODS ===#
 
-    def _is_applicable_for(self, product, qty_in_product_uom):
-        """Check whether the current rule is valid for the given product & qty.
+    def _is_applicable_for(self, product, quantity, *, uom=None, qty_in_product_uom=False, **kwargs):
+        """Check whether the current rule is valid for the given product, qty and uom.
 
         Note: self.ensure_one()
 
         :param product: product record (product.product/product.template)
-        :param float qty_in_product_uom: quantity, expressed in product UoM
+        :param float quantity: quantity of products requested (in given uom)
+        :param float qty_in_product_uom: quantity of products requested (in product's base uom)
+        :param uom: Selected unit of measure (uom.uom record)
         :returns: Whether rules is valid or not
         :rtype: bool
         """
@@ -525,9 +536,21 @@ class ProductPricelistItem(models.Model):
         res = True
 
         is_product_template = product._name == 'product.template'
-        if self.min_quantity and qty_in_product_uom < self.min_quantity:
-            res = False
+        product_uom = product.uom_id
+        uom = uom or product_uom
 
+        # Filter the rules restricted to specific units of measure.
+        if self.uom_id and uom != self.uom_id:
+            return False
+
+        qty_to_consider = quantity
+        if uom not in product_uom + self.uom_id:
+            # Convert the quantity to consider to the product base uom if the requested uom is not
+            # in the rule allowed unit of measures.
+            qty_to_consider = uom._compute_quantity(quantity, product_uom)
+
+        if self.min_quantity and qty_to_consider < self.min_quantity:
+            res = False
         elif self.applied_on == "2_product_category":
             if not product.categ_id or (
                 product.categ_id != self.categ_id

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -144,7 +144,7 @@ class ProductProduct(models.Model):
     )
 
     base_unit_count = fields.Float(
-        string="Base Unit Count",
+        string="Reference Unit",
         help="Display base unit price. Set to 0 to hide it for this product.",
         required=True,
         default=1,

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -219,7 +219,7 @@ class ProductTemplate(models.Model):
     show_sales_price_page = fields.Boolean(compute='_compute_show_sales_price_page')
 
     base_unit_count = fields.Float(
-        string="Base Unit Count",
+        string="Reference Unit",
         help="Display base unit price. Set to 0 to hide it for this product.",
         compute='_compute_base_unit_count',
         inverse='_set_base_unit_count',

--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -56,22 +56,37 @@ class ProductPricelistReport(models.AbstractModel):
 
     def _get_product_data(self, is_product_tmpl, product, pricelist, quantities, date):
         product = product.with_context(display_default_code=False)
-        data = {
-            'id': product.id,
-            'name': (is_product_tmpl and product.name) or product.display_name,
-            'price': dict.fromkeys(quantities, 0.0),
-            'uom': product.uom_id.name,
-            'default_code': product.default_code,
-            'barcode': product.barcode,
-            'category': product.categ_id.name,
-        }
-        for qty in quantities:
-            data['price'][qty] = pricelist._get_product_price(product, qty, date=date)
+        has_multiple_variants = is_product_tmpl and product.product_variant_count > 1
 
-        if is_product_tmpl and product.product_variant_count > 1:
-            data['variants'] = [
+        # Determine applicable UoMs
+        if product._has_multiple_uoms() and not has_multiple_variants:
+            product_uoms = pricelist._get_related_uoms(product) + product.uom_id
+        else:
+            product_uoms = product.uom_id
+
+        data = {
+            "id": product.id,
+            "name": product.name if is_product_tmpl else product.display_name,
+            "price": {uom.id: {qty: {} for qty in quantities} for uom in product_uoms},
+            "uoms": product_uoms.read(["id", "name"]),
+            "default_code": product.default_code,
+            "barcode": product.barcode,
+            "category": product.categ_id.name,
+            "show_product_data": not has_multiple_variants,
+        }
+
+        if has_multiple_variants:
+            # Expand variants when template has multiple variants
+            data["variants"] = [
                 self._get_product_data(False, variant, pricelist, quantities, date)
                 for variant in product.product_variant_ids
             ]
+        else:
+            # Compute prices only when we actually show product data
+            for uom in product_uoms:
+                for qty in quantities:
+                    data["price"][uom.id][qty] = pricelist._get_product_price(
+                        product, qty, date=date, uom=uom
+                    )
 
         return data

--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -44,37 +44,85 @@
                                     <th class="px-1" colspan="100%" t-out="current_category">Services</th>
                                 </t>
 
-                                <tr>
+                                <tr t-foreach="product['uoms']" t-as="product_uom">
                                     <td t-att-class="is_product_tmpl and 'fw-bold px-1' or None">
-                                        <a t-if="is_html_type" href="#" class="o_action" t-att-data-model="is_product_tmpl and 'product.template' or 'product.product'" t-att-data-res-id="product['id']">
+                                        <a
+                                            t-if="is_html_type"
+                                            href="#"
+                                            class="o_action"
+                                            t-att-data-model="is_product_tmpl and 'product.template' or 'product.product'"
+                                            t-att-data-res-id="product['id']"
+                                        >
                                             <span t-out="product['name']">Virtual Interior Design</span>
                                         </a>
                                         <span t-else="" t-out="product['name']">Acme Widget</span>
                                     </td>
                                     <td class="px-1" t-out="product['default_code'] or ''">VINT_1000</td>
-                                    <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
+                                    <td
+                                        groups="uom.group_uom"
+                                        class="px-1"
+                                        t-out="product_uom['name'] if product['show_product_data'] else ''"
+                                    />
                                     <t t-foreach="quantities" t-as="qty">
                                         <td class="text-end px-1">
-                                            <span t-out="product['price'][qty]" t-options='{"widget": "monetary", "display_currency": currency}'>$15.00</span>
+                                            <span
+                                                t-if="product['show_product_data']"
+                                                t-out="product['price'][product_uom['id']][qty]"
+                                                t-options='{"widget": "monetary", "display_currency": currency}'
+                                            >
+                                                $15.00
+                                            </span>
                                         </td>
                                     </t>
                                 </tr>
                                 <t t-if="is_product_tmpl and 'variants' in product">
-                                    <tr t-foreach="product['variants']" t-as="variant">
-                                        <td class="px-1">
-                                            <a t-if="is_html_type" href="#" class="o_action ms-4" data-model="product.product" t-att-data-res-id="variant['id']">
-                                                <span t-out="variant['name']">Acme Widget - Blue</span>
-                                            </a>
-                                            <span t-else="" class="ms-4" t-out="variant['name']">Acme Widget - Blue</span>
-                                        </td>
-                                        <td class="px-1" t-out="variant['default_code'] or ''">VINT_1000</td>
-                                        <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
-                                        <t t-foreach="quantities" t-as="qty">
-                                            <td class="text-end px-1">
-                                                <span t-out="variant['price'][qty]" t-options='{"widget": "monetary", "display_currency": currency}'>$14.00</span>
+                                    <t t-foreach="product['variants']" t-as="variant">
+                                        <tr t-foreach="variant['uoms']" t-as="variant_uom">
+                                            <td class="px-1">
+                                                <a
+                                                    t-if="is_html_type"
+                                                    href="#"
+                                                    class="o_action ms-4"
+                                                    data-model="product.product"
+                                                    t-att-data-res-id="variant['id']"
+                                                >
+                                                    <span t-out="variant['name']">
+                                                        Acme Widget - Blue
+                                                    </span>
+                                                </a>
+                                                <span
+                                                    t-else=""
+                                                    class="ms-4"
+                                                    t-out="variant['name']"
+                                                >
+                                                    Acme Widget - Blue
+                                                </span>
                                             </td>
-                                        </t>
-                                    </tr>
+                                            <td
+                                                class="px-1"
+                                                t-out="variant['default_code'] or ''"
+                                            >
+                                                VINT_1000
+                                            </td>
+                                            <td
+                                                groups="uom.group_uom"
+                                                class="px-1"
+                                                t-out="variant_uom['name']"
+                                            />
+                                            <td
+                                                t-foreach="quantities"
+                                                t-as="qty"
+                                                class="text-end px-1"
+                                            >
+                                                <span
+                                                    t-out="variant['price'][variant_uom['id']][qty]"
+                                                    t-options='{"widget": "monetary", "display_currency": currency}'
+                                                >
+                                                    $14.00
+                                                </span>
+                                            </td>
+                                        </tr>
+                                    </t>
                                 </t>
                             </t>
                         </tbody>

--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -543,3 +543,51 @@ class TestPricelist(ProductVariantsCommon):
         self.assertEqual(pricelist.item_ids.applied_on, "1_product")
         # check that product_id is cleared
         self.assertFalse(pricelist.item_ids.product_id)
+
+    def test_pricelist_packaging_rules(self):
+        self.product_template_sofa.uom_ids = [Command.link(self.uom_dozen.id)]
+        packaging_pricelist = self.env["product.pricelist"].create({
+            "name": "Packaging Pricelist",
+            "item_ids": [
+                Command.create({
+                    "applied_on": "1_product",
+                    "compute_price": "fixed",
+                    "fixed_price": 10.0,
+                    "product_tmpl_id": self.product_template_sofa.id,
+                    "min_quantity": 6,
+                })
+            ],
+        })
+        packaging_rule_1 = self.env["product.pricelist.item"].create({
+            "applied_on": "1_product",
+            "compute_price": "fixed",
+            "fixed_price": 10.0,
+            "product_tmpl_id": self.product_template_sofa.id,
+            "min_quantity": 6,
+            "pricelist_id": packaging_pricelist.id,
+            "uom_id": self.uom_unit.id,
+        })
+        packaging_rule_2 = self.env["product.pricelist.item"].create({
+            "applied_on": "1_product",
+            "compute_price": "fixed",
+            "fixed_price": 10.0,
+            "product_tmpl_id": self.product_template_sofa.id,
+            "min_quantity": 6,
+            "pricelist_id": packaging_pricelist.id,
+            "uom_id": self.uom_dozen.id,
+        })
+
+        self.assertEqual(
+            packaging_pricelist._get_product_rule(
+                self.product_template_sofa, 6.0, uom=self.uom_unit
+            ),
+            packaging_rule_1.id,
+            "Packaging rule with uom_unit should be applied",
+        )
+        self.assertEqual(
+            packaging_pricelist._get_product_rule(
+                self.product_template_sofa, 6.0, uom=self.uom_dozen
+            ),
+            packaging_rule_2.id,
+            "Packaging rule with uom_dozen should be applied",
+        )

--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -114,6 +114,14 @@
                     required="1"
                 />
                 <field name="min_quantity" colspan="4"/>
+                <field
+                    name="uom_id"
+                    widget="many2one_uom"
+                    groups="uom.group_uom"
+                    invisible="display_applied_on != '1_product'"
+                    options="{'product_field': 'product_tmpl_id'}"
+                    optional="show"
+                />
                 <field name="currency_id" column_invisible="True"/>
                 <field name="date_start" optional="show"/>
                 <field name="date_end" optional="show"/>
@@ -177,14 +185,34 @@
                                 </t>
                             </div>
                         </group>
-                        <group name="pricelist_rule_limits">
-                            <field name="min_quantity" string="Min Qty"/>
-                            <field name="date_start"
-                                string="Validity"
-                                widget="daterange"
-                                options="{'end_date_field': 'date_end'}"/>
-                            <field name="date_end" invisible="1"/>
-                        </group>
+                        <div name="pricelist_rule_limits">
+                            <group name="min_quantity">
+                                <label for="min_quantity" string="Min Qty"/>
+                                <div class="o_row gap-3">
+                                    <field name="min_quantity"/>
+                                    <!-- apply allowed_uom_ids domain only if product template is selected -->
+                                    <field
+                                        name="uom_id"
+                                        placeholder="Units"
+                                        domain="[('id', 'in', allowed_uom_ids)] if allowed_uom_ids else []"
+                                        groups="uom.group_uom"
+                                        invisible="display_applied_on != '1_product'"
+                                        widget="many2one_uom"
+                                        options="{'no_create': 1, 'product_field': 'product_tmpl_id'}"
+                                        nolabel="1"
+                                    />
+                                </div>
+                            </group>
+                            <group name="date_range">
+                                <field
+                                    name="date_start"
+                                    string="Validity"
+                                    widget="daterange"
+                                    options="{'end_date_field': 'date_end'}"
+                                />
+                                <field name="date_end" invisible="1"/>
+                            </group>
+                        </div>
                     </group>
                     <group name="pricelist_rule_base" invisible="compute_price != 'formula'">
                         <group>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -77,13 +77,19 @@
                                     <field name="name" string="Apply on"/>
                                     <field name="min_quantity"/>
                                     <field
+                                        name="uom_id"
+                                        invisible="display_applied_on != '1_product'"
+                                        groups="uom.group_uom"
+                                        colspan="4"
+                                    />
+                                    <field
                                         name="date_start"
                                         string="Validity"
                                         widget="daterange"
                                         options="{'end_date_field': 'date_end'}"
                                         optional="show"
                                     />
-                                    <field name="price" string="Price"/>
+                                    <field name="price"/>
                                     <field name="base" column_invisible="True"/>
                                     <field name="price_discount" column_invisible="True"/>
                                     <field name="applied_on" column_invisible="True"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -212,6 +212,14 @@
                                     />
                                     <field name="min_quantity" optional="show"/>
                                     <field
+                                        name="uom_id"
+                                        domain="[('id', 'in', allowed_uom_ids)] if allowed_uom_ids else []"
+                                        groups="uom.group_uom"
+                                        widget="many2one_uom"
+                                        options="{'no_create': 1, 'product_field': 'product_tmpl_id'}"
+                                        optional="show"
+                                    />
+                                    <field
                                         name="date_start"
                                         string="Validity"
                                         widget="daterange"
@@ -220,7 +228,7 @@
                                     />
                                     <field
                                         name="fixed_price"
-                                        string="Price"
+                                        string="Unit Price"
                                         widget="monetary"
                                         options="{'currency_field': 'currency_id'}"
                                     />

--- a/addons/sale/views/product_pricelist_item_views.xml
+++ b/addons/sale/views/product_pricelist_item_views.xml
@@ -6,38 +6,26 @@
         <field name="model">product.pricelist.item</field>
         <field name="inherit_id" ref="product.product_pricelist_item_form_view"/>
         <field name="arch" type="xml">
-            <group name="pricelist_rule_limits" position="replace">
-                <div>
-                    <group name="pricelist_rule_limits">
-                        <field name="min_quantity" string="Min Qty"/>
-                        <field
-                            name="date_start"
-                            string="Validity"
-                            widget="daterange"
-                            options="{'end_date_field': 'date_end'}"
-                        />
-                        <field name="date_end" invisible="1"/>
-                    </group>
-                    <div groups="sale.group_discount_per_so_line">
-                        <div
-                            class="alert alert-info"
-                            role="alert"
-                            invisible="compute_price != 'percentage'"
-                        >
-                            <div id="discount_price_warning">
-                                In sale order line original price is unit price and discount is in
-                                discount column.
-                            </div>
+            <group name="date_range" position="after">
+                <div groups="sale.group_discount_per_so_line">
+                    <div
+                        class="alert alert-info"
+                        role="alert"
+                        invisible="compute_price != 'percentage'"
+                    >
+                        <div id="discount_price_warning">
+                            In sale order line original price is unit price and discount is in
+                            discount column.
                         </div>
-                        <div
-                            class="alert alert-info"
-                            role="alert"
-                            invisible="compute_price == 'percentage'"
-                        >
-                            <div id="formula_fixed_price_warning">
-                                For formula or fixed pricing, the original price isn’t shown in
-                                sale orders.
-                            </div>
+                    </div>
+                    <div
+                        class="alert alert-info"
+                        role="alert"
+                        invisible="compute_price == 'percentage'"
+                    >
+                        <div id="formula_fixed_price_warning">
+                            For formula or fixed pricing, the original price isn’t shown in
+                            sale orders.
                         </div>
                     </div>
                 </div>

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -295,7 +295,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 43  # To increase this number you must ask the permission to al
+        query_count = 42  # To increase this number you must ask the permission to al
         queries = {
             'orm_signaling_registry': 1,
             'website': 1,
@@ -309,7 +309,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             'res_users': 1,
             'res_partner': 2,
             'product_category': 1,
-            'product_pricelist_item': 2,
+            'product_pricelist_item': 1,
             'account_tax': 1,
             'res_currency': 1,
             'account_account_tag': 1,

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -636,6 +636,19 @@ class ProductTemplate(models.Model):
             # the product
             combination_info["compare_list_price"] = 0
 
+        if product_or_template._has_multiple_uoms():
+            # for packaging pricings
+            combination_info["packaging_prices"] = {}
+            for product_uom in product_or_template._get_available_uoms():
+                uom_price = pricelist._get_product_price(  # unit price in packaging UOM
+                    product=product_or_template, quantity=quantity, uom=product_uom
+                )
+                base_uom_price = product_uom._compute_price(  # convert packaging prices to base UOM
+                    price=uom_price, to_unit=product_or_template.uom_id
+                )
+
+                combination_info["packaging_prices"][product_uom.id] = base_uom_price
+
         return combination_info
 
     def _get_dynamic_attribute_images(self, combination_ids, website_id):

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -30,6 +30,11 @@ export class ProductPage extends Interaction {
             't-on-change': this.onChangeAttribute
         },
         '.o_variant_pills': { 't-on-click': this.onChangePillsAttribute },
+        ".o_packaging_button": {
+            "t-on-mouseenter": this.onHoverPackagingButton,
+            "t-on-mouseleave": this.onMouseLeavePackagingButton,
+            "t-on-click": this.onMouseLeavePackagingButton,
+        },
     };
 
     start() {
@@ -163,6 +168,30 @@ export class ProductPage extends Interaction {
                 );
             }
         });
+    }
+
+    onHoverPackagingButton(ev) {
+        const parent = ev.target.closest(".js_product");
+        const currentPackagingPrice = Number(this._getUoMPrice(parent).toFixed(2));
+        const hoveredPackagingPrice = Number(
+            parseFloat(
+                ev.target.querySelector("input[name='uom_id']").dataset.packagingPrice
+            ).toFixed(2)
+        );
+        if (currentPackagingPrice !== hoveredPackagingPrice) {
+            parent
+                .querySelector("p[name='packaging_price_value']")
+                .querySelector(".oe_currency_value").textContent = this._priceToStr(
+                hoveredPackagingPrice,
+                false
+            );
+            parent.querySelector("span[name='packaging_price']").classList.remove("d-none");
+        }
+    }
+
+    onMouseLeavePackagingButton(ev) {
+        const parent = ev.target.closest(".js_product");
+        parent.querySelector("span[name='packaging_price']").classList.add("d-none");
     }
 
     /**
@@ -343,6 +372,12 @@ export class ProductPage extends Interaction {
 
         this._onChangeCombination(ev, parent, combinationInfo, attributeValueImages);
         this._checkExclusions(parent, combination);
+    }
+
+    _getUoMPrice(element) {
+        return parseFloat(
+            element.querySelector("input[name='uom_id']:checked")?.dataset.packagingPrice
+        );
     }
 
     /**
@@ -567,6 +602,11 @@ export class ProductPage extends Interaction {
             }
         }
 
+        if ("packaging_prices" in combination) {
+            this._handlePackagingInfo(parent, combination);
+        }
+
+        // handle GMC tracking
         if ('product_tracking_info' in combination) {
             const product = document.querySelector('#product_detail');
             // Trigger an event to track variant changes in Google Analytics.
@@ -667,6 +707,23 @@ export class ProductPage extends Interaction {
         ));
 
         this.handleCustomValues(ev.target);
+    }
+
+    /**
+     * Update the packaging prices.
+     * @private
+     * @param {Element} parent
+     * @param {Object} combination
+     * */
+    _handlePackagingInfo(parent, combination) {
+        Object.entries(combination.packaging_prices).forEach(([uomId, price]) => {
+            const el = parent.querySelector(`input[name="uom_id"]#uom-${uomId}`);
+            if (!el) {
+                return;
+            }
+
+            el.dataset.packagingPrice = price;
+        });
     }
 
     /**

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -7,8 +7,7 @@
             class="o_base_unit_price"
             t-out="base_unit_price"
             t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
-        />
-         / <span class="oe_custom_base_unit" t-field="product.base_unit_name"/>
+        />/<span class="oe_custom_base_unit" t-field="product.base_unit_name"/>
     </template>
 
     <template id="website_sale.product" name="Product" track="1">
@@ -123,10 +122,15 @@
                                         class="o_wsale_product_details_content_section o_wsale_product_details_content_section_price mb-4"
                                     >
                                         <t t-call="website_sale.product_price"/>
-                                        <small t-if="combination_info.get('base_unit_price')"
-                                            class="ms-1 text-muted o_base_unit_price_wrapper d-none">
-                                            <t t-call="website_sale.base_unit_price"
-                                                base_unit_price="combination_info['base_unit_price']"/>
+                                        <small
+                                            t-if="combination_info.get('base_unit_price')"
+                                            class="text-muted o_base_unit_price_wrapper d-block d-none"
+                                        >
+                                            (<t
+                                                t-call="website_sale.base_unit_price"
+                                                product="product"
+                                                base_unit_price="combination_info['base_unit_price']"
+                                            />)
                                         </small>
                                     </div>
 
@@ -444,7 +448,18 @@
     </template>
 
     <template id="website_sale.packaging_title" name="Packaging title">
-        <h6 class="attribute_name mb-2">Packaging</h6>
+        <h6 class="attribute_name d-inline">Packaging</h6>
+        <span name="packaging_price" class="d-inline-flex d-none text-muted">
+            -
+            <p
+                name="packaging_price_value"
+                class="mb-0 ms-1"
+                t-out="combination_info.get('packaging_prices', {}).get(product.uom_id.id, False)"
+                t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+            />
+            /
+            <p t-field="product.uom_name" class="mb-0"/>
+        </span>
     </template>
 
     <template id="website_sale.product_packaging_selector" name="Product Packaging Selector">
@@ -455,11 +470,14 @@
             >
                 <li>
                     <t t-call="website_sale.packaging_title"/>
-                    <ul class="btn-group-toggle list-inline list-unstyled" data-bs-toggle="buttons">
+                    <ul
+                        class="btn-group-toggle list-inline list-unstyled mt-2"
+                        data-bs-toggle="buttons"
+                    >
                         <t t-set="product_uoms" t-value="product_variant._get_available_uoms()"/>
                         <t t-foreach="product_uoms" t-as="uom">
                             <t t-set="is_main_uom" t-value="uom.id == product.uom_id.id"/>
-                            <li t-attf-class="o_variant_pills border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if is_main_uom else ''}">
+                            <li t-attf-class="o_packaging_button o_variant_pills border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if is_main_uom else ''}">
                                 <input
                                     class="position-absolute opacity-0 cursor-pointer"
                                     type="radio"
@@ -467,7 +485,9 @@
                                     name="uom_id"
                                     t-att-value="uom.id"
                                     t-attf-id="uom-{{uom.id}}"
-                                    t-att-autocomplete="off"/>
+                                    t-att-autocomplete="off"
+                                    t-att-data-packaging-price="combination_info.get('packaging_prices', {}).get(uom.id, False)"
+                                />
                                 <label class="radio_input_value cursor-pointer" t-attf-for="uom-{{uom.id}}">
                                     <span t-field="uom.name"/>
                                 </label>
@@ -604,7 +624,7 @@
                 <span name="o_wsale_cta_wrapper_boxed_price_label" class="text-muted">Price</span>
                 <div>
                     <t t-call="website_sale.product_price"/>
-                    <small 
+                    <small
                         t-if="combination_info.get('base_unit_price')"
                         class="ms-1 text-muted o_base_unit_price_wrapper d-none"
                     >


### PR DESCRIPTION
Before this commit:

 * Pricelist rules could only be defined for a product’s base UoM.
 * It wasn’t possible to apply rules specifically to product packagings.

After this commit:

 * Pricelist rules can now be defined for specific product packagings.
 * If no packaging is specified, the rule defaults to the product’s base UoM.
 * On eCommerce, when a product has multiple packagings with different prices,
   the packaging button now displays each packaging’s price based on the selected
   quantity on hover.
 * The pricelist report has also been enhanced to show product prices per
   packaging when applicable.
 * Also since now we have UOM specific pricelists we filter rules early with
   `min_quantity` when no UOM is given this also does little performance boost
   to pricelist logic.

task-4875803

See Also:
- https://github.com/odoo/enterprise/pull/99225


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
