### PR TITLE
[FIX] mail: check rights for upload activity

### DIFF
--- a/addons/test_mail/tests/test_mail_activity_plan.py
+++ b/addons/test_mail/tests/test_mail_activity_plan.py
@@ -6,8 +6,9 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
 from odoo import Command, fields
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.test_mail_activity import ActivityScheduleCase
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form, tagged, users
 from odoo.tools.misc import format_date
 
@@ -179,6 +180,21 @@ class TestActivitySchedule(ActivityScheduleCase):
         self.assertEqual(len(self.test_records[2].activity_ids), 2)
         self.assertEqual(len(self.test_records[3].activity_ids), 0)
         self.assertEqual(len(self.test_records[4].activity_ids), 0)
+
+    @users('admin')
+    def test_activity_schedule_rights_upload(self):
+        user = mail_new_test_user(
+            self.env,
+            groups='base.group_public',
+            login='bert',
+            name='Bert Tartignole',
+        )
+        demo_record = self.env['mail.test.access'].create({'access': 'admin', 'name': 'Record'})
+        form = self._instantiate_activity_schedule_wizard(demo_record)
+        form.activity_type_id = self.env.ref('test_mail.mail_act_test_upload_document')
+        with self.assertRaises(UserError):
+            form.activity_user_id = user
+        form.save()
 
     @users('employee')
     def test_plan_mode(self):


### PR DESCRIPTION
Step To Reproduce:
- install Project
- login with admin and open any Project settings, say Project 1.
- create a upload document activity for 'marc demo'
- ensure marc demo has 'User' access  for project
-  login with marc demo
- open same project (kanban card -> view)
- upload a document for the created activity

Observation:
-  Traceback

```
TypeError: Cannot destructure property 'id' of '(intermediate value)' as it
is undefined at Activity.onFileUploaded
```
Cause:
- upload request to `/mail/attachment/upload` , calls `mail_attachment_upload` which then tries to access thread for 'write' mode, 'project.project ' model .
- as marc demo does not have write access to this model, no thread is returned
- so `NotFound()` is raised

https://github.com/odoo/odoo/blob/322c6d0468bf79e9d29e1375c49aa13d4a7b7a67/addons/mail/controllers/attachment.py#L48-L55

Fix:
- we check if selected user has appropriate rights or not for upload activity

opw-5160132


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
