### PR TITLE
[IMP] tests: better canonical tags for js tests

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -81,7 +81,7 @@ class PostgreSQLHandler(logging.Handler):
                 metadata = {}
                 if modules.module.current_test:
                     with contextlib.suppress(Exception):
-                        metadata['test'] = modules.module.current_test.get_log_metadata()
+                        metadata['test'] = modules.module.current_test.get_log_metadata(record)
 
                 if metadata:
                     cr.execute("""

--- a/odoo/tests/case.py
+++ b/odoo/tests/case.py
@@ -250,19 +250,42 @@ class TestCase(_TestCase):
 
     @property
     def canonical_tag(self):
+        return self.get_canonical_tag()
+
+    def _make_canonical_tag(self=None, tag='', module=None, test_class=None, test_method=None, params=None):
+        if module:
+            tag = f'{tag}/{module}'
+        if test_class:
+            tag = f'{tag}:{test_class}'
+        if test_method:
+            tag = f'{tag}.{test_method}'
+        if params:
+            tag = f'{tag}[{params}]'
+        return tag
+
+    def _get_canonical_tags_params(self, log):
         module = self.__module__
         for prefix in ('odoo.addons.', 'odoo.upgrade.'):
             if module.startswith(prefix):
                 module = module[len(prefix):]
 
         module = module.replace('.', '/')
-        return f'/{module}.py:{self.__class__.__name__}.{self._testMethodName}'
+        module = f'{module}.py'
 
-    def get_log_metadata(self):
-        metadata = {
-            'canonical_tag': self.canonical_tag,
+        return {
+            'module': module,
+            'test_class': self.__class__.__name__,
+            'test_method': self._testMethodName,
+            'params': None,
         }
-        return metadata
+
+    def get_canonical_tag(self, log=None):
+        return self._make_canonical_tag(**self._get_canonical_tags_params(log))
+
+    def get_log_metadata(self, _log):
+        return {
+            'canonical_tag': self.get_canonical_tag(_log),
+        }
 
 
 class _SubTest(TestCase):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -934,6 +934,11 @@ class CrossModule(case.TestCase):
     def _callTestMethod(self, method):
         method(self._test_modules)
 
+    def _get_canonical_tags_params(self, log=None):
+        result = super()._get_canonical_tags_params(log)
+        result['module'] = None
+        return result
+
 
 class Like:
     """


### PR DESCRIPTION
Js tests are cross modules, meaning that the canonical tags given by the tests are incorrect

eg: `/web.test_unit_desktop` does not allow to run `@mail/some_test` hoot test since /web.test_unit_desktop will filter only web hoot test removing the mail ones

The canonical tag is also not usable as it is since disabling .test_unit_desktop will actually disable the complete suite. 

The correct way would be to tag this tests `.test_unit_desktop[@mail/some_test]`, this is the solution proposed in this pull request.