### PR TITLE
[I18N] l10n_br: Add translations for Brasil-specific fields

### DIFF
--- a/addons/l10n_br/i18n/l10n_br.pot
+++ b/addons/l10n_br/i18n/l10n_br.pot
@@ -118,6 +118,7 @@ msgstr ""
 
 #. module: l10n_br
 #: model_terms:ir.ui.view,arch_db:l10n_br.address_form_fields
+#: model_terms:ir.ui.view,arch_db:l10n_br.address_form_fields
 #: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
 msgid "Complement"
 msgstr ""
@@ -497,6 +498,12 @@ msgstr ""
 #. module: l10n_br
 #: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
 msgid "Street #"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.address_form_fields
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
+msgid "Street Number"
 msgstr ""
 
 #. module: l10n_br

--- a/addons/l10n_br/i18n/pt_BR.po
+++ b/addons/l10n_br/i18n/pt_BR.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #. module: l10n_br
 #: model_terms:ir.ui.view,arch_db:l10n_br.address_form_fields
+#: model_terms:ir.ui.view,arch_db:l10n_br.br_partner_address_form
 msgid "Street Number"
 msgstr ""
 


### PR DESCRIPTION
When selecting "Brazil" in the _Country_ field in a checkout
 delivery form, four new fields appear: _Street_, _Street Number_,
_Complement_ and _Neighborhood_. These fields would never be translated.

### Steps to reproduce:
1. Have the following modules installed:
	- Website (`website`)
	- eCommerce (`website_sale`)
	- Brazilian - Accounting (`l10n_br`)
2. Use a Brazilian company
3. Go to Settings > Website and set the website's company to the Brazilian company, and add a few languages (e.g., Portuguese (BR), Portuguese)
4. In incognito mode, open the website, go to the _Shop_ tab, add an item to cart, and proceed to checkout.
5. During checkout, switch to any language other than English (e.g., Portuguese)
6. Change the _Country_ field to "Brazil"
7. Four fields appeared (_Street_, _Street Number_, _Complement_ and _Neighborhood_), but they're not translated to the selected language

This fix adds the Portuguese translations for these fields. After applying the fix, following the same steps will display
 these fields translated into Portuguese when that language is selected.

opw-5123922