### PR TITLE
[IMP] l10n_tr_nilvera_einvoice_extended:  Restrict CTSP num check to GIB export

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice_extended/i18n/l10n_tr_nilvera_einvoice_extended.pot
+++ b/addons/l10n_tr_nilvera_einvoice_extended/i18n/l10n_tr_nilvera_einvoice_extended.pot
@@ -352,6 +352,12 @@ msgid "GIB Tax Offices"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice_extended
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_bank_statement_line__l10n_tr_is_export_invoice
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_move__l10n_tr_is_export_invoice
+msgid "GİB Product Export Invoice"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice_extended
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_chart_template__id
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_edi_xml_ubl_tr__id
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_move__id
@@ -386,12 +392,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice_extended
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice_extended.account_move_form_view_l10n_tr_nilvera_extended
 msgid "Invoice Type"
-msgstr ""
-
-#. module: l10n_tr_nilvera_einvoice_extended
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_bank_statement_line__l10n_tr_is_export_invoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_move__l10n_tr_is_export_invoice
-msgid "Is GIB Export"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice_extended

--- a/addons/l10n_tr_nilvera_einvoice_extended/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice_extended/i18n/tr.po
@@ -364,6 +364,12 @@ msgid "GIB Tax Offices"
 msgstr "Vergi Daireleri"
 
 #. module: l10n_tr_nilvera_einvoice_extended
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_bank_statement_line__l10n_tr_is_export_invoice
+#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_move__l10n_tr_is_export_invoice
+msgid "GİB Product Export Invoice"
+msgstr "GİB Ürün İhracat Faturası"
+
+#. module: l10n_tr_nilvera_einvoice_extended
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_chart_template__id
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_edi_xml_ubl_tr__id
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_move__id
@@ -399,12 +405,6 @@ msgstr "GİB Fatura Senaryosu"
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice_extended.account_move_form_view_l10n_tr_nilvera_extended
 msgid "Invoice Type"
 msgstr "GİB Fatura Türü"
-
-#. module: l10n_tr_nilvera_einvoice_extended
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_bank_statement_line__l10n_tr_is_export_invoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice_extended.field_account_move__l10n_tr_is_export_invoice
-msgid "Is GIB Export"
-msgstr "GİB İhracat Faturası"
 
 #. module: l10n_tr_nilvera_einvoice_extended
 #: model:ir.model,name:l10n_tr_nilvera_einvoice_extended.model_account_move

--- a/addons/l10n_tr_nilvera_einvoice_extended/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/account_move.py
@@ -27,7 +27,7 @@ class AccountMove(models.Model):
         ],
         help="The type of invoice to be sent to GİB.",
     )
-    l10n_tr_is_export_invoice = fields.Boolean(string="Is GIB Export")
+    l10n_tr_is_export_invoice = fields.Boolean(string="GİB Product Export Invoice")
     l10n_tr_shipping_type = fields.Selection(
         selection=[
             ("1", "Sea Transportation"),

--- a/addons/l10n_tr_nilvera_einvoice_extended/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/account_move_send.py
@@ -11,7 +11,7 @@ class AccountMoveSend(models.AbstractModel):
     def _get_alerts(self, moves, moves_data):
         # EXTENDS 'account'
         alerts = super()._get_alerts(moves, moves_data)
-        tr_moves = moves.filtered(lambda m: m.country_code == "TR")
+        tr_moves = moves.filtered(lambda m: m.country_code == "TR" and m.l10n_tr_is_export_invoice)
 
         # Warning alert if product is missing CTSP Number
         if non_eligible_tr_products := tr_moves.invoice_line_ids.product_id.filtered(
@@ -22,7 +22,7 @@ class AccountMoveSend(models.AbstractModel):
                     "The following products are missing a CTSP Number:\n%(products)s\n",
                     products="\n".join(f"- {product.display_name}" for product in non_eligible_tr_products),
                 ),
-                "level": "warning",
+                "level": "danger",
                 "action_text": _("View Product(s)"),
                 "action": non_eligible_tr_products._get_records_action(
                     name=_("Check Products"),


### PR DESCRIPTION
Currently, the system validates the CTSP Number for all invoice types. This causes unnecessary confusion to the users.

In this commit:
---
- The CTSP missing product alert is shown only when the invoice is marked as a GIB Product Export Invoice.
- Change CTSP alert level from `warning` to `danger` for export invoices.
- The field `(Is GIB Export)` is renamed to `(GİB Product Export Invoice)`, since it is relevant only for product exports, not services.


---
task-5166118
