### PR TITLE
[FIX] l10n_sa_edi, l10n_sa_edi_pos: patch up POS usability

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -300,6 +300,14 @@ class AccountMove(models.Model):
             'total_tax': invoice_vals['vals']['tax_total_vals'][-1]['tax_amount'],
         }
 
+    def _retry_edi_documents_error_hook(self):
+        ''' Overriden to reset the attachment and allow re-submission of ZATCA invoices,
+            Ensures that reciepts on POS are updated after a failed submission.
+        '''
+        zatca = self.env.ref('l10n_sa_edi.edi_sa_zatca')
+        self.filtered(lambda m: m._get_edi_document(zatca))._detach_attachments()
+        return super()._retry_edi_documents_error_hook()
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -10,7 +10,8 @@ patch(PaymentScreen.prototype, {
         await super._finalizeValidation(...arguments);
         const order = this.currentOrder;
         // note: isSACompany guarantees order.is_to_invoice()
-        if (order.isSACompany && order.finalized && order.l10n_sa_invoice_edi_state !== "sent") {
+        // note: Skips entirely if journal is not onboarded or electronic invoicing is not selected
+        if (order.isSACompany && order.finalized && !order.l10n_sa_invoice_qr_code_str) {
             const orderError = _t("%s by going to Backend > Orders > Invoice", order.pos_reference);
             const href = `/odoo/customer-invoices/${this.currentOrder?.raw?.account_move}`;
             const link = markup(

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_store.js
@@ -7,8 +7,7 @@ patch(PosStore.prototype, {
         const result = super.getReceiptHeaderData(...arguments);
         if (order && order.isSACompany && !result.is_settlement) {
             // is_settlement is assigned in super l10n_sa_pos
-            result.not_legal =
-                !order.l10n_sa_invoice_qr_code_str || order.l10n_sa_invoice_edi_state !== "sent";
+            result.not_legal = !order.l10n_sa_invoice_qr_code_str;
             result.qr_code = result.not_legal ? "" : qrCodeSrc(order.l10n_sa_invoice_qr_code_str);
         }
         return result;


### PR DESCRIPTION
Ensure proper handling of QR code generation and POS EDI behavior by fixing multiple issues across invoice reprints and journal onboarding. QR codes now correctly appear on reprinted invoices when journal problems occur during order confirmation. POS correctly falls back to the Phase 1 flow when the journal is not onboarded and electronic invoicing is not enabled. Additionally, POS receipts now display the proper Phase 1 QR code whenever the EDI module is installed.

Problem 1: If ZATCA does not properly receive the invoice generated
from a POS order (wrong onboarding, wrong details on company, etc.)
the invoice printed from POS will not contain the QR code, even after
successfully resubmitting the invoice to ZATCA, load the order and 
reprint the invoice to see this

Testing the fix: Change the VAT number on the company to be faulty, 
create a POS order, Fix the VAT number and resubmit the invoice, load
the POS order and reprint invoice, it will now show the QR code.

Problem 2: When disabling the E-invoicing for a phase 2 journal,
the POS receipt will still try to print the phase 2 QR code but the system
will flag it as 'not legal' leaving the POS receipt empty, when it should
instead print the phase 1 QR code

Testing the fix: On the journal, disable the E-invoicing, and create a POS
order, it will now show the phase 1 QR code on the receipt

task-5032474

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
