### PR TITLE
[FIX] web: redirect scoped apps urls without losing the state

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -181,7 +181,7 @@ export function urlToState(urlObj) {
 
     const [prefix, ...splitPath] = urlObj.pathname.split("/").filter(Boolean);
 
-    if (prefix === "odoo" || isScopedApp()) {
+    if (["odoo", "scoped_app"].includes(prefix)) {
         const actionParts = [...splitPath.entries()].filter(
             ([_, part]) => !isNumeric(part) && part !== "new"
         );
@@ -225,6 +225,11 @@ export function urlToState(urlObj) {
         if (activeAction) {
             Object.assign(state, activeAction);
             state.actionStack = actions;
+        }
+        if (prefix === "scoped_app" && !isDisplayStandalone()) {
+            // make sure /scoped_app are redirected to /odoo when using the browser instead of the PWA
+            const url = browser.location.origin + router.stateToUrl(state);
+            urlObj.href = url;
         }
     }
     return state;

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { click, on } from "@odoo/hoot-dom";
-import { tick } from "@odoo/hoot-mock";
+import { mockMatchMedia, tick } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
@@ -1660,6 +1660,24 @@ describe("History", () => {
         expect.verifySteps(["ROUTE_CHANGE"]);
     });
 });
+
+describe("Scoped apps", () => {
+    test("url location is changed to /odoo if the client is not used in a standalone scoped app", async () => {
+        Object.assign(browser.location, { pathname: "/scoped_app/some-path" });
+        createRouter();
+        router.pushState({ app_name: "some_app", path: "scoped_app/some_path" });
+        await tick();
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo/some-path?app_name=some_app&path=scoped_app%2Fsome_path");
+    });
+    test("url location is preserved as /scoped_app if the client is used in a standalone scoped app", async () => {
+        mockMatchMedia({ ["display-mode"]: "standalone" });
+        Object.assign(browser.location, { pathname: "/scoped_app/some-path" });
+        createRouter();
+        router.pushState({ app_name: "some_app", path: "scoped_app/some_path" });
+        await tick();
+        expect(browser.location.href).toBe("https://www.hoot.test/scoped_app/some-path?app_name=some_app&path=scoped_app%2Fsome_path");
+    });
+})
 
 describe("Retrocompatibility", () => {
     test("parse an url with hash (key/values)", async () => {


### PR DESCRIPTION
This commit fixes the '/scoped_app' redirection to '/odoo' without loosing the history state.

Previously, when opening a route such as '/scoped_app/discuss', the webclient would use an empty state and redirect to the home screen with '/odoo' instead of redirecting to '/odoo/discuss'.

Two tests have been added in router to assert the different redirection behavior when using scoped apps from the browser instead of a standalone app.

task-5159471