### PR TITLE
[IMP] mrp: consumption issues warning wizard revamp

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -246,7 +246,6 @@
             <field name="product_tmpl_id" ref="product_product_computer_desk_product_template"/>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">3</field>
-            <field name="consumption">flexible</field>
             <field name="days_to_prepare_mo">3</field>
         </record>
         <record id="mrp_routing_workcenter_5" model="mrp.routing.workcenter">

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -67,19 +67,6 @@ class MrpBom(models.Model):
     company_id = fields.Many2one(
         'res.company', 'Company', index=True,
         default=lambda self: self.env.company)
-    consumption = fields.Selection([
-        ('flexible', 'Allowed'),
-        ('warning', 'Allowed with warning'),
-        ('strict', 'Blocked')],
-        help="Defines if you can consume more or less components than the quantity defined on the BoM:\n"
-             "  * Allowed: allowed for all manufacturing users.\n"
-             "  * Allowed with warning: allowed for all manufacturing users with summary of consumption differences when closing the manufacturing order.\n"
-             "  Note that in the case of component Highlight Consumption, where consumption is registered manually exclusively, consumption warnings will still be issued when appropriate also.\n"
-             "  * Blocked: only a manager can close a manufacturing order when the BoM consumption is not respected.",
-        default='warning',
-        string='Flexible Consumption',
-        required=True
-    )
     possible_product_template_attribute_value_ids = fields.Many2many(
         'product.template.attribute.value',
         compute='_compute_possible_product_template_attribute_value_ids')

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -128,7 +128,6 @@ class MrpWorkorder(models.Model):
     production_date = fields.Datetime('Production Date', compute='_compute_production_date', store=True)
     json_popover = fields.Char('Popover Data JSON', compute='_compute_json_popover')
     show_json_popover = fields.Boolean('Show Popover?', compute='_compute_json_popover')
-    consumption = fields.Selection(related='production_id.consumption')
     qty_reported_from_previous_wo = fields.Float('Carried Quantity', digits='Product Unit', copy=False,
         help="The quantity already produced awaiting allocation in the backorders chain.")
     is_planned = fields.Boolean(related='production_id.is_planned')

--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -17,6 +17,7 @@ from . import test_multicompany
 from . import test_backorder
 from . import test_performance
 from . import test_consume_component
+from . import test_consumption_warning
 from . import test_manual_consumption
 from . import test_workcenter
 from . import test_workorder

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -9,7 +9,7 @@ from odoo.addons.stock.tests.common import TestStockCommon
 class TestMrpCommon(TestStockCommon):
 
     @classmethod
-    def generate_mo(cls, tracking_final='none', tracking_base_1='none', tracking_base_2='none', qty_final=5, qty_base_1=4, qty_base_2=1, picking_type_id=False, consumption=False):
+    def generate_mo(cls, tracking_final='none', tracking_base_1='none', tracking_base_2='none', qty_final=5, qty_base_1=4, qty_base_2=1, picking_type_id=False):
         """ This function generate a manufacturing order with one final
         product and two consumed product. Arguments allows to choose
         the tracking/qty for each different products. It returns the
@@ -39,7 +39,6 @@ class TestMrpCommon(TestStockCommon):
             'uom_id': cls.uom_unit.id,
             'product_qty': 1.0,
             'type': 'normal',
-            'consumption': consumption if consumption else 'flexible',
             'bom_line_ids': [
                 Command.create({'product_id': product_to_use_2.id, 'product_qty': qty_base_2}),
                 Command.create({'product_id': product_to_use_1.id, 'product_qty': qty_base_1}),
@@ -157,7 +156,6 @@ class TestMrpCommon(TestStockCommon):
             'product_tmpl_id': cls.product_4.product_tmpl_id.id,
             'uom_id': cls.uom_unit.id,
             'product_qty': 4.0,
-            'consumption': 'flexible',
             'operation_ids': [
             ],
             'type': 'normal',
@@ -169,7 +167,6 @@ class TestMrpCommon(TestStockCommon):
             'product_id': cls.product_5.id,
             'product_tmpl_id': cls.product_5.product_tmpl_id.id,
             'uom_id': cls.product_5.uom_id.id,
-            'consumption': 'flexible',
             'product_qty': 1.0,
             'operation_ids': [
                 Command.create({'name': 'Gift Wrap Maching', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 15, 'sequence': 1}),
@@ -185,7 +182,6 @@ class TestMrpCommon(TestStockCommon):
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
             'uom_id': cls.uom_dozen.id,
             'ready_to_produce': 'asap',
-            'consumption': 'flexible',
             'product_qty': 2.0,
             'operation_ids': [
                 Command.create({'name': 'Cutting Machine', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
@@ -200,7 +196,6 @@ class TestMrpCommon(TestStockCommon):
         cls.bom_4 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
-            'consumption': 'flexible',
             'product_qty': 1.0,
             'operation_ids': [Command.create({
                 'name': 'Rub it gently with a cloth',
@@ -216,7 +211,6 @@ class TestMrpCommon(TestStockCommon):
         cls.bom_5 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
-            'consumption': 'flexible',
             'product_qty': 1.0,
             'operation_ids': [Command.create({
                 'name': 'Rub it gently with a cloth two at once',
@@ -232,7 +226,6 @@ class TestMrpCommon(TestStockCommon):
         cls.bom_6 = cls.env['mrp.bom'].create({
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
-            'consumption': 'flexible',
             'product_qty': 1.0,
             'operation_ids': [Command.create({
                 'name': 'Rub it gently with a cloth two at once',

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -14,6 +14,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, skip_consumption=True))
         cls.env.ref('base.group_user').write({
             'implied_ids': [Command.link(cls.env.ref('stock.group_production_lot').id)],
         })
@@ -300,7 +301,6 @@ class TestMrpProductionBackorder(TestMrpCommon):
             'uom_id': self.uom_unit.id,
             'product_qty': 1.0,
             'type': 'normal',
-            'consumption': 'flexible',
             'bom_line_ids': [Command.create({
                 'product_id': product_component.id,
                 'product_qty': 1,
@@ -954,6 +954,7 @@ class TestMrpWorkorderBackorder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestMrpWorkorderBackorder, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, skip_consumption=True))
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
         cls.finished1 = cls.env['product.product'].create({
             'name': 'finished1',
@@ -982,7 +983,6 @@ class TestMrpWorkorderBackorder(TransactionCase):
             'product_tmpl_id': cls.finished1.product_tmpl_id.id,
             'uom_id': cls.uom_unit.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
                 Command.create({'product_id': cls.compfinished1.id, 'product_qty': 1}),

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -277,7 +277,6 @@ class TestBoM(TestMrpCommon):
             'product_tmpl_id': self.product_9.product_tmpl_id.id,
             'uom_id': self.product_9.uom_id.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'normal'
         })
         test_bom_4 = self.env['mrp.bom'].create({
@@ -285,7 +284,6 @@ class TestBoM(TestMrpCommon):
             'product_tmpl_id': self.product_10.product_tmpl_id.id,
             'uom_id': self.product_10.uom_id.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'phantom'
         })
         test_bom_3.bom_line_ids = [Command.create({

--- a/addons/mrp/tests/test_cancel_mo.py
+++ b/addons/mrp/tests/test_cancel_mo.py
@@ -132,7 +132,7 @@ class TestMrpCancelMO(TestMrpCommon):
             'bom_id': self.bom_1.id,
         })
         mo.action_confirm()
-        mo.with_context(skip_consumption=True).button_mark_done()
+        mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
         with self.assertRaises(UserError):
             mo.action_cancel()

--- a/addons/mrp/tests/test_cancel_mo.py
+++ b/addons/mrp/tests/test_cancel_mo.py
@@ -53,7 +53,7 @@ class TestMrpCancelMO(TestMrpCommon):
         after post inventory.
         """
         # Create MO
-        manufacturing_order = self.generate_mo(consumption='strict')[0]
+        manufacturing_order = self.generate_mo()[0]
         # Produce some quantity (not all to avoid to done the MO when post inventory)
         mo_form = Form(manufacturing_order)
         mo_form.qty_producing = 2
@@ -132,7 +132,7 @@ class TestMrpCancelMO(TestMrpCommon):
             'bom_id': self.bom_1.id,
         })
         mo.action_confirm()
-        mo.button_mark_done()
+        mo.with_context(skip_consumption=True).button_mark_done()
         self.assertEqual(mo.state, 'done')
         with self.assertRaises(UserError):
             mo.action_cancel()

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -77,7 +77,6 @@ class TestConsumeComponentCommon(common.TransactionCase):
         cls.bom_none = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.produced_none.product_tmpl_id.id,
             'uom_id': cls.produced_none.uom_id.id,
-            'consumption': 'flexible',
             'sequence': 1
         })
 
@@ -86,7 +85,6 @@ class TestConsumeComponentCommon(common.TransactionCase):
         cls.bom_lot = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.produced_lot.product_tmpl_id.id,
             'uom_id': cls.produced_lot.uom_id.id,
-            'consumption': 'flexible',
             'sequence': 2
         })
 
@@ -95,7 +93,6 @@ class TestConsumeComponentCommon(common.TransactionCase):
         cls.bom_serial = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.produced_serial.product_tmpl_id.id,
             'uom_id': cls.produced_serial.uom_id.id,
-            'consumption': 'flexible',
             'sequence': 1
         })
 
@@ -414,7 +411,6 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         bom = self.env['mrp.bom'].create({
             'product_tmpl_id': sfg_product.product_tmpl_id.id,
             'uom_id': sfg_product.uom_id.id,
-            'consumption': 'flexible',
             'sequence': 1
         })
         self.create_bom_lines(bom, compo1, [1])

--- a/addons/mrp/tests/test_consumption_warning.py
+++ b/addons/mrp/tests/test_consumption_warning.py
@@ -1,0 +1,413 @@
+from odoo.fields import Command
+from odoo.tests import tagged, common, Form
+
+
+@tagged('at_install', '-post_install')  # LEGACY at_install
+class TestConsumptionWarning(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.group_ids += cls.env.ref('uom.group_uom')
+        cls.uom_ml = cls.env.ref('uom.product_uom_milliliter')
+        cls.uom_l = cls.env.ref('uom.product_uom_litre')
+        cls.uom_m3 = cls.env.ref('uom.product_uom_cubic_meter')
+        cls.uom_g = cls.env.ref('uom.product_uom_gram')
+        cls.uom_kg = cls.env.ref('uom.product_uom_kgm')
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.uom_6 = cls.env.ref('uom.product_uom_pack_6')
+        cls.uom_dozen = cls.env.ref('uom.product_uom_dozen')
+
+        cls.soup, cls.pack, cls.seasoning = cls.env['product.product'].create([
+            {'name': 'Soup', 'uom_id': cls.uom_l.id},
+            {'name': 'Pack of Instant Ramen', 'uom_id': cls.uom_unit.id},
+            {'name': 'Seasoning', 'uom_id': cls.uom_unit.id},
+        ])
+
+        cls.water, cls.noodles, cls.msg, cls.salt, cls.oil = cls.env['product.product'].create([
+            {'name': 'Hot Water', 'uom_id': cls.uom_l.id},
+            {'name': 'Dry Noodles', 'uom_id': cls.uom_g.id},
+            {'name': 'MSG', 'uom_id': cls.uom_g.id},
+            {'name': 'Salt', 'uom_id': cls.uom_g.id},
+            {'name': 'Oil', 'uom_id': cls.uom_ml.id},
+        ])
+
+        # Nested kit to test successful explosion
+        cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.seasoning.product_tmpl_id.id,
+            'uom_id': cls.uom_g.id,
+            'product_qty': 5,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': cls.msg.id, 'product_qty': 2}),
+                Command.create({'product_id': cls.salt.id, 'product_qty': 2}),
+                Command.create({'product_id': cls.oil.id, 'product_qty': 1}),
+            ],
+        })
+        cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.pack.product_tmpl_id.id,
+            'uom_id': cls.uom_dozen.id,
+            'product_qty': 2,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': cls.noodles.id,
+                    'uom_id': cls.uom_kg.id,
+                    'product_qty': 4.8,
+                }),
+                Command.create({
+                    'product_id': cls.seasoning.id,
+                    'uom_id': cls.uom_kg.id,
+                    'product_qty': 0.12,
+                }),
+            ],
+        })
+
+        # Normal child BoM we don't use, just to make sure it's ignored when checking for kits.
+        cls.oxygen, cls.hydrogen = cls.env['product.product'].create([
+            {'name': 'Oxygen', 'uom_id': cls.uom_g.id},
+            {'name': 'Hydrogen', 'uom_id': cls.uom_kg.id},
+        ])
+        cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.water.product_tmpl_id.id,
+            'uom_id': cls.uom_l.id,
+            'product_qty': 10,
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({'product_id': cls.oxygen.id, 'product_qty': 1116}),
+                Command.create({'product_id': cls.hydrogen.id, 'product_qty': 8855}),
+            ],
+        })
+
+        cls.soup_recipe = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.soup.product_tmpl_id.id,
+            'uom_id': cls.uom_m3.id,
+            'product_qty': 0.25,
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': cls.water.id,
+                    'uom_id': cls.uom_m3.id,
+                    'product_qty': 0.2,
+                }),
+                Command.create({
+                    'product_id': cls.pack.id,
+                    'uom_id': cls.uom_6.id,
+                    'product_qty': 150,
+                }),
+                Command.create({
+                    'product_id': cls.salt.id,
+                    'uom_id': cls.uom_kg.id,
+                    'product_qty': 5,
+                })
+            ],
+        })
+
+    def _make_mo(self, bom, qty, uom):
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = bom
+        mo_form.product_qty = qty
+        mo_form.uom_id = uom
+        return mo_form.save()
+
+    def test_consumption_warning_with_uom_and_kits(self):
+        """Check that the consumption warning wizard does not trigger on false positives."""
+        mo = self._make_mo(self.soup_recipe, 5, self.uom_m3)
+        mo.action_confirm()
+        result = mo.button_mark_done()
+        # Make sure there is no warning.
+        self.assertIs(result, True, "Base case failed. This wasn't supposed to trigger a warning.")
+
+        # Soup recipe (5 m³, serves 14 285 people)
+        ingredients = mo.move_raw_ids
+        for ingredient in ingredients:
+            if ingredient.product_id == self.msg:
+                # 2 g MSG in 5 g seasoning
+                # => 0,4 g MSG in 1 g seasoning
+                # 0,12 kg seasoning in 2 dozen-packs of ramen
+                # => 2 g MSG in 1 pack of ramen
+                # 150 six-packs of ramen in 0,25 m³ soup
+                # => 3600 packs of ramen in 1 m³ soup => 7200 g MSG in 1 m³ soup
+                # 5 m³ soup in our recipe
+                # => 36 000 g MSG in our recipe
+                self.assertEqual(ingredient.quantity, 36_000, "Consumed component quantity ended up wrong.")
+                ingredients -= ingredient
+            elif ingredient.product_id == self.salt:
+                # From seasoning
+                if ingredient.uom_id == self.uom_g:
+                    # 2 g salt in 5 g seasoning
+                    # => 0,4 g salt in 1 g seasoning
+                    # 0,12 kg seasoning in 2 dozen-packs of ramen
+                    # => 2 g salt in 1 pack of ramen
+                    # 150 six-packs of ramen in 0,25 m³ soup
+                    # => 3600 packs of ramen in 1 m³ soup => 7200 g salt in 1 m³ soup
+                    # 5 m³ soup in our recipe
+                    # => 36 000 g salt in our recipe
+                    self.assertEqual(ingredient.quantity, 36_000, "Consumed component quantity ended up wrong.")
+                    ingredients -= ingredient
+                # From recipe
+                elif ingredient.uom_id == self.uom_kg:
+                    # 5 kg salt in 0,25 m³ soup
+                    # => 20 kg salt in 1 m³ soup
+                    # 5 m³ soup in our recipe
+                    # => 100 kg salt in our recipe
+                    self.assertEqual(ingredient.quantity, 100, "Consumed component quantity ended up wrong.")
+                    ingredients -= ingredient
+            elif ingredient.product_id == self.noodles:
+                # 4,8 kg noodles in 2 dozen-packs of ramen
+                # => 0,2 kg noodles in 1 pack of ramen
+                # 150 six-packs of ramen in 0,25 m³ soup
+                # => 3600 packs of ramen in 1 m³ soup => 720 kg noodles in 1 m³ soup
+                # 5 m³ soup in our recipe
+                # => 3600 kg noodles in our recipe
+                self.assertEqual(ingredient.quantity, 3600, "Consumed component quantity ended up wrong.")
+                ingredients -= ingredient
+            elif ingredient.product_id == self.oil:
+                # 1 mL oil in 5 g seasoning
+                # => 0,2 mL oil in 1 g seasoning
+                # 0,12 kg seasoning in 2 dozen-packs of ramen
+                # => 1 mL oil in 1 pack of ramen
+                # 150 six-packs of ramen in 0,25 m³ soup
+                # => 3600 packs of ramen in 1 m³ soup => 3600 mL oil in 1 m³ soup
+                # 5 m³ soup in our recipe
+                # => 18 000 mL oil in our recipe
+                self.assertEqual(ingredient.quantity, 18_000, "Consumed component quantity ended up wrong.")
+                ingredients -= ingredient
+            elif ingredient.product_id == self.water:
+                # 0,2 m³ water in 0,25 m³ soup
+                # => 0,8 m³ water in 1 m³ soup
+                # 5 m³ soup in our recipe
+                # => 4 m³ water in our recipe
+                self.assertEqual(ingredient.quantity, 4, "Consumed component quantity ended up wrong.")
+                ingredients -= ingredient
+        self.assertFalse(ingredients, "There are components in the MO that were not accounted for.")
+
+    def test_consumption_warning_with_extra_and_missing_components(self):
+        """Check that the consumption wizard triggers on missing components and
+        recreates them according to the BoM, as well as detects components that
+        aren't a part of the BoM and zeroes their quantities if requested.
+        """
+        mo = self._make_mo(self.soup_recipe, 5, self.uom_m3)
+        mo.action_confirm()
+
+        self.env['stock.move'].create({
+            'product_id': self.oxygen.id,
+            'uom_id': self.uom_kg.id,
+            'product_uom_qty': 2500,
+            'raw_material_production_id': mo.id,
+        })
+        mo.move_raw_ids.filtered(lambda move: move.product_id in (self.msg, self.water)).unlink()
+
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
+            {
+                'product_id': self.oxygen.id,
+                'product_consumed_qty_uom': 2500,
+                'product_expected_qty_uom': 0,
+            },
+            {
+                'product_id': self.water.id,
+                'product_consumed_qty_uom': 0,
+                'product_expected_qty_uom': 4,
+            },
+            {
+                'product_id': self.msg.id,
+                'product_consumed_qty_uom': 0,
+                'product_expected_qty_uom': 36_000,
+            },
+        ])
+        warning.action_set_qty()
+
+        recreated_moves = mo.move_raw_ids.filtered(lambda move: move.product_id in (self.msg, self.water))
+        # The extra move should be kept as-is but no quantity should be consumed.
+        self.assertEqual(len(recreated_moves), 2, "The wizard didn't recreate the expected moves.")
+        for move in recreated_moves:
+            if move.product_id == self.water:
+                self.assertEqual(move.product_uom_qty, 4, "The quantity of the recreated move is wrong.")
+                self.assertEqual(move.uom_id, self.uom_m3, "The UoM of the recreated move is wrong.")
+            elif move.product_id == self.msg:
+                self.assertEqual(move.product_uom_qty, 36_000, "The quantity of the recreated move is wrong.")
+                self.assertEqual(move.uom_id, self.uom_g, "The UoM of the recreated move is wrong.")
+        self.assertEqual(mo.move_raw_ids.filtered(lambda move: move.product_id == self.oxygen).quantity,
+                         0, "A foreign component was consumed and the wizard failed to catch it.")
+
+        result = mo.button_mark_done()
+        # Make sure there's no warning again.
+        self.assertIs(result, True, "The moves the wizard recreated didn't conform to the BoM.")
+
+    def test_consumption_warning_with_flipped_uom_and_wrong_quantity(self):
+        """Check that the consumption wizard successfully detects and fixes
+        over-/underconsumed quantities whilst taking UoM conversions into
+        account."""
+        mo = self._make_mo(self.soup_recipe, 5, self.uom_m3)
+        mo.action_confirm()
+
+        for move in mo.move_raw_ids:
+            if move.product_id == self.water:
+                move.uom_id = self.uom_ml
+                move.product_uom_qty = 8_000_000
+            elif move.product_id == self.msg:
+                move.uom_id = self.uom_kg
+                move.product_uom_qty = 20
+
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
+            {
+                'product_id': self.water.id,
+                'product_consumed_qty_uom': 8_000_000,
+                'product_expected_qty_uom': 4_000_000,
+                'uom_id': self.uom_ml.id,
+            },
+            {
+                'product_id': self.msg.id,
+                'product_consumed_qty_uom': 20,
+                'product_expected_qty_uom': 36,
+                'uom_id': self.uom_kg.id,
+            },
+        ])
+        warning.action_set_qty()
+
+        result = mo.button_mark_done()
+        # Make sure there's no warning again.
+        self.assertIs(result, True, "The quantities the wizard readjusted didn't conform to the BoM.")
+
+        for move in mo.move_raw_ids:
+            if move.product_id == self.water:
+                self.assertEqual(move.uom_id, self.uom_ml, "The wizard reverted the component UoM.")
+                self.assertEqual(move.quantity, 4_000_000, "The wizard failed to correct the consumed quantity.")
+            elif move.product_id == self.msg:
+                self.assertEqual(move.uom_id, self.uom_kg, "The wizard reverted the component UoM.")
+                self.assertEqual(move.quantity, 36, "The wizard failed to correct the consumed quantity.")
+
+    def test_consumption_warning_with_readded_component(self):
+        """Check that the consumption warning wizard can match readded
+        components with BoM lines that are missing move counterparts."""
+        mo = self._make_mo(self.soup_recipe, 5, self.uom_m3)
+        mo.action_confirm()
+
+        mo.move_raw_ids.filtered(lambda move: move.product_id in (self.water, self.msg)).unlink()
+        self.env['stock.move'].create([
+            # Correct product and quantity, but incorrect UoM. This will be considered foreign, given 0 quantity,
+            # and a new move will be created to take its place.
+            {
+                'product_id': self.water.id,
+                'uom_id': self.uom_l.id,
+                'product_uom_qty': 4000,
+                'raw_material_production_id': mo.id,
+            },
+            # Correct product and UoM, but incorrect quantity. The wizard will correct the quantity for us.
+            {
+                'product_id': self.msg.id,
+                'uom_id': self.uom_g.id,
+                'product_uom_qty': 24_000,
+                'raw_material_production_id': mo.id,
+            },
+        ])
+
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
+            # Considered foreign.
+            {
+                'product_id': self.water.id,
+                'product_consumed_qty_uom': 4000,
+                'product_expected_qty_uom': 0,
+                'uom_id': self.uom_l.id,
+            },
+            # Recognised as belonging to the BoM, just with the wrong quantity.
+            {
+                'product_id': self.msg.id,
+                'product_consumed_qty_uom': 24_000,
+                'product_expected_qty_uom': 36_000,
+                'uom_id': self.uom_g.id,
+            },
+            # Still missing.
+            {
+                'product_id': self.water.id,
+                'product_consumed_qty_uom': 0,
+                'product_expected_qty_uom': 4,
+                'uom_id': self.uom_m3.id,
+            },
+        ])
+        warning.action_set_qty()
+
+        result = mo.button_mark_done()
+        # Make sure there's no warning again.
+        self.assertIs(result, True, "The wizard failed to make the components conform to the BoM.")
+
+        self.assertEqual(len(mo.move_raw_ids.filtered(lambda move: move.product_id == self.water)), 2,
+                         "The final result must contain the (empty) component with the wrong BoM "
+                         "and the component with the correct BoM & quantity created by the wizard.")
+        for move in mo.move_raw_ids:
+            if move.product_id == self.water:
+                if move.uom_id == self.uom_l:
+                    self.assertEqual(move.quantity, 0,
+                                     "We consumed the foreign component with the wrong UoM.")
+                else:
+                    self.assertEqual(move.uom_id, self.uom_m3,
+                                     "Somehow, the move the wizard added back ended up with a completely unrelated UoM.")
+                    self.assertEqual(move.quantity, 4,
+                                     "The move was readded with the wrong quantity.")
+            elif move.product_id == self.msg:
+                self.assertEqual(move.uom_id, self.uom_g,
+                                 "Somehow, the move we added back ended up with a completely unrelated UoM.")
+                self.assertEqual(move.quantity, 36_000,
+                                 "The move was readded with the wrong quantity.")
+            else:
+                self.assertIn(move.product_id, (self.noodles, self.oil, self.salt),
+                              "Foreign component in the MO.")
+
+    def test_consumption_warning_no_bom(self):
+        """Check that the consumption warning wizard will work even without
+        a BoM, using the 'To Consume' quantity as the goal."""
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.soup
+        mo_form.product_qty = 1
+        mo_form.uom_id = self.uom_l
+
+        # Reset the BoM and add custom components
+        mo_form.bom_id = self.env['mrp.bom']
+        with mo_form.move_raw_ids.new() as move:
+            move.product_id = self.noodles
+            move.uom_id = self.uom_kg
+            move.product_uom_qty = 0.25
+            move.quantity = 0.2
+        with mo_form.move_raw_ids.new() as move:
+            move.product_id = self.water
+            move.uom_id = self.uom_l
+            move.product_uom_qty = 1.2
+            move.quantity = 0.8
+        with mo_form.move_raw_ids.new() as move:
+            move.product_id = self.salt
+            move.uom_id = self.uom_g
+            move.product_uom_qty = 5
+
+        mo = mo_form.save()
+        mo.action_confirm()
+
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
+            {
+                'product_id': self.noodles.id,
+                'uom_id': self.uom_kg.id,
+                'product_consumed_qty_uom': 0.2,
+                'product_expected_qty_uom': 0.25,
+            },
+            {
+                'product_id': self.water.id,
+                'uom_id': self.uom_l.id,
+                'product_consumed_qty_uom': 0.8,
+                'product_expected_qty_uom': 1.2,
+            },
+        ])
+        warning.action_set_qty()
+
+        result = mo.button_mark_done()
+        # Make sure there's no warning again.
+        self.assertIs(result, True, "The wizard failed to make the components conform to the BoM.")
+
+        for move in mo.move_raw_ids:
+            if move.product_id == self.noodles:
+                self.assertEqual(move.quantity, 0.25, "Wrong quantity of the component was consumed.")
+            elif move.product_id == self.water:
+                self.assertEqual(move.quantity, 1.2, "Wrong quantity of the component was consumed.")
+            else:
+                self.assertEqual(move.product_id, self.salt, "Foreign component in the MO.")

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -72,7 +72,6 @@ class TestManualConsumption(TestMrpCommon):
         - Mark the MO as done.
         - Another move should be created and merged with the first move.
         """
-        self.bom_4.consumption = 'warning'
         component = self.bom_4.bom_line_ids.product_id
         component.write({
             'is_storable': True,

--- a/addons/mrp/tests/test_performance.py
+++ b/addons/mrp/tests/test_performance.py
@@ -46,7 +46,6 @@ class TestMrpSerialMassProducePerformance(common.TransactionCase):
             'uom_id': finished.uom_id.id,
             'product_qty': 1.0,
             'type': 'normal',
-            'consumption': 'flexible',
             'bom_line_ids': [(0, 0, {'product_id': p[0]['id'], 'product_qty': 1}) for p in raw_materials]
         })
 

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -95,7 +95,7 @@ class TestProcurement(TestMrpCommon):
         mo_form.qty_producing = production_product_6.product_qty
         production_product_6 = mo_form.save()
         # Check procurement and Production state for product 6.
-        production_product_6.button_mark_done()
+        production_product_6.with_context(skip_consumption=True).button_mark_done()
         self.assertEqual(production_product_6.state, 'done', 'Production order should be in state done')
         self.assertEqual(self.product_6.qty_available, 24, 'Wrong quantity available of finished product.')
 
@@ -426,7 +426,6 @@ class TestProcurement(TestMrpCommon):
             'product_tmpl_id': product_1.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
                 Command.create({'product_id': product_2.id, 'product_qty': 1}),
@@ -551,7 +550,7 @@ class TestProcurement(TestMrpCommon):
         mo.move_raw_ids.quantity = 15
         mo_form.qty_producing = 15
         mo = mo_form.save()
-        mo.button_mark_done()
+        mo.with_context(skip_consumption=True).button_mark_done()
 
         self.assertEqual(pick_output.move_ids.quantity, 10, "Completed products should have been auto-reserved in picking")
 
@@ -614,7 +613,6 @@ class TestProcurement(TestMrpCommon):
             'product_tmpl_id': product.product_tmpl_id.id,
             'uom_id': product.uom_id.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
                 Command.create({'product_id': component.id, 'product_qty': 1}),
@@ -701,7 +699,6 @@ class TestProcurement(TestMrpCommon):
             'product_tmpl_id': product_1.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [Command.create({'product_id': product_2.id, 'product_qty': 1})]
         })
@@ -711,7 +708,6 @@ class TestProcurement(TestMrpCommon):
             'product_tmpl_id': product_2.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [Command.create({'product_id': product_3.id, 'product_qty': 1})]
         })
@@ -721,7 +717,6 @@ class TestProcurement(TestMrpCommon):
             'product_tmpl_id': product_3.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [Command.create({'product_id': product_4.id, 'product_qty': 1})]
         })
@@ -878,7 +873,6 @@ class TestProcurement(TestMrpCommon):
             'uom_id': self.uom_unit.id,
             'product_qty': 1.0,
             'type': 'normal',
-            'consumption': 'flexible',
             'bom_line_ids': [
                 Command.create({'product_id': comp1.id, 'product_qty': 1}),
                 Command.create({'product_id': comp2.id, 'product_qty': 2}),

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -95,7 +95,7 @@ class TestProcurement(TestMrpCommon):
         mo_form.qty_producing = production_product_6.product_qty
         production_product_6 = mo_form.save()
         # Check procurement and Production state for product 6.
-        production_product_6.with_context(skip_consumption=True).button_mark_done()
+        production_product_6.button_mark_done()
         self.assertEqual(production_product_6.state, 'done', 'Production order should be in state done')
         self.assertEqual(self.product_6.qty_available, 24, 'Wrong quantity available of finished product.')
 
@@ -550,7 +550,11 @@ class TestProcurement(TestMrpCommon):
         mo.move_raw_ids.quantity = 15
         mo_form.qty_producing = 15
         mo = mo_form.save()
-        mo.with_context(skip_consumption=True).button_mark_done()
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
+            {'product_consumed_qty_uom': 1, 'product_expected_qty_uom': 0},
+        ])
+        warning.action_confirm()
 
         self.assertEqual(pick_output.move_ids.quantity, 10, "Completed products should have been auto-reserved in picking")
 

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -46,7 +46,6 @@ class TestWarehouseMrp(common.TestMrpCommon):
             'product_tmpl_id': cls.laptop.product_tmpl_id.id,
             'product_qty': 1,
             'uom_id': cls.uom_unit.id,
-            'consumption': 'flexible',
             'bom_line_ids': [Command.create({
                 'product_id': cls.graphics_card.id,
                 'product_qty': 1,

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -172,7 +172,6 @@ class TestTraceability(TestMrpCommon):
             'product_tmpl_id': product_final.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
                 Command.create({'product_id': product_1.id, 'product_qty': 1}),

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -986,7 +986,12 @@ class TestUnbuild(TestMrpCommon):
 
         mo.qty_producing = 1.0
         mo.move_raw_ids.write({'quantity': 15, 'picked': True})
-        mo.with_context(skip_consumption=True).button_mark_done()
+
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
+            {'product_consumed_qty_uom': 15, 'product_expected_qty_uom': 20},
+        ])
+        warning.action_confirm()
 
         Form.from_action(self.env, mo.button_unbuild()).save().action_validate()
         self.assertEqual(mo.unbuild_ids.produce_line_ids.filtered(lambda m: m.product_id == self.product_3).product_uom_qty, 15)
@@ -1102,7 +1107,7 @@ class TestUnbuild(TestMrpCommon):
         mo_form.qty_producing = 4.0
         mo_form.save()
 
-        mo.with_context(skip_consumption=True).button_mark_done()
+        mo.button_mark_done()
 
         unbuild_wizard = Form(self.env['mrp.unbuild'])
         unbuild_wizard.mo_id = mo

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -970,7 +970,6 @@ class TestUnbuild(TestMrpCommon):
         bom = self.env['mrp.bom'].create({
             'product_id': self.product_2.id,
             'product_tmpl_id': self.product_2.product_tmpl_id.id,
-            'consumption': 'flexible',
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [
@@ -987,7 +986,7 @@ class TestUnbuild(TestMrpCommon):
 
         mo.qty_producing = 1.0
         mo.move_raw_ids.write({'quantity': 15, 'picked': True})
-        mo.button_mark_done()
+        mo.with_context(skip_consumption=True).button_mark_done()
 
         Form.from_action(self.env, mo.button_unbuild()).save().action_validate()
         self.assertEqual(mo.unbuild_ids.produce_line_ids.filtered(lambda m: m.product_id == self.product_3).product_uom_qty, 15)
@@ -998,7 +997,6 @@ class TestUnbuild(TestMrpCommon):
         bom = self.env['mrp.bom'].create({
             'product_id': self.product_2.id,
             'product_tmpl_id': self.product_2.product_tmpl_id.id,
-            'consumption': 'flexible',
             'product_qty': 1.0,
             'type': 'normal',
             'bom_line_ids': [Command.create({'product_id': self.product_3.id, 'product_qty': 1})]
@@ -1104,7 +1102,7 @@ class TestUnbuild(TestMrpCommon):
         mo_form.qty_producing = 4.0
         mo_form.save()
 
-        mo.button_mark_done()
+        mo.with_context(skip_consumption=True).button_mark_done()
 
         unbuild_wizard = Form(self.env['mrp.unbuild'])
         unbuild_wizard.mo_id = mo

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -312,14 +312,10 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         """
         with Form(self.warehouse_1) as warehouse:
             warehouse.manufacture_steps = 'pbm_sam'
-        bom = self.env['mrp.bom'].search([
-            ('product_id', '=', self.finished_product.id)
-        ])
         new_product = self.env['product.product'].create({
             'name': 'New product',
             'is_storable': True,
         })
-        bom.consumption = 'flexible'
         production_form = Form(self.env['mrp.production'])
         production_form.product_id = self.finished_product
         production_form.picking_type_id = self.picking_type_manu
@@ -512,7 +508,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         mo_form.qty_producing = 20
         mo = mo_form.save()
 
-        action = mo.button_mark_done()
+        action = mo.with_context(skip_consumption=True).button_mark_done()
         backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
         backorder.save().action_backorder()
 

--- a/addons/mrp/tests/test_workcenter.py
+++ b/addons/mrp/tests/test_workcenter.py
@@ -17,7 +17,6 @@ class TestWorkcenterOverview(common.TestMrpCommon):
             'product_tmpl_id': self.product_2.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'operation_ids': [
                 Command.create({
                     'name': 'Make it look you are working',

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -170,11 +170,6 @@
                         <page string="Miscellaneous" name="miscellaneous">
                             <group>
                                 <group>
-                                    <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
-                                    <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
-                                    <field name="note" />
-                                </group>
-                                <group>
                                     <field name="picking_type_id" invisible="type == 'phantom'" groups="stock.group_adv_location"/>
                                     <label for="produce_delay" string="Manuf. Lead Time"/>
                                     <div>
@@ -193,6 +188,11 @@
                                         <field name="batch_size" class="w-50" invisible="not enable_batch_size" decoration-danger="batch_size &lt;= 0.0"/>
                                         <field name="uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size"/>
                                     </div>
+                                </group>
+                                <group>
+                                    <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
+                                    <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
+                                    <field name="note"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -171,7 +171,6 @@
                             <group>
                                 <group>
                                     <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
-                                    <field name="consumption" invisible="type == 'phantom'" widget="radio"/>
                                     <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
                                     <field name="note" />
                                 </group>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -215,7 +215,6 @@
                     <field name="qty_produced" invisible="1"/>
                     <field name="unreserve_visible" invisible="1"/>
                     <field name="reserve_visible" invisible="1"/>
-                    <field name="consumption" invisible="1"/>
                     <field name="is_planned" invisible="1"/>
                     <field name="show_allocation" invisible="1"/>
                     <field name="workorder_ids" invisible="1"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -60,7 +60,6 @@
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
             <list multi_edit="1">
-                <field name="consumption" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="is_produced" column_invisible="True"/>
                 <field name="is_user_working" column_invisible="True"/>

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -12,22 +12,12 @@ class MrpConsumptionWarning(models.TransientModel):
     mrp_production_ids = fields.Many2many('mrp.production')
     mrp_production_count = fields.Integer(compute="_compute_mrp_production_count")
 
-    consumption = fields.Selection([
-        ('flexible', 'Allowed'),
-        ('warning', 'Allowed with warning'),
-        ('strict', 'Blocked')], compute="_compute_consumption")
     mrp_consumption_warning_line_ids = fields.One2many('mrp.consumption.warning.line', 'mrp_consumption_warning_id')
 
     @api.depends("mrp_production_ids")
     def _compute_mrp_production_count(self):
         for wizard in self:
             wizard.mrp_production_count = len(wizard.mrp_production_ids)
-
-    @api.depends("mrp_consumption_warning_line_ids.consumption")
-    def _compute_consumption(self):
-        for wizard in self:
-            consumption_map = set(wizard.mrp_consumption_warning_line_ids.mapped("consumption"))
-            wizard.consumption = "strict" in consumption_map and "strict" or "warning" in consumption_map and "warning" or "flexible"
 
     def action_confirm(self):
         ctx = dict(self.env.context)
@@ -92,7 +82,6 @@ class MrpConsumptionWarningLine(models.TransientModel):
 
     mrp_consumption_warning_id = fields.Many2one('mrp.consumption.warning', "Parent Wizard", readonly=True, required=True, ondelete="cascade")
     mrp_production_id = fields.Many2one('mrp.production', "Manufacturing Order", readonly=True, required=True, ondelete="cascade")
-    consumption = fields.Selection(related="mrp_production_id.consumption")
 
     product_id = fields.Many2one('product.product', "Product", readonly=True, required=True)
     uom_id = fields.Many2one('uom.uom', "Unit", related="product_id.uom_id", readonly=True)

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models, api
-from odoo.exceptions import UserError
+from odoo import fields, models, api
 
 
 class MrpConsumptionWarning(models.TransientModel):
     _name = 'mrp.consumption.warning'
-    _description = "Wizard in case of consumption in warning/strict and more component has been used for a MO (related to the bom)"
+    _description = "Wizard for warning about mismatching expected vs actual component consumption quantities for MOs"
 
     mrp_production_ids = fields.Many2many('mrp.production')
     mrp_production_count = fields.Integer(compute="_compute_mrp_production_count")
@@ -25,44 +24,22 @@ class MrpConsumptionWarning(models.TransientModel):
         return self.mrp_production_ids.with_context(ctx, skip_consumption=True).button_mark_done()
 
     def action_set_qty(self):
-        missing_move_vals = []
-        problem_tracked_products = self.env['product.product']
+        existing_moves_lines = self.mrp_consumption_warning_line_ids.filtered('move_id')
         for production in self.mrp_production_ids:
-            for line in self.mrp_consumption_warning_line_ids:
+            for line in existing_moves_lines:
                 if line.mrp_production_id != production:
                     continue
-                for move in production.move_raw_ids:
-                    if line.product_id != move.product_id:
-                        continue
-                    qty_expected = line.uom_id._compute_quantity(line.product_expected_qty_uom, move.uom_id)
-                    qty_compare_result = move.uom_id.compare(qty_expected, move.quantity)
-                    if qty_compare_result != 0:
-                        move.quantity = qty_expected
-                    # move should be set to picked to correctly consume the product
-                    move.picked = True
-                    # in case multiple lines with same product => set others to 0 since we have no way to know how to distribute the qty done
-                    line.product_expected_qty_uom = 0
-                # move was deleted before confirming MO or force deleted somehow
-                if not line.uom_id.is_zero(line.product_expected_qty_uom):
-                    missing_move_vals.append({
-                        'product_id': line.product_id.id,
-                        'uom_id': line.uom_id.id,
-                        'product_uom_qty': line.product_expected_qty_uom,
-                        'quantity': line.product_expected_qty_uom,
-                        'raw_material_production_id': line.mrp_production_id.id,
-                        'additional': True,
-                        'picked': True,
-                    })
-        if problem_tracked_products:
-            products_list = "".join(f"\n- {product_name}" for product_name in problem_tracked_products.mapped("name"))
-            raise UserError(
-                _(
-                    "Values cannot be set and validated because a Lot/Serial Number needs to be specified for a tracked product that is having its consumed amount increased:%(products)s",
-                    products=products_list,
-                ),
-            )
-        if missing_move_vals:
-            self.env['stock.move'].create(missing_move_vals)
+                line.move_id.quantity = line.product_expected_qty_uom
+                line.move_id.picked = True
+        self.env['stock.move'].create([{
+            'product_id': line.product_id.id,
+            'uom_id': (line.uom_id or line.product_id.uom_id).id,
+            'product_uom_qty': line.product_expected_qty_uom,
+            'quantity': line.product_expected_qty_uom,
+            'raw_material_production_id': line.mrp_production_id.id,
+            'additional': True,
+            'picked': True,
+        } for line in self.mrp_consumption_warning_line_ids - existing_moves_lines])
         return self.action_confirm()
 
     def action_cancel(self):
@@ -84,6 +61,7 @@ class MrpConsumptionWarningLine(models.TransientModel):
     mrp_production_id = fields.Many2one('mrp.production', "Manufacturing Order", readonly=True, required=True, ondelete="cascade")
 
     product_id = fields.Many2one('product.product', "Product", readonly=True, required=True)
-    uom_id = fields.Many2one('uom.uom', "Unit", related="product_id.uom_id", readonly=True)
+    uom_id = fields.Many2one('uom.uom', "Unit", readonly=True)
     product_consumed_qty_uom = fields.Float("Consumed", readonly=True)
     product_expected_qty_uom = fields.Float("To Consume", readonly=True)
+    move_id = fields.Many2one('stock.move', readonly=True)

--- a/addons/mrp/wizard/mrp_consumption_warning_views.xml
+++ b/addons/mrp/wizard/mrp_consumption_warning_views.xml
@@ -9,14 +9,10 @@
             <field name="arch" type="xml">
                 <form string="Consumption Warning">
                     <field name="mrp_production_ids" invisible="1"/>
-                    <field name="consumption" invisible="1"/>
                     <field name="mrp_production_count" invisible="1"/>
                     <div class="m-2">
                         You consumed a different quantity than expected for the following products.
-                        <b invisible="consumption == 'strict'">
-                            Please confirm it has been done on purpose.
-                        </b>
-                        <b invisible="consumption != 'strict'">
+                        <b>
                             Please review your component consumption or ask a manager to validate
                             <span invisible="mrp_production_count != 1">this manufacturing order</span>
                             <span invisible="mrp_production_count == 1">these manufacturing orders</span>.
@@ -25,7 +21,6 @@
                     <field name="mrp_consumption_warning_line_ids" nolabel="1">
                         <list create="0" delete="0" editable="top">
                             <field name="mrp_production_id" column_invisible="parent.mrp_production_count == 1" force_save="1"/>
-                            <field name="consumption" column_invisible="True" force_save="1"/>
                             <field name="product_id" force_save="1"/>
                             <field name="uom_id" groups="uom.group_uom" force_save="1" widget="many2one_uom"/>
                             <field name="product_expected_qty_uom" force_save="1"/>
@@ -33,10 +28,7 @@
                         </list>
                     </field>
                     <footer>
-                        <button name="action_confirm" string="Force" data-hotkey="q"
-                            groups="mrp.group_mrp_manager" invisible="consumption != 'strict'"
-                            colspan="1" type="object" class="btn-primary"/>
-                        <button name="action_confirm" string="Confirm" invisible="consumption == 'strict'" data-hotkey="q"
+                        <button name="action_confirm" string="Confirm" data-hotkey="q"
                             colspan="1" type="object" class="btn-primary" barcode_trigger="NEXT"/>
                         <button name="action_set_qty" string="Set Quantities &amp; Validate" colspan="1" type="object" class="btn-secondary" invisible="'is_subcontracting_portal' in context"/>
                         <button name="action_cancel" string="Discard" data-hotkey="x"

--- a/addons/mrp/wizard/mrp_consumption_warning_views.xml
+++ b/addons/mrp/wizard/mrp_consumption_warning_views.xml
@@ -11,17 +11,15 @@
                     <field name="mrp_production_ids" invisible="1"/>
                     <field name="mrp_production_count" invisible="1"/>
                     <div class="m-2">
-                        You consumed a different quantity than expected for the following products.
-                        <b>
-                            Please review your component consumption or ask a manager to validate
-                            <span invisible="mrp_production_count != 1">this manufacturing order</span>
-                            <span invisible="mrp_production_count == 1">these manufacturing orders</span>.
-                        </b>
+                        You consumed a different quantity than expected for the following products
+                        and/or consumed a product that is not included in the bill of materials.
+                        Please confirm it has been done on purpose.
                     </div>
                     <field name="mrp_consumption_warning_line_ids" nolabel="1">
                         <list create="0" delete="0" editable="top">
                             <field name="mrp_production_id" column_invisible="parent.mrp_production_count == 1" force_save="1"/>
                             <field name="product_id" force_save="1"/>
+                            <field name="move_id" force_save="1" column_invisible="1"/>
                             <field name="uom_id" groups="uom.group_uom" force_save="1" widget="many2one_uom"/>
                             <field name="product_expected_qty_uom" force_save="1"/>
                             <field name="product_consumed_qty_uom" force_save="1"/>

--- a/addons/mrp_account/tests/test_valuation_layers.py
+++ b/addons/mrp_account/tests/test_valuation_layers.py
@@ -139,7 +139,10 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self.assertEqual(self.glass.total_value, 20)
         self.assertEqual(self.dining_table.total_value, 8.8)
         self._produce(mo)
-        mo.button_mark_done()
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        for warning_line in warning.mrp_consumption_warning_line_ids:
+            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
+        warning.action_confirm()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 8.8 * 2)
 
@@ -170,7 +173,10 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self.assertEqual(self.glass.total_value, 100)
         self.assertEqual(self.dining_table.total_value, PRICE + 100)
         self._produce(mo)
-        mo.button_mark_done()
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        for warning_line in warning.mrp_consumption_warning_line_ids:
+            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
+        warning.action_confirm()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 2 * (PRICE + 100))
 
@@ -212,7 +218,10 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self.assertEqual(self.glass.total_value, 100)
         self.assertEqual(self.dining_table.total_value, 1000)
         self._produce(mo)
-        mo.button_mark_done()
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        for warning_line in warning.mrp_consumption_warning_line_ids:
+            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
+        warning.action_confirm()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 2000)
 
@@ -242,7 +251,10 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self.assertEqual(self.glass.total_value, 15)
         self.assertEqual(self.dining_table.total_value, PRICE + 15)
         self._produce(mo)
-        mo.button_mark_done()
+        warning = Form.from_action(self.env, mo.button_mark_done()).save()
+        for warning_line in warning.mrp_consumption_warning_line_ids:
+            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
+        warning.action_confirm()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 2 * PRICE + 30)
 

--- a/addons/mrp_product_expiry/tests/test_mrp_product_expiry.py
+++ b/addons/mrp_product_expiry/tests/test_mrp_product_expiry.py
@@ -48,7 +48,6 @@ class TestStockLot(TestStockCommon):
             'product_tmpl_id': cls.product_apple_pie.product_tmpl_id.id,
             'uom_id': cls.uom_unit.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
                 (0, 0, {'product_id': cls.product_apple.id, 'product_qty': 3}),

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -525,8 +525,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         self.assertEqual(len(mo), 1)
 
     def test_flow_flexible_bom_1(self):
-        """ Record Component for a bom subcontracted with a flexible and flexible + warning consumption """
-        self.bom.consumption = 'flexible'
+        """ Record component for a subcontracted BoM. """
         # Create a receipt picking from the subcontractor
         picking_form = Form(self.env['stock.picking'])
         picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
@@ -720,7 +719,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         """ Tests to set a quantity done directly on a subcontracted move without using the subcontracting wizard.
             Checks that it does the same as it would do with the wizard.
         """
-        self.bom.consumption = 'flexible'
         quantities = [10, 15, 12, 14]
 
         with Form(self.env['stock.picking']) as picking_form:
@@ -748,7 +746,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
     def test_change_reception_serial(self):
         self.env.ref('base.group_user').write({'implied_ids': [(4, self.env.ref('stock.group_production_lot').id)]})
         self.finished.tracking = 'serial'
-        self.bom.consumption = 'flexible'
 
         finished_lots = self.env['stock.lot'].create([{
             'name': 'lot_%s' % number,
@@ -798,7 +795,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         self.assertEqual(len(subcontracted_mo.filtered(lambda p: p.lot_producing_ids != new_lot)), 2)
 
     def test_decrease_quantity_done(self):
-        self.bom.consumption = 'flexible'
         supplier_location = self.env.ref('stock.stock_location_suppliers')
         uom_duo = self.env['uom.uom'].create({
             'name': 'Duos',
@@ -894,7 +890,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
 
     def test_validate_partial_subcontracting_without_backorder(self):
         """ Test the validation of a partial subcontracting without creating a backorder."""
-        self.bom.consumption = 'flexible'
         supplier_location = self.env.ref('stock.stock_location_suppliers')
         receipt = self.env['stock.picking'].create({
             'partner_id': self.subcontractor_partner1.id,
@@ -1466,7 +1461,6 @@ class TestSubcontractingSerialMassReceipt(TransactionCase):
             'product_qty': 1.0,
             'type': 'subcontract',
             'subcontractor_ids': [Command.link(self.subcontractor.id)],
-            'consumption': 'strict',
             'bom_line_ids': [
                 Command.create({'product_id': self.raw_material.id, 'product_qty': 1}),
             ]

--- a/addons/mrp_subcontracting/views/mrp_bom_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_bom_views.xml
@@ -8,9 +8,6 @@
             <xpath expr="//field[@name='type']" position="after">
                 <field name="subcontractor_ids" widget="many2many_tags" invisible="type != 'subcontract'" required="type == 'subcontract'"/>
             </xpath>
-            <xpath expr="//field[@name='consumption']" position="attributes">
-                <attribute name="invisible">type == 'phantom' or type == 'subcontract'</attribute>
-            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -305,7 +305,6 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             'product_id': final_product.id,
             'product_tmpl_id': final_product.product_tmpl_id.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'phantom',
             'bom_line_ids': [
                 (0, 0, {'product_id': product_a.id, 'product_qty': 1}),

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -514,7 +514,6 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             'product_tmpl_id': finished.product_tmpl_id.id,
             'uom_id': self.uom_unit.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'operation_ids': [
             ],
             'type': 'normal',

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -58,7 +58,6 @@ class TestSaleMrpKitBom(BaseCommon):
             'product_id': product_variant_ids[0].id,
             'product_tmpl_id': product_variant_ids[0].product_tmpl_id.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'phantom',
             'bom_line_ids': [(0, 0, {'product_id': component_1.id, 'product_qty': 1})]
         })
@@ -67,7 +66,6 @@ class TestSaleMrpKitBom(BaseCommon):
             'product_id': product_variant_ids[1].id,
             'product_tmpl_id': product_variant_ids[1].product_tmpl_id.id,
             'product_qty': 1.0,
-            'consumption': 'flexible',
             'type': 'phantom',
             'bom_line_ids': [(0, 0, {'product_id': component_2.id, 'product_qty': 1})]
         })
@@ -707,7 +705,6 @@ class TestSaleMrpKitBom(BaseCommon):
             'product_id': kit_product.id,
             'product_tmpl_id': kit_product.product_tmpl_id.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'phantom',
             'bom_line_ids': [(0, 0, {'product_id': component_a.id, 'product_qty': 1})]
         })
@@ -820,7 +817,6 @@ class TestSaleMrpKitBom(BaseCommon):
             'product_id': kit_product.id,
             'product_tmpl_id': kit_product.product_tmpl_id.id,
             'product_qty': 1,
-            'consumption': 'flexible',
             'type': 'phantom',
             'bom_line_ids': [(0, 0, {'product_id': component_product.id, 'product_qty': 1})]
         })


### PR DESCRIPTION
### redo of odoo/odoo#211184

(Spec change from the previous PR: `consumption` field is to be removed altogether, not just delegated to a technical field. `mrp.consumption.warning.line` model is being kept as well.)

---

Here we remove the `consumption` field that determines whether the over-/underconsumption warning wizard kicks in when an MO consumes more or less than the quantity determined by the BoM. The previous options were 'strict' (never allow), 'warning' (allow with a warning) and 'flexible' (silently allow). 'warning' is the new default behaviour.

'flexible' was the value consistently used for this field in tests because we seldom actually want to test the wizard itself, and prefer to focus on the relevant part of the flow instead. The following table explains how we deal with the tests under the new default behaviour.

|                     | flexible                                                                                                 | warning                                       | strict                                                                                                               |
|---------------------|----------------------------------------------------------------------------------------------------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
| expected problems   | We produce with `skip_consumption=True` and test a flow where the user bypasses the test for simplicity. | The test takes the wizard into account.       | Not applicable. Tests checking for strict behaviour were removed. |
| no problems         | No change. Tests checking for flexible behaviour were removed.                                           | No change.                                    | No change.                                                                                                           |
| unexpected problems | The unexpected wizard will break the test if something goes wrong.                                       | The wizard will misbehave and break the test. | The unexpected wizard will break the test if something goes wrong.                                                   |

Secondly, we adapt the wizard to work with MOs that lack BoMs, ~~which is going to break even more tests~~. The new behaviour is as follows:

* A component is missing: It will be reported as missing (consumed quantity: 0).
* A component is too high or too low in quantity: It will be reported as mismatching.
* A component that wasn't in the BoM is added: It will be reported as foreign (expected quantity: 0).
* A component is removed but readded verbatim: It will **not** be reported (despite the fact that the move has no associated BoM line) if the move's product id and unit of measure (if enabled) match the orphaned BoM line.
* A component is removed and readded in a different way (different UoM, split into multiple moves etc): It will be reported as missing (consumed quantity: 0) and the readded moves will be considered foreign (expected quantity: 0). We don't add up moves of the same product even if they have the same UoM, and treat them all distinctly.
* There is no BoM: The expected quantity of the move will be used as reference to compare against instead.

**TODO:** ~~Handle kit logic.~~ Handled.

Task ID: [4441090](https://www.odoo.com/odoo/action-4043/4441090), [4603609](https://www.odoo.com/odoo/action-4043/4603609)


---

~~From now on, instead of marking BoMs as `consumption='flexible'` in tests, we're going to call `button_mark_done()` on the MO with the context parameter `skip_consumption=True` if we're sure it's going to trigger the wizard and we don't care to test the wizard in this use-case. In cases where the whole test class is expected to violate consumption expectations, the parameter can be embedded in the environment like `self.env = self.env(context=dict(self.env.context, skip_consumption=True))` (in which case you need to do `with_context(skip_consumption=False).button_mark_done()` to test the wizard in each test), but it's better to explicitly mark each test instead, so the wizard can function as a sanity check for cases where consumption is expected to be regular.~~

Never mind, we're going to manually handle the wizard in every test that triggers the wizard.