### PR TITLE
[IMP] core: Fully comply PDF/A-3A on all supported pypdf versions

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -328,7 +328,7 @@
                 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
                     <rdf:Description xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/" rdf:about="">
                         <pdfaid:part>3</pdfaid:part>
-                        <pdfaid:conformance>B</pdfaid:conformance>
+                        <pdfaid:conformance>A</pdfaid:conformance>
                     </rdf:Description>
                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
                         <dc:title>

--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -208,6 +208,8 @@ class AccountMoveSend(models.TransientModel):
                     'date': fields.Date.context_today(self),
                 },
             )
+            if "<pdfaid:conformance>B</pdfaid:conformance>" in content:
+                content.replace("<pdfaid:conformance>B</pdfaid:conformance>", "<pdfaid:conformance>A</pdfaid:conformance>")
             writer.add_file_metadata(content.encode())
 
         # Replace the current content.

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -516,4 +516,6 @@ class AccountEdiFormat(models.Model):
                     'date': fields.Date.context_today(self),
                 },
             )
+            if "<pdfaid:conformance>B</pdfaid:conformance>" in content:
+                content.replace("<pdfaid:conformance>B</pdfaid:conformance>", "<pdfaid:conformance>A</pdfaid:conformance>")
             pdf_writer.add_file_metadata(content.encode())

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -326,8 +326,8 @@ class OdooPdfFileWriter(PdfFileWriter):
 
         adapted_subtype = subtype
         if REGEX_SUBTYPE_UNFORMATED.match(subtype):
-            # _pypdf2_2 does the formating when creating a NameObject
-            if SUBMOD == '._pypdf2_2':
+            # _pypdf2_2 and _pypdf does the formating when creating a NameObject
+            if SUBMOD in ('._pypdf2_2', '._pypdf'):
                 return '/' + subtype
             adapted_subtype = '/' + subtype.replace('/', '#2F')
 
@@ -431,16 +431,18 @@ class OdooPdfFileWriter(PdfFileWriter):
         """
         # Set the PDF version to 1.7 (as PDF/A-3 is based on version 1.7) and make it PDF/A compliant.
         # See https://github.com/veraPDF/veraPDF-validation-profiles/wiki/PDFA-Parts-2-and-3-rules#rule-612-1
+        self._header = b"%PDF-1.7"
 
         # " The file header shall begin at byte zero and shall consist of "%PDF-1.n" followed by a single EOL marker,
         # where 'n' is a single digit number between 0 (30h) and 7 (37h) "
         # " The aforementioned EOL marker shall be immediately followed by a % (25h) character followed by at least four
-        # bytes, each of whose encoded byte values shall have a decimal value greater than 127 "
-        self._header = b"%PDF-1.7"
-        if SUBMOD != '._pypdf2_2':
-            self._header += b"\n"
+        # bytes, each of whose encoded byte values shall have a decimal value greater than 127 ".
+        # PyPDF2 2.X+ already adds these 4 characters by default (so ._pypdf2_2 and ._pypdf don't need it).
+        # The injected character `\xc3\xa9` is equivalent to the character `é`.
+        # Therefore, on `_pypdf2_1`, the header will look like: `%PDF-1.7\n%éééé`,
+        # while on `_pypdf2_2` and `_pypdf`, it will look like: `%PDF-1.7\n%âãÏÓ`.
         if SUBMOD == '._pypdf2_1':
-            self._header += b"%\xDE\xAD\xBE\xEF"
+            self._header += b"\n%\xc3\xa9\xc3\xa9\xc3\xa9\xc3\xa9"
 
         # Add a document ID to the trailer. This is only needed when using encryption with regular PDF, but is required
         # when using PDF/A
@@ -511,6 +513,14 @@ class OdooPdfFileWriter(PdfFileWriter):
 
         outlines = self._root_object['/Outlines'].getObject()
         outlines[NameObject('/Count')] = NumberObject(1)
+
+        # [6.7.2.2-1] include a MarkInfo dictionary containing "Marked" with true value
+        mark_info = DictionaryObject({NameObject("/Marked"): BooleanObject(True)})
+        self._root_object[NameObject("/MarkInfo")] = mark_info
+
+        # [6.7.3.3-1] include minimal document structure in the catalog
+        struct_tree_root = DictionaryObject({NameObject("/Type"): NameObject("/StructTreeRoot")})
+        self._root_object[NameObject("/StructTreeRoot")] = struct_tree_root
 
         # Set odoo as producer
         self.addMetadata({


### PR DESCRIPTION
This commit upgrades our PDF/A compliance from 3B to 3A, and fixes a few issues previously undetected due to the different PyPDF libraries we're currently supporting that made the previous PDF fails even the 3B validation.

Improvement 1:

PDFA validators were previously detecting our file as 3B. Hence we update the metadata content `conformance` to `A`.

Issue 2:

When using `._pypdf` library, we failed the 6.1.2-2 and 6.8-1 rule even
though we have implemented them on the previous version. It seems that
this is caused by the `if SUBMOD...` check only ensuring it's not equal
to `_pypdf2_2` (which makes it trigger for the new `_pypdf`). Hence, we
reclarify the comments and fix the IF check.


Issue 3:

After implementing issue 2, it seems that a traceback occurs every time we're using `._pypdf` and calling the pdf write method. This is because the added characters on the header can't be decoded with `UTF-8`. Hence we change it to other greater-than-127-bytes characters that can still be decoded with `UTF-8`. (The actual character used here doesn't matter).

Improvement 4:

To be compliant with the new 3A rules (additional rules not there in 3B when we first implemented them), we add a minimal mark info dictionary and document structure on the PDF catalog object (`_root_object`).

task-None