### PR TITLE
[IMP] website_sale: make cart layout dynamic

### DIFF
--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -1,3 +1,4 @@
+import { markup } from '@odoo/owl';
 import { Interaction } from '@web/public/interaction';
 import { browser } from '@web/core/browser/browser';
 import { registry } from '@web/core/registry';
@@ -61,6 +62,8 @@ export class CartLine extends Interaction {
             product_id: parseInt(input.dataset.productId),
             quantity: quantity,
         }));
+
+        data['website_sale.cart_lines'] = markup(data['website_sale.cart_lines']);
 
         if (!data.cart_quantity) {
             // Ensure the last cart removal is recorded.

--- a/addons/website_sale/static/src/interactions/quick_reorder.js
+++ b/addons/website_sale/static/src/interactions/quick_reorder.js
@@ -1,3 +1,4 @@
+import { markup } from '@odoo/owl';
 import { ProductCombo } from '@sale/js/models/product_combo';
 import { serializeComboItem } from '@sale/js/sale_utils';
 import { serializeDateTime } from '@web/core/l10n/dates';
@@ -139,6 +140,11 @@ export class QuickReorder extends Interaction {
             quantity: quantity,
             ...(isCombo && { linked_products: linkedProducts }),
         }));
+
+        data['website_sale.shorter_cart_summary'] = markup(
+            data['website_sale.shorter_cart_summary']
+        );
+        data['website_sale.cart_lines'] = markup(data['website_sale.cart_lines']);
 
         // Add the product to the cart and update the DOM.
         const cart = this.el.closest('#shop_cart');

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -1,7 +1,6 @@
-import { markup } from '@odoo/owl';
 import { browser } from '@web/core/browser/browser';
 import { _t } from '@web/core/l10n/translation';
-import { setElementContent } from '@web/core/utils/html';
+import { createElementWithContent } from '@web/core/utils/html';
 
 /**
  * Updates both navbar cart
@@ -28,15 +27,10 @@ function updateCartNavBar(data) {
     }
 
     const cartLines = document.querySelectorAll('.js_cart_lines');
-    cartLines[0]?.insertAdjacentHTML('beforebegin', markup(data['website_sale.cart_lines']));
+    cartLines[0]?.insertAdjacentHTML('beforebegin', data['website_sale.cart_lines']);
     cartLines.forEach(el => el.remove());
 
     updateCartSummary(data);
-
-    // Adjust the cart's left column width to accommodate the cart summary (right column). The left
-    // column of an empty cart initially takes the full width, but adding products (e.g. via quick
-    // reorder) enables the cart summary on the right.
-    document.querySelector('.oe_cart').classList.toggle('col-lg-7', !!data.cart_quantity);
 
     if (data.cart_ready) {
         document.querySelector("a[name='website_sale_main_button']")?.classList.remove('disabled');
@@ -54,7 +48,10 @@ function updateCartNavBar(data) {
 function updateCartSummary(data) {
     if (data['website_sale.shorter_cart_summary']) {
         const shorterCartSummaryEl = document.querySelector('.o_wsale_shorter_cart_summary');
-        setElementContent(shorterCartSummaryEl, markup(data['website_sale.shorter_cart_summary']));
+        const newShorterCartSummaryEl = createElementWithContent(
+            'div', data['website_sale.shorter_cart_summary'],
+        );
+        shorterCartSummaryEl.replaceWith(...newShorterCartSummaryEl.childNodes);
     }
     if (data['website_sale.total']) {
         document.querySelectorAll('div.o_cart_total').forEach(

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -196,20 +196,15 @@
                             <t t-call="website_sale.wizard_checkout"/>
                         </div>
                         <!-- Checkout Page Content | Left Column -->
-                        <div
-                            t-attf-class="oe_clear_stucture oe_cart col-12 #{'col-lg-7' if website_sale_order and website_sale_order.website_order_line else ''}"
-                        >
+                        <div t-attf-class="oe_clear_stucture oe_cart col">
                             <t t-out="0"/>
                         </div>
 
                         <!-- Short Checkout Summary displayed on /cart | Right Column -->
-                        <div
+                        <t
                             t-if="show_shorter_cart_summary"
-                            class="o_wsale_shorter_cart_summary offset-xxl-1 col-lg-5 col-xxl-4"
-                        >
-                            <!-- Parent element needed for proper JS side rendering -->
-                            <t t-call="website_sale.shorter_cart_summary"/>
-                        </div>
+                            t-call="website_sale.shorter_cart_summary"
+                        />
                         <!-- Full Checkout Summary displayed on all checkout pages | Right Column -->
                         <div
                             t-else=""
@@ -303,12 +298,20 @@
 
     <template id="website_sale.shorter_cart_summary">
         <div
-            t-if="website_sale_order and website_sale_order.website_order_line"
-            class="o_total_card card o_wsale_sticky_object sticky-lg-top"
+            t-attf-class="o_wsale_shorter_cart_summary #{
+                'offset-xxl-1 col-lg-5 col-xxl-4'
+                if website_sale_order and website_sale_order.website_order_line
+                else ''
+            }"
         >
-            <div class="card-body p-0 p-lg-4" name="o_cart_total_card_body">
-                <t t-call="website_sale.total" _cart_total_classes.f="o_checkout_cart_total pt-2 pt-lg-0"/>
-                <t t-call="website_sale.navigation_buttons"/>
+            <div
+                t-if="website_sale_order and website_sale_order.website_order_line"
+                class="o_total_card card o_wsale_sticky_object sticky-lg-top"
+            >
+                <div class="card-body p-0 p-lg-4" name="o_cart_total_card_body">
+                    <t t-call="website_sale.total" _cart_total_classes.f="o_checkout_cart_total pt-2 pt-lg-0"/>
+                    <t t-call="website_sale.navigation_buttons"/>
+                </div>
             </div>
         </div>
     </template>


### PR DESCRIPTION
The current cart page layout supports two states:
- Empty cart: A single column spans the entire screen width to display a simple message in the center.
- Non-empty cart: Two columns are displayed, where the left column shows a detailed view of each order line, and the right column shows a summary and navigation buttons.

Before #226128, using the quick reorder feature on the cart page would break the page layout. The initial single-column layout would span the entire screen width, forcing the cart summary onto a new row.

The fix in #226128 used a small trick in JavaScript to adjust the cart's column widths on the client side, ensuring compatibility with existing database templates.

This commit reworks how the `website_sale.shorter_cart_summary` template is updated. Instead of replacing the inner content of a hook element in the layout, we now replace the hook element entirely with a new version of itself. This ensures that custom styling classes applied to the hook element are updated as well, resolving cart layout discrepancies.

Additionally, to reduce the risk of XSS attacks, the "markup-ing" of the updated HTML is now performed at the moment it is fetched from the server. This ensures that the new element is escaped back to a regular string if it is tampered with in any way before being inserted into the page.

task-5082207

See also:
- https://github.com/odoo/enterprise/pull/104917

