### PR TITLE
[FIX] im_livechat: no auto-zoom input for livechat visitor in mobile

### DIFF
--- a/addons/im_livechat/static/src/embed/common/composer.scss
+++ b/addons/im_livechat/static/src/embed/common/composer.scss
@@ -1,0 +1,5 @@
+.o-mail-Composer-input, .o-mail-Composer-fake {
+    .o-mobile {
+        font-size: 16px;
+    }
+}

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -40,7 +40,8 @@
                     <div class="position-relative flex-grow-1">
                         <t t-set="inputClasses" t-value="'form-control px-3 border-0 rounded-3'"/>
                         <textarea class="o-mail-Composer-input bg-view shadow-none overflow-auto"
-                            t-att-class="inputClasses"
+                            t-att-class="{ 'o-mobile': isMobileOS() }"
+                            t-attf-class="{{ inputClasses }}"
                             t-ref="textarea"
                             style="height:40px;"
                             t-on-keydown="onKeydown"
@@ -59,7 +60,8 @@
                         -->
                         <textarea
                             class="o-mail-Composer-fake overflow-hidden position-absolute"
-                            t-att-class="inputClasses"
+                            t-att-class="{ 'o-mobile': isMobileOS() }"
+                            t-attf-class="{{ inputClasses }}"
                             t-model="props.composer.textInputContent"
                             t-ref="fakeTextarea"
                             disabled="1"


### PR DESCRIPTION
Before this commit, when using livechat for visitors on mobile devices, click on input would zoom on input of about 115%.

This zoom would hide send button at the very end of composer input, and would force users to pinch-to-unzoom, making the UX quite poor.

This problem happens because mobile devices have an auto-zoom feature that is triggered when font-size is below 16px. The discuss UI is designed with 14px font size (web client font size), and since 14px < 16px, it zooms on input focus to about 115%.

This commit fixes the issue by using a font-size of 16px specifically for livechat visitor on mobile devices, so that this doesn't auto-zoom. Note that this problem doesn't happen on the web client even though this uses a font-size of 14px because it specifically disable the autozoom feature:
https://github.com/odoo/odoo/blob/17.0/addons/web/views/webclient_templates.xml#L250

This solution is not practical for livechat, for which it has to work on any external website.

opw-5229076

Before
<img width="199" height="431" alt="after" src="https://github.com/user-attachments/assets/cc2f8e04-bde7-4eeb-84d5-b2efa2763490" />

After
<img width="199" height="431" alt="before" src="https://github.com/user-attachments/assets/6c6679fc-9c16-40e7-ab6f-21540d20d59d" />