### PR TITLE
[IMP] payment: pricelist and amount filters for providers

### DIFF
--- a/addons/account_payment/tests/test_payment_provider.py
+++ b/addons/account_payment/tests/test_payment_provider.py
@@ -33,3 +33,21 @@ class TestPaymentProvider(AccountPaymentCommon):
             })
             provider_duplicated.invalidate_recordset(fnames=['journal_id'])
             self.assertEqual(provider_duplicated.journal_id, bank_journal)
+
+    def test_provider_not_compatible_with_unavailable_pricelists(self):
+        """Test that the provider is not compatible with a pricelist that is not available."""
+        pricelist_10 = self.env['product.pricelist'].create({
+            'name': 'EUR 10',
+            'currency_id': self.currency_euro.id,
+        })
+        pricelist_20 = self.env['product.pricelist'].create({
+            'name': 'EUR 20',
+            'currency_id': self.currency_euro.id,
+        })
+        self.partner.property_product_pricelist = pricelist_10
+        self.provider.available_pricelist_ids = pricelist_20
+
+        compatible_providers = self.env['payment.provider']._get_compatible_providers(
+            self.company.id, self.partner.id, self.amount,
+        )
+        self.assertNotIn(self.provider, compatible_providers)

--- a/addons/account_payment/views/payment_provider_views.xml
+++ b/addons/account_payment/views/payment_provider_views.xml
@@ -17,6 +17,14 @@
                     required="state != 'disabled' and code not in ['none', 'custom']"/>
                 <field name="support_refund" groups="base.group_no_one"/>
             </group>
+            <field name="available_country_ids" position="after">
+                <field
+                    name="available_pricelist_ids"
+                    widget="many2many_tags"
+                    placeholder="All Pricelists"
+                    options="{'no_create': True}"
+                />
+            </field>
         </field>
     </record>
 

--- a/addons/payment/const.py
+++ b/addons/payment/const.py
@@ -540,7 +540,7 @@ CURRENCY_MINOR_UNITS = {
 }
 
 REPORT_REASONS_MAPPING = {
-    'exceed_max_amount': _lt("maximum amount exceeded"),
+    'exceed_min_or_max_amount': _lt("minimum or maximum amount exceeded"),
     'express_checkout_not_supported': _lt("express checkout not supported"),
     'incompatible_country': _lt("incompatible country"),
     'incompatible_currency': _lt("incompatible currency"),

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -83,6 +83,7 @@
                                     <field name="allow_express_checkout" invisible="not support_express_checkout"/>
                                 </group>
                                 <group string="Availability" name="availability">
+                                    <field name="minimum_amount"/>
                                     <field name="maximum_amount"/>
                                     <label for="available_currency_ids"/>
                                     <!-- Use `o_row` to allow placing a button next to the field in overrides. -->


### PR DESCRIPTION
Adding filtering based on partner pricelist to restrict providers to allowed pricelists. Extending amount validation to include minimum amount filtering alongside existing maximum amount checks.

See also:

- https://github.com/odoo/enterprise/pull/99114

task-5129542

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
