### PR TITLE
[REM] html_builder: remove obsolete TODO comment in SelectMany2X

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<!-- TODO: support more features from the previous implementation: "callWith", "filterInModel", "filterInField", "nullText" -->
-
 <t t-name="html_builder.SelectMany2X">
     <SelectMenu
         choices="this.filteredSearchResult().map(e => ({ value: e, label: e.display_name  }))"


### PR DESCRIPTION
The TODO referenced features from the pre-website-refactoring [1] implementation.

`filterInModel` and `filterInField` were originally introduced in [2] and used only for online appointment option implemented in [3]. After the website refactoring, that logic is now implemented directly in the updated option code [4], making the old mechanism irrelevant for SelectMany2X.

`callWith` is already implemented in VisibilityOptionPlugin, as it was the only use case.
`nullText` is implemented in SelectMany2X.

task-5248164

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[2]: https://github.com/odoo/odoo/commit/be9f264011363565333f450d7601e2bafea3c409
[3]: https://github.com/odoo/enterprise/commit/64a7eb0006a59240f3a95e77628cedfc02b8e585
[4]: https://github.com/odoo/enterprise/commit/689a2186fbe3b932b90bef3b64716c8443bad551#diff-651f0a74ed9cb6ecf1eb5ac2c6e889f59ced60eef289c4949956db721f54e085R30-R35