### PR TITLE
[FIX] mrp: calculate correctly the consumed element

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1863,8 +1863,16 @@ class MrpProduction(models.Model):
         moves_to_finish.picked = True
         moves_to_finish = moves_to_finish._action_done(cancel_backorder=cancel_backorder)
         for order in self:
-            consume_move_lines = moves_to_do_by_order[order.id].mapped('move_line_ids')
-            order.move_finished_ids.move_line_ids.consume_line_ids = [(6, 0, consume_move_lines.ids)]
+            if order.product_id.tracking == 'serial' and False:
+                for consumable in [a for a in tools_groupby(moves_to_do_by_order[order.id].mapped('move_line_ids'), key=lambda m: m.product_id.id)]:
+                    for finished_product in order.move_finished_ids.move_line_ids:
+                        if len(consumable[1]) > 0:
+                            finished_product.consume_line_ids = consumable[1][0]
+                        else:
+                            finished_product.consume_line_ids = consumable[1]
+            else:
+                consume_move_lines = moves_to_do_by_order[order.id].mapped('move_line_ids')
+                order.move_finished_ids.move_line_ids.consume_line_ids = [(6, 0, consume_move_lines.ids)]
         return True
 
     @api.model

--- a/addons/stock/report/stock_traceability.py
+++ b/addons/stock/report/stock_traceability.py
@@ -4,6 +4,7 @@
 from odoo import api, models, _
 from odoo.tools import format_datetime
 from markupsafe import Markup
+from odoo.tools.misc import OrderedSet, format_date, groupby as tools_groupby, topological_sort
 
 
 rec = 0
@@ -66,6 +67,7 @@ class StockTraceabilityReport(models.TransientModel):
         elif  rec_id and model == 'stock.move.line' and context.get('lot_name'):
             record = self.env[model].browse(rec_id)
             dummy, is_used = self._get_linked_move_lines(record)
+            tools_groupby
             if is_used:
                 lines = is_used
         elif rec_id and model in ('stock.picking', 'mrp.production'):
@@ -204,6 +206,9 @@ class StockTraceabilityReport(models.TransientModel):
             else:
                 # Traceability in case of consumed in.
                 lines = self._get_move_lines(move_line, line_id=line_id)
+        move_line = self.env[model].browse(model_id)
+        index = list(move_line.move_id.lot_ids.ids).index(move_line.lot_id)
+        lots = tools_groupby(lines, key=lambda l: l.product_id.id)
         for line in lines:
             unfoldable = False
             if line.consume_line_ids or (model != "stock.lot" and line.lot_id and self._get_move_lines(line)):


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create 1 product that is serialized, add a BoM that has one component
2. Create a manufacturing order for multiple units of the finished product, each consuming one component
3. Generate the serial numbers for the finished products, then validate the manufacturing order
4. Open the traceability report, every component is listed under every finished product, making it seem that every component was used to manufacture each unit

Observation:
-----------
The traceability use the consume_line_ids to know what element the move_line consumed : https://github.com/odoo/odoo/blob/10e5ac9943a68f03a31c149ff14ade1cf3937e3d/addons/mrp/models/stock_traceability.py#L32

 the assigning of the consume_line_ids every finished moves form the order will have inside their consume moves, all the conmponent from all the finished_moves, which create this situation:
https://github.com/odoo/odoo/blob/1e8d8b51b2b5b99f6fe9f01b8219441863111763/addons/mrp/models/mrp_production.py#L1852-L1853

This issue appeard on 19.0 since this commit allowed to manufacture several serial number with only one MO: https://github.com/odoo/odoo/commit/4bb4e08066449177f89382718ceadd840ce90d0e#diff-4ea85ad9b881e3fdcbc31b3674f4c79965fd643e79c1e746c934ad824e4eccceL98

before the issue was not present since all element had different mo orders.

Why the fix:
------------
I think is too risky to create new moves lines for each product, it would impact other elements than just the traceability.

Could also try to change the values directly inside the tracability files -> working in this.

opw-5133629

