### PR TITLE
[FIX] mail: no overflow in discuss app on toggling call sidebar

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -203,6 +203,8 @@ export class Call extends Component {
         if (!this.grid.el) {
             return;
         }
+        this.grid.el.style.setProperty("--width", "0");
+        this.grid.el.style.setProperty("--height", "0");
         const { width, height } = this.grid.el.getBoundingClientRect();
         const aspectRatio = this.minimized ? 1 : 16 / 9;
         const tileCount = this.grid.el.children.length;
@@ -241,5 +243,7 @@ export class Call extends Component {
             tileHeight: optimal.tileHeight,
             columnCount: optimal.columnCount,
         });
+        this.grid.el.style.setProperty("--width", `${this.state.tileWidth}px`);
+        this.grid.el.style.setProperty("--height", `${this.state.tileHeight}px`);
     }
 }


### PR DESCRIPTION
Before this commit, when in a discuss call in the Discuss app with sidebar not compact and a right panel open, click on Discuss sidebar would overflow horizontally the UI.

This happens because the rearrange of tiles of the discuss call grid would be triggered from sidebar toggle state change, but the rearrange of tiles was mistakenly coded to preserve the height of main tile. This is a problem with discuss call sidebar because while the overall height of call view should stay unchanged, the main card must have its height reduced to compensate with discuss call sidebar when shown.

This commit fixes the issue by resetting temporarily the height of call card tile in `arrangeTiles()`, so that it takes into account when it has to adapt its height.

Before
![before](https://github.com/user-attachments/assets/615a2df2-3062-4783-ba87-cd1431fd3848)

After
![after](https://github.com/user-attachments/assets/2cf6a24f-ae41-4735-a6f9-ae475d4a06ad)
