### PR TITLE
[REF] mail: explicit props.thread in actionPanelComponentProps

### DIFF
--- a/addons/crm_livechat/static/src/core/thread_actions.js
+++ b/addons/crm_livechat/static/src/core/thread_actions.js
@@ -9,18 +9,19 @@ import { usePopover } from "@web/core/popover/popover_hook";
 registerThreadAction("create-lead", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: LivechatCommandDialog,
-    actionPanelComponentProps: ({ action }) => ({
+    actionPanelComponentProps: ({ action, thread }) => ({
         close: () => action.actionPanelClose(),
         commandName: "lead",
         placeholderText: _t("e.g. Product pricing"),
+        thread,
         title: _t("Create Lead"),
         icon: "fa fa-handshake-o",
     }),
     actionPanelOpen({ owner, thread }) {
-        this.popover?.open(owner.root.el.querySelector(`[name="${this.id}"]`), {
-            thread,
-            ...this.actionPanelComponentProps,
-        });
+        this.popover?.open(
+            owner.root.el.querySelector(`[name="${this.id}"]`),
+            this.actionPanelComponentProps
+        );
     },
     actionPanelOuterClass: "bg-100",
     condition: false, // managed by ThreadAction patch

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -7,6 +7,7 @@ import { joinChannelAction } from "@mail/discuss/core/web/thread_actions";
 
 registerThreadAction("livechat-info", {
     actionPanelComponent: LivechatChannelInfoList,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     condition: ({ channel, owner }) =>
         channel?.channel_type === "livechat" && !owner.isDiscussSidebarChannelActions,
@@ -17,6 +18,7 @@ registerThreadAction("livechat-info", {
 });
 registerThreadAction("livechat-status", {
     actionPanelComponent: LivechatChannelInfoList,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     condition: ({ channel, owner }) =>
         channel?.channel_type === "livechat" && !channel.livechat_end_dt && !owner.isDiscussContent,

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -69,7 +69,7 @@
         <div t-if="!props.chatWindow.folded or ui.isSmall" class="d-flex flex-column h-100 overflow-auto o-scrollbar-thin position-relative bg-inherit" t-att-class="{ 'opacity-50': state.editingName }" t-ref="content">
             <t name="thread content">
                 <div t-if="threadActions.activeAction?.actionPanelComponentCondition" class="h-100" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}">
-                    <t t-component="threadActions.activeAction.actionPanelComponent" t-props="{ ...threadActions.activeAction.actionPanelComponentProps, thread: channel.thread }"/>
+                    <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                 </div>
                 <t t-else="">
                     <Thread autofocus="isMobileOS ? props.chatWindow.autofocus : undefined" thread="channel.thread" t-key="channel.thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage"/>

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -55,6 +55,7 @@ registerThreadAction("close", {
 });
 registerThreadAction("search-messages", {
     actionPanelComponent: SearchMessagesPanel,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOuterClass: "o-mail-SearchMessagesPanel bg-inherit",
     condition: ({ owner, thread }) =>
         ["discuss.channel", "mail.box"].includes(thread?.model) &&
@@ -79,6 +80,7 @@ registerThreadAction("search-messages", {
 });
 registerThreadAction("meeting-chat", {
     actionPanelComponent: MeetingChat,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOuterClass: "bg-100 border border-secondary",
     badge: ({ thread }) => thread.isUnread,
     badgeIcon: ({ thread }) => !thread.importantCounter && "fa fa-circle text-700",

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -72,7 +72,7 @@
                             <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                         </div>
                         <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0" t-att-class="{ 'w-100': ui.isSmall }">
-                            <t t-component="threadActions.activeAction.actionPanelComponent" thread="thread" t-props="threadActions.activeAction.actionPanelComponentProps"/>
+                            <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                         </div>
                     </t>
                     <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'notification') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100">

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -12,7 +12,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 
 export class CallSettings extends Component {
     static template = "discuss.CallSettings";
-    static props = ["withActionPanel?", "*"];
+    static props = ["withActionPanel?", "isCompact?"];
     static defaultProps = {
         withActionPanel: true,
     };
@@ -153,6 +153,6 @@ export class CallSettingsDialog extends Component {
             <CallSettings withActionPanel="false"/>
         </Dialog>
     `;
-    static props = ["*"];
+    static props = [];
     static components = { CallSettings, Dialog };
 }

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -7,7 +7,7 @@
                     <Call hasOverlay="false" isPip="props.isPip"/>
                 </div>
                 <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0 rounded-2" t-att-class="{ 'w-100': ui.isSmall }">
-                    <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps" thread="channel.thread"/>
+                    <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                 </div>
             </div>
             <div class="pt-2 d-flex justify-content-between overflow-x-auto flex-shrink-0" t-att-class="{'p-2 pb-3': ui.isSmall}">

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -76,6 +76,7 @@ registerThreadAction("unset-favorite", {
 registerThreadAction("notification-settings", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: NotificationSettings,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOpen({ owner, store, thread }) {
         if (owner.isDiscussSidebarChannelActions || owner.env.inMeetingView) {
             store.env.services.dialog?.add(ChannelActionDialog, {
@@ -113,6 +114,7 @@ registerThreadAction("notification-settings", {
 });
 registerThreadAction("attachments", {
     actionPanelComponent: AttachmentPanel,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     condition: ({ owner, thread }) =>
         thread?.hasAttachmentPanel &&
         (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
@@ -125,7 +127,10 @@ registerThreadAction("attachments", {
 registerThreadAction("invite-people", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: ChannelInvitation,
-    actionPanelComponentProps: ({ action }) => ({ close: () => action.actionPanelClose() }),
+    actionPanelComponentProps: ({ action, thread }) => ({
+        close: () => action.actionPanelClose(),
+        thread,
+    }),
     actionPanelOpen({ owner, store, thread }) {
         if (owner.isDiscussSidebarChannelActions) {
             store.env.services.dialog?.add(ChannelActionDialog, {
@@ -170,12 +175,13 @@ registerThreadAction("member-list", {
         }
     },
     actionPanelComponent: ChannelMemberList,
-    actionPanelComponentProps: ({ actions }) => ({
+    actionPanelComponentProps: ({ actions, thread }) => ({
         openChannelInvitePanel({ keepPrevious } = {}) {
             actions.actions
                 .find(({ id }) => id === "invite-people")
                 ?.actionPanelOpen({ keepPrevious });
         },
+        thread,
     }),
     actionPanelOpen: ({ owner, store }) => {
         if (owner.env.inDiscussApp) {
@@ -207,8 +213,8 @@ registerThreadAction("mark-read", {
 registerThreadAction("delete-thread", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: DeleteThreadDialog,
-    actionPanelComponentProps({ action }) {
-        return { close: () => action.actionPanelClose() };
+    actionPanelComponentProps({ action, thread }) {
+        return { close: () => action.actionPanelClose(), thread };
     },
     actionPanelOuterClass: "bg-100",
     condition({ owner, store, thread }) {

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -8,7 +8,10 @@ import { usePopover } from "@web/core/popover/popover_hook";
 registerThreadAction("show-threads", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: SubChannelList,
-    actionPanelComponentProps: ({ action }) => ({ close: () => action.actionPanelClose() }),
+    actionPanelComponentProps: ({ action, thread }) => ({
+        close: () => action.actionPanelClose(),
+        thread,
+    }),
     actionPanelOpen({ owner, thread }) {
         const channel = thread?.parent_channel_id || thread;
         this.popover?.open(owner.root.el.querySelector(`[name="${this.id}"]`), { thread: channel });

--- a/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
@@ -7,6 +7,7 @@ import { _t } from "@web/core/l10n/translation";
 
 registerThreadAction("pinned-messages", {
     actionPanelComponent: PinnedMessagesPanel,
+    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOuterClass: "o-discuss-PinnedMessagesPanel bg-inherit",
     condition: ({ channel, owner }) =>
         channel &&


### PR DESCRIPTION
Before this commit, `actionPanelComponentProps` of thread actions had implicit `props.thread` passed to thread actions components.

This `actionPanelComponentProps` was only used by thread actions in the past so this made sense to make it implicit. But now that this is intended to be used by other types of discuss actions, it should have explicit prop list.

We also want to make channel component more specific by passing `channel`, so some thread actions would want to pass `channel` rather than `thread`. This change also allow to do that.

https://github.com/odoo/enterprise/pull/99121