### PR TITLE
[IMP] l10n_us_account: show enable checkbox for Wise in settings

### DIFF
--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -11,6 +11,7 @@
     'depends': ['l10n_us', 'account'],
     'data': [
         'views/res_bank_views.xml',
+        'views/res_config_settings_views.xml',
         'data/tax_report.xml',
         'data/uom_data.xml',
     ],

--- a/addons/l10n_us_account/models/__init__.py
+++ b/addons/l10n_us_account/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import res_bank
+from . import res_config_settings
 from . import template_us

--- a/addons/l10n_us_account/models/res_config_settings.py
+++ b/addons/l10n_us_account/models/res_config_settings.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    module_l10n_us_direct_deposit = fields.Boolean("U.S. Direct Deposit (via Wise)")

--- a/addons/l10n_us_account/views/res_config_settings_views.xml
+++ b/addons/l10n_us_account/views/res_config_settings_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.wise</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <setting id="sepa_payments" position="after">
+                <setting id="wise_payment_settings" string="U.S. Direct Deposit (via Wise)" company_dependent="1" help="Initiate payments in one-click using a Wise Business account"
+                    invisible="country_code != 'US'">
+                    <field name="module_l10n_us_direct_deposit" widget="upgrade_boolean"/>
+                    <div id="wise_payment_content" class="content-group" invisible="not module_l10n_us_direct_deposit">
+                        <div class="text-warning mt16 mb4">
+                            Save this page and come back here to set up the feature.
+                        </div>
+                    </div>
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
As the `l10n_us_direct_deposit` module was merged in stable, it is not discoverable via the settings page like other optional features and can only be seen in the apps list. This PR allows customers who have the US localization installed to configure the module as necessary.

task-5080414
