### PR TITLE
[FIX] html_editor: fix selection blocker predicates

### DIFF
--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -37,7 +37,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
             }
         },
         selection_blocker_predicates: (blocker) => {
-            if (blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE) || !isBlock(blocker)) {
+            if (!isBlock(blocker) || blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) {
                 return false;
             } else if (isNotEditableNode(blocker)) {
                 return true;


### PR DESCRIPTION
To reproduce:
=============
- with website appointments installed go to appointments page
- try to edit the page -> error

Problem:
========
when entering edit mode, we call `selection_blocker_predicates` on editable nodes which will call `node.hasAttribute` internally. However, some nodes are text nodes and thus do not have this method, leading to an error.

Solution:
=========
`isBlock` method checks several things on the node, including if it's a text node. so swapping the order of the conditions will fix the problem.

opw-5239754

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
