### PR TITLE
[FIX][17.0] mail: fix incorrect avatar display mode

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -89,7 +89,7 @@
         'ms-3': threadActions.actions.length lte 4 and !isMobileFoldedForLivechatVisitor,
         'me-1': !isMobileFoldedForLivechatVisitor,
     }">
-        <img t-att-class="{ 'o-isMobileFoldedForLivechatVisitor rounded-circle': isMobileFoldedForLivechatVisitor, 'rounded': !isMobileFoldedForLivechatVisitor }" t-att-src="thread.imgUrl" alt="Thread Image"/>
+        <img t-att-class="{ 'o-isMobileFoldedForLivechatVisitor rounded-circle o_object_fit_cover': isMobileFoldedForLivechatVisitor, 'rounded o_object_fit_cover': !isMobileFoldedForLivechatVisitor }" t-att-src="thread.imgUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.type === 'chat' and thread.chatPartner" thread="thread"/>
     <div t-if="!state.editingName and !isMobileFoldedForLivechatVisitor" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>

--- a/addons/mail/static/src/core/common/discuss.xml
+++ b/addons/mail/static/src/core/common/discuss.xml
@@ -7,7 +7,7 @@
         <div t-if="thread and (store.inPublicPage or !(ui.isSmall and ['chat', 'channel'].includes(store.discuss.activeTab)))" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 bg-view overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-3 bg-view border-bottom d-flex flex-shrink-0 align-items-center">
                 <div t-if="thread and ['channel', 'group', 'chat'].includes(thread.type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
-                    <img class="rounded" t-att-src="thread.imgUrl" alt="Thread Image"/>
+                    <img class="rounded o_object_fit_cover" t-att-src="thread.imgUrl" alt="Thread Image"/>
                     <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded="(data) => this.onFileUploaded(data)">
                         <t t-set-slot="toggler">
                             <a href="#" class="position-absolute z-index-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -51,7 +51,7 @@
             t-on-click="(ev) => this.openThread(ev, thread)"
         >
             <div class="bg-inherit position-relative d-flex ms-4 flex-shrink-0" style="width:30px;height:30px">
-                <img class="w-100 h-100 rounded" t-att-src="thread.imgUrl" alt="Thread Image"/>
+                <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.imgUrl" alt="Thread Image"/>
                 <ThreadIcon t-if="thread.type === 'chat' or (thread.type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
             </div>
             <span class="ms-3 me-2 text-truncate" t-att-class="{ 'o-item-unread fw-bolder': thread.message_unread_counter > 0 and !thread.muteUntilDateTime }">


### PR DESCRIPTION


Before this commit, user avatars in the mail UI were not displayed using the `object-fit: cover` style, causing distorted or improperly scaled images.

This issue is specific to version 17.0 — both versions 16.0 and 18.0 correctly apply the `cover` mode.

After this commit, avatars are now rendered with `object-fit: cover` to ensure proper aspect ratio and consistent display across versions.


ex bad ui
before
<img width="365" height="49" alt="Screenshot 2025-11-08 at 11 39 13 AM" src="https://github.com/user-attachments/assets/7195c594-12c3-4c67-8001-99d1b9e2eebb" />


after
<img width="350" height="50" alt="Screenshot 2025-11-08 at 11 38 37 AM" src="https://github.com/user-attachments/assets/500c9f39-abd9-42b7-aba6-7a56e01cd6e2" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
