### PR TITLE
[IMP] maintenance: improve maintenance request workflow and refine views

### DIFF
--- a/addons/maintenance/data/maintenance_data.xml
+++ b/addons/maintenance/data/maintenance_data.xml
@@ -17,13 +17,11 @@
         <field name="name">Repaired</field>
         <field name="sequence" eval="3" />
         <field name="fold" eval="True" />
-        <field name="done" eval="True" />
     </record>
     <record id="stage_4" model="maintenance.stage">
         <field name="name">Scrap</field>
         <field name="sequence" eval="4" />
         <field name="fold" eval="True" />
-        <field name="done" eval="True" />
     </record>
 
 </data>

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -229,8 +229,6 @@ class MaintenanceRequest(models.Model):
         ('done', 'Done'),
         ('cancelled', 'Cancelled'),
     ], string='State', required=True, default='normal', tracking=True, copy=False)
-    # active = fields.Boolean(default=True, help="Set active to false to hide the maintenance request without deleting it.")
-    archive = fields.Boolean(default=False, help="Set archive to true to hide the maintenance request without deleting it.")
     maintenance_type = fields.Selection([('corrective', 'Corrective'), ('preventive', 'Preventive')], string='Maintenance Type', default="corrective")
     schedule_date = fields.Datetime('Scheduled Date', help="Date the maintenance team plans the maintenance.  It should not differ much from the Request Date. ")
     schedule_end = fields.Datetime(

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -240,12 +240,6 @@ class MaintenanceRequest(models.Model):
     maintenance_team_id = fields.Many2one('maintenance.team', string='Team', required=True, index=True, default=_get_default_team_id,
                                           compute='_compute_maintenance_team_id', store=True, readonly=False, check_company=True)
     duration = fields.Float(help="Duration in hours.", compute='_compute_duration', store=True)
-    instruction_type = fields.Selection([
-        ('pdf', 'PDF'), ('google_slide', 'Google Slide'), ('text', 'Text')],
-        string="Instruction", default="text"
-    )
-    instruction_pdf = fields.Binary('PDF')
-    instruction_google_slide = fields.Char('Google Slide', help="Paste the url of your Google Slide. Make sure the access to the document is public.")
     instruction_text = fields.Html('Text')
     recurring_maintenance = fields.Boolean(string="Recurrent", compute='_compute_recurring_maintenance', store=True, readonly=False)
     repeat_interval = fields.Integer(string='Repeat Every', default=1)

--- a/addons/maintenance/static/src/views/calendar_with_recurrence/calendar_with_recurrence_model.js
+++ b/addons/maintenance/static/src/views/calendar_with_recurrence/calendar_with_recurrence_model.js
@@ -12,7 +12,7 @@ export class CalendarWithRecurrenceModel extends CalendarModel {
                 id: recordsCounter,
             };
             recordsCounter++;
-            if (rawRecord.recurring_maintenance && !rawRecord.done && !rawRecord.archive) {
+            if (rawRecord.recurring_maintenance && !['done', 'cancelled'].includes(rawRecord.state)) {
                 let { start, end } = data.range;
                 if (rawRecord.repeat_type == 'until') {
                     end = luxon.DateTime.min(end, deserializeDateTime(rawRecord.repeat_until)).endOf('day');

--- a/addons/maintenance/static/src/widgets/maintenance_request_state_selection.js
+++ b/addons/maintenance/static/src/widgets/maintenance_request_state_selection.js
@@ -1,0 +1,69 @@
+import { StateSelectionField, stateSelectionField } from "@web/views/fields/state_selection/state_selection_field";
+import { registry } from "@web/core/registry";
+
+export class MaintenanceRequestStateSelection extends StateSelectionField {
+    static template = "maintenance.MaintenanceRequestStateSelection";
+
+    static props = {
+        ...stateSelectionField.component.props,
+        viewType: { type: String },
+    };
+
+    setup() {
+        super.setup();
+        this.icons = {
+            normal: "o_status",
+            changes_requested: "fa fa-lg fa-exclamation-circle",
+            approved: "o_status o_status_green",
+            done: "fa fa-lg fa-check-circle",
+            cancelled: "fa fa-lg fa-times-circle",
+        };
+        this.colorIcons = {
+            normal: "",
+            changes_requested: "o_status_changes_requested",
+            approved: "text-success",
+            done: "text-success",
+            cancelled: "text-danger",
+        };
+        this.colorButton = {
+            normal: "btn-outline-secondary",
+            changes_requested: "btn-outline-warning",
+            approved: "btn-outline-success",
+            done: "btn-outline-success",
+            cancelled: "btn-outline-danger",
+        };
+    }
+
+    stateIcon(value) {
+        return this.icons[value] || "";
+    }
+
+    statusColor(value) {
+        return this.colorIcons[value] || "";
+    }
+
+    get options() {
+        const labels = new Map(super.options);
+        return ["normal", "changes_requested", "approved", "cancelled", "done"].map((state) => [state, labels.get(state)]);
+    }
+
+    get isKanbanOrMobileView() {
+        return this.props.viewType === "kanban" || this.env.isSmall;
+    }
+
+    getTogglerClass(currentValue) {
+        return this.isKanbanOrMobileView ? "p-0" : `o_state_button btn rounded-pill ${this.colorButton[currentValue]}`;
+    }
+}
+
+export const maintenanceRequestStateSelectionField = {
+    ...stateSelectionField,
+    component: MaintenanceRequestStateSelection,
+    extractProps({ viewType }) {
+        const props = stateSelectionField.extractProps(...arguments);
+        props.viewType = viewType;
+        return props;
+    },
+};
+
+registry.category("fields").add("maintenance_request_state_selection", maintenanceRequestStateSelectionField);

--- a/addons/maintenance/static/src/widgets/maintenance_request_state_selection.scss
+++ b/addons/maintenance/static/src/widgets/maintenance_request_state_selection.scss
@@ -1,0 +1,39 @@
+.o_field_maintenance_request_state_selection {
+    .o_status {
+        width: $o-bubble-color-size-xl;
+        height: $o-bubble-color-size-xl;
+        text-align: center;
+        margin-top: -0.5px;
+    }
+
+    .fa-lg {
+        font-size: 1.75em;
+        margin-top: -2.5px;
+        max-width: 20px;
+        max-height: 20px;
+    }
+
+    .o_status_changes_requested {
+        color: $warning;
+    }
+}
+
+.maintenance_request_state_selection_menu {
+    .fa {
+        margin-top: -1.5px;
+        font-size: 1.315em;
+        vertical-align: -6%;
+        transform: translateX(-50%);
+    }
+
+    .o_status {
+        margin-top: 1px;
+        width: 14.65px;
+        height: 14.65px;
+        text-align: center;
+    }
+
+    .o_status_changes_requested {
+        color: $warning;
+    }
+}

--- a/addons/maintenance/static/src/widgets/maintenance_state_selection.xml
+++ b/addons/maintenance/static/src/widgets/maintenance_state_selection.xml
@@ -1,0 +1,32 @@
+<templates>
+    <t t-name="maintenance.MaintenanceRequestStateSelection" t-inherit="web.StateSelectionField" t-inherit-mode="primary">
+        <xpath expr="//Dropdown/button/div" position="replace">
+            <div t-if="isKanbanOrMobileView" class="d-flex align-items-center" t-att-title="label">
+                <i t-attf-class="{{ stateIcon(currentValue) }} {{ statusColor(currentValue) }}"/>
+            </div>
+            <div t-else="" class="d-flex align-items-center">
+                <span class="o_status_label" t-out="label"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//Dropdown" position="attributes">
+            <attribute name="menuClass" separator=" + " add="' maintenance_request_state_selection_menu'"/>
+        </xpath>
+
+        <xpath expr="//Dropdown/button" position="attributes">
+            <attribute name="class" remove="p-0" add="shadow-none" separator=" "/>
+            <attribute name="t-att-class">getTogglerClass(currentValue)</attribute>
+        </xpath>
+
+        <xpath expr="//CheckboxItem/span[1]" position="attributes">
+            <attribute name="t-attf-class" separator=" " add="{{ stateIcon(option[0]) }}" remove="o_status"/>
+        </xpath>
+        <xpath expr="//CheckboxItem/span[2]" position="attributes">
+            <attribute name="t-attf-class">{{ statusColor(option[0]) }}</attribute>
+        </xpath>
+        <!-- Dropdown divider -->
+        <xpath expr="//CheckboxItem" position="before">
+            <div t-if="option[0] === 'cancelled'" role="separator" class="dropdown-divider"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -28,9 +28,6 @@
                 <separator/>
                 <filter string="Unscheduled" name="unscheduled" domain="[('state', 'not in', ['done', 'cancelled']), ('schedule_date', '=', False)]"/>
                 <separator/>
-                <filter name="filter_schedule_date" date="schedule_date"/>
-                <filter name="filter_close_date" date="close_date"/>
-                <separator/>
                 <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                 <separator/>
                 <filter invisible="1" string="My Activities" name="filter_activities_my"
@@ -43,9 +40,6 @@
                     domain="[('my_activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
-                <separator/>
-                <filter string="Active" name="active" domain="[('archive', '=', False)]"/>
-                <filter string="Cancelled" name="inactive" domain="[('archive', '=', True)]"/>
                 <group>
                     <filter string='Assigned to' name="assigned" domain="[]" context="{'group_by': 'user_id'}"/>
                     <filter string='Category' name="category" domain="[]" context="{'group_by' : 'category_id'}"/>
@@ -103,7 +97,6 @@
                             <field name="equipment_id" context="{'default_company_id':company_id, 'default_category_id':category_id}" required="1"/>
                             <field name="category_id" groups="maintenance.group_equipment_manager" context="{'default_company_id':company_id}" invisible="not equipment_id"/>
                             <field name="close_date" readonly="True" invisible="state != 'done'"/>
-                            <field name="archive" invisible="1"/>
                             <field name="maintenance_type" widget="radio"/>
                         </group>
                         <group>
@@ -232,7 +225,6 @@
                 <field name="repeat_unit" invisible="1"/>
                 <field name="repeat_type" invisible="1"/>
                 <field name="repeat_until" invisible="1"/>
-                <field name="archive" invisible="1"/>
                 <field name="duration" invisible="1"/>
                 <field name="state" invisible="1"/>
             </calendar>
@@ -247,8 +239,8 @@
         <field name="view_mode">kanban,list,form,pivot,graph,calendar,activity</field>
         <field name="view_id" ref="hr_equipment_request_view_kanban"/>
         <field name="context">{
-            'search_default_active': True,
-            'default_user_id': uid
+            'search_default_todo': True,
+            'default_user_id': uid,
         }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
@@ -267,7 +259,9 @@
         <field name="view_id" ref="hr_equipment_request_view_kanban"/>
         <field name="context">{
             'search_default_category_id': [active_id],
-            'search_default_active': True,
+            'search_default_todo': True,
+            'search_default_done': True,
+            'search_default_cancelled': True,
             'default_category_id': active_id,
         }</field>
         <field name="help" type="html">
@@ -285,7 +279,9 @@
         <field name="binding_model_id" ref="maintenance.model_maintenance_equipment"/>
         <field name="view_mode">kanban,list,form,pivot,graph,calendar,activity</field>
         <field name="context">{
-            'search_default_active': True,
+            'search_default_todo': True,
+            'search_default_done': True,
+            'search_default_cancelled': True,
             'default_equipment_id': active_id,
         }</field>
         <field name="domain">[('equipment_id', '=', active_id)]</field>
@@ -303,7 +299,6 @@
         <field name="res_model">maintenance.request</field>
         <field name="view_mode">kanban,list,form,pivot,graph,calendar,activity</field>
         <field name="context">{
-            'search_default_active': True,
             'search_default_maintenance_team_id': active_id,
             'default_maintenance_team_id': active_id,
         }</field>
@@ -323,10 +318,7 @@
         <field name="path">maintenance-calendar</field>
         <field name="view_mode">calendar,kanban,list,form,pivot,graph,activity</field>
         <field name="view_id" ref="hr_equipment_view_calendar"/>
-        <field name="context">{
-            'search_default_active': True,
-            'search_default_todo': True,
-        }</field>
+        <field name="context">{'search_default_todo': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Add a new maintenance request
@@ -341,9 +333,7 @@
         <field name="res_model">maintenance.request</field>
         <field name="path">maintenance-requests-analysis</field>
         <field name="view_mode">graph,pivot,kanban,list,form,calendar,activity</field>
-        <field name="context">{
-            'search_default_active': True,
-        }</field>
+        <field name="context">{'search_default_todo': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Add a new maintenance request
@@ -365,7 +355,7 @@
                         <button name="%(hr_equipment_request_action_from_equipment)d"
                             type="action"
                             class="oe_stat_button"
-                            context="{'search_default_active': True, 'default_company_id': company_id, 'default_maintenance_team_id': maintenance_team_id}"
+                            context="{'default_company_id': company_id, 'default_maintenance_team_id': maintenance_team_id}"
                             icon="fa-wrench">
                             <field string="Maintenance" name="maintenance_count" widget="statinfo"/>
                         </button>
@@ -847,7 +837,7 @@
                         </div>
                     </t>
                     <t t-name="card">
-                        <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action">
+                        <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1}">
                             <field name="name" class="fw-bold fs-4 ms-2"/>
                         </a>
                         <div class="row g-0 mt-3 ms-2 pb-4">

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -131,12 +131,7 @@
                             <field name='description' placeholder="Internal Notes"/>
                         </page>
                         <page string="Instructions">
-                            <group col="1">
-                                <field name="instruction_type" widget="radio" nolabel="1"/>
-                                <field name="instruction_pdf" help="Upload your PDF file." widget="pdf_viewer" invisible="instruction_type != 'pdf'" required="instruction_type == 'pdf'" nolabel="1"/>
-                                <field name="instruction_google_slide" placeholder="Google Slide Link" widget="google_slide_viewer" invisible="instruction_type != 'google_slide'" required="instruction_type == 'google_slide'" nolabel="1"/>
-                                <field name="instruction_text" placeholder="Your instructions" invisible="instruction_type != 'text'" nolabel="1"/>
-                            </group>
+                            <field name="instruction_text" placeholder="Your instructions"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -16,15 +16,17 @@
                 <field name="maintenance_team_id"/>
                 <filter string="My Maintenances" name="my_maintenances" domain="[('user_id', '=', uid)]"/>
                 <separator/>
-                <filter string="To Do" name="todo" domain="[('stage_id.done', '=', False)]"/>
-                <filter string="Done" name="done" domain="[('stage_id.done', '=', True)]"/>
+                <filter string="Open" name="todo" domain="[('state', 'not in', ['done', 'cancelled'])]"/>
+                <filter string="Done" name="done" domain="[('state', '=', 'done')]"/>
+                <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancelled')]"/>
                 <separator/>
-                <filter string="Blocked" name="kanban_state_block" domain="[('stage_id.done', '=', False), ('kanban_state', '=', 'blocked')]"/>
-                <filter string="Ready" name="done" domain="[('stage_id.done', '=', False), ('kanban_state', '=', 'done')]"/>
+                <filter string="In Progress" name="in_progress" domain="[('state', '=', 'normal')]"/>
+                <filter string="Changes Requested" name="changes_requested" domain="[('state', '=', 'changes_requested')]"/>
+                <filter string="Approved" name="approved" domain="[('state', '=', 'approved')]"/>
                 <separator/>
-                <filter string="High-priority" name="high_priority" domain="[('stage_id.done', '=', False), ('priority', '=', '3')]"/>
+                <filter string="High-priority" name="high_priority" domain="[('state', 'not in', ['done', 'cancelled']), ('priority', '=', '3')]"/>
                 <separator/>
-                <filter string="Unscheduled" name="unscheduled" domain="[('stage_id.done', '=', False), ('schedule_date', '=', False)]"/>
+                <filter string="Unscheduled" name="unscheduled" domain="[('state', 'not in', ['done', 'cancelled']), ('schedule_date', '=', False)]"/>
                 <separator/>
                 <filter name="filter_schedule_date" date="schedule_date"/>
                 <filter name="filter_close_date" date="close_date"/>
@@ -83,15 +85,12 @@
                 <field name="company_id" invisible="1"/>
                 <field name="category_id" invisible="1"/>
                 <header>
-                    <button string="Cancel" name="archive_equipment_request" type="object" invisible="archive"/>
-                    <button string="Reopen Request" name="reset_equipment_request" type="object" invisible="not archive"/>
-                    <field name="stage_id" widget="statusbar" options="{'clickable': '1'}" invisible="archive"/>
+                    <button string="Cancel" name="cancel_equipment_request" type="object" invisible="state == 'cancelled'"/>
+                    <button string="Reopen Request" name="reset_equipment_request" type="object" invisible="state != 'cancelled'"/>
+                    <field name="stage_id" widget="statusbar" options="{'clickable': '1'}" invisible="state == 'cancelled'"/>
                 </header>
                 <sheet>
-                    <div invisible="not archive">
-                        <span class="badge text-bg-warning float-end">Cancelled</span>
-                    </div>
-                    <field name="kanban_state" widget="state_selection"/>
+                    <field name="state" widget="maintenance_request_state_selection" class="float-end"/>
                     <div class="oe_title">
                         <label for="name" string="Request"/>
                         <h1>
@@ -103,8 +102,7 @@
                             <field name="owner_user_id" string="Requested By" invisible="1"/>
                             <field name="equipment_id" context="{'default_company_id':company_id, 'default_category_id':category_id}" required="1"/>
                             <field name="category_id" groups="maintenance.group_equipment_manager" context="{'default_company_id':company_id}" invisible="not equipment_id"/>
-                            <field name="done" invisible="1"/>
-                            <field name="close_date" readonly="True" invisible="not done"/>
+                            <field name="close_date" readonly="True" invisible="state != 'done'"/>
                             <field name="archive" invisible="1"/>
                             <field name="maintenance_type" widget="radio"/>
                         </group>
@@ -152,8 +150,7 @@
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
             <kanban highlight_color="color" default_group_by="stage_id" sample="1">
-                <field name="archive" />
-                <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
+                <progressbar field="state" colors='{"done": "success", "cancelled": "danger"}'/>
                 <templates>
                     <t t-name="menu">
                         <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit...</a></t>
@@ -161,23 +158,22 @@
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
                     <t t-name="card">
-                        <field name="name" class="fw-bold fs-5"/>
-                        <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/></span>
-                        <span t-if="record.equipment_id.raw_value"><field name="equipment_id"/><span t-if="record.category_id.raw_value"> (<field name="category_id"/>)</span></span>
-                        <field name="schedule_date"/>
-                        <footer>
-                            <div class="d-flex">
-                                <field name="priority" widget="priority"/>
-                                <field name="activity_ids" widget="kanban_activity" class="ms-3"/>
-                            </div>
-                            <div class="d-flex ms-auto align-items-center">
-                                <div class="badge text-bg-warning float-end" invisible="not archive">
-                                    Cancelled
+                        <main t-att-class="['done', 'cancelled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
+                            <field name="name" class="fw-bold fs-5"/>
+                            <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/></span>
+                            <span t-if="record.equipment_id.raw_value"><field name="equipment_id"/><span t-if="record.category_id.raw_value"> (<field name="category_id"/>)</span></span>
+                            <field name="schedule_date"/>
+                            <footer>
+                                <div class="d-flex">
+                                    <field name="priority" widget="priority"/>
+                                    <field name="activity_ids" widget="kanban_activity" class="ms-3"/>
                                 </div>
-                                <field name="kanban_state" widget="state_selection" class="ms-1"/>
-                                <field name="user_id" widget="many2one_avatar_user" class="ms-1"/>
-                            </div>
-                        </footer>
+                                <div class="d-flex ms-auto align-items-center">
+                                    <field name="state" widget="maintenance_request_state_selection"/>
+                                    <field name="user_id" widget="many2one_avatar_user" class="ms-1"/>
+                                </div>
+                            </footer>
+                        </main>
                     </t>
                 </templates>
             </kanban>
@@ -241,9 +237,9 @@
                 <field name="repeat_unit" invisible="1"/>
                 <field name="repeat_type" invisible="1"/>
                 <field name="repeat_until" invisible="1"/>
-                <field name="done" invisible="1"/>
                 <field name="archive" invisible="1"/>
                 <field name="duration" invisible="1"/>
+                <field name="state" invisible="1"/>
             </calendar>
         </field>
     </record>
@@ -376,7 +372,7 @@
                             class="oe_stat_button"
                             context="{'search_default_active': True, 'default_company_id': company_id, 'default_maintenance_team_id': maintenance_team_id}"
                             icon="fa-wrench">
-                            <field string="Maintenance" name="maintenance_open_count" widget="statinfo"/>
+                            <field string="Maintenance" name="maintenance_count" widget="statinfo"/>
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
@@ -598,7 +594,7 @@
                         type="action"
                         class="oe_stat_button"
                         icon="fa-wrench">
-                        <field string="Maintenance" name="maintenance_open_count" widget="statinfo"/>
+                        <field string="Maintenance" name="maintenance_count" widget="statinfo"/>
                     </button>
                 </div>
                 <div class="oe_title">
@@ -699,7 +695,6 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="fold"/>
-                <field name="done"/>
             </list>
         </field>
     </record>
@@ -821,17 +816,17 @@
                                     </div>
                                     <div role="menuitem">
                                         <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1}">
-                                            To Do
-                                        </a>
-                                    </div>
-                                    <div role="menuitem">
-                                        <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_progress': 1}">
-                                            In Progress
+                                            Open
                                         </a>
                                     </div>
                                     <div role="menuitem">
                                         <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_done': 1}">
                                             Done
+                                        </a>
+                                    </div>
+                                    <div role="menuitem">
+                                        <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_cancelled': 1}">
+                                            Cancelled
                                         </a>
                                     </div>
                                 </div>
@@ -867,7 +862,7 @@
                                 </button>
                             </div>
                             <div class="col-6">
-                                <a t-if="record.todo_request_count_date.raw_value > 0" name="%(hr_equipment_request_action_cal)d" type="action" context="{'search_default_todo': 1, 'search_default_maintenance_team_id': id}" class="d-block">
+                                <a t-if="record.todo_request_count_date.raw_value > 0" name="%(hr_equipment_request_action_cal)d" type="action" context="{'search_default_maintenance_team_id': id}" class="d-block">
                                     <field name="todo_request_count_date"/>
                                     Scheduled
                                 </a>
@@ -875,11 +870,11 @@
                                     <field name="todo_request_count_high_priority"/>
                                     Top Priorities
                                 </a>
-                                <a t-if="record.todo_request_count_block.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_kanban_state_block': 1}" class="d-block">
-                                    <field name="todo_request_count_block"/>
-                                    Blocked
+                                <a t-if="record.todo_request_count_changes_requested.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_changes_requested': 1}" class="d-block">
+                                    <field name="todo_request_count_changes_requested"/>
+                                    Changes Requested
                                 </a>
-                                <a t-if="record.todo_request_count_unscheduled.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1, 'search_default_unscheduled': 1}" class="d-block">
+                                <a t-if="record.todo_request_count_unscheduled.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_unscheduled': 1}" class="d-block">
                                     <field name="todo_request_count_unscheduled"/>
                                     Unscheduled
                                 </a>


### PR DESCRIPTION
Currently, Maintenance Requests (MRs) can only be `marked as Done` by moving them to the `Done` stage, while `cancelling a request` requires opening the form view and clicking the `Cancel` button. These are common day-to-day actions, yet they are not easily accessible from views like kanban, making the workflow slower and less intuitive than expected.

The `Instructions tab` also presents usability issues. Different types of instructions (`PDF, Google Slides, and plain text`) are grouped together in a single tab, resulting in a cluttered layout that is difficult to manage and does not clearly separate procedural content. In addition, maintenance requests automatically `create and update activities` based on field changes, which often adds unnecessary clutter for users when they don't really need an activity for that request.

Furthermore, `several fields and filters` present in maintenance form and search views are rarely used. They seems unnecessary and make the UI feel heavier without providing meaningful value to most users.

This PR focuses on simplifying the Maintenance app by improving common actions, cleaning up the UI, and removing redundant automation.

- Introduces quick `Done` and `Cancel` actions through a new `maintenance_request_state_selection widget`, allowing users to manage request states directly from both kanban and form views without relying on stage changes or form view actions.

- Simplifies the `Instructions` tab by removing mixed instruction formats and keeping only the text input, resulting in a cleaner layout and a single, consistent way to manage maintenance instructions.

- Removes automatic `activity creation and updates` triggered by maintenance request field changes, keeping the workflow lightweight.

- Cleans up `unused filters and fields` from maintenance form and search views, reducing UI clutter and making the interface clearer and easier to use.

Overall, these changes make maintenance requests faster to manage, easier to understand, and more consistent across views. By reducing unnecessary steps and visual complexity, the Maintenance app becomes more user-friendly and better suited for everyday operational use.

TaskId-5150425