### PR TITLE
[FIX] website_sale : fix typo youy -> you

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1534,7 +1534,7 @@
                         <div class="css_non_editable_mode_hidden">
                             <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none o_default_snippet_text">
                                 Your Dynamic Snippet will be displayed here...
-                                This message is displayed because youy did not provide both a filter and a template to use.
+                                This message is displayed because you did not provide both a filter and a template to use.
                             </div>
                         </div>
                         <div class="dynamic_snippet_template"></div>

--- a/doc/cla/individual/cnc-sherif.md
+++ b/doc/cla/individual/cnc-sherif.md
@@ -1,0 +1,9 @@
+Turkey, 2025-11-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Serif Elashry shouldtheone@gmail.com https://github.com/cnc-sherif


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes a typo that was found in website_sale module.
There is a mistake in writing "you"

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
