### PR TITLE
[FIX] base_import: handle CSV extension case-insensitively

### DIFF
--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -27,7 +27,7 @@
                     Use first row as header
                 </CheckBox>
             </div>
-            <div t-if="fileExtension === '.csv'" class="o_import_formatting pt-3 pb-4 border-top">
+            <div t-if="fileExtension.toLowerCase() === '.csv'" class="o_import_formatting pt-3 pb-4 border-top">
                 <h4>Formatting</h4>
                 <div t-foreach="Object.entries(props.formattingOptions)" t-as="option" t-key="`${option[0]}-${option_index}`" class="o_import_options">
                     <label t-att-for="`${option[0]}-${option_index}`">

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -570,6 +570,28 @@ QUnit.module("Base Import Tests", (hooks) => {
         );
     });
 
+    QUnit.test("Import view: import a CSV file with uppercase extension", async function (assert) {
+        registerFakeHTTPService((route, params) => {
+            assert.strictEqual(route, "/base_import/set_file");
+            assert.strictEqual(
+                params.ufile[0].name,
+                "fake_file.CSV",
+                "file with uppercase .CSV extension is correctly uploaded to the server"
+            );
+        });
+        await createImportAction();
+
+        // Simulate uploading a .CSV file (uppercase extension)
+        const file = new File(["fake_file"], "fake_file.CSV", { type: "text/plain" });
+        await editInput(target, ".o_control_panel_main_buttons .d-none input[type='file']", file);
+
+        assert.containsOnce(
+            target,
+            ".o_import_data_sidepanel .o_import_formatting",
+            "formatting options are shown for uppercase extention .CSV file"
+        );
+    });
+
     QUnit.test("Import view: additional options in debug", async function (assert) {
         patchWithCleanup(odoo, { debug: true });
         registerFakeHTTPService();


### PR DESCRIPTION
Before this fix, the import side panel displayed the formatting options 
only when the uploaded file had a lowercase .csv extension.
Files with an uppercase .CSV extension could still be imported but did 
not show the format selection section, leading to inconsistent behavior.

This commit updates the condition to perform a
case-insensitive comparison on the file extension.

Task-5145031

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
