### PR TITLE
[IMP] mail: widen call sidebar and hide inset card

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -131,6 +131,20 @@ export class Call extends Component {
         ];
     }
 
+    get sidebarCards() {
+        const selfCards = [];
+        const otherVisibleCards = [];
+        const cards = this.channel.visibleCards;
+        for (let i = 0; i < cards.length; i++) {
+            if (cards[i].session?.eq(this.rtc.selfSession)) {
+                selfCards.push(cards[i]);
+            } else {
+                otherVisibleCards.push(cards[i]);
+            }
+        }
+        return selfCards.concat(otherVisibleCards);
+    }
+
     /**
      * @param {import("models").RtcSession} session
      * @param {import("@mail/discuss/call/common/rtc_service").VideoType} [videoType]

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -6,12 +6,22 @@
     height: 50%; // ensures that the view returns to the right height when resized
     min-height: 50%;
     background-color: inherit;
+    display: grid;
+    grid-template-columns: 1fr;
 
     &.o-selfInCall {
         background-color: var(--o-discuss-Call-bgColor, #{$dark});
 
         .o-discuss-Call-main {
             background-color: rgba(0, 0, 0, 0.5);
+        }
+    }
+
+    &:has(.o-discuss-Call-sidebar) {
+        grid-template-columns: 1fr 230px;
+
+        @include media-breakpoint-down(sm) {
+            grid-template-columns: 1fr 160px;
         }
     }
 
@@ -42,8 +52,6 @@
 }
 
 .o-discuss-Call-sidebar {
-    width: 120px;
-    min-width: 120px;
     overflow-y: auto;
     overflow-x: hidden;
 

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.Call">
         <PttAdBanner/>
-        <div class="o-discuss-Call user-select-none d-flex position-relative shadow-sm" t-att-class="{
+        <div class="o-discuss-Call user-select-none position-relative shadow-sm" t-att-class="{
             'o-fullSize': isFullSize,
             'o-compact': props.compact and !isMobileOs,
             'o-minimized': minimized,
@@ -13,7 +13,7 @@
             'o-selfInCall': isActiveCall,
             'border-bottom': !isActiveCall,
         }" t-ref="root">
-            <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto o-scrollbar-thin" t-on-mouseleave="onMouseleaveMain">
+            <div class="o-discuss-Call-main d-flex flex-column align-items-center justify-content-center position-relative overflow-auto o-scrollbar-thin" t-on-mouseleave="onMouseleaveMain">
                 <BlurPerformanceWarning t-if="store.settings.blurPerformanceWarning"/>
                 <div
                     class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
@@ -58,7 +58,7 @@
                 </div>
             </div>
             <div t-if="state.sidebar and channel.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">
-                <CallParticipantCard t-foreach="channel.visibleCards" t-as="cardData" t-key="cardData.key"
+                <CallParticipantCard t-foreach="sidebarCards" t-as="cardData" t-key="cardData.key"
                     cardData="cardData"
                     className="'o-discuss-Call-sidebarCard w-100 p-1'"
                     channel="channel"
@@ -66,7 +66,7 @@
                 />
             </div>
             <CallParticipantCard
-                t-if="channel.videoCount > 0 and state.insetCard"
+                t-if="channel.videoCount > 0 and state.insetCard and !state.sidebar"
                 cardData="state.insetCard"
                 className="'o-discuss-Call-mainCardStyle o-bg-black'"
                 channel="channel"

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -39,7 +39,7 @@
             <t t-if="rtcSession">
                 <!-- overlay -->
                 <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1" t-att-class="{ 'o-proportional-container w-50': isSmall }" t-att-data-connection-state="rtcSession.connectionState">
-                    <span t-if="!props.minimized and !props.inset" class="rounded-1 text-truncate opacity-75 w-100 o-proportional-text o-discuss-CallParticipantCard-overlayBottomName" t-att-class="{'o-minimized px-1': isSmall, 'p-0': !isSmall }" t-esc="name"/>
+                    <span t-if="!props.minimized and !props.inset" class="rounded-1 text-truncate opacity-75 o-proportional-text o-discuss-CallParticipantCard-overlayBottomName" t-att-class="{'o-minimized px-1': isSmall, 'p-0': !isSmall }" t-esc="name"/>
                     <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-proportional-text o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
                         LIVE
                     </small>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -312,6 +312,24 @@ test("Click on inset card should replace the inset and active stream together", 
     await contains("video[type='camera']:not(.o-inset)");
 });
 
+test("Inset card is hidden when sidebar is open", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click("[title='Turn camera on']");
+    await click("[title='Share Screen']");
+    await contains(".o-discuss-CallParticipantCard.o-inset");
+    await hover(".o-discuss-Call-mainCards");
+    await click(".o-discuss-Call-sidebarToggler");
+    await contains(".o-discuss-Call-sidebar");
+    await contains(".o-discuss-CallParticipantCard.o-inset", { count: 0 });
+    await hover(".o-discuss-Call-mainCards");
+    await click(".o-discuss-Call-sidebarToggler");
+    await contains(".o-discuss-CallParticipantCard.o-inset");
+});
+
 test("join/leave sounds are only played on main tab", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
**Purpose of this PR:**

- Increase the width of the call sidebar using css grid.
- Hide the inset participant card when the call sidebar is open.
- Sort sidebar participant cards to show the user's own cards first,
since the inset card is hidden when the sidebar is open.
- Other cards maintain the existing sorting order.

**Before vs After (Sidebar):**
<div>
  <img width="49%" height="923" alt="image" src="https://github.com/user-attachments/assets/2fd6d4b7-fc7d-49b5-9a20-26d4e6e06759" />
  <img width="49%" height="931" alt="image" src="https://github.com/user-attachments/assets/2834302c-86a0-4f3a-9ea5-058f12883b70" />
</div>

task-[5386281](https://www.odoo.com/odoo/project/1519/tasks/5227387/action-4665/5386281)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr