### PR TITLE
[FIX] html_editor: fix traceback when editing website appointment page

### DIFF
--- a/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
@@ -21,7 +21,7 @@ class LayoutColumnOptionPlugin extends Plugin {
             }
         },
         selection_blocker_predicates: (blocker) => {
-            if (blocker.classList.contains("row")) {
+            if (blocker.nodeType === Node.ELEMENT_NODE && blocker.classList.contains("row")) {
                 return false;
             }
         },

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -37,7 +37,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
             }
         },
         selection_blocker_predicates: (blocker) => {
-            if (blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE) || !isBlock(blocker)) {
+            if ((blocker.nodeType === Node.ELEMENT_NODE && blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) || !isBlock(blocker)) {
                 return false;
             } else if (isNotEditableNode(blocker)) {
                 return true;

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -53,7 +53,7 @@ export class ToggleBlockPlugin extends Plugin {
         move_node_blacklist_selectors: `${toggleSelector} ${titleSelector} *`,
         selection_blocker_predicates: (blocker) => {
             // Prevent the insertion of selection placeholders around toggle blocks.
-            if (blocker.dataset.embedded === "toggleBlock") {
+            if (blocker.nodeType === Node.ELEMENT_NODE && blocker.dataset.embedded === "toggleBlock") {
                 return false;
             }
         },


### PR DESCRIPTION
**Steps to reproduce:**
- Install website_appointment_sale with demo data
- Start booking an appointment and stop at the `Date & Time` selection page
- Open the `website editor` and click the `edit` option
- A traceback occurs

**Issue:**
- A traceback occurs when trying to edit the page,

Error:
`TypeError: blocker.hasAttribute is not a function
    at selection_blocker_predicates`

**Cause:**
- The `selection_blocker_predicates` function assumed every `blocker` was an Element
 and called `blocker.hasAttribute(...)`. When a non-element node (text, comment, or object)
was encountered, the call raised a 'TypeError'.

<img width="778" height="177" alt="image" src="https://github.com/user-attachments/assets/7ef14d01-56e0-45b7-a39e-3e9fb6a4c6ce" />

>  nodeType = 3 then it’s a `text node`

https://github.com/odoo/odoo/blob/700fac2532d2de6abc6f87e30a5b056dcfc109d1/addons/html_editor/static/src/main/selection_placeholder_plugin.js#L39-L45

**Solution:**
- Make the function defensive by checking that `blocker` is an instance of `Element`
- before accessing DOM methods. Non-element nodes are now safely check.

---

opw : 5241222

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
