### PR TITLE
[FIX] resource: prevent division by zero in salary rule computation f…

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -109,7 +109,7 @@ class ResourceCalendar(models.Model):
     two_weeks_explanation = fields.Char('Explanation', compute="_compute_two_weeks_explanation")
     flexible_hours = fields.Boolean(string="Flexible Hours",
                                     help="When enabled, it will allow employees to work flexibly, without relying on the company's working schedule (working hours).")
-    hours_per_week = fields.Float(compute="_compute_hours_per_week", string="Hours per Week", store=True)
+    hours_per_week = fields.Float(compute="_compute_hours_per_week", string="Hours per Week", store=True, readonly=False)
     full_time_required_hours = fields.Float(string="Company Full Time", help="Number of hours to work on the company schedule to be considered as fulltime.")
     is_fulltime = fields.Boolean(compute='_compute_work_time_rate', string="Is Full Time")
     work_time_rate = fields.Float(string='Work Time Rate', compute='_compute_work_time_rate', search='_search_work_time_rate',

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -61,24 +61,32 @@
                         <group name="resource_working_hours">
                             <field name="flexible_hours"/>
                             <label for="full_time_required_hours" invisible="flexible_hours"/>
-                            <label for="full_time_required_hours" string="Hours per Week" invisible="not flexible_hours"/>
+                            <label for="full_time_required_hours" string="Required Full Time" invisible="not flexible_hours"/>
                             <div>
                                 <field name="full_time_required_hours" style="width: 6ch;" widget="float_time"/>
                                 <span>hours/week</span>
                             </div>
                             <field name="hours_per_day" widget="float_time" readonly="not flexible_hours"/>
-                            <label for="work_time_rate" string="Work Time Rate" invisible="flexible_hours"/>
-                            <div invisible="flexible_hours">
-                                <field name="work_time_rate" nolabel="1"  style="width: 5ch;"/>
+                            <label for="work_time_rate" string="Work Time Rate"/>
+                            <div>
+                                <field name="work_time_rate" nolabel="1" style="width: 5ch;"/>
                                 <span class="ms-1">%</span>
                             </div>
                             <field name="is_fulltime" invisible="1"/>
                         </group>
-                        <group name="resource_company">
-                            <field name="active" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
-                            <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
-                            <field name="tz_offset" invisible="1"/>
+                        <group>
+                            <group name="resource_company" colspan="2">
+                                <field name="company_id" placeholder="Visible to all"/>
+                                <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}"/>
+                                <field name="tz_offset" invisible="1"/>
+                            </group>
+                            <group name="flex_details" invisible="not flexible_hours" colspan="2">
+                                <label for="hours_per_week" string="Total"/>
+                                <div class="d-flex">
+                                    <field name="hours_per_week" nolabel="1" style="width: 6ch;" widget="float_time"/>
+                                    <span class="ms-2">hours/week</span>
+                                </div>
+                            </group>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
…or flexible working schedules

```
odoo.exceptions.UserError: Código Python erróneo definido para:
- Empleado: Donovan Raziel Castillo
- Versión: False
- Recibo de nómina: Payslip Simulation
- Regla salarial: Holidays On Time to Substruct (HOLIDAY_TO_SUB)
- Error: float division by zero
```
Steps to reproduce:
1. Create a new database in saas-18.4 and install: resource, l10n_mx, l10n_mx_hr_payroll, hr_payroll, hr_contract_salary_payroll
2. Go to the Recruitment app → create a Salary Offer.
3. Assign a name, an applicant, and a contract template.
4. In the contract template:
   - Name: Department
   - Contract Type: Permanent, employee_mexico
   - Working Hours: create a new schedule
5. Set Schedule Type = Flexible
6. Fill Hours per Week (`full_time_required_hours`) (e.g., 48) → Notice that Hours per Week and Work Time Rate are not visible.

In saas-18.4, when a working schedule is configured as Flexible, the computation of `work_time_rate` results in 0.0 because the field `hours_per_week` remains unset (it is only visible when Flexible Hours is [False](https://github.com/odoo/odoo/blob/saas-18.4/addons/resource/views/resource_calendar_views.xml#L85-L92)). As a result, during migration, when the computation occurs in `hr_contract_salary_offer`, A division by zero error is raised during the salary rule Python computation.

Root cause:
When the calendar is flexible, and Hours per Week (`full_time_required_hours`) are defined, the computation of `work_time_rate` returns 0.0. As a result, when the salary rule computation (`_compute_rule`) performs a division using this zero value, a ZeroDivisionError occurs.

Technical point of view:
The error occurs because the Work Time Rate is not being calculated correctly. In both versions [18.4 ](https://github.com/odoo/odoo/blob/saas-18.4/addons/resource/models/resource_calendar.py#L143-L151)and [19.0](https://github.com/odoo/odoo/blob/19.0/addons/resource/models/resource_calendar.py#L250-L258), the compute logic is the same — it depends on the fields `hours_per_week` and `full_time_required_hours`.

However, in this case, the computation behaves incorrectly. If the customer provides a value for Equivalent Working Hours, the code enters the `if` [condition](https://github.com/odoo/odoo/blob/saas-18.4/addons/resource/models/resource_calendar.py#L146) to calculate the Work Time Rate. Since the field `hours_per_week` is only visible and its [computation] (https://github.com/odoo/odoo/blob/saas-18.4/addons/resource/models/resource_calendar.py#L136-L141) happens when Flexible Hours is [False](https://github.com/odoo/odoo/blob/saas-18.4/addons/resource/views/resource_calendar_views.xml#L85), its value remains 0, which leads to a Work Time Rate of 0.0 always.

On the other hand, in the `else` [condition](https://github.com/odoo/odoo/blob/saas-18.4/addons/resource/models/resource_calendar.py#L148), the Work Time Rate is directly set to 100. This means that when Flexible Hours = True and Equivalent Working Hours is not filled in, the calculation always results in 100.

Solution:
To fix this issue, we should make both Work Time Rate and Hours per Week visible in the form view for the customer. This fix aligns the behavior with the version 19.0 [In 19.0 the both `hours_per_week` and `work_time_rate` visible for the user from this [IMP](https://github.com/odoo/odoo/commit/5cb102546ea4370b4fe5e4a4f37cccdc90c263fd) fix.] by making both `hours_per_week` and `work_time_rate` visible in the working schedule form view. This allows users to correctly configure these fields when using flexible calendars and prevents incorrect or zero-based calculations.

In summary:
The issue only occurs when Flexible Hours = True — in that case, the Work Time Rate calculation always results in 0.0. Showing both fields to the user ensures proper configuration and avoids incorrect computation.

UPG:- 3269714
OPW:- 5124639
Errro-Pad :- https://pad.odoo.com/p/issue_5124639_labo

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
