### PR TITLE
[IMP] payment_authorize: support webhook

### DIFF
--- a/addons/payment_authorize/README.md
+++ b/addons/payment_authorize/README.md
@@ -22,14 +22,16 @@ passed to the Accept.js SDK, the solution qualifies for SAQ A-EP.
 - Tokenization with or without payment
 - Full manual capture
 - Full refunds
+- Webhook notifications
 
 ## Missing features
 
 - Partial manual capture
-- Webhook notifications: not available
 
 ## Module history
 
+- `19.3`
+  - Webhook support is added for delayed payments synchronization. odoo/odoo#235070
 - `16.1`
   - The "Authorize Currency" field is replaced by the generic "Currencies" field of `payment`.
     odoo/odoo#101018

--- a/addons/payment_authorize/const.py
+++ b/addons/payment_authorize/const.py
@@ -1,5 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+PAYMENT_REQUEST_ROUTE = "/payment/authorize/payment"
+WEBHOOK_ROUTE = "/payment/authorize/webhook"
+
 # The codes of the payment methods to activate when Authorize is activated.
 DEFAULT_PAYMENT_METHOD_CODES = {
     # Primary payment methods.
@@ -13,7 +16,12 @@ DEFAULT_PAYMENT_METHOD_CODES = {
 }
 
 # Mapping of payment method codes to Authorize codes.
-PAYMENT_METHODS_MAPPING = {"amex": "americanexpress", "diners": "dinersclub", "card": "creditcard"}
+PAYMENT_METHODS_MAPPING = {
+    "ach_direct_debit": "echeck",
+    "amex": "americanexpress",
+    "card": "creditcard",
+    "diners": "dinersclub",
+}
 
 # Mapping of payment status on Authorize side to transaction statuses.
 # See https://developer.authorize.net/api/reference/index.html#transaction-reporting-get-transaction-details.
@@ -23,3 +31,16 @@ TRANSACTION_STATUS_MAPPING = {
     "voided": ["voided"],
     "refunded": ["refundPendingSettlement", "refundSettledSuccessfully"],
 }
+
+# Mapping of webhook event types to their corresponding transaction type
+WEBHOOK_EVENT_TYPE_MAPPING = {
+    "net.authorize.payment.authcapture.created": "auth_capture",
+    "net.authorize.payment.authorization.created": "auth_only",
+    "net.authorize.payment.capture.created": "auth_capture",
+    "net.authorize.payment.priorAuthCapture.created": "prior_auth_capture",
+    "net.authorize.payment.refund.created": "refund",
+    "net.authorize.payment.void.created": "void",
+}
+
+# Supported webhook event types
+HANDLED_WEBHOOK_EVENTS = set(WEBHOOK_EVENT_TYPE_MAPPING)

--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -1,6 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import hashlib
+import hmac
 import pprint
+
+from werkzeug.exceptions import Forbidden
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
@@ -8,12 +12,13 @@ from odoo.http import request
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
+from odoo.addons.payment_authorize import const
 
 _logger = get_payment_logger(__name__)
 
 
 class AuthorizeController(http.Controller):
-    @http.route("/payment/authorize/payment", type="jsonrpc", auth="public")
+    @http.route(const.PAYMENT_REQUEST_ROUTE, type="jsonrpc", auth="public")
     def authorize_payment(self, reference, partner_id, access_token, opaque_data):
         """Make a payment request and handle the response.
 
@@ -36,8 +41,7 @@ class AuthorizeController(http.Controller):
         # This prevents sql concurrent updates, which stops ORM from automatically
         # retrying the route and consuming the single-use OTS token a second time.
         tx_sudo.env.cr.execute(
-            "SELECT 1 FROM payment_transaction WHERE id = %s FOR NO KEY UPDATE",
-            [tx_sudo.id]
+            "SELECT 1 FROM payment_transaction WHERE id = %s FOR NO KEY UPDATE", [tx_sudo.id]
         )
 
         # Send the payment request to Authorize.Net.
@@ -50,3 +54,62 @@ class AuthorizeController(http.Controller):
             pprint.pformat(response_content),
         )
         tx_sudo._process("authorize", {"response": response_content})
+
+    @http.route(const.WEBHOOK_ROUTE, type="http", auth="public", methods=["POST"], csrf=False)
+    def authorize_webhook(self):
+        """Process the payment data sent by Authorize.net to the webhook.
+
+        See https://developer.authorize.net/api/reference/features/webhooks.html
+
+        :return: An empty string to acknowledge the notification.
+        :rtype: str
+        """
+        data = request.get_json_data()
+        _logger.info(
+            "Notification received from Authorize.net with data:\n%s", pprint.pformat(data)
+        )
+        event_type = data.get("eventType")
+        if event_type in const.HANDLED_WEBHOOK_EVENTS:
+            tx_sudo = (
+                request.env["payment.transaction"].sudo()._search_by_reference("authorize", data)
+            )
+            if tx_sudo and data.get("webhookId") == tx_sudo.provider_id.authorize_webhook_id:
+                # Check the integrity of the notification
+                signature_header = request.httprequest.headers.get("X-ANET-Signature")
+                signature = signature_header and signature_header.split("=", 1)[1].upper()
+                self._verify_signature(signature, request.httprequest.get_data(), tx_sudo)
+
+                # Process the payment data. The data are structured in the same format as the
+                # transaction API's responses.
+                payload = data.get("payload", {})
+                payment_data = {
+                    "response": {
+                        "x_response_code": str(payload.get("responseCode")),
+                        "x_trans_id": payload.get("id"),
+                        "x_type": const.WEBHOOK_EVENT_TYPE_MAPPING[event_type],
+                    }
+                }
+                tx_sudo._process("authorize", payment_data)
+        return request.make_json_response("")
+
+    @staticmethod
+    def _verify_signature(signature, request_body, tx_sudo):
+        """Check that the received signature matches the expected one.
+
+        :param str signature: The extracted HMAC signature value.
+        :param bytes request_body: The raw request body.
+        :param payment.transaction tx_sudo: The sudoed transaction referenced by the payment data.
+        :rtype: None
+        :raise Forbidden: If the signatures don't match.
+        """
+        if not signature:
+            _logger.warning("Received notification with missing signature.")
+            raise Forbidden
+
+        signature_key = tx_sudo.provider_id.authorize_signature_key
+        expected_signature = (
+            hmac.new(signature_key.encode(), request_body, hashlib.sha512).hexdigest().upper()
+        )
+        if not hmac.compare_digest(expected_signature, signature):
+            _logger.warning("Received notification with invalid signature.")
+            raise Forbidden

--- a/addons/payment_authorize/models/payment_provider.py
+++ b/addons/payment_authorize/models/payment_provider.py
@@ -6,6 +6,7 @@ import pprint
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command
+from odoo.tools import urls
 
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_authorize import const
@@ -42,6 +43,12 @@ class PaymentProvider(models.Model):
         string="API Client Key",
         help="The public client key. To generate directly from Odoo or from Authorize.Net backend.",
         copy=False,
+    )
+    authorize_webhook_id = fields.Char(
+        string="Authorize Webhook ID",
+        help="The ID of the webhook created in Authorize.net.",
+        copy=False,
+        groups="base.group_system",
     )
 
     # === CONSTRAINT METHODS ===#
@@ -103,6 +110,41 @@ class PaymentProvider(models.Model):
         self.available_currency_ids = [Command.set(currency.ids)]
         self.authorize_client_key = res_content.get("publicClientKey")
 
+    def action_authorize_create_webhook(self):
+        """Create a new webhook and display a toast notification.
+
+        Note: `self.ensure_one()`
+
+        :return: A notification action to display the result.
+        :rtype: dict
+        """
+        self.ensure_one()
+
+        if self.state == "disabled":
+            raise UserError(_("This action cannot be performed while the provider is disabled."))
+
+        webhook_url = urls.urljoin(self.get_base_url(), const.WEBHOOK_ROUTE)
+        response = self._send_api_request(
+            "POST",
+            "/rest/v1/webhooks",
+            json={
+                "name": self.company_id.name,
+                "url": webhook_url,
+                "eventTypes": list(const.HANDLED_WEBHOOK_EVENTS),
+                "status": "active",
+            },
+        )
+        self.authorize_webhook_id = response["webhookId"]
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "success",
+                "message": self.env._("Your Authorize.Net webhook was successfully set up!"),
+                "next": {"type": "ir.actions.client", "tag": "soft_reload"},
+            },
+        }
+
     # === BUSINESS METHODS ===#
 
     def _get_validation_amount(self):
@@ -133,3 +175,19 @@ class PaymentProvider(models.Model):
             "client_key": self.authorize_client_key,
         }
         return json.dumps(inline_form_values)
+
+    def _build_request_url(self, endpoint, **kwargs):
+        """Override of `payment` to build the full URL for Authorize.Net's REST API."""
+        if self.code != "authorize":
+            return super()._build_request_url(endpoint, **kwargs)
+
+        if self.state == "enabled":
+            return f"https://api.authorize.net{endpoint}"
+        return f"https://apitest.authorize.net{endpoint}"
+
+    def _build_request_auth(self, **kwargs):
+        """Override of `payment` to build HTTP Basic Auth for Authorize.Net's REST API."""
+        if self.code != "authorize":
+            return super()._build_request_auth(**kwargs)
+
+        return self.authorize_login, self.authorize_transaction_key

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -2,7 +2,7 @@
 
 import pprint
 
-from odoo import _, models
+from odoo import _, api, models
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -178,6 +178,17 @@ class PaymentTransaction(models.Model):
         # Authorize supports only one currency per account.
         currency = self.provider_id.available_currency_ids  # The currency is still linked.
         return {"amount": float(amount), "currency_code": currency.name}
+
+    @api.model
+    def _extract_reference(self, provider_code, payment_data):
+        """Override of `payment` to extract the reference from the payment data.
+
+        This override only supports the webhook flow because server-to-server request responses
+        do not include the transaction reference.
+        """
+        if provider_code != "authorize":
+            return super()._extract_reference(provider_code, payment_data)
+        return payment_data.get("payload", {}).get("invoiceNumber")
 
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""

--- a/addons/payment_authorize/tests/__init__.py
+++ b/addons/payment_authorize/tests/__init__.py
@@ -1,3 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import common, test_authorize, test_refund_flows
+from . import (
+    common,
+    test_authorize,
+    test_payment_transaction,
+    test_processing_flows,
+    test_refund_flows,
+)

--- a/addons/payment_authorize/tests/common.py
+++ b/addons/payment_authorize/tests/common.py
@@ -16,9 +16,28 @@ class AuthorizeCommon(PaymentCommon):
                 "authorize_login": "dummy",
                 "authorize_transaction_key": "dummy",
                 "authorize_signature_key": "00000000",
+                "authorize_webhook_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                 "available_currency_ids": [Command.set(cls.currency_usd.ids)],
             },
         )
 
         cls.provider = cls.authorize
         cls.currency = cls.currency_usd
+        cls.trans_id = "60123456789"
+
+        # Base webhook notification structure
+        cls.webhook_authcapture_data = {
+            "notificationId": "e4bc2a42-69e7-4cc4-bf0b-00d0c1a34c8e",
+            "eventType": "net.authorize.payment.authcapture.created",
+            "eventDate": "2023-10-15T10:30:00.000Z",
+            "webhookId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "payload": {
+                "responseCode": 1,
+                "authCode": "123456",
+                "avsResponse": "Y",
+                "authAmount": cls.amount,
+                "entityName": "transaction",
+                "id": cls.trans_id,
+                "invoiceNumber": cls.reference,
+            },
+        }

--- a/addons/payment_authorize/tests/test_payment_transaction.py
+++ b/addons/payment_authorize/tests/test_payment_transaction.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.payment_authorize.tests.common import AuthorizeCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentTransaction(AuthorizeCommon):
+    def test_search_by_reference_finds_transaction_from_webhook_data(self):
+        """Test that a transaction is correctly found from webhook data using invoiceNumber."""
+        tx = self._create_transaction("direct")
+        found_tx = self.env["payment.transaction"]._search_by_reference(
+            "authorize", self.webhook_authcapture_data
+        )
+        self.assertEqual(tx, found_tx)

--- a/addons/payment_authorize/tests/test_processing_flows.py
+++ b/addons/payment_authorize/tests/test_processing_flows.py
@@ -1,0 +1,83 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+from werkzeug.exceptions import Forbidden
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.addons.payment_authorize import const
+from odoo.addons.payment_authorize.controllers.main import AuthorizeController
+from odoo.addons.payment_authorize.tests.common import AuthorizeCommon
+
+
+@tagged("post_install", "-at_install")
+class TestProcessingFlows(AuthorizeCommon, PaymentHttpCommon):
+    @mute_logger("odoo.addons.payment_authorize.controllers.main")
+    def test_webhook_notification_triggers_processing(self):
+        """Test that receiving a valid webhook notification triggers the processing of the
+        payment data."""
+        self._create_transaction("direct")
+        url = self._build_url(const.WEBHOOK_ROUTE)
+
+        with (
+            patch(
+                "odoo.addons.payment_authorize.controllers.main.AuthorizeController._verify_signature"
+            ),
+            patch(
+                "odoo.addons.payment.models.payment_transaction.PaymentTransaction._process"
+            ) as process_mock,
+        ):
+            self._make_json_request(url, data=self.webhook_authcapture_data)
+        self.assertEqual(process_mock.call_count, 1)
+
+    @mute_logger("odoo.addons.payment_authorize.controllers.main")
+    def test_webhook_notification_triggers_signature_check(self):
+        """Test that receiving a webhook notification triggers a signature check."""
+        self._create_transaction("direct")
+        url = self._build_url(const.WEBHOOK_ROUTE)
+
+        with (
+            patch(
+                "odoo.addons.payment_authorize.controllers.main.AuthorizeController._verify_signature"
+            ) as signature_check_mock,
+            patch("odoo.addons.payment.models.payment_transaction.PaymentTransaction._process"),
+        ):
+            self._make_json_request(url, data=self.webhook_authcapture_data)
+            self.assertEqual(signature_check_mock.call_count, 1)
+
+    @mute_logger("odoo.addons.payment_authorize.controllers.main")
+    def test_accept_notification_with_valid_signature(self):
+        """Test that webhook notification with valid signature is accepted."""
+        tx = self._create_transaction("direct")
+        body = json.dumps(self.webhook_authcapture_data).encode("utf-8")
+        signature_key = self.authorize.authorize_signature_key
+        signature = (
+            hmac.new(signature_key.encode("utf-8"), body, hashlib.sha512).hexdigest().upper()
+        )
+
+        self._assert_does_not_raise(
+            Forbidden, AuthorizeController._verify_signature, signature, body, tx
+        )
+
+    @mute_logger("odoo.addons.payment_authorize.controllers.main")
+    def test_webhook_notification_rejects_missing_signature(self):
+        """Test that webhook notification with missing signature is rejected."""
+        tx = self._create_transaction("direct")
+        body = json.dumps(self.webhook_authcapture_data).encode("utf-8")
+
+        self.assertRaises(Forbidden, AuthorizeController._verify_signature, None, body, tx)
+
+    @mute_logger("odoo.addons.payment_authorize.controllers.main")
+    def test_webhook_notification_rejects_invalid_signature(self):
+        """Test that webhook notification with invalid signature is rejected."""
+        tx = self._create_transaction("direct")
+        body = json.dumps(self.webhook_authcapture_data).encode("utf-8")
+        self.assertRaises(
+            Forbidden, AuthorizeController._verify_signature, "INVALIDSIGNATURE", body, tx
+        )

--- a/addons/payment_authorize/views/payment_provider_views.xml
+++ b/addons/payment_authorize/views/payment_provider_views.xml
@@ -14,20 +14,51 @@
                     <label for="authorize_client_key"/>
                     <div class="o_row" col="2">
                         <field name="authorize_client_key"/>
-                        <button class="oe_link" icon="fa-refresh" type="object"
-                                name="action_update_merchant_details"
-                                string="Generate Client Key"/>
+                        <button
+                            string="Generate Client Key"
+                            type="object"
+                            name="action_update_merchant_details"
+                            invisible="state == 'disabled'"
+                            class="oe_link"
+                            icon="fa-refresh"
+                        />
+                    </div>
+                    <label
+                        for="authorize_webhook_id"
+                        invisible="not (authorize_login and authorize_transaction_key and authorize_signature_key)"
+                    />
+                    <div
+                        class="o_row"
+                        invisible="not (authorize_login and authorize_transaction_key and authorize_signature_key)"
+                    >
+                        <field string="Webhook ID" name="authorize_webhook_id"/>
+                        <button
+                            string="Generate Your Webhook"
+                            name="action_authorize_create_webhook"
+                            type="object"
+                            class="btn-primary"
+                            invisible="authorize_webhook_id or state == 'disabled'"
+                        />
+                        <button
+                            string="Re-generate Your Webhook"
+                            name="action_authorize_create_webhook"
+                            type="object"
+                            class="btn-secondary"
+                            invisible="not authorize_webhook_id or state == 'disabled'"
+                        />
                     </div>
                     <widget colspan="2" name="documentation_link" path="/applications/finance/payment_providers/authorize.html" label="How to get paid with Authorize.Net"/>
                 </group>
             </group>
             <div name="available_currencies" position="inside">
-                <button string="Set Account Currency"
-                        type="object"
-                        name="action_update_merchant_details"
-                        invisible="code != 'authorize'"
-                        icon="fa-refresh"
-                        class="oe_link"/>
+                <button
+                    string="Set Account Currency"
+                    type="object"
+                    name="action_update_merchant_details"
+                    invisible="code != 'authorize' or state == 'disabled'"
+                    icon="fa-refresh"
+                    class="oe_link"
+                />
             </div>
         </field>
     </record>


### PR DESCRIPTION
Implement a webhook endpoint to receive real-time transaction updates from
`Authorize.Net` with signature verification and automatic webhook management setup.

task-4737060
SEE ALSO:
Documentation PR:https://github.com/odoo/documentation/pull/15333

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
