### PR TITLE
[FIX] l10n_us_account: prevent error when uninstalling invoicing module

### DIFF
--- a/addons/l10n_us_account/__init__.py
+++ b/addons/l10n_us_account/__init__.py
@@ -3,3 +3,11 @@
 # The purpose of l10n_us_account is to automatically trigger the installation of l10n_us for the new US databases
 # Also, l10n_us_account should contains all the accounting-related dependencies of US localization package
 from . import models
+
+
+def uninstall_hook(env):
+    """Remove ir.model.data records for account.asset that match account_asset_us_.*"""
+    env['ir.model.data'].search([
+        ('model', '=', 'account.asset'),
+        ('name', 'like', '%account_asset_us_%'),
+    ]).unlink()

--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -19,6 +19,7 @@
         'demo/demo_company.xml',
     ],
     'installable': True,
+    'uninstall_hook': 'uninstall_hook',
     'auto_install': ['account'],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',


### PR DESCRIPTION
The system will crash when user tries to uninstall the `invoicing` module.

**Steps to produce:**
- Install `Accounting` module without demo data.
- Go to Accounting > Configuration > Settings > Set fiscal localization as
  `United States`.
- Go to `Apps > Accounting > uninstall`.
- Now try to uninstall `Invoicing` module.

**Error:**
`KeyError: 'account.asset'`

**Cause:**
- [Here] in `l10n_us_account` module, we define data of `account.asset` model.
- When we uninstall the `accountant` module, it also uninstalls `account_asset` module and also uninstall the `account.asset` model.
- the asset data loaded by `l10n_us_account` was incorrectly owned by the `account` module.
- When we later uninstall the `account` module, it finds `account.asset` data and tries to delete it.

**Solution:**
- Added uninstall_hook in l10n_us_account to unlink the account.asset record.

[Here]https://github.com/odoo/odoo/blob/e1dd3852b118eacc8d77e9e3d8c7769195c6edb1/addons/l10n_us_account/data/template/account.asset-us.csv#L2-L8

**sentry-6938852090**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
