### PR TITLE
[FIX] iot_drivers: webrtc deprecation warning

### DIFF
--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -19,7 +19,7 @@ class WebRtcClient(Thread):
         super().__init__()
         self.connections: set[RTCDataChannel] = set()
         self.chunked_message_in_progress: dict[RTCDataChannel, str] = {}
-        self.event_loop = asyncio.get_event_loop_policy().get_event_loop()
+        self.event_loop = asyncio.new_event_loop()
 
     def offer(self, request: dict):
         return asyncio.run_coroutine_threadsafe(


### PR DESCRIPTION
In Python 3.12 the `asyncio.get_event_loop()` function was deprecated, and now logs a warning when it is used. To fix this we replace it with `asyncio.new_event_loop()`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
