### PR TITLE
[FIX] hw_drivers: built-in serial port shows as device

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/SerialInterface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/SerialInterface.py
@@ -14,7 +14,7 @@ class SerialInterface(Interface):
         serial_devices = {
             port.device: {'identifier': port.device}
             for port in comports()
-            if platform.system() == 'Windows' or port.subsystem != 'amba'
+            if platform.system() == 'Windows' or port.device != '/dev/ttyAMA10'
             # RPI 5 uses ttyAMA10 as a console serial port for system messages: odoo interprets it as scale -> avoid it
         }
         return serial_devices


### PR DESCRIPTION
The serial interface previously included a filter to not include the built-in serial port on the Pi 5, however this filter is now broken in Raspberry Pi OS Trixie. To ensure the filter works in all versions, we now explicitly look for the device `/dev/ttyAMA10` and ignore it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
