### PR TITLE
[FIX] base: convert attachments from remote to local

### DIFF
--- a/addons/cloud_storage/models/ir_attachment.py
+++ b/addons/cloud_storage/models/ir_attachment.py
@@ -1,10 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import logging
+import requests
 import uuid
 
 from odoo import models, fields, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.http import Stream
+
+_logger = logging.getLogger(__name__)
 
 
 class CloudStorageAttachment(models.Model):
@@ -40,6 +44,25 @@ class CloudStorageAttachment(models.Model):
                     'type': 'cloud_storage',
                     'url': record._generate_cloud_storage_url(),
                 })
+
+    def _migrate_remote_to_local(self):
+        if self.type != 'cloud_storage':
+            return super()._migrate_remote_to_local()
+        url = self._generate_cloud_storage_download_info()['url']
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        if response.status_code != 200:
+            raise ValidationError(_(
+                "Failed to download attachment (%(id)s) from cloud: %(code)s - %(reason)s",
+                id=self.id, code=response.status_code, reason=response.reason,
+            ))
+        attachment_data = response.content
+        _logger.info("Migrating attachment (%s) with url (%s) from cloud_storage to binary.", self.id, self.url)
+        self.write({
+            'type': 'binary',
+            'url': False,
+            'raw': attachment_data,
+        })
 
     def _generate_cloud_storage_blob_name(self):
         """

--- a/addons/cloud_storage_azure/models/ir_attachment.py
+++ b/addons/cloud_storage_azure/models/ir_attachment.py
@@ -66,7 +66,7 @@ class IrAttachment(models.Model):
     )
 
     def _get_cloud_storage_azure_info(self):
-        match = self._cloud_storage_azure_url_pattern.match(self.url or '')
+        match = self._cloud_storage_azure_url_pattern.fullmatch(self.url or '')
         if not match:
             raise ValidationError(f'"{self.url}" is not a valid Azure Blob Storage URL.')
         return {

--- a/addons/cloud_storage_google/models/ir_attachment.py
+++ b/addons/cloud_storage_google/models/ir_attachment.py
@@ -36,7 +36,7 @@ class IrAttachment(models.Model):
     _cloud_storage_google_url_pattern = re.compile(r'https://storage\.googleapis\.com/(?P<bucket_name>[\w\-.]+)/(?P<blob_name>[^?]+)')
 
     def _get_cloud_storage_google_info(self):
-        match = self._cloud_storage_google_url_pattern.match(self.url)
+        match = self._cloud_storage_google_url_pattern.fullmatch(self.url or '')
         if not match:
             raise ValidationError('%s is not a valid Google Cloud Storage URL.', self.url)
         return {

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -6,7 +6,7 @@ from markupsafe import Markup
 from urllib.parse import urlparse
 
 from odoo import api, fields, models, modules, tools, _
-from odoo.exceptions import UserError, AccessError, RedirectWarning
+from odoo.exceptions import UserError, AccessError, RedirectWarning, ValidationError
 from odoo.service import security
 from odoo.tools.safe_eval import safe_eval, time
 from odoo.tools.misc import find_in_path
@@ -1186,28 +1186,10 @@ class IrActionsReport(models.Model):
 
     @api.model
     def _prepare_local_attachments(self, attachments):
-        attachments_with_data = self.env['ir.attachment']
         for attachment in attachments:
-            if not attachment._is_remote_source():
-                attachments_with_data |= attachment
-            elif (stream := attachment._to_http_stream()) and stream.url:
-                # call `_to_http_stream()` in case the attachment is an url or cloud storage attachment
+            if attachment._is_remote_source():
                 try:
-                    response = requests.get(stream.url, timeout=10)
-                    response.raise_for_status()
-                    attachment_data = response.content
-                    if not attachment_data:
-                        _logger.warning("Attachment %s at with URL %s retrieved successfully, but no content was found.", attachment.id, attachment.url)
-                        continue
-                    attachments_with_data |= self.env['ir.attachment'].new({
-                        'db_datas': attachment_data,
-                        'name': attachment.name,
-                        'mimetype': attachment.mimetype,
-                        'res_model': attachment.res_model,
-                        'res_id': attachment.res_id
-                    })
-                except requests.exceptions.RequestException as e:
-                    _logger.error("Request for attachment %s with URL %s failed: %s", attachment.id, attachment.url, e)
-            else:
-                _logger.error("Unexpected edge case: Is not being considered as a local or remote attachment, attachment ID:%s will be skipped.", attachment.id)
-        return attachments_with_data
+                    attachment._migrate_remote_to_local()
+                except (ValidationError, requests.exceptions.RequestException) as e:
+                    _logger.error("Failed to migrate attachment %s to local: %s", attachment.id, e)
+        return attachments.filtered(lambda a: not a._is_remote_source())

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -839,3 +839,9 @@ class IrAttachment(models.Model):
     def _is_remote_source(self):
         self.ensure_one()
         return self.url and not self.file_size and self.url.startswith(('http://', 'https://', 'ftp://'))
+
+    def _migrate_remote_to_local(self):
+        if self.type == 'binary':
+            return
+        if self.type == 'url':
+            raise ValidationError(_("URL attachment (%s) shouldn't be migrated to local.", self.id))


### PR DESCRIPTION
During commit #226094, several methods were added to allow fetching remote resources for certain reports.

After that commit, we notice that some attachments (like images -> image_src) must need the file localy.

To avoid this issue we decided to convert this documents from remote to localy (binary), to be able to manage them.

It'll just happen for the reports that need to add attachments from the chatter.

OPW-5036638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
