### PR TITLE
[IMP] account,stock: remove useless groups attributes in static templates

### DIFF
--- a/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
+++ b/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
@@ -18,9 +18,7 @@
     </t>
 
     <t t-name="account.JournalUploadLink">
-        <t groups="account.group_account_invoice">
-            <a t-att-class="props.btnClass" href="#" t-out="props.linkText" draggable="false"/>
-        </t>
+        <a t-att-class="props.btnClass" href="#" t-out="props.linkText" draggable="false"/>
     </t>
 
 </templates>

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -108,7 +108,7 @@
                         </tr>
                     </table>
                 </div>
-                <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" t-if="!props.is_exchange" style="margin-top:5px; margin-bottom:5px;" groups="account.group_account_invoice" t-on-click="() => props._onRemoveMoveReconcile(props.move_id, props.partial_id)">Unreconcile</button>
+                <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" t-if="!props.is_exchange" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onRemoveMoveReconcile(props.move_id, props.partial_id)">Unreconcile</button>
                 <button class="btn btn-sm btn-secondary js_open_payment float-end" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onOpenMove(props.move_id)">View</button>
             </div>
         </div>

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -15,7 +15,6 @@
                             type="object"
                             name="action_create_vendor_bill"
                             journal_type="purchase"
-                            groups="account.group_account_invoice"
                             t-on-click="() => this.handleButtonClick('action_create_vendor_bill')"
                         >
                             try our sample
@@ -48,7 +47,6 @@
                                 type="object"
                                 class="btn btn-link px-0 fw-normal"
                                 t-on-click="() => this.handleButtonClick('action_create_new')"
-                                groups="account.group_account_invoice"
                             >
                                 Create manually
                             </a>
@@ -67,7 +65,6 @@
                                 type="object"
                                 class="o_invoice_new"
                                 t-on-click="() => this.handleButtonClick('action_create_new')"
-                                groups="account.group_account_invoice"
                             >
                                 Create a bill manually
                             </a>

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -47,7 +47,7 @@
                 <div t-attf-class="col-md-auto text-center #{props.docs.virtual_available &lt; 0 and 'text-danger'}" name="forecasted_value">
                     <div class="h3">
                         <span t-out="_formatFloat(this.virtualAvailable)"/>
-                        <span t-out="' ' + this.uom" groups="uom.group_uom"/>
+                        <span t-out="' ' + this.uom"/>
                     </div>
                     <div>Forecasted</div>
                 </div>


### PR DESCRIPTION
The `groups` attribute in used in the QWeb template to display nodes
based on access groups. This attribute is only available on server-side
templates.

This commit removes the useless `groups` attributes from client-side
(aka. `static`) templates as they are not applied anyway.
