### PR TITLE
[FIX] html_builder: copy oe-many2one-id when replicating fields

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -8,6 +8,7 @@ declare module "plugins" {
     import { CustomizeTabShared } from "@html_builder/core/customize_tab_plugin";
     import { DisableSnippetsShared } from "@html_builder/core/disable_snippets_plugin";
     import { dropzone_selector, DropZoneShared } from "@html_builder/core/drop_zone_plugin";
+    import { after_replication_handlers } from "@html_builder/core/field_change_replication_plugin";
     import { MediaWebsiteShared } from "@html_builder/core/media_website_plugin";
     import { OperationShared } from "@html_builder/core/operation_plugin";
     import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
@@ -60,6 +61,7 @@ declare module "plugins" {
     export type BuilderResources = EditorResources & ResourcesTypesFactory<BuilderResourcesList>;
     export interface BuilderResourcesList {
         // Handlers
+        after_replication_handlers: after_replication_handlers;
         after_save_handlers: after_save_handlers;
         after_setup_editor_handlers: after_setup_editor_handlers;
         before_save_handlers: before_save_handlers;

--- a/addons/html_builder/static/src/core/field_change_replication_plugin.js
+++ b/addons/html_builder/static/src/core/field_change_replication_plugin.js
@@ -2,6 +2,10 @@ import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef {((arg: { sourceEl: HTMLElement, targetEl: HTMLElement }) => void)[]} after_replication_handlers
+ */
+
 export class FieldChangeReplicationPlugin extends Plugin {
     static id = "fieldChangeReplication";
     static dependencies = ["dom"];
@@ -17,9 +21,7 @@ export class FieldChangeReplicationPlugin extends Plugin {
     }
 
     /**
-     * @typedef { import("./history_plugin").HistoryMutationRecord } HistoryMutationRecord
-     *
-     * @param { HistoryMutationRecord[] } records
+     * @param { import("@html_editor/core/history_plugin").HistoryMutationRecord[] } records
      */
     handleMutations(records) {
         records
@@ -107,6 +109,7 @@ export class FieldChangeReplicationPlugin extends Plugin {
                             touchedEls.add(targetEl);
                         }
                     }
+                    this.dispatchTo("after_replication_handlers", { sourceEl, targetEl });
                 }
             }
         }

--- a/addons/html_builder/static/src/plugins/many2one_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/many2one_option_plugin.js
@@ -12,6 +12,17 @@ export class Many2OneOptionPlugin extends Plugin {
             Many2OneAction,
         },
         content_not_editable_selectors: "[data-oe-field][data-oe-many2one-id]",
+        after_replication_handlers: ({ sourceEl, targetEl }) => {
+            if (
+                sourceEl.hasAttribute("data-oe-many2one-model") &&
+                targetEl.hasAttribute("data-oe-many2one-model")
+            ) {
+                targetEl.setAttribute(
+                    "data-oe-many2one-id",
+                    sourceEl.getAttribute("data-oe-many2one-id")
+                );
+            }
+        },
     };
 }
 


### PR DESCRIPTION
When replicating changes from one field to other occurences of the same field in the document, the `data-oe-many2one-id` was not copied (for many2one fields). Thus it could lead to showing incorrect values in the sidebar, or saving them.

This commit fixes that by adding a dispatch to handlers after the replication, and implementing a handler that copies the `data-oe-many2one-id` when needed.

Steps to reproduce:
- Open website builder on a blog post
- Enable the "Sidebar"
- Enable the "Author" in the sidebar
- Click on the second occurence of the name of the author in the page
- Change the "Contact" associated with the author of the post
- Click on the first occurence of the name of the author in the page
- Bug: the name of "Contact" is the old one
- Change the "Contact" to yet another one
- Save
- Bug: the author is not the last one selected

task-5252648