### PR TITLE
[FIX] pos_loyalty: skip loading rewards with archived or invalid reward products

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -8,7 +8,7 @@
                 <t t-set="_eWalletRewards" t-value="_getEWalletRewards(pos.get_order())" />
                 <button t-att-class="buttonClass"
                     t-on-click="onClickWallet"
-                    t-attf-class="{{(_orderTotal lt 0 and _eWalletPrograms.length gte 1) or _eWalletRewards.length gte 1 ? 'highlight text-action': ''}}">
+                    t-attf-class="{{(_orderTotal lt 0 and _eWalletPrograms.length gte 1) or _eWalletRewards.length gte 1 ? 'highlight text-action': 'disabled'}}">
                     <i class="fa fa-credit-card me-1" />
                     <t t-if="_orderTotal lt 0 and _eWalletPrograms.length">eWallet Refund</t>
                     <t t-elif="_eWalletRewards.length">eWallet Pay</t>

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -56,8 +56,8 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "1.00"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "2.00"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "3.00"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             PosLoyalty.isRewardButtonHighlighted(false),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "4.00"),
             PosLoyalty.isRewardButtonHighlighted(true),
 

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -73,7 +73,7 @@ export function isRewardButtonHighlighted(isHighlighted, closeModal = true) {
         {
             trigger: isHighlighted
                 ? '.control-buttons button.highlight:contains("Reward")'
-                : '.control-buttons button:contains("Reward"):not(:has(.highlight))',
+                : '.control-buttons button.disabled:contains("Reward")',
         },
     ];
     if (closeModal) {
@@ -89,7 +89,7 @@ export function eWalletButtonState({ highlighted, text = "eWallet", click = fals
     const step = {
         trigger: highlighted
             ? `.control-buttons button.highlight:contains("${text}")`
-            : `.control-buttons button:contains("${text}"):not(:has(.highlight))`,
+            : `.control-buttons button.disabled:contains("${text}")`,
     };
     if (click) {
         step.run = "click";

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2294,8 +2294,8 @@ class TestUi(TestPointOfSaleHttpCommon):
             'reward_product_tag_id': free_product_tag.id,
         })
 
-        self.product_b.active = False
-        product_c.active = False
+        self.product_b.product_tmpl_id.active = False
+        product_c.product_tmpl_id.active = False
 
         self.start_tour(
             "/pos/web?config_id=%d" % self.main_pos_config.id,
@@ -2303,7 +2303,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="pos_user",
         )
 
-        product_c.active = True
+        product_c.product_tmpl_id.active = True
         self.start_tour(
             "/pos/web?config_id=%d" % self.main_pos_config.id,
             "PosLoyaltyArchivedRewardProductsActive",


### PR DESCRIPTION
Steps:
---------
- Install pos_loyalty.
- Add a product to a loyalty reward’s reward product, or assign a product tag with no actual products as a reward product tag.
- Archive/delete the reward product.
- Open session.

Issue:
----------
- A traceback appears when attempting to apply the affected reward, due to the archived/deleted or invalid reward product is being loaded in the POS.

FIX:
-----------
- Skip loading loyalty rewards whose reward product is archived/deleted or whose reward product tag contains no valid products.

Task-5226654
