### PR TITLE
[FIX] mail: broken uninstallation of module 'mail'

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -10,6 +10,9 @@ from odoo import api, exceptions, models, tools, _
 from odoo.addons.mail.tools.alias_error import AliasError
 from odoo.tools import parse_contact_from_email
 from odoo.tools.mail import email_normalize, email_split_and_format
+from odoo.tools.sql import column_exists
+
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 import logging
 
@@ -35,7 +38,13 @@ class Base(models.AbstractModel):
         # Override unlink to delete records activities through (res_model, res_id)
         record_ids = self.ids if (not self._abstract and not self._transient) else []
         result = super().unlink()
-        if record_ids:
+        if record_ids and (
+            # during uninstallation of module mail, the search below will crash
+            not self.env.context.get(MODULE_UNINSTALL_FLAG) or (
+                column_exists(self.env.cr, 'mail_activity', 'res_model')
+                and column_exists(self.env.cr, 'mail_activity', 'res_id')
+            )
+        ):
             self.env['mail.activity'].with_context(active_test=False).sudo().search(
                 [('res_model', '=', self._name), ('res_id', 'in', record_ids)]
             ).unlink()


### PR DESCRIPTION
When uninstalling module mail, an override of `unlink()` deletes the activities of the records being deleted.  However, this override crashes whenever columns of `mail.activity` have been dropped already.  As a consequence, it may prevent the deletion of the field `mail_message_id` of model `mail.tracking.value`, and its table, too.  And this causes the reinstallation of module mail to log error:
```
column "mail_message_id" of relation "mail_tracking_value" contains null values
```
See https://runbot.odoo.com/odoo/runbot.build.error/233618 for the cases where it failed.

The fix consists in checking whether the columns of `mail.activity` still exist before searching for activities.