### PR TITLE
[FIX] sale_purchase_stock, purchase_stock: select valid seller for PO

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -64,6 +64,11 @@ class StockRule(models.Model):
                     quantity=procurement.product_qty,
                     date=max(procurement_date_planned.date(), fields.Date.today()),
                     uom_id=procurement.product_uom)
+                if not supplier:
+                    supplier = procurement.product_id.with_company(procurement.company_id.id)._select_seller(
+                        quantity=procurement.product_qty,
+                        date=max(procurement_date_planned.date(), fields.Date.today()),
+                        uom_id=procurement.product_uom)
 
             # Fall back on a supplier for which no price may be defined. Not ideal, but better than
             # blocking the user.


### PR DESCRIPTION
**Issue**
A PO triggered by a SO could have an invalid vendor selected.

**Steps to reproduce**
- Install Sale and Purchase apps
- Create a product with:
  - Two routes: MTO and Buy (Inventory tab)
  - Two sellers in this order (Purchase tab):
    1. With an expired `end_date`
    2. With a valid `end_date`
- Create a SO for that product with a client that is **not** one of the vendors
→ A PO is created with the first vendor instead of the second (valid) one.

**Cause**
In the method `_run_buy`, to retrieve the vendor for the PO, `_select_seller` is called with the associated partner of the SO:
https://github.com/odoo/odoo/blob/fa8bfc7306c7f85b013d7f5e336dcfe0586990df/addons/purchase_stock/models/stock_rule.py#L62C1-L66C52

That method calls `_get_filtered_sellers` with that associated partner:
https://github.com/odoo/odoo/blob/fa8bfc7306c7f85b013d7f5e336dcfe0586990df/addons/product/models/product_product.py#L699

Which returns an empty recordset because every seller record is filtered out since every one of them has an associated partner different than the one set on the SO:
https://github.com/odoo/odoo/blob/fa8bfc7306c7f85b013d7f5e336dcfe0586990df/addons/product/models/product_product.py#L673C1-L674C25

Then, in `_run_buy`, the fallback is to call `_prepare_sellers` with no param, and to select the first one found:
https://github.com/odoo/odoo/blob/fa8bfc7306c7f85b013d7f5e336dcfe0586990df/addons/purchase_stock/models/stock_rule.py#L70C1-L72C18

And since, `_prepare_sellers` sorts the records according the sequence (among other thing but not the end_date):
https://github.com/odoo/odoo/blob/1478cbcfbf8d1e0184fce6236c5201ba4b59a159/addons/product/models/product_product.py#L653
it will select the first one (here, the one with an expired end_date)

**Solution**
One option would be to not indicate the vendor when calling `_select_seller` in `_run_buy`, but this would prevent specifying a vendor explicitly.
Instead, add a better fallback where we call `_select_seller` again without specifying the vendor, ensuring a valid seller is selected even when the SO partner doesn’t match any vendor.

opw-5145683