### PR TITLE
[FIX] html_editor: handle empty blockquote on backspace

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -458,17 +458,18 @@ export class FontPlugin extends Plugin {
     }
 
     /**
-     * Transform an empty heading, blockquote or pre at the beginning of the
-     * editable into a paragraph.
+     * Transform an empty heading or pre at the beginning of the
+     * editable into a base container. An empty blockquote is transformed
+     * into a base container, regardless of its position in the editable.
      */
     handleDeleteBackward({ startContainer, startOffset, endContainer, endOffset }) {
         // Detect if cursor is at the start of the editable (collapsed range).
         const rangeIsCollapsed = startContainer === endContainer && startOffset === endOffset;
-        if (!rangeIsCollapsed) {
+        const closestHandledElement = closestElement(endContainer, handledElemSelector);
+        if (!rangeIsCollapsed && closestHandledElement?.tagName !== "BLOCKQUOTE") {
             return;
         }
         // Check if cursor is inside an empty heading, blockquote or pre.
-        const closestHandledElement = closestElement(endContainer, handledElemSelector);
         if (!closestHandledElement || closestHandledElement.textContent.length) {
             return;
         }

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1903,12 +1903,22 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should delete if first element and append in paragraph", async () => {
+    test("should convert empty blockquote into base container regardless of its position in editable", async () => {
         await testEditor({
             contentBefore: `<blockquote><br>[]</blockquote>`,
             stepFunction: deleteBackward,
-            contentAfter: `<p>[]<br></p>`,
+            contentAfter: `<div>[]<br></div>`,
+            config: { baseContainer: "DIV" },
         });
+        await testEditor({
+            contentBefore: `<div><br></div><blockquote><br>[]</blockquote>`,
+            stepFunction: deleteBackward,
+            contentAfter: `<div><br></div><div>[]<br></div>`,
+            config: { baseContainer: "DIV" },
+        });
+    });
+
+    test("should delete if first element and append in paragraph", async () => {
         await testEditor({
             contentBefore: `<h1><br>[]</h1>`,
             stepFunction: deleteBackward,


### PR DESCRIPTION
### Steps to reproduce:

- Create a new Project task.
- Insert a Table of Contents (e.g., /tableofcontent).
- Insert a quote below it (e.g., /blockquote).
- Place the cursor at the start of the empty quote and press Backspace.
- The Table of Contents is removed.

### Desired behavior after PR is merged:

- Empty blockquote is converted into a base container when backspace is pressed.

task-5246130

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
