### PR TITLE
[FIX] product: let update-extra-prices button persist between web saves

### DIFF
--- a/addons/product/tests/test_update_pav_wizard.py
+++ b/addons/product/tests/test_update_pav_wizard.py
@@ -37,16 +37,14 @@ class TestUpdateProductAttributeValueWizard(ProductVariantsCommon):
         )
 
         self.color_attribute_red.default_extra_price = 20.0
-        action = self.color_attribute_red.action_update_prices()
+        self.assertTrue(self.color_attribute_red.default_extra_price_changed)
 
-        with Form(self.env[action['res_model']].with_context(action['context'])) as wizard:
-            wizard_record = wizard.save()
-
-        wizard_record.action_confirm()
-
+        wizard = Form.from_action(self.env, self.color_attribute_red.action_update_prices()).save()
+        wizard.action_confirm()
         self.assertEqual(
             self.product_template_sofa.attribute_line_ids.product_template_value_ids.filtered(
                 lambda ptav: ptav.product_attribute_value_id == self.color_attribute_red,
             ).price_extra,
             20.0,
         )
+        self.assertFalse(any(self.color_attribute.value_ids.mapped('default_extra_price_changed')))


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a product with multiple variants;
2. go to one of its attributes;
3. in the form, change the default extra price on multiple lines;
4. click on "Update extra prices";
5. add the updated variants to a sale order.

Issue
-----
Only the line on which "Update extra prices" was clicked has been updated, even though the button disappeared on all lines after clicking it.

Cause
-----
The `_compute_default_extra_price_changed` method only compares the `default_extra_price` of the current record to its `_origin` value. Consequently, after saving the form, it will return `False`, even though only one attribute has been updated.

Solution
--------
Aside from checking whether the value changed on the form, also check whether any product template attribute value has a `price_extra` that's different from the product attribute value's `default_extra_price`.

This way, clicking on "Update extra prices" once won't make the other update buttons disappear.

opw-5240236