### PR TITLE
[IMP] hr_attendnace: Split Attendance for Cross Days - yoahm  

### DIFF
--- a/addons/hr_attendance/tests/__init__.py
+++ b/addons/hr_attendance/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_hr_attendance_domain_translation
 from . import test_load_scenario
 from . import test_hr_attendance_kiosk
 from . import test_hr_attendance_rulesets
+from . import test_hr_attendance_cross_day

--- a/addons/hr_attendance/tests/test_hr_attendance_cross_day.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_cross_day.py
@@ -1,0 +1,80 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+from datetime import datetime
+import pytz
+from pytz import timezone
+from odoo.tests import tagged
+
+
+@tagged('at_install', '-post_install')
+class TestAttendanceCrossDay(TransactionCase):
+
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAttendanceCrossDay, cls).setUpClass()
+        cls.attendance = cls.env['hr.attendance']
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Test Employee',
+            'tz': 'Europe/Brussels',
+        })
+
+    def test_01_single_normal_day_attendance(self):
+        """ 
+        check-in :O9:00 Mon
+        check-out:17:00 Mon
+        no split
+        """
+        check_in = datetime(2025, 11, 3, 9, 0)
+        check_out = datetime(2025, 11, 3, 17, 0)
+        normal_attendance = self.attendance.create([{
+            'employee_id': self.employee.id,
+            'check_in': check_in,
+            'check_out': check_out,
+        }])
+        self.assertEqual(len(normal_attendance), 1)
+        self.assertEqual(normal_attendance.check_in, check_in)
+        self.assertEqual(normal_attendance.check_out, check_out)
+
+    def test_02_standard_overnight_checkout(self):
+        """ 
+        check-in :20:00 Tue
+        check-out:04:00 Wed
+        split using the write() method
+        """
+        check_in = datetime(2025, 11, 4, 20, 0, 0)
+        open_attendance = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': check_in,
+        })
+        check_out = datetime(2025, 11, 5, 4, 0, 0)
+        open_attendance.write({'check_out': check_out})
+
+        self.assertEqual(open_attendance.worked_hours, 4.0, "Day 1 should have 4 hours (20:00-00:00 local)")        
+        day2_attendance = self.attendance.search([
+            ('employee_id', '=', self.employee.id),
+            ('id', '!=', open_attendance.id)
+        ])
+        self.assertTrue(day2_attendance, "A new record will be created for Day 2")
+        self.assertEqual(day2_attendance.worked_hours, 4.0, "Day 2 should have 4 hours (00:00-04:00 local)")
+
+    def test_03_multi_day_manual_entry(self):
+        """ 
+        check-in :20:00 Wed
+        check-out:10:00 Fri
+        split using the create() method
+        """
+        check_in = datetime(2025, 11, 5, 20, 0, 0)
+        check_out = datetime(2025, 11, 7, 10, 0, 0)
+        new_records = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': check_in,
+            'check_out': check_out,
+        })
+
+        map = {rec.date: rec.worked_hours for rec in new_records}
+        self.assertEqual(len(new_records), 3, "The 3-day shift should result in exactly 3 separate attendance records.")
+        self.assertEqual(map.get(datetime(2025, 11, 5).date()), 4.0, "Slice 1 (Wednesday) should have 4.0 hours.")
+        self.assertEqual(map.get(datetime(2025, 11, 6).date()), 23.0, "Slice 2 (Thursday) should have 23.0 hours.")
+        self.assertEqual(map.get(datetime(2025, 11, 7).date()), 10.0, "Slice 3 (Friday) should have 10.0 hours.")

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -202,6 +202,7 @@ class HrLeave(models.Model):
         'ir.attachment', string="Attach File", compute='_compute_supported_attachment_ids',
         inverse='_inverse_supported_attachment_ids')
     supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids')
+    attachment_is_visible = fields.Boolean(compute='_compute_attachment_is_visible', compute_sudo=True)
     # UX fields
     leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit', readonly=True)
     leave_type_support_document = fields.Boolean(related="holiday_status_id.support_document")
@@ -714,6 +715,18 @@ Versions:
         for holiday in self:
             holiday.supported_attachment_ids = holiday.attachment_ids
             holiday.supported_attachment_ids_count = len(holiday.attachment_ids.ids)
+
+    @api.depends_context('uid')
+    @api.depends('leave_type_support_document')
+    def _compute_attachment_is_visible(self):
+        is_privileged_user = (
+            self.env.user.has_group('hr_holidays.group_hr_holidays_user') or
+            self.env.user.has_group('hr_holidays.group_hr_holidays_manager'))
+        for leave in self:
+            if leave.leave_type_support_document and (is_privileged_user or leave.user_id == self.env.user):
+                leave.attachment_is_visible = True
+            else:
+                leave.attachment_is_visible = False
 
     @api.depends('employee_id', 'holiday_status_id')
     def _compute_leaves(self):

--- a/addons/hr_holidays/static/src/components/hr_leave_chatter_patch/hr_leave_chatter_patch.js
+++ b/addons/hr_holidays/static/src/components/hr_leave_chatter_patch/hr_leave_chatter_patch.js
@@ -1,0 +1,42 @@
+import { patch } from "@web/core/utils/patch";
+import { Chatter } from "@mail/chatter/web_portal/chatter";
+import { useService } from "@web/core/utils/hooks";
+
+
+patch(Chatter.prototype, {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+
+        this.state.hasAttachmentPreview = this.props.hasAttachmentPreview ?? true;
+        this.state.isAttachmentBoxOpened = this.props.isAttachmentBoxOpened ?? true;
+        this.state.isAttachmentBoxVisibleInitially = this.props.isAttachmentBoxVisibleInitially ?? true;
+
+        this.applyConditionalAttachmentVisibility();
+    },
+
+    async applyConditionalAttachmentVisibility() {
+        try {
+            if (this.props.threadModel === "hr.leave" && this.props.threadId) {
+                const record = await this.orm.read(
+                    "hr.leave",
+                    [this.props.threadId],
+                    ["attachment_is_visible"]
+                );
+
+                const isVisible = record?.[0]?.attachment_is_visible;
+
+                if (!isVisible) {
+                    this.state.hasAttachmentPreview = false;
+                    this.state.isAttachmentBoxOpened = false;
+                    this.state.isAttachmentBoxVisibleInitially = false;
+                    if (this.state.thread) {
+                        this.state.thread.attachments = []; // Clear attachments
+                    }
+                }
+            }
+        } catch (error) {
+            console.warn("Failed to check attachment visibility:", error);
+        }
+    },
+});

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -288,7 +288,7 @@
                                     groups="hr_holidays.group_hr_holidays_user">
                                     Refuse
                                 </button>
-                                <button t-if="record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0 text-danger">
+                                <button t-if="record.attachment_is_visible and record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0 text-danger">
                                     <i class="fa fa-paperclip"> <field name="supported_attachment_ids_count" nolabel="1"/></i>
                                 </button>
                             </bottom>
@@ -406,7 +406,7 @@
                             <field name="name" readonly="state != 'confirm'" widget="text" nolabel="1" colspan="2" placeholder="No description provided" />
                         </group>
                         <group>
-                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="state != 'confirm'" />
+                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="not attachment_is_visible or state != 'confirm'" />
                         </group>
                     </div>
                     <div class="o_hr_leave_column col_right col-md-6 col-12">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: split attendance shifts that cross midnight, ensuring worked hours are correctly attributed to the calendar day they were

Current behavior before PR: 
The system fails to recognize the calendar day boundary during overnight shifts:
A shift from 20:00 Tuesday to 04:00 Wednesday is recorded as a single block of 8 hours attributed entirely to Tuesday's date, This causes Wednesday to incorrectly show 0 hours worked, leading to errors in scheduling and payroll summaries.

Desired behavior after PR is merged:
All cross-day shifts are sliced at midnight based on the employee's local time.
The original attendance record is modified to end at 00:00.
A new attendance record is created for the remaining hours on the next day.
Result: The hours shift is correctly split into the corresponding days:

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
