### PR TITLE
[IMP] hr_attendnace: Split Attendance for Cross Days - yoahm  

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -341,9 +341,57 @@ class HrAttendance(models.Model):
         self.env.add_to_compute(self._fields['validated_overtime_hours'], all_attendances)
         self.env.add_to_compute(self._fields['overtime_status'], all_attendances)
 
+    # Split the Attendance Shift If it across the employee local midnight and save in UTC
+    def _split_attendance_intervals(self, employee, check_in, check_out):
+        if check_out < check_in:
+            return
+        tz = ZoneInfo(employee._get_tz())
+        current_start_utc = check_in
+        while current_start_utc < check_out:
+            local_start = current_start_utc.replace(tzinfo=UTC).astimezone(tz)
+            next_day_date = local_start.date() + timedelta(days=1)
+            local_midnight = datetime.combine(next_day_date, datetime.min.time(), tzinfo=tz)
+            midnight_utc = local_midnight.astimezone(UTC).replace(tzinfo=None)
+            current_end_utc = min(midnight_utc, check_out)
+            yield (current_start_utc, current_end_utc)
+            current_start_utc = current_end_utc
+
+    def _check_cross_day_shift(self, vals, attendance=None):
+        employee_id = self.env['hr.employee'].browse(vals['employee_id']) if vals.get('employee_id') else attendance.employee_id if attendance else None
+        check_in = fields.Datetime.from_string(vals.get('check_in')) if vals.get('check_in') else attendance.check_in if attendance else None
+        check_out = fields.Datetime.from_string(vals.get('check_out')) if vals.get('check_out') else attendance.check_out if attendance else None
+        if not (employee_id and check_in and check_out):
+            return [vals]
+
+        tz = ZoneInfo(employee_id._get_tz())
+        # Same Day Shift
+        if check_out.astimezone(tz).date() <= check_in.astimezone(tz).date():
+            vals.update({
+                'employee_id': employee_id.id,
+                'check_in': fields.Datetime.to_string(check_in),
+                'check_out': fields.Datetime.to_string(check_out),
+            })
+            return [vals]
+
+        # Cross Day Shift
+        intervals = list(self._split_attendance_intervals(employee_id, check_in, check_out))
+        new_vals_list = []
+        for current_check_in, current_check_out in intervals:
+            current_vals = vals.copy()
+            current_vals.update({
+                'employee_id': employee_id.id,
+                'check_in': fields.Datetime.to_string(current_check_in),
+                'check_out': fields.Datetime.to_string(current_check_out),
+            })
+            new_vals_list.append(current_vals)
+        return new_vals_list
+
     @api.model_create_multi
     def create(self, vals_list):
-        res = super().create(vals_list)
+        final_vals_list = []
+        for vals in vals_list:
+            final_vals_list.extend(self._check_cross_day_shift(vals))
+        res = super().create(final_vals_list)
         res._update_overtime()
         return res
 
@@ -354,6 +402,15 @@ class HrAttendance(models.Model):
             self.env['hr.employee'].sudo().browse(vals['employee_id']).attendance_manager_id.id != self.env.user.id:
             raise AccessError(_("Do not have access, user cannot edit the attendances that are not their own or if they are not the attendance manager of the employee."))
         domain_pre = self._get_overtimes_to_update_domain()
+
+        if ('check_out' in vals):
+            for attendance in self:
+                new_vals_list = self._check_cross_day_shift(vals, attendance)
+                vals['check_in'] = new_vals_list[0]['check_in']
+                vals['check_out'] = new_vals_list[0]['check_out']
+                vals['employee_id'] = new_vals_list[0].get('employee_id', attendance.employee_id.id)
+                for extra_vals in new_vals_list[1:]:
+                    self.env['hr.attendance'].create(extra_vals)
         result = super().write(vals)
         if any(field in vals for field in ['employee_id', 'check_in', 'check_out']):
             # Merge attendance dates before and after write to recompute the
@@ -599,7 +656,12 @@ class HrAttendance(models.Model):
 
                 # Attendances where Last open attendance time + previously worked time on that day + tolerance greater than the attendances hours (including lunch) in his calendar
                 if (current_attendance_duration + previous_attendances_duration - max_tol) > expected_worked_hours:
-                    att.check_out = att.check_in.replace(hour=23, minute=59, second=59)
+                    tz = ZoneInfo(att.employee_id._get_tz())
+                    check_in_local = att.check_in.replace(tzinfo=UTC).astimezone(tz)
+                    estimated_checkout_local = check_in_local.replace(hour=23, minute=59, second=59)
+                    estimated_checkout = estimated_checkout_local.astimezone(UTC).replace(tzinfo=None)
+                    att.check_out = estimated_checkout
+
                     excess_hours = att.worked_hours - (expected_worked_hours + max_tol - previous_attendances_duration)
                     att.write({
                         "check_out": max(att.check_out - relativedelta(hours=excess_hours), att.check_in + relativedelta(seconds=1)),

--- a/addons/hr_attendance/tests/__init__.py
+++ b/addons/hr_attendance/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_performance
 from . import test_hr_attendance_access_rights
 from . import test_hr_attendance_self_edit_role
 from . import test_hr_attendance_manager
+from . import test_hr_attendance_cross_day

--- a/addons/hr_attendance/tests/test_hr_attendance_cross_day.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_cross_day.py
@@ -1,0 +1,231 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import date, datetime
+
+from odoo import Command
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged('at_install', '-post_install')
+class TestAttendanceCrossDay(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ruleset = cls.env['hr.attendance.overtime.ruleset'].create({
+        'name': 'Ruleset for overtime testing',
+        'rule_ids': [Command.create({
+                'name': 'Ruleset for overtime testing - Rule 1',
+                'base_off': 'quantity',
+                'expected_hours_from_contract': True,
+                'quantity_period': 'day',
+            })],
+        })
+        cls.company = cls.env['res.company'].create({
+            'name': 'BE Inc.',
+        })
+        cls.attendance = cls.env['hr.attendance']
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Youssef Ahmed',
+            'company_id': cls.company.id,
+            'date_version': date(2020, 1, 1),
+            'contract_date_start': date(2020, 1, 1),
+            'ruleset_id': cls.ruleset.id,
+            'resource_calendar_id': cls.company.resource_calendar_id.id,
+            'tz': 'Europe/Brussels',
+        })
+
+    def test_01_single_normal_day_attendance(self):
+        """
+        check-in -> (3rd) O9:00
+        check-out-> (3rd) 17:00
+        No split
+        """
+        normal_attendance = self.attendance.create([{
+            'employee_id': self.employee.id,
+            'check_in': datetime(2025, 11, 3, 9, 0),
+            'check_out': datetime(2025, 11, 3, 17, 0),
+        }])
+        self.assertEqual(len(normal_attendance), 1)
+        self.assertEqual(normal_attendance.check_in, datetime(2025, 11, 3, 9, 0))
+        self.assertEqual(normal_attendance.check_out, datetime(2025, 11, 3, 17, 0))
+
+    def test_02_standard_overnight_checkout(self):
+        """
+        check-in -> (4th) 08:00 (UTC)
+        check-out-> (5th) 11:00 (UTC)
+        Attendnace splitted acording to employee local midnight (Brussels) into 2 records:
+        1st record : (4th) 08:00 -> (4th) 23:00 (15hrs worked & 7hrs overtime)
+        2nd record : (4th) 23:00 -> (5th) 11:00 (12hrs worked & 4hrs overtime)
+        """
+        cross_day_attendance = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2025, 11, 4, 8, 0, 0),
+            'check_out': datetime(2025, 11, 5, 11, 0, 0)
+        })
+
+        self.assertEqual(len(cross_day_attendance), 2, "The overnight shift should result in exactly 2 separate attendance records.")
+
+        self.assertEqual(cross_day_attendance[0].check_in, datetime(2025, 11, 4, 8, 0, 0))
+        self.assertEqual(cross_day_attendance[0].check_out, datetime(2025, 11, 4, 23, 0))
+        self.assertEqual(cross_day_attendance[0].worked_hours, 15.0)
+        self.assertEqual(cross_day_attendance[0].overtime_hours, 7.0)
+
+        self.assertEqual(cross_day_attendance[1].check_in, datetime(2025, 11, 4, 23, 0, 0))
+        self.assertEqual(cross_day_attendance[1].check_out, datetime(2025, 11, 5, 11, 0))
+        self.assertEqual(cross_day_attendance[1].worked_hours, 12.0)
+        self.assertEqual(cross_day_attendance[1].overtime_hours, 4.0)
+
+    def test_03_multi_day_manual_entry(self):
+        """
+        check-in -> (5th) 20:00 (UTC)
+        check-out-> (7th) 10:00 (UTC)
+        Attendnace splitted acording to employee local midnight (Brussels) into 3 records:
+        1st record : (5th) 20:00 -> (5th) 23:00 (3hrs worked  & 0hrs overtime)
+        2nd record : (5th) 23:00 -> (6th) 23:00 (24hrs worked & 16hrs overtime)
+        3rd record : (6th) 23:00 -> (7th) 10:00 (13hrs worked & 5hrs overtime)
+        """
+        cross_day_attendance = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2025, 11, 5, 20, 0, 0),
+            'check_out': datetime(2025, 11, 7, 12, 0, 0),
+        })
+
+        self.assertEqual(len(cross_day_attendance), 3, "The overnight shift should result in exactly 3 separate attendance records.")
+
+        self.assertEqual(cross_day_attendance[0].check_in, datetime(2025, 11, 5, 20, 0, 0))
+        self.assertEqual(cross_day_attendance[0].check_out, datetime(2025, 11, 5, 23, 0))
+        self.assertEqual(cross_day_attendance[0].worked_hours, 3.0)
+        self.assertEqual(cross_day_attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(cross_day_attendance[1].check_in, datetime(2025, 11, 5, 23, 0, 0))
+        self.assertEqual(cross_day_attendance[1].check_out, datetime(2025, 11, 6, 23, 0))
+        self.assertEqual(cross_day_attendance[1].worked_hours, 24.0)
+        self.assertEqual(cross_day_attendance[1].overtime_hours, 16.0)
+
+        self.assertEqual(cross_day_attendance[2].check_in, datetime(2025, 11, 6, 23, 0, 0))
+        self.assertEqual(cross_day_attendance[2].check_out, datetime(2025, 11, 7, 12, 0))
+        self.assertEqual(cross_day_attendance[2].worked_hours, 13.0)
+        self.assertEqual(cross_day_attendance[2].overtime_hours, 5.0)
+
+    def test_04_multiple_multi_day_creates(self):
+        """
+        check-in -> (10th)  07:00 (UTC)
+        check-out-> (11st)  23:00 (UTC)
+        Attendnace splitted acording to employee local midnight (Brussels) into 2 records:
+        1st record : (10th) 07:00 -> (10th) 23:00 (16hrs worked  & 8hrs overtime)
+        2nd record : (10th) 23:00 -> (11th) 23:00 (24hrs worked & 16hrs overtime)
+
+        check-in -> (11st) 23:30 (UTC)
+        check-out-> (14th) 09:00 (UTC)
+        Attendnace splitted acording to employee local midnight (Brussels) into 3 records:
+        1st record : (11st) 23:30 -> (12nd) 23:00 (23.5hrs worked & 15.5hrs overtime)
+        2nd record : (12nd) 23:00 -> (13rd) 23:00 (24hrs   worked & 16hrs overtime)
+        3rd record : (13rd) 23:00 -> (14th) 09:00 (10hrs   worked & 2hrs overtime)
+        """
+        attendance = self.attendance.create([
+            {
+                'employee_id': self.employee.id,
+                'check_in': datetime(2025, 11, 10, 7, 0, 0),
+                'check_out': datetime(2025, 11, 11, 23, 0, 0),
+            },
+            {
+                'employee_id': self.employee.id,
+                'check_in': datetime(2025, 11, 11, 23, 30, 0),
+                'check_out': datetime(2025, 11, 14, 9, 0, 0),
+            }
+        ])
+
+        self.assertEqual(len(attendance), 5, "The batch create should result in 5 total split records.")
+
+        # SHIFT 1: Record 1 (Monday)
+        self.assertEqual(attendance[0].check_in, datetime(2025, 11, 10, 7, 0, 0))
+        self.assertEqual(attendance[0].check_out, datetime(2025, 11, 10, 23, 0, 0))
+        self.assertEqual(attendance[0].worked_hours, 16.0)
+        self.assertEqual(attendance[0].overtime_hours, 8.0)
+
+        # SHIFT 1: Record 2 (Tuesday)
+        self.assertEqual(attendance[1].check_in, datetime(2025, 11, 10, 23, 0, 0))
+        self.assertEqual(attendance[1].check_out, datetime(2025, 11, 11, 23, 0, 0))
+        self.assertEqual(attendance[1].worked_hours, 24.0)
+        self.assertEqual(attendance[1].overtime_hours, 16.0)
+
+        # SHIFT 2: Record 3 (Wednesday)
+        self.assertEqual(attendance[2].check_in, datetime(2025, 11, 11, 23, 30, 0))
+        self.assertEqual(attendance[2].check_out, datetime(2025, 11, 12, 23, 0, 0))
+        self.assertEqual(attendance[2].worked_hours, 23.5)
+        self.assertEqual(attendance[2].overtime_hours, 15.5)
+
+        # SHIFT 2: Record 4 (Thursday)
+        self.assertEqual(attendance[3].check_in, datetime(2025, 11, 12, 23, 0, 0))
+        self.assertEqual(attendance[3].check_out, datetime(2025, 11, 13, 23, 0, 0))
+        self.assertEqual(attendance[3].worked_hours, 24.0)
+        self.assertEqual(attendance[3].overtime_hours, 16.0)
+
+        # SHIFT 2: Record 5 (Friday)
+        self.assertEqual(attendance[4].check_in, datetime(2025, 11, 13, 23, 0, 0))
+        self.assertEqual(attendance[4].check_out, datetime(2025, 11, 14, 9, 0, 0))
+        self.assertEqual(attendance[4].worked_hours, 10.0)
+        self.assertEqual(attendance[4].overtime_hours, 2.0)
+
+    def test_05_cron_auto_check_out_without_split_shift(self):
+        """
+        check-in -> (10th)  09:00 (UTC)
+        check-out-> .....
+        """
+        self.company.write({
+            'auto_check_out': True,
+            'auto_check_out_tolerance': 2.0
+        })
+
+        check_in = datetime(2025, 11, 10, 9, 0, 0)
+        open_attendnace = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': check_in,
+        })
+
+        open_attendnace._cron_auto_check_out()
+
+        closed_attendance = self.attendance.search([
+            ('employee_id', '=', self.employee.id),
+            ('check_in', '=', check_in),
+        ])
+
+        self.assertEqual(closed_attendance.check_out, datetime(2025, 11, 10, 19, 0, 0),
+                        "Monday checkout should be adjusted back to 19:00 (9:00 + 8h work + 2h tol)")
+        self.assertEqual(closed_attendance.out_mode, 'auto_check_out')
+        self.assertAlmostEqual(closed_attendance.worked_hours, 10.0)
+
+    def test_06_cron_auto_check_out_with_split_shift(self):
+        """
+        check-in -> (10th)  20:00 (UTC)
+        check-out-> .....
+        """
+        self.company.write({
+            'auto_check_out': True,
+            'auto_check_out_tolerance': 2.0
+        })
+
+        check_in = datetime(2025, 11, 10, 20, 0, 0)
+        open_attendnace = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': check_in,
+        })
+
+        # Attendnace splitted acording to employee local midnight (Brussels) into 2 records
+        open_attendnace._cron_auto_check_out()
+
+        closed_attendances = self.attendance.search([
+            ('employee_id', '=', self.employee.id),
+            ('check_in', '>=', check_in)
+        ], order='check_in asc')
+
+        self.assertEqual(closed_attendances[0].check_out, datetime(2025, 11, 10, 23, 0, 0))
+        self.assertEqual(closed_attendances[0].out_mode, 'auto_check_out')
+        self.assertAlmostEqual(closed_attendances[0].worked_hours, 3.0)
+
+        self.assertEqual(closed_attendances[1].check_out, datetime(2025, 11, 11, 6, 0, 0))
+        self.assertEqual(closed_attendances[1].out_mode, 'auto_check_out')
+        self.assertAlmostEqual(closed_attendances[1].worked_hours, 7.0)
+
+        self.assertEqual(sum(closed_attendances.mapped('worked_hours')), 10, "total worked hours (20:00 + 8h work + 2h tol)")

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -487,7 +487,10 @@ class TestHrAttendanceOvertime(HttpCase):
         # as his ruleset is per day; this employee works from 23h to 0h the 19th
         # and from 0h to 12h the 30th -> so he did 4h of overtime for this day
 
-        self.assertAlmostEqual(early_attendance2.overtime_hours, 4)
+        # First day you only work 1 hour & Second day you work 12 hours
+        self.assertItemsEqual(early_attendance2.mapped('worked_hours'), [1.0, 12.0])
+        self.assertItemsEqual(early_attendance2.mapped('overtime_hours'), [0.0, 4.0])
+
         overtime_record2 = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.europe_employee.id),
                                                               ('date', '=', datetime(2024, 5, 30))])
         self.assertAlmostEqual(overtime_record2.duration, 4)
@@ -548,7 +551,21 @@ class TestHrAttendanceOvertime(HttpCase):
         self.assertEqual(attendance_utc_pending.check_out, datetime(2024, 2, 1, 18, 0))
         self.assertEqual(attendance_utc_pending_within_allotted_hours.check_out, False)
         self.assertEqual(attendance_utc_done.check_out, datetime(2024, 2, 1, 17, 0))
-        self.assertEqual(attendance_jpn_pending.check_out, datetime(2024, 2, 1, 21, 0))
+
+        # These attendances represent an auto-checkout that cross the day and has been automatically split into two records:
+        # - First attendance from 12:00 to 15:00
+        # - Second attendance continues from the first check-out 15:00 to 21:00
+        # This ensures that the split logic correctly handles shifts crossing multiple days
+        attendance_jpn_pending_records = self.env['hr.attendance'].search([
+            ('employee_id', '=', self.jpn_employee.id),
+        ], order='check_in asc')
+        self.assertEqual(len(attendance_jpn_pending_records), 2, "The overnight shift should result in exactly 2 separate attendance records.")
+
+        self.assertEqual(attendance_jpn_pending_records[0].check_in, datetime(2024, 2, 1, 12, 0))
+        self.assertEqual(attendance_jpn_pending_records[0].check_out, datetime(2024, 2, 1, 15, 0))
+
+        self.assertEqual(attendance_jpn_pending_records[1].check_in, datetime(2024, 2, 1, 15, 0))
+        self.assertEqual(attendance_jpn_pending_records[1].check_out, datetime(2024, 2, 1, 21, 0))
 
         # Employee with flexible working schedule should not be checked out
         self.assertEqual(attendance_flexible_pending.check_out, False)
@@ -832,17 +849,22 @@ class TestHrAttendanceOvertime(HttpCase):
         # he should works 8h
         # 13 - 8 = 5h of overtime
         # so he should have 12 hours of overtime this day
+        # First day works 15hrs with overtime 7hrs
+        # Second day works 13hrs with overtime 5hrs
         overtime = self.env['hr.attendance.overtime.line'].search([
             ('employee_id', '=', self.employee.id),
         ])
+
+        self.assertItemsEqual(attendance.mapped('worked_hours'), [15, 13])
         self.assertItemsEqual(overtime.mapped('duration'), [7, 5])
-        self.assertEqual(attendance.validated_overtime_hours, 0)
+        self.assertItemsEqual(attendance.mapped('validated_overtime_hours'), [0, 0])
+
         overtime.action_approve()
-        self.assertEqual(attendance.validated_overtime_hours, 12)
-        self.assertEqual(attendance.overtime_hours, attendance.validated_overtime_hours)
+        self.assertItemsEqual(attendance.mapped('validated_overtime_hours'), [7, 5])
+        self.assertItemsEqual(overtime.mapped('duration'), attendance.mapped('validated_overtime_hours'))
 
         attendance.action_refuse_overtime()
-        self.assertEqual(attendance.validated_overtime_hours, 0)
+        self.assertItemsEqual(attendance.mapped('validated_overtime_hours'), [0, 0])
 
         # Create 2 attendance to avoid to work during lunch period; the overtime duration should be one hour less
         attendances = self.env['hr.attendance'].create([
@@ -1297,8 +1319,11 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2026, 2, 4, 2, 0),
         })
 
-        self.assertEqual(attendance.worked_hours, 4.0)
-        self.assertEqual(attendance.overtime_hours, 0.0)
+        self.assertEqual(attendance[0].worked_hours, 2.0)
+        self.assertEqual(attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(attendance[1].worked_hours, 2.0)
+        self.assertEqual(attendance[1].overtime_hours, 0.0)
 
         overtime_attendance = self.env['hr.attendance'].create({
             'employee_id': self.europe_employee.id,
@@ -1306,8 +1331,11 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2026, 2, 6, 10, 0),
         })
 
-        self.assertEqual(overtime_attendance.worked_hours, 12.0)
-        self.assertEqual(overtime_attendance.overtime_hours, 2.0)  # overtime should be 2 hours as the employee works 10 hours on the 5th of February
+        self.assertEqual(overtime_attendance[0].worked_hours, 2.0)
+        self.assertEqual(overtime_attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(overtime_attendance[1].worked_hours, 10.0)
+        self.assertEqual(overtime_attendance[1].overtime_hours, 2.0)
 
     def test_overtime_across_midnight_in_utc_plus_timezone(self):
         self.jpn_employee.ruleset_id = self.ruleset
@@ -1317,8 +1345,11 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2026, 2, 3, 17, 0),   # 4th 02:00 in Tokyo is 3rd 17:00 UTC
         })
 
-        self.assertEqual(attendance.worked_hours, 4.0)
-        self.assertEqual(attendance.overtime_hours, 0.0)
+        self.assertEqual(attendance[0].worked_hours, 2.0)
+        self.assertEqual(attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(attendance[1].worked_hours, 2.0)
+        self.assertEqual(attendance[1].overtime_hours, 0.0)
 
         overtime_attendance = self.env['hr.attendance'].create({
             'employee_id': self.jpn_employee.id,        # UTC+9
@@ -1326,8 +1357,11 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2026, 2, 6, 1, 0),    # 6th 10:00 in Tokyo is 6h 01:00 UTC
         })
 
-        self.assertEqual(overtime_attendance.worked_hours, 12.0)
-        self.assertEqual(overtime_attendance.overtime_hours, 2.0)
+        self.assertEqual(overtime_attendance[0].worked_hours, 2.0)
+        self.assertEqual(overtime_attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(overtime_attendance[1].worked_hours, 10.0)
+        self.assertEqual(overtime_attendance[1].overtime_hours, 2.0)
 
     def test_overtime_across_midnight_in_utc_minus_timezone(self):
         self.honolulu_employee.ruleset_id = self.ruleset
@@ -1337,8 +1371,11 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2026, 2, 4, 12, 0),   # 4th 02:00 in Honolulu is 4th 12:00 UTC
         })
 
-        self.assertEqual(attendance.worked_hours, 4.0)
-        self.assertEqual(attendance.overtime_hours, 0.0)
+        self.assertEqual(attendance[0].worked_hours, 2.0)
+        self.assertEqual(attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(attendance[1].worked_hours, 2.0)
+        self.assertEqual(attendance[1].overtime_hours, 0.0)
 
         overtime_attendance = self.env['hr.attendance'].create({
             'employee_id': self.honolulu_employee.id,   # UTC-10
@@ -1346,5 +1383,8 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2026, 2, 6, 20, 0),   # 6th 10:00 in Honolulu is 6th 20:00 UTC
         })
 
-        self.assertEqual(overtime_attendance.worked_hours, 12.0)
-        self.assertEqual(overtime_attendance.overtime_hours, 2.0)
+        self.assertEqual(overtime_attendance[0].worked_hours, 2.0)
+        self.assertEqual(overtime_attendance[0].overtime_hours, 0.0)
+
+        self.assertEqual(overtime_attendance[1].worked_hours, 10.0)
+        self.assertEqual(overtime_attendance[1].overtime_hours, 2.0)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** 

. Scenario: An employee works an overnight shift from 20:00 to 04:00 the next day → that is, 4 hours on the first day and 4 hours on the following day. 
. Result: The system records all 8 hours on the first day of attendance. 
. Expected result: The shift should be split across both days it covers, so that the worked hours are correctly reflected for each day.

**Current behavior before PR:** 
The system fails to recognize the calendar day boundary during overnight shifts:

**Desired behavior after PR is merged:**
. Attendance shifts are now automatically split at the employee's local midnight using the employee's specific timezone (e.g., Europe/Brussels) to determine the exact UTC timestamp of midnight.
. Both create and write methods now intercept values to detect multi-day spans before record creation.
. Shifts spanning multiple days (e.g., a 72-hour shift) are recursively split into distinct 24-hour records for each calendar day involved.
. Ensure accurate worked hours and overtime calculations & Overtime rules still works normally
. If a forced auto check-out occurs on a split shift occurs normally if it across two days

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr