### PR TITLE
[FIX] hr: Correct the behavior of _onchange of related fields on employee

### DIFF
--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -658,3 +658,14 @@ class TestHrVersion(TransactionCase):
             fields_without_tracking,
             f"The following hr.version fields should have tracking=True: {fields_without_tracking}"
         )
+
+    def test_related_fields_on_version_onchange(self):
+        """ This test is to ensure that each _onchange method on version has a corresponding _onchange on employee that calls it. """
+        version_methods = {method for method in dir(self.env['hr.version']) if method.startswith('_onchange')}
+        employee_methods = {method for method in dir(self.env['hr.employee']) if method.startswith('_onchange')}
+        not_implemented_onchanges = version_methods - employee_methods
+        self.assertFalse(
+            not_implemented_onchanges,
+            f"""The following _onchange methods on hr.version should have corresponding methods implemented on hr.employee: {not_implemented_onchanges}\n
+                You might need to implement methods with the same name on hr.employee and call the corresponding self.version_id._onchange inside"""
+        )


### PR DESCRIPTION

purpose: when changing fields of employee in the UI, the `_onchange` of the fields doesn't trigger because it's defined on `hr.version`

-added `test_related_fields_on_version_onchange` to check if `_onchange` methods are implemented on `hr.employee` to call the corresponding methods on `hr.version`

task-id: 5173389

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
