### PR TITLE
[FIX] mail: discuss command palette avatar smaller in desktop

### DIFF
--- a/addons/mail/controllers/discuss/search.py
+++ b/addons/mail/controllers/discuss/search.py
@@ -9,7 +9,7 @@ from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
 class SearchController(http.Controller):
     @http.route("/discuss/search", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
-    def search(self, term, category_id=None, limit=8):
+    def search(self, term, category_id=None, limit=10):
         store = Store()
         self.get_search_store(store, search_term=term, limit=limit)
         return store.get_result()

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -154,7 +154,7 @@ export class DiscussCommandPalette {
 
     /** @param {Record[]} [filtered] persona or thread to filters, e.g. being build already in a category in a patch such as MENTIONS or RECENT */
     buildResults(filtered) {
-        const TOTAL_LIMIT = this.ui.isSmall ? 7 : 8;
+        const TOTAL_LIMIT = this.ui.isSmall ? 7 : 10;
         const remaining = TOTAL_LIMIT - (filtered ? filtered.size : 0);
         let partners = [];
         if (this.store.self_partner) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.scss
@@ -28,3 +28,14 @@
 .o-mail-DiscussCommand-actionIcon {
     font-size: 0.75rem;
 }
+
+.o-mail-DiscussCommand-img {
+    width: 26px;
+    height: 26px;
+
+    &.o-uiSmall {
+        width: 32px;
+        height: 32px;
+    }
+}
+

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-DiscussCommand o_command_default d-flex align-items-center ps-3 pe-4" t-att-class="{ 'o-uiSmall': ui.isSmall }">
             <i t-if="props.channel" class="fa-fw opacity-75 text-muted me-2" t-att-class="props.channel.parent_channel_id ? 'fa fa-comments-o' : props.channel.discussAppCategory?.icon ?? 'oi oi-user opacity-0'"/>
             <i t-elif="props.persona" class="oi fa-fw oi-user opacity-75 text-muted me-2"/>
-            <img class="rounded-3 me-2 object-fit-cover shadow-sm" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 32px; height: 32px"/>
+            <img class="o-mail-DiscussCommand-img rounded-3 me-2 object-fit-cover shadow-sm" t-if="props.imgUrl" t-att-src="props.imgUrl" t-att-class="{ 'o-uiSmall': ui.isSmall }"/>
             <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
             <span class="o-mail-DiscussCommand-nameContainer pe-1 text-ellipsis d-flex align-items-center fw-bold" t-att-class="{ 'o-action': props.action }">
                 <t t-if="props.channel?.parent_channel_id">

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -941,7 +941,7 @@ export async function mail_data(request) {
 registerRoute("/discuss/search", search);
 /** @type {RouteCallback} */
 async function search(request) {
-    const { term, limit = 8 } = await parseRequestParams(request);
+    const { term, limit = 10 } = await parseRequestParams(request);
 
     /** @type {import("mock_models").DiscussChannel} */
     const DiscussChannel = this.env["discuss.channel"];


### PR DESCRIPTION
Discuss command avatar were much bigger than rest of discuss UI, such as discuss sidebar.

Discuss sidebar avatar size was reduced in 19.0, but discuss command palette still had big size like before this change.

This commit fixes the issue with reduced size.
To compensate with reduced size, more items are shown at once. This change only applies to desktop: in mobile the avatar need to be bigger, so this commit doesn't affect small UI.

Part of Task-5227387

Before
<img width="1280" height="946" alt="Screenshot 2025-11-10 at 12 59 56" src="https://github.com/user-attachments/assets/532c7d7f-a381-43f4-8a65-b0e3db7d6809" />

After
<img width="1281" height="946" alt="Screenshot 2025-11-10 at 12 59 43" src="https://github.com/user-attachments/assets/9e018c92-a862-4aee-a2ad-dadd880b21f3" />
