### PR TITLE
[FIX] website_slides: prevent error when setting the video link for slide

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1368,7 +1368,6 @@ class WebsiteSlides(WebsiteProfile):
             })
 
             if not slide.video_source_type:
-                slide.unlink()
                 return {'error': _("Could not find your video. Please check if your link is correct and if the video can be accessed.")}
 
             if slide.video_source_type == 'youtube':


### PR DESCRIPTION
When a user sets an invalid video link for a slide, a traceback occurs.

Steps to reproduce the error:
- Install ``website_slides`` module with demo data
- Go to Website > Courses > Open Taking care of Trees course
- Add Content > Video > Add valid video link (ex. https://www.youtube.com/shorts/SXHMnicI6Pg) > Save and Publish > Delete
- Repeat above step
- Add content > Video > Add any text in video link > Save and Publish

Traceback:
```py
AssertionError: Could not find all values of slide.slide(12,) to flush them
```

https://github.com/odoo/odoo/blob/7bbfb207f8699973f8580ea18821f82b1a83e149/addons/website_slides/controllers/main.py#L1363-L1372
New record is created using ``new()`` to fetch external metadata for the slide.
This record only exists in memory and is not stored in the database.
When the video link is invalid, ``video_source_type`` is False, and the code attempts to ``unlink()`` the slide.
Unlinking the record triggers field recomputations,
and it will lead to the above error when flushing the new record.

ref: https://github.com/odoo/odoo/commit/71233fa2cb8984b65f8e7ac55405fdbc054756a0

sentry-6964031088

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
