### PR TITLE
[FIX] im_livechat: show user answer for final chatbot step in side panel

### DIFF
--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -148,7 +148,7 @@ export class Chatbot extends Record {
      * Go to the next step of the chatbot, fetch it if needed.
      */
     async _goToNextStep() {
-        if (!this.thread || this.currentStep?.isLast) {
+        if (!this.thread) {
             return;
         }
         if (this.steps.at(-1)?.eq(this.currentStep)) {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_user_input_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_user_input_tour.js
@@ -1,0 +1,54 @@
+import { registry } from "@web/core/registry";
+import { rpcBus } from "@web/core/network/rpc";
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_user_input_saved_on_last_step", {
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Enter your phone number)",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "edit +919876543210",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "press Enter",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Enter your email address)",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "edit test@example.com",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            async run(helpers) {
+                // We wait for the request to complete to ensure the final user input is persisted in the database before moving forward.
+                let requestId;
+                rpcBus.addEventListener("RPC:REQUEST", function onRequest({ detail }) {
+                    if (detail.url === "/chatbot/step/trigger") {
+                        requestId = detail.data.id;
+                        rpcBus.removeEventListener("RPC:REQUEST", onRequest);
+                    }
+                });
+                await helpers.press("ENTER");
+                await new Promise((resolve) => {
+                    rpcBus.addEventListener("RPC:RESPONSE", function onResponse({ detail }) {
+                        if (detail.data.id === requestId) {
+                            rpcBus.removeEventListener("RPC:RESPONSE", onResponse);
+                            resolve();
+                        }
+                    });
+                });
+            },
+        },
+        {
+            trigger: ".o-livechat-root:shadow span:contains(This livechat conversation has ended)",
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -324,6 +324,29 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
         self.env.ref("website.default_website").channel_id = livechat_channel.id
         self.start_tour("/", "website_livechat.chatbot_continue_tour")
 
+    def test_chatbot_user_input_saved_on_last_step(self):
+        chatbot_script = self.env["chatbot.script"].create({"title": "Test User Input Bot"})
+        _, email_step = self.env["chatbot.script.step"].create([
+            {
+                "step_type": "question_phone",
+                "chatbot_script_id": chatbot_script.id,
+                "message": "Enter your phone number",
+            },
+            {
+                "step_type": "question_email",
+                "chatbot_script_id": chatbot_script.id,
+                "message": "Enter your email address",
+            },
+        ])
+        self.livechat_channel.rule_ids = self.env["im_livechat.channel.rule"].create({"chatbot_script_id": chatbot_script.id})
+        self.start_tour("/", "website_livechat.chatbot_user_input_saved_on_last_step")
+        user_answer_message = self.env["chatbot.message"].search([
+            ("script_step_id", "=", email_step.id),
+            ("discuss_channel_id.livechat_channel_id", "=", self.livechat_channel.id),
+        ], limit=1)
+        self.assertIn("test@example.com", user_answer_message.user_raw_answer, "Email was saved on last step")
+        self.assertTrue(user_answer_message.discuss_channel_id.livechat_end_dt, "Livechat ended after last step")
+
 
 @tests.tagged("post_install", "-at_install")
 class TestLivechatChatbotUIMoblie(TestLivechatChatbotUICommon):


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

When reaching the last chatbot step, the frontend stopped before calling `/chatbot/step/trigger` due to the `isLast` check in `_goToNextStep()`. As a result, `_process_answer()` was not executed, and the user's final answer was not saved, which resulted in the `rawAnswer` field remaining empty and the answer not appearing in the side panel. The chat session was also not marked as closed since the backend route was never called.

**Current behavior before PR:**
---------------------------------

- The final chatbot answer is not visible in the side panel  
- The chat session remains open after the final step  

**Desired behavior after PR is merged:**
-----------------------------------------

- The final chatbot answer is saved and displayed in the side panel  
- The backend route is triggered for the last step  
- The chat session is properly marked as closed  

**Task:** 5172125

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
