### PR TITLE
[REF] html_editor: export isUnremovable as a shared function

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -99,7 +99,14 @@ export const unremovableNodePredicates = [
 export class DeletePlugin extends Plugin {
     static dependencies = ["baseContainer", "selection", "history", "input", "userCommand"];
     static id = "delete";
-    static shared = ["deleteBackward", "deleteForward", "deleteRange", "deleteSelection", "delete"];
+    static shared = [
+        "deleteBackward",
+        "deleteForward",
+        "deleteRange",
+        "deleteSelection",
+        "delete",
+        "isUnremovable",
+    ];
     /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -575,7 +575,7 @@ export class DomPlugin extends Plugin {
             (isParagraphRelatedElement(block) ||
                 isListItemElement(block) ||
                 isPhrasingContent(block)) &&
-            this.getResource("unremovable_node_predicates").some((predicate) => predicate(block))
+            this.dependencies.delete.isUnremovable(block)
         );
     }
 

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -57,7 +57,7 @@ function isFormatted(formatPlugin, format) {
 
 export class FormatPlugin extends Plugin {
     static id = "format";
-    static dependencies = ["selection", "history", "input", "split"];
+    static dependencies = ["selection", "history", "input", "split", "delete"];
     // TODO ABD: refactor to handle Knowledge comments inside this plugin without sharing mergeAdjacentInlines.
     static shared = [
         "isSelectionFormat",
@@ -208,7 +208,7 @@ export class FormatPlugin extends Plugin {
         if (
             !emptyZWS ||
             !emptyZWS.parentElement.isContentEditable ||
-            this.getResource("unremovable_node_predicates").some((p) => p(emptyZWS))
+            this.dependencies.delete.isUnremovable(emptyZWS)
         ) {
             return insertedNode;
         }
@@ -549,7 +549,7 @@ export class FormatPlugin extends Plugin {
             this.cleanZWS(element, { preserveSelection });
             return;
         }
-        if (this.getResource("unremovable_node_predicates").some((p) => p(element))) {
+        if (this.dependencies.delete.isUnremovable(element)) {
             return;
         }
         if (

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -54,10 +54,7 @@ export class SplitPlugin extends Plugin {
             // An unmergeable element is unsplittable and vice-versa (as
             // split and merge are reverse operations from one another).
             // Therefore, unremovable nodes are also unsplittable.
-            (node) =>
-                this.getResource("unremovable_node_predicates").some((predicate) =>
-                    predicate(node)
-                ),
+            (node) => this.dependencies.delete.isUnremovable(node),
             // "Unbreakable" is a legacy term that means unsplittable and
             // unmergeable.
             (node) => node.classList?.contains("oe_unbreakable"),

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -77,6 +77,7 @@ export class FontPlugin extends Plugin {
         "dom",
         "format",
         "lineBreak",
+        "delete",
     ];
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -562,7 +563,7 @@ export class FontPlugin extends Plugin {
             return;
         }
         // Check if unremovable.
-        if (this.getResource("unremovable_node_predicates").some((p) => p(closestHandledElement))) {
+        if (this.dependencies.delete.isUnremovable(closestHandledElement)) {
             return;
         }
         const baseContainer = this.dependencies.baseContainer.createBaseContainer();

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -10,7 +10,7 @@ import { childNodeIndex } from "@html_editor/utils/position";
 
 export class LinkPastePlugin extends Plugin {
     static id = "linkPaste";
-    static dependencies = ["link", "clipboard", "selection", "dom", "history"];
+    static dependencies = ["link", "clipboard", "selection", "dom", "history", "delete"];
     /** @type {import("plugins").EditorResources} */
     resources = {
         before_paste_handlers: this.selectFullySelectedLink.bind(this),
@@ -108,7 +108,7 @@ export class LinkPastePlugin extends Plugin {
         if (
             link?.parentElement?.isContentEditable &&
             cleanZWChars(selection.textContent()) === cleanZWChars(link.innerText) &&
-            !this.getResource("unremovable_node_predicates").some((p) => p(link))
+            !this.dependencies.delete.isUnremovable(link)
         ) {
             this.dependencies.selection.setSelection({
                 anchorNode: link.parentElement,


### PR DESCRIPTION
Before this commit: many plugins call the resources to do unremovable_node_predicates checks or create a local isUnremovable function

After this commit: the delete_plugin has the isUnremovable function shared and other plugins can call it directly through the dependency. Note that the check of unremovable_node_predicates in base_container_plugin is kept to avoid looping dependency.

task-5186834


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
