### PR TITLE
[REF] spreadsheet: rename isReadonly to hasWriteAccess for clarity

### DIFF
--- a/addons/spreadsheet/static/tests/helpers/data.js
+++ b/addons/spreadsheet/static/tests/helpers/data.js
@@ -133,7 +133,7 @@ function mockSpreadsheetDataController(_request, { res_model, res_id }) {
         data: JSON.parse(record.spreadsheet_data),
         name: record.name,
         revisions: [],
-        isReadonly: false,
+        has_write_access: true,
         writable_rec_name_field: "name",
     };
 }


### PR DESCRIPTION
Current behavior before PR:
- The variable isReadonly was used for both spreadsheet readonly mode
and user access control, causing confusion.

Desired behavior after PR is merged:
- Renamed user access variable to hasWriteAccess for better distinction.
- When hasWriteAccess is not provided from the server, the spreadsheet
  open in readonly mode.

Task: [5030282](https://www.odoo.com/odoo/2328/tasks/5030282)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
