### PR TITLE
[IMP] web: add __formatted_display_name in web_name_search results

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -46,7 +46,12 @@ class Base(models.AbstractModel):
         if len(specification) == 1 and 'display_name' in specification:
             return [{'id': id, 'display_name': name, '__formatted_display_name': self.with_context(formatted_display_name=True).browse(id).display_name} for id, name in id_name_pairs]
         records = self.browse([id for id, _ in id_name_pairs])
-        return records.web_read(specification)
+        results = records.with_context(formatted_display_name=True).web_read(specification)
+        if 'display_name' in specification:
+            for i, result in enumerate(results):
+                result["__formatted_display_name"] = result.get("display_name")
+                result["display_name"] = records[i].display_name
+        return results
 
     @api.model
     @api.readonly

--- a/addons/web/tests/test_web_search_read.py
+++ b/addons/web/tests/test_web_search_read.py
@@ -40,3 +40,13 @@ class TestWebSearchRead(common.TransactionCase):
         result = self.env["res.partner"].web_name_search("", {"display_name": {}})[0]
         self.assertTrue("display_name" in result)
         self.assertTrue("__formatted_display_name" in result)
+
+        result = self.env["res.partner"].web_name_search("", {"display_name": {}, "street": {}})[0]
+        self.assertTrue("display_name" in result)
+        self.assertTrue("street" in result)
+        self.assertTrue("__formatted_display_name" in result)
+
+        result = self.env["res.partner"].web_name_search("", {"street": {}})[0]
+        self.assertTrue("display_name" not in result)
+        self.assertTrue("street" in result)
+        self.assertTrue("__formatted_display_name" not in result)


### PR DESCRIPTION
Before this commit, the __formatted_display_name returned in web_name_search
when the specifications contain only display_name. If any other field was
requested, the __formatted_display_name wasn't put in the result.

Now, the __formatted_display_name is added to the result of web_name_search
when display_name is in the specifications.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
