### PR TITLE
[FIX] purchase: test failure on pg18

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -9,7 +9,7 @@ from odoo.tools import mute_logger
 
 from datetime import timedelta
 from freezegun import freeze_time
-from psycopg2.errors import ForeignKeyViolation
+from psycopg2.errors import IntegrityError
 import pytz
 
 
@@ -1103,7 +1103,7 @@ class TestPurchase(AccountTestInvoicingCommon):
                 })],
         })
 
-        with (self.assertRaises(ForeignKeyViolation), self.cr.savepoint(), mute_logger("odoo.sql_db")):
+        with (self.assertRaises(IntegrityError), self.cr.savepoint(), mute_logger("odoo.sql_db")):
             uom_test.unlink()
 
         self.assertEqual(po.order_line[0].product_uom, uom_test)


### PR DESCRIPTION
Apparently in pg18 a standard-compliance
fix (postgres/postgres@086c84b23d99c2ad268f97508cd840efc1fdfd79) has led to `RESTRICT_VIOLATION` being emitted in cases which formerly emitted `FOREIGN_KEY_VIOLATION`. One such case is specifically being tested for by `test_purchase_order_line_without_uom`, leading to this test failing systematically when running pg18:

    psycopg2.errors.RestrictViolation: update or delete on table "uom_uom" violates RESTRICT setting of foreign key constraint "purchase_order_line_product_uom_id_fkey" on table "purchase_order_line"
    DETAIL:  Key (id)=(29) is referenced from table "purchase_order_line".

Update the test to use the more generic `IntegrityError` as it's probably more than sufficient for our purposes. Technically we could pass a tuple of `(ForeignKeyViolation, RestrictViolation)` but it doesn't really seem necessary. And it would require fixing the `_raisesContext` override as currently it is very much *not* compatible with that.
