### PR TITLE
[FIX] sale{,_management}: fix order line name using quotation template

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -377,7 +377,7 @@ class SaleOrderLine(models.Model):
     @api.depends('product_id', 'linked_line_id', 'linked_line_ids')
     def _compute_name(self):
         for line in self:
-            if not line.product_id and not line.is_downpayment:
+            if (not line.product_id and not line.is_downpayment) or not line.order_id:
                 continue
 
             lang = line.order_id._get_lang()

--- a/addons/sale_management/models/sale_order_line.py
+++ b/addons/sale_management/models/sale_order_line.py
@@ -10,7 +10,7 @@ class SaleOrderLine(models.Model):
 
     sale_order_option_ids = fields.One2many('sale.order.option', 'line_id', 'Optional Products Lines')
 
-    @api.depends('product_id')
+    @api.depends('product_id', 'order_id')
     def _compute_name(self):
         # Take the description on the order template if the product is present in it
         super()._compute_name()
@@ -21,7 +21,10 @@ class SaleOrderLine(models.Model):
                         # If a specific description was set on the template, use it
                         # Otherwise the description is handled by the super call
                         lang = line.order_id.partner_id.lang
-                        line.name = template_line.with_context(lang=lang).name + line.with_context(lang=lang)._get_sale_order_line_multiline_description_variants()
+                        name = template_line.with_context(lang=lang).product_id.display_name
+                        name += '\n' + template_line.with_context(lang=lang).name
+                        name += line.with_context(lang=lang)._get_sale_order_line_multiline_description_variants()
+                        line.name = name
                         break
 
     def _use_template_name(self):


### PR DESCRIPTION
### Issue:
In this issue, when a quotation template is used in sale order, the end line is missing between name and description in the invoice pdf.

#### Steps to reproduce:
1- Install a db with sale and invoicing installed
2- Create a quotation template, and add a description in the line.
3- Create a quotation with the created template.
4- Confirm the order and create an invoice for the sale order.
5- Print the pdf, as seen the name and description are shown in the same line, while if the sale order was created without a template, we would have seen the description from product in the next line.

### Cause:
There is a mismatch between `line.name` when it's from template and when it's from product itself, causing this issue.

In the case, the line is not coming from template we have: https://github.com/odoo/odoo/blob/aaad780e897e941a3d5cf9b3a881252907ba266a/addons/sale/models/sale_order_line.py#L405-L416 in which:
https://github.com/odoo/odoo/blob/aaad780e897e941a3d5cf9b3a881252907ba266a/addons/sale/models/sale_order_line.py#L432-L435 https://github.com/odoo/odoo/blob/aaad780e897e941a3d5cf9b3a881252907ba266a/addons/product/models/product_product.py#L852-L861

Which means the name will be
```python
product_id.display_name + product_id.description_sale +
line._get_sale_order_line_multiline_description_variants()
```

While when the quotation is coming from template the name is:
```python
template_line.name +
line._get_sale_order_line_multiline_description_variants()
```
As `template_line.name` is the template line description, we can add the `product_id.display_name` in `_compute_name` so both logic match.

opw-5130171