### PR TITLE
[FIX] web: readGroup fix when we aggregate by the gropuby field

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -1213,9 +1213,13 @@ export class PivotModel extends Model {
      * @returns {Promise<Object[]>}
      */
     async _getSubGroups(groupBy, params) {
-        const { resModel, groupDomain, measureSpecs, kwargs, mapping } = params;
+        const { resModel, groupDomain, kwargs, mapping } = params;
         const key = JSON.stringify(groupBy);
         if (!mapping[key]) {
+            const measureSpecs = params.measureSpecs.map((measureSpec) => {
+                const fieldName = measureSpec.split(":")[0];
+                return groupBy.includes(fieldName) ? fieldName : measureSpec;
+            });
             mapping[key] = this.orm.readGroup(resModel, groupDomain, measureSpecs, groupBy, kwargs);
         }
         return mapping[key];

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -4550,3 +4550,24 @@ test("missing deleted property field definition is created", async function (ass
     expect.verifySteps([`["properties.my_char"]`]);
     expect(getCurrentValues()).toBe("4,2,1");
 });
+
+test("do not count distinct a measure field if we are grouping by it", async () => {
+    onRpc("read_group", ({ kwargs }) => {
+        expect(kwargs.fields.length).toBe(1);
+        if (kwargs.groupby.length === 0) {
+            expect(kwargs.fields).toEqual(["product_id:count_distinct"]);
+        }
+        if (kwargs.groupby.length === 1) {
+            expect(kwargs.fields).toEqual(["product_id"]);
+        }
+    });
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `
+			<pivot>
+				<field name="product_id" type="measure"/>
+			</pivot>`,
+        groupBy: ["product_id"],
+    });
+});


### PR DESCRIPTION
Steps to reproduce
------------------
1. On a new DB, go to PoS > Reporting > Orders
2. Choose the Pivot view
3. Click on a row, click 'add custom group', choose 'Order'

The row should expand showing the orders belonging to it, but instead,
only one entry is added, and it's not showing the order name, just "1".

What's happening
----------------
We are grouping by 'order_id', but since 'order_id:count_distinct' is in
the `measureSpecs`, we're counting the number of orders instead of
returning their IDs. In other words, since we are grouping by a unique
field 'order_id', and also counting the number of row in such a group,
we always get 1.

Solution
--------
If the goupby field exists in `measureSpecs`, return it as is without
aggregating on it.

opw-5187181