### PR TITLE
[FIX] account: tests for `review_state` in community

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3729,8 +3729,10 @@ class AccountMove(models.Model):
         return _('This entry has been reversed from %s', self._get_html_link()) if default.get('reversed_entry_id') else _('This entry has been duplicated from %s', self._get_html_link())
 
     def _check_user_access(self, vals_list):
-        is_user_able_to_review = self.env.user.has_group('account.group_account_user')
+        if self.env.su:
+            return
         is_user_able_to_supervise = self.env.user.has_group('account.group_account_manager')
+        is_user_able_to_review = self.env.user.has_group('account.group_account_user')
         for vals in vals_list:
             if (
                 ((vals.get('review_state') == 'reviewed' or not vals.get('review_state', True)) and not is_user_able_to_review)

--- a/addons/account/tests/test_account_to_check.py
+++ b/addons/account/tests/test_account_to_check.py
@@ -126,6 +126,8 @@ class TestCheckAccountMoves(AccountTestInvoicingCommon):
         self.assertEqual(last_recurring.review_state, 'reviewed')
 
     def test_create_statement_line_auto_check(self):
+        if 'account_accountant' not in self.env["ir.module.module"]._installed():
+            self.skipTest('account_accountant is not installed')  # required for `_try_auto_reconcile_statement_lines`
         """Test if a user changes the reconciliation on a st_line, it marks the bank move as 'To Review'"""
         payment = self.env['account.payment'].create({
             'payment_type': 'inbound',


### PR DESCRIPTION
The recent changes[^1] broken the test suite when `account_accountant` is not installed or when `accountant` is not installed.

The check on `env.su` is needed because by default no user has `account.group_account_user` by default, not even the cron user.

runbot-233950
runbot-233951
