### PR TITLE
[FIX] account: allow excluding archived journals in journal groups

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -23,7 +23,7 @@ class AccountJournalGroup(models.Model):
         help="Define which company can select the multi-ledger in report filters. If none is provided, available for all companies",
         default=lambda self: self.env.company,
     )
-    excluded_journal_ids = fields.Many2many('account.journal', string="Excluded Journals")
+    excluded_journal_ids = fields.Many2many('account.journal', string="Excluded Journals", context={'active_test': False})
     sequence = fields.Integer(default=10)
 
     _uniq_name = models.Constraint(


### PR DESCRIPTION
A journal is still excluded from the ledger even if it is archived. To reproduce:
* create a new journal
* create a journal entry impacting the P&L in that journal
* create a Multi-Ledger (journal group) excluding this journal
* archive the journal
* open the P&L

The journal entry is impacting the report, because the journal is not excluded.

task-5251383
