### PR TITLE
[FIX] hr: make sure hr user can access to employee form view

### DIFF
--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.js
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.js
@@ -35,7 +35,7 @@ export class VersionsTimeline extends StatusBarField {
                         record.evalContext
                     );
                 }
-                return orm.searchRead(relation, domain, fieldNames);
+                return orm.searchRead(relation, domain, fieldNames.filter((fName) => fName in record.fields));
             });
         }
 
@@ -48,6 +48,12 @@ export class VersionsTimeline extends StatusBarField {
                 return { type: "date" };
             },
         });
+    }
+
+    displayContractLines() {
+        return ["contract_type_id", "contract_date_start", "contract_date_end"].every(
+            (fieldName) => fieldName in this.props.record.fields
+        );
     }
 
     async createVersion(date) {
@@ -88,7 +94,9 @@ export class VersionsTimeline extends StatusBarField {
             return luxon.DateTime.fromISO(dateString).toFormat("MMM dd, yyyy");
         }
         const items = super.getAllItems();
-
+        if (!this.displayContractLines) {
+            return items;
+        }
         const dataById = new Map(this.specialData.data.map(d => [d.id, d]));
 
         const selectedVersion = items.find(item => item.isSelected)?.value;

--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.xml
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.xml
@@ -62,6 +62,7 @@
                         t-esc="item.label"
                         t-on-click="() => this.selectItem(item)"/>
                     <div
+                        t-if="displayContractLines"
                         t-att-class="{
                             o_first: item_first,
                             o_last: item_last,


### PR DESCRIPTION
Before this commit, the version timeline component needs to read contract_type_id and contract dates fields to be able to add an extra line below the versions to mention the versions inside the same contract. The problem is `contract_type_id` and the contract dates fields are not available when the user cannot see the payroll tab in the employee form.

This commit makes sure the fields needed to display the extra line inside the version timeline are only used if the user has access to them otherwise no extra line will be displayed since some information is missing to be able to display it.

task-5253864

X-original-commit: 0b1d4b006908b1ad993177f024d65a484d477078

