### PR TITLE
[FIX] hr_attendance: mismatched attandence hours in report

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1015,6 +1015,32 @@ class TestHrAttendanceOvertime(TransactionCase):
             },
         ])
 
+    def test_expected_hours_from_schedule(self):
+        """ Test that expected_hours is calculated from employee's schedule, not from worked hours."""
+
+        attendance_undertime = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2025, 11, 10, 8, 0),
+            'check_out': datetime(2025, 11, 10, 10, 0),
+        })
+        self.assertEqual(attendance_undertime.expected_hours, 8.0, 'Expected hours should be 8 from schedule, not 2 from worked hours')
+
+        attendance_overtime = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2025, 11, 11, 8, 0),
+            'check_out': datetime(2025, 11, 11, 19, 0),
+        })
+
+        self.assertAlmostEqual(attendance_overtime.expected_hours, 8.0, 2, 'Expected hours should be 8 from schedule, not affected by overtime')
+
+        attendance_exact = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2025, 11, 12, 8, 0),
+            'check_out': datetime(2025, 11, 12, 17, 0),
+        })
+
+        self.assertAlmostEqual(attendance_exact.expected_hours, 8.0, 2, 'Expected hours matches worked hours when exact')
+
     def test_overtime_rule_combined(self):
         # TODO
         pass


### PR DESCRIPTION
**Description:**
In the attendance report, when an employee worked less than their scheduled hours, the expected hours incorrectly matched the worked hours instead of showing the actual scheduled hours from their contract. This resulted in a difference of 0 hours instead of showing the attendance deficit (undertime).

**Steps to reproduce:**
1. Create an employee with a standard working schedule (8 hours/day)
2. Create an attendance record where the employee works less than scheduled hours (only 2 hours)
3. View the attendance report
4. Observe that expected_hours equals worked_hours instead of showing the scheduled hours from the employee's contract

**Root Cause:**
The `_compute_expected_hours` method calculated expected hours using the formula: `expected_hours = worked_hours - overtime_hours`

This formula only worked correctly when negative overtime (undertime) records were created. In v19, the overtime system was changed to skip creating negative overtime records, causing overtime_hours to remain 0 when employees work less than expected.
compute expected_hours from employee schedule

**Solution:**
Calculate `expected_hours` directly from the employee's resource calendar/working schedule using `_employee_attendance_intervals`, rather than deriving it from worked_hours and overtime_hours.

opw-5178845