### PR TITLE
[IMP] mail, im_livechat: manage downgrade of local storage

### DIFF
--- a/addons/im_livechat/static/tests/upgrade_19_1.test.js
+++ b/addons/im_livechat/static/tests/upgrade_19_1.test.js
@@ -2,7 +2,7 @@ import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helper
 
 import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
 import { makeRecordFieldLocalId } from "@mail/model/misc";
-import { toRawValue } from "@mail/utils/common/local_storage";
+import { LocalStorageEntry } from "@mail/utils/common/local_storage";
 import { contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
@@ -34,7 +34,7 @@ test("category 'Livechat' is folded", async () => {
         DiscussAppCategory.localId("im_livechat.category_default"),
         "is_open"
     );
-    expect(localStorage.getItem(defaultLivechat_is_open)).toBe(toRawValue(false));
+    expect(new LocalStorageEntry(defaultLivechat_is_open).get()).toBe(false);
     expect(
         localStorage.getItem("discuss_sidebar_category_folded_im_livechat.category_default")
     ).toBe(null);

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -14,8 +14,10 @@ export const upgrade_19_1 = {
     },
 };
 
+export const MESSAGE_SOUND_LS_19_1 = "Settings,undefined:messageSound";
+
 upgrade_19_1.add("mail.user_setting.message_sound", {
-    key: "Settings,undefined:messageSound",
+    key: MESSAGE_SOUND_LS_19_1,
     value: false,
 });
 

--- a/addons/mail/static/src/core/common/upgrade/upgrade_helpers.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_helpers.js
@@ -104,8 +104,12 @@ function getUpgradeMap() {
  */
 function applyUpgrade(upgradeData) {
     const oldEntry = new LocalStorageEntry(upgradeData.key);
-    const oldValue = oldEntry.rawGet() ?? oldEntry.get();
-    if (oldValue === undefined) {
+    const versionedValue = oldEntry.getVersioned();
+    const oldValue = oldEntry.get() ?? oldEntry.rawGet();
+    if (
+        [undefined, null].includes(oldValue) ||
+        (versionedValue && parseVersion(upgradeData.version).isLowerThan(versionedValue.version))
+    ) {
         return; // could not upgrade (cannot parse or more recent version)
     }
     const { key, value } =
@@ -114,5 +118,5 @@ function applyUpgrade(upgradeData) {
             : upgradeData.upgrade;
     oldEntry.remove();
     const newEntry = new LocalStorageEntry(key);
-    newEntry.set(value);
+    newEntry.set(value, upgradeData.version);
 }

--- a/addons/mail/static/src/core/common/upgrade/upgrade_service.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_service.js
@@ -7,12 +7,12 @@ export const discussUpgradeService = {
     dependencies: [],
     start() {
         const lse = new LocalStorageEntry("discuss.upgrade.version");
-        const oldVersion = lse.get() ?? "1.0";
+        const oldVersion = lse.getVersioned()?.version ?? "1.0";
         const currentVersion = getCurrentLocalStorageVersion();
-        lse.set(currentVersion);
         if (parseVersion(oldVersion).isLowerThan(currentVersion)) {
             upgradeFrom(oldVersion);
         }
+        lse.set(true); // update version
     },
 };
 

--- a/addons/mail/static/src/model/model_internal.js
+++ b/addons/mail/static/src/model/model_internal.js
@@ -1,5 +1,7 @@
 import { toRaw } from "@odoo/owl";
 import { ATTR_SYM, MANY_SYM, ONE_SYM } from "./misc";
+import { parseVersion } from "@mail/utils/common/misc";
+import { getCurrentLocalStorageVersion } from "@mail/utils/common/local_storage";
 
 export class ModelInternal {
     /** @type {Map<string, boolean>} */
@@ -75,12 +77,17 @@ export class ModelInternal {
                 function fieldLocalStorageCompute() {
                     const record = toRaw(this)._raw;
                     const lse = record._.fieldsLocalStorage.get(fieldName);
-                    const value = lse.get();
-                    if (value === undefined) {
+                    const versionedValue = lse.getVersioned();
+                    if (
+                        versionedValue?.value === undefined ||
+                        parseVersion(getCurrentLocalStorageVersion()).isLowerThan(
+                            versionedValue.version
+                        )
+                    ) {
                         lse.remove();
                         return this[fieldName];
                     }
-                    return value;
+                    return versionedValue.value;
                 }
             );
 

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -6,7 +6,8 @@ import { RecordInternal } from "./record_internal";
 import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
 import { IS_DELETED_SYM, isCommand, isMany } from "./misc";
 import { browser } from "@web/core/browser/browser";
-import { parseRawValue } from "@mail/utils/common/local_storage";
+import { getCurrentLocalStorageVersion, parseRawValue } from "@mail/utils/common/local_storage";
+import { parseVersion } from "@mail/utils/common/misc";
 
 const Markup = markup().constructor;
 
@@ -55,7 +56,10 @@ export class StoreInternal extends RecordInternal {
                 record._proxy[fieldName] = record._.fieldsDefault.get(fieldName);
             } else {
                 const parsed = parseRawValue(ev.newValue);
-                if (!parsed) {
+                if (
+                    !parsed ||
+                    parseVersion(getCurrentLocalStorageVersion()).isLowerThan(parsed.version)
+                ) {
                     record._proxy[fieldName] = record._.fieldsDefault.get(fieldName);
                 } else {
                     record._proxy[fieldName] = parsed.value;

--- a/addons/mail/static/tests/core/common/downgrade_19_0.test.js
+++ b/addons/mail/static/tests/core/common/downgrade_19_0.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { contains, defineMailModels, start } from "@mail/../tests/mail_test_helpers";
+import { getService } from "@web/../tests/web_test_helpers";
+import { MESSAGE_SOUND_LS_19_1 } from "@mail/core/common/upgrade/upgrade_19_1";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("message sound 'off' from 19.1 is dropped when downgrading to 19.0", async () => {
+    localStorage.setItem(MESSAGE_SOUND_LS_19_1, `{"value":false,"version":"19.1"}`);
+    await start({ serverVersion: [19, 0] });
+    getService("action").doAction({
+        tag: "mail.discuss_notification_settings_action",
+        type: "ir.actions.client",
+    });
+    await contains("label:has(h5:contains('Message sound')) input:checked");
+    expect(localStorage.getItem(MESSAGE_SOUND_LS_19_1)).toBe(null);
+});

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -11,7 +11,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { makeRecordFieldLocalId } from "@mail/model/misc";
-import { toRawValue } from "@mail/utils/common/local_storage";
+import { LocalStorageEntry } from "@mail/utils/common/local_storage";
 import { Settings } from "@mail/core/common/settings_model";
 import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
 import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
@@ -30,7 +30,7 @@ test("message sound is 'off'", async () => {
     });
     await contains("label:has(h5:contains('Message sound')) input:not(:checked)");
     const messageSoundKey = makeRecordFieldLocalId(Settings.localId(), "messageSound");
-    expect(localStorage.getItem(messageSoundKey)).toBe(toRawValue(false));
+    expect(new LocalStorageEntry(messageSoundKey).get()).toBe(false);
     expect(localStorage.getItem("mail.user_setting.message_sound")).toBe(null);
 });
 
@@ -58,14 +58,14 @@ test("use blur is 'on'", async () => {
         "label[title='Edge blur intensity'] .o-discuss-DiscussCallSettings-width-text-percentage:text('30%')"
     );
     const useBlurKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
-    expect(localStorage.getItem(useBlurKey)).toBe(toRawValue(true));
+    expect(new LocalStorageEntry(useBlurKey).get()).toBe(true);
     const backgroundBlurAmountKey = makeRecordFieldLocalId(
         Settings.localId(),
         "backgroundBlurAmount"
     );
-    expect(localStorage.getItem(backgroundBlurAmountKey)).toBe(toRawValue(2));
+    expect(new LocalStorageEntry(backgroundBlurAmountKey).get()).toBe(2);
     const edgeBlurAmountKey = makeRecordFieldLocalId(Settings.localId(), "edgeBlurAmount");
-    expect(localStorage.getItem(edgeBlurAmountKey)).toBe(toRawValue(6));
+    expect(new LocalStorageEntry(edgeBlurAmountKey).get()).toBe(6);
     expect(localStorage.getItem("mail_user_setting_use_blur")).toBe(null);
     expect(localStorage.getItem("mail_user_setting_background_blur_amount")).toBe(null);
     expect(localStorage.getItem("mail_user_setting_edge_blur_amount")).toBe(null);
@@ -85,7 +85,7 @@ test("show only video 'on'", async () => {
     await contains(".o-discuss-CallSettings");
     await contains("input[title='Show video participants only']:checked");
     const showOnlyVideoKey = makeRecordFieldLocalId(Settings.localId(), "showOnlyVideo");
-    expect(localStorage.getItem(showOnlyVideoKey)).toBe(toRawValue(true));
+    expect(new LocalStorageEntry(showOnlyVideoKey).get()).toBe(true);
     expect(localStorage.getItem("mail_user_setting_show_only_video")).toBe(null);
 });
 
@@ -106,7 +106,7 @@ test("voice activation threshold", async () => {
         Settings.localId(),
         "voiceActivationThreshold"
     );
-    expect(localStorage.getItem(voiceActivationThresholdKey)).toBe(toRawValue(0.3));
+    expect(new LocalStorageEntry(voiceActivationThresholdKey).get()).toBe(0.3);
     expect(localStorage.getItem("mail_user_setting_voice_threshold")).toBe(null);
 });
 
@@ -123,11 +123,12 @@ test("member default open is 'off'", async () => {
         DiscussApp.localId(),
         "isMemberPanelOpenByDefault"
     );
-    expect(localStorage.getItem(isMemberPanelOpenByDefaultKey)).toBe(toRawValue(false));
+    const isMemberPanelOpenByDefaultEntry = new LocalStorageEntry(isMemberPanelOpenByDefaultKey);
+    expect(isMemberPanelOpenByDefaultEntry.get()).toBe(false);
     expect(localStorage.getItem("mail.user_setting.no_members_default_open")).toBe(null);
     await click(".o-mail-ActionList-button[title='Members']");
     await contains(".o-mail-ActionList-button[title='Members'].active"); // just to validate .active is correct selector
-    expect(localStorage.getItem(isMemberPanelOpenByDefaultKey)).toBe(null);
+    expect(isMemberPanelOpenByDefaultEntry.get()).toBe(undefined);
 });
 
 test("sidebar compact is 'on'", async () => {
@@ -136,7 +137,7 @@ test("sidebar compact is 'on'", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar.o-compact");
     const isSidebarCompact = makeRecordFieldLocalId(DiscussApp.localId(), "isSidebarCompact");
-    expect(localStorage.getItem(isSidebarCompact)).toBe(toRawValue(true));
+    expect(new LocalStorageEntry(isSidebarCompact).get()).toBe(true);
     expect(localStorage.getItem("mail.user_setting.discuss_sidebar_compact")).toBe(null);
 });
 
@@ -149,7 +150,7 @@ test("category 'Channels' is folded", async () => {
         DiscussAppCategory.localId("channels"),
         "is_open"
     );
-    expect(localStorage.getItem(channels_is_open)).toBe(toRawValue(false));
+    expect(new LocalStorageEntry(channels_is_open).get()).toBe(false);
     expect(localStorage.getItem("discuss_sidebar_category_folded_channels")).toBe(null);
 });
 
@@ -161,7 +162,7 @@ test("category 'Direct messages' is folded", async () => {
         ".o-mail-DiscussSidebarCategory:contains('Direct messages') .oi.oi-chevron-right"
     );
     const chats_is_open = makeRecordFieldLocalId(DiscussAppCategory.localId("chats"), "is_open");
-    expect(localStorage.getItem(chats_is_open)).toBe(toRawValue(false));
+    expect(new LocalStorageEntry(chats_is_open).get()).toBe(false);
     expect(localStorage.getItem("discuss_sidebar_category_folded_chats")).toBe(null);
 });
 
@@ -176,7 +177,7 @@ test("last active id of discuss app", async () => {
     await openDiscuss();
     await contains(".o-mail-Thread:contains('Welcome to #test')");
     const lastActiveId = makeRecordFieldLocalId(DiscussApp.localId(), "lastActiveId");
-    expect(localStorage.getItem(lastActiveId)).toBe(toRawValue(`discuss.channel_${channelId}`));
+    expect(new LocalStorageEntry(lastActiveId).get()).toBe(`discuss.channel_${channelId}`);
     expect(localStorage.getItem("mail.user_setting.discuss_last_active_id")).toBe(null);
 });
 
@@ -192,7 +193,7 @@ test("call auto focus is 'off", async () => {
     await contains(".o-dropdown-item:contains('Autofocus speaker')");
     // correct local storage values
     const useCallAutoFocusKey = makeRecordFieldLocalId(Settings.localId(), "useCallAutoFocus");
-    expect(localStorage.getItem(useCallAutoFocusKey)).toBe(toRawValue(false));
+    expect(new LocalStorageEntry(useCallAutoFocusKey).get()).toBe(false);
     expect(localStorage.getItem("mail_user_setting_disable_call_auto_focus")).toBe(null);
 });
 
@@ -265,14 +266,14 @@ test("device input/output id", async () => {
     await contains("label[title='Camera'] option[value=video_input_2_id]");
     // correct local storage values
     const audioInputDeviceIdKey = makeRecordFieldLocalId(Settings.localId(), "audioInputDeviceId");
-    expect(localStorage.getItem(audioInputDeviceIdKey)).toBe(toRawValue("audio_input_2_id"));
+    expect(new LocalStorageEntry(audioInputDeviceIdKey).get()).toBe("audio_input_2_id");
     const audioOutputDeviceIdKey = makeRecordFieldLocalId(
         Settings.localId(),
         "audioOutputDeviceId"
     );
-    expect(localStorage.getItem(audioOutputDeviceIdKey)).toBe(toRawValue("audio_output_2_id"));
+    expect(new LocalStorageEntry(audioOutputDeviceIdKey).get()).toBe("audio_output_2_id");
     const videoInputDeviceIdKey = makeRecordFieldLocalId(Settings.localId(), "cameraInputDeviceId");
-    expect(localStorage.getItem(videoInputDeviceIdKey)).toBe(toRawValue("video_input_2_id"));
+    expect(new LocalStorageEntry(videoInputDeviceIdKey).get()).toBe("video_input_2_id");
     expect(localStorage.getItem("mail_user_setting_audio_input_device_id")).toBe(null);
     expect(localStorage.getItem("mail_user_setting_audio_output_device_id")).toBe(null);
     expect(localStorage.getItem("mail_user_setting_camera_input_device_id")).toBe(null);


### PR DESCRIPTION
This commit adds versioning to local storage entries, so that when version is more recent than current version, business code can have a strategy to drop the values.

This strategy is the one used by local storage field: older versions are most updated and upgraded fields so 19.1 is implicitly valid for 19.2 and 19.3. 20.0 is invalid as it can potentially be affected by unknown upgrade scripts of current version (19.3), thus it's dropped.

Part of Task-5003012

https://github.com/odoo/enterprise/pull/100037