### PR TITLE
[FIX] hr: Fix "no attribute" runbot build error

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -685,7 +685,12 @@ class TestVersionCron(TransactionCase):
 
         # Saving current employee data to compare later on
         employee_values = {}
-        employee_fields = self.env['hr.employee']._fields.keys()
+        # some fields cannot be accessed. We need to filter them out
+        employee_fields = [
+            field
+            for field in self.env['hr.employee']._fields
+            if hasattr(self.employee, field)
+        ]
         for field in employee_fields:
             employee_values[field] = self.employee[field]
 


### PR DESCRIPTION
This test had a bug: `self.env['hr.employee']._fields.keys()` may contain fields that do not exist in an `hr.employee` record.

Now, employee fields that cannot be accessed are filtered out using `hasattr()`. To avoid further crashes.

Runbot build error: https://runbot.odoo.com/odoo/runbot.build.error/233942 Bug has been introduced by task-5103739

task-5254322



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
