### PR TITLE
[IMP] sale: batch read in _get_product_information

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -298,6 +298,10 @@ class SaleProductConfiguratorController(Controller):
             combination_ids=combination.ids,
         )
         product_or_template = product or product_template
+        ptals = product_template.attribute_line_ids
+        attrs_map = dict(zip(ptals.ids, ptals.attribute_id.read(['id', 'name', 'display_type'])))
+        ptavs = ptals.product_template_value_ids.filtered(lambda p: p.ptav_active or combination and p.id in combination.ids)
+        ptavs_map = dict(zip(ptavs.ids, ptavs.read(['name', 'html_color', 'image', 'is_custom'])))
 
         values = dict(
             product_tmpl_id=product_template.id,
@@ -314,10 +318,10 @@ class SaleProductConfiguratorController(Controller):
             quantity=quantity,
             attribute_lines=[dict(
                 id=ptal.id,
-                attribute=dict(**ptal.attribute_id.read(['id', 'name', 'display_type'])[0]),
+                attribute=dict(**attrs_map[ptal.id]),
                 attribute_values=[
                     dict(
-                        **ptav.read(['name', 'html_color', 'image', 'is_custom'])[0],
+                        **ptavs_map[ptav.id],
                         price_extra=self._get_ptav_price_extra(
                             ptav, currency, so_date, product_or_template
                         ),


### PR DESCRIPTION
Performing read operations on attributes and values in batch yields a significant performance improvement and is standard practice.

Tested with 60 attributes and 8000 values: went from 2.7s to 0.8s (-70%)

No task


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
