### PR TITLE
[FIX] project: inactive chatter in the portal when the task is not saved

### DIFF
--- a/addons/project/static/src/project_sharing/chatter/composer_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/composer_patch.js
@@ -1,8 +1,18 @@
 import { Composer } from "@mail/core/common/composer";
 
 import { patch } from "@web/core/utils/patch";
+import { onWillStart } from "@odoo/owl";
 
 patch(Composer.prototype, {
+    setup() {
+        super.setup();
+        onWillStart(() => {
+            if (!this.thread.id) {
+                this.state.active = false;
+            }
+        });
+    },
+
     get extraData() {
         const extraData = super.extraData;
         if (this.env.projectSharingId) {


### PR DESCRIPTION
Currently, an error occurs when a portal user opens a `shared project` and tries 
to `mention(@)` someone in the chatter of a `new(unsaved) task`.

**Steps to produce:**

- Install the `project` module.
- Open the project app and create a new project with at least one task.
- From the project’s `dropdown menu(⋮)`, select `Share Project`.
- Add a `collaborator: Joel Willis`, with `Edit access` mode, copy the public link, 
  and click `Share Project`.
- Open the shared link in an incognito window and sign in as a portal user.
- Open the `project folder` > open any task > click `New` > type `'@'` in the chatter.

**Error**:
`ValueError: Expected singleton: project.task()`

**Root cause:**
The `composer(message box)` allows typing and mention suggestions even when 
the task record is not yet saved (`self.thread.id` is `undefined`). At [1], the method 
is called on an `empty` recordset, causing an `error`.

**Fix:**
This commit prevents users from writing in the chatter by stopping the composer 
initialization when the record(thread) is `unsaved`.

[1]:
https://github.com/odoo/odoo/blob/5cf96828652c2388808b3e49ae67e188c401ec63/addons/project/models/project_task.py#L2051-L2071

sentry-6982269693