### PR TITLE
[IMP] product: add placeholders for attribute and value fields

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -92,9 +92,10 @@
                         <list string="Variants" editable="bottom" decoration-info="value_count &lt;= 1">
                             <field name="value_count" column_invisible="True"/>
                             <field name="sequence" widget="handle"/>
-                            <field name="attribute_id" readonly="id"/>
+                            <field name="attribute_id" placeholder="Attribute name (e.g. Color, Size, ... )" readonly="id"/>
                             <field
                                     name="value_ids"
+                                    placeholder="List of possible values (e.g. Blue, Green, White, ... )"
                                     widget="many2many_tags"
                                     options="{
                                         'on_tag_click': 'open_form',


### PR DESCRIPTION
## **Purpose:**
When creating a new product variant using attributes and values,
new users often find it unclear how these fields should be filled in
whether each line represents a combination or a single attribute.
This lack of guidance can lead to confusion during product variant setup.

**Before This PR:**
<img width="1011" height="364" alt="image" src="https://github.com/user-attachments/assets/6408683e-5fbc-47d5-bd39-0ecb4183ba5b" />

## **With This PR:**
To make the process clearer and more intuitive, placeholders are added to the
attribute and value fields:
- Attribute: Attribute name (e.g. Color, Size, …)
- Values: List of possible values (e.g. Blue, Green, White, …)

These hints help users understand how to correctly define product attributes
and their possible values when creating variants.

**After This PR:**
<img width="936" height="350" alt="image" src="https://github.com/user-attachments/assets/f661f1d6-033b-428f-ab4d-1b83bf3d2a56" />


Task - 5173800