### PR TITLE
[IMP] website: dummy snippet demonstrating mutationobserver usage

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -50,6 +50,7 @@
         'views/snippets/s_image_text_box.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_dummy_snippet.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_mockup_image.xml',
         'views/snippets/s_instagram_page.xml',

--- a/addons/website/static/src/snippets/s_dummy_snippet/dummy_snippet.js
+++ b/addons/website/static/src/snippets/s_dummy_snippet/dummy_snippet.js
@@ -1,0 +1,8 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class DummySnippet extends Interaction {
+    static selector = ".s_dummy_snippet";
+}
+
+registry.category("public.interactions").add("website.dummy_snippet", DummySnippet);

--- a/addons/website/static/src/snippets/s_dummy_snippet/dummy_snippet_edit.js
+++ b/addons/website/static/src/snippets/s_dummy_snippet/dummy_snippet_edit.js
@@ -1,0 +1,46 @@
+import { registry } from "@web/core/registry";
+import { DummySnippet } from "./dummy_snippet";
+
+const DummySnippetEdit = (I) =>
+    class extends I {
+        setup() {
+            super.setup();
+            const targetNode = this.el;
+
+            // Define the callback for the observer
+            const callback = (mutationsList, observer) => {
+                for (const mutation of mutationsList) {
+                    console.log("Mutation detected:", mutation);
+                }
+            };
+
+            // Create the observer instance
+            this.observer = new MutationObserver(callback);
+
+            // Observer configuration
+            const config = {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                characterData: true,
+            };
+
+            // Start observing the target node
+            this.observer.observe(targetNode, config);
+
+            console.log("MutationObserver started for:", targetNode);
+        }
+
+        destroy() {
+            if (this.observer) {
+                this.observer.disconnect();
+                console.log("MutationObserver disconnected");
+            }
+            super.destroy();
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.dummy_snippet", {
+    Interaction: DummySnippet,
+    mixin: DummySnippetEdit,
+});

--- a/addons/website/views/snippets/s_dummy_snippet.xml
+++ b/addons/website/views/snippets/s_dummy_snippet.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_dummy_snippet" name="Dummy Snippet">
+    <section class="s_dummy_snippet pt136 pb136">
+        <div class="container" style="text-align: center;">
+            <div class="container py-5 text-center">
+                <h3 contenteditable="true">Mutation Observer Demo</h3>
+                <p contenteditable="true">Try editing or dropping another block here.</p>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -485,6 +485,7 @@
             <t t-snippet="website.s_card" string="Card" t-thumbnail="/website/static/src/img/snippets_thumbs/s_card.svg"/>
             <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg"/>
             <t t-snippet="website.s_social_media" string="Social Media" t-thumbnail="/website/static/src/img/snippets_thumbs/s_social_media.svg"/>
+            <t t-snippet="website.s_dummy_snippet" string="Dummy Snippet" t-thumbnail="/website/static/src/img/snippets_thumbs/s_social_media.svg"/>
             <t t-snippet="website.s_facebook_page" string="Facebook" t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg"/>
             <t t-snippet="website.s_searchbar_input" string="Search" t-thumbnail="/website/static/src/img/snippets_thumbs/s_searchbar_inline.svg" t-forbid-sanitize="form" t-grid-column-span="5"/>
             <t id="mass_mailing_newsletter_hook"/>


### PR DESCRIPTION
This commit introduces a new dummy snippet for the website builder that showcases the use of MutationObserver to monitor changes in the snippet.
