### PR TITLE
[IMP] hr: Mobile view UI/UX enhancement

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -36,7 +36,7 @@
             <field name="res_model">hr.employee.public</field>
             <field name="path">org-chart-public</field>
             <field name="view_mode">hierarchy,kanban,list,form,graph,pivot</field>
-            <field name="mobile_view_mode">hierarchy,kanban,list,form,graph,pivot</field>
+            <field name="mobile_view_mode">hierarchy</field>
             <field name="domain">[]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -36,6 +36,7 @@
             <field name="res_model">hr.employee.public</field>
             <field name="path">org-chart-public</field>
             <field name="view_mode">hierarchy,kanban,list,form,graph,pivot</field>
+            <field name="mobile_view_mode">hierarchy,kanban,list,form,graph,pivot</field>
             <field name="domain">[]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -89,6 +89,7 @@
             <field name="res_model">hr.employee</field>
             <field name="path">org-chart</field>
             <field name="view_mode">hierarchy,kanban,list,form,activity,graph,pivot</field>
+            <field name="mobile_view_mode">hierarchy,kanban,list,form,activity,graph,pivot</field>
             <field name="domain">[]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -89,7 +89,7 @@
             <field name="res_model">hr.employee</field>
             <field name="path">org-chart</field>
             <field name="view_mode">hierarchy,kanban,list,form,activity,graph,pivot</field>
-            <field name="mobile_view_mode">hierarchy,kanban,list,form,activity,graph,pivot</field>
+            <field name="mobile_view_mode">hierarchy</field>
             <field name="domain">[]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -60,26 +60,30 @@
             <field name="arch" type="xml">
                 <form string="Users">
                     <sheet>
-                        <div class="d-flex gap-3">
-                            <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'zoom': true, 'size': [130,130], 'img_class': 'rounded-4'}"/>
-                            <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
-                            <div class="d-flex flex-column flex-grow-1 justify-content-center">
-                                <h1 class="mb-0 w-100">
-                                    <field name="name" placeholder="e.g. John Doe" required="1"/>
-                                </h1>
-                                <div class="d-flex align-items-baseline w-100">
-                                    <field name="email" invisible="1"/> <!-- needed to update partner's email from on_change_login() -->
-                                    <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>
-                                    <field name="email_domain_placeholder" invisible="1" /> <!-- needed to compute the placeholder whenever the dialog opens -->
-                                    <field name="login" class="w-100" options="{'placeholder_field': 'email_domain_placeholder'}"/>
-                                </div>
-                                <div class="d-flex align-items-baseline w-100">
-                                    <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>
-                                    <field name="phone" class="w-100" widget="phone" placeholder="Phone"/>
-                                </div>
-                                <div class="d-flex align-items-baseline w-100" groups="base.group_multi_company">
-                                    <i class="fa fa-fw me-1 fa-building text-primary" title="Company"/>
-                                    <field name="company_id" class="w-100" context="{'user_preference': 0}" placeholder="Company"/>
+                        <div class="d-flex gap-3 flex-column flex-sm-row mb-3">
+                            <div class="text-center">
+                                <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'zoom': true, 'size': [130,130], 'img_class': 'rounded-4'}"/>
+                                <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
+                            </div>
+                            <div class="flex-fill d-flex">
+                                <div class="d-flex flex-column flex-grow-1 justify-content-center">
+                                    <h1 class="d-flex align-items-baseline w-100">
+                                        <field name="name" class="w-100" placeholder="e.g. John Doe" required="1"/>
+                                    </h1>
+                                    <div class="d-flex align-items-baseline w-100">
+                                        <field name="email" invisible="1"/> <!-- needed to update partner's email from on_change_login() -->
+                                        <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>
+                                        <field name="email_domain_placeholder" invisible="1" /> <!-- needed to compute the placeholder whenever the dialog opens -->
+                                        <field name="login" class="w-100" options="{'placeholder_field': 'email_domain_placeholder'}"/>
+                                    </div>
+                                    <div class="d-flex align-items-baseline w-100">
+                                        <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>
+                                        <field name="phone" class="w-100" widget="phone" placeholder="Phone"/>
+                                    </div>
+                                    <div class="d-flex align-items-baseline w-100" groups="base.group_multi_company">
+                                        <i class="fa fa-fw me-1 fa-building text-primary" title="Company"/>
+                                        <field name="company_id" class="w-100" context="{'user_preference': 0}" placeholder="Company"/>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Issue 1:
**Steps to Reproduce:** 
- Open an employee record. 
- Set managers for the employee. 
- Open the employee’s form view on mobile. 
- Click the Full Chart button next to the organization chart. 

**Before:** 
- On mobile, the Full Chart button opened the Kanban view by default. 

**After:** 
- On mobile, the Full Chart button now opens the Hierarchy view by default.
---
### Issue 2:
**Steps to Reproduce:**
- Open an employee record (the employee should not be a user) on mobile.
- Click the Create User button.

**Before:** 
- On mobile, the employee’s picture and details were displayed side by side.

**After:**
- On mobile, the employee’s picture is centered, and the details are displayed below it.

task-5245129

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
