### PR TITLE
[FIX] l10n_tr_nilvera_{*}: Add Dispatch reference in e-Invoice XML

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/__manifest__.py
+++ b/addons/l10n_tr_nilvera_edispatch/__manifest__.py
@@ -2,11 +2,12 @@
     'name': "Türkiye - e-Irsaliye (e-Dispatch)",
     'description': "Allows the users to create the UBL 1.2.1 e-Dispatch file",
     'countries': ['tr'],
-    'depends': ['l10n_tr_nilvera', 'stock'],
+    'depends': ['l10n_tr_nilvera_einvoice', 'stock'],
     'license': "LGPL-3",
     'category': 'Accounting/Localizations',
     'data': [
         'security/ir.model.access.csv',
+        'views/account_move_views.xml',
         'views/l10n_tr_nilvera_trailer_plate_views.xml',
         'views/res_partner_views.xml',
         'views/stock_picking_views.xml',

--- a/addons/l10n_tr_nilvera_edispatch/models/__init__.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/__init__.py
@@ -1,3 +1,6 @@
+from . import account_edi_xml_ubl_tr
+from . import account_move_send
+from . import account_move
 from . import l10n_tr_nilvera_trailer_plate
 from . import res_partner
 from . import stock_picking

--- a/addons/l10n_tr_nilvera_edispatch/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/account_edi_xml_ubl_tr.py
@@ -1,0 +1,19 @@
+from odoo import models
+
+
+class AccountEdiXmlUblTr(models.AbstractModel):
+    _inherit = 'account.edi.xml.ubl.tr'
+
+    def _get_dispatch_document_reference_vals(self, invoice):
+        dispatch_document_vals = []
+        for picking in invoice.l10n_tr_nilvera_edispatch_ids:
+            dispatch_document_vals.append({
+                'cbc:ID': {'_text': picking._get_nilvera_document_serial_number()},
+                'cbc:IssueDate': {'_text': picking.scheduled_date.date()},
+                'cbc:DocumentTypeCode': {'_text': 'SEVK'},
+            })
+        return dispatch_document_vals
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cac:DespatchDocumentReference'] = self._get_dispatch_document_reference_vals(vals['invoice'])

--- a/addons/l10n_tr_nilvera_edispatch/models/account_move.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/account_move.py
@@ -1,0 +1,42 @@
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_tr_nilvera_edispatch_ids = fields.Many2many(
+        'stock.picking',
+        string='e-Dispatch Orders',
+        copy=False,
+    )
+
+    l10n_tr_nilvera_company_einvoice_status = fields.Selection(
+        string="Company Nilvera Status",
+        related='company_id.partner_id.l10n_tr_nilvera_customer_status',
+    )
+
+    def _prefill_l10n_tr_nilvera_edispatch_ids(self):
+        for move in self:
+            if (
+                move.move_type != 'out_invoice'
+                or move.country_code != "TR"
+                or move.l10n_tr_nilvera_company_einvoice_status != 'einvoice'
+                or not move.invoice_line_ids._fields.get("sale_line_ids")
+            ):
+                continue
+            move.l10n_tr_nilvera_edispatch_ids = move.invoice_line_ids.sale_line_ids.order_id.picking_ids.filtered(
+                    lambda p: p.l10n_tr_nilvera_dispatch_state == "sent"
+                    and p.state == "done"
+                    and p.picking_type_code == "outgoing"
+                    and p.partner_id == move.partner_id,
+                ).ids
+
+    def create(self, vals_list):
+        moves = super().create(vals_list)
+        moves._prefill_l10n_tr_nilvera_edispatch_ids()
+        return moves
+
+    def _has_unlinked_dispatches(self):
+        if not self.invoice_line_ids._fields.get("sale_line_ids"):
+            return False
+        return self.invoice_line_ids.sale_line_ids.order_id.picking_ids and not self.l10n_tr_nilvera_edispatch_ids

--- a/addons/l10n_tr_nilvera_edispatch/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/account_move_send.py
@@ -1,0 +1,23 @@
+from odoo import _, models
+
+
+class AccountMoveSend(models.AbstractModel):
+    _inherit = 'account.move.send'
+
+    def _get_alerts(self, moves, moves_data):
+        alerts = super()._get_alerts(moves, moves_data)
+        tr_nilvera_moves = moves.filtered(lambda m: 'tr_nilvera' in moves_data[m]['extra_edis'])
+        # If the invoice is linked to an SO and that SO has e-Dispatch orders, it is required to select the
+        # dispatches before sending to Nilvera.
+        if moves_with_unlinked_dispatches := tr_nilvera_moves.filtered(lambda m: m._has_unlinked_dispatches()):
+            alerts['tr_moves_with_unlinked_dispatches'] = {
+                'level': 'danger',
+                'message': _(
+                    "Please ensure the e-Dispatch Order field has all related orders "
+                    "before sending the invoice to Nilvera.",
+                ),
+                'action_text': _("View Invoice(s)"),
+                'action': moves_with_unlinked_dispatches._get_records_action(name=_("Check data on Invoice(s)")),
+            }
+
+        return alerts

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -548,3 +548,12 @@ class StockPicking(models.Model):
         if files_with_errors:
             result['skipped_xmls'] = files_with_errors
         return result
+
+    def _get_nilvera_document_serial_number(self):
+        """
+        Returns the serial number for the e-Dispatch document in a format accepted by Nilvera.
+        The format is: '[Picking Type Code][Year (YYYY)][Sequence Number of 9 digits padded with 0]'
+        Example: 'OUT2025123456789'
+        """
+        sequence_number = self.name.removeprefix(self.picking_type_id.sequence_id.prefix or '').removesuffix(self.picking_type_id.sequence_id.suffix or '')
+        return f"{self.picking_type_id.sequence_code.upper()}{self.scheduled_date.year}{sequence_number.zfill(9)}"

--- a/addons/l10n_tr_nilvera_edispatch/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_edispatch/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_ereceipt_upload
+from . import test_xml_ubl_tr

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+    <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+    <cbc:ID>EIN2025000000001</cbc:ID>
+    <cbc:CopyIndicator>false</cbc:CopyIndicator>
+    <cbc:UUID>___ignore___</cbc:UUID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    <cbc:InvoiceTypeCode>SATIS</cbc:InvoiceTypeCode>
+    <cbc:Note>3 products</cbc:Note>
+    <cbc:Note>YALNIZ : YÜZELLIÜÇ TRY ONIKI KURUS</cbc:Note>
+    <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+    <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+    <cac:OrderReference>
+        <cbc:ID>EIN/2025/1</cbc:ID>
+        <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    </cac:OrderReference>
+    <cac:DespatchDocumentReference>
+        <cbc:ID>TRW/OUT/2025000000001</cbc:ID>
+        <cbc:IssueDate>2025-03-05</cbc:IssueDate>
+        <cbc:DocumentTypeCode>SEVK</cbc:DocumentTypeCode>
+    </cac:DespatchDocumentReference>
+    <cac:DespatchDocumentReference>
+        <cbc:ID>TRW/OUT/2025000000002</cbc:ID>
+        <cbc:IssueDate>2025-03-05</cbc:IssueDate>
+        <cbc:DocumentTypeCode>SEVK</cbc:DocumentTypeCode>
+    </cac:DespatchDocumentReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>3281. Cadde</cbc:StreetName>
+                <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+                <cbc:CityName>Düzce</cbc:CityName>
+                <cbc:PostalZone>06810</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID>3297552117</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+                <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1729171602</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>einvoice_partner</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+                <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+                <cbc:CityName>Ankara</cbc:CityName>
+                <cbc:PostalZone>06934</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+                <cbc:CompanyID>1729171602</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+                <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>TR0123456789</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="TRY">21.12</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+            <cbc:Percent>20.0</cbc:Percent>
+            <cac:TaxCategory>
+                <cac:TaxScheme>
+                    <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+                    <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="TRY">-5.28</cbc:TaxAmount>
+            <cbc:Percent>-4.0</cbc:Percent>
+            <cac:TaxCategory>
+                <cac:TaxScheme>
+                    <cbc:Name>KDV Tevkifatı</cbc:Name>
+                    <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="TRY">153.12</cbc:TaxInclusiveAmount>
+        <cbc:AllowanceTotalAmount currencyID="TRY">18.00</cbc:AllowanceTotalAmount>
+        <cbc:PayableAmount currencyID="TRY">153.12</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+            <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="TRY">21.12</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+                <cbc:Percent>20.0</cbc:Percent>
+                <cac:TaxCategory>
+                    <cac:TaxScheme>
+                        <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+                        <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="TRY">-5.28</cbc:TaxAmount>
+                <cbc:Percent>-4.0</cbc:Percent>
+                <cac:TaxCategory>
+                    <cac:TaxScheme>
+                        <cbc:Name>KDV Tevkifatı</cbc:Name>
+                        <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>product_a</cbc:Description>
+            <cbc:Name>product_a</cbc:Name>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_xml_ubl_tr.py
@@ -1,0 +1,43 @@
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tools import file_open
+from odoo.addons.l10n_tr_nilvera_einvoice.tests.test_xml_ubl_tr_common import TestUBLTRCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestEdispatchUBLTr(TestUBLTRCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse_1 = cls.env['stock.warehouse'].create({
+            'reception_steps': 'one_step',
+            'delivery_steps': 'ship_only',
+            'code': 'TRW',
+            'sequence': 5,
+        })
+
+    def test_xml_invoice_with_edispatches(self):
+        with freeze_time('2025-03-05'):
+            self.eidspatch_ids = self.env['stock.picking'].create([
+                {
+                    'partner_id': self.einvoice_partner.id,
+                    'picking_type_id': self.warehouse_1.out_type_id.id,
+                    'location_id': self.warehouse_1.lot_stock_id.id,
+                    'move_line_ids': [
+                        Command.create({'product_id': self.product_a.id, 'qty_done': qty}),
+                    ],
+                    'l10n_tr_nilvera_dispatch_state': 'sent',
+                } for qty in [1, 2]
+            ])
+            generated_xml = self._generate_invoice_xml(
+                partner_id=self.einvoice_partner,
+                l10n_tr_nilvera_edispatch_ids=self.eidspatch_ids.ids
+            )
+
+        with file_open('l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))

--- a/addons/l10n_tr_nilvera_edispatch/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_edispatch/views/account_move_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_move_form_l10n_tr_nilvera_edispatch" model="ir.ui.view">
+        <field name="name">account.move.form.l10n_tr.nilvera.edispatch</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@id='header_left_group']" position="inside">
+                <field 
+                    name="l10n_tr_nilvera_edispatch_ids"
+                    invisible="country_code != 'TR' or move_type != 'out_invoice' or l10n_tr_nilvera_company_einvoice_status != 'einvoice'"
+                    options="{'no_create': True}"
+                    context="{'search_default_partner_id': partner_id}"
+                    domain="[('picking_type_code', '=', 'outgoing'), ('state', '=', 'done'), ('l10n_tr_nilvera_dispatch_state', '=', 'sent')]"
+                    widget="many2many_tags"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_tr_nilvera_einvoice/tools/ubl_tr_invoice.py
+++ b/addons/l10n_tr_nilvera_einvoice/tools/ubl_tr_invoice.py
@@ -44,6 +44,7 @@ TrInvoice = {
     'cac:InvoicePeriod': cac.Period,
     'cac:OrderReference': cac.OrderReference,
     'cac:BillingReference': cac.BillingReference,
+    'cac:DespatchDocumentReference': cac.DocumentReference,
     'cac:AdditionalDocumentReference': cac.DocumentReference,
     'cac:Signature': cac.Signature,
     'cac:AccountingSupplierParty': cac.SupplierParty,


### PR DESCRIPTION
If the invoice is created from sale order and that SO has some deliveries linked to it, then in the e-invoice we send to nilvera, the dispatches needs to be mentioned.
This commit adds the reference to those e-dispatches in the e-invoice in the `<cac:DespatchDocumentReference>` tag.

task-5024394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
