### PR TITLE
[FIX] stock_account: prevent browsing falsy ID when valuation account is missing

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -95,7 +95,8 @@ class ResCompany(models.Model):
         account_data = defaultdict(float)
         stock_valuation_accounts_ids = set()
         for dummy, accounts in accounts_by_product.items():
-            stock_valuation_accounts_ids.add(accounts['valuation'].id)
+            if accounts['valuation']:
+                stock_valuation_accounts_ids.add(accounts['valuation'].id)
         stock_valuation_accounts = self.env['account.account'].browse(stock_valuation_accounts_ids)
         domain = Domain([
             ('account_id', 'in', stock_valuation_accounts.ids),


### PR DESCRIPTION
Issue before this commit:
=========================
When opening the Inventory Valuation menu without a configured Valuation Account, 
the system raised: `AssertionError: Invalid falsy real id.`

Steps to Reproduce:
=========================
- Install the account and stock_account modules.
- Switch to another company where the default Valuation Account is not set.
- Open the Inventory Valuation menu → traceback occurs.

Cause of the issue:
=========================
After a recent ORM change in this [PR](https://github.com/odoo/odoo/pull/227477),
Calling browse() with falsy IDs is no longer allowed. When a company has no 
Valuation Account configured, the code attempts to browse a falsy ID, triggering this error.

With This Commit:
=========================
Add a safeguard to ensure that only valid valuation account records are added before browsing.
This prevents issues when opening the Inventory Valuation menu for companies that don’t have 
a Valuation Account configured.
