### PR TITLE
[IMP] mail,account: improve audit view in mail and account

### DIFF
--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -43,7 +43,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
     def assertTrail(self, trail, expected):
         self.assertEqual(len(trail), len(expected))
         for message, expected_needle in zip(trail, expected[::-1]):
-            self.assertIn(expected_needle, message.account_audit_log_preview)
+            self.assertIn(expected_needle, message.audit_log_preview)
 
     def test_can_reset_deferred_invoice(self):
         customer = self.env['res.partner'].create({'name': 'Rob Odoo'})

--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -43,7 +43,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
     def assertTrail(self, trail, expected):
         self.assertEqual(len(trail), len(expected))
         for message, expected_needle in zip(trail, expected[::-1]):
-            self.assertIn(expected_needle, message.audit_log_preview)
+            self.assertIn(expected_needle, message.tracking_value_formatted)
 
     def test_can_reset_deferred_invoice(self):
         customer = self.env['res.partner'].create({'name': 'Rob Odoo'})
@@ -108,15 +108,15 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.action_post()
-        messages.append("Updated\nFalse ⇨ MISC/2021/04/0001 (Number)\nDraft ⇨ Posted (Status)")
+        messages.append("None ⇨ MISC/2021/04/0001 (Number)\nDraft ⇨ Posted (Status)")
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.button_draft()
-        messages.append("Updated\nPosted ⇨ Draft (Status)")
+        messages.append("Posted ⇨ Draft (Status)")
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.name = "nawak"
-        messages.append("Updated\nMISC/2021/04/0001 ⇨ nawak (Number)")
+        messages.append("MISC/2021/04/0001 ⇨ nawak (Number)")
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.line_ids = [
@@ -130,30 +130,30 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         messages.extend([
             "updated\n100.0 ⇨ 300.0",
             "updated\n-100.0 ⇨ -200.0",
-            "created\n ⇨ 400000 Product Sales (Account)\n0.0 ⇨ -100.0 (Balance)",
+            "created\nNone ⇨ 400000 Product Sales (Account)\n0.0 ⇨ -100.0 (Balance)",
         ])
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.line_ids[0].tax_ids = self.env.company.account_purchase_tax_id
         suspense_account_code = self.env.company.account_journal_suspense_account_id.code
         messages.extend([
-            "updated\n ⇨ 15% (Taxes)",
-            "created\n ⇨ 131000 Tax Paid (Account)\n0.0 ⇨ 45.0 (Balance)\nFalse ⇨ 15% (Label)",
-            f"created\n ⇨ {suspense_account_code} Bank Suspense Account (Account)\n0.0 ⇨ -45.0 (Balance)\nFalse ⇨ Automatic Balancing Line (Label)",
+            "updated\nNone ⇨ 15% (Taxes)",
+            "created\nNone ⇨ 131000 Tax Paid (Account)\n0.0 ⇨ 45.0 (Balance)\nNone ⇨ 15% (Label)",
+            f"created\nNone ⇨ {suspense_account_code} Bank Suspense Account (Account)\n0.0 ⇨ -45.0 (Balance)\nNone ⇨ Automatic Balancing Line (Label)",
         ])
         self.assertTrail(self.get_trail(self.move), messages)
         self.move.with_context(dynamic_unlink=True).line_ids.unlink()
         messages.extend([
-            "deleted\n400000 Product Sales ⇨  (Account)\n300.0 ⇨ 0.0 (Balance)\n15% ⇨  (Taxes)",
-            "deleted\n400000 Product Sales ⇨  (Account)\n-200.0 ⇨ 0.0 (Balance)",
-            "deleted\n400000 Product Sales ⇨  (Account)\n-100.0 ⇨ 0.0 (Balance)",
-            "deleted\n131000 Tax Paid ⇨  (Account)\n45.0 ⇨ 0.0 (Balance)\n15% ⇨ False (Label)",
-            f"deleted\n{suspense_account_code} Bank Suspense Account ⇨  (Account)\n-45.0 ⇨ 0.0 (Balance)\nAutomatic Balancing Line ⇨ False (Label)",
+            "deleted\n400000 Product Sales ⇨ None (Account)\n300.0 ⇨ 0.0 (Balance)\n15% ⇨ None (Taxes)",
+            "deleted\n400000 Product Sales ⇨ None (Account)\n-200.0 ⇨ 0.0 (Balance)",
+            "deleted\n400000 Product Sales ⇨ None (Account)\n-100.0 ⇨ 0.0 (Balance)",
+            "deleted\n131000 Tax Paid ⇨ None (Account)\n45.0 ⇨ 0.0 (Balance)\n15% ⇨ None (Label)",
+            f"deleted\n{suspense_account_code} Bank Suspense Account ⇨ None (Account)\n-45.0 ⇨ 0.0 (Balance)\nAutomatic Balancing Line ⇨ None (Label)",
         ])
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.env.company.restrictive_audit_trail = True
-        messages_company = ["Updated\nFalse ⇨ True (Restrictive Audit Trail)"]
+        messages_company = ["None ⇨ True (Restrictive Audit Trail)"]
         self.assertTrail(self.get_trail(self.company), messages_company)
 
     def test_partner_notif(self):

--- a/addons/account/views/mail_message_views.xml
+++ b/addons/account/views/mail_message_views.xml
@@ -1,66 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="view_message_tree_audit_log" model="ir.ui.view">
-        <field name="name">mail.message.list.inherit.audit.log</field>
-        <field name="model">mail.message</field>
-        <field name="priority">99</field>
-        <field name="mode">primary</field>
-        <field name="arch" type="xml">
-            <list edit="0" delete="0" create="0" action="action_open_document" type="object">
-                <field name="date"/>
-                <field name="author_id" widget="many2one_avatar"/>
-                <field name="res_id" string="Name"/>
-                <field name="account_audit_log_preview"/>
-            </list>
-        </field>
-    </record>
-
     <record id="view_message_tree_audit_log_search" model="ir.ui.view">
         <field name="name">mail.message.search</field>
         <field name="model">mail.message</field>
-        <field name="priority">99</field>
-        <field name="mode">primary</field>
+        <field name="inherit_id" ref="mail.mail_message_view_search_audit_trail"/>
         <field name="arch" type="xml">
-            <search string="Messages Search">
+            <field name='author_id' position="before">
                 <field name="account_audit_log_move_id"/>
                 <field name="account_audit_log_account_id"/>
                 <field name="account_audit_log_tax_id"/>
                 <field name="account_audit_log_partner_id"/>
                 <field name="account_audit_log_company_id"/>
-                <field name="author_id"/>
-                <field name="date"/>
+            </field>
+            <filter name='res_partner' position="before">
                 <filter string="Journal Entry" name="account_move" domain="[('model', '=', 'account.move')]"/>
                 <filter string="Account" name="account_account" domain="[('model', '=', 'account.account')]"/>
                 <filter string="Taxes" name="account_tax" domain="[('model', '=', 'account.tax')]"/>
-                <filter string="Partners" name="res_partner" domain="[('model', '=', 'res.partner')]"/>
-                <filter string="Company" name="res_company" domain="[('model', '=', 'res.company')]"/>
-                <separator/>
-                <field string="Field Value" name="tracking_value_ids" filter_domain="[
-                    '|', ('tracking_value_ids.old_value_char', 'ilike', self),
-                    '|', ('tracking_value_ids.new_value_char', 'ilike', self),
-                    '|', ('tracking_value_ids.old_value_text', 'ilike', self),
-                         ('tracking_value_ids.new_value_text', 'ilike', self),
-                ]"/>
-                <field string="Field" name="tracking_value_ids" filter_domain="[('tracking_value_ids.field_id', 'ilike', self)]"/>
-                <separator/>
-                <filter string="Update" name="update_only" domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
-                <filter string="Create" name="create_only" domain="[('tracking_value_ids', '=', False)]" groups="base.group_system"/>
+            </filter>
+            <filter name='create_only' position="after">
                 <filter string="Restricted" name="restricted_by_audit_trail" domain="[('account_audit_log_restricted', '=', True)]"/>
-                <separator/>
-                <filter name="date" string="Date" date="date"/>
-                <group>
-                    <filter string="Date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
-                    <filter string="Updated Data" name="group_by_res_id" domain="[]" context="{'group_by': 'res_id'}"/>
-                </group>
-            </search>
+            </filter>
         </field>
     </record>
 
     <record id="action_account_audit_trail_report" model="ir.actions.act_window">
         <field name="name">Audit Trail</field>
         <field name="res_model">mail.message</field>
-        <field name="view_id" ref="view_message_tree_audit_log"/>
+        <field name="view_id" ref="mail.mail_message_view_list_audit_trail"/>
         <field name="view_mode">list</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">This is the Audit Trail Report</p>

--- a/addons/account/views/mail_message_views.xml
+++ b/addons/account/views/mail_message_views.xml
@@ -14,9 +14,9 @@
                 <field name="account_audit_log_company_id"/>
             </field>
             <filter name='res_partner' position="before">
-                <filter string="Journal Entry" name="account_move" domain="[('model', '=', 'account.move')]"/>
-                <filter string="Account" name="account_account" domain="[('model', '=', 'account.account')]"/>
-                <filter string="Taxes" name="account_tax" domain="[('model', '=', 'account.tax')]"/>
+                <filter string="Journal Entry" name="model_account_move" domain="[('model', '=', 'account.move')]"/>
+                <filter string="Account" name="model_account_account" domain="[('model', '=', 'account.account')]"/>
+                <filter string="Taxes" name="model_account_tax" domain="[('model', '=', 'account.tax')]"/>
             </filter>
             <filter name='create_only' position="after">
                 <filter string="Restricted" name="restricted_by_audit_trail" domain="[('account_audit_log_restricted', '=', True)]"/>
@@ -34,8 +34,12 @@
         </field>
         <field name="domain">[
             ('message_type', '=', 'notification'),
-            ('model', 'in', ('account.move', 'account.account', 'account.tax', 'res.partner', 'res.company')),
         ]</field>
+        <field name="context">{
+            'search_default_model_account_move': 1,
+            'search_default_model_account_account': 1,
+            'search_default_model_account_tax': 1,
+        }</field>
         <field name="search_view_id" ref="view_message_tree_audit_log_search"/>
     </record>
 

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1587,7 +1587,7 @@ We can redirect you to the public employee list."""
             self.version_id.write(version_vals)
 
             for employee in self:
-                employee._track_set_log_message(Markup("<b>%s</b>") % self.env._("Modified on the Employee Record '%s'") % employee.version_id.display_name)
+                employee._track_set_log_message(Markup("<b>%s</b>") % self.env._("As of %s") % employee.version_id.display_name)
         if res and 'resource_calendar_id' in vals:
             resources_per_calendar_id = defaultdict(lambda: self.env['resource.resource'])
             for employee in self:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -319,8 +319,6 @@ class MailMessage(models.Model):
         for message in tracking_messages:
             title = message.subject or message.preview
             tracking_value_ids = message.sudo().tracking_value_ids._filter_has_field_access(self.env)
-            if not title and tracking_value_ids:
-                title = self.env._("Updated")
             if not title and message.subtype_id and not message.subtype_id.internal:
                 title = message.subtype_id.display_name
             format_value = title + '\n' if title else ''

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -185,6 +185,11 @@ class MailMessage(models.Model):
         groups="base.group_system",
         help='Tracked values are stored in a separate model. This field allow to reconstruct '
              'the tracking and to generate statistics on the model.')
+    tracking_value_formatted = fields.Text(
+        string="Description",
+        compute="_compute_tracking_value_formatted",
+        search="_search_tracking_value_formatted",
+    )
     # mail gateway
     reply_to_force_new = fields.Boolean(
         'No threading for answers',
@@ -307,11 +312,52 @@ class MailMessage(models.Model):
         for message in self:
             message.starred = message in starred
 
+    @api.depends('tracking_value_ids')
+    def _compute_tracking_value_formatted(self):
+        tracking_messages = self.filtered(lambda m: m.message_type == 'notification')
+        (self - tracking_messages).tracking_value_formatted = False
+        for message in tracking_messages:
+            title = message.subject or message.preview
+            tracking_value_ids = message.sudo().tracking_value_ids._filter_has_field_access(self.env)
+            if not title and tracking_value_ids:
+                title = self.env._("Updated")
+            if not title and message.subtype_id and not message.subtype_id.internal:
+                title = message.subtype_id.display_name
+            format_value = title + '\n' if title else ''
+            format_value += "\n".join(
+                "%(old_value)s ⇨ %(new_value)s (%(field)s)" % {
+                    'old_value': fmt_vals['oldValue'],
+                    'new_value': fmt_vals['newValue'],
+                    'field': fmt_vals['fieldInfo']['changedField'],
+                }
+                for fmt_vals in tracking_value_ids._tracking_value_format()
+            )
+            message.tracking_value_formatted = format_value
+
     @api.model
     def _search_starred(self, operator, operand):
         if operator != 'in':
             return NotImplemented
         return [('starred_partner_ids', 'in', self.env.user.partner_id.ids)]
+
+    @api.model
+    def _search_tracking_value_formatted(self, operator, value):
+        if operator not in ['=', 'like', '=like', 'ilike'] or not isinstance(value, str):
+            return NotImplemented
+
+        matched_message_ids = self.env['mail.tracking.value'].sudo().search(
+            Domain.OR([
+                [('old_value_char', operator, value)],
+                [('new_value_char', operator, value)],
+                [('old_value_text', operator, value)],
+                [('new_value_text', operator, value)],
+            ])
+        ).mapped('mail_message_id')
+
+        return Domain.AND([
+            [('message_type', '=', 'notification')],
+            [('id', 'in', matched_message_ids.ids)],
+        ])
 
     # ------------------------------------------------------
     # CRUD / ORM

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -292,6 +292,12 @@ class MailTrackingValue(models.Model):
             'text': ('old_value_text', 'new_value_text'),
         }
 
+        default_field_values = {
+            'integer': 0,
+            'float': 0.0,
+            'monetary': 0.0,
+        }
+
         result = []
         for record in self:
             value_fname = field_mapping.get(
@@ -299,6 +305,8 @@ class MailTrackingValue(models.Model):
             )[bool(new)]
             value = record[value_fname]
 
+            if not value:
+                value = default_field_values.get(field_type)
             if field_type in {'integer', 'float', 'char', 'text', 'monetary'}:
                 result.append(value)
             elif field_type in {'date', 'datetime'}:

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -183,5 +183,44 @@
             </field>
         </record>
 
+        <record id="mail_message_view_list_audit_trail" model="ir.ui.view">
+            <field name="name">audit.trail.list</field>
+            <field name="model">mail.message</field>
+            <field name="arch" type="xml">
+                <list edit="0" delete="0" create="0" action="action_open_document" type="object">
+                    <field name="date"/>
+                    <field name="author_id" widget="many2one_avatar"/>
+                    <field name="res_id" string="Name"/>
+                    <field name="tracking_value_formatted"/>
+                </list>
+            </field>
+        </record>
+
+        <record id="mail_message_view_search_audit_trail" model="ir.ui.view">
+            <field name="name">audit.trail.search</field>
+            <field name="model">mail.message</field>
+            <field name="arch" type="xml">
+                <search string="Audit Trail Search">
+                    <field name="author_id"/>
+                    <field name="date"/>
+                    <filter string="Partners" name="res_partner" domain="[('model', '=', 'res.partner')]"/>
+                    <filter string="Company" name="res_company" domain="[('model', '=', 'res.company')]"/>
+                    <separator/>
+                    <field string="Field Value" name="tracking_value_formatted"/>
+                    <field string="Field" name="tracking_value_ids" filter_domain="[('tracking_value_ids.field_id', 'ilike', self)]"/>
+                    <separator/>
+                    <filter string="Update" name="update_only" domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
+                    <filter string="Create" name="create_only" domain="[('tracking_value_ids', '=', False)]" groups="base.group_system"/>
+                    <separator/>
+                    <filter name="date" string="Date" date="date"/>
+                    <group>
+                        <filter string="Date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
+                        <filter string="Updated Data" name="group_by_res_id" domain="[]" context="{'group_by': 'res_id'}"/>
+                        <filter string="Author" name="group_by_author" domain="[]" context="{'group_by': 'author_id'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
     </data>
 </odoo>


### PR DESCRIPTION
Commit 1: 
-----------
account, mail: move audit trail stuff from account to mail module
 The purpose is that we can also reuse the functionality in the payroll module.

Commit 2: 
--------
 account, mail: improve style of falsy value on audit trail preview and test case
This commit improves how falsy values are displayed in the audit trail when 
tracking field changes. Previously, when a tracked field was empty, the value 
appeared as an empty string. Now, the system returns a more meaningful falsy 
value based on the field type:

   - Float, Monetary → 0.0
   - Other fields → None

Example:
   
   - Previously:
         ' ' → Test (Name)
         ' ' → 1000 (Amount)
    
   - Now:
        None → Test (Name)
        0.0 → 1000 (Amount)

Commit 3:
-----
 hr: modify tracking message when employee version is updated
 
 Commit 4:
 ----
 account: improve action for audit trail in account
 This commit removes the domain that previously restricted the audit trail window
action to accounting-related records and instead adds a default filter through
context to show only accounting-related records when the audit trail is opened
(i.e., records from account.move, account.account, and account.tax)

### **_NOTE:_**
Since the domain restriction has been removed, clearing all filters from list will display 
audit entries from other model as well, including records unrelated to accounting.


task-5223898

