### PR TITLE
[FIX] mail_plugin: prevent errors when finding and creating company using IAP

### DIFF
--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -50,7 +50,7 @@ class MailPluginController(http.Controller):
         company, enrichment_info = self._create_company_from_iap(normalized_email)
 
         if company:
-            partner.write({'parent_id': company})
+            partner.write({'parent_id': company.id})
 
         return {
             'enrichment_info': enrichment_info,


### PR DESCRIPTION
Currently, an error occurs when the user clicks the `Create and Enrich Partner` button.

**Error:**
    `ProgrammingError: can't adapt type 'res.partner'`

This error occurs when the user clicks the `Create and Enrich Partner` button. Then it tries to find or 
create the company using IAP. From here [1], it returns the record as company, and here [2], it writes 
this record into the partner as the parent_id. However, since the parent_id is a record instead of an ID, 
when the system tries to browse the partner by this record [3], the error is raised.

This commit ensures that when writing the parent_id of the partner, the actual ID is used instead 
of the record.

[1]- https://github.com/odoo/odoo/blob/591584268cfcbad54ee675ea62d047c3900ed629/addons/mail_plugin/controllers/mail_plugin.py#L386

[2]- https://github.com/odoo/odoo/blob/591584268cfcbad54ee675ea62d047c3900ed629/addons/mail_plugin/controllers/mail_plugin.py#L52-L53

[3]- https://github.com/odoo/odoo/blob/591584268cfcbad54ee675ea62d047c3900ed629/addons/account/models/partner.py#L801

sentry-6831922000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
