### PR TITLE
[FIX] point_of_sale: prevent offline service from disabling PoS ui

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -121,6 +121,7 @@
             'web/static/lib/bootstrap/scss/_maps.scss',
             ("include", "web._assets_bootstrap_backend"),
             ('include', 'web._assets_core'),
+            "point_of_sale/static/src/app/services/offline_service.js",
             ("remove", "web/static/src/core/browser/router.js"),
             ("remove", "web/static/src/core/debug/**/*"),
             ('include', 'web.icons_fonts'),

--- a/addons/point_of_sale/static/src/app/services/offline_service.js
+++ b/addons/point_of_sale/static/src/app/services/offline_service.js
@@ -1,0 +1,28 @@
+import { offlineService } from "@web/core/offline/offline_service";
+import { patch } from "@web/core/utils/patch";
+import { session } from "@web/session";
+
+/**
+ * Patch the default Odoo offline service to customize behavior for the POS.
+ *
+ * In the standard implementation, when Odoo detects it is offline,
+ * it disables all interactive UI elements (buttons, inputs, etc.)
+ * by adding the `disabled` attribute and the `o_disabled_offline` CSS class.
+ *
+ * However, for the Point of Sale (POS) and Self-Ordering mode, we *want it to
+ * remain functional offline*,
+ *
+ * This patch prevents the offline service from disabling UI components
+ */
+patch(offlineService, {
+    async start() {
+        // Skip offline UI disabling if we’re in POS or Self-Ordering mode.
+        if (odoo.pos_config_id || session.data?.config_id) {
+            return {
+                status: {},
+                _checkConnection: () => Promise.resolve(),
+            };
+        }
+        return super.start(...arguments);
+    },
+});


### PR DESCRIPTION
In this commit:
---
- After the changes from this commit  https://github.com/odoo/odoo/pull/229492/commits/0cad4bcc970129fb27527016c70d76febac29ab1, when Odoo goes offline, all buttons and input fields are disabled by default.
- However, the POS is designed to work fully in offline mode using its own mechanisms (IndexedDB, etc.).
- To ensure POS remains functional, we patched the `offlineService` to skip disabling UI elements when the current page is the POS frontend.

task-5255369

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
