### PR TITLE
[IMP] hr_recruitment: made applicant properties company-based instead of job

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -148,7 +148,7 @@ class HrApplicant(models.Model):
         ('archived', 'Archived'),
     ], compute="_compute_application_status", search="_search_application_status")
     application_count = fields.Integer(compute='_compute_application_count', help='Applications with the same email or phone or mobile')
-    applicant_properties = fields.Properties('Properties', definition='job_id.applicant_properties_definition', copy=True)
+    applicant_properties = fields.Properties('Properties', definition='company_id.applicant_properties_definition', precompute=False, copy=True)
     applicant_notes = fields.Html()
     refuse_date = fields.Datetime('Refuse Date')
     talent_pool_ids = fields.Many2many(comodel_name="hr.talent.pool", string="Talent Pools")

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -86,7 +86,6 @@ class HrJob(models.Model):
 
     job_properties = fields.Properties('Properties', definition='company_id.job_properties_definition', groups="hr_recruitment.group_hr_recruitment_interviewer")
 
-    applicant_properties_definition = fields.PropertiesDefinition('Applicant Properties', groups="hr_recruitment.group_hr_recruitment_interviewer")
     no_of_hired_employee = fields.Integer(
         compute='_compute_no_of_hired_employee',
         string='Hired', copy=False, groups="hr_recruitment.group_hr_recruitment_interviewer",

--- a/addons/hr_recruitment/models/res_company.py
+++ b/addons/hr_recruitment/models/res_company.py
@@ -7,3 +7,4 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     job_properties_definition = fields.PropertiesDefinition("Job Properties")
+    applicant_properties_definition = fields.PropertiesDefinition("Applicant Properties", groups="hr_recruitment.group_hr_recruitment_interviewer")


### PR DESCRIPTION
Before this PR it was not possible to assign or manage properties for Talents or Applicants who were not linked to any specific Job Position.

After this PR  the properties are defined based on the company , allowing properties to be managed at the company level and used for applicants without job_id.

Task-5212981
