### PR TITLE
[FIX] web: allow records grouped by property fields to export

### DIFF
--- a/addons/test_xlsx_export/models.py
+++ b/addons/test_xlsx_export/models.py
@@ -29,6 +29,10 @@ class GroupOperator(models.Model):
     many2one = fields.Many2one('export.integer')
     one2many = fields.One2many('export.group_operator.one2many', 'parent_id')
     active = fields.Boolean(default=True)
+    parent_id = fields.Many2one('export.group_operator', string='Parent')
+    definition_properties = fields.PropertiesDefinition('Definitions')
+    properties = fields.Properties('Properties', definition='parent_id.definition_properties')
+
 
 class GroupOperatorO2M(models.Model):
     _name = 'export.group_operator.one2many'

--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -407,6 +407,34 @@ class TestGroupedExport(XlsxCreatorCase):
             ['1'                ,'86420.86'],
         ])
 
+    def test_groupby_properties_type_field(self):
+        """Test that exporting works for record grouped by a property field."""
+
+        property_def = [{'name': 'date', 'type': 'date', 'string': 'Date', 'default': '2025-11-11'}]
+        record = self.env['export.group_operator'].create({'definition_properties': property_def})
+        values = [
+            {'int_sum': 10, 'properties': {'date': '2025-11-09'}, 'parent_id': record.id, 'float_min': 86.8},
+            {'int_sum': 10, 'properties': {'date': '2025-11-12'}, 'parent_id': record.id, 'float_min': 82.8},
+            {'int_sum': 10, 'properties': {'date': '2025-09-09'}, 'parent_id': record.id, 'float_min': 20.8},
+        ]
+        export = self.export(
+            values,
+            fields=['int_sum', 'properties'],
+            params={
+                'groupby': ['properties.date:month'],
+                'domain': [('int_sum', '=', 10)],
+            },
+        )
+
+        self.assertExportEqual(export, [
+            ['Int Sum', 'Properties'],
+            ['September 2025 (1)', ''],
+            ['10', "{'date': '2025-09-09'}"],
+            ['November 2025 (2)', ''],
+            ['10', "{'date': '2025-11-09'}"],
+            ['10', "{'date': '2025-11-12'}"],
+        ])
+
 @tagged('-at_install', 'post_install')
 class TestExport(common.HttpCase):
 

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -483,7 +483,7 @@ class ExportFormat(object):
 
         groupby = params.get('groupby')
         if not import_compat and groupby:
-            groupby_type = [Model._fields[x.split(':')[0]].type for x in groupby]
+            groupby_type = [Model._fields[x.split(':', 1)[0].split('.', 1)[0]].type for x in groupby]
             domain = [('id', 'in', ids)] if ids else domain
             groups_data = Model.with_context(active_test=False).read_group(domain, ['__count'], groupby, lazy=False)
 


### PR DESCRIPTION
Step to reproduce
- open a task
- add a property field , say test
- add values for this field in few records
- go to list view and group by test
- select a record from result and export it (from Action btn)

Observation:
- traceback
```
  File "/home/odoo/17.0/addons/web/controllers/export.py", line 486, in base
    groupby_type = [Model._fields[x.split(':')[0]].type for x in groupby]
                    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'task_properties.b60ee9baefee14a8'
```

Cause:
- The issue is caused by splitting, which didn't considered property field
- it tried to look for `task_properties.b60ee9baefee14a8` in _fields which causes KeyError

FIx:
- split the field name properly to bring out actual field name while considering granularity as well as the property fields

opw-5159155


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
