### PR TITLE
[FIX] hr_work_entry: correct context for reset work entry

### DIFF
--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -102,7 +102,7 @@ export class WorkEntryCalendarModel extends CalendarModel {
     async resetWorkEntries(dates, recordIds) {
         const cellsFormattedData = dates.map((date) => ({
             date,
-            employee_id: this.meta.context.active_id,
+            employee_id: this.meta.context.default_employee_id,
         }));
         await this.orm.call("hr.work.entry.regeneration.wizard", "regenerate_work_entries", [
             [],


### PR DESCRIPTION
Steps to reproduce:
- Install the hr_payroll module.
- Open the form view of an employee with a running contract and click on the Payslip smart button.
- Create or open an existing payslip, then open the Work Entries using the smart button.
- Select any work entry and click Reset Selected Work Entries.

Issue:
Clicking Reset Selected Work Entries removes the work entry for that day and leaves it empty.

Cause:
The issue occurs because an incorrect active_id is passed in the context. It works correctly when coming from the employee form (where active_id is the employee ID), but fails when accessed from the payslip (where active_id is the payslip ID).

Fix:
This PR updates the context to ensure the correct employee ID is passed.

Task-5095098