### PR TITLE
[FIX] product: prevent text overflow in product attribute kanban card

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -653,7 +653,7 @@ action = {
                     <t t-name="card" class="p-0">
                     <!-- TODO : not getting border when select record -->
                         <div class="d-flex flex-grow-1 m-2">
-                            <div class="p-2 pt-1 d-flex flex-column m-0 w-100"
+                            <div class="p-2 pt-1 d-flex flex-column m-0 overflow-hidden"
                                     t-attf-id="product-{{record.id.raw_value}}">
                                 <div class="d-flex">
                                     <field class="mt-1 me-1"


### PR DESCRIPTION
Steps to reproduce:
1. Go to Products > Create a new product.
2. Add or create a new attribute with a long text value.
3. Go to Sales > Open any quotation.
4. In the sale order line, click on "Catalog" and search for the created product.

Issue:
- The product image and attribute value text overflow outside the product card in the kanban view, causing layout misalignment and breaking the UI design.
<img width="647" height="225" alt="image" src="https://github.com/user-attachments/assets/afc592bb-e25a-4d81-882b-0e7cc7ad1064" />

Cause:
- The inner div containing the attribute text lacked overflow control, allowing long text to exceed the container width and pushing other elements.

Solution:
- Added the Bootstrap class `overflow-hidden` to the div element to ensure the image and text remain properly contained within the card layout.

<img width="587" height="171" alt="image" src="https://github.com/user-attachments/assets/580ce1e5-42bd-4c2d-b6bf-14315759626d" />



opw-5222002