### PR TITLE
[FIX] mail: no auto-zoom input for livechat visitor in mobile (2)

### DIFF
--- a/addons/im_livechat/static/src/embed/common/composer.scss
+++ b/addons/im_livechat/static/src/embed/common/composer.scss
@@ -1,5 +1,5 @@
 .o-mail-Composer-input, .o-mail-Composer-fake {
-    .o-mobile {
+    &.o-mobile {
         font-size: 16px;
     }
 }


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/234967

Style rule was not applied due to missing `&` in SCSS, which this commit fixes.