### PR TITLE
[FIX] account: Allow deferred invoices to be reset multiple times

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3863,7 +3863,7 @@ class AccountMove(models.Model):
                 to_unlink += move
         to_unlink.filtered(lambda m: m.state in ('posted', 'cancel')).button_draft()
         to_unlink.filtered(lambda m: m.state == 'draft').unlink()
-        to_cancel.button_cancel()
+        to_cancel.filtered(lambda m: m.state != 'cancel').button_cancel()
         return to_reverse._reverse_moves(cancel=True)
 
     def _post(self, soft=True):

--- a/addons/account_audit_trail/tests/test_audit_trail.py
+++ b/addons/account_audit_trail/tests/test_audit_trail.py
@@ -43,6 +43,28 @@ class TestAuditTrail(AccountTestInvoicingCommon):
                 expected
             )
 
+    def test_can_reset_deferred_invoice(self):
+        customer = self.env['res.partner'].create({'name': 'Rob Odoo'})
+        invoice = self.env['account.move'].create({
+            'invoice_date': '2025-09-01',
+            'invoice_date_due': '2025-09-01',
+            'invoice_line_ids': [
+                (0, 0, {'name': 'Line1',
+                        'price_unit': 100.0,
+                        'deferred_start_date': '2025-09-01',
+                        'deferred_end_date': '2025-12-31',
+                       }
+                ),
+            ],
+            'move_type': 'out_invoice',
+            'name': 'INVOICE_00001',
+            'partner_id': customer.id,
+        })
+
+        for i in range(4):
+            invoice.action_post()
+            invoice.button_draft()
+
     def test_can_unlink_draft(self):
         self.move.unlink()
 


### PR DESCRIPTION
Resetting a vendor bill or invoice with deferred amounts will unlink or reset all existing deferred entries. If the audit trail is enabled, some of these entries must be cancelled instead.

[AccountMove.button_draft()](https://github.com/odoo/enterprise/blob/a3f461040cb3443fbcb190c28fddae7044bbd1e7/account_accountant/models/account_move.py#L80-L88)

If a protected entry is already cancelled, `AccountMove._unlink_or_reverse()` will still attempt to cancel it. This prevents entries from being Reset to Draft more than once.

The current commit removes this restriction.

opw-5187737

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
