### PR TITLE
[FIX] sale_mrp: set sale_line_id on manufacturing order during MTO route

### DIFF
--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -8,6 +8,8 @@ class StockRule(models.Model):
         res = super()._prepare_mo_vals(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, bom)
         if values.get('sale_line_id'):
             res['sale_line_id'] = values['sale_line_id']
+        else:
+            res['sale_line_id'] = values.get('move_dest_ids') and values['move_dest_ids'].sale_line_id.id
         return res
 
     def _get_stock_move_values(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values):

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2661,6 +2661,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(sale_order.mrp_production_count, 1)
         mo = sale_order.mrp_production_ids
         self.assertEqual(mo.sale_order_count, 1)
+        self.assertEqual(mo.sale_line_id, sale_order.order_line)
 
     def test_so_with_kit_and_multiple_same_component(self):
         """Test that a Sale Order with a kit product containing multiple identical components


### PR DESCRIPTION
Problem:
Manufacturing Orders should contain information about their origin, but during an MTO route, sale_line_id remains unset after the MO is created when the Sales Order is confirmed.

Solution:
While preparing the values for the MO (`_prepare_mo_vals`), we will assign the `sale_line_id` based on the MO's move, which has the origin sale_line_id during the MTO route.

Steps to replicate on Runbot 18:
- Product with MTO and Manufacture routes
- BoM with at least one component
1. Create a Sales Order for the product and confirm
2. Navigate to the MO via the smart button
3. Check the field sale_line_id with the inspector, note it is False.

opw-5257401