### PR TITLE
[FIX] repair: show correct failure location on product moves

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -577,6 +577,8 @@ class RepairOrder(models.Model):
             raise UserError(_("Repair must be under repair in order to end reparation."))
         partial_moves = set()
         picked_moves = set()
+        if self.quality_check_fail:
+            self.product_location_dest_id = self.quality_check_ids.failure_location_id
         for move in self.move_ids:
             if move.product_uom.compare(move.quantity, move.product_uom_qty) < 0:
                 partial_moves.add(move.id)


### PR DESCRIPTION
Before this commit:
-------------------------
- In the Repair module, when a quality check for a product was marked as failed, Even after selecting a failure location, the final product move showed an Incorrect destination location.
- Instead of showing the selected failure location, the system displayed another location as the move destination after completing the repair process.

Steps to reproduce:
-------------------------
1. Install the Repair and Quality modules.
2. In Quality, create a Control Point with:
   - Type = Pass-Fail
   - Control Per = Product
   - Set at least 1 Failure Location
3. Create a Repair Order for any product and start the repair process.
4. Perform a quality check, set it to Fail, and select a failure location.
5. Open the product moves, the destination location is incorrect (not the selected failure location).

Cause of the issue
-------------------------
The failure location was not correctly assigned when the quality check failed during the repair process because the logic relied on stock pickings to determine the destination location. However, in repairs, quality checks are performed independently of stock pickings.

After this commit:
-----------------------
- When a quality check fails in a repair order, the product’s destination location is correctly set to the failure location selected by the user.
- This ensures accurate traceability of failed products and simplifies stock adjustments across locations.

Task ID: 5254334