### PR TITLE
[FIX] hr_org_chart: org chart not working in mobile view

### DIFF
--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -4,6 +4,7 @@
         <field name="name">Org Chart</field>
         <field name="res_model">hr.employee</field>
         <field name="view_mode">hierarchy,kanban,tree,form,activity,graph,pivot</field>
+        <field name="mobile_view_mode">hierarchy</field>
         <field name="domain">[]</field>
         <field name="context">{'chat_icon': True}</field>
         <field name="view_id" eval="False"/>


### PR DESCRIPTION
Steps to Reproduce:
- Open an employee record.
- Set managers for the employee.
- Open the employee’s form view on mobile.
- Click org chart stat button.

Before:
- On mobile, the org chart button opened the Kanban view by default.

After:
- On mobile, the org chart button now opens the Hierarchy view by default.

task-5245129

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
