### PR TITLE
[FIX] hr_holidays: correct accrued days calculation in accrual allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -880,6 +880,7 @@ class HolidaysAllocation(models.Model):
             return
         self.lastcall = self.date_from
         self.nextcall = False
+        self.already_accrued = False
         self.number_of_days_display = 0.0
         self.number_of_hours_display = 0.0
         self.number_of_days = 0.0


### PR DESCRIPTION
Version:
* 17.0

Steps to Reproduce:

1. Create an accrual plan with:
   * Accrued gain time: At the start of the accrual period
   * Carry-over time: Other
   * Carry-over date: 1 January
   * Add a milestone where the employee accrues 2 days monthly, with a milestone reached = 0 days.
2. Create a new allocation:
   * Set allocation Type to accrual allocation
   * Select the accrual plan created above
   * Set date_from to the 1st of the previous month

Issue:
* The expected accrued days are 4, but the system only calculates 2.

Fix:
* When changing the `date_from` value, set `already_accrued` to False.
* This ensures `_process_accrual_plans` runs `_add_days_to_allocation` properly and recalculates the correct accrued days.

After:
* Accrued days now calculate correctly based on the accrual plan.

task-5236714



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
