### PR TITLE
[FIX] website_sale: Toggle eCommerce category in mega menu

### DIFF
--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -82,6 +82,26 @@ registerWebsitePreviewTour(
         clickOnExtraMenuItem({}, true),
         toggleMegaMenu({}),
         {
+            content: "Wait for the mega menu content to appear.",
+            trigger: ":iframe .o_mega_menu",
+        },
+        {
+            content: "Select the mega menu content to view its properties.",
+            trigger: ":iframe .o_mega_menu", // Target the main container of the dropdown
+            run: "click",
+        },
+        // Your original steps will now execute in the correct context.
+        {
+            content: "Toggle the 'Fetch Ecom Categories' switch on.",
+            trigger: "[data-action-id='toggleFetchEcomCategories'] input[type='checkbox']",
+            run: "click",
+        },
+        {
+            content: "Toggle the 'Fetch Ecom Categories' switch off again.",
+            trigger: "[data-action-id='toggleFetchEcomCategories'] input[type='checkbox']",
+            run: "click",
+        },
+        {
             content: "Select the last menu link of the first column",
             trigger: ":iframe .s_mega_menu_odoo_menu .row > div:first-child .nav > :nth-child(6)", // 6th is the last one
             run: "click",

--- a/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
@@ -38,9 +38,8 @@ export class ToggleFetchEcomCategoriesAction extends BuilderAction {
             editingElement,
             true
         );
-        const cls = [...editingElement.firstElementChild.classList].find((cls) =>
-            cls.startsWith("s_mega_menu_")
-        );
+        const target = editingElement.querySelector('[class*="s_mega_menu_"]');
+        const cls = [...target.classList].find(c => c.startsWith("s_mega_menu_"));
         const templateKey = `${module}${cls}`;
         await this.dependencies.customizeWebsite.loadTemplateKey(templateKey);
         return templateKey;


### PR DESCRIPTION
A traceback would occur when clicking the "eCommerce Categories" toggle in the mega menu's style options.

Steps to reproduce:
1. Go to the Website editor.
2. Add a mega menu to the page header.
3. Edit and Click on the mega menu's
4. In the sidebar, click the "eCommerce Categories" toggle. -> Traceback.

Cause:
When loading it was trying to find a specific class name (starting with `s_mega_menu_`) to identify the snippet. It was hardcoded to only look at the `firstElementChild` of the snippet's container.

This assumption was too rigid. If the first element was a `<p>` tag or another element without the required class, the code would fail to find it. This resulted in an `undefined` value being sent to the server, causing the traceback.

Solution:
Use `querySelector` to search for any element with a class name containing `s_mega_menu_`.

opw-5245777
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
