### PR TITLE
[FIX] web: reset limit when restoring a view after ungrouping

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -290,7 +290,7 @@ export class RelationalModel extends Model {
                 delete config.groups;
             }
         }
-        if (!config.isMonoRecord && this.root && params.domain) {
+        if (!config.isMonoRecord && params.domain) {
             // always reset the offset to 0 when reloading from above with a domain
             const resetOffset = (config) => {
                 config.offset = 0;
@@ -298,8 +298,10 @@ export class RelationalModel extends Model {
                     resetOffset(group.list);
                 }
             };
-            resetOffset(config);
-            if (!!config.groupBy.length !== !!currentGroupBy.length) {
+            if (this.root) {
+                resetOffset(config);
+            }
+            if (!!config.groupBy?.length !== !!currentGroupBy?.length) {
                 // from grouped to ungrouped or the other way around -> force the limit to be reset
                 delete config.limit;
             }


### PR DESCRIPTION
Steps to reproduce
==================

- Add a group by in the kanban product view
- Switch to the list view
- Remove the group by
- Switch back to the kanban view -> No limit is applied, and the webclient can crash if too many records
   are returned.

Cause of the issue
==================

The groupsLimit is set as MAX_SAFE_INTEGER in the kanban view

https://github.com/odoo/odoo/blob/df959e05ac9cf3136d1724bc80b7597a70932225/addons/web/static/src/views/kanban/kanban_controller.js#L168

Which is then reused as the limit

https://github.com/odoo/odoo/blob/df959e05ac9cf3136d1724bc80b7597a70932225/addons/web/static/src/model/relational_model/relational_model.js#L368

Solution
========

There is already a code path to reset the limit when switching from grouped to ungrouped, but is wasn't called on the first load (when this.root isn't set yet)

opw-5167769