### PR TITLE
[IMP] web,bus,mail: promote Promise.withResolvers

### DIFF
--- a/addons/bus/static/src/workers/bus_worker_utils.js
+++ b/addons/bus/static/src/workers/bus_worker_utils.js
@@ -27,6 +27,8 @@ export function debounce(func, wait, immediate) {
 }
 
 /**
+ * @deprecated Use Promise.withResolvers() instead.
+ *
  * Deferred is basically a resolvable/rejectable extension of Promise.
  */
 export class Deferred extends Promise {

--- a/addons/mail/static/src/webclient/web/webclient.js
+++ b/addons/mail/static/src/webclient/web/webclient.js
@@ -54,7 +54,7 @@ patch(WebClient.prototype, {
      * @return {Promise<void>}
      */
     async _subscribePush(numberTry = 1) {
-        await this.serviceWorkerActivatedDeferred;
+        await this.serviceWorkerIsActivated;
         const pushManager = await this.pushManager();
         if (!pushManager) {
             return;
@@ -124,7 +124,7 @@ patch(WebClient.prototype, {
      * @return {Promise<void>}
      */
     async _unsubscribePush() {
-        await this.serviceWorkerActivatedDeferred;
+        await this.serviceWorkerIsActivated;
         const pushManager = await this.pushManager();
         if (!pushManager) {
             return;

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -150,6 +150,7 @@ This module provides the core of the Odoo Web Client.
         'web.assets_frontend_minimal': [
             'web/static/src/polyfills/object.js',
             'web/static/src/polyfills/array.js',
+            'web/static/src/polyfills/promise.js',
             'web/static/src/module_loader.js',
             'web/static/src/polyfills/set.js',
             'web/static/src/session.js',

--- a/addons/web/static/lib/hoot-dom/helpers/time.js
+++ b/addons/web/static/lib/hoot-dom/helpers/time.js
@@ -451,6 +451,8 @@ export async function waitUntil(predicate, options) {
 }
 
 /**
+ * @deprecated Use Promise.withResolvers() instead.
+ *
  * Manually resolvable and rejectable promise. It introduces 2 new methods:
  *  - {@link reject} rejects the deferred with the given reason;
  *  - {@link resolve} resolves the deferred with the given value.

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -1,4 +1,3 @@
-import { Deferred } from "@web/core/utils/concurrency";
 import { useAutofocus, useForwardRefToParent, useService } from "@web/core/utils/hooks";
 import { isScrollableY, scrollTo } from "@web/core/utils/scrolling";
 import { useDebounced } from "@web/core/utils/timing";
@@ -362,7 +361,7 @@ export class AutoComplete extends Component {
     }
     async onInput() {
         this.inEdition = true;
-        this.pendingPromise = this.pendingPromise || new Deferred();
+        this.pendingPromise = this.pendingPromise || Promise.withResolvers();
         this.loadingPromise = this.pendingPromise;
         this.debouncedProcessInput();
     }
@@ -400,7 +399,7 @@ export class AutoComplete extends Component {
                 ev.preventDefault();
             }
 
-            await this.loadingPromise;
+            await this.loadingPromise.promise;
         }
 
         switch (hotkey) {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -23,7 +23,6 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { isMobileOS } from "@web/core/browser/feature_detection";
-import { Deferred } from "../utils/concurrency";
 import { Dialog } from "../dialog/dialog";
 import { getTemplate } from "@web/core/templates";
 
@@ -554,13 +553,13 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
     function open(ref, openProps) {
         state.isOpen = true;
         if (ui.isSmall || isMobileOS()) {
-            const def = new Deferred();
+            const { promise, resolve } = Promise.withResolvers();
             const pickerMobileProps = {
                 PickerComponent,
                 onSelect: (...args) => {
                     const func = openProps?.onSelect ?? props?.onSelect;
                     const res = func?.(...args);
-                    def.resolve(true);
+                    resolve(true);
                     return res;
                 },
             };
@@ -585,11 +584,11 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
                     context: component,
                     onClose: () => {
                         state.isOpen = false;
-                        return def.resolve(false);
+                        return resolve(false);
                     },
                 });
             }
-            return def;
+            return promise;
         }
         return popover.open(ref.el, { ...props, ...openProps });
     }

--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -9,7 +9,7 @@ import {
     translatedTerms,
     translatedTermsGlobal,
     translationLoaded,
-    translationIsReady,
+    translationResolvers,
 } from "./translation";
 import { objectToUrlEncodedString } from "../utils/urls";
 import { IndexedDB } from "../utils/indexed_db";
@@ -93,7 +93,7 @@ export const localizationService = {
         }
 
         translatedTerms[translationLoaded] = true;
-        translationIsReady.resolve(true);
+        translationResolvers.resolve(true);
 
         const locale = user.lang || browser.navigator.language;
         Settings.defaultLocale = locale;

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -2,7 +2,6 @@ import { markup } from "@odoo/owl";
 
 import { formatList } from "@web/core/l10n/utils";
 import { isIterable } from "@web/core/utils/arrays";
-import { Deferred } from "@web/core/utils/concurrency";
 import { htmlSprintf } from "@web/core/utils/html";
 import { isObject } from "@web/core/utils/objects";
 import { sprintf } from "@web/core/utils/strings";
@@ -17,7 +16,8 @@ export const translatedTerms = {
  * found within the module's context, or when the context is not known.
  */
 export const translatedTermsGlobal = {};
-export const translationIsReady = new Deferred();
+export const translationResolvers = Promise.withResolvers();
+export const translationIsReady = translationResolvers.promise;
 
 const Markup = markup().constructor;
 

--- a/addons/web/static/src/core/name_service.js
+++ b/addons/web/static/src/core/name_service.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { unique, zip } from "@web/core/utils/arrays";
-import { Deferred } from "@web/core/utils/concurrency";
 
 export const ERROR_INACCESSIBLE_OR_MISSING = Symbol("INACCESSIBLE OR MISSING RECORD ID");
 
@@ -39,7 +38,7 @@ export const nameService = {
         function addDisplayNames(resModel, displayNames) {
             const mapping = getMapping(resModel);
             for (const resId in displayNames) {
-                mapping[resId] = new Deferred();
+                mapping[resId] = Promise.withResolvers();
                 mapping[resId].resolve(displayNames[resId]);
             }
         }
@@ -58,10 +57,10 @@ export const nameService = {
                     throw new Error(`Invalid ID: ${resId}`);
                 }
                 if (!(resId in mapping)) {
-                    mapping[resId] = new Deferred();
+                    mapping[resId] = Promise.withResolvers();
                     resIdsToFetch.push(resId);
                 }
-                proms.push(mapping[resId]);
+                proms.push(mapping[resId].promise);
             }
             if (resIdsToFetch.length) {
                 if (batches[resModel]) {

--- a/addons/web/static/src/core/network/rpc_cache.js
+++ b/addons/web/static/src/core/network/rpc_cache.js
@@ -1,4 +1,3 @@
-import { Deferred } from "@web/core/utils/concurrency";
 import { IndexedDB } from "@web/core/utils/indexed_db";
 import { deepCopy } from "../utils/objects";
 
@@ -140,7 +139,7 @@ export class RPCCache {
 
             // execute the fallback and write the result in the caches
             const prom = new Promise((resolve, reject) => {
-                const fromCache = new Deferred();
+                const fromCache = Promise.withResolvers();
                 let fromCacheValue;
                 const onFullfilled = (result) => {
                     resolve(result);
@@ -161,7 +160,7 @@ export class RPCCache {
                     return result;
                 };
                 const onRejected = async (error) => {
-                    await fromCache;
+                    await fromCache.promise;
                     if (!request.invalidated) {
                         delete this.pendingRequests[requestKey];
                         if (!fromCacheValue) {

--- a/addons/web/static/src/core/utils/concurrency.js
+++ b/addons/web/static/src/core/utils/concurrency.js
@@ -177,6 +177,8 @@ export class Race {
 }
 
 /**
+ * @deprecated Use Promise.withResolvers() instead.
+ *
  * Deferred is basically a resolvable/rejectable extension of Promise.
  */
 export class Deferred extends Promise {

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -157,7 +157,7 @@ export const PublicRoot = publicWidget.Widget.extend({
      *        only initialize the public widgets whose `selector` matches the
      *        element or one of its descendant (default to the wrapwrap element)
      * @param {Object} [options]
-     * @returns {Deferred}
+     * @returns {Promise}
      */
     _startWidgets: function ($from, options) {
         var self = this;

--- a/addons/web/static/src/model/model.js
+++ b/addons/web/static/src/model/model.js
@@ -1,6 +1,6 @@
 import { RPCError } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { Deferred, Race } from "@web/core/utils/concurrency";
+import { Race } from "@web/core/utils/concurrency";
 import { useService } from "@web/core/utils/hooks";
 import { useSetupAction } from "@web/search/action_hook";
 import { SEARCH_KEYS } from "@web/search/with_search/with_search";
@@ -34,8 +34,8 @@ export class Model {
         this.orm = services.orm;
         this.bus = new EventBus();
         this.isReady = false;
-        this.whenReady = new Deferred();
-        this.whenReady.then(() => {
+        this.whenReady = Promise.withResolvers();
+        this.whenReady.promise.then(() => {
             this.isReady = true;
             this.notify();
         });

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -9,7 +9,6 @@ import {
 } from "@web/core/l10n/dates";
 import { x2ManyCommands } from "@web/core/orm_service";
 import { evaluateExpr } from "@web/core/py_js/py";
-import { Deferred } from "@web/core/utils/concurrency";
 import { omit } from "@web/core/utils/objects";
 import { effect } from "@web/core/utils/reactive";
 import { batched } from "@web/core/utils/timing";
@@ -764,16 +763,14 @@ export function useRecordObserver(callback) {
         if (!props.record) {
             return;
         }
-        const def = new Deferred();
+        const { promise, resolve, reject } = Promise.withResolvers();
         const effectId = currentId;
         let firstCall = true;
         effect(
             (record) => {
                 if (firstCall) {
                     firstCall = false;
-                    return Promise.resolve(callback(record, props))
-                        .then(def.resolve)
-                        .catch(def.reject);
+                    return Promise.resolve(callback(record, props)).then(resolve).catch(reject);
                 } else {
                     return batched(
                         (record) => {
@@ -783,16 +780,16 @@ export function useRecordObserver(callback) {
                                 return;
                             }
                             return Promise.resolve(callback(record, props))
-                                .then(def.resolve)
-                                .catch(def.reject);
+                                .then(resolve)
+                                .catch(reject);
                         },
-                        () => new Promise((resolve) => window.requestAnimationFrame(resolve))
+                        () => new Promise((res) => window.requestAnimationFrame(res))
                     )(record);
                 }
             },
             [props.record]
         );
-        return def;
+        return promise;
     };
     onWillDestroy(() => {
         currentId = uniqueId();

--- a/addons/web/static/src/polyfills/promise.js
+++ b/addons/web/static/src/polyfills/promise.js
@@ -1,0 +1,11 @@
+// @odoo-module ignore
+if (!Promise.withResolvers) {
+    Promise.withResolvers = function withResolvers() {
+        let resolve, reject;
+        const promise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return { promise, resolve, reject };
+    };
+}

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -325,7 +325,7 @@ export class ListController extends Component {
         if (!this.model.isReady && !this.model.config.groupBy.length && this.editable) {
             // If the view isn't grouped and the list is editable, a new record row will be added,
             // in edition. In this situation, we must wait for the model to be ready.
-            await this.model.whenReady;
+            await this.model.whenReady.promise;
         }
         const list = (group && group.list) || this.model.root;
         if (this.editable && !list.isGrouped) {

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -6,7 +6,7 @@ import { evaluateExpr } from "@web/core/py_js/py";
 import { rpc, rpcBus } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
-import { Deferred, KeepLast } from "@web/core/utils/concurrency";
+import { KeepLast } from "@web/core/utils/concurrency";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { View, ViewNotFoundError } from "@web/views/view";
 import { ActionDialog } from "./action_dialog";
@@ -1119,16 +1119,16 @@ export function makeActionManager(env, router = _router) {
         }
 
         if (options.clearBreadcrumbs && !options.noEmptyTransition) {
-            const def = new Deferred();
+            const { promise, resolve } = Promise.withResolvers();
             env.bus.trigger("ACTION_MANAGER:UPDATE", {
                 id: ++id,
                 Component: BlankComponent,
                 componentProps: {
-                    onMounted: () => def.resolve(),
+                    onMounted: () => resolve(),
                     withControlPanel: action.type === "ir.actions.act_window",
                 },
             });
-            await def;
+            await promise;
         }
         if (options.onActionReady) {
             options.onActionReady(action);

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
@@ -2,7 +2,6 @@ import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
 
 import { Component, useState, useRef, useEffect } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
-import { Deferred } from "@web/core/utils/concurrency";
 
 export class SettingsPage extends Component {
     static template = "web.SettingsPage";
@@ -74,14 +73,14 @@ export class SettingsPage extends Component {
         );
     }
     onRightSwipe() {
-        this.tabChangeProm = new Deferred();
+        this.tabChangeProm = Promise.withResolvers();
         this.state.selectedTab = this.props.modules[this.getCurrentIndex() - 1].key;
-        return this.tabChangeProm;
+        return this.tabChangeProm.promise;
     }
     onLeftSwipe() {
-        this.tabChangeProm = new Deferred();
+        this.tabChangeProm = Promise.withResolvers();
         this.state.selectedTab = this.props.modules[this.getCurrentIndex() + 1].key;
-        return this.tabChangeProm;
+        return this.tabChangeProm.promise;
     }
 
     scrollToSelectedTab() {

--- a/addons/web/static/tests/legacy/helpers/utils.js
+++ b/addons/web/static/tests/legacy/helpers/utils.js
@@ -1,6 +1,5 @@
 /** @odoo-module alias=@web/../tests/helpers/utils default=false */
 
-import { Deferred } from "@web/core/utils/concurrency";
 import { patch } from "@web/core/utils/patch";
 import { isVisible } from "@web/core/utils/ui";
 import { registerCleanup } from "./cleanup";
@@ -45,10 +44,6 @@ export function getFixture() {
 export async function nextTick() {
     await new Promise((resolve) => window.requestAnimationFrame(resolve));
     await new Promise((resolve) => setTimeout(resolve));
-}
-
-export function makeDeferred() {
-    return new Deferred();
 }
 
 function findElement(el, selector) {

--- a/addons/web/static/tests/legacy/utils.js
+++ b/addons/web/static/tests/legacy/utils.js
@@ -5,7 +5,6 @@ import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import {
     click as webClick,
     getFixture,
-    makeDeferred,
     triggerEvents as webTriggerEvents,
 } from "@web/../tests/helpers/utils";
 
@@ -241,7 +240,7 @@ class Contains {
      */
     run() {
         this.done = false;
-        this.def = makeDeferred();
+        this.def = Promise.withResolvers();
         this.scrollListeners = new Set();
         this.onScroll = () => this.runOnce("after scroll");
         if (!this.runOnce("immediately")) {
@@ -267,7 +266,7 @@ class Contains {
                 }
             });
         }
-        return this.def;
+        return this.def.promise;
     }
 
     /**


### PR DESCRIPTION
This commit deprecates the `Deferred` class (i.e. basically a
resolvable/rejectable extension of `Promise`), to promote the usage of
the standard `Promise.withResolvers()` instead, which provides similar
features.

While being supported by every modern browsers,
`Promise.withResolvers()` is still relatively new (Baseline since March
2024), a polyfill is provided and can be included in the asset bundles
requiring to support a wider range of browsers (i.e.
website/frontend...).

Reference:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers