### PR TITLE
[IMP] html_editor: make links clickable in history dialog

### DIFF
--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.scss
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.scss
@@ -40,6 +40,10 @@
 .history-view-inner {
     min-height: 0;
 
+    [data-embedded] {
+        pointer-events: none;
+    }
+
     .embedded-history-dialog-placeholder {
         border: $border-width * 2 dashed $border-color;
 

--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.xml
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.xml
@@ -119,9 +119,7 @@
                                     <t t-call="html_editor.HistoryDialog.LoadingSpinner"/>
                                 </t>
                                 <t t-elif="this.state.revisionContent?.length">
-                                    <div class="pe-none">
-                                        <HtmlViewer config="this.getConfig('revisionContent')"/>
-                                    </div>
+                                    <HtmlViewer config="this.getConfig('revisionContent')"/>
                                 </t>
                                 <t t-else="" t-out="this.props.noContentHelper" />
                             </div>
@@ -135,7 +133,7 @@
                                     <div t-attf-class="history-comparison-split position-relative h-100 #{!this.state.isComparisonSplit ? 'd-none' : ''}">
                                         <HtmlViewer config="this.getConfig('revisionComparisonSplit')"/>
                                     </div>
-                                    <div t-attf-class="pe-none history-comparison-unified #{this.state.isComparisonSplit ? 'd-none' : ''}">
+                                    <div t-attf-class="history-comparison-unified #{this.state.isComparisonSplit ? 'd-none' : ''}">
                                         <HtmlViewer config="this.getConfig('revisionComparison')"/>
                                     </div>
                                 </t>

--- a/addons/html_editor/static/tests/history_dialog.test.js
+++ b/addons/html_editor/static/tests/history_dialog.test.js
@@ -1,0 +1,33 @@
+import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
+import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
+import { getService, mountWithCleanup, onRpc } from "@web/../tests/web_test_helpers";
+import { MainComponentsContainer } from "@web/core/main_components_container";
+
+test("HistoryDialog links are clickable and open in new tab", async () => {
+    await mountWithCleanup(MainComponentsContainer);
+    onRpc(({ method }) =>
+        method === "read"
+            ? [
+                  {
+                      create_date: "2023-01-01 12:00:00",
+                      create_uid: [1, "User"],
+                      description: '<a href="https://odoo.com">Link</a>',
+                  },
+              ]
+            : ""
+    );
+
+    getService("dialog").add(HistoryDialog, {
+        recordId: 1,
+        recordModel: "res.partner",
+        historyMetadata: [],
+        versionedFieldName: "description",
+        restoreRequested: () => {},
+    });
+
+    await waitFor(".html-history-loaded");
+    expect(".history-content-view a").toHaveAttribute("href", "https://odoo.com");
+    expect(".history-content-view a").toHaveAttribute("target", "_blank");
+    expect(".history-content-view .pe-none").toHaveCount(0);
+});


### PR DESCRIPTION
Before: Links in task/todo description history were blocked by pointer-events:none, making URLs hidden behind labels inaccessible without restoring old versions.

After: Links are now clickable and open in new tabs. The pe-none wrapper was removed since HtmlViewer already handles readonly content properly with its built-in retargetLinks() method.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
