### PR TITLE
[IMP] account{,_peppol}: Backport dynamic selection field + Reduce list of EAS countries

### DIFF
--- a/addons/account/static/src/components/dynamic_selection/dynamic_selection.js
+++ b/addons/account/static/src/components/dynamic_selection/dynamic_selection.js
@@ -1,0 +1,66 @@
+/** @odoo-module **/
+
+import {registry} from "@web/core/registry";
+import {SelectionField} from "@web/views/fields/selection/selection_field";
+
+export class DynamicSelectionField extends SelectionField {
+
+    get availableOptions() {
+        var availableFieldData = this.props.record.data[this.props.available_field];
+        return availableFieldData ? availableFieldData.split(",") : [];
+    }
+
+    /**
+     * Filter the options with the accepted available options.
+     * @override
+     */
+    get options() {
+        const availableOptions = this.availableOptions;
+        return super.options.filter(x => availableOptions.includes(x[0]));
+    }
+
+    /**
+     * In dynamic selection field, sometimes we can have no options available.
+     * This override handles that case by adding optional chaining when accessing the found options.
+     * @override
+     */
+    get string() {
+        if (this.type === "selection") {
+            if (this.props.record.data[this.props.name] === false) {
+                return "";
+            }
+            const foundOption = this.options.find((o) => o[0] === this.props.record.data[this.props.name]);
+            return foundOption ? foundOption[1] : "";
+        }
+        return super.string;
+    }
+
+}
+
+DynamicSelectionField.props = {
+    ...SelectionField.props,
+    available_field: {type: String}
+}
+
+DynamicSelectionField.extractProps = ({attrs}) => {
+    return {
+        ...SelectionField.extractProps({attrs}),
+        available_field: attrs.options.available_field,
+    };
+};
+
+/*
+EXAMPLE USAGE:
+
+In python:
+the_available_field = fields.Char()  # string of comma separated available selection field keys
+the_selection_field = fields.Selection([ ... ])
+
+In the views:
+<field name="the_available_field" column_invisible="1"/>
+<field name="the_selection_field"
+       widget="dynamic_selection"
+       options="{'available_field': 'the_available_field'}"/>
+ */
+
+registry.category("fields").add("dynamic_selection", DynamicSelectionField);

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -33,7 +33,10 @@
                                         <label string="Peppol EAS"
                                                for="account_peppol_eas"
                                                class="col-lg-3 o_light_label"/>
-                                        <field name="account_peppol_eas"/>
+                                        <field name="account_peppol_eas_identifier" invisible="1"/>
+                                        <field name="account_peppol_eas"
+                                               widget="dynamic_selection"
+                                               options="{'available_field': 'account_peppol_eas_identifier'}"/>
                                     </div>
                                     <div class="row">
                                         <label string="Peppol Endpoint"

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -29,7 +29,10 @@
                              To generate complete electronic invoices, also set a country for this partner.
                         </div>
                         <field name="ubl_cii_format" widget="selection"/>
-                        <field name="peppol_eas" widget="selection"
+                        <field name="peppol_eas_identifier" invisible="1"/>
+                        <field name="peppol_eas"
+                               widget="dynamic_selection"
+                               options="{'available_field': 'peppol_eas_identifier'}"
                                attrs="{'invisible': [('ubl_cii_format', '=', False)]}"/>
                         <field name="peppol_endpoint"
                                attrs="{'invisible': [('ubl_cii_format', '=', False)]}"/>


### PR DESCRIPTION
**Commit 1: [IMP] account: add dynamic selection field** 

Backport of commit https://github.com/odoo/odoo/commit/f256b3c9bbc2d61b4edd6ad86f9dd13800e519d4.

This commit creates a new widget "dynamic_selection", that enables us to create selection fields with dynamic options on the views.

To make it possible, we need 2 fields; one as the string of available
options separated by comma, and the other as the actual selection field
we want to make dynamic.

The available field are passed in the xml through the options of the
widget. Of course, the mentioned available must also be present (usually with invisible=1) for this field to function. Otherwise, it will just show an empty selection.

Task-none

---

**Commit 2: [IMP] account_peppol: reduce list of EAS countries** 

This commit aims to improve the UX for Peppol Registration in Configuration and the Partner form view by reducing the list of available EAS fields to just the ones relevant to the respective country_code.

Task-5237054

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
