### PR TITLE
[FIX] html_editor, mass_mailing: deepest position inside non-editable

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -13,7 +13,6 @@ import {
 } from "../utils/dom";
 import {
     allowsParagraphRelatedElements,
-    getDeepestPosition,
     isContentEditable,
     isContentEditableAncestor,
     isEmptyBlock,
@@ -29,6 +28,7 @@ import {
     listElementSelector,
     isEditorTab,
     isPhrasingContent,
+    getDeepestEditablePosition,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -453,7 +453,7 @@ export class DomPlugin extends Plugin {
 
         if (!this.config.allowInlineAtRoot && this.isEditionBoundary(lastPosition[0])) {
             // Correct the position if it happens to be in the editable root.
-            lastPosition = getDeepestPosition(...lastPosition);
+            lastPosition = getDeepestEditablePosition(...lastPosition);
         }
         this.dependencies.selection.setSelection(
             { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -17,7 +17,7 @@ import {
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { parseHTML } from "@html_editor/utils/html";
 import { beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
-import { click, queryFirst } from "@odoo/hoot-dom";
+import { click, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import {
     App,
@@ -582,13 +582,17 @@ describe("Selection after embedded component insertion", () => {
         });
         editor.shared.dom.insert(parseHTML(editor.document, `<div data-embedded="counter"></div>`));
         editor.shared.history.addStep();
-        await animationFrame();
+        // Insertion triggers selectionchange & addStep creates selection
+        // placeholder.fixSelectionInsideEditableRoot moves selection into it,
+        // trigger another selectionchange that removes selection placeholder.
+        // So we must wait for the o-we-hint.
+        await waitFor(".o-we-hint");
         cleanHints(editor);
         expect(getContent(el)).toBe(
             unformat(`
                 <p data-selection-placeholder=""><br></p>
-                <div data-embedded="counter" data-oe-protected="true" contenteditable="false">[]<span class="counter">Counter:0</span></div>
-                <p data-selection-placeholder=""><br></p>`)
+                <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
+                <p>[]<br></p>`)
         );
     });
     test("block at the end of paragraph", async () => {
@@ -597,13 +601,17 @@ describe("Selection after embedded component insertion", () => {
         });
         editor.shared.dom.insert(parseHTML(editor.document, `<div data-embedded="counter"></div>`));
         editor.shared.history.addStep();
-        await animationFrame();
+        // Insertion triggers selectionchange & addStep creates selection
+        // placeholder.fixSelectionInsideEditableRoot moves selection into it,
+        // trigger another selectionchange that removes selection placeholder.
+        // So we must wait for the o-we-hint.
+        await waitFor(".o-we-hint");
         cleanHints(editor);
         expect(getContent(el)).toBe(
             unformat(`
                 <p>a</p>
-                <div data-embedded="counter" data-oe-protected="true" contenteditable="false">[]<span class="counter">Counter:0</span></div>
-                <p data-selection-placeholder=""><br></p>`)
+                <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
+                <p>[]<br></p>`)
         );
     });
     test("block at the start of paragraph", async () => {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -928,10 +928,14 @@ test("Embed video by pasting video URL", async () => {
 
     // Press Enter to select first option in the powerbox ("Embed Youtube Video").
     await press("Enter");
-    await animationFrame();
+    // Insertion triggers selectionchange & addStep creates selection
+    // placeholder.fixSelectionInsideEditableRoot moves selection into it,
+    // trigger another selectionchange that removes selection placeholder.
+    // So we must wait for the o-we-hint.
+    await waitFor(".o-we-hint");
     const videoIframe = queryOne("div.media_iframe_video");
     expect(videoIframe.nextElementSibling).toHaveOuterHTML(
-        '<div class="o-paragraph" data-selection-placeholder=""><br></div>'
+        `<div class="o-paragraph o-we-hint" o-we-hint-text="Type &quot;/&quot; for commands"><br></div>`
     );
     expect(
         `div.media_iframe_video iframe[data-src="https://www.youtube.com/embed/${videoId}"]`
@@ -1180,13 +1184,11 @@ test("add Vimeo video link in 'Videos' tab of MediaDialog", async () => {
     });
     setSelectionInHtmlField();
 
-    await onRpc("/html_editor/video_url/data", async () => {
-        return {
-            video_id: "1128489814",
-            platform: "vimeo",
-            embed_url: vimeoVideoLink,
-        };
-    });
+    await onRpc("/html_editor/video_url/data", async () => ({
+        video_id: "1128489814",
+        platform: "vimeo",
+        embed_url: vimeoVideoLink,
+    }));
 
     // Insert Vimeo video link
     await insertText(htmlEditor, "/video");

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -8,6 +8,7 @@ import { cleanHints } from "../_helpers/dispatch";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { addStep } from "../_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
+import { waitFor } from "@odoo/hoot-dom";
 
 function span(text) {
     const span = document.createElement("span");
@@ -267,9 +268,17 @@ describe("collapsed selection", () => {
             parseHTML(editor.document, `<p data-oe-protected="true">in</p>`).firstElementChild
         );
         editor.shared.history.addStep();
+        // Insertion triggers selectionchange & addStep creates selection
+        // placeholder.fixSelectionInsideEditableRoot moves selection into it,
+        // trigger another selectionchange that removes selection placeholder.
+        // So we must wait for the o-we-hint.
+        await waitFor(".o-we-hint");
         cleanHints(editor);
         expect(getContent(editor.editable, { sortAttrs: true })).toBe(
-            `<p data-selection-placeholder=""><br></p><p contenteditable="false" data-oe-protected="true">in[]</p><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <p contenteditable="false" data-oe-protected="true">in</p>
+                <p>[]<br></p>`)
         );
     });
 

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
@@ -30,7 +30,7 @@ registry.category("web_tour.tours").add('mass_mailing_dynamic_placeholder_tour',
         },
          {
             content: "Insert text inside editable",
-            trigger: ':iframe .odoo-editor-editable',
+            trigger: ":iframe .odoo-editor-editable .o_mail_no_options",
             async run(actions) {
                 await actions.editor(`/`);
                 const iframe = document.querySelector("iframe");


### PR DESCRIPTION
### Desired behavior after PR is merged:

- Introduces `getDeepestEditablePosition`, a helper that resolves a given [node, offset] to the deepest editable descendant.
- If deepest position detected by `getDeepestPosition` lies inside a non-editable element, the method walks up to nearest editable ancestor and computes a corrected offset that places the position just before or after the non-editable region.

task-5200822

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
