### PR TITLE
[FIX] account_edi_ubl_cii: correct UBL discount import and align Factur-X export

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -33,24 +33,10 @@
 
                     <!-- Amounts. -->
                     <ram:SpecifiedLineTradeAgreement>
-                        <!-- Line information: unit_price
-                        NB: the gross_price_unit should be the price tax excluded!
-                        if price_unit = 100 and tax 10% price_include -> then the gross_price_unit is 91
-                        -->
-                        <ram:GrossPriceProductTradePrice>
-                            <ram:ChargeAmount t-out="format_monetary(line_vals['gross_price_total_unit'], 2)"/>
-                            <!-- Discount. -->
-                            <ram:AppliedTradeAllowanceCharge t-if="line.discount">
-                                <ram:ChargeIndicator>
-                                    <udt:Indicator t-translation="off">false</udt:Indicator>
-                                </ram:ChargeIndicator>
-                                <ram:ActualAmount t-out="format_monetary(line_vals['price_discount_unit'], 2)"/>
-                            </ram:AppliedTradeAllowanceCharge>
-                        </ram:GrossPriceProductTradePrice>
                         <!-- Line unit price, with discount applied -->
                         <ram:NetPriceProductTradePrice>
                             <ram:ChargeAmount
-                                t-out="format_monetary(line_vals['price_subtotal_unit'], 2)"/>
+                                t-out="format_monetary(line_vals['gross_price_total_unit'], 2)"/>
                         </ram:NetPriceProductTradePrice>
                     </ram:SpecifiedLineTradeAgreement>
 
@@ -88,8 +74,12 @@
                                     <udt:Indicator t-esc="allowance_charge_vals['indicator']"/>
                                 </ram:ChargeIndicator>
                                 <ram:ActualAmount t-esc="format_monetary(allowance_charge_vals['amount'], 2)"/>
-                                <ram:ReasonCode t-esc="allowance_charge_vals['reason_code']"/>
-                                <ram:Reason t-esc="allowance_charge_vals['reason']"/>
+                                <ram:ReasonCode
+                                    t-if="allowance_charge_vals.get('reason_code')"
+                                    t-esc="allowance_charge_vals['reason_code']"/>
+                                <ram:Reason
+                                    t-if="allowance_charge_vals.get('reason')"
+                                    t-esc="allowance_charge_vals['reason']"/>
                             </ram:SpecifiedTradeAllowanceCharge>
                         </t>
 

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -690,10 +690,10 @@ class AccountEdiCommon(models.AbstractModel):
         quantity = billed_qty * qty_factor
 
         # price_unit
-        if gross_price_unit is not None:
-            price_unit = gross_price_unit / basis_qty
-        elif net_price_unit is not None:
-            price_unit = (net_price_unit + rebate) / basis_qty
+        if net_price_unit is not None:
+            price_unit = net_price_unit / basis_qty
+        elif gross_price_unit is not None:
+            price_unit = (gross_price_unit - rebate) / basis_qty
         elif price_subtotal is not None:
             price_unit = (price_subtotal + allow_charge_amount) / (billed_qty or 1)
         else:

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -968,7 +968,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'rebate': './{*}Price/{*}AllowanceCharge/{*}Amount',
             'net_price_unit': './{*}Price/{*}PriceAmount',
             'billed_qty':  './{*}InvoicedQuantity' if invoice_line.move_id.move_type in ('in_invoice', 'out_invoice') or qty_factor == -1 else './{*}CreditedQuantity',
-            'allowance_charge': './/{*}AllowanceCharge',
+            'allowance_charge': './{*}AllowanceCharge',
             'allowance_charge_indicator': './{*}ChargeIndicator',
             'allowance_charge_amount': './{*}Amount',
             'allowance_charge_reason': './{*}AllowanceChargeReason',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case1.xml
@@ -26,9 +26,6 @@
                 <ram:Name>product_a</ram:Name>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>99.00</ram:ChargeAmount>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>99.00</ram:ChargeAmount>
                 </ram:NetPriceProductTradePrice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case2.xml
@@ -26,9 +26,6 @@
                 <ram:Name>product_a</ram:Name>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>98.00</ram:ChargeAmount>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>98.00</ram:ChargeAmount>
                 </ram:NetPriceProductTradePrice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case3.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case3.xml
@@ -26,9 +26,6 @@
                 <ram:Name>product_a</ram:Name>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>99.00</ram:ChargeAmount>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>99.00</ram:ChargeAmount>
                 </ram:NetPriceProductTradePrice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice.xml
@@ -24,17 +24,8 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>990.00</ram:ChargeAmount>
-          <ram:AppliedTradeAllowanceCharge>
-            <ram:ChargeIndicator>
-              <udt:Indicator>false</udt:Indicator>
-            </ram:ChargeIndicator>
-            <ram:ActualAmount>99.00</ram:ActualAmount>
-          </ram:AppliedTradeAllowanceCharge>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
-          <ram:ChargeAmount>891.00</ram:ChargeAmount>
+          <ram:ChargeAmount>990.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
       </ram:SpecifiedLineTradeAgreement>
       <ram:SpecifiedLineTradeDelivery>
@@ -46,6 +37,12 @@
           <ram:CategoryCode>S</ram:CategoryCode>
           <ram:RateApplicablePercent>21.0</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeAllowanceCharge>
+          <ram:ChargeIndicator>
+            <udt:Indicator>false</udt:Indicator>
+          </ram:ChargeIndicator>
+          <ram:ActualAmount>198.00</ram:ActualAmount>
+        </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
           <ram:LineTotalAmount>1782.00</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
@@ -59,9 +56,6 @@
         <ram:Name>product_b</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>100.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>100.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
@@ -88,9 +82,6 @@
         <ram:Name>product_b</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>100.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>100.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice_tax_incl.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice_tax_incl.xml
@@ -24,9 +24,6 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>95.24</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>95.24</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
@@ -53,9 +50,6 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>100.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>100.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
@@ -82,17 +76,8 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>190.48</ram:ChargeAmount>
-          <ram:AppliedTradeAllowanceCharge>
-            <ram:ChargeIndicator>
-              <udt:Indicator>false</udt:Indicator>
-            </ram:ChargeIndicator>
-            <ram:ActualAmount>19.05</ram:ActualAmount>
-          </ram:AppliedTradeAllowanceCharge>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
-          <ram:ChargeAmount>171.43</ram:ChargeAmount>
+          <ram:ChargeAmount>190.48</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
       </ram:SpecifiedLineTradeAgreement>
       <ram:SpecifiedLineTradeDelivery>
@@ -104,6 +89,12 @@
           <ram:CategoryCode>S</ram:CategoryCode>
           <ram:RateApplicablePercent>5.0</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeAllowanceCharge>
+          <ram:ChargeIndicator>
+            <udt:Indicator>false</udt:Indicator>
+          </ram:ChargeIndicator>
+          <ram:ActualAmount>19.05</ram:ActualAmount>
+        </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
           <ram:LineTotalAmount>171.43</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
@@ -117,17 +108,8 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>200.00</ram:ChargeAmount>
-          <ram:AppliedTradeAllowanceCharge>
-            <ram:ChargeIndicator>
-              <udt:Indicator>false</udt:Indicator>
-            </ram:ChargeIndicator>
-            <ram:ActualAmount>20.00</ram:ActualAmount>
-          </ram:AppliedTradeAllowanceCharge>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
-          <ram:ChargeAmount>180.00</ram:ChargeAmount>
+          <ram:ChargeAmount>200.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
       </ram:SpecifiedLineTradeAgreement>
       <ram:SpecifiedLineTradeDelivery>
@@ -139,6 +121,12 @@
           <ram:CategoryCode>S</ram:CategoryCode>
           <ram:RateApplicablePercent>5.0</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeAllowanceCharge>
+          <ram:ChargeIndicator>
+            <udt:Indicator>false</udt:Indicator>
+          </ram:ChargeIndicator>
+          <ram:ActualAmount>20.00</ram:ActualAmount>
+        </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
           <ram:LineTotalAmount>180.00</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_refund.xml
@@ -24,17 +24,8 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>990.00</ram:ChargeAmount>
-          <ram:AppliedTradeAllowanceCharge>
-            <ram:ChargeIndicator>
-              <udt:Indicator>false</udt:Indicator>
-            </ram:ChargeIndicator>
-            <ram:ActualAmount>99.00</ram:ActualAmount>
-          </ram:AppliedTradeAllowanceCharge>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
-          <ram:ChargeAmount>891.00</ram:ChargeAmount>
+          <ram:ChargeAmount>990.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
       </ram:SpecifiedLineTradeAgreement>
       <ram:SpecifiedLineTradeDelivery>
@@ -46,6 +37,12 @@
           <ram:CategoryCode>S</ram:CategoryCode>
           <ram:RateApplicablePercent>21.0</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeAllowanceCharge>
+          <ram:ChargeIndicator>
+            <udt:Indicator>false</udt:Indicator>
+          </ram:ChargeIndicator>
+          <ram:ActualAmount>198.00</ram:ActualAmount> 
+        </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
           <ram:LineTotalAmount>1782.00</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
@@ -59,9 +56,6 @@
         <ram:Name>product_b</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>100.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>100.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
@@ -88,9 +82,6 @@
         <ram:Name>product_b</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>100.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>100.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_positive_discount_price_unit.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_positive_discount_price_unit.xml
@@ -24,9 +24,6 @@
         <ram:Name>product_a</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>100.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>100.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>
@@ -53,9 +50,6 @@
         <ram:Name>product_b</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
-        <ram:GrossPriceProductTradePrice>
-          <ram:ChargeAmount>50.00</ram:ChargeAmount>
-        </ram:GrossPriceProductTradePrice>
         <ram:NetPriceProductTradePrice>
           <ram:ChargeAmount>50.00</ram:ChargeAmount>
         </ram:NetPriceProductTradePrice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_test_import_partner.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_test_import_partner.xml
@@ -26,9 +26,6 @@
                 <ram:Name>product_a</ram:Name>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>0.00</ram:ChargeAmount>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>0.00</ram:ChargeAmount>
                 </ram:NetPriceProductTradePrice>


### PR DESCRIPTION
This commit fixes an issue in how UBL BIS 3 discounts were imported and aligns the Factur-X export to be consistent with this new logic.

UBL BIS 3 Import:
- Update to use "net price" over "gross price" for the invoice/order line unit price when importing
This is more of a change on business meaning than a technical one. In my opinion, `cac:Price/cac:AllowanceCharge` explains how the supplier arrived at the net unit price, whereas `cac:LineItem/cac:AllowanceCharge` acts as an actual line level discount.
- Update `xpath_dict['allowance_charge']` to only get line level nodes. Previously got Price level discount as well, without factoring in the quantity
This is the actual bug I found out but technically does not break the system since the aggregated `allowance_charge` value is only used for fallback calculation when some fields (both net price and gross price, where at least net price is a mandatory field) are missing. So likely this code will never execute with correctly formatted XML files.

Factur-X (CII) Alignment:
- Updated FacturX's export code as well to include line level discount as AllowanceCharge node on line instead of Amount node. This aligns the behavior more closely to the export of UBL BIS.
The changes to the base import logic broke the Factur-X export, which previously exported discounts inside the price block (ram:SpecifiedLineTradeAgreement). To align with the new logic, the Factur-X export is updated to create discounts at the line level instead of the price level. The CII 22 Qweb template is also updated to render this new structure, and the corresponding Factur-X unit test values are updated to match.
This change will affect line unit price and line discount only, others are left unchanged.

[Task-5252977](https://www.odoo.com/odoo/my-tasks/5252977)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
