### PR TITLE
[FIX] l10n_cl: prevent traceback when confirming an invoice

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -223,7 +223,7 @@ class AccountMove(models.Model):
                     if export else currency_round_other_currency.round(self.amount_total),
                 'round_currency': currency_round_other_currency.decimal_places,
                 'name': self._l10n_cl_normalize_currency_name(currency_round_other_currency.name),
-                'rate': round(abs(self.amount_total_signed) / self.amount_total, 4),
+                'rate': round(abs(self.amount_total_signed) / self.amount_total, 4) if self.amount_total else 1,
             }
         for line in self.line_ids:
             if line.tax_line_id and line.tax_line_id.l10n_cl_sii_code == 14:


### PR DESCRIPTION
Steps to reproduce:
--------------------
1. Install l10n_cl and switch to the CL company
2. Create a new invoice:
   - Change the currency to a value different from the company currency
     (e.g., from CLP to USD)
   - Add an invoice line with a price value of 0
   - Remove the default tax value
3. Try to confirm the invoice

Issue:
------
A traceback occurs:
`ZeroDivisionError: float division by zero`

Cause:
------
Since the price value is 0, the `amount_total` of the move becomes 0. 
When computing the currency rate, it tries to divides by `amount_total`, resulting in a ZeroDivisionError.

Solution:
---------
Add a conditional check before division to ensure the `amount_total` is non-zero

Related enterprise PR: https://github.com/odoo/enterprise/pull/99518

opw-5247058

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
