### PR TITLE
[FIX] mail: error when computing last message seen by all

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -596,7 +596,7 @@ export class Thread extends Record {
                 return;
             }
             const otherMembers = this.channelMembers.filter((member) =>
-                member.persona.notEq(this.store.self)
+                member.notEq(this.selfMember)
             );
             if (otherMembers.length === 0) {
                 return;


### PR DESCRIPTION
The `lastMessageSeenByAllId` compute function sometimes crashes when the persona linked to a member is unknown. This occurs because the compute function compares the member's persona to determine if it belongs to the current user. However, members are not always sent along with their persona.

The compute function should instead compare the member directly to the current user's member. This fixes the issue and makes more sense.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
