### PR TITLE
[FIX] pos_online_payment: skip confirm page issue

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -289,13 +289,9 @@ class PaymentPortal(payment_portal.PaymentPortal):
         tx_sudo._process_pos_online_payment()
 
         rendering_context['state'] = 'success'
-        self._on_payment_successful(pos_order_sudo)
         if exit_route:
             return request.redirect(exit_route)
         return self._render_pay_confirmation(rendering_context)
 
     def _render_pay_confirmation(self, rendering_context):
         return request.render('pos_online_payment.pay_confirmation', rendering_context)
-
-    def _on_payment_successful(self, pos_order):
-        return

--- a/addons/pos_online_payment/tests/online_payment_common.py
+++ b/addons/pos_online_payment/tests/online_payment_common.py
@@ -28,7 +28,7 @@ class OnlinePaymentCommon(PaymentHttpCommon):
     def _fake_open_pos_order_pay_confirmation_page(self, pos_order_id, access_token, tx_id, exit_route=None):
         self._fake_http_get_request(PaymentPortal._get_landing_route(pos_order_id, access_token, tx_id=tx_id, exit_route=exit_route))
 
-    def _fake_online_payment(self, pos_order_id, access_token, expected_payment_provider_id, exit_route=None):
+    def _fake_online_payment(self, pos_order_id, access_token, expected_payment_provider_id, exit_route=None, confirmation_page=True):
         payment_context = self._fake_open_pos_order_pay_page(pos_order_id, access_token)
 
         # Code inspired by addons/payment/tests/test_flows.py
@@ -53,4 +53,5 @@ class OnlinePaymentCommon(PaymentHttpCommon):
             processing_values = self._fake_request_pos_order_pay_transaction_page(pos_order_id, route_values)
         tx_sudo = self._get_tx(processing_values['reference'])
         tx_sudo._set_done()
-        self._fake_open_pos_order_pay_confirmation_page(pos_order_id, access_token, tx_sudo.id, exit_route=exit_route)
+        if confirmation_page:
+            self._fake_open_pos_order_pay_confirmation_page(pos_order_id, access_token, tx_sudo.id, exit_route=exit_route)

--- a/addons/pos_online_payment_self_order/tests/__init__.py
+++ b/addons/pos_online_payment_self_order/tests/__init__.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_self_order_frontend
 from . import test_self_order_mobile
+from . import test_self_order_fake_payment

--- a/addons/pos_online_payment_self_order/tests/test_self_order_fake_payment.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_fake_payment.py
@@ -1,0 +1,82 @@
+import odoo.tests
+from odoo import Command
+
+from odoo.addons.pos_online_payment_self_order.tests.test_self_order_mobile import (
+    TestSelfOrderMobile,
+)
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderFakePayment(TestSelfOrderMobile):
+
+    def test_online_payment_mobile(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_order_online_payment_method_id': self.online_payment_method.id,
+            'use_presets': False,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_online_payment_mobile_self_order_preparation_changes")
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft')
+
+        self._fake_online_payment(order.id, order.access_token, self.payment_provider.id, exit_route="/", confirmation_page=True)
+        self.assertEqual(order.state, 'paid')
+
+    def test_online_payment_mobile_no_confirmation_page(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_order_online_payment_method_id': self.online_payment_method.id,
+            'use_presets': False,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_online_payment_mobile_self_order_preparation_changes")
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft')
+
+        self._fake_online_payment(order.id, order.access_token, self.payment_provider.id, exit_route="/", confirmation_page=False)
+        self.assertEqual(order.state, 'paid')
+
+    def test_online_payment_kiosk(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_service_mode': 'counter',
+            'payment_method_ids': [Command.set(self.online_payment_method.ids)],
+            'use_presets': False,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_online_payment_kiosk_qr_code")
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft')
+
+        self._fake_online_payment(order.id, order.access_token, self.payment_provider.id, exit_route="/", confirmation_page=True)
+        self.assertEqual(order.state, 'paid')
+
+    def test_online_payment_kiosk_no_confirmation_page(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_service_mode': 'counter',
+            'payment_method_ids': [Command.set(self.online_payment_method.ids)],
+            'use_presets': False,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_online_payment_kiosk_qr_code")
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft')
+
+        self._fake_online_payment(order.id, order.access_token, self.payment_provider.id, exit_route="/", confirmation_page=False)
+        self.assertEqual(order.state, 'paid')

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -1,11 +1,20 @@
 
 import odoo.tests
 from odoo import Command
-from odoo.addons.pos_online_payment.tests.online_payment_common import OnlinePaymentCommon
+
+from odoo.addons.pos_online_payment.tests.online_payment_common import (
+    OnlinePaymentCommon,
+)
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
 
 @odoo.tests.tagged("post_install", "-at_install")
 class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
+
+    def _fake_online_payment(self, pos_order_id, access_token, expected_payment_provider_id, exit_route=None, confirmation_page=True):
+        res = super()._fake_online_payment(pos_order_id, access_token, expected_payment_provider_id, exit_route=exit_route, confirmation_page=confirmation_page)
+        self.env.ref('payment.cron_post_process_payment_tx').method_direct_trigger()  # Cron triggered in _handle_notification_data()
+        return res
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
..., pos_online_payment_self_order
Task: [#5217268](https://www.odoo.com/odoo/project/1737/tasks/5217268)

---

Previously, when an online payment was made, the user was supposed to be redirected to a payment confirmation page, which triggered the payment transaction post-processing.
However, in some cases, the user never reaches this page.
For example: the user sees that the payment succeeded in their banking app and closes the tab before being redirected to the confirmation page.

To still process the orders, a cron runs every 10 minutes to post-process transactions that were not processed yet.
However, for POS self-orders this is not ideal: we need the order to be processed as soon as possible since we are in direct contact with the user.
A situation where the customer insists their payment went through but the cashier sees no updated order creates unnecessary confusion.

---

To fix this, we now trigger the cron directly after receiving the callback from the payment provider.
This ensures that the transaction (and therefore the order) is always post-processed immediately and kept up-to-date, even if the user never reaches the confirmation page.