### PR TITLE
[FIX] point_of_sale: unset module_pos_* flags on uninstall

### DIFF
--- a/addons/pos_discount/__init__.py
+++ b/addons/pos_discount/__init__.py
@@ -2,3 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+
+
+def uninstall_hook(env):
+    env['pos.config'].search([('module_pos_discount', '=', True)]).module_pos_discount = False

--- a/addons/pos_discount/__manifest__.py
+++ b/addons/pos_discount/__manifest__.py
@@ -33,4 +33,5 @@ discount to a customer.
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'uninstall_hook': 'uninstall_hook',
 }

--- a/addons/pos_hr/__init__.py
+++ b/addons/pos_hr/__init__.py
@@ -3,3 +3,7 @@
 from . import models
 from . import report
 from . import wizard
+
+
+def uninstall_hook(env):
+    env['pos.config'].search([('module_pos_hr', '=', True)]).module_pos_hr = False

--- a/addons/pos_hr/__manifest__.py
+++ b/addons/pos_hr/__manifest__.py
@@ -35,4 +35,5 @@ The actual till still requires one user but an unlimited number of employees can
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'uninstall_hook': 'uninstall_hook',
 }

--- a/addons/pos_restaurant/__init__.py
+++ b/addons/pos_restaurant/__init__.py
@@ -11,3 +11,7 @@ def _auto_install_pos_urban_piper_with_demo(env):
     module_pos_restaurant = env['ir.module.module']._get('pos_restaurant')
     if module_pos_restaurant.demo and module_pos_urban_piper and module_pos_urban_piper.state == 'uninstalled':
         module_pos_urban_piper.button_install()
+
+
+def uninstall_hook(env):
+    env['pos.config'].search([('module_pos_restaurant', '=', True)]).module_pos_restaurant = False

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -53,4 +53,5 @@ This module adds several features to the Point of Sale that are specific to rest
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'uninstall_hook': 'uninstall_hook',
 }

--- a/addons/pos_sms/__init__.py
+++ b/addons/pos_sms/__init__.py
@@ -1,1 +1,5 @@
 from . import models
+
+
+def uninstall_hook(env):
+    env['pos.config'].search([('module_pos_sms', '=', True)]).module_pos_sms = False

--- a/addons/pos_sms/__manifest__.py
+++ b/addons/pos_sms/__manifest__.py
@@ -18,4 +18,5 @@
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'uninstall_hook': 'uninstall_hook',
 }


### PR DESCRIPTION
PURPOSE:
------------------
Ensure POS configuration flags are reset when optional POS modules (e.g., pos_restaurant) are uninstalled.

STEPS TO REPRODUCE:
----------------------
1. Enable Restaurant in POS config (module_pos_restaurant=True).
2. Uninstall pos_restaurant. → The “Bar/Restaurant” option in POS config remains checked.

FIX:
------------------
Added uninstall_hook in __init__.py of each POS addon:
- pos_restaurant
- pos_discount
- pos_hr
- pos_sms

Each uninstall hook resets the corresponding module_pos_* flag to False in all pos.config records.

Task-5166200
Related PR- https://github.com/odoo/enterprise/pull/99250
