### PR TITLE
[FIX] stock_account: invalid field currency_id

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -94,7 +94,7 @@ class StockMove(models.Model):
             if computed_value_data['description'] == move.value_justification:
                 move.value_computed_justification = False
             else:
-                value = move.currency_id.format(computed_value_data['value'])
+                value = move.company_currency_id.format(computed_value_data['value'])
                 move.value_computed_justification = self.env._(
                     'Computed value: %(value)s\n%(description)s',
                     value=value, description=computed_value_data['description'])


### PR DESCRIPTION
commit 9c63ac283b89807c23a8a1934eef8074a312c36d
Introduced a bug since it uses the field `currency_id` instead of the correct field `company_currency_id`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
