### PR TITLE
[FIX] website: fix form performance issue

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -53,7 +53,10 @@ class IrModel(models.Model):
     def get_authorized_fields(self, model_name, property_origins):
         """ Return the fields of the given model name as a mapping like method `fields_get`. """
         model = self.env[model_name]
-        fields_get = model.fields_get()
+        fields_get = model.fields_get(attributes=[
+            'required', 'domain', 'readonly', 'type', 'relation',
+            'definition_record', 'definition_record_field', 'string',
+        ])
 
         for val in model._inherits.values():
             fields_get.pop(val, None)


### PR DESCRIPTION
__Before this commit:__
1. Open the website editor
2. Drag & drop a form snippet
3. Click on a form field
=> The style tab takes a while to open. This is especially noticeable
when many modules are installed like on runbot .

__Cause:__
Since [this commit][1], a [`_search` call][2] has been added in the
`join` method of the orm if we are not in `sudo` mode.

This makes the call to `get_authorized_fields` take way more time.

__Description of the fix:__
Avoid this `_search` call by requesting to `fields_get` only the field
attributes needed for `get_authorized_fields`.

[1]: https://github.com/odoo/odoo/commit/6d6a93d7a735728a486f59649d6652c
[2]: https://github.com/odoo/odoo/blob/6d6a93d7a735728a486f59649d6652c/odoo/orm/fields_relational.py#L540

task-5242265