### PR TITLE
[FIX] hr: prevent access error when admin without HR rights creates an employee

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -259,7 +259,8 @@
                     <field name="employee_id" invisible="1"/>
                     <button string="Create employee"
                             type="object" name="action_create_employee"
-                            invisible="not id or share or employee_id"/>
+                            invisible="not id or share or employee_id"
+                            groups="hr.group_hr_user"/>
                             <!-- share is not correctly recomputed because it depends on fields of reified view => invisible before saving (id=False) -->
                 </xpath>
                 <xpath expr="//div[@name='button_box']" position="inside">


### PR DESCRIPTION
**Version:**
- 17.0

**Steps to reproduce:**
- Make sure Marc Demo is an Administrator but has no Employees (HR) access rights.
- Log in as Marc Demo.
- Go to Settings → Users → Create a new user.
- Enter a name and email, then Save.
- You’ll see the "Create Employee" button it appears even though the user has no HR rights.
- Click it → an Access Error occurs.

**Isuue:**
- The "Create Employee" button is visible for users who don’t have HR permissions, causing an access error when clicked.

**Solution:**
- Hide the "Create Employee" button for users without HR access by adding the correct group restriction.

task-5212464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
