### PR TITLE
[FIX] website_sale: Toggle eCommerce category in mega menu

### DIFF
--- a/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
@@ -38,9 +38,8 @@ export class ToggleFetchEcomCategoriesAction extends BuilderAction {
             editingElement,
             true
         );
-        const cls = [...editingElement.firstElementChild.classList].find((cls) =>
-            cls.startsWith("s_mega_menu_")
-        );
+        const target = editingElement.querySelector('[class*="s_mega_menu_"]');
+        const cls = [...target.classList].find((c) => c.startsWith("s_mega_menu_"));
         const templateKey = `${module}${cls}`;
         await this.dependencies.customizeWebsite.loadTemplateKey(templateKey);
         return templateKey;

--- a/addons/website_sale/static/tests/builder/mega_menu_option.test.js
+++ b/addons/website_sale/static/tests/builder/mega_menu_option.test.js
@@ -1,0 +1,33 @@
+import { expect, test } from "@odoo/hoot";
+import { defineWebsiteModels, setupWebsiteBuilder } from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+test("Toggle eCommerce Categories in mega menu", async () => {
+    // Minimal mega menu structure: a dropdown-menu.o_mega_menu with nested
+    // content containing an element with a class starting with s_mega_menu_.
+    const { getEditor } = await setupWebsiteBuilder(`
+        <header>
+            <div class="dropdown">
+                <a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Shop</a>
+                <div class="dropdown-menu o_mega_menu" data-name="Mega Menu" data-oe-field="mega_menu_content" data-oe-model="website.menu" data-oe-id="1">
+                    <div class="some-wrapper">
+                        <section class="s_mega_menu_big_icons" data-snippet="s_mega_menu_big_icons"></section>
+                    </div>
+                </div>
+            </div>
+        </header>
+    `);
+    const editor = getEditor();
+    const megaMenuEl = editor.document.querySelector(".o_mega_menu");
+    expect(megaMenuEl).not.toBe(null);
+
+    // Ensure the mega menu option plugin is available and the builder action
+    // can be resolved.
+    const toggleAction = editor.shared.builderActions.getAction("toggleFetchEcomCategories");
+
+    // Call the action's load/apply cycle and ensure it does not crash.
+    const templateKey = await toggleAction.load({ editingElement: megaMenuEl });
+    expect(templateKey.includes("s_mega_menu_")).toBe(true);
+
+    await toggleAction.apply({ editingElement: megaMenuEl, loadResult: templateKey });
+});


### PR DESCRIPTION
A server traceback would occur when clicking the "eCommerce Categories" toggle in the mega menu's style options.

Steps to reproduce:
1. Go to the Website editor.
2. Add a mega menu to the page header.
3. Edit and Click on the mega menu's
4. In the sidebar, click the "eCommerce Categories" toggle. -> Traceback.

Cause:
When loading it was trying to find a specific class name (starting with `s_mega_menu_`) to identify the snippet. It was hardcoded to only look at the `firstElementChild` of the snippet's container.

This assumption was too rigid. If the first element was a `<p>` tag or another element without the required class, the code would fail to find it. This resulted in an `undefined` value being sent to the server, causing the traceback.

Solution:
Use `querySelector` to search for any element with a class name containing `s_mega_menu_`.

opw-5245777
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
