### PR TITLE
[FIX] html_editor: Add shape on images from Unsplash

### DIFF
--- a/addons/html_editor/static/src/utils/image_processing.js
+++ b/addons/html_editor/static/src/utils/image_processing.js
@@ -186,7 +186,7 @@ export async function loadImageInfo(el, attachmentSrc = "") {
     }
 
     const srcUrl = new URL(src, docHref);
-    let relativeSrc = srcUrl.pathname;
+    let relativeSrc = decodeURI(srcUrl.pathname);
 
     let match = relativeSrc.match(/\/(?:web_editor|html_editor)\/image_shape\/(\w+\.\w+)/);
     if (el.dataset.shape && match) {


### PR DESCRIPTION
Steps to reproduce:
===================
- Connect Unsplash to your database
- Add a snippet on your website page like "Feature wall" for example
- Double click on an existing image
- type at least two words separated by a space like "Sleeping cat"
- select any image from the list.
- Add a shape to this image -> Traceback

Cause:
======
When an image is chosen from Unsplash using a multi-word search, its URL contains encoded characters (e.g., `%20` for a space).

The image processing utility was extracting the `pathname` directly from the image's URL. This path, however, remained URL-encoded. This encoded path was then used in a subsequent RPC call to fetch the original image data before applying the shape.
https://github.com/odoo/odoo/blob/b9435baa1948f54e19f2dd5702a39d073e8eb57d/addons/html_editor/static/src/utils/image_processing.js#L204

This caused the fetch operation to fail, returning an `undefined` value. The attempt to apply a shape to this `undefined` result is what triggered the traceback.

Solution:
=========
The `srcUrl.pathname` is now wrapped in `decodeURIComponent()`.

This function correctly decodes URL-encoded sequences (like `%20`) back into their original characters before the path is sent to the server. The backend now receives a clean, valid path, resolving the traceback.

opw-5241317
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
