### PR TITLE
[FIX] website_livechat: fix non-deterministic lazy bus tour

### DIFF
--- a/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
+++ b/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
@@ -1,62 +1,54 @@
-import { delay } from "@web/core/utils/concurrency";
-import { registry } from "@web/core/registry";
 import { WORKER_STATE } from "@bus/services/worker_service";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat.lazy_frontend_bus", {
     url: "/",
-    steps: () => [
-        {
-            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
-            async run() {
-                await odoo.__WOWL_DEBUG__.root.env.services["mail.store"].isReady;
-                if (odoo.__WOWL_DEBUG__.root.env.services.bus_service.isActive) {
-                    throw new Error("Bus service should not start when loading the page");
-                }
-                if (
-                    odoo.__WOWL_DEBUG__.root.env.services.worker_service.state !==
-                    WORKER_STATE.UNINITIALIZED
-                ) {
-                    throw new Error("Worker service should not start when loading the page");
-                }
+    steps: () => {
+        const busService = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
+        if (busService.isActive) {
+            throw new Error("The bus service should not be started at page load.");
+        }
+        patchWithCleanup(busService, {
+            start() {
+                document.body.classList.add("o-bus-service-started");
+                return super.start(...arguments);
             },
-        },
-        {
-            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
-            run: "click",
-        },
-        {
-            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
-            run: "edit Hello, I need help!",
-        },
-        {
-            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
-            async run(helpers) {
-                if (odoo.__WOWL_DEBUG__.root.env.services.bus_service.isActive) {
-                    throw new Error("Bus service should not start for temporary live chat");
-                }
-                if (
-                    odoo.__WOWL_DEBUG__.root.env.services.worker_service.state !==
-                    WORKER_STATE.UNINITIALIZED
-                ) {
-                    throw new Error("Worker service should not start when loading the page");
-                }
-                await helpers.press("Enter");
-                await delay(1000);
+        });
+        const workerService = odoo.__WOWL_DEBUG__.root.env.services.worker_service;
+        if (workerService._state !== WORKER_STATE.UNINITIALIZED) {
+            throw new Error("The worker service should not be started at page load.");
+        }
+        patchWithCleanup(workerService, {
+            ensureWorkerStarted() {
+                document.body.classList.add("o-worker-service-started");
+                return super.ensureWorkerStarted(...arguments);
             },
-        },
-        {
-            trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Hello, I need help!)",
-            run() {
-                if (!odoo.__WOWL_DEBUG__.root.env.services.bus_service.isActive) {
-                    throw new Error("Bus service should start after first live chat message");
-                }
-                if (
-                    odoo.__WOWL_DEBUG__.root.env.services.worker_service.state !==
-                    WORKER_STATE.INITIALIZED
-                ) {
-                    throw new Error("Worker service should start after first live chat message");
-                }
+        });
+        odoo.__WOWL_DEBUG__.root.env.services["mail.store"].isReady.then(() =>
+            document.body.classList.add("o-mail-store-ready")
+        );
+        return [
+            {
+                trigger:
+                    "body.o-mail-store-ready:not(.o-bus-service-started):not(.o-worker-service-started)",
             },
-        },
-    ],
+            {
+                trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+                run: "click",
+            },
+            {
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                run: "edit Hello, I need help!",
+            },
+            {
+                trigger: "body:not(.o-bus-service-started):not(.o-worker-service-started)",
+            },
+            {
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                run: "press Enter",
+            },
+            { trigger: "body.o-bus-service-started.o-worker-service-started" },
+        ];
+    },
 });


### PR DESCRIPTION
The `test_bus_not_started` test ensures the live chat only starts the bus/worker service when needed (i.e. when the customer starts to chat). This is done to ensure we do not waste any server resources.

However, this test waits 1 second to see if the worker/bus has started, which is not always enough: the shared worker script needs to be fetched, the worker service proceeds to an initial handshake to ensure the worker is properly started, and the bus ervice initializes by sending an initial request to the worker as well.

All those steps can take time, especially when the CPU is bloated and/or the network is slow.

This worker/bus service only has one entry method: `bus_service@start`, `worker_service.ensureWorkerStarted`. Instead of waiting for those async operations to complete, the test now checks whether those methods were called.

fixes runbot-233814

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
