### PR TITLE
[IMP] core : Handle multi-company access check

### DIFF
--- a/addons/sale_project/tests/__init__.py
+++ b/addons/sale_project/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_reinvoice
 from . import test_sale_project
 from . import test_so_line_milestones
 from . import test_sale_project_dashboard
+from . import test_sale_order

--- a/addons/sale_project/tests/test_sale_order.py
+++ b/addons/sale_project/tests/test_sale_order.py
@@ -1,0 +1,73 @@
+from odoo import Command
+from odoo.tests import TransactionCase
+
+
+class TestSaleOrderAccess(TransactionCase):
+
+    def setUp(self):
+
+        self.company_1 = self.env['res.company'].create({
+            'name': 'Company 1',
+            'currency_id': self.env.ref('base.USD').id,
+        })
+        self.company_2 = self.env['res.company'].create({
+            'name': 'Company 2',
+            'currency_id': self.env.ref('base.EUR').id,
+        })
+        self.user_company_1 = self.env['res.users'].create({
+            'name': 'User 1',
+            'login': 'user1',
+            'password': 'password',
+            'company_ids': [(6, 0, [self.company_1.id])],
+            'company_id': self.company_1.id,
+            'group_ids': [Command.link(self.env.ref('sales_team.group_sale_salesman_all_leads').id)],
+        })
+        self.admin_user = self.env['res.users'].create({
+            'name': 'Admin User',
+            'login': 'adminn',
+            'password': 'password',
+            'company_ids': [(6, 0, [self.company_1.id, self.company_2.id])],
+            'company_id': self.company_1.id,
+            'group_ids': [(6, 0, [
+                self.env.ref('sales_team.group_sale_manager').id,
+                self.env.ref('project.group_project_manager').id,
+            ])],
+            })
+        self.partner = self.env['res.partner'].create({
+            'name': 'XYZ',
+            'type': 'contact'
+        })
+        self.project_company_2 = self.env['project.project'].create({
+            'name': 'Project Company 2',
+            'user_id': self.admin_user.id,
+            'company_id': self.company_2.id,
+            'partner_id': self.partner.id,
+            'allow_billable': True,
+        })
+        self.sale_order_company_1 = self.env['sale.order'].create({
+            'user_id': self.admin_user.id,
+            'partner_id': self.partner.id,
+            'company_id': self.company_1.id,
+            'state': 'sale',
+            'project_id': self.project_company_2.id
+        })
+        self.sale_line = self.env['sale.order.line'].create({
+            'name': 'XA',
+            'product_uom_qty': 1.00,
+            'price_unit': 20.00,
+            'order_id': self.sale_order_company_1.id,
+            'project_id': self.project_company_2.id,
+        })
+        self.project_company_2.write({
+            'sale_order_id': self.sale_order_company_1.id,
+            'sale_line_id': self.sale_line.id,
+        })
+
+    def test_user_with_company_1_access_can_open_sale_order(self):
+        so = self.sale_order_company_1.with_user(self.user_company_1).with_company(self.company_1).read(['partner_id'])
+        self.assertEqual(so[0]['partner_id'], (self.partner.id, self.partner.display_name))
+        self.assertEqual(
+            self.sale_order_company_1.project_id.id,
+            self.project_company_2.id,
+            "Sale Order should remain linked to the project from Company 2."
+        )

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -456,6 +456,16 @@ def is_cors_preflight(request, endpoint):
     return request.httprequest.method == 'OPTIONS' and endpoint.routing.get('cors', False)
 
 
+def get_context(exception):
+    current = exception
+    while current:
+        ctx = getattr(current, "context", None)
+        if ctx:  # return as soon as context is found
+            return ctx
+        current = current.__cause__
+    return {}
+
+
 def serialize_exception(exception, *, message=None, arguments=None):
     name = type(exception).__name__
     module = type(exception).__module__
@@ -464,7 +474,7 @@ def serialize_exception(exception, *, message=None, arguments=None):
         'name': f'{module}.{name}' if module else name,
         'message': exception_to_unicode(exception) if message is None else message,
         'arguments': exception.args if arguments is None else arguments,
-        'context': getattr(exception, 'context', {}),
+        'context': get_context(exception),
         'debug': ''.join(traceback.format_exception(exception)),
     }
 

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1494,7 +1494,7 @@ class Many2many(_RelationalMulti):
                     for co_id in new_co_ids - old_relation[rec_id]
                 ).check_access('read')
             except AccessError as e:
-                raise AccessError(model.env._("Failed to write field %s", self) + "\n" + str(e))
+                raise AccessError(model.env._("Failed to write field %s", self) + "\n" + str(e)) from e
 
         # update the cache of self
         for record in records:


### PR DESCRIPTION
**Steps to reproduce:** 

1. Create a database in 19.0 version.
2. Create a second company (so there are two companies in total).
3. Install the Sales and Project applications.
4. In Company 1, create a Sales Order.
5. In Company 2, create a Project that is restricted to Company 2 only (i.e., not shared across companies) and ensure it is billable.
6. Inside that project, create a Task and link it to the Sales Order from Company 1. Make sure both companies are selected in your company switcher.
7. Now, switch to only Company 1, and try to open the Sales Order that is linked to the task in Company 2.
8. At this point, an AccessError will be raised, even though the user has access rights in both companies.

**Description of the issue:**

The `AccessError` is being raised even though the user already has read access.
This issue started after the following commit : (https://github.com/odoo/odoo/commit/aae732957c3c3b3590f5686cfccc0ab264d0b5c9)

In that update, a new check was added requiring **read access** when performing operations on **many2many fields**. This behavior is correct and improves security.

However, a problem occurs in **multi-company environments**.
For example, if a user has access to two companies (Company A and Company B), and a **Sales Order** belongs to Company A while the linked **Project** belongs to Company B, then when the user opens or writes records with only one company selected, an `AccessError` is raised — even though the user has access to both companies.



**Current behavior before PR:**

When writing on a many2many field that links records across different companies, an `AccessError` is raised.
This happens because the context does not include the `suggested_company`, so the system cannot detect that the user has access to both companies.

In the [commit](https://github.com/odoo/upgrade/pull/7960/files#diff-df0a10c9996a33faffbfcd4f2126eb2143cc9ecaa7dc1c28dad7fe930b3c1388R475-R489) , the issue was avoided during tests by adding the `suggested_company` from the context to the allowed company list.
But in the related Odoo commit: [6213c40](https://github.com/odoo/odoo/commit/6213c40932236101b529b82f0ea9fce1829c8c24#diff-706c5300f0b758ed43a362c85fa84a655c8bae12339bd882e98dc419623facc2R208) the context is always empty, meaning no company is added to the allowed list — leading to an unnecessary AccessError.



**Desired behavior after PR is merged:**

The `context` is now added before raising the AccessError.
If the user has access to both companies (e.g., the one linked to the Sales Order and the one linked to the Project), the system correctly identifies this and does **not** raise an AccessError.
If the user does **not** have access to the other company, the AccessError is still raised — ensuring that security remains intact.
Desired behavior after PR is merged:c




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
