### PR TITLE
[FIX] hr: correctly set display name when opening chat with employee

### DIFF
--- a/addons/hr/static/src/store_service_patch.js
+++ b/addons/hr/static/src/store_service_patch.js
@@ -36,7 +36,7 @@ const storeServicePatch = {
                 }
                 user.partner_id = employeeData.user_partner_id[0];
                 this.Persona.insert({
-                    displayName: employeeData.user_partner_id[1],
+                    display_name: employeeData.user_partner_id[1],
                     id: employeeData.user_partner_id[0],
                     type: "partner",
                 });

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -16,6 +16,14 @@ registry.category("web_tour.tours").add('hr_employee_tour', {
         run: 'click',
     },
     {
+        content: "Open a chat with the employee",
+        trigger: ".o_employee_chat_btn",
+        run: "click",
+    },
+    {
+        trigger: ".o-mail-ChatWindow .o-mail-ChatWindow-header:contains('Johnny H.')",
+    },
+    {
         content: "Open user account menu",
         trigger: ".o_user_menu .dropdown-toggle",
         run: 'click',

--- a/addons/hr/tests/test_ui.py
+++ b/addons/hr/tests/test_ui.py
@@ -6,9 +6,11 @@ from odoo.tests import HttpCase, tagged, new_test_user
 class TestEmployeeUi(HttpCase):
     def test_employee_profile_tour(self):
         user = new_test_user(self.env, login='davidelora', groups='base.group_user')
+        johnny_user = new_test_user(self.env, login="johnny", name="Johnny H.")
 
         self.env['hr.employee'].create([{
             'name': 'Johnny H.',
+            "user_id": johnny_user.id,
         }, {
             'name': 'David Elora',
             'user_id': user.id,

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -77,6 +77,8 @@ export class Persona extends Record {
     type;
     /** @type {string} */
     name;
+    /** @type {string} */
+    display_name;
     country_id = fields.One("res.country");
     /** @type {string} */
     email;
@@ -123,7 +125,7 @@ export class Persona extends Record {
      * computation, override the displayName getter.
      */
     _computeDisplayName() {
-        return this.name;
+        return this.name || this.display_name;
     }
 
     get avatarUrl() {


### PR DESCRIPTION
Before this commit, when opening a chat with an employee from the form view it would result in a traceback.

Steps to reproduce:
1. Open the form view of an employee that has a user associated
2. Click the "chat" icon next to their name -> traceback

This happens because the `getChat` method would insert a Persona record in the Store with a displayName field which has been changed to a setter in [1].

This commit fixes the issue by setting the `name` field instead.

[1] https://github.com/odoo/odoo/pull/234702