### PR TITLE
[IMP] website, *: add layout & scrollMode options for quote carousel

### DIFF
--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -8,6 +8,7 @@ import { rowSize } from "@html_builder/utils/grid_layout_utils";
 import { isEditable, isVisible } from "@html_builder/utils/utils";
 import { DragAndDropMoveHandle } from "./drag_and_drop_move_handle";
 import { selectElements } from "@html_editor/utils/dom_traversal";
+import { quoteCarouselSelector } from "@html_builder/plugins/utils";
 
 /**
  * @typedef {{
@@ -465,6 +466,14 @@ export class DragAndDropPlugin extends Plugin {
 
                 dragAndDropResolve();
                 this.dependencies.builderOptions.updateContainers(this.overlayTarget);
+                // Update index of each quote carousel slide after reordering.
+                const quoteCarouselEl = this.overlayTarget.closest(quoteCarouselSelector);
+                if (quoteCarouselEl) {
+                    const carouselSlideEls = quoteCarouselEl.querySelectorAll(".carousel-slide");
+                    carouselSlideEls.forEach((carouselSlideEl, index) => {
+                        carouselSlideEl.dataset.index = index;
+                    });
+                }
             },
         };
 

--- a/addons/html_builder/static/src/plugins/utils.js
+++ b/addons/html_builder/static/src/plugins/utils.js
@@ -24,3 +24,6 @@ export function getEditingEls(rootEl, { selector, exclude, applyTo }) {
     }
     return targetEls;
 }
+
+export const quoteCarouselSelector =
+    "section[data-snippet='s_quotes_carousel'] > div, section[data-snippet='s_quotes_carousel_minimal'] > div";

--- a/addons/website/static/src/builder/plugins/carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_option.xml
@@ -13,7 +13,7 @@
         </BuilderSelect>
     </BuilderRow>
 
-    <BuilderRow label.translate="Control" level="1">
+    <BuilderRow t-if="!this.state?.shouldHide" label.translate="Control" level="1">
         <BuilderSelect>
             <BuilderSelectItem classAction="''">Indicators Inside</BuilderSelectItem>
             <BuilderSelectItem classAction="'s_carousel_controllers_indicators_outside'">Indicators Outside</BuilderSelectItem>
@@ -29,7 +29,7 @@
         </BuilderSelect>
     </BuilderRow>
 
-    <BuilderRow label.translate="Indicators" applyTo="'.carousel-indicators'" level="1">
+    <BuilderRow t-if="!this.state?.shouldHide" label.translate="Indicators" applyTo="'.carousel-indicators'" level="1">
         <BuilderSelect>
             <BuilderSelectItem classAction="''">Bars</BuilderSelectItem>
             <BuilderSelectItem classAction="'s_carousel_indicators_dots'">Dots</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -8,7 +8,12 @@ import { withSequence } from "@html_editor/utils/resource";
 import { between } from "@html_builder/utils/option_sequence";
 import { WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW } from "@website/builder/option_sequence";
 import { selectElements } from "@html_editor/utils/dom_traversal";
-import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { patch } from "@web/core/utils/patch";
+import { MovePlugin } from "@html_builder/core/move_plugin";
+import { RemovePlugin } from "@html_builder/core/remove_plugin";
+import { ClonePlugin } from "@html_builder/core/clone_plugin";
+import { quoteCarouselSelector } from "@html_builder/plugins/utils";
 
 /**
  * @typedef { Object } CarouselOptionShared
@@ -33,6 +38,20 @@ export class CarouselOption extends BaseOptionComponent {
     static exclude =
         ".s_carousel_intro_wrapper, .s_carousel_cards_wrapper, .s_quotes_carousel_wrapper:has(>.s_quotes_carousel_compact)";
     static applyTo = ":scope > .carousel";
+    setup() {
+        super.setup();
+        this.state = useDomState((editingElement) => {
+            const isQuoteCarousel = editingElement.closest(quoteCarouselSelector);
+            if (!isQuoteCarousel) {
+                return { shouldHide: false };
+            }
+            return {
+                shouldHide:
+                    editingElement.dataset.scrollMode === "single" &&
+                    editingElement.dataset.numberOfElements !== "1",
+            };
+        });
+    }
 }
 
 export class CarouselBottomControllersOption extends BaseOptionComponent {
@@ -47,6 +66,13 @@ export class CarouselCardsOption extends BaseOptionComponent {
     static applyTo = ".s_carousel_cards";
 }
 
+export class CarouselQuotesLayoutOption extends BaseOptionComponent {
+    static template = "website.CarouselQuotesLayoutOptions";
+    static selector =
+        "section[data-snippet='s_quotes_carousel'], section[data-snippet='s_quotes_carousel_minimal']";
+    static applyTo = ".s_quotes_carousel";
+}
+
 export class CarouselOptionPlugin extends Plugin {
     static id = "carouselOption";
     static dependencies = ["clone", "builderOptions", "builderActions"];
@@ -58,6 +84,7 @@ export class CarouselOptionPlugin extends Plugin {
             CarouselOption,
             CarouselBottomControllersOption,
             withSequence(CAROUSEL_CARDS_SEQUENCE, CarouselCardsOption),
+            CarouselQuotesLayoutOption,
         ],
         builder_header_middle_buttons: {
             Component: CarouselItemHeaderMiddleButtons,
@@ -83,6 +110,7 @@ export class CarouselOptionPlugin extends Plugin {
             SlideCarouselAction,
             ToggleControllersAction,
             ToggleCardImgAction,
+            UpdateCarouselLayoutAction,
         },
         on_cloned_handlers: this.onCloned.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
@@ -121,16 +149,38 @@ export class CarouselOptionPlugin extends Plugin {
     }
 
     /**
+     * Return the active or focused slide element.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     */
+    getActiveOrFocusedSlide(editingElement) {
+        if (editingElement) {
+            const className =
+                editingElement?.dataset.scrollMode === "single" ? "o-focused-slide" : "active";
+            return editingElement.querySelector(`.carousel-item.${className}`);
+        }
+    }
+
+    /**
      * Adds a slide.
      *
      * @param {HTMLElement} editingElement the carousel element.
      */
     async addSlide(editingElement) {
         // Clone the active item and remove the "active" class.
-        const activeItemEl = editingElement.querySelector(".carousel-item.active");
+        const activeItemEl = this.getActiveOrFocusedSlide(editingElement);
         const newItemEl = await this.dependencies.clone.cloneElement(activeItemEl, {
             activateClone: false,
         });
+        // No additional handling is required for the Quotes carousel, except
+        // for the compact variant, since the remaining cases are already
+        // covered by the patched Clone plugin.
+        if (
+            editingElement.closest(quoteCarouselSelector) ||
+            newItemEl.classList.contains("s_blockquote")
+        ) {
+            return;
+        }
         newItemEl.classList.remove("active");
 
         // Show the controllers (now that there is always more than one item).
@@ -141,13 +191,15 @@ export class CarouselOptionPlugin extends Plugin {
 
         // Add the new indicator.
         const indicatorsEl = editingElement.querySelector(".carousel-indicators");
-        const newIndicatorEl = this.document.createElement("button");
-        newIndicatorEl.setAttribute("data-bs-target", "#" + editingElement.id);
-        newIndicatorEl.setAttribute("aria-label", _t("Carousel indicator"));
-        indicatorsEl.appendChild(newIndicatorEl);
+        addIndicatorButton("", editingElement.id, indicatorsEl);
 
         // Slide to the new item.
-        await this.slide(editingElement, "next");
+        await slide(
+            editingElement,
+            this.dependencies["builderOptions"],
+            this.slideTimestamp,
+            "next"
+        );
     }
 
     /**
@@ -157,24 +209,46 @@ export class CarouselOptionPlugin extends Plugin {
      */
     async removeSlide(editingElement) {
         const itemEls = [...editingElement.querySelectorAll(".carousel-item")];
+        const scrollMode = editingElement.dataset.scrollMode;
+        const numberOfElements = parseInt(editingElement.dataset.numberOfElements);
+        const shouldSlide = scrollMode === "all" || itemEls.length > numberOfElements;
+        const isQuoteCarousel = editingElement.closest(quoteCarouselSelector);
         const newLength = itemEls.length - 1;
         if (newLength > 0) {
-            const activeItemEl = editingElement.querySelector(".carousel-item.active");
+            const selectedItemEl = this.getActiveOrFocusedSlide(editingElement);
             const activeIndicatorEl = editingElement.querySelector(
                 ".carousel-indicators > .active"
             );
-            // Slide to the previous item.
-            await this.slide(editingElement, "prev");
+            // Should not slide if carousel items count is less than or equal
+            // to numberOfElements especially in single scroll mode.
+            if (shouldSlide || !isQuoteCarousel) {
+                // Slide to the previous item.
+                await slide(
+                    editingElement,
+                    this.dependencies["builderOptions"],
+                    this.slideTimestamp,
+                    "prev"
+                );
+            }
 
             // Remove the carousel item and the indicator.
-            activeItemEl.remove();
-            activeIndicatorEl.remove();
+            selectedItemEl.remove();
+            activeIndicatorEl?.remove();
 
-            // Hide the controllers if there is only one slide left.
+            // If we didn't slide and the removed item was active, then we need
+            // to manually activate the first slide for quote carousel.
+            if (!shouldSlide && selectedItemEl.classList.contains("active") && isQuoteCarousel) {
+                const firstSlideEl = editingElement.querySelector(".carousel-slide");
+                firstSlideEl.classList.add("active");
+            }
+
+            // Hide the controllers if the slide count is one or less than
+            // numberOfElements as per scrollMode.
             const controlEls = editingElement.querySelectorAll(carouselControlsSelector);
-            controlEls.forEach((controlEl) =>
-                controlEl.classList.toggle("d-none", newLength === 1)
-            );
+            const isSingleMode = editingElement.dataset.scrollMode === "single";
+            const shouldHide = isSingleMode ? newLength <= numberOfElements : newLength <= 1;
+            controlEls.forEach((controlEl) => controlEl.classList.toggle("d-none", shouldHide));
+            updateSlideIndex(editingElement);
         }
     }
 
@@ -185,67 +259,12 @@ export class CarouselOptionPlugin extends Plugin {
      * @param {String} direction "prev" or "next".
      */
     async slideCarousel(editingElement, direction) {
-        await this.slide(editingElement, direction);
-    }
-
-    /**
-     * Slides the carousel in the given direction.
-     *
-     * @param {String|Number} direction the direction in which to slide:
-     *     - "prev": the previous slide;
-     *     - "next": the next slide;
-     *     - number: a slide number.
-     * @param {Element} editingElement the carousel element.
-     * @returns {Promise}
-     */
-    slide(editingElement, direction) {
-        editingElement.addEventListener("slide.bs.carousel", () => {
-            this.slideTimestamp = window.performance.now();
-        });
-
-        return new Promise((resolve) => {
-            editingElement.addEventListener(
-                "slid.bs.carousel",
-                () => {
-                    // slid.bs.carousel is most of the time fired too soon by
-                    // bootstrap since it emulates the transitionEnd with a
-                    // setTimeout. We wait here an extra 20% of the time before
-                    // retargeting edition, which should be enough...
-                    const slideDuration = window.performance.now() - this.slideTimestamp;
-                    setTimeout(() => {
-                        // Setting the active indicator manually, as Bootstrap
-                        // could not do it because the `data-bs-slide-to`
-                        // attribute is not here in edit mode anymore.
-                        const itemEls = editingElement.querySelectorAll(".carousel-item");
-                        const activeItemEl = editingElement.querySelector(".carousel-item.active");
-                        const activeIndex = [...itemEls].indexOf(activeItemEl);
-                        const indicatorEls = editingElement.querySelectorAll(
-                            ".carousel-indicators > *"
-                        );
-                        const activeIndicatorEl = [...indicatorEls][activeIndex];
-                        activeIndicatorEl.classList.add("active");
-                        activeIndicatorEl.setAttribute("aria-current", "true");
-
-                        // Activate the active item.
-                        this.dependencies["builderOptions"].setNextTarget(activeItemEl);
-
-                        resolve();
-                    }, 0.2 * slideDuration);
-                },
-                { once: true }
-            );
-
-            const carouselInstance = window.Carousel.getOrCreateInstance(editingElement, {
-                ride: false,
-                pause: true,
-                keyboard: false,
-            });
-            if (typeof direction === "number") {
-                carouselInstance.to(direction);
-            } else {
-                carouselInstance[direction]();
-            }
-        });
+        await slide(
+            editingElement,
+            this.dependencies["builderOptions"],
+            this.slideTimestamp,
+            direction
+        );
     }
 
     onCloned({ cloneEl }) {
@@ -308,19 +327,30 @@ export class CarouselOptionPlugin extends Plugin {
         if (optionName === "Carousel") {
             const carouselEl = activeItemEl.closest(".carousel");
 
+            itemEls.forEach((itemEl, index) => {
+                itemEl.dataset.index = index;
+            });
+            const scrollMode = carouselEl.dataset.scrollMode;
+            const newPosition = itemEls.indexOf(activeItemEl);
+
             // Replace the content with the new slides.
             const carouselInnerEl = carouselEl.querySelector(".carousel-inner");
-            const newCarouselInnerEl = document.createElement("div");
-            newCarouselInnerEl.classList.add("carousel-inner");
-            newCarouselInnerEl.append(...itemEls);
-            carouselInnerEl.replaceWith(newCarouselInnerEl);
+            carouselInnerEl.replaceChildren(...itemEls);
 
-            // Update the indicators.
-            const newPosition = itemEls.indexOf(activeItemEl);
-            updateCarouselIndicators(carouselEl, newPosition);
-
-            // Activate the active slide.
-            this.dependencies.builderOptions.setNextTarget(activeItemEl);
+            // Update the index of each element.
+            updateSlideIndex(carouselInnerEl);
+            if (scrollMode === "single") {
+                itemEls.forEach((itemEl) => {
+                    itemEl.classList.remove("active", "o-focused-slide");
+                });
+                itemEls[0].classList.add("active", "o-focused-slide");
+                this.dependencies.builderOptions.setNextTarget(itemEls[0]);
+            } else {
+                // Update the indicators.
+                updateCarouselIndicators(carouselEl, newPosition);
+                // Activate the active slide.
+                this.dependencies.builderOptions.setNextTarget(activeItemEl);
+            }
         }
     }
 }
@@ -395,5 +425,382 @@ export class ToggleCardImgAction extends BuilderAction {
         return !!cardImgEl;
     }
 }
+
+export class UpdateCarouselLayoutAction extends BuilderAction {
+    static id = "updateQuotesCarouselLayout";
+    static dependencies = ["builderOptions"];
+
+    apply({ editingElement }) {
+        const activeSlideEl = triggerQuotesCarouselRebuild(editingElement);
+        this.dependencies.builderOptions.setNextTarget(activeSlideEl);
+    }
+}
+
+/**
+ * Update the index of each slide.
+ *
+ * @param {HTMLElement} editingElement the carousel element.
+ */
+function updateSlideIndex(editingElement) {
+    const carouselSlideEls = editingElement.querySelectorAll(".carousel-slide");
+    carouselSlideEls.forEach((carouselSlideEl, index) => {
+        carouselSlideEl.dataset.index = index;
+    });
+}
+
+/**
+ * Adds an indicator button to the carousel’s indicator container.
+ *
+ * @param {number} index – The slide index that this indicator represents.
+ * @param {string} editingElementId – The ID of the carousel root element.
+ * @param {HTMLElement} indicatorEl – The indicator container to append button.
+ */
+function addIndicatorButton(index, editingElementId, indicatorEl) {
+    const btnEl = document.createElement("button");
+    btnEl.type = "button";
+    btnEl.dataset.bsTarget = `#${editingElementId}`;
+    btnEl.dataset.bsSlideTo = index.toString();
+    btnEl.setAttribute("aria-label", _t("Carousel indicator"));
+    btnEl.classList.add(...(index === 0 ? ["active"] : []));
+    indicatorEl.appendChild(btnEl);
+}
+
+/**
+ * Replaces all classes on the element that start with given prefix and adds
+ * the provided class.
+ *
+ * @param {HTMLElement} el - The element whose classes will be updated.
+ * @param {string} classToAdd - The class to add to the element.
+ * @param {string} classPrefix - The prefix used to identify classes to remove.
+ */
+function modifyElementClass(el, classToAdd, classPrefix) {
+    const classesToRemove = Array.from(el.classList).filter((cls) => cls.startsWith(classPrefix));
+    el.classList.remove(...classesToRemove);
+    el.classList.add(classToAdd);
+}
+
+/**
+ * Resets carousel layout, classes and inline styles.
+ *
+ * @param {HTMLElement} carouselEl the carousel root element.
+ * @param {Array<HTMLElement>} carouselSlideEls the carousel slide elements.
+ * @param {HTMLElement} carouselInnerEl the carousel inner element.
+ * @param {HTMLElement} indicatorEl the carousel indicator element.
+ * @param {number} layoutSize the number of items per slide.
+ */
+function resetCarouselLayout(
+    carouselEl,
+    carouselSlideEls,
+    carouselInnerEl,
+    indicatorEl,
+    layoutSize
+) {
+    carouselInnerEl.replaceChildren();
+    indicatorEl.replaceChildren();
+    carouselSlideEls.forEach((carouselSlideEl) =>
+        carouselSlideEl.classList.remove("carousel-item", "active")
+    );
+    carouselEl.style.removeProperty("--o-carousel-item-width-percentage");
+    carouselEl.classList.remove("o_carousel_multi_items");
+    indicatorEl.classList.remove("d-none");
+    if (carouselEl.classList.contains("o_container_small") && layoutSize > 2) {
+        carouselEl.classList.replace("o_container_small", "container");
+    }
+}
+
+/**
+ * Updates blockquote width classes based on layout size.
+ *
+ * @param {Array<HTMLElement>} carouselSlideEls the carousel slide elements.
+ * @param {number} layoutSize the number of items per slide.
+ */
+function updateBlockquoteWidths(carouselSlideEls, layoutSize) {
+    //Maps numberOfElements to width classes: 1->w-50, 2->w-75, 3+->w-100.
+    const widthClass = `w-${Math.min((1 + layoutSize) * 25, 100)}`;
+    carouselSlideEls.forEach((carouselSlideEl) => {
+        const blockquoteEls = carouselSlideEl.querySelectorAll(".s_blockquote");
+        blockquoteEls.forEach((blockquoteEl) => modifyElementClass(blockquoteEl, widthClass, "w-"));
+    });
+}
+
+/**
+ * Builds carousel item elements for "all" scroll mode.
+ *
+ * @param {Array<Array<HTMLElement>>} groups grouped slide elements.
+ * @param {string} colClass the Bootstrap column class for slide width.
+ * @returns {Array<HTMLElement>} carousel item elements.
+ */
+function generateAllModeCarousel(groups, colClass) {
+    return groups.map((group) => {
+        const carouselItemEl = document.createElement("div");
+        carouselItemEl.className = "carousel-item";
+        carouselItemEl.dataset.name = "Slide";
+        const rowEl = document.createElement("div");
+        rowEl.classList.add("row");
+        group.forEach((carouselSlideEl) => {
+            modifyElementClass(carouselSlideEl, colClass, "col-lg-");
+            carouselSlideEl.dataset.name = "";
+            rowEl.appendChild(carouselSlideEl);
+        });
+        carouselItemEl.appendChild(rowEl);
+        return carouselItemEl;
+    });
+}
+
+/**
+ * Builds carousel item elements for "single" scroll mode.
+ *
+ * @param {Array<HTMLElement>} carouselSlideEls the carousel slide elements.
+ * @param {string} colClass the Bootstrap column class for slide width.
+ * @returns {Array<HTMLElement>} carousel item elements.
+ */
+function generateSingleModeCarousel(carouselSlideEls, colClass) {
+    return carouselSlideEls.map((carouselSlideEl) => {
+        carouselSlideEl.dataset.name = "Slide";
+        modifyElementClass(carouselSlideEl, colClass, "col-lg-");
+        carouselSlideEl.classList.add("carousel-item");
+        return carouselSlideEl;
+    });
+}
+
+/**
+ * Populates the carousel inner element with carousel items and indicators.
+ *
+ * @param {HTMLElement} carouselEl the carousel root element.
+ * @param {Array<HTMLElement>} carouselItems the carousel item elements.
+ * @param {HTMLElement} carouselInnerEl the carousel inner element.
+ * @param {HTMLElement} indicatorEl the carousel indicator element.
+ */
+function populateCarouselItems(carouselEl, carouselItems, carouselInnerEl, indicatorEl) {
+    carouselItems.forEach((item, index) => {
+        carouselInnerEl.appendChild(item);
+        addIndicatorButton(index, carouselEl.id, indicatorEl);
+    });
+}
+
+/**
+ * Applies layout-specific styling for multi-item carousel.
+ *
+ * @param {HTMLElement} carouselEl the carousel root element.
+ * @param {number} layoutSize the number of items per slide.
+ * @param {HTMLElement} indicatorEl the carousel indicator element.
+ */
+function applyMultiItemLayout(carouselEl, layoutSize, indicatorEl) {
+    if (layoutSize === 1) {
+        return;
+    }
+    carouselEl.classList.add("o_carousel_multi_items");
+    carouselEl.style.setProperty("--o-carousel-item-width-percentage", `${100 / layoutSize}%`);
+    indicatorEl.classList.add("d-none");
+}
+
+/**
+ * Updates carousel arrow visibility based on total slide count.
+ *
+ * @param {HTMLElement} carouselEl the carousel root element.
+ * @param {number} totalSlideCount the total number of slides.
+ * @param {number} numberOfElements the number of elements per slide.
+ * @param {HTMLElement} indicatorEl the carousel indicator element.
+ */
+function updateControllersVisibility(carouselEl, totalSlideCount, numberOfElements, indicatorEl) {
+    const prevButtonEl = carouselEl.querySelector(".carousel-control-prev");
+    const nextButtonEl = carouselEl.querySelector(".carousel-control-next");
+    const hideControllers = totalSlideCount <= numberOfElements;
+    [prevButtonEl, nextButtonEl].forEach((btn) => btn?.classList.toggle("d-none", hideControllers));
+    hideControllers && indicatorEl.classList.add("d-none");
+}
+
+/**
+ * Rebuilds the quotes carousel layout after option changes.
+ *
+ * @param {HTMLElement} carouselEl the carousel root element.
+ * @param {Object} config layout configuration.
+ */
+function regenerateCarouselLayout(carouselEl, config) {
+    const { numberOfElements, scrollMode } = config;
+    const layoutSize = parseInt(numberOfElements);
+    const colClass = `col-lg-${12 / layoutSize}`;
+    const carouselInnerEl = carouselEl.querySelector(".carousel-inner");
+    const indicatorEl = carouselEl.querySelector(".indicators-container");
+    // Fetch and sort carousel slides
+    const carouselSlideEls = Array.from(carouselEl.querySelectorAll(".carousel-slide"));
+    carouselSlideEls.sort(
+        (slideA, slideB) => parseInt(slideA.dataset.index) - parseInt(slideB.dataset.index)
+    );
+    const totalSlideCount = carouselSlideEls.length;
+    resetCarouselLayout(carouselEl, carouselSlideEls, carouselInnerEl, indicatorEl, layoutSize);
+    updateBlockquoteWidths(carouselSlideEls, layoutSize);
+    let carouselItems;
+    if (scrollMode === "all" && layoutSize > 1) {
+        const groups = [];
+        for (let i = 0; i < carouselSlideEls.length; i += layoutSize) {
+            groups.push(carouselSlideEls.slice(i, i + layoutSize));
+        }
+        carouselItems = generateAllModeCarousel(groups, colClass);
+    } else {
+        carouselItems = generateSingleModeCarousel(carouselSlideEls, colClass);
+    }
+    populateCarouselItems(carouselEl, carouselItems, carouselInnerEl, indicatorEl);
+    if (scrollMode === "single") {
+        applyMultiItemLayout(carouselEl, layoutSize, indicatorEl);
+    }
+    updateControllersVisibility(carouselEl, totalSlideCount, numberOfElements, indicatorEl);
+    carouselEl.dispatchEvent(new CustomEvent("content_changed"));
+}
+
+/**
+ * Function to trigger carousel regeneration.
+ *
+ * @param {HTMLElement} carouselEl the carousel root element.
+ * @returns {HTMLElement} the new active carousel item element.
+ */
+function triggerQuotesCarouselRebuild(carouselEl) {
+    const carouselItemEls = carouselEl.querySelectorAll(".carousel-item");
+    const activeItemEl = carouselEl.querySelector(".carousel-item.active");
+    const oldIndex = [...carouselItemEls].indexOf(activeItemEl);
+    updateSlideIndex(carouselEl);
+    const { numberOfElements, scrollMode } = carouselEl.dataset;
+    regenerateCarouselLayout(carouselEl, { numberOfElements, scrollMode });
+    const newCarouselItemEls = carouselEl.querySelectorAll(".carousel-item");
+    const targetIndex = Math.min(oldIndex, newCarouselItemEls.length - 1);
+    if (newCarouselItemEls.length > 0) {
+        newCarouselItemEls[targetIndex].classList.add("active");
+        updateCarouselIndicators(carouselEl, targetIndex);
+        return newCarouselItemEls[targetIndex];
+    }
+}
+
+/**
+ * Slides the carousel in the given direction.
+ *
+ * @param {Element} editingElement the carousel element.
+ * @param {Object} builderOptions the builder options service.
+ * @param {number} slideTimestamp the timestamp of the slide action.
+ * @param {String|Number} direction the direction in which to slide:
+ *     - "prev": the previous slide;
+ *     - "next": the next slide;
+ *     - number: a slide number.
+ * @returns {Promise}
+ */
+async function slide(editingElement, builderOptions, slideTimestamp, direction) {
+    editingElement.addEventListener("slide.bs.carousel", () => {
+        slideTimestamp = window.performance.now();
+    });
+
+    return new Promise((resolve) => {
+        editingElement.addEventListener(
+            "slid.bs.carousel",
+            () => {
+                // slid.bs.carousel is most of the time fired too soon by
+                // bootstrap since it emulates the transitionEnd with a
+                // setTimeout. We wait here an extra 20% of the time before
+                // retargeting edition, which should be enough...
+                const slideDuration = window.performance.now() - slideTimestamp;
+                setTimeout(() => {
+                    // Setting the active indicator manually, as Bootstrap
+                    // could not do it because the `data-bs-slide-to`
+                    // attribute is not here in edit mode anymore.
+                    const itemEls = editingElement.querySelectorAll(".carousel-item");
+                    const activeItemEl = editingElement.querySelector(".carousel-item.active");
+                    const activeIndex = [...itemEls].indexOf(activeItemEl);
+                    updateCarouselIndicators(editingElement, activeIndex);
+
+                    // Activate the active item.
+                    builderOptions.setNextTarget(activeItemEl);
+
+                    resolve();
+                }, 0.2 * slideDuration);
+            },
+            { once: true }
+        );
+
+        const carouselInstance = window.Carousel.getOrCreateInstance(editingElement, {
+            ride: false,
+            pause: true,
+            keyboard: false,
+        });
+        if (typeof direction === "number") {
+            carouselInstance.to(direction);
+        } else {
+            carouselInstance[direction]();
+        }
+    });
+}
+
+// To update index of each quote carousel slide after moving. It helps to keep
+// the correct order of slides during layout or scrollMode option changes.
+patch(MovePlugin.prototype, {
+    onMoveClick(direction) {
+        super.onMoveClick(direction);
+        const parentEl = this.overlayTarget.closest(".row");
+        if (parentEl && parentEl.closest(quoteCarouselSelector)) {
+            updateSlideIndex(parentEl);
+        }
+    },
+});
+
+// Triggers a quotes carousel rebuild after a slide item is removed.
+// Without rebuilding, the slide grouping becomes inconsistent.
+// For example:
+// Before removal:
+//   Slide 1 → [a, b, c] and Slide 2 → [d, e, f]
+// If "b" is removed without rebuilding:
+//   Slide 1 → [a, c] and Slide 2 → [d, e, f]
+// However, the expected behavior is to rebalance the items so that
+// slides remain properly grouped:
+//   Slide 1 → [a, c, d] and Slide 2 → [e, f]
+patch(RemovePlugin.prototype, {
+    removeCurrentTarget(toRemoveEl, optionsTargetEls) {
+        const carouselEl = toRemoveEl.closest(quoteCarouselSelector);
+        const nextTarget = super.removeCurrentTarget(toRemoveEl, optionsTargetEls);
+        if (!carouselEl || toRemoveEl.classList.contains("s_blockquote")) {
+            return nextTarget;
+        }
+        triggerQuotesCarouselRebuild(carouselEl);
+        this.dependencies.builderOptions.setNextTarget(nextTarget);
+        carouselEl.querySelector(".o-focused-slide")?.classList.remove("o-focused-slide");
+        nextTarget.classList.add("o-focused-slide");
+        return nextTarget;
+    },
+});
+
+// Triggers a quotes carousel rebuild after a slide item is cloned.
+// Without rebuilding, the slide grouping becomes inconsistent.
+// For example:
+// Before cloning:
+//   Slide 1 → [a, b, c] and Slide 2 → [d, e]
+// If "b" is cloned without rebuilding:
+//   Slide 1 → [a, b, b', c] and Slide 2 → [d, e]
+// However, the expected behavior is to rebalance the items so that
+// slides remain properly grouped:
+//   Slide 1 → [a, b, b'] and Slide 2 → [c, d, e]
+patch(ClonePlugin.prototype, {
+    async cloneElement(el, options = {}) {
+        const cloneEl = await super.cloneElement(el, options);
+        const carouselEl = cloneEl.closest(quoteCarouselSelector);
+        // Skip rebuild for non-carousel and for blockquote clone
+        if (!carouselEl || cloneEl.classList.contains("s_blockquote")) {
+            return cloneEl;
+        }
+        const { numberOfElements, scrollMode } = carouselEl.dataset;
+        triggerQuotesCarouselRebuild(carouselEl);
+        const totalSlideCount = carouselEl.querySelectorAll(".carousel-item").length;
+        const isFirstInSlide = Number(cloneEl.dataset.index) % Number(numberOfElements) === 0;
+        const isNotSlide = !cloneEl.classList.contains("carousel-slide");
+        const isSingleMode = scrollMode === "single" && numberOfElements < totalSlideCount;
+        const shouldSlideNext =
+            (isFirstInSlide || isNotSlide || isSingleMode) && totalSlideCount !== 1;
+        if (shouldSlideNext) {
+            await slide(carouselEl, this.dependencies.builderOptions, this.slideTimestamp, "next");
+        }
+        // Focus the cloned element when not sliding or 'isNotSlide' is true.
+        if (!shouldSlideNext || !isNotSlide) {
+            this.dependencies.builderOptions.setNextTarget(cloneEl);
+        }
+        carouselEl.querySelector(".o-focused-slide")?.classList.remove("o-focused-slide");
+        cloneEl.classList.add("o-focused-slide");
+        return cloneEl;
+    },
+});
 
 registry.category("website-plugins").add(CarouselOptionPlugin.id, CarouselOptionPlugin);

--- a/addons/website/static/src/builder/plugins/carousel_quotes_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_quotes_option.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website.CarouselQuotesLayoutOptions">
+        <BuilderRow label.translate="Layout">
+            <BuilderSelect action="'updateQuotesCarouselLayout'" dataAttributeAction="'numberOfElements'">
+                <BuilderSelectItem id="'one'" dataAttributeActionValue="'1'">1 element</BuilderSelectItem>
+                <BuilderSelectItem id="'two'" dataAttributeActionValue="'2'">2 elements</BuilderSelectItem>
+                <BuilderSelectItem id="'three'" dataAttributeActionValue="'3'">3 elements</BuilderSelectItem>
+                <BuilderSelectItem id="'four'" dataAttributeActionValue="'4'">4 elements</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+
+        <t t-if="!isActiveItem('one')">
+            <BuilderRow label.translate="Scrolling Mode" level="1">
+                <BuilderButtonGroup action="'updateQuotesCarouselLayout'" dataAttributeAction="'scrollMode'">
+                    <BuilderButton dataAttributeActionValue="'all'">All</BuilderButton>
+                    <BuilderButton dataAttributeActionValue="'single'">Single</BuilderButton>
+                </BuilderButtonGroup>
+            </BuilderRow>
+        </t>
+    </t>
+</templates>

--- a/addons/website/static/src/builder/plugins/options/utils.js
+++ b/addons/website/static/src/builder/plugins/options/utils.js
@@ -5,3 +5,6 @@ export const BASE_ONLY_BG_IMAGE_SELECTOR = "footer .oe_structure > *:not(.o_foot
 
 export const CARD_DISABLE_WIDTH_APPLY_TO = ":scope > .s_card:not(.s_carousel_cards_card)";
 export const WEBSITE_BG_APPLY_TO = ":scope > .s_carousel_cards_card";
+
+export const QUOTE_CAROUSEL_SLIDE_SELECTOR =
+    "section[data-snippet='s_quotes_carousel'] .row > div, section[data-snippet='s_quotes_carousel_minimal'] .row > div";

--- a/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
@@ -1,7 +1,11 @@
 import { BaseWebsiteBackgroundOption } from "@website/builder/plugins/options/background_option";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
-import { CARD_PARENT_HANDLERS, BASE_ONLY_BG_IMAGE_SELECTOR } from "./utils";
+import {
+    CARD_PARENT_HANDLERS,
+    BASE_ONLY_BG_IMAGE_SELECTOR,
+    QUOTE_CAROUSEL_SLIDE_SELECTOR,
+} from "./utils";
 import { BLOCKQUOTE_PARENT_HANDLERS } from "@html_builder/core/utils";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC_BEFORE } from "@html_builder/utils/option_sequence";
@@ -20,8 +24,7 @@ export class WebsiteBackgroundCarouselOption extends BaseWebsiteBackgroundOption
 }
 
 export class WebsiteBackgroundBGColorImageOption extends BaseWebsiteBackgroundOption {
-    static selector =
-        "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, .s_ecomm_categories_showcase_block, .s_bento_grid_avatars .row > div";
+    static selector = `section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, .s_ecomm_categories_showcase_block, .s_bento_grid_avatars .row > div, ${QUOTE_CAROUSEL_SLIDE_SELECTOR}`;
     static exclude = `${BASE_ONLY_BG_IMAGE_SELECTOR}, .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_item, .s_dynamic_snippet_category .s_dynamic_snippet_title`;
     static defaultProps = {
         withColors: true,
@@ -34,7 +37,7 @@ export class WebsiteBackgroundBGColorImageOption extends BaseWebsiteBackgroundOp
 export class WebsiteBackgroundBGColorOption extends BaseWebsiteBackgroundOption {
     static selector =
         "section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge";
-    static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, ${CARD_PARENT_HANDLERS}, .s_website_form_cover .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, ${BLOCKQUOTE_PARENT_HANDLERS}, .s_bento_grid_avatars .row > div`;
+    static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, ${CARD_PARENT_HANDLERS}, .s_website_form_cover .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, ${BLOCKQUOTE_PARENT_HANDLERS}, .s_bento_grid_avatars .row > div, ${QUOTE_CAROUSEL_SLIDE_SELECTOR}`;
     static defaultProps = {
         withColors: true,
         withImages: false,

--- a/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
@@ -1,6 +1,9 @@
 import { CarouselSlider } from "@website/interactions/carousel/carousel_slider";
 import { registry } from "@web/core/registry";
 
+const quoteCarouselInnerSelector =
+    "section[data-snippet='s_quotes_carousel'] .carousel-inner, section[data-snippet='s_quotes_carousel_minimal'] .carousel-inner";
+
 const CarouselSliderEdit = (I) =>
     class extends I {
         dynamicContent = {
@@ -9,6 +12,11 @@ const CarouselSliderEdit = (I) =>
                 ...this.dynamicContent._root,
                 "t-on-content_changed": this.onContentChanged,
             },
+            [quoteCarouselInnerSelector]: {
+                "t-on-click": this.onClick,
+                "t-on-slide.bs.carousel": this.onSlideCarousel,
+                "t-on-slid.bs.carousel": this.onSlidCarousel,
+            },
         };
         // Pause carousel in edit mode.
         carouselOptions = { ride: false, pause: true, keyboard: false };
@@ -16,6 +24,23 @@ const CarouselSliderEdit = (I) =>
 
         onContentChanged() {
             this.computeMaxHeight();
+        }
+        removeFocusedSlideClass() {
+            this.carouselInnerEl
+                .querySelector(".o-focused-slide")
+                ?.classList.remove("o-focused-slide");
+        }
+        onClick(event) {
+            this.removeFocusedSlideClass();
+            event.target.closest(".carousel-slide")?.classList.add("o-focused-slide");
+        }
+        onSlideCarousel(ev) {
+            this.removeFocusedSlideClass();
+            super.onSlideCarousel(ev);
+        }
+        onSlidCarousel(event) {
+            super.onSlidCarousel(event);
+            event.relatedTarget.classList.add("o-focused-slide");
         }
     };
 

--- a/addons/website/static/src/snippets/s_quotes_carousel/002.scss
+++ b/addons/website/static/src/snippets/s_quotes_carousel/002.scss
@@ -10,3 +10,34 @@
         }
     }
 }
+
+section[data-snippet="s_quotes_carousel"][data-vcss="002"],
+section[data-snippet="s_quotes_carousel_minimal"][data-vcss="002"] {
+    // Prevent container padding to avoid visual misalignment.
+    > .container-fluid, > .container, > .o_container_small {
+        padding: 0;
+    }
+    .s_quotes_carousel:not([data-number-of-elements="1"]) {
+        @include media-breakpoint-up(md) {
+            .carousel-control-prev,
+            .carousel-control-next {
+                width: 4%;
+            }
+            $item-padding: 1%;
+            $slide-padding: 4%;
+            .carousel-item {
+                padding: 0 $item-padding;
+                .carousel-slide {
+                    padding: 0 $slide-padding;
+                }
+            }
+            &[data-scroll-mode="single"] .carousel-inner {
+                // Forcefully remove gap between slides.
+                gap: 0;
+                > .carousel-item {
+                    padding: 0 $slide-padding;
+                }
+            }
+        }
+    }
+}

--- a/addons/website/static/tests/builder/website_builder/carousel_quotes.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel_quotes.test.js
@@ -1,0 +1,77 @@
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+} from "@website/../tests/builder/website_helpers";
+import { getDragMoveHelper } from "@html_builder/../tests/helpers";
+
+defineWebsiteModels();
+
+function checkDatasetIndex(carouselSlideEls) {
+    carouselSlideEls.forEach((carouselSlideEl, index) => {
+        expect(carouselSlideEl.dataset.index).toBe(index.toString());
+    });
+}
+
+function isSingleMode(carouselEl, count) {
+    const expectedStyle = `${100 / count}%`;
+    return (
+        carouselEl.classList.contains("o_carousel_multi_items") &&
+        carouselEl.style.getPropertyValue("--o-carousel-item-width-percentage") === expectedStyle
+    );
+}
+
+async function testQuoteCarousel(snippetName, getEditableContent) {
+    const editableEl = getEditableContent();
+    await contains(`:iframe section[data-snippet="${snippetName}"]`).click();
+    await contains("[data-label='Layout'] .dropdown-toggle").click();
+    await contains(
+        ".o-overlay-item [data-action-id='updateQuotesCarouselLayout']:nth-child(4)"
+    ).click();
+
+    // Assert "all" mode layout
+    const carouselEl = editableEl.querySelector(".s_quotes_carousel");
+    expect(isSingleMode(carouselEl, 4)).toBe(false);
+    const rowEls = editableEl.querySelectorAll(".carousel-item .row");
+    expect(rowEls[0].querySelectorAll(".carousel-slide").length).toBe(4);
+    const carouselSlideEls = carouselEl.querySelectorAll(".carousel-item .carousel-slide");
+    checkDatasetIndex(carouselSlideEls);
+
+    // Test slide reorder in "all" mode
+    await contains(":iframe .carousel-item blockquote").click();
+    const { moveTo, drop } = await contains(".o_overlay_options .o_move_handle").drag();
+    await moveTo(":iframe .s_quotes_carousel .carousel-item .row:last-child");
+    await drop(getDragMoveHelper());
+    checkDatasetIndex(editableEl.querySelectorAll(".carousel-item .carousel-slide"));
+    await contains(".overlay .o-we-toolbar button[title='Move up']").click();
+    checkDatasetIndex(editableEl.querySelectorAll(".carousel-item .carousel-slide"));
+
+    await contains(
+        "[data-label='Scrolling Mode'] [data-action-id='updateQuotesCarouselLayout']:nth-child(2)"
+    ).click();
+
+    // Assert "single" mode layout
+    expect(isSingleMode(carouselEl, 4)).toBe(true);
+    const carouselItemEls = carouselEl.querySelectorAll(".carousel-item.carousel-slide");
+    const indicatorContainerEl = editableEl.querySelector(".indicators-container");
+    expect(indicatorContainerEl).toHaveClass("d-none");
+    checkDatasetIndex(carouselItemEls);
+
+    // Removed the elements on which testing is done to avoid interference with
+    // other tests
+    await contains(".oe_snippet_remove").click();
+}
+
+test("Quote carousel layout and it's related options test", async () => {
+    const carousels = ["s_quotes_carousel", "s_quotes_carousel_minimal"];
+    const { getEditableContent } = await setupWebsiteBuilderWithSnippet(carousels);
+    for (const carousel of carousels) {
+        await testQuoteCarousel(carousel, getEditableContent);
+    }
+});
+
+// TODO: Add the following test cases after task-5269350 by SHSA is merged.
+// 1. Load the "website.carousel_slider" interaction.
+// 2. Click on a slide and expect ".carousel-slide.o-focused-slide".
+// 3. Click the next arrow and expect ".carousel-slide.o-focused-slide.active".

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -4,11 +4,11 @@
 <template id="s_quotes_carousel" name="Quotes">
     <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
-        <div t-attf-id="myQuoteCarousel{{uniq}}" class="s_quotes_carousel s_carousel_boxed carousel carousel-dark slide o_cc o_cc2" data-bs-ride="true" data-bs-interval="10000">
+        <div t-attf-id="myQuoteCarousel{{uniq}}" class="s_quotes_carousel s_carousel_boxed carousel carousel-dark slide o_cc o_cc2" data-bs-ride="true" data-bs-interval="10000" data-number-of-elements="1" data-scroll-mode="all">
             <!-- Content -->
             <div class="carousel-inner">
                 <!-- #01 -->
-                <div class="carousel-item active oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 50%;" data-name="Slide">
+                <div class="carousel-item carousel-slide active oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 50%;" data-name="Slide" data-index="0">
                     <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
                         <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
                         <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
@@ -27,7 +27,7 @@
                     </blockquote>
                 </div>
                 <!-- #02 -->
-                <div class="carousel-item oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_1'); background-position: 50% 50%;" data-name="Slide">
+                <div class="carousel-item carousel-slide oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_1'); background-position: 50% 50%;" data-name="Slide" data-index="1">
                     <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
                         <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
                         <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
@@ -46,7 +46,7 @@
                     </blockquote>
                 </div>
                 <!-- #03 -->
-                <div class="carousel-item oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_2'); background-position: 50% 50%;" data-name="Slide">
+                <div class="carousel-item carousel-slide oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_2'); background-position: 50% 50%;" data-name="Slide" data-index="2">
                     <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
                         <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
                         <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
@@ -64,6 +64,25 @@
                         </div>
                     </blockquote>
                 </div>
+                <!-- 04 -->
+                <div class="carousel-item carousel-slide oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_1'); background-position: 50% 50%;" data-name="Slide" data-index="3">
+                    <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
+                            <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <span class="o_small">
+                                    <strong>John DOE</strong><br/>
+                                    <span class="text-muted">CCO of MyCompany</span>
+                                </span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
             </div>
             <!-- Controls -->
             <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide="prev" aria-label="Previous" title="Previous">
@@ -75,10 +94,11 @@
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
-            <div class="carousel-indicators s_carousel_indicators_dots o_not_editable">
+            <div class="carousel-indicators s_carousel_indicators_dots o_not_editable indicators-container">
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="3" aria-label="Carousel indicator"/>
             </div>
         </div>
     </section>

--- a/addons/website/views/snippets/s_quotes_carousel_minimal.xml
+++ b/addons/website/views/snippets/s_quotes_carousel_minimal.xml
@@ -4,11 +4,11 @@
 <template id="s_quotes_carousel_minimal" name="Quotes Minimal">
     <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
-        <div t-attf-id="myQuoteCarouselMinimal{{uniq}}" class="s_quotes_carousel s_carousel_default carousel carousel-dark slide" data-bs-ride="true" data-bs-interval="10000">
+        <div t-attf-id="myQuoteCarouselMinimal{{uniq}}" class="s_quotes_carousel s_carousel_default carousel carousel-dark slide" data-bs-ride="true" data-bs-interval="10000" data-number-of-elements="1" data-scroll-mode="all">
             <!-- Content -->
             <div class="carousel-inner">
                 <!-- #01 -->
-                <div class="carousel-item active pt80 pb80" data-name="Slide">
+                <div class="carousel-item carousel-slide active pt80 pb80" data-name="Slide" data-index="0">
                     <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_animable position-relative d-flex flex-column gap-4 w-75 mx-auto my-4 p-5 fst-normal" data-vcss="001">
                         <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
                         <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
@@ -27,7 +27,7 @@
                     </blockquote>
                 </div>
                 <!-- #02 -->
-                <div class="carousel-item pt80 pb80" data-name="Slide">
+                <div class="carousel-item carousel-slide pt80 pb80" data-name="Slide" data-index="1">
                     <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_animable position-relative d-flex flex-column gap-4 w-75 mx-auto my-4 p-5 fst-normal" data-vcss="001">
                         <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
                         <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
@@ -46,7 +46,7 @@
                     </blockquote>
                 </div>
                 <!-- #03 -->
-                <div class="carousel-item pt80 pb80" data-name="Slide">
+                <div class="carousel-item carousel-slide pt80 pb80" data-name="Slide" data-index="2">
                     <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_animable position-relative d-flex flex-column gap-4 w-75 mx-auto my-4 p-5 fst-normal" data-vcss="001">
                         <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
                         <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
@@ -64,6 +64,25 @@
                         </div>
                     </blockquote>
                 </div>
+                <!-- #04 -->
+                <div class="carousel-item carousel-slide pt80 pb80" data-name="Slide" data-index="3">
+                    <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_animable position-relative d-flex flex-column gap-4 w-75 mx-auto my-4 p-5 fst-normal" data-vcss="001">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right fa-3x d-block mx-auto" role="img"/>
+                        </div>
+                        <p class="s_blockquote_quote my-auto h3-fs" style="text-align:center;">" A trusted partner for growth. <br/>Professional, efficient, and always ahead of the curve. "</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
+                            <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <span class="o_small">
+                                    <strong>John DOE</strong><br/>
+                                    <span class="text-muted">CCO of MyCompany</span>
+                                </span>
+                            </div>
+                        </div>
+                    </blockquote>
+                </div>
             </div>
             <!-- Controls -->
             <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide="prev" aria-label="Previous" title="Previous">
@@ -75,10 +94,11 @@
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
-            <div class="carousel-indicators s_carousel_indicators_dots">
+            <div class="carousel-indicators s_carousel_indicators_dots indicators-container">
                 <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="3" aria-label="Carousel indicator"/>
             </div>
         </div>
     </section>


### PR DESCRIPTION
[*]=html_builder

This PR introduces new _Layout_ and _Scroll Mode_ options for the "**s_quotes_carousel**" and "**s_quotes_carousel_minimal**" snippets. The core logic implemented here is to modify the DOM structure of the carousel rather than rendering a new template based on the selected layout and scrollMode options. This is achieved through the following changes:

1. Added new option templates along with their corresponding _BuilderAction_.
2. Patched the _move_ plugin to update slide indices after the element is moved.
3. Patched the _clone_ and _remove_ plugins to rebuild the DOM and adjust the scroll position when needed.
4. Moved the _slide_ function outside the "**CarouselLayoutOption**" class for shared usage across functions.
5. Added quote carousel selectors for background related options in the _website_background_option_plugin.js_ file when layouts with two or more elements are selected.
6. Updated `drag_and_drop_plugin.js` file to handle updation of slide indices after drag-and-drop operations.
7. Introduced a new class `o-slide-focused` to keep track of current focused slide which helps while cloning or deleting that element.

task-4624043