### PR TITLE
[FIX] point_of_sale: prevent traceback when making partial payment using SEPA QR

### DIFF
--- a/addons/l10n_test_pos_qr_payment/static/tests/test_pos_payment_tour.js
+++ b/addons/l10n_test_pos_qr_payment/static/tests/test_pos_payment_tour.js
@@ -22,14 +22,16 @@ function isQRDisplayedinDialog() {
     ].flat();
 }
 
-function addProductandPay() {
+function addProductandPay(isPartialPay = false) {
     return [
         ProductScreen.addOrderline("Hand Bag", "10"),
         ProductScreen.selectedOrderlineHas("Hand Bag", "10.0"),
         ProductScreen.clickPayButton(),
 
         PaymentScreen.totalIs("48"),
-        PaymentScreen.clickPaymentMethod("QR Code", true, { amount: "48" }),
+        ...(isPartialPay
+            ? [PaymentScreen.clickPaymentMethod("QR Code"), PaymentScreen.clickNumpad("+10")]
+            : [PaymentScreen.clickPaymentMethod("QR Code", true, { amount: "48" })]),
         {
             content: "Display QR Code Payment dialog",
             trigger: ".button.send_payment_request.highlight",
@@ -58,6 +60,8 @@ registry.category("web_tour.tours").add("PaymentScreenWithQRPayment", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+
+            // --- FULL PAYMENT ---
             addProductandPay(),
             isQRDisplayedinDialog(),
             Dialog.cancel(),
@@ -74,6 +78,16 @@ registry.category("web_tour.tours").add("PaymentScreenWithQRPayment", {
                 trigger: '.receipt-screen .button.next.highlight:contains("New Order")',
                 run: "click",
             },
+
+            // --- PARTIAL PAYMENT ---
+            addProductandPay(true),
+            isQRDisplayedinDialog(),
+            Dialog.confirm(),
+            {
+                trigger: ".electronic_status:contains('Successful')",
+            },
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -94,7 +94,8 @@
                                         </div>
                                     </t>
                                     <t t-else="">
-                                        <div></div>
+                                        <!-- Todo: remove in master -->
+                                        <div class="d-none"></div>
                                     </t>
                                 </t>
                                 <t t-elif="line.payment_status == 'reversed'">

--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen_payment_lines/payment_screen_payment_lines.js
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen_payment_lines/payment_screen_payment_lines.js
@@ -1,0 +1,22 @@
+import { patch } from "@web/core/utils/patch";
+import { PaymentScreenPaymentLines } from "@point_of_sale/app/screens/payment_screen/payment_lines/payment_lines";
+
+patch(PaymentScreenPaymentLines.prototype, {
+    async sendPaymentAdjust(line) {
+        const prevAmount = line.get_amount();
+        const amountDiff =
+            line.pos_order_id.get_total_with_tax() - line.pos_order_id.get_total_paid();
+        const newAmount = prevAmount + amountDiff;
+
+        line.set_amount(newAmount);
+        line.set_payment_status("waiting");
+
+        const isAdjustSuccessful =
+            await line.payment_method_id.payment_terminal?.send_payment_adjust(line.uuid);
+        if (!isAdjustSuccessful) {
+            line.set_amount(prevAmount);
+        }
+
+        line.set_payment_status("done");
+    },
+});

--- a/addons/pos_restaurant/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_payment.js
@@ -7,6 +7,9 @@ patch(PosPayment.prototype, {
         if (this.payment_method_id.payment_terminal) {
             return this.payment_method_id.payment_terminal.canBeAdjusted(this.uuid);
         }
-        return !this.payment_method_id.is_cash_count;
+        return (
+            !this.payment_method_id.is_cash_count &&
+            this.payment_method_id.payment_method_type != "qr_code"
+        );
     },
 });


### PR DESCRIPTION
Steps to reproduce:
====================
- Create a SEPA QR payment method (for a BE company).
- Create an order and select this payment method.
- Manually change the payment amount (partial amount).
- Confirm the partial payment.
- Click on the "Adjust Amount" button a traceback occurs.

Issue:
=======
In the XML template, the JS method `sendPaymentAdjust()` was being called, but this method was not defined on the JS side, leading to a traceback when the button was clicked.

Fix:
=====
- Restricted visibility of the "Adjust Amount" button to payment terminal methods that support adjustment.
- Added the missing JS method to handle the call and prevent traceback.

Task-5241346


