### PR TITLE
[FIX] web,calendar: contrast event dot color

### DIFF
--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -45,7 +45,7 @@
     }
 
     &.o_event_dot {
-        &.o_attendee_status_needsAction, &.o_event_hatched {
+        &.o_attendee_status_needsAction {
             &:before {
                 content: "\f1db"; // fa-circle-thin
             }

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -99,6 +99,11 @@
             &:hover {
                 --o-bg-opacity: 1;
             }
+
+            &.o_event_hatched:before {
+                content: "\f1db"; // fa-circle-thin
+                color: $body-color;
+            }
         }
     }
 
@@ -657,7 +662,7 @@
             &.o_event_dot {
                 background-color: rgba(var(--o-event-bg--subtle-rgb), var(--o-bg-opacity));
 
-                &:before {
+                &:where(:not(.o_event_hatched)):before {
                     color: var(--o-event-bg, #{$info});
                 }
             }


### PR DESCRIPTION
When pills are hatched (unpublished event) in the calendar view (eg. planning) the `o_event_dot` is barely visible. 

Additionally the styling to display the dot as outlined on hatched event is wrongly scoped in `/calendar` with the calendar status styling. It should be in the view instead. Otherwise, for the planning module which doesn't depend on calendar, the styling is not applied if calendar is not installed, rendering the filled dot.

task-3916768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
