### PR TITLE
[REF] mail, im_livechat: make channel_member_list use channel instead…

### DIFF
--- a/addons/im_livechat/static/src/core/common/channel_member_list_patch.xml
+++ b/addons/im_livechat/static/src/core/common/channel_member_list_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.ChannelMemberList" t-inherit="discuss.ChannelMemberList" t-inherit-mode="extension">
         <xpath expr="//button[@name='inviteButton']" position="attributes">
-            <attribute name="t-if">!props.thread.livechat_end_dt</attribute>
+            <attribute name="t-if">!props.channel.livechat_end_dt</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -8,33 +8,33 @@ import { useService } from "@web/core/utils/hooks";
 
 export class ChannelMemberList extends Component {
     static components = { ActionPanel, ChannelMember };
-    static props = ["thread", "openChannelInvitePanel", "className?"];
+    static props = ["channel", "openChannelInvitePanel", "className?"];
     static template = "discuss.ChannelMemberList";
 
     setup() {
         super.setup();
         this.store = useService("mail.store");
         onWillStart(() => {
-            if (this.props.thread.fetchMembersState === "not_fetched") {
-                this.props.thread.fetchChannelMembers();
+            if (this.props.channel.fetchMembersState === "not_fetched") {
+                this.props.channel.fetchChannelMembers();
             }
         });
         onWillUpdateProps((nextProps) => {
-            if (nextProps.thread.fetchMembersState === "not_fetched") {
-                nextProps.thread.fetchChannelMembers();
+            if (nextProps.channel.fetchMembersState === "not_fetched") {
+                nextProps.channel.fetchChannelMembers();
             }
         });
     }
 
     get onlineSectionText() {
         return _t("Online - %(online_count)s", {
-            online_count: this.props.thread.onlineMembers.length,
+            online_count: this.props.channel.onlineMembers.length,
         });
     }
 
     get offlineSectionText() {
         return _t("Offline - %(offline_count)s", {
-            offline_count: this.props.thread.offlineMembers.length,
+            offline_count: this.props.channel.offlineMembers.length,
         });
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -4,26 +4,26 @@
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
             <button name="inviteButton" t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3"><i class="oi oi-user-plus"/><span>Invite a User</span></button>
-            <t t-if="props.thread.onlineMembers.length > 0">
+            <t t-if="props.channel.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="props.thread.onlineMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="props.channel.onlineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <t name="offlineMembers" t-if="props.thread.offlineMembers.length > 0">
+            <t name="offlineMembers" t-if="props.channel.offlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="offlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="props.thread.offlineMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="props.channel.offlineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <span t-if="props.thread.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
-            <span t-if="props.thread.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-esc="props.thread.unknownMembersCount"/> other members.</span>
-            <div t-if="!props.thread.areAllMembersLoaded" class="mx-2 my-1">
-                <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => props.thread.fetchChannelMembers()">Load more</button>
+            <span t-if="props.channel.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
+            <span t-if="props.channel.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-esc="props.channel.unknownMembersCount"/> other members.</span>
+            <div t-if="!props.channel.areAllMembersLoaded" class="mx-2 my-1">
+                <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => props.channel.fetchChannelMembers()">Load more</button>
             </div>
         </ActionPanel>
     </t>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -175,13 +175,13 @@ registerThreadAction("member-list", {
         }
     },
     actionPanelComponent: ChannelMemberList,
-    actionPanelComponentProps: ({ actions, thread }) => ({
+    actionPanelComponentProps: ({ actions, channel }) => ({
         openChannelInvitePanel({ keepPrevious } = {}) {
             actions.actions
                 .find(({ id }) => id === "invite-people")
                 ?.actionPanelOpen({ keepPrevious });
         },
-        thread,
+        channel,
     }),
     actionPanelOpen: ({ owner, store }) => {
         if (owner.env.inDiscussApp) {
@@ -189,8 +189,8 @@ registerThreadAction("member-list", {
         }
     },
     actionPanelOuterClass: "o-discuss-ChannelMemberList bg-inherit",
-    condition: ({ owner, thread }) =>
-        thread?.hasMemberList &&
+    condition: ({ owner, channel }) =>
+        channel?.hasMemberList &&
         (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
         !owner.isDiscussSidebarChannelActions,
     icon: "oi oi-fw oi-users",


### PR DESCRIPTION
… of thread

Before this commit, the channel_member_list component received a thread as a prop.
This commit updates it to use the channel directly.

PR enterprise: https://github.com/odoo/enterprise/pull/99267