### PR TITLE
[FIX] im_livechat: preserve breadcrumb on opening visitor contact

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -21,6 +21,7 @@ export class LivechatChannelInfoList extends Component {
 
     setup() {
         super.setup();
+        this.actionService = useService("action");
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.tagEditPopover = usePopover(ConversationTagEdit, {
@@ -87,6 +88,13 @@ export class LivechatChannelInfoList extends Component {
         } else {
             this.props.thread.openChatWindow({ focus: true });
         }
+        this.actionService.doAction({
+            type: "ir.actions.act_window",
+            res_model: "res.partner",
+            res_id: this.props.thread.livechatVisitorMember.partner_id.id,
+            views: [[false, "form"]],
+            target: "current",
+        });
     }
 
     get visitorProfileURL() {

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelInfoList">
         <ActionPanel title.translate="Information" minWidth="200" initialWidth="env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
-            <a t-if="visitorProfileURL" class="btn btn-primary mt-1" t-on-click="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
+            <a t-if="visitorProfileURL" class="btn btn-primary mt-1" t-on-click.prevent="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
                 View Contact
             </a>
             <div t-if="!props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">


### PR DESCRIPTION
Previously, when we click on the "View Contact" button, the corresponding
partner's form is opened but via  a href link which does not preserve the 
breadcrumb.

Purpose of this commit is to use the action service instead, to open the form 
view of the partner, which will preserve the breadcrumb so that navigating
back to that session is handy.
 
Part of Task-5190261
