### PR TITLE
[FIX] point_of_sale: apply modal css properly

### DIFF
--- a/addons/point_of_sale/static/src/app/components/dialog/dialog.scss
+++ b/addons/point_of_sale/static/src/app/components/dialog/dialog.scss
@@ -3,6 +3,7 @@
     --modal-header-border-width: 0;
 
     .modal-header {
+        padding-bottom: 0;
         &:has(.btn-close) {
             margin-right: var(--modal-header-padding-y);
         }
@@ -14,11 +15,15 @@
     }
 
     .modal-body {
-        --modal-padding: 0 16px;
+        --modal-padding: 16px;
 
         > p:last-child {
             margin-bottom: 4px;
         }
+    }
+
+    .modal-footer {
+        padding-top: 0;
     }
 }
 


### PR DESCRIPTION
In this commit:
------------------
- Adjusted dialog structure to ensure consistent styling even when header or footer is absent.
- Added padding to all sides of the body while removing bottom padding from the header and top padding from the footer for balanced spacing.

task: 5246635

Reference:
--------------
<img width="2896" height="1776" alt="Untitled-1" src="https://github.com/user-attachments/assets/8dc85ee7-50b4-4b68-9825-aa102bf180bc" />

