### PR TITLE
[FIX] hr_work_entry: get work entry wihtout being attendance manager

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -175,7 +175,7 @@ class HrVersion(models.Model):
         version_vals = []
         bypassing_work_entry_type_codes = self._get_bypassing_work_entry_type_codes()
 
-        attendances_by_resource = self._get_attendance_intervals(start_dt, end_dt)
+        attendances_by_resource = self.sudo()._get_attendance_intervals(start_dt, end_dt)
 
         resource_calendar_leaves = self._get_resource_calendar_leaves(start_dt, end_dt)
         # {resource: resource_calendar_leaves}


### PR DESCRIPTION
When we try to read the work entries, we've got an access rights error if we are not attendance manager.

As we are still supposed to read the work entries, we get the attendance interval in sudo


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
