### PR TITLE
[FIX] mail: no crash on closing chat window in livechat support page

### DIFF
--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -10,5 +10,8 @@ const discussChannelPatch = {
         super.setup(...arguments);
         this.livechat_channel_id = fields.One("im_livechat.channel", { inverse: "channel_ids" });
     },
+    get membersThatCanSeen() {
+        return super.membersThatCanSeen.filter((member) => member.livechat_member_type !== "bot");
+    },
 };
 patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -66,10 +66,6 @@ patch(Thread.prototype, {
         return this.newestPersistentOfAllMessage?.isSelfAuthored;
     },
 
-    get membersThatCanSeen() {
-        return super.membersThatCanSeen.filter((member) => member.livechat_member_type !== "bot");
-    },
-
     get avatarUrl() {
         if (this.channel?.channel_type === "livechat") {
             return this.livechat_operator_id.avatarUrl;

--- a/addons/im_livechat/static/tests/tours/support/im_livechat_basic_tour.js
+++ b/addons/im_livechat/static/tests/tours/support/im_livechat_basic_tour.js
@@ -12,5 +12,16 @@ registry.category("web_tour.tours").add("im_livechat.basic_tour", {
         {
             trigger: ".o-livechat-root:shadow .o-mail-ChatWindow",
         },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Message",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-ChatWindow [title*='Close Chat Window']",
+            run: "click",
+        },
+        {
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatHub:not(:visible):not(:has(.o-mail-ChatWindow))",
+        },
     ],
 });

--- a/addons/im_livechat/tests/test_im_livechat_support_page.py
+++ b/addons/im_livechat/tests/test_im_livechat_support_page.py
@@ -13,6 +13,7 @@ class TestImLivechatSupportPage(TestGetOperatorCommon):
             {"name": "Support Channel", "user_ids": [operator.id]}
         )
         self.start_tour(f"/im_livechat/support/{livechat_channel.id}", "im_livechat.basic_tour")
+        self.start_tour(f"/im_livechat/support/{livechat_channel.id}", "im_livechat.basic_tour", login=operator.login)
 
     def test_load_modules_cors(self):
         operator = self._create_operator()

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -70,6 +70,15 @@ export class DiscussChannel extends Record {
             }
         },
     });
+    /**
+     * To be overridden.
+     * The purpose is to exclude technical channel_member_ids like bots and avoid
+     * "wrong" seen message indicator
+     * @returns {import("models").ChannelMember[]}
+     */
+    get membersThatCanSeen() {
+        return this.channel_member_ids;
+    }
     otherTypingMembers = fields.Many("discuss.channel.member", {
         /** @this {import("models").Thread} */
         compute() {

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -15,7 +15,7 @@ const messagePatch = {
         this.hasEveryoneSeen = fields.Attr(false, {
             /** @this {import("models").Message} */
             compute() {
-                return this.thread?.membersThatCanSeen.every((m) => m.hasSeen(this));
+                return this.channel_id?.membersThatCanSeen.every((m) => m.hasSeen(this));
             },
         });
         this.hasNewMessageSeparator = fields.Attr(false, {
@@ -36,7 +36,7 @@ const messagePatch = {
         this.hasSomeoneSeen = fields.Attr(false, {
             /** @this {import("models").Message} */
             compute() {
-                return this.thread?.membersThatCanSeen
+                return this.channel_id?.membersThatCanSeen
                     .filter((member) => member.persona.notEq(this.author))
                     .some((m) => m.hasSeen(this));
             },
@@ -63,7 +63,7 @@ const messagePatch = {
     },
     /** @returns {import("models").ChannelMember[]} */
     get channelMemberHaveSeen() {
-        return this.thread.membersThatCanSeen.filter(
+        return this.channel_id.membersThatCanSeen.filter(
             (m) => m.hasSeen(this) && m.persona.notEq(this.author)
         );
     },

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -366,15 +366,6 @@ const threadPatch = {
             });
         }).then(() => (this.markingAsRead = false));
     },
-    /**
-     * To be overridden.
-     * The purpose is to exclude technical channel_member_ids like bots and avoid
-     * "wrong" seen message indicator
-     * @returns {import("models").ChannelMember[]}
-     */
-    get membersThatCanSeen() {
-        return this.channel.channel_member_ids;
-    },
     /** @override */
     get needactionCounter() {
         return this.isChatChannel


### PR DESCRIPTION
Steps to reproduce:
- open livechat support with at least 1 human agent available
- click on button to open chat window
- immediately close the chat window => crash

This happens from welcome message triggering message seen code, which triggers access to `hasEveryoneSeen` which implies `membersThatCanSeen` being accessed in compute. When closing the chat window, the chat window is closed then the channel is deleted. Deletion of the the channel makes deletion of channel object and then the thread object. As the message is still present on channel object deletion, it retriggers compute of `hasEveryoneSeen` which also calls `membersThatCanSeen` on `thread` object still alive for a short time. In this getter, `this.channel` of `thread` was not guarded, thus it crashed.

This commit fixes the issue by guarding access of `this.channel` in this flow like in the many other flows of `thread` model that accesses `this.channel`.