### PR TITLE
[FIX] web_editor: fix non-deterministic tests

### DIFF
--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -1692,7 +1692,7 @@ describe("Selection collapsed", () => {
             });
         });
         describe("Unordered to checklist", () => {
-            test("should merge an unordered list into an checklist list", async () => {
+            test("should merge an unordered list into an checklist list (1)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul class="o_checklist"><li class="o_checked">a</li></ul><ul><li>[]b</li></ul>',
@@ -1702,6 +1702,8 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
                 });
+            });
+            test("should merge an unordered list into an checklist list (2)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul class="o_checklist"><li class="o_checked">a</li></ul><ul><li><p>[]b</p></li></ul>',
@@ -1712,6 +1714,8 @@ describe("Selection collapsed", () => {
                     // Paragraphs in list items are treated as nonsense.
                     contentAfter: '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
                 });
+            });
+            test("should merge an unordered list into an checklist list (3)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul class="o_checklist"><li class="o_checked"><p>a</p></li></ul><ul><li>[]b</li></ul>',
@@ -1723,6 +1727,8 @@ describe("Selection collapsed", () => {
                     contentAfter:
                         '<ul class="o_checklist"><li class="o_checked"><p>a[]b</p></li></ul>',
                 });
+            });
+            test("should merge an unordered list into an checklist list (4)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul class="o_checklist"><li class="o_checked"><p>a</p></li></ul><ul><li><p>[]b</p></li></ul>',

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -5357,7 +5357,7 @@ describe('List', () => {
                         });
                     });
                     describe('Unordered to checklist', () => {
-                        it('should merge an unordered list into an checklist list', async () => {
+                        it('should merge an unordered list into an checklist list (1)', async () => {
                             await testEditor(BasicEditor, {
                                 removeCheckIds: true,
                                 contentBefore:
@@ -5369,6 +5369,8 @@ describe('List', () => {
                                 contentAfter:
                                     '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
                             });
+                        });
+                        it('should merge an unordered list into an checklist list (2)', async () => {
                             await testEditor(BasicEditor, {
                                 removeCheckIds: true,
                                 contentBefore:
@@ -5381,6 +5383,8 @@ describe('List', () => {
                                 contentAfter:
                                     '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
                             });
+                        });
+                        it('should merge an unordered list into an checklist list (3)', async () => {
                             await testEditor(BasicEditor, {
                                 removeCheckIds: true,
                                 contentBefore:
@@ -5393,6 +5397,8 @@ describe('List', () => {
                                 contentAfter:
                                     '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
                             });
+                        });
+                        it('should merge an unordered list into an checklist list (4)', async () => {
                             await testEditor(BasicEditor, {
                                 removeCheckIds: true,
                                 contentBefore:


### PR DESCRIPTION


    Split the test timer between the four tests rather than applying
    a single timer over all of them, for when the runbot is slower.

    runbot-233975