### PR TITLE
[IMP] web: fine-tune BS `nav-underline` design

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
@@ -135,3 +135,7 @@ $dropdown-bg: $body-bg !default;
 // Navbar
 
 $navbar-light-toggler-border-color: rgba($body-emphasis-color, 0.15) !default;
+
+// Nav and Tabs
+
+$nav-underline-border-width: $border-width * 3 !default;

--- a/addons/web/static/src/scss/bootstrap_review_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_frontend.scss
@@ -346,3 +346,14 @@ $-color-for-gray-200-bg: adjust-color-to-background($body-color, $gray-200);
 .form-range:disabled::-webkit-slider-thumb {
     border-color: $input-disabled-border-color;
 }
+
+
+// Fine-tune the style of Bootstrap's nav-underline component
+.nav-underline {
+    border-bottom: $border-width solid $border-color;
+
+    .nav-link.active, .nav-link:hover, .nav-link:focus, .show > .nav-link {
+        font-weight: $font-weight-normal;
+        border-bottom-color: $primary;
+    }
+}


### PR DESCRIPTION
This commit fine-tunes the default `.nav-underline` design from Bootstrap in order to provide a sleeker and more standard design for the component in the frontend.

task-5252772

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
