### PR TITLE
[FIX] website_sale_product_feed: fix google merchant feed traceback

### DIFF
--- a/addons/website_sale_product_feed/models/product_feed.py
+++ b/addons/website_sale_product_feed/models/product_feed.py
@@ -309,7 +309,11 @@ class ProductFeed(models.Model):
         combination_info = product.with_context(
             **price_context,
         ).product_tmpl_id._get_additionnal_combination_info(
-            product, 1.0, fields.Date.context_today(self), self.website_id,
+            product,
+            quantity=1.0,
+            uom=product.uom_id,
+            date=fields.Date.context_today(self),
+            website=self.website_id,
         )
         if combination_info['prevent_zero_price_sale']:
             return {}


### PR DESCRIPTION
Issue:
In this issue, google merchant feed traceback raises a traceback error.

To reproduce:
1- Install Ecommerce app
2- Enable `Google Merchant Center` in setting
3- Create a consumable product and publish it
4- From `Google Merchant Center` setting, open `Manage feeds`
5- Copy the URL into the browser

Cause:
- on 30th June 2025: 7b56a6afda919f3c09d08eb1256416e0a2b4b1d9 added a required `uom` parameter to `_get_additionnal_combination_info`  method 
- on 17th October 2025: b3f6541e9b6a1e8c6676cf2cad7418046f63e51b forward-port didn't take this change into account

In Odoo 19, this is already fixed.

opw-5229777
