### PR TITLE
[IMP] l10n_hk : add asset models, depreciation and expense account to fixed assets

### DIFF
--- a/addons/l10n_hk/data/template/account.account-hk.csv
+++ b/addons/l10n_hk/data/template/account.account-hk.csv
@@ -1,75 +1,104 @@
-"id","name","code","account_type","tag_ids","reconcile"
-"l10n_hk_11","Fixed Assets","11","asset_fixed","","False"
-"l10n_hk_1110","Furniture and Fixtures","1110","asset_non_current","","False"
-"l10n_hk_1130","Equipment","1130","asset_non_current","","False"
-"l10n_hk_1140","Decoration","1140","asset_non_current","","False"
-"l10n_hk_1160","Investments","1160","asset_non_current","","False"
-"l10n_hk_12","Current Assets","12","asset_current","","False"
-"l10n_hk_1240","Account Receivable","1240","asset_receivable","","True"
-"l10n_hk_1241","Utility & Rental Deposit","1241","asset_current","","True"
-"l10n_hk_1242","Supplier Prepayments","1242","asset_current","","False"
-"l10n_hk_1243","Account Receivable (PoS)","1243","asset_receivable","","True"
-"l10n_hk_1245","Sundry Deposits","1245","asset_current","","False"
-"l10n_hk_1246","Other Receivable","1246","asset_receivable","","True"
-"l10n_hk_1250","Stock Interim Account (Received)","1250","asset_current","","False"
-"l10n_hk_1260","Stock Interim Account (Delivered)","1260","asset_current","","False"
-"l10n_hk_1270","Stock Valuation Account","1270","asset_current","","False"
-"l10n_hk_1400","Prepaid Expenses","1400","asset_current","","False"
-"l10n_hk_21","Non-current Liabilities","21","liability_non_current","","False"
-"l10n_hk_2107","Unearned Income from System","2107","liability_current","","False"
-"l10n_hk_22","Current Liabilities","22","liability_current","","False"
-"l10n_hk_2210","Accruals","2210","liability_current","","False"
-"l10n_hk_221001","MPF Accrued (Employer)","221001","liability_current","","True"
-"l10n_hk_221002","MPF Witheld (Employee)","221002","liability_current","","True"
-"l10n_hk_2211","Account Payable","2211","liability_payable","","True"
-"l10n_hk_2212","Receipt in Advance (Customer Prepayments)","2212","liability_current","","False"
-"l10n_hk_2214","Provision for Taxation","2214","liability_current","","False"
-"l10n_hk_2215","Proposed Dividend","2215","liability_current","","False"
-"l10n_hk_2216","Other Payable","2216","liability_payable","","True"
-"l10n_hk_31","Paid Capital","31","liability_current","","False"
-"l10n_hk_32","Accumulated Profit & Loss","32","liability_current","","False"
-"l10n_hk_33","Profit & Loss Account","33","liability_current","","False"
-"l10n_hk_34","Short-term Borrowing","34","liability_current","","False"
-"l10n_hk_41","Trade Income","41","income","account.account_tag_operating","False"
-"l10n_hk_42","Other Income and Gains","42","income","account.account_tag_operating","False"
-"l10n_hk_4210","Sundry Income","4210","income","account.account_tag_operating","False"
-"l10n_hk_4220","Exchange Adjustment","4220","income","account.account_tag_operating","False"
-"l10n_hk_4230","Bank Interest Income","4230","income","account.account_tag_operating","False"
-"l10n_hk_4240","Foreign Exchange Gain","4240","income","account.account_tag_operating","False"
-"l10n_hk_4250","Cash Discount Gain","4250","income_other","account.account_tag_operating","False"
-"l10n_hk_51","Costs","51","expense","account.account_tag_operating","False"
-"l10n_hk_5101","Trade Costs","5101","expense","account.account_tag_operating","False"
-"l10n_hk_5105","Misc. Costs","5105","expense","account.account_tag_operating","False"
-"l10n_hk_5106","Costs of Transportation","5106","expense","account.account_tag_operating","False"
-"l10n_hk_5111","Declaration Fees","5111","expense","account.account_tag_operating","False"
-"l10n_hk_5112","Packing Fees","5112","expense","account.account_tag_operating","False"
-"l10n_hk_52","Expenses","52","expense","account.account_tag_operating","False"
-"l10n_hk_5201","Bank Charges","5201","expense","account.account_tag_operating","False"
-"l10n_hk_5202","Entertainment","5202","expense","account.account_tag_operating","False"
-"l10n_hk_5203","Electricity & Water Fees","5203","expense","account.account_tag_operating","False"
-"l10n_hk_5205","Postage & Stamps","5205","expense","account.account_tag_operating","False"
-"l10n_hk_5206","Printing & Stationery","5206","expense","account.account_tag_operating","False"
-"l10n_hk_5207","Rent & Rates","5207","expense","account.account_tag_operating","False"
-"l10n_hk_5208","Sundry Expenses","5208","expense","account.account_tag_operating","False"
-"l10n_hk_5209","Telecommunication Expenses","5209","expense","account.account_tag_operating","False"
-"l10n_hk_5210","Traffic Fees","5210","expense","account.account_tag_operating","False"
-"l10n_hk_5211","IT Expenses","5211","expense","account.account_tag_operating","False"
-"l10n_hk_5214","Insurance","5214","expense","account.account_tag_operating","False"
-"l10n_hk_5215","Sales Commission","5215","expense","account.account_tag_operating","False"
-"l10n_hk_5216","Overseas Traveling","5216","expense","account.account_tag_operating","False"
-"l10n_hk_5217","MPF Contribution (Employer)","5217","expense","account.account_tag_operating","False"
-"l10n_hk_5218","Wages & Salaries","5218","expense","account.account_tag_operating","False"
-"l10n_hk_5219","Bonus Payment","5219","expense","account.account_tag_operating","False"
-"l10n_hk_5221","Taxation","5221","expense","account.account_tag_operating","False"
-"l10n_hk_5222","Local Delivery","5222","expense","account.account_tag_operating","False"
-"l10n_hk_5223","Management Fees","5223","expense","account.account_tag_operating","False"
-"l10n_hk_5224","Depreciation","5224","expense","account.account_tag_operating","False"
-"l10n_hk_5225","Audit Fees","5225","expense","account.account_tag_operating","False"
-"l10n_hk_5226","Bad Debts","5226","expense","account.account_tag_operating","False"
-"l10n_hk_5228","Legal & Professional Fees","5228","expense","account.account_tag_operating","False"
-"l10n_hk_5229","Dividend","5229","expense","account.account_tag_operating","False"
-"l10n_hk_5231","Disposal","5231","expense","account.account_tag_operating","False"
-"l10n_hk_5234","Repair and Maintenance","5234","expense","account.account_tag_operating","False"
-"l10n_hk_5235","Advertising","5235","expense","account.account_tag_operating","False"
-"l10n_hk_5240","Foreign Exchange Loss","5240","expense","account.account_tag_operating","False"
-"l10n_hk_5250","Cash Discount Loss","5250","expense","account.account_tag_operating","False"
+id,name,code,account_type,description,tag_ids,reconcile,asset_model_created,asset_model,depreciation_account,expense_account
+l10n_hk_11,Fixed Assets,11,asset_fixed,Tangible assets held by the company for use in the production or supply of goods or services,,False,True,,l10n_hk_1500,l10n_hk_5224
+l10n_hk_110001,Technology,11,asset_fixed,Technological products or services bought for your business,,False,True,3 years,l10n_hk_1510,l10n_hk_522401
+l10n_hk_110002,Land,11,asset_fixed,Purchases of lands without buildings,,False,False,None,,
+l10n_hk_110003,Construction,11,asset_fixed,Construction of buildings and costs associated to buildings,,False,True,30 years,l10n_hk_151001,l10n_hk_522402
+l10n_hk_110004,Installations,11,asset_fixed,"Purchases of installations related to buildings, like solar panels or heater",,False,True,10 years,l10n_hk_151002,l10n_hk_522402
+l10n_hk_110005,Machines,11,asset_fixed,Machinery and tools directly related to your business,,False,True,5 years,l10n_hk_151003,l10n_hk_522402
+l10n_hk_110006,Other property,11,asset_fixed,"Other type of property, like plants, machinery or various equipment",,False,True,5 years,l10n_hk_151004,l10n_hk_522402
+l10n_hk_110007,Furniture & material,11,asset_fixed,Large expenses related to workplaces,,False,True,5 years,l10n_hk_151005,l10n_hk_522402
+l10n_hk_110008,Vehicle,11,asset_fixed,"Purchase of a car, including second hand or after-lease contract",,False,True,5 years,l10n_hk_151006,l10n_hk_522402
+l10n_hk_110009,Vehicle accessories,11,asset_fixed,All accessories purchases related to your professional vehicle,,False,True,3 years,l10n_hk_151007,l10n_hk_522402
+l10n_hk_1110,Furniture and Fixtures,1110,asset_non_current,Long-term assets for office and workplace furnishings.,,False,,,,
+l10n_hk_111220,Funds in Transit,111220,asset_current,"Money transferred between accounts or locations, not yet received by the destination.",,True,,,,
+l10n_hk_1130,Equipment,1130,asset_non_current,Long-term assets such as specialized tools or operational hardware.,,False,,,,
+l10n_hk_1140,Decoration,1140,asset_non_current,Costs capitalized for interior or exterior decorative improvements.,,False,,,,
+l10n_hk_1160,Investments,1160,asset_non_current,Assets held for long-term capital appreciation or income generation.,,False,,,,
+l10n_hk_12,Current Assets,12,asset_current,"Assets expected to be sold, consumed, or converted to cash within one year.",,False,,,,
+l10n_hk_120001,Bank,120001,bank_cash,Funds held in the company's primary operational bank accounts.,,True,,,,
+l10n_hk_120002,Stripe Issuing,120002,bank_cash,Funds held within specialized payment processing platforms.,,True,,,,
+l10n_hk_120003,Bank Suspense Account,120003,asset_current,Temporary account for transactions where the final destination is pending.,,True,,,,
+l10n_hk_120004,Outstanding Receipts,120004,asset_current,Cash or cheques received but not yet deposited in the bank.,,True,,,,
+l10n_hk_120005,Outstanding Payments,120005,asset_current,Cheques or payments issued but not yet cleared by the bank.,,True,,,,
+l10n_hk_1240,Account Receivable,1240,asset_receivable,Amounts due from customers for goods or services already sold.,,True,,,,
+l10n_hk_1241,Utility & Rental Deposit,1241,asset_current,Recoverable deposits placed with landlords or utility providers.,,True,,,,
+l10n_hk_1242,Supplier Prepayments,1242,asset_current,Payments made to suppliers in advance of receiving the goods or services.,,False,,,,
+l10n_hk_1243,Account Receivable (PoS),1243,asset_receivable,Amounts due from customers specifically via Point of Sale transactions.,,True,,,,
+l10n_hk_1245,Sundry Deposits,1245,asset_current,Miscellaneous recoverable deposits made to third parties.,,False,,,,
+l10n_hk_1246,Other Receivable,1246,asset_receivable,Amounts due from parties other than primary trade customers.,,True,,,,
+l10n_hk_1250,Stock Interim Account (Received),1250,asset_current,Temporary account for inventory received but not yet recorded in final stock.,,False,,,,
+l10n_hk_1260,Stock Interim Account (Delivered),1260,asset_current,Temporary account for inventory delivered but not yet invoiced.,,False,,,,
+l10n_hk_1270,Stock Valuation Account,1270,asset_current,Represents the total value of inventory currently held in stock.,,False,,,,
+l10n_hk_1400,Prepaid Expenses,1400,asset_current,Payments made for expenses that will be consumed in a future accounting period.,,False,,,,
+l10n_hk_1500,Depreciation - Fixed Assets (Control),1500,asset_current,Total accumulated wear and tear across all fixed assets.,,False,,,,
+l10n_hk_1510,Depreciation - Technology,1510,asset_current,Total accumulated depreciation for technology assets.,,False,,,,
+l10n_hk_151001,Depreciation - Construction,1510,asset_current,Total accumulated depreciation for buildings/construction.,,False,,,,
+l10n_hk_151002,Depreciation - Installations,1510,asset_current,Total accumulated depreciation for installations.,,False,,,,
+l10n_hk_151003,Depreciation - Machines & tools,1510,asset_current,Total accumulated depreciation for machinery and tools.,,False,,,,
+l10n_hk_151004,Depreciation - Other property,1510,asset_current,Total accumulated depreciation for other property and equipment.,,False,,,,
+l10n_hk_151005,Depreciation - Furniture & material,1510,asset_current,Total accumulated depreciation for furniture and material.,,False,,,,
+l10n_hk_151006,Depreciation - Vehicle,1510,asset_current,Total accumulated depreciation for vehicles.,,False,,,,
+l10n_hk_151007,Depreciation - Vehicle accessories,1510,asset_current,Total accumulated depreciation for vehicle accessories.,,False,,,,
+l10n_hk_21,Non-current Liabilities,21,liability_non_current,Debts payable in more than one year.,,False,,,,
+l10n_hk_2107,Unearned Income from System,2107,liability_current,Payments received in advance for services not yet provided.,,False,,,,
+l10n_hk_22,Current Liabilities,22,liability_current,Debts payable within one year.,,False,,,,
+l10n_hk_2210,Accruals,2210,liability_current,Expenses incurred but not yet billed or paid.,,False,,,,
+l10n_hk_221001,MPF Accrued (Employer),2210,liability_current,Mandatory MPF (pension fund) contributions due by the employer.,,True,,,,
+l10n_hk_221002,MPF Witheld (Employee),2210,liability_current,MPF contributions withheld from employee salaries and due to the scheme.,,True,,,,
+l10n_hk_2211,Account Payable,2211,liability_payable,Amounts owed to suppliers for goods or services received.,,True,,,,
+l10n_hk_2212,Receipt in Advance (Customer Prepayments),2212,liability_current,Funds received from customers for orders not yet delivered.,,False,,,,
+l10n_hk_2214,Provision for Taxation,2214,liability_current,Estimated income tax (Profits Tax) liability due to the government.,,False,,,,
+l10n_hk_2215,Proposed Dividend,2215,liability_current,Dividends that the board has proposed to pay shareholders.,,False,,,,
+l10n_hk_2216,Other Payable,2216,liability_payable,Miscellaneous amounts owed to third parties not classified as Accounts Payable.,,True,,,,
+l10n_hk_31,Paid Capital,31,liability_current,Value of share capital paid into the company by shareholders.,,False,,,,
+l10n_hk_32,Accumulated Profit & Loss,32,liability_current,Total net profits or losses carried forward from prior years.,,False,,,,
+l10n_hk_33,Profit & Loss Account,33,liability_current,Net result (profit or loss) for the current financial year.,,False,,,,
+l10n_hk_34,Short-term Borrowing,34,liability_current,Bank loans or other debts due to be repaid in less than one year.,,False,,,,
+l10n_hk_41,Trade Income,41,income,Revenue generated from the company's core business activities (sales of goods or services).,account.account_tag_operating,False,,,,
+l10n_hk_42,Other Income and Gains,42,income,Auxiliary income from non-core sources.,account.account_tag_operating,False,,,,
+l10n_hk_4210,Sundry Income,4210,income,"Small, miscellaneous, and occasional revenue items.",account.account_tag_operating,False,,,,
+l10n_hk_4220,Exchange Adjustment,4220,income,Unrealized foreign currency rate adjustments.,account.account_tag_operating,False,,,,
+l10n_hk_4230,Bank Interest Income,4230,income,Interest earned on the company's bank deposits.,account.account_tag_operating,False,,,,
+l10n_hk_4240,Foreign Exchange Gain,4240,income,Realized profit from foreign currency transactions.,account.account_tag_operating,False,,,,
+l10n_hk_4250,Cash Discount Gain,4250,income_other,Gain earned by receiving early payment from customers.,account.account_tag_operating,False,,,,
+l10n_hk_51,Costs,51,expense,General header for expenses directly linked to generating primary revenue.,account.account_tag_operating,False,,,,
+l10n_hk_5101,Trade Costs,5101,expense,Direct costs associated with buying or producing trade goods or services.,account.account_tag_operating,False,,,,
+l10n_hk_5105,Misc. Costs,5105,expense,Miscellaneous small costs related to trade or direct operations.,account.account_tag_operating,False,,,,
+l10n_hk_5106,Costs of Transportation,5106,expense,"Expenses for transporting goods, typically inbound or directly for sales.",account.account_tag_operating,False,,,,
+l10n_hk_5111,Declaration Fees,5111,expense,Fees associated with customs or regulatory declarations.,account.account_tag_operating,False,,,,
+l10n_hk_5112,Packing Fees,5112,expense,Costs incurred for packaging goods for sale or delivery.,account.account_tag_operating,False,,,,
+l10n_hk_52,Expenses,52,expense,General header for administrative and operational expenditures.,account.account_tag_operating,False,,,,
+l10n_hk_5201,Bank Charges,5201,expense,Fees and commissions charged by banks and financial institutions.,account.account_tag_operating,False,,,,
+l10n_hk_5202,Entertainment,5202,expense,"Costs for entertaining clients, customers, or business partners.",account.account_tag_operating,False,,,,
+l10n_hk_5203,Electricity & Water Fees,5203,expense,Utility expenses for electricity and water consumption.,account.account_tag_operating,False,,,,
+l10n_hk_5205,Postage & Stamps,5205,expense,"Costs for mail, delivery services, and stamps.",account.account_tag_operating,False,,,,
+l10n_hk_5206,Printing & Stationery,5206,expense,"Costs for office supplies, paper, and printing services.",account.account_tag_operating,False,,,,
+l10n_hk_5207,Rent & Rates,5207,expense,Expenses for rent (office/storage) and local property taxes (Rates).,account.account_tag_operating,False,,,,
+l10n_hk_5208,Sundry Expenses,5208,expense,"Various small, miscellaneous expenses not fitting other categories.",account.account_tag_operating,False,,,,
+l10n_hk_5209,Telecommunication Expenses,5209,expense,"Bills for phone, mobile, and internet services.",account.account_tag_operating,False,,,,
+l10n_hk_5210,Traffic Fees,5210,expense,"Fees and tolls related to vehicle usage (e.g., tunnel tolls).",account.account_tag_operating,False,,,,
+l10n_hk_5211,IT Expenses,5211,expense,"Costs for software, IT support, and technology services.",account.account_tag_operating,False,,,,
+l10n_hk_5214,Insurance,5214,expense,Premiums paid for various types of business insurance coverage.,account.account_tag_operating,False,,,,
+l10n_hk_5215,Sales Commission,5215,expense,Payments made to sales staff or agents based on performance.,account.account_tag_operating,False,,,,
+l10n_hk_5216,Overseas Traveling,5216,expense,Expenses incurred for business travel outside of Hong Kong.,account.account_tag_operating,False,,,,
+l10n_hk_5217,MPF Contribution (Employer),5217,expense,Employer's share of Mandatory Provident Fund contributions.,account.account_tag_operating,False,,,,
+l10n_hk_5218,Wages & Salaries,5218,expense,Gross payroll payments to employees.,account.account_tag_operating,False,,,,
+l10n_hk_5219,Bonus Payment,5219,expense,Payments made to employees outside of regular wages/salaries.,account.account_tag_operating,False,,,,
+l10n_hk_5221,Taxation,5221,expense,Expenses for various taxes and duties (excluding Profits Tax provision).,account.account_tag_operating,False,,,,
+l10n_hk_5222,Local Delivery,5222,expense,Costs for delivering goods within Hong Kong.,account.account_tag_operating,False,,,,
+l10n_hk_5223,Management Fees,5223,expense,Fees paid for general management or administrative services.,account.account_tag_operating,False,,,,
+l10n_hk_5224,Depreciation,5224,expense,General depreciation expense for company assets.,account.account_tag_operating,False,,,,
+l10n_hk_522401,Depreciation of intangible assets,5224,expense,"Expense for the loss in value of intangible items (e.g., software or licenses).",account.account_tag_operating,False,,,,
+l10n_hk_522402,"Depreciation of property, plant and equipment",5224,expense,Expense for the loss in value of physical assets (ex: buildings or machines).,account.account_tag_operating,False,,,,
+l10n_hk_5225,Audit Fees,5225,expense,Fees paid to external auditors for statutory financial reviews.,account.account_tag_operating,False,,,,
+l10n_hk_5226,Bad Debts,5226,expense,Losses resulting from customer accounts deemed uncollectible.,account.account_tag_operating,False,,,,
+l10n_hk_5228,Legal & Professional Fees,5228,expense,"Fees paid to lawyers, consultants, or other professionals.",account.account_tag_operating,False,,,,
+l10n_hk_5229,Dividend,5229,expense,Expense related to the distribution of profits to shareholders.,account.account_tag_operating,False,,,,
+l10n_hk_5231,Disposal,5231,expense,Loss incurred from the sale or retirement of an asset.,account.account_tag_operating,False,,,,
+l10n_hk_5234,Repair and Maintenance,5234,expense,Costs to keep and repair fixed assets in working condition.,account.account_tag_operating,False,,,,
+l10n_hk_5235,Advertising,5235,expense,"Expenses for marketing, publicity, and advertising campaigns.",account.account_tag_operating,False,,,,
+l10n_hk_5240,Foreign Exchange Loss,5240,expense,Realized loss from foreign currency transactions.,account.account_tag_operating,False,,,,
+l10n_hk_5250,Cash Discount Loss,5250,expense,Loss incurred by granting early payment discounts to customers.,account.account_tag_operating,False,,,,
+l10n_hk_999001,Cash Difference Gain,999001,income_other,Revenue resulting from an unexplained cash overage.,,False,,,,
+l10n_hk_999002,Cash Difference Loss,999002,expense,Expense resulting from an unexplained cash shortage.,,False,,,,
+l10n_hk_999999,Undistributed Profits/Losses,999999,current_year_earnings,Final equity account where the current year's profit or loss is closed.,,False,,,,


### PR DESCRIPTION
As odoo wants to simplify the using of its app for users in Hong Kong, the assets models for each asset was added so that the users don't have to register the model manually each time. Also, each fixed asset was linked to an expense account and its corresponding depreciation account. Taxes were not added because I found that Hong Kong doesn't have the concept of TVA in its accounting system.

task-5246719

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
