### PR TITLE
[FIX] account: fix exchange partial reconcile group payment

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2650,11 +2650,21 @@ class AccountMoveLine(models.Model):
 
         # ==== Create the partial exchange journal entries ====
         exchange_moves = self._create_exchange_difference_moves(exchange_diff_values_list)
+        used_exchange_moves = set()
+        used_partials = set()
+
         for partial in partials:
             for exchange_move in exchange_moves:
                 linked_move_lines = exchange_move.line_ids.reconciled_lines_ids
-                if any(line == partial.debit_move_id or line == partial.credit_move_id for line in linked_move_lines):
+
+                if (
+                    any(line == partial.debit_move_id or line == partial.credit_move_id for line in linked_move_lines)
+                    and exchange_move not in used_exchange_moves
+                    and partial not in used_partials
+                ):
                     partial.exchange_move_id = exchange_move
+                    used_exchange_moves.add(exchange_move)
+                    used_partials.add(partial)
 
         # ==== Create entries for cash basis taxes ====
         def is_cash_basis_needed(amls):

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -3616,12 +3616,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'debit': 1.85,     'credit': 0.0,      'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.env.company.expense_currency_exchange_account_id.id},
         ])
         self.assertRecordValues(caba_transition_exchange_moves_2[1].line_ids, [
-            {'debit': 0.01,     'credit': 0.0,      'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
-            {'debit': 0.0,      'credit': 0.01,     'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.env.company.income_currency_exchange_account_id.id},
-        ])
-        self.assertRecordValues(caba_transition_exchange_moves_2[2].line_ids, [
             {'debit': 0.0,      'credit': 1.86,     'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
             {'debit': 1.86,     'credit': 0.0,      'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.env.company.expense_currency_exchange_account_id.id},
+        ])
+        self.assertRecordValues(caba_transition_exchange_moves_2[2].line_ids, [
+            {'debit': 0.01,     'credit': 0.0,      'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
+            {'debit': 0.0,      'credit': 0.01,     'amount_currency': 0.0,     'currency_id': currency_id,     'account_id': self.env.company.income_currency_exchange_account_id.id},
         ])
 
         self.assertAmountsGroupByAccount([
@@ -5875,3 +5875,43 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'amount': 1001.0, 'debit_move_id': line_2.id, 'credit_move_id': line_5.id},
             {'amount': 1002.0, 'debit_move_id': line_3.id, 'credit_move_id': line_4.id},
         ])
+
+    def test_exchange_move_assignment_with_group_payment(self):
+        """
+        Test that when doing a group payment the exchange_moves are correctly assigned to the invoices
+        """
+        foreign_curr = self.setup_other_currency('EUR', rates=[
+            ('2025-01-01', 0.054493834023),
+            ('2025-01-02', 0.054363189597),
+        ])
+
+        inv1, inv2 = [
+            self.init_invoice(
+                'out_invoice',
+                partner=self.partner_a,
+                invoice_date='2025-01-01',
+                post=True,
+                products=[self.product_a],
+                amounts=[amount],
+                currency=foreign_curr,
+             )
+             for amount in [500.0, 10.0]
+        ]
+
+        payment = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=(inv1 + inv2).ids,
+        ).create({
+            'payment_date': '2025-01-02',
+            'group_payment': True,
+            'amount': 510.0,
+            'currency_id': foreign_curr.id,
+        })._create_payments()
+
+        partials = self.env['account.partial.reconcile'].search([
+            ('debit_move_id.move_id', 'in', [inv1.id, inv2.id]),
+            ('credit_move_id.move_id', '=', payment.move_id.id),
+        ])
+
+        # Check that there is two exchanges for the two partials
+        self.assertEqual(len(partials.mapped('exchange_move_id')), 2)


### PR DESCRIPTION
# How to reproduce the issue:
- Create two currency rates: one for today and one for the day before.
- Create two invoices with different `amount_total`, both using the rate from yesterday.
- Create a group payment dated today.

Check the generated payment, its journal entry, and the reconciled items. Two exchange moves are created — one for each invoice. However, on the invoices themselves, only one of those exchange moves is associated with both invoices.

Since commit 5420e40ff337080912edf7414257e03853be026a, the logic that associates exchange moves to `account.partial.reconcile` records was changed.

It links an exchange move to a partial if any of its reconciled lines match either the partial's `debit_move_id` or `credit_move_id`.

In a group payment scenario:
- Two partials are created (one per invoice).
- Each has a different `debit_move_id` (the invoice lines) but shares the same `credit_move_id` (the single payment line).
- As a result, both partials match the same exchange move via the shared credit line — leading to incorrect assignment.

opw-5147281

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
