### PR TITLE
[FIX] im_livechat: no auto-open live chat on new msg when not member

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -42,7 +42,9 @@ patch(Thread.prototype, {
     },
     get autoOpenChatWindowOnNewMessage() {
         return (
-            (this.channel_type === "livechat" && !this.store.chatHub.compact) ||
+            (this.channel_type === "livechat" &&
+                !this.store.chatHub.compact &&
+                this.self_member_id) ||
             super.autoOpenChatWindowOnNewMessage
         );
     },

--- a/addons/im_livechat/static/src/views/livechat_form_renderer.js
+++ b/addons/im_livechat/static/src/views/livechat_form_renderer.js
@@ -1,6 +1,6 @@
 import { Discuss } from "@mail/core/public_web/discuss";
 
-import { onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
+import { onWillDestroy, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { FormRenderer } from "@web/views/form/form_renderer";
@@ -17,10 +17,23 @@ export class LivechatSessionFormRenderer extends FormRenderer {
         this.store = useState(useService("mail.store"));
         onWillStart(async () => {
             await this.getChannel(this.props);
+            this.setCurrentThreadShadowedBySelf(true);
         });
         onWillUpdateProps(async (nextProps) => {
+            if (nextProps.record.resId === this.props.record.resId) {
+                return;
+            }
+            this.setCurrentThreadShadowedBySelf(false);
             await this.getChannel(nextProps);
+            this.setCurrentThreadShadowedBySelf(true);
         });
+        onWillDestroy(() => this.setCurrentThreadShadowedBySelf(false));
+    }
+
+    setCurrentThreadShadowedBySelf(shadowedBySelf) {
+        if (this.thread) {
+            this.thread.shadowedBySelf = shadowedBySelf;
+        }
     }
 
     /**

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -44,7 +44,9 @@ patch(Thread.prototype, {
                     }
                 }
             }
-            this.store.env.services["mail.out_of_focus"].notify(message, this);
+            if (this.notifyWhenOutOfFocus) {
+                this.store.env.services["mail.out_of_focus"].notify(message, this);
+            }
         }
     },
     /** Condition for whether the conversation should become present in chat hub on new message */
@@ -53,6 +55,9 @@ patch(Thread.prototype, {
     },
     get autoOpenChatWindowOnNewMessage() {
         return false;
+    },
+    get notifyWhenOutOfFocus() {
+        return true;
     },
     /** @param {boolean} pushState */
     setAsDiscussThread(pushState) {


### PR DESCRIPTION
Before this commit, when live chat had new messages, all agents including non-members had auto-open of chat window when conversation is not in chat hub.

This is meant to make agent active or assigned to conversation to be explicitly aware of conversation and action is needed. However non-members should not have auto-open of chat window since their are not liable.

This commit fixes the issue by limiting the auto-open of chat window of livechat on new message for users that are member of conversation.