### PR TITLE
[FIX] l10n_de_pos_cert: prevent paying an so with no partner address

### DIFF
--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -12,7 +12,9 @@ import { accountTaxHelpers } from "@account/helpers/account_tax";
 patch(PosStore.prototype, {
     async onClickSaleOrder(clickedOrderId) {
         const sale_order = await this._getSaleOrder(clickedOrderId);
-
+        await this._processSaleOrder(sale_order);
+    },
+    async _processSaleOrder(sale_order) {
         const currentSaleOrigin = this.getOrder()
             .getOrderlines()
             .find((line) => line.sale_order_origin_id)?.sale_order_origin_id;


### PR DESCRIPTION
### Description
According to Fiskaly regulations, partners linked to PoS orders must have an address (street and zip code). A previous [commit] (https://github.com/odoo/enterprise/commit/af3a59ee8492693e20807ae30dc58038229f96cb) prevented adding such a client on a normal flow.
However, before this commit it was still possible to pay a sale order linked to such a contact through PoS and this will raise a bad request error when closing the session and will prevent closing it.

### How to reproduce:
* Setup a Fiskaly PoS config and open it.
* Create a normal sale order linked to a partner with no address.
* Select the sale order from pos and pay it.
* Close the session

opw-5228944
