### PR TITLE
[FIX] account_peppol: delete (hidden) service configuration

### DIFF
--- a/addons/account_peppol/wizard/peppol_config_wizard.py
+++ b/addons/account_peppol/wizard/peppol_config_wizard.py
@@ -136,10 +136,7 @@ class PeppolConfigWizard(models.TransientModel):
             self_billing_services.write({'enabled': wizard.peppol_activate_self_billing})
 
     def button_sync_form_with_peppol_proxy(self):
-        """Update the peppol contact email on IAP.
-        Note: The service configuration is DEPRECATED / hidden in the view.
-        Disabling services can lead to complicance issues and is not necessary
-        since all existing services should just work."""
+        """Update the peppol contact email on IAP."""
         self.ensure_one()
 
         # Update company details

--- a/addons/account_peppol/wizard/peppol_config_wizard.xml
+++ b/addons/account_peppol/wizard/peppol_config_wizard.xml
@@ -33,25 +33,6 @@
                     <field name="peppol_activate_self_billing" invisible="account_peppol_proxy_state not in ('sender', 'receiver')"/>
                     <field name="peppol_self_billing_reception_journal_id" invisible="account_peppol_proxy_state != 'receiver'"/>
                 </group>
-                <!-- Note: Deprecated -->
-                <!-- Disabling services can lead to complicance issues and is not necessary -->
-                <!-- since all existing services should just work. -->
-                <group string="Configure your Peppol Services and allowed formats" invisible="1">
-                    <div colspan="2">
-                        <field name="service_info" role="status" class="o_field_html alert alert-info" invisible="not service_info"/>
-                        <field name="service_ids"
-                               nolabel="1"
-                               widget="one2many"
-                               columns="2">
-                            <list create="false" delete="false" edit="true">
-                                <field name="wizard_id" column_invisible="1"/>
-                                <field name="document_name" readonly="1"/>
-                                <field name="document_identifier" invisible="1"/>
-                                <field name="enabled" widget="boolean_toggle"/>
-                            </list>
-                        </field>
-                    </div>
-                </group>
                 <group string="Danger zone" invisible="account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
                     <button string="Remove from Peppol"
                             name="button_peppol_unregister"


### PR DESCRIPTION
In commit 9c0930402ba5fb81ba2e9c0ba085ff3298abaae8 we hid the service configuration in the wizard view.
It was a FW-port from stable so we did not outright delete it from the view

On master we can just remove it

Task from the commit mentioned above:
task-4737164