### PR TITLE
[FIX] delivery: set carrier from partner when adding shipping

### DIFF
--- a/addons/delivery/tests/test_delivery_availability.py
+++ b/addons/delivery/tests/test_delivery_availability.py
@@ -194,3 +194,16 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
         }))
         choose_delivery_carrier = delivery_wizard.save()
         self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is set on one product in the order")
+
+    def test_partner_carrier_is_set_in_wizard(self):
+        """Test that the partner's default delivery carrier is correctly preselected in the delivery wizard."""
+        self.sale_order.partner_id.property_delivery_carrier_id = self.carrier
+        delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
+            'default_order_id': self.sale_order.id,
+        }))
+        choose_delivery_carrier = delivery_wizard.save()
+        self.assertIn(
+            self.carrier,
+            choose_delivery_carrier.carrier_id,
+            "Delivery carrier set on the partner should be set in the delivery wizard",
+        )

--- a/addons/delivery/wizard/choose_delivery_carrier.py
+++ b/addons/delivery/wizard/choose_delivery_carrier.py
@@ -16,7 +16,10 @@ class ChooseDeliveryCarrier(models.TransientModel):
     carrier_id = fields.Many2one(
         'delivery.carrier',
         string="Shipping Method",
+        compute='_compute_carrier_id',
+        store=True,
         required=True,
+        readonly=False,
         domain="[('id', 'in', available_carrier_ids)]",
     )
     delivery_type = fields.Selection(related='carrier_id.delivery_type')
@@ -64,6 +67,18 @@ class ChooseDeliveryCarrier(models.TransientModel):
         for rec in self:
             carriers = self.env['delivery.carrier'].search(self.env['delivery.carrier']._check_company_domain(rec.order_id.company_id))
             rec.available_carrier_ids = carriers.available_carriers(rec.order_id.partner_shipping_id, rec.order_id) if rec.partner_id else carriers
+
+    @api.depends('partner_id', 'available_carrier_ids', 'company_id')
+    def _compute_carrier_id(self):
+        for rec in self:
+            if not rec.partner_id or not rec.company_id:
+                rec.carrier_id = False
+                continue
+            partner_carrier = (
+                rec.with_company(rec.company_id).partner_id.property_delivery_carrier_id
+                or rec.with_company(rec.company_id).partner_id.commercial_partner_id.property_delivery_carrier_id
+            )
+            rec.carrier_id = partner_carrier if partner_carrier and partner_carrier.id in rec.available_carrier_ids.ids else False
 
     def _get_delivery_rate(self):
         vals = self.carrier_id.with_context(order_weight=self.total_weight).rate_shipment(self.order_id)


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product “P1”
- Go to partner *Azure Interior*:
  - Set 'property_delivery_carrier_id' to any carrier
- Create a sale order:
  - Customer: Azure Interior
  - Add 1 unit of P1
  - Click on "Add shipping"

Problem:
Since this commit: https://github.com/odoo/odoo/pull/203955/files#diff-9f1fd37c63903c4c029f099d485a3f9831446850be55695a4603c05ef298885bL134-L137 the carrier defined on the partner is no longer loaded by default.

Solution:
Check if the carrier defined on the partner is among the allowed carriers, and if so, set it automatically.

opw-5220118
