### PR TITLE
[FIX] hr: Fix user timezone Settings - yoahm

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1396,7 +1396,7 @@ We can redirect you to the public employee list."""
             self._remove_work_contact_id(user, vals.get('company_id'))
         if 'work_permit_expiration_date' in vals:
             vals['work_permit_scheduled_activity'] = False
-        if 'tz' in vals:
+        if vals.get('tz'):
             users_to_update = self.env['res.users']
             for employee in self:
                 if employee.user_id and employee.company_id == employee.user_id.company_id and vals['tz'] != employee.user_id.tz:


### PR DESCRIPTION
Description of the issue/feature this PR addresses: On Odoo 19.0 and master, setting an employee’s timezone to None would cause a traceback when creating or updating the employee.

Current behavior before PR: a traceback when creating or updating the employee.

Desired behavior after PR is merged: A Validation Error occurs because it missing required value for the field 'Timezone' (tz).
Model: 'Resources' (resource.resource)

task-5257749

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
