### PR TITLE
[FIX] hr: Fix user timezone Settings - yoahm

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1634,7 +1634,7 @@ class HrEmployee(models.Model):
             self._remove_work_contact_id(user, vals.get('company_id'))
         if 'work_permit_expiration_date' in vals:
             vals['work_permit_scheduled_activity'] = False
-        if 'tz' in vals:
+        if vals.get('tz'):
             users_to_update = self.env['res.users']
             for employee in self:
                 if employee.user_id and employee.company_id == employee.user_id.company_id and vals['tz'] != employee.user_id.tz:

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -10,6 +10,7 @@ from odoo.tests import Form, users, new_test_user, HttpCase, tagged, Transaction
 from odoo.addons.hr.tests.common import TestHrCommon
 from odoo.tools import mute_logger
 from odoo.exceptions import ValidationError
+from psycopg2.errors import NotNullViolation
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -86,6 +87,10 @@ class TestHrEmployee(TestHrCommon):
         employee_form.work_email = 'raoul@example.com'
         employee = employee_form.save()
         self.assertEqual(employee.tz, _tz)
+
+    def test_employee_null_timezone(self):
+        with mute_logger('odoo.sql_db'), self.assertRaises(NotNullViolation):
+            self.res_users_hr_officer.company_id.resource_calendar_id.write({'tz': None})
 
     def test_employee_from_user(self):
         _tz = 'Pacific/Apia'


### PR DESCRIPTION
Description of the issue/feature this PR addresses: On Odoo 19.0 and master, setting an employee’s timezone to None would cause a traceback when creating or updating the employee.

Current behavior before PR: a traceback when creating or updating the employee.

Desired behavior after PR is merged: A Validation Error occurs because it missing required value for the field 'Timezone' (tz).
Model: 'Resources' (resource.resource)

task-5257749



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
