### PR TITLE
[IMP] web: improve date time picker week days colors

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.dark.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.dark.scss
@@ -1,0 +1,7 @@
+// = DateTime Picker
+// ============================================================================
+// No CSS hacks, variables overrides only
+
+.o_datetime_picker {
+    --DateTimePicker__day-week-cell-bg: #{$gray-300};
+}

--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -86,6 +86,10 @@
         }
     }
 
+    .o_day_of_week_cell, .o_week_number_cell {
+        background-color: var(--DateTimePicker__day-week-cell-bg, #{$gray-100});
+    }
+
     .o_week_number_cell {
         font-variant: tabular-nums;
     }

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -9,7 +9,7 @@
                 >
                     <t t-foreach="month.daysOfWeek" t-as="dayOfWeek" t-key="dayOfWeek[0]">
                         <div
-                            class="o_day_of_week_cell bg-100 fw-bolder d-flex align-items-center justify-content-center"
+                            class="o_day_of_week_cell fw-bolder d-flex align-items-center justify-content-center"
                             t-att-title="dayOfWeek[1]"
                         >
                             <div class="text-nowrap overflow-hidden" t-esc="props.daysOfWeekFormat === 'narrow' ? dayOfWeek[2] : dayOfWeek[0]"/>
@@ -18,7 +18,7 @@
                     <t t-foreach="month.weeks" t-as="week" t-key="week.number">
                         <t t-if="props.showWeekNumbers">
                             <div
-                                class="o_week_number_cell d-flex justify-content-end align-items-center pe-3 bg-100 fw-bolder"
+                                class="o_week_number_cell d-flex justify-content-center align-items-center fw-bolder"
                                 t-esc="week.number"
                             />
                         </t>


### PR DESCRIPTION
In commit[1] the days and week cells got a background, however in darkmode it breaks the elevation. Since neither bg-200 nor bg-400 provides enough contrast it's better to match the background color of the popover in darkmode.

task-5238000

[1]: odoo/odoo@f65d9a8c87b44558679bf5c6351e439f6ec2e990

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
