### PR TITLE
[FIX] pos_hr, point_of_sale: allow only admin user to override max diff

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -164,8 +164,10 @@ export class ClosePosPopup extends Component {
         );
     }
     hasUserAuthority() {
+        return this.props.is_manager || this.allowedDifference();
+    }
+    allowedDifference() {
         return (
-            this.props.is_manager ||
             this.props.amount_authorized_diff == null ||
             this.getMaxDifference() <= this.props.amount_authorized_diff
         );

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -91,6 +91,12 @@ export function clickBtn(name, { expectUnloadPage = false } = {}) {
         expectUnloadPage,
     };
 }
+export function hasBtn(name) {
+    return {
+        content: `Check button ${name} exist`,
+        trigger: `body button:contains(${name})`,
+    };
+}
 export function fillTextArea(target, value) {
     return {
         content: `Fill text area with ${value}`,

--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -31,7 +31,10 @@ class HrEmployee(models.Model):
 
         employees = employees.read(fields, load=False)
         for employee in employees:
-            if employee['id'] in manager_ids or employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
+            if employee['id'] in manager_ids:
+                role = 'manager'
+                employee['_user_role'] = "admin"
+            elif employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
                 role = 'manager'
             else:
                 role = 'cashier'

--- a/addons/pos_hr/static/src/overrides/components/closing_popup/closing_popup.js
+++ b/addons/pos_hr/static/src/overrides/components/closing_popup/closing_popup.js
@@ -3,11 +3,21 @@ import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { AccordionItem } from "@point_of_sale/app/generic_components/accordion_item/accordion_item";
 
-patch(ClosePosPopup, {
+patch(ClosePosPopup.prototype, {
     components: { ...ClosePosPopup.components, AccordionItem },
     get paymentMethodBreakdownTitle() {
         return _t("Payments in %(paymentMethod)s", {
             paymentMethod: this.props.default_cash_details.name,
         });
+    },
+    hasUserAuthority() {
+        if (!this.pos.config.module_pos_hr) {
+            return super.hasUserAuthority();
+        }
+        const cashier = this.pos.cashier;
+        return (
+            (cashier._role == "manager" && cashier._user_role == "admin") ||
+            this.allowedDifference()
+        );
     },
 });

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -278,3 +278,33 @@ registry
                 Chrome.notExistMenuOption("Backend"),
             ].flat(),
     });
+
+registry.category("web_tour.tours").add("test_maximum_closing_difference", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            ProductScreen.enterOpeningAmount("10"),
+            Chrome.clickBtn("Open Register"),
+
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Manager 2", { run: "click" }),
+            PosHr.enterPin("5652"),
+            Chrome.clickMenuOption("Close Register"),
+            Chrome.clickBtn("Close Register"),
+            {
+                trigger: negate(`button:contains("Proceed anyway")`),
+            },
+            Chrome.clickBtn("Ok"),
+            Chrome.clickBtn("Discard"),
+
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Chrome.clickMenuOption("Close Register"),
+            Chrome.clickBtn("Close Register"),
+            Chrome.hasBtn("Proceed anyway"),
+            Chrome.clickBtn("Proceed anyway"),
+            PosHr.loginScreenIsShown(),
+        ].flat(),
+});

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -169,3 +169,25 @@ class TestUi(TestPosHrHttpCommon):
         self.start_pos_tour("pos_hr_go_backend_closed_registered", login="manager_user")
         self.start_pos_tour("pos_hr_go_backend_opened_registered", login="manager_user")
         self.start_pos_tour("pos_hr_go_backend_opened_registered_different_user_logged", login="emp1_user")
+
+    def test_maximum_closing_difference(self):
+        self.main_pos_config.set_maximum_difference = True
+        self.main_pos_config.amount_authorized_diff = 0
+
+        # Admin users should still be able to override max difference
+        # regardless if they are the connected user or not
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_maximum_closing_difference",
+            login="pos_user"
+        )
+
+        # Advanced rights employees should not override max difference
+        # when the connected user has admin rights (they never should)
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_maximum_closing_difference",
+            login="pos_admin"
+        )


### PR DESCRIPTION
Currently, the behavior of the "Maximum closing difference" feature with employees depends on the user connected in the backend and not the employee using the pos.

Steps to reproduce:
-------------------
* Set max closing difference as 0
* Have 1 admin user and 1 pos user
* Have 2 employees
* Set admin user and employee 1 as advanced employees of the pos
* Set pos user and employee 2 as basic employees

Steps with admin:
* Make sure you are logged as the admin in the database
* Open pos (could be a session opened by other user)
* Log in with Admin user
* Try to close the pos with a difference of 10 -> You can, ok
* Log in with employee 1 (advanced)
* Try to close the pos with a difference of 10 -> You ca but shouldn't

Steps with pos user
* Now log in the database as pos user
* Open pos (could be a session opened by other user
* Log in with employee 1 (advanced)
* Try to close the pos with a difference of 10 -> You cannot, ok
* Log in with Admin user
* Try to close the pos with a difference of 10 -> you cannot but should

Why the fix:
------------
Employees that have no linked user should not ba able to override the max difference.

Employees who have a connected user should only be able to override the max difference if their user is admin of the pos.

opw-5184041