### PR TITLE
[FIX] website: Adapt query count between community and enterprise.

### DIFF
--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -526,16 +526,17 @@ class TestQwebDataSnippet(TransactionCase):
         ir_ui_view_queries = [q for q in actual_queries if re_sql.search(q)]
 
         # nb_snippets = 156
-        first_search = 1
-        t_call_snippets = 3
-        fetch_snippets = 0
-        get_root_view = 3
-        combine_views = 3
+        first_search = 1  # for key & website
+        t_call_snippets = 3  # number of nested t-calls (t-call > view > t-call > other views...)
+        fetch_snippets = 0  # number of fetches (normally performed with the previous search)
+        get_root_view = 3  # determine the root views
+        combine_views = 3  # Queries performed to execute the read combine
 
         all_ir_ui_view_queries = first_search + t_call_snippets + fetch_snippets + get_root_view + combine_views  # 10
         self.assertEqual(len(ir_ui_view_queries), all_ir_ui_view_queries, f'ir_ui_view queries: {all_ir_ui_view_queries}')
 
         re_sql = re.compile(r'\bwebsite\b', re.IGNORECASE)
         website_queries = [q for q in actual_queries if re_sql.search(q)]
+        str_queries = "\n".join(website_queries)
 
-        self.assertLessEqual(len(website_queries), 19, f'Maximum queries: {19}')
+        self.assertLessEqual(len(website_queries), 20, f'Maximum queries: {20}\n{str_queries}')


### PR DESCRIPTION
The test is primarily intended to determine the number of requests to ir.ui.view. The information on the website is supplementary but less important. It mainly serves to inform performance considerations during development.

Issue on runbot for single app test 
https://runbot.odoo.com/odoo/runbot.build.error/231557