### PR TITLE
[FIX] web: tests - cancel pending drag sequences

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -59,6 +59,8 @@ import * as _network from "../mock/network";
 import * as _notification from "../mock/notification";
 import * as _window from "../mock/window";
 
+const { isPrevented, mockPreventDefault } = _window;
+
 /**
  * @typedef {{
  *  readonly config: (config: JobConfig) => CurrentConfigurators;
@@ -198,15 +200,6 @@ function formatAssertions(assertions) {
         }
     }
     return lines;
-}
-
-/**
- * @param {Event} ev
- */
-function safePrevent(ev) {
-    if (ev.cancelable) {
-        ev.preventDefault();
-    }
 }
 
 /**
@@ -1784,7 +1777,7 @@ export class Runner {
         const error = ensureError(ev);
         if (handledErrors.has(error)) {
             // Already handled
-            return safePrevent(ev);
+            return ev.preventDefault();
         }
         handledErrors.add(error);
 
@@ -1792,27 +1785,29 @@ export class Runner {
             ev = new ErrorEvent("error", { error });
         }
 
+        mockPreventDefault(ev);
+
         if (error.message.includes(RESIZE_OBSERVER_MESSAGE)) {
             // Stop event
             ev.stopImmediatePropagation();
             if (ev.bubbles) {
                 ev.stopPropagation();
             }
-            return safePrevent(ev);
+            return ev.preventDefault();
         }
 
         if (this.state.currentTest && !(error instanceof HootError)) {
             // Handle the error in the current test
             const handled = this._handleErrorInTest(ev, error);
             if (handled) {
-                return safePrevent(ev);
+                return ev.preventDefault();
             }
         } else {
             this._handleGlobalError(ev, error);
         }
 
         // Prevent error event
-        safePrevent(ev);
+        ev.preventDefault();
 
         // Log error
         if (error.level) {
@@ -1832,7 +1827,7 @@ export class Runner {
     _handleErrorInTest(ev, error) {
         for (const callbackRegistry of this._getCallbackChain(this.state.currentTest)) {
             callbackRegistry.callSync("error", ev, logger.error);
-            if (ev.defaultPrevented) {
+            if (isPrevented(ev)) {
                 // Prevented in tests
                 return true;
             }

--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -60,6 +60,7 @@ const {
     Object: {
         assign: $assign,
         defineProperties: $defineProperties,
+        defineProperty: $defineProperty,
         entries: $entries,
         getOwnPropertyDescriptor: $getOwnPropertyDescriptor,
         getPrototypeOf: $getPrototypeOf,
@@ -69,9 +70,11 @@ const {
     Reflect: { ownKeys: $ownKeys },
     Set,
     WeakMap,
+    WeakSet,
 } = globalThis;
 
 const { addEventListener, removeEventListener } = EventTarget.prototype;
+const { preventDefault } = Event.prototype;
 
 //-----------------------------------------------------------------------------
 // Internal
@@ -326,6 +329,11 @@ function mockedMatchMedia(mediaQueryString) {
     return new MockMediaQueryList(mediaQueryString);
 }
 
+function mockedPreventDefault() {
+    preventedEvents.add(this);
+    return preventDefault.call(this, ...arguments);
+}
+
 /** @type {typeof removeEventListener} */
 function mockedRemoveEventListener(...args) {
     if (getRunner().dry) {
@@ -443,6 +451,8 @@ const mockConsole = new MockConsole();
 const mockLocalStorage = new MockStorage();
 const mockMediaValues = { ...DEFAULT_MEDIA_VALUES };
 const mockSessionStorage = new MockStorage();
+/** @type {WeakSet<Event>} */
+const preventedEvents = new WeakSet();
 let mockTitle = "";
 
 // Mock descriptors
@@ -577,12 +587,28 @@ export function getViewPortWidth() {
 }
 
 /**
+ * @param {Event} event
+ */
+export function isPrevented(event) {
+    return event.defaultPrevented || preventedEvents.has(event);
+}
+
+/**
  * @param {Record<string, string>} name
  */
 export function mockMatchMedia(values) {
     $assign(mockMediaValues, values);
 
     callMediaQueryChanges($keys(values));
+}
+
+/**
+ * @param {Event} event
+ */
+export function mockPreventDefault(event) {
+    $defineProperty(event, "preventDefault", {
+        value: mockedPreventDefault,
+    });
 }
 
 /**

--- a/addons/web/static/tests/_framework/dom_test_helpers.js
+++ b/addons/web/static/tests/_framework/dom_test_helpers.js
@@ -124,12 +124,18 @@ const waitForTouchDelay = async (delay) => {
     }
 };
 
-let unconsumedContains = [];
+/** @type {(() => any) | null} */
+let cancelCurrentDragSequence = null;
+/** @type {Target[]} */
+const unconsumedContains = [];
 
-afterEach(() => {
+afterEach(async () => {
+    if (cancelCurrentDragSequence) {
+        await cancelCurrentDragSequence();
+    }
     if (unconsumedContains.length) {
         const targets = unconsumedContains.map(String).join(", ");
-        unconsumedContains = [];
+        unconsumedContains.length = 0;
         throw new Error(
             `called 'contains' on "${targets}" without any action: use 'waitFor' if no interaction is intended`
         );
@@ -202,11 +208,11 @@ export function contains(target, options) {
          * @returns {Promise<DragHelpers>}
          */
         drag: async (options) => {
-            consumeContains();
             /** @type {typeof cancel} */
             const cancelWithDelay = async (options) => {
                 await cancel(options);
                 await advanceFrame();
+                cancelCurrentDragSequence = null;
             };
 
             /** @type {typeof drop} */
@@ -216,6 +222,7 @@ export function contains(target, options) {
                 }
                 await drop();
                 await advanceFrame();
+                cancelCurrentDragSequence = null;
             };
 
             /** @type {typeof moveTo} */
@@ -225,6 +232,11 @@ export function contains(target, options) {
 
                 return helpersWithDelay;
             };
+
+            consumeContains();
+
+            await cancelCurrentDragSequence?.();
+            cancelCurrentDragSequence = cancelWithDelay;
 
             const { cancel, drop, moveTo } = await drag(nodePromise, options);
             const helpersWithDelay = {
@@ -246,6 +258,9 @@ export function contains(target, options) {
          */
         dragAndDrop: async (target, dropOptions, dragOptions) => {
             consumeContains();
+
+            await cancelCurrentDragSequence?.();
+
             const [from, to] = await Promise.all([nodePromise, waitFor(target)]);
             const { drop, moveTo } = await drag(from, dragOptions);
 


### PR DESCRIPTION
Before this commit, when initiating an unfinished drag sequence (i.e. calling `drag` without `drop` or `cancel`), the drag sequence was ended by destroying the component, which could throw asynchronous errors after the test finished.

One possible fix would be to wait for these errors upon ending a test, but this process is handled by Owl and through a possible chain of promises, which would have to be accounted for by an arbitrary amount of 'animationFrame' or 'advanceTime' calls.

Instead, the `contains...drag` and `contains...dragAndDrop` now handle a single drag sequence at a time, with a systematic cleanup after each test in case a drag sequence has been left pending. In such cases, the sequence is canceled.

Enterprise: https://github.com/odoo/enterprise/pull/99369

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
