### PR TITLE
[FIX] web: fix wrong styling for `website` systray dropdowns

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -156,7 +156,7 @@
             --NavBar-entry-color--hover: var(--NavBar-entry-color, #{$o-navbar-entry-color});
         }
 
-        .o_nav_entry, .dropdown-toggle:not(:disabled) {
+        .o_nav_entry, .dropdown-toggle:not(:disabled, .o-dropdown-toggle-custo) {
             background: var(--NavBar-entry-backgroundColor, #{$o-navbar-background});
             border: $border-width solid transparent;
 
@@ -173,7 +173,7 @@
             }
         }
 
-        .dropdown.show.dropdown-toggle {
+        .dropdown.show.dropdown-toggle:not(.o-dropdown-toggle-custo) {
             border-color: var(--NavBar-entry-borderColor-active, transparent);
             background: var(--NavBar-entry-backgroundColor--active, #{$o-navbar-entry-bg--active});
             color: var(--NavBar-entry-color--active, #{$o-navbar-entry-color--active});


### PR DESCRIPTION
This commit fixes a side effect introduced in Commit[^1]. With Commit[^1], we aimed to improve the design of systray items, mainly in terms of accessibility, by providing a set of styles for the different states (`:hover`, `:focus`, ...).

| Master | This PR |
|--------|--------|
| <img width="143" height="47" alt="image" src="https://github.com/user-attachments/assets/0647aeec-5c10-4b1b-8637-3539809c63c9" /> | <img width="133" height="47" alt="image" src="https://github.com/user-attachments/assets/ac6f4aff-47c3-4a58-a927-6f8437827a8e" /> | 

While we paid attention to the frontend environment when implementing these changes, some cases were overlooked — specifically the `Edit` button, which becomes a `.dropdown-toggle` when the website can be translated.

This caused the button to inherit styles defined for the backend, leading to inconsistencies.

This commit fixes the issue by excluding the `+New` and `Edit` buttons from these styles, ensuring they correctly inherit the right ones.

task-5259182

[^1]: https://github.com/odoo/odoo/commit/c001d7e0b04317a815e29dc4a4aed7f7c95ee550

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
