### PR TITLE
[FIX] point_of_sale: price_subtotal is the total line price not unit

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -193,7 +193,7 @@ export class PosOrderAccounting extends Base {
         this.amount_total = this.currency.round(this.priceIncl);
         this.amount_return = this.change; // Already rounded by the getter
         this.lines.forEach((line) => {
-            line.price_subtotal = line.displayPriceUnit;
+            line.price_subtotal = line.priceExcl;
             line.price_subtotal_incl = line.displayPrice;
         });
     }

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -466,11 +466,11 @@ describe("pos_store.js", () => {
             expect(order.amount_tax).toEqual(2.85);
             expect(order.lines[0].qty).toEqual(3);
             expect(order.lines[0].price_unit).toEqual(3);
-            expect(order.lines[0].price_subtotal).toEqual(3);
+            expect(order.lines[0].price_subtotal).toEqual(9);
             expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
             expect(order.lines[1].qty).toEqual(2);
             expect(order.lines[1].price_unit).toEqual(3);
-            expect(order.lines[1].price_subtotal).toEqual(3);
+            expect(order.lines[1].price_subtotal).toEqual(6);
             expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
 
             order.is_refund = true;
@@ -481,11 +481,11 @@ describe("pos_store.js", () => {
             expect(order.amount_tax).toEqual(-2.85);
             expect(order.lines[0].qty).toEqual(-3);
             expect(order.lines[0].price_unit).toEqual(3);
-            expect(order.lines[0].price_subtotal).toEqual(3);
+            expect(order.lines[0].price_subtotal).toEqual(9);
             expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
             expect(order.lines[1].qty).toEqual(-2);
             expect(order.lines[1].price_unit).toEqual(3);
-            expect(order.lines[1].price_subtotal).toEqual(3);
+            expect(order.lines[1].price_subtotal).toEqual(6);
             expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
         });
     });


### PR DESCRIPTION
Steps to reproduce
------------------
1. Create a product with price 1, no need to add taxes, and add it to PoS
2. In PoS, select this product, and set the quantity to 2, the price is 2 as expected
3. Finalize the order
4. In the backend, open this order and observe that the "Tax Excl." for that line shows $1 instead of $2. While "Tax Incl." shows $2 as expected.

The client has reproduced this issue in a different way, by printing the sales report for that order, he found out that the total is 1 instead of 2.

Why it's happening
------------------
This issue was introduced in 9538698f13d5763b49b00f4c06a1a2afc0d6b39e. We are setting the field `price_subtotal` to the unit price of the product, and not to the actual price per line, i.e. we're ignoring the quantity!!

The Fix
-------
We now set the `price_subtotal` to `priceExcl` which takes into account the quantity on that line.

opw-5242022