### PR TITLE
[FIX] hr_homeworking_calendar: show homeworking locations in month view

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -5,7 +5,7 @@ import { AttendeeCalendarRenderer } from "@calendar/views/attendee_calendar/atte
 import { user } from "@web/core/user";
 import { patch } from "@web/core/utils/patch";
 import { onPatched } from "@odoo/owl";
-import { renderToString } from "../../../../../web/static/src/core/utils/render";
+import { renderToString } from "@web/core/utils/render";
 
 const { DateTime } = luxon;
 
@@ -33,7 +33,6 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
                     }
                 }
             },
-            dayCellDidMount: this.onDayCellDidMount,
             dayHeaderDidMount: this.onDayHeaderDidMount,
             dayCellContent: this.dayCellContent,
             dayHeaderWillUnmount: this.onDayHeaderWillUnmount,
@@ -103,7 +102,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
         const showLine = ["week", "month"].includes(this.props.model.scale);
         let worklocation = this.props.model.worklocations[parsedDate];
         if (!worklocation) {
-            return super.headerTemplateProps(date);
+            return { ...super.headerTemplateProps(date), showLine };
         }
         const workLocationSetForCurrentUser =
             multiCalendar ?

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.scss
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.scss
@@ -5,6 +5,10 @@
     .o_worklocation_text, .o_worklocation_line {
         box-shadow: 0 1px 0 rgba(0,0,0, 0.3)
     }
+    .o_worklocation_text.o_cw_custom_highlight {
+      box-shadow: 0 0 1px 2px rgba(0, 0, 0, 0.3);
+      z-index: 2; // for the shadow to go over the events below
+    }
 }
 
 .o_worklocation_line {
@@ -29,6 +33,54 @@
     .o_worklocation_btn {
         margin-top: 0px;
     }
+}
+
+.fc-day {
+  .fc-daygrid-day-number {
+    width: 100%;
+    padding-right: 0;
+    color: var(--o-cw-color);
+    &:not(:has(.o_worklocation_text)) {
+      padding-left: 0;
+    }
+  }
+
+  .o_day_label {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    margin-top: 4px;
+  }
+
+  .o_day_label:before {
+    content: "";
+    z-index: -1;
+    display: none;
+    @include o_position-absolute($top: 50%, $left: 50%);
+    transform: translate(-50%, -50%);
+    aspect-ratio: 1/1;
+    height: 120%;
+    border-radius: 100%;
+    background: var(--o-cw-bg, none);
+    padding: var(--o-circle-padding);
+  }
+
+  .fc-daygrid-day-number:before {
+    display: none;
+  }
+
+  &.fc-day-today {
+    .fc-daygrid-day-number:before {
+        display: none !important;
+    }
+
+    .o_day_label:before {
+      --o-cw-color: #{color-contrast($o-cw-color-today-accent)};
+      --o-cw-bg: #{$o-cw-color-today-accent};
+      display: block;
+    }
+  }
 }
 
 @include media-breakpoint-down(md) {

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_model.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_model.js
@@ -49,11 +49,11 @@ patch(AttendeeCalendarModel.prototype, {
                     }
                     if (res[employeeId].exceptions && dayISO in res[employeeId].exceptions) {
                         // check if exception for that date
-                        const { location_type } = res[employeeId].exceptions[dayISO];
-                        if (location_type in events[dayISO]) {
-                            events[dayISO][location_type].push(this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId].exceptions[dayISO]));
+                        const { location_name } = res[employeeId].exceptions[dayISO];
+                        if (location_name in events[dayISO]) {
+                            events[dayISO][location_name].push(this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId].exceptions[dayISO]));
                         } else {
-                            events[dayISO][location_type] = [this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId].exceptions[dayISO])];
+                            events[dayISO][location_name] = [this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId].exceptions[dayISO])];
                         }
                     }
                     else {
@@ -61,14 +61,14 @@ patch(AttendeeCalendarModel.prototype, {
                         if (!(locationKeyName in res[employeeId])) {
                             continue;
                         }
-                        const {location_type} = res[employeeId][locationKeyName];
-                        if (!location_type) {
+                        const {location_name} = res[employeeId][locationKeyName];
+                        if (!location_name) {
                             continue;
                         }
-                        if (location_type in events[dayISO]) {
-                            events[dayISO][location_type].push(this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId][locationKeyName]));
+                        if (location_name in events[dayISO]) {
+                            events[dayISO][location_name].push(this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId][locationKeyName]));
                         } else {
-                            events[dayISO][location_type] = [this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId][locationKeyName])];
+                            events[dayISO][location_name] = [this.createHomeworkingRecordAt(res[employeeId], startDay, res[employeeId][locationKeyName])];
                         }
                     }
                 } else {

--- a/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
+++ b/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
@@ -315,8 +315,8 @@ QUnit.module("Homeworking Calendar", ({ beforeEach }) => {
         assert.equal(target.querySelector(".o_cw_popover div[name='employee_name']").textContent, "Aaron");
         assert.containsOnce(target, ".o_cw_popover .o_cw_popover_edit", "should show edit button");
         assert.containsOnce(target, ".o_cw_popover .o_cw_popover_delete", "should show delete button");
-
         await click(target.querySelector(".o_cw_popover_close"));
+        await click(workLocations.at(-2), '.o_worklocation_line');
         assert.verifySteps(["hr_homeworking_calendar.set_location_wizard_action", "2020-12-11"]);
         mockRegistry.add("get_worklocation", previousMock, { force: true });
     });

--- a/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
+++ b/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
@@ -317,7 +317,6 @@ QUnit.module("Homeworking Calendar", ({ beforeEach }) => {
         assert.containsOnce(target, ".o_cw_popover .o_cw_popover_delete", "should show delete button");
 
         await click(target.querySelector(".o_cw_popover_close"));
-        await click(workLocations.at(-2), '.o_worklocation_line');
         assert.verifySteps(["hr_homeworking_calendar.set_location_wizard_action", "2020-12-11"]);
         mockRegistry.add("get_worklocation", previousMock, { force: true });
     });
@@ -336,7 +335,7 @@ QUnit.module("Homeworking Calendar", ({ beforeEach }) => {
             const records = target.querySelectorAll(`.fc-col-header-cell[data-date="${date}"] .o_worklocation_btn .o_homeworking_content`);
             records.forEach(record => {
                 const { employee, location } = record.dataset;
-                assert.equal(multiCalendarData[employee][`${s.weekdayLong.toLowerCase()}_location_id`].location_type, location);
+                assert.equal(multiCalendarData[employee][`${s.weekdayLong.toLowerCase()}_location_id`].location_type, location.toLowerCase());
             });
         });
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

After a refactor, the month view no longer displayed homeworking locations as in previous versions. This PR fixes the issue and adapts the component using the updated version of the FullCalendar library.

Also fixes a small issue of when different locations with same icons are grouped together when they shouldn't

Current behavior before PR:

All days in the calendar month view displayed the 'Set location' button, regardless of whether a location record existed for the day or not.

Locations of a different type sharing the same icon (Office, Building 1...):

<img width="262" height="135" alt="before" src="https://github.com/user-attachments/assets/51745152-5f90-4917-9627-07aa0959eb3d" />

Desired behavior after PR is merged:

Locations are shown in the month view, and can be interacted with in the same way as in the week/day views, both for single and multicalendar:

<img width="1230" height="504" alt="multicalendar" src="https://github.com/user-attachments/assets/34108f57-2c25-400e-9fbe-106e2233c677" />

<img width="1232" height="382" alt="singlecalendar" src="https://github.com/user-attachments/assets/f4a0cf32-636f-49ce-a4cc-e53a9ac45643" />

Locations of a different type sharing the same icon:

<img width="256" height="132" alt="after" src="https://github.com/user-attachments/assets/643dd304-aeeb-48ec-abef-755e3eb5fdf0" />

---
Task ID: 5215931
