### PR TITLE
[FIX] auth_timeout: adapt update_presence to ws or http request

### DIFF
--- a/addons/auth_timeout/models/ir_websocket.py
+++ b/addons/auth_timeout/models/ir_websocket.py
@@ -1,5 +1,5 @@
 from odoo import models
-from odoo.http import root
+from odoo.http import request, root
 from odoo.addons.bus.websocket import wsrequest
 
 
@@ -16,7 +16,10 @@ class IrWebsocket(models.AbstractModel):
         :param float inactivity_period: Duration of user inactivity in milliseconds.
         :return: None
         """
-        self.env["ir.http"]._set_session_inactivity(wsrequest.session, inactivity_period)
+        #  This method can either be called due to an http (/websocket/update_bus_presence)
+        # or a websocket request.
+        req = request or wsrequest
+        self.env["ir.http"]._set_session_inactivity(req.session, inactivity_period)
         super()._update_mail_presence(inactivity_period)
 
     def _on_websocket_closed(self, cookies):


### PR DESCRIPTION
update_presence can both be called in http and with websocket as explained here:
https://github.com/odoo/odoo/commit/de6de48deb983be910876c6133c2869907c142f7





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
