### PR TITLE
[FIX] setup: websocket-client version on iot box

### DIFF
--- a/setup/iot_box_builder/configuration/requirements.txt
+++ b/setup/iot_box_builder/configuration/requirements.txt
@@ -13,4 +13,4 @@ schedule==1.2.1; sys_platform == "win32"
 
 # The following requirements are needed on every platforms:
 python-escpos==3.1
-websocket-client==1.6.3
+websocket-client


### PR DESCRIPTION
Version 1.6 could lead to issues when receiving long messages in the channel. We removed the version marker in order to get the latest version.