### PR TITLE
[FIX] mail: edit message does not remove 1st line

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4926,7 +4926,7 @@ class MailThread(models.AbstractModel):
                     etree.SubElement(last_div_element, "span", attrib={"class": "o-mail-Message-edited"})
                     msg_values["body"] = (
                         # markup: it is considered safe, as coming from html.fragment_fromstring
-                        Markup("".join(etree.tostring(child, encoding="unicode") for child in tree))
+                        (tree.text or "") + Markup("".join(etree.tostring(child, encoding="unicode") for child in tree))
                     )
                 else:  # body is plain text
                     # keep html if already Markup, otherwise escape

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -976,6 +976,12 @@ class TestAPI(ThreadRecipients):
         self.assertFalse((attachments + new_attachments).exists())
         self.assertEqual(message.body, Markup('<p>Another Body, void attachments <span class="o-mail-Message-edited"></span></p>'))
 
+        ticket_record._message_update_content(
+            message,
+            body=Markup("line1<br>edit<br>line2<br>line3"),
+        )
+        self.assertEqual(message.body, Markup('<p>line1 <br>edit<br>line2<br>line3<span class="o-mail-Message-edited"></span></p>'))
+
     @mute_logger('openerp.addons.mail.models.mail_mail')
     @users('employee')
     def test_message_update_content_check(self):


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/231004

Before this commit, when editing a message with at least 1 line, the 1st line was removed after edition.

Steps to reproduce:
- type message with line breaks:
```
line1
line2
line3
```
- posts message
- start editing of message
- add "edit" in its own line in-between line1 and line2:
```
line1
edit
line2
line3
```
- save the edition => message saved has lost the 1st line. The resulting message is:
```

edit
line2
line3
```

This happens because message with line breaks are formatted with `<br/>`:
```
line1<br/>line2<br/>line3
```

When message is edited with new content:
```
line1<br/>edit</br>line2<br/>line3
```

The resulting content was:
```
 <br/>edit</br>line2<br/>line3
```

This happens because the html of body has no wrapped tag and consists of just text nodes joined by `<br/>`. While client-side DOM would say each `<br/>` are children (and text nodes are not), the `etree` lib that is used to parse the html has different definition of children:
```
<br/>edit   # 1st child
<br/>line2  # 2nd child
<br/>line3  # 3rd child
```

Parsing of body as html is used to insert the "(edited)" label at the end, attempting to insert in the last children for having the label inline to text content otherwise at the end.
When producing the resulting body with "(edited)" label, only the children were joined. Therefore the resulting body was produced:
```
 <br/>edit</br>line2<br/>line3<span.o-mail-Message-edited/>
```

Where the `.o-mail-Message-edited` represents the "(edited)" that is rendered on template for translation and style. `line1` is missing because this is not a child: this is text content before the 1st child. This `line1` should still be present in resulting string.

This commit fixes the issue by adding missing `tree.text` to the resulting message body with "(edited)" label, which is the text content that is present before the 1st child, i.e. the `line1` in example above.