### PR TITLE
[IMP] pos_*, whatsapp_pos : Send sms and whatsapp messages...

### DIFF
--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
@@ -44,12 +44,14 @@
                     placeholder="Email"
                     t-model="state.email"
                     t-att-disabled="partnerIsSelected" />
-                <t t-if="preset.needsPartner">
-                    <input type="text"
+                <input t-if="preset.needsName || preset.needsPartner"
+                        type="text"
                         class="form-control form-control-lg"
                         placeholder="Phone"
                         t-model="state.phone"
                         t-att-disabled="partnerIsSelected"/>
+                <p t-if="!checkPhoneFormat()" class="text-danger">Enter a valid phone number starting with the country code (e.g. +32)</p>
+                <t t-if="preset.needsPartner">
                     <select class="partner-select form-select form-select-lg" t-model="state.countryId" t-att-disabled="partnerIsSelected">
                         <option value="">
                             Select a country

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -43,7 +43,7 @@ registry.category("web_tour.tours").add("self_order_preset_delivery_tour", {
         Utils.clickBtn("Order"),
         CartPage.fillInput("Name", "Dr Dre"),
         CartPage.fillInput("Email", "dre@dr.com"),
-        CartPage.fillInput("Phone", "0490 90 43 90"),
+        CartPage.fillInput("Phone", "+32490904390"),
         CartPage.fillInput("Street and Number", "Rue du Bronx 90"),
         CartPage.fillInput("Zip", "9999"),
         CartPage.fillInput("City", "New York"),

--- a/addons/pos_self_order/static/tests/unit/components/preset_info_popup.test.js
+++ b/addons/pos_self_order/static/tests/unit/components/preset_info_popup.test.js
@@ -36,7 +36,7 @@ test("validSelection", async () => {
     // Partner
     preset.identification = "address";
     expect(comp.validSelection).toBeEmpty();
-    comp.state.phone = "987-654-3210";
+    comp.state.phone = "+1987-654-3210";
     comp.state.street = "21, Wonderfull Street";
     comp.state.city = "Vice City";
     comp.state.zip = "000021";

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -65,7 +65,7 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
         self.assertEqual(last_order.partner_id.street, 'Rue du Bronx 90')
         self.assertEqual(last_order.partner_id.zip, '9999')
         self.assertEqual(last_order.partner_id.city, 'New York')
-        self.assertEqual(last_order.partner_id.phone, '0490 90 43 90')
+        self.assertEqual(last_order.partner_id.phone, '+32490904390')
 
     def test_preset_with_slot_tour(self):
         resource_calendar = self.env['resource.calendar'].create({


### PR DESCRIPTION
… to warn the client about order status

This task aims to provide a solution for communicating the status of various customer orders. Now, the POS can send an SMS or a WhatsApp message when an order at the self-service is placed, either through WhatsApp, SMS, or both. When the order is completed, the customer can also be notified.

task : 5246552

enterprise pr : https://github.com/odoo/enterprise/pull/99318

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
