### PR TITLE
[FIX] mail: better message list readability in white theme

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -98,7 +98,7 @@
         &.#{$_type} {
             $_border-base: mix($_color, $body-color, 75%);
             --o-message-bubble-bg: #{mix($o-view-background-color, $_color, 90%)};
-            --o-message-bubble-border-color: #{mix($o-view-background-color, $_border-base, 70%)};
+            --o-message-bubble-border-color: #{mix($o-view-background-color, $_border-base, 80%)};
             --o-message-bubble-color-base: #{$_color};
         }
     }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -37,7 +37,7 @@
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': isEditing }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.isNote, 'pe-2': props.asCard and isMobileOS }" name="header">
                             <span t-if="message.authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
-                                <strong class="me-1 fw-bold" t-esc="message.authorName"/>
+                                <strong class="me-1 o-fw-600" t-esc="message.authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
                             <t t-if="isAlignedRight and !message.bubbleColor and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>

--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -1,3 +1,7 @@
+.o-mail-MessageInReply-author {
+    opacity: 75%;
+}
+
 .o-mail-MessageInReply-avatar {
     width: $o-mail-Avatar-size / 2;
     aspect-ratio: 1;

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -11,7 +11,7 @@
                     <t t-if="!props.message.parent_id.isEmpty">
                         <img class="o-mail-MessageInReply-avatar me-2 rounded object-fit-cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parent_id.authorName" alt="Avatar"/>
                         <span class="o-mail-MessageInReply-content overflow-hidden smaller">
-                            <b class="o-mail-MessageInReply-author"><t t-out="props.message.parent_id.authorName"/></b>:
+                            <b class="o-mail-MessageInReply-author o-fw-600"><t t-out="props.message.parent_id.authorName"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">
                                 <t t-if="!props.message.parent_id.isBodyEmpty">
                                     <t t-out="props.message.parent_id.inlineBody"/>


### PR DESCRIPTION
- reduce slightly message border opacity, so that they are less distracting than message list content itself.
- add more weight on message author names so they are more distinct more message text content. Harmonize weight in message reply but with reduced opacity.

These changes should make using Discuss in white theme less fatiguing.

Before
<img width="953" height="791" alt="Screenshot 2025-11-12 at 18 29 01" src="https://github.com/user-attachments/assets/dc9f37d2-acea-44ae-99e7-e3ecdcc40a9d" />

After
<img width="962" height="789" alt="Screenshot 2025-11-12 at 18 29 09" src="https://github.com/user-attachments/assets/0239f581-a344-44e1-9a84-0e7877cab047" />

