### PR TITLE
[IMP] orm: fields.Json empty collections

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1325,7 +1325,7 @@ class AccountMoveLine(models.Model):
             line.analytic_distribution = self._merge_distribution(
                 old_distribution=old_distributions.get(line._origin.id) or {},
                 new_distribution=line.analytic_distribution or {},
-            )
+            ) or False
         lines_to_modify.analytic_line_ids.unlink()
         lines_to_modify._create_analytic_lines()
 

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2192,7 +2192,7 @@ class AccountTax(models.Model):
         return {
             'partner_id': base_line['partner_id'].id,
             'currency_id': base_line['currency_id'].id,
-            'analytic_distribution': base_line['analytic_distribution'],
+            'analytic_distribution': base_line['analytic_distribution'] or False,
             'account_id': base_line['account_id'].id,
             'tax_ids': [Command.set(base_line['tax_ids'].ids)],
         }
@@ -2222,7 +2222,7 @@ class AccountTax(models.Model):
                 base_line_grouping_key['analytic_distribution']
                 if tax.analytic or not tax_rep.use_in_tax_closing
                 else False
-            ),
+            ) or False,
             'account_id': tax_rep_data['account'].id or base_line_grouping_key['account_id'],
             'tax_ids': [Command.set(tax_rep_data['taxes'].ids)],
             'tax_tag_ids': [Command.set(tax_rep_data['tax_tags'].ids)],
@@ -2245,7 +2245,7 @@ class AccountTax(models.Model):
             'partner_id': tax_line['partner_id'].id,
             'currency_id': tax_line['currency_id'].id,
             'group_tax_id': tax_line['group_tax_id'].id,
-            'analytic_distribution': tax_line['analytic_distribution'],
+            'analytic_distribution': tax_line['analytic_distribution'] or False,
             'account_id': tax_line['account_id'].id,
             'tax_ids': [Command.set(tax_line['tax_ids'].ids)],
             'tax_tag_ids': [Command.set(tax_line['tax_tag_ids'].ids)],

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -5196,10 +5196,10 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             analytic_account_b.id: 100,
         }
         analytic_distribution_a_serialized = {
-            str(analytic_account_a.id): 100,
+            str(analytic_account_a.id): 100.0,
         }
         analytic_distribution_b_serialized = {
-            str(analytic_account_b.id): 100,
+            str(analytic_account_b.id): 100.0,
         }
 
         tax = self.env['account.tax'].create({
@@ -5383,10 +5383,10 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             analytic_account_b.id: 100,
         }
         analytic_distribution_a_serialized = {
-            str(analytic_account_a.id): 100,
+            str(analytic_account_a.id): 100.0,
         }
         analytic_distribution_b_serialized = {
-            str(analytic_account_b.id): 100,
+            str(analytic_account_b.id): 100.0,
         }
 
         tax = self.env['account.tax'].create({

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -535,8 +535,8 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertRecordValues(wizard, [{
             'move_id': invoice.id,
             'sending_methods': ['email', 'manual'],
-            'extra_edis': False,
-            'extra_edi_checkboxes': False,
+            'extra_edis': {},
+            'extra_edi_checkboxes': {},
             'pdf_report_id': wizard._get_default_pdf_report_id(invoice).id,
             'display_pdf_report_id': False,
             'template_id': wizard._get_default_mail_template_id(invoice).id,

--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -560,8 +560,8 @@ class TestTransferWizard(AccountTestInvoicingCommon):
         transfer_move = self.env['account.move'].browse(wizard.do_action()['res_id'])
 
         self.assertRecordValues(transfer_move.line_ids, [
-            {'balance': -4000, 'analytic_distribution': {str(self.analytic_account_1.id): 50, str(self.analytic_account_2.id): 25}},
-            {'balance': 1000, 'analytic_distribution': {str(self.analytic_account_1.id): 100}},
-            {'balance': 2000, 'analytic_distribution': {str(self.analytic_account_1.id): 50, str(self.analytic_account_2.id): 50}},
-            {'balance': 1000, 'analytic_distribution': False},
+            {'balance': -4000.0, 'analytic_distribution': {str(self.analytic_account_1.id): 50.0, str(self.analytic_account_2.id): 25.0}},
+            {'balance': 1000.0, 'analytic_distribution': {str(self.analytic_account_1.id): 100.0}},
+            {'balance': 2000.0, 'analytic_distribution': {str(self.analytic_account_1.id): 50.0, str(self.analytic_account_2.id): 50.0}},
+            {'balance': 1000.0, 'analytic_distribution': False},
         ])

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -194,12 +194,12 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                     distribution_values = counterpart_distribution_amount[grouping_key]
                     distribution_values[account_id] = (line.balance * distribution + distribution_values.get(account_id, 0) * 100) / 100
             counterpart_balances[grouping_key]['analytic_distribution'] = counterpart_distribution_amount[grouping_key] or {}
-            grouped_source_lines[(
+            grouped_source_lines[
                 line.partner_id,
                 line.currency_id,
                 line.account_id,
-                line.analytic_distribution and frozendict(line.analytic_distribution),
-            )] += line
+                frozendict(line.analytic_distribution) if line.analytic_distribution else False,
+            ] += line
 
         # Generate counterpart lines' vals
         for (counterpart_partner, counterpart_currency), counterpart_vals in counterpart_balances.items():

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -281,7 +281,7 @@ class TestExpenses(TestExpenseCommon):
                 'tax_ids': [],
                 'tax_amount_currency': 0.00,
                 'untaxed_amount_currency': 200.00,
-                'analytic_distribution': False,
+                'analytic_distribution': {},
                 'split_expense_origin_id': expense.id,
             }, {
                 'name': expense.name,
@@ -291,7 +291,7 @@ class TestExpenses(TestExpenseCommon):
                 'tax_ids': [self.tax_purchase_a.id],
                 'tax_amount_currency': 39.13,
                 'untaxed_amount_currency': 260.87,
-                'analytic_distribution': {str(self.analytic_account_1.id): 100},
+                'analytic_distribution': {str(self.analytic_account_1.id): 100.0},
                 'split_expense_origin_id': expense.id,
             }, {
                 'name': expense.name,
@@ -301,7 +301,7 @@ class TestExpenses(TestExpenseCommon):
                 'tax_ids': [self.tax_purchase_a.id, self.tax_purchase_b.id],
                 'tax_amount_currency': 115.38,
                 'untaxed_amount_currency': 384.62,
-                'analytic_distribution': {str(self.analytic_account_2.id): 100},
+                'analytic_distribution': {str(self.analytic_account_2.id): 100.0},
                 'split_expense_origin_id': expense.id,
             }
         ])

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -582,7 +582,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         self.assertRecordValues(wizard, [{
             'sending_methods': ['manual'],
             'invoice_edi_format': 'ubl_bis3',
-            'extra_edi_checkboxes': False,
+            'extra_edi_checkboxes': {},
         }])
         self._assert_mail_attachments_widget(wizard, [
             {

--- a/addons/l10n_account_withholding_tax/models/account_withholding_line.py
+++ b/addons/l10n_account_withholding_tax/models/account_withholding_line.py
@@ -444,7 +444,7 @@ class AccountWithholdingLine(models.AbstractModel):
         # /!\ Please keep this aligned with _prepare_withholding_lines_commands to ensure correct computation.
         return frozendict({
             'name': self.name,
-            'analytic_distribution': self.analytic_distribution,
+            'analytic_distribution': self.analytic_distribution or False,
             'account': self.account_id.id,
             'tax_id': self.tax_id.id,
             'skip': False,

--- a/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
+++ b/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
@@ -665,13 +665,13 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             {'balance': -200.0,   'analytic_distribution': False},
             # withholding lines:
             {'balance': 2.0,      'analytic_distribution': {
-                str(self.analytic_account_3.id): 50,
-                str(self.analytic_account_4.id): 50,
+                str(self.analytic_account_3.id): 50.0,
+                str(self.analytic_account_4.id): 50.0,
             }},
             # base line:
             {'balance': 200.0,    'analytic_distribution': {
-                str(self.analytic_account_3.id): 50,
-                str(self.analytic_account_4.id): 50,
+                str(self.analytic_account_3.id): 50.0,
+                str(self.analytic_account_4.id): 50.0,
             }},
             # Counterpart:
             {'balance': -200.0,   'analytic_distribution': False},

--- a/addons/l10n_in/tests/test_tds_tcs_alert.py
+++ b/addons/l10n_in/tests/test_tds_tcs_alert.py
@@ -109,7 +109,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             account_id=self.internet_account,
         )
 
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
     def test_tcs_tds_warning_on_exceeded_per_transaction_limit(self):
         '''
@@ -154,7 +154,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 company_id=self.branch_a,
                 account_id=self.rent_account,
             )
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
         with freeze_time('2024-07-06'):
             move_1 = self._create_invoice_one_line(
@@ -163,7 +163,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 company_id=self.branch_b,
                 account_id=self.rent_account,
             )
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
         with freeze_time('2024-07-16'):
             move_2 = self._create_invoice_one_line(
@@ -179,7 +179,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 company_id=self.branch_c,
                 account_id=self.rent_account,
             )
-        self.assertEqual(move_3.l10n_in_warning, False)
+        self.assertEqual(move_3.l10n_in_warning, {})
 
         with freeze_time('2024-09-16'):
             move_4 = self._create_invoice_one_line(
@@ -201,7 +201,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             company_id=self.branch_a,
             account_id=self.internet_account,
         )
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
         move_1 = self._create_invoice_one_line(
             partner_id=self.partner_foreign_2,
@@ -209,7 +209,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             company_id=self.branch_b,
             account_id=self.internet_account,
         )
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
         # same pan number
         move_2 = self._create_invoice_one_line(
@@ -217,7 +217,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             company_id=self.branch_a,
             account_id=self.internet_account,
         )
-        self.assertEqual(move_2.l10n_in_warning, False)
+        self.assertEqual(move_2.l10n_in_warning, {})
 
         move_3 = self._create_invoice_one_line(
             partner_id=self.partner_b,
@@ -236,7 +236,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 price_unit=20000,
                 company_id=self.branch_a,
             )
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
         with freeze_time('2024-07-06'):
             move_1 = self._create_invoice_one_line(
@@ -244,7 +244,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 price_unit=20000,
                 company_id=self.branch_b,
             )
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
         with freeze_time('2024-08-06'):
             move_2 = self._create_invoice_one_line(
@@ -259,14 +259,14 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 price_unit=5000,
                 company_id=self.branch_a,
             )
-        self.assertEqual(move_3.l10n_in_warning, False)
+        self.assertEqual(move_3.l10n_in_warning, {})
 
         with freeze_time('2024-10-07'):
             move_4 = self._create_invoice_one_line(
                 price_unit=20000,
                 company_id=self.branch_b,
             )
-        self.assertEqual(move_4.l10n_in_warning, False)
+        self.assertEqual(move_4.l10n_in_warning, {})
 
         with freeze_time('2024-11-08'):
             move_5 = self._create_invoice_one_line(
@@ -286,7 +286,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             company_id=self.branch_a,
             account_id=self.internet_account
         )
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
         move_1 = self._create_invoice_one_line(
             partner_id=self.partner_b,
@@ -296,14 +296,14 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
         )
         self._reverse_invoice(move, date='2024-09-01')
 
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
         move_2 = self._create_invoice_one_line(
             price_unit=2000,
             company_id=self.branch_a,
             account_id=self.internet_account
         )
-        self.assertEqual(move_2.l10n_in_warning, False)
+        self.assertEqual(move_2.l10n_in_warning, {})
 
     def test_tcs_tds_warning_cleared_on_available_tax(self):
         '''
@@ -318,7 +318,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             company_id=self.branch_a,
         )
 
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
     def test_tcs_tds_warning_for_multiple_accounts_in_lines(self):
         '''
@@ -347,7 +347,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
         self.tds_wizard_entry(move=move_1, lines=[(self.tax_194ib, 100000), (self.tax_194j, 100000), (self.tax_194c, 100000)])
         move_1.button_draft()
         move_1.action_post()
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
     def test_tcs_tds_warning_for_if_line_has_price_zero(self):
         '''
@@ -366,7 +366,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             price_unit=0,
             company_id=self.branch_a,
         )
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
     def test_tcs_tds_warning_for_all_lines_do_not_have_taxes(self):
         '''
@@ -382,7 +382,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
         self.assertEqual(move.l10n_in_warning['tds_tcs_threshold_alert']['message'], "It's advisable to deduct TDS u/s 194C on this transaction.")
         self.tds_wizard_entry(move=move, lines=[(self.tax_194c, 100000)])
         move.line_ids.remove_move_reconcile()
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
     def test_tcs_tds_warning_for_company_branches(self):
         '''
@@ -422,7 +422,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             company_id=self.branch_a,
             account_id=self.sale_account
         )
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
     def test_tcs_tds_warning_tds_use_in_invoice(self):
         '''
@@ -434,7 +434,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             price_unit=110000,
             company_id=self.branch_a,
         )
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
     def test_tcs_tds_warning_for_multiple_accounts_same_section_in_lines(self):
         '''
@@ -458,14 +458,14 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
                 self._prepare_invoice_line(price_unit=13000, account_id=self.purchase_account),
             ],
         )
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
         move_2 = self._create_invoice_one_line(
             price_unit=30000,
             company_id=self.branch_a,
             account_id=self.house_expense_account,
         )
-        self.assertEqual(move_2.l10n_in_warning, False)
+        self.assertEqual(move_2.l10n_in_warning, {})
 
         move_3 = self._create_invoice_one_line(
             price_unit=10000,
@@ -485,14 +485,14 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
             account_id=self.purchase_account,
         )
         move.button_cancel()
-        self.assertEqual(move.l10n_in_warning, False)
+        self.assertFalse(move.l10n_in_warning)
 
         move_1 = self._create_invoice_one_line(
             price_unit=25000,
             company_id=self.branch_a,
             account_id=self.purchase_account,
         )
-        self.assertEqual(move_1.l10n_in_warning, False)
+        self.assertEqual(move_1.l10n_in_warning, {})
 
         move_2 = self._create_invoice_one_line(
             price_unit=85000,

--- a/addons/sale_crm/tests/test_res_partner.py
+++ b/addons/sale_crm/tests/test_res_partner.py
@@ -108,7 +108,7 @@ class TestResPartner(TestCrmCommon):
                 [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 3, 'tagClass': 'o_tag_color_8'},
                  {'iconClass': 'fa-usd', 'label': 'Sale Orders', 'value': 1, 'tagClass': 'o_tag_color_2'}],
                 [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 2, 'tagClass': 'o_tag_color_8'}],
-                False,
+                [],
             ),
             strict=True,
         ):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -438,7 +438,7 @@ class TestViewInheritance(ViewCase):
             ],
         )
 
-        self.assertEqual(child_primary_no_arch.invalid_locators, False)
+        self.assertEqual(child_primary_no_arch.invalid_locators, [])
 
     def test_invalid_locators_with_valid_xpath(self):
         """ Check ir.ui.view's invalid_locators field is computed correctly."""
@@ -537,7 +537,7 @@ class TestViewInheritance(ViewCase):
         # Assert that accessing invalid_locators does not cause database writes.
         actual_queries = []
         with contextmanager(lambda: self._patchExecute(actual_queries))():
-            self.assertEqual(child_applied.invalid_locators, False)
+            self.assertEqual(child_applied.invalid_locators, [])
         self.assertTrue(len(actual_queries) > 0)
 
         re_sql_update = re.compile(r'\bupdate\b', re.IGNORECASE)
@@ -546,7 +546,7 @@ class TestViewInheritance(ViewCase):
         self.assertEqual(child_view.invalid_locators, [{'tag': 'xpath', 'attrib': {'expr': "//div[hasclass('parasite')]", 'position': 'inside'}, 'sourceline': 8}])
         self.assertEqual(child_view2.invalid_locators, [{'tag': 'field', 'attrib': {'name': 'user_id', 'position': 'after'}, 'sourceline': 5}])
         self.assertEqual(child_view3.invalid_locators, [{'tag': 'xpath', 'attrib': {'expr': "//div[hasclass('parasite')]", 'position': 'inside'}, 'sourceline': 2}])
-        self.assertEqual(child_view4.invalid_locators, False)
+        self.assertEqual(child_view4.invalid_locators, [])
 
     def test_nested_move_invalid_locator(self):
         """ Check ir.ui.view's invalid_locators field is computed correctly."""
@@ -575,7 +575,7 @@ class TestViewInheritance(ViewCase):
             </data>
             """,
         })
-        self.assertEqual(child_view.invalid_locators, False)
+        self.assertEqual(child_view.invalid_locators, [])
 
         child_view.arch = """
             <data>

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -6,7 +6,7 @@ import typing
 
 from psycopg2.extras import Json as PsycopgJson
 
-from odoo.tools import SQL
+from odoo.tools import SQL, json_default
 
 from .fields import Field
 from .identifiers import IdType
@@ -54,8 +54,8 @@ class Boolean(Field[bool]):
 
 class Json(Field):
     """ JSON Field that contain unstructured information in jsonb PostgreSQL column.
-    This field is still in beta
-    Some features have not been implemented and won't be implemented in stable versions, including:
+
+    Some features won't be implemented, including:
     * searching
     * indexing
     * mutating the values.
@@ -71,10 +71,12 @@ class Json(Field):
     def convert_to_cache(self, value, record, validate=True):
         if not value:
             return None
-        return json.loads(json.dumps(value))
+        return json.loads(json.dumps(value, default=json_default))
 
     def convert_to_column(self, value, record, values=None, validate=True):
-        if not value:
+        if validate:
+            value = self.convert_to_cache(value, record)
+        if value is None:
             return None
         return PsycopgJson(value)
 

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -69,7 +69,9 @@ class Json(Field):
         return False if value is None else copy.deepcopy(value)
 
     def convert_to_cache(self, value, record, validate=True):
-        if not value:
+        # we don't save the false value as it is what convert_to_record is
+        # returning by default
+        if value is None or value is False:
             return None
         return json.loads(json.dumps(value, default=json_default))
 


### PR DESCRIPTION

The field did not change for quite some time. It mainly serves as a way of storing and retrieving some unstructured data.
Use default serialization function when assiging values to Json fields. The `convert_to_column` logic is simplified to save falsy values as well if requested.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
