### PR TITLE
[FIX] sale: prevent error when replacing combo product on sale order line

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -921,10 +921,15 @@ class SaleOrder(models.Model):
     @api.onchange('order_line')
     def _onchange_order_line(self):
         for index, line in enumerate(self.order_line):
-            if line.product_type != 'combo':
-                continue
             combo_item_lines = line._get_linked_lines().filtered('combo_item_id')
-            if line.selected_combo_items:
+            if line.product_template_id.type != 'combo':
+                if combo_item_lines:
+                    # Delete any linked combo item lines if the line's product is no longer a combo
+                    # product.
+                    self.order_line = [
+                        Command.delete(linked_line.id) for linked_line in combo_item_lines
+                    ]
+            elif line.selected_combo_items:
                 selected_combo_items = json.loads(line.selected_combo_items)
                 if (
                     selected_combo_items
@@ -966,7 +971,11 @@ class SaleOrder(models.Model):
                 # Clear `selected_combo_items` to avoid applying the same changes multiple times.
                 line.selected_combo_items = False
                 self.order_line = delete_commands + create_commands + update_commands
-            elif combo_item_lines:
+            elif (
+                combo_item_lines
+                # Only update the combo item lines if the line's combo choices haven't changed.
+                and combo_item_lines.combo_item_id.combo_id == line.product_template_id.combo_ids
+            ):
                 combo_item_lines.update({
                     'product_uom_qty': line.product_uom_qty,
                     'discount': line.discount,


### PR DESCRIPTION
Currently, an error occurs when a user replaces a `combo product` with another 
product in a sale order line before the order is saved.

**Steps to produce:**

- Install the `sale_management` module with demo data.
- Open `sale order`, click `Add a product`, and add a `combo product` (Office Combo). 
  (`Make sure the form is not saved`)
- Click on the `combo name` (Office combo x 1) and replace it with another product.

**Error:**
`IndexError: tuple index out of range`

**Root cause:**
After PR [1], at [2], when a combo product is replaced before the order is
saved, the code attempts to update the combo item lines even though the
template type (`product_template_id.type`) is not `combo`. This leads to an
update of `product_uom_qty`, which triggers the `_compute_price_unit` method
and results in the error at [3].

**Fix:**
This commit prevents errors when a user replaces a combo product with another product.

[1]:
https://github.com/odoo/odoo/pull/194496

[2]:
https://github.com/odoo/odoo/blob/47e561bd1f6bc14724d60ebf09a66e458dfd4799/addons/sale/models/sale_order.py#L966-L970

[3]:
https://github.com/odoo/odoo/blob/c758b93a57cd98ab76c26c03bd0097f2eef50961/addons/sale/models/sale_order_line.py#L766

sentry-7009976704