### PR TITLE
[IMP] hr_work_entry: only include work details that are work entries

### DIFF
--- a/addons/hr_work_entry/models/resource_calendar.py
+++ b/addons/hr_work_entry/models/resource_calendar.py
@@ -7,6 +7,17 @@ from odoo.fields import Domain
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
 
+    def _include_all_attendances(self):
+        # to override in modules that want to include all work details regardless of
+        # `category` in their calculation
+        return False
+
+    def _get_working_time_domain(self):
+        return Domain.OR([
+            Domain('work_entry_type_id', '=', False),
+            Domain('work_entry_type_id.category', '=', 'working_time'),
+        ])
+
     # Override the method to add 'attendance_ids.work_entry_type_id.category' to
     # the dependencies
     @api.depends('attendance_ids.work_entry_type_id.category')
@@ -14,12 +25,11 @@ class ResourceCalendar(models.Model):
         super()._compute_hours_per_week()
 
     def _get_global_attendances(self):
-        global_attendances = super()._get_global_attendances()
-        return global_attendances.filtered_domain(
-            Domain.OR(
-                [
-                    Domain('work_entry_type_id', '=', False),
-                    Domain('work_entry_type_id.category', '=', 'working_time'),
-                ],
-            ),
-        )
+        return super()._get_global_attendances().filtered_domain(self._get_working_time_domain())
+
+    def _attendance_intervals_batch(self, start_dt, end_dt, resources_per_tz=None, domain=None):
+        work_domain = domain if self._include_all_attendances() else Domain.AND([
+            domain or Domain.TRUE,
+            self._get_working_time_domain(),
+        ])
+        return super()._attendance_intervals_batch(start_dt, end_dt, resources_per_tz, work_domain)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -198,7 +198,7 @@ class ResourceCalendar(models.Model):
             Domain('display_type', '=', False),
         ])
 
-        attendances = self.env['resource.calendar.attendance'].search(domain)
+        attendances = self.env['resource.calendar.attendance'].sudo().search(domain)
         duration_based_attendances = attendances.filtered('duration_based')
         all_duration_based_attendances = attendances.calendar_id.attendance_ids.filtered('duration_based')
         # Resource specific attendances
@@ -397,7 +397,7 @@ class ResourceCalendar(models.Model):
         # retrieve leave intervals in (start_dt, end_dt)
         result = defaultdict(list)
         tz_dates = {}
-        all_leaves = self.env['resource.calendar.leaves'].search(domain)
+        all_leaves = self.env['resource.calendar.leaves'].sudo().search(domain)
         for leave in all_leaves:
             leave_resource = leave.resource_id
             leave_company = leave.company_id


### PR DESCRIPTION
This commits adds an optional domain when creating work entries to only include the work details that are `is_work` or that don't have a work_entry_type_id, this is needed by a lot of localizations

task-5076624

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
