### PR TITLE
[IMP] html_editor: disable drag and drop handlers on mobile

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -1,10 +1,11 @@
-import { MAIN_PLUGINS } from "./plugin_sets";
+import { MAIN_PLUGINS, MOBILE_OS_EXCLUDED_PLUGINS } from "./plugin_sets";
 import { createBaseContainer, SUPPORTED_BASE_CONTAINER_NAMES } from "./utils/base_container";
 import { fillShrunkPhrasingParent, removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
 import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
 import { setElementContent } from "@web/core/utils/html";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /** @typedef {import("plugins").EditorResources} EditorResources */
 /** @typedef {import("plugins").GlobalResources} GlobalResources */
@@ -163,7 +164,11 @@ export class Editor {
     }
 
     preparePlugins() {
-        const Plugins = sortPlugins(this.config.Plugins || MAIN_PLUGINS);
+        const pluginList = this.config.Plugins || MAIN_PLUGINS;
+        const filteredPluginList = isMobileOS()
+            ? pluginList.filter((p) => !MOBILE_OS_EXCLUDED_PLUGINS.includes(p))
+            : pluginList;
+        const Plugins = sortPlugins(filteredPluginList);
         this.config = Object.assign({}, ...Plugins.map((P) => P.defaultConfig), this.config);
         this.pluginsMap = new Map();
         for (const P of Plugins) {

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.js
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.js
@@ -7,9 +7,12 @@ import {
     convertCSSColorToRgba,
 } from "@web/core/utils/colors";
 import { CheckBox } from "@web/core/checkbox/checkbox";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class GradientPicker extends Component {
-    static components = { ColorPicker, CheckBox };
+    static components = { ColorPicker, CheckBox, Dropdown, DropdownItem };
     static template = "html_editor.GradientPicker";
     static props = {
         onGradientChange: { type: Function, optional: true },
@@ -39,6 +42,7 @@ export class GradientPicker extends Component {
         this.knobRef = useRef("gradientAngleKnob");
 
         this.onToggleRepeatingBound = this.onToggleRepeating.bind(this);
+        this.isMobileOS = isMobileOS();
 
         if (this.props.selectedGradient && isColorGradient(this.props.selectedGradient)) {
             // initialization of the gradient with the selected value

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
@@ -4,11 +4,32 @@
 
             <div class="align-items-center d-flex justify-content-between my-3 o_type_row">
                 Type
-                <span class="d-flex justify-content-between">
-                    <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'linear' ? 'active' : ''}}" t-on-click="() => this.selectType('linear')"> Linear </button>
-                    <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'radial' ? 'active' : ''}}" t-on-click="() => this.selectType('radial')"> Radial </button>
-                    <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'conic' ? 'active' : ''}}" t-on-click="() => this.selectType('conic')"> Conic </button>
-                </span>
+                <t t-if="isMobileOS">
+                    <Dropdown>
+                        <button class="btn btn-light d-flex justify-content-between w-100 ms-2 border border-dark rounded-0">
+                            <span class="px-1" t-esc="this.state.type"/>
+                            <i class="fa fa-caret-down ms-2"/>
+                        </button>
+                        <t t-set-slot="content">
+                            <DropdownItem onSelected="() => this.selectType('linear')">
+                                Linear
+                            </DropdownItem>
+                            <DropdownItem onSelected="() => this.selectType('radial')">
+                                Radial
+                            </DropdownItem>
+                            <DropdownItem onSelected="() => this.selectType('conic')">
+                                Conic
+                            </DropdownItem>
+                        </t>
+                    </Dropdown>
+                </t>
+                <t t-else="">
+                    <span class="d-flex justify-content-between">
+                        <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'linear' ? 'active' : ''}}" t-on-click="() => this.selectType('linear')"> Linear </button>
+                        <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'radial' ? 'active' : ''}}" t-on-click="() => this.selectType('radial')"> Radial </button>
+                        <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'conic' ? 'active' : ''}}" t-on-click="() => this.selectType('conic')"> Conic </button>
+                    </span>
+                </t>
             </div>
 
             <div t-if="this.state.type === 'radial'">

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -176,3 +176,5 @@ export const EXTRA_PLUGINS = [
     EditorVersionPlugin,
     QWebPlugin,
 ];
+
+export const MOBILE_OS_EXCLUDED_PLUGINS = [MoveNodePlugin];

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -5,6 +5,9 @@ import { isCSSColor, isColorGradient, normalizeCSSColor } from "@web/core/utils/
 import { cookie } from "@web/core/browser/cookie";
 import { POSITION_BUS } from "../position/position_hook";
 import { registry } from "../registry";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 // These colors are already normalized as per normalizeCSSColor in @web/legacy/js/widgets/colorpicker
 export const DEFAULT_COLORS = [
@@ -34,7 +37,7 @@ export const DEFAULT_THEME_COLOR_VARS = [
 
 export class ColorPicker extends Component {
     static template = "web.ColorPicker";
-    static components = { CustomColorPicker };
+    static components = { CustomColorPicker, Dropdown, DropdownItem };
     static props = {
         state: {
             type: Object,
@@ -86,6 +89,7 @@ export class ColorPicker extends Component {
         this.onApplyCallback = () => {};
         this.onPreviewRevertCallback = () => {};
         this.getPreviewColor = () => {};
+        this.isMobileOS = isMobileOS();
 
         this.state = useState({
             activeTab: this.props.state.selectedTab || this.getDefaultTab(),

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -3,11 +3,29 @@
     <div t-attf-class="o_font_color_selector user-select-none {{this.props.className}}"
         t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root">
         <div class="px-1 mb-1 pt-2 d-flex">
-            <t t-foreach="this.tabs" t-as="tab" t-key="tab.id">
-                <button t-attf-class="btn btn-sm text-truncate btn-tab #{tab.id}-tab #{ isDarkTheme ? 'btn-secondary' : 'btn-light'} #{state.activeTab === tab.id ? 'active' : ''}"
-                    t-on-click="() => this.setTab(tab.id)">
-                    <t t-out="tab.name" />
-                </button>
+            <t t-if="isMobileOS">
+                <Dropdown>
+                    <button class="btn btn-light d-flex justify-content-between w-100 border border-dark">
+                        <span class="px-1" t-esc="state.activeTab"/>
+                        <i class="fa fa-caret-down ms-2"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <t t-foreach="this.tabs" t-as="item" t-key="item.id">
+                            <DropdownItem
+                                onSelected="() => this.setTab(item.id)">
+                                    <t t-esc="item.name"/>
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+            </t>
+            <t t-else="">
+                <t t-foreach="this.tabs" t-as="tab" t-key="tab.id">
+                    <button t-attf-class="btn btn-sm text-truncate btn-tab #{tab.id}-tab #{ isDarkTheme ? 'btn-secondary' : 'btn-light'} #{state.activeTab === tab.id ? 'active' : ''}"
+                        t-on-click="() => this.setTab(tab.id)">
+                        <t t-out="tab.name" />
+                    </button>
+                </t>
             </t>
             <div class="flex-grow-1" />
             <button t-attf-class="btn btn-sm fa fa-trash #{ isDarkTheme ? 'btn-secondary' : 'btn-light'}"


### PR DESCRIPTION
Purpose:

- Drag and drop handlers don’t function on mobile devices. Therefore, they have been removed for mobile devices.
- On mobile devices, tab buttons used for color tabs and gradient types can exceed the available viewport width, causing layout overflow. Replace these tab buttons with a dropdown on mobile to prevent overflow and improve usability.

task-5155786
