### PR TITLE
[FIX] mail: show warning when no mic permission in systray call menu

### DIFF
--- a/addons/mail/static/src/core/common/action_list.dark.scss
+++ b/addons/mail/static/src/core/common/action_list.dark.scss
@@ -5,6 +5,7 @@
     --mail-ActionList-successBgColor: #{rgba(saturate($success, 20%), .5)};
     --mail-ActionList-buttonInlineIconOpacity: #{85%};
     --mail-ActionList-dangerColor: #{lighten($danger, 5%)};
+    --o-mail-ActionList-dropdownSuccessUnfocusedColor: #{lighten($success, 10%)};
     --o-mail-ActionList-dropdownDangerUnfocusedColor: #{lighten($danger, 10%)};
 
     .o-hasBtnBg.o-tag-SUCCESS {

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -80,13 +80,25 @@
                 transform: translateY(.5px);
             }
         }
-        &.o-dropdown-item.btn-danger:not(.o-tag-JOIN_LEAVE_CALL) {
-            &.focus {
-                background-color: rgba($danger, 0.75);
-                color: white;
+        &.o-dropdown-item {
+
+            &.btn-success:not(.o-tag-JOIN_LEAVE_CALL) {
+                &.focus {
+                    background-color: rgba($success, 0.75);
+                    color: white;
+                }
+                &:not(.focus) {
+                    color: var(--o-mail-ActionList-dropdownSuccessUnfocusedColor, #{$success});
+                }
             }
-            &:not(.focus) {
-                color: var(--o-mail-ActionList-dropdownDangerUnfocusedColor, #{$danger});
+            &.btn-danger:not(.o-tag-JOIN_LEAVE_CALL) {
+                &.focus {
+                    background-color: rgba($danger, 0.75);
+                    color: white;
+                }
+                &:not(.focus) {
+                    color: var(--o-mail-ActionList-dropdownDangerUnfocusedColor, #{$danger});
+                }
             }
         }
     }

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -129,7 +129,7 @@
 </t>
 
 <t t-name="mail.Action.badge">
-    <span class="fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center" t-attf-class="{{ extraBadgeClass }}" t-att-class="{ 'bg-warning': action.tags.includes('WARNING_BADGE'), 'o-discuss-badge': action.tags.includes('IMPORTANT_BADGE') }" style="aspect-ratio: 1; font-size: 0.6rem;">
+    <span class="fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center" t-attf-class="{{ extraBadgeClass }}" t-att-class="{ 'bg-warning o-discuss-warningBadge': action.tags.includes('WARNING_BADGE'), 'o-discuss-badge': action.tags.includes('IMPORTANT_BADGE') }" style="aspect-ratio: 1; font-size: 0.6rem;">
         <i t-if="action.badgeIcon" t-att-class="action.badgeIcon"/><span t-elif="action.badgeText" t-esc="action.badgeText"/>
     </span>
 </t>

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -14,6 +14,10 @@ a.o-discuss-mention {
     color: $o-main-text-color;
 }
 
+.o-discuss-warningBadge .i {
+    text-shadow: 0px 0px 5px rgba(0, 0, 0, .5);
+}
+
 .o-secondary {
     --o-secondary: #{$o-gray-700};
 }

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -52,6 +52,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     }
 }
 
+.o-discuss-warningBadge {
+    background-color: $warning !important;
+}
+
 @function o-rounded-bubble() {
     @return calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
 }

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -31,14 +31,11 @@ export function registerCallAction(id, definition) {
 }
 
 export const muteAction = {
-    badge: ({ owner, store }) =>
-        !owner.env.inCallMenu && store.rtc.microphonePermission !== "granted",
+    badge: ({ owner, store }) => store.rtc.microphonePermission !== "granted",
     badgeIcon: "fa fa-exclamation",
     condition: ({ channel, store }) => channel?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
-    isActive: ({ store }) =>
-        (store.rtc.selfSession?.isMute && store.rtc.microphonePermission === "granted") ||
-        store.rtc.selfSession?.is_deaf,
+    isActive: ({ store }) => store.rtc.selfSession?.isMute,
     isTracked: true,
     icon: ({ action, store }) =>
         action.isActive

--- a/addons/mail/static/src/discuss/call/common/call_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_menu.js
@@ -21,12 +21,25 @@ export class CallMenu extends Component {
         this.isEnterprise = odoo.info && odoo.info.isEnterprise;
     }
 
+    get lastSelfAction() {
+        return this.rtc.callActions.find((action) => action.id === this.rtc.lastSelfCallAction);
+    }
+
+    get lastSelfActionAttClass() {
+        const { lastSelfAction } = this;
+        if (!lastSelfAction) {
+            return {};
+        }
+        return {
+            "text-danger": lastSelfAction.isActive && lastSelfAction.tags.includes("DANGER"),
+            "text-success": lastSelfAction.isActive && lastSelfAction.tags.includes("SUCCESS"),
+        };
+    }
+
     get icon() {
-        const res = this.rtc.callActions.find(
-            (action) => action.id === this.rtc.lastSelfCallAction
-        )?.icon;
+        const res = this.lastSelfAction?.icon;
         return (typeof res === "function" ? res() : res) ?? "fa fa-microphone";
     }
 }
 
-registry.category("systray").add("discuss.CallMenu", { Component: CallMenu }, { sequence: 100 });
+registry.category("systray").add("discuss.CallMenu", { Component: CallMenu }, { sequence: 105 });

--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -13,10 +13,14 @@
     }
 }
 
-.o-discuss-CallMenu-animation {
+.o-discuss-CallMenu-animationContainer {
     top: 4px;
     left: 6px;
-    animation: flash 2s;
+}
+
+.o-discuss-CallMenu-animation {
+    --flash-low-opacity: .35;
+    animation: flash 2.5s;
     animation-direction: alternate;
     animation-iteration-count: 2;
 
@@ -29,4 +33,9 @@
     &:hover {
         background-color: mix($gray-200, $gray-300) !important;
     }
+}
+
+.o-discuss-CallMenu-warningBadge {
+    top: -4px;
+    right: -4px;
 }

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -5,8 +5,8 @@
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
             <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow px-0 rounded-2" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center btn-group rounded-2" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
-                    <small class="o-discuss-CallMenu-animation d-flex position-absolute smaller bg-inherit o-p-0_5 rounded-circle m-n2 z-2">
-                        <i class="fa fa-volume-up o-discuss-inCallIconColor bg-inherit rounded-circle" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>
+                    <small class="o-discuss-CallMenu-animationContainer d-flex position-absolute o-xsmaller bg-inherit o-p-0_5 rounded-circle m-n2 z-2">
+                        <i class="fa fa-volume-up o-discuss-inCallIconColor bg-inherit rounded-circle o-discuss-CallMenu-animation" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>
                     </small>
                     <div class="o-discuss-CallMenu-channelInfo text-truncate btn btn-group-item border-0 m-0 p-0 d-flex align-items-center gap-1 o-ps-1_5 pe-1 rounded-2 rounded-end-0 align-self-stretch bg-inherit opacity-75 opacity-100-hover" role="button" title="Open Conversation">
                         <span class="position-relative small bg-inherit">
@@ -16,9 +16,12 @@
                     </div>
                     <span class="o-rounded-bubble h-100 py-2 border-end border-dark border-opacity-25"/>
                     <Dropdown state="dropdownState">
-                        <button class="o-discuss-CallMenu-dropdownMore btn btn-group-item border-0 m-0 pe-1 o-ps-0_5 rounded-2 rounded-start-0 opacity-100-hover text-body" t-att-class="{ 'opacity-75 bg-transparent': !dropdownState.isOpen, 'opacity-100': dropdownState.isOpen }" title="Select Actions">
-                            <i class="fa fa-fw o-fs-small" t-att-class="icon"/>
-                            <i class="oi oi-chevron-down o-xxsmaller opacity-75"/>
+                        <button class="o-discuss-CallMenu-dropdownMore btn btn-group-item border-0 m-0 pe-1 o-ps-0_5 rounded-2 rounded-start-0 opacity-100-hover text-body" t-att-class="{ 'opacity-75 bg-transparent': !dropdownState.isOpen and !lastSelfAction?.tags.includes('WARNING_BADGE'), 'opacity-100': dropdownState.isOpen or lastSelfAction?.tags.includes('WARNING_BADGE') }" title="Select Actions">
+                            <i class="fa fa-fw o-fs-small" t-attf-class="{{ icon }}" t-att-class="lastSelfActionAttClass"/>
+                            <i class="oi oi-chevron-down o-xxsmaller opacity-75" t-att-class="{ 'mt-2': lastSelfAction?.tags.includes('WARNING_BADGE') }"/>
+                            <span t-if="lastSelfAction?.tags.includes('WARNING_BADGE')" class="o-discuss-CallMenu-warningBadge fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center o-discuss-warningBadge position-absolute bg-warning" style="aspect-ratio: 1; font-size: 0.6rem;">
+                                <i t-if="lastSelfAction?.badgeIcon" t-att-class="lastSelfAction.badgeIcon"/><span t-elif="lastSelfAction.badgeText" t-esc="lastSelfAction.badgeText"/>
+                            </span>
                         </button>
                         <t t-set-slot="content">
                             <ActionList actions="callActions.actions" dropdown="true"/>

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -438,7 +438,10 @@ export class Rtc extends Record {
                         this.actionsStack.unshift(action.id);
                     }
                 } else {
-                    this.actionsStack.splice(this.actionsStack.indexOf(action.id), 1);
+                    const index = this.actionsStack.indexOf(action.id);
+                    if (index !== -1) {
+                        this.actionsStack.splice(index, 1);
+                    }
                 }
             }
             this.lastSelfCallAction = this.actionsStack[0];

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -42,7 +42,7 @@
                     </div>
                 </div>
             </div>
-            <div t-if="indicators.length" class="position-absolute rounded-circle p-0 smaller o-mail-DiscussSidebarChannel-indicatorCompact lh-1 bg-inherit" name="indicator-compact">
+            <div t-if="indicators.length" class="position-absolute rounded-circle p-0 o-xsmaller o-mail-DiscussSidebarChannel-indicatorCompact lh-1 bg-inherit" name="indicator-compact">
                 <t t-component="indicators[0]" t-props="{ channel }"/>
             </div>
             <t t-if="channel.self_member_id?.message_unread_counter > 0 and !channel.self_member_id?.mute_until_dt and channel.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>

--- a/addons/web/static/src/scss/animation.scss
+++ b/addons/web/static/src/scss/animation.scss
@@ -34,7 +34,7 @@
     }
 
     25%, 75% {
-        opacity: 0;
+        opacity: var(--flash-low-opacity, 0);
     }
 }
 


### PR DESCRIPTION
Call menu now shows a warning badge when mic permission have not been granted like in call action list. The warning is also shown in the call action dropdown list, inciting click to open the permission dialog.

This commit also makes other minor improvements to systray call menu:
- tracked action use active color of action. For example, muted mic uses red colored icon.
- Success actions now has correct style in dropdown mode (was missing, only danger had correct style)
- flash effect of the volume-up icon has been reduced.
- improve readability of the warning badge in all call actions in dark theme.
- Fix a race-condition bug where initial discuss call could show incorrect active tracked call action.
- Systray call menu has been moved to left-most systray item.

Task-5382871