### PR TITLE
[FIX] account: invalid field in accounting setup wizard

### DIFF
--- a/addons/account/models/onboarding_onboarding_step.py
+++ b/addons/account/models/onboarding_onboarding_step.py
@@ -60,7 +60,6 @@ class OnboardingOnboardingStep(models.Model):
     @api.model
     def action_open_step_fiscal_year(self):
         company = self.env['account.journal'].browse(self.env.context.get('journal_id', None)).company_id or self.env.company
-        new_wizard = self.env['account.financial.year.op'].create({'company_id': company.id})
         view_id = self.env.ref('account.setup_financial_year_opening_form').id
 
         return {
@@ -69,10 +68,10 @@ class OnboardingOnboardingStep(models.Model):
             'view_mode': 'form',
             'res_model': 'account.financial.year.op',
             'target': 'new',
-            'res_id': new_wizard.id,
             'views': [[view_id, 'form']],
             'context': {
                 'dialog_size': 'medium',
+                'default_company_id': company.id,
             }
         }
 

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -12,6 +12,7 @@
                     </div>
                     <sheet>
                         <group>
+                            <field name="company_id" invisible="1"/>  <!-- Otherwise not present in the vals in the create -->
                             <field name="opening_move_posted" invisible="1"/>
                             <field name="opening_date" readonly="opening_move_posted"/>
 


### PR DESCRIPTION
When creating the setup wizard, if created beforehand and shown to the user it will try to save when the wizard is opened. Since the opening date has no value and is a required field, it will fail and display the field red.

To fix this, we are creating the wizard by passing a default company_id which mean the wizard hasn't been created yet and so it's not trying to save when opening the wizard.

odoo/odoo#231956
odoo/enterprise#95760

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
