### PR TITLE
[FIX] website_sale_collect: fix cash on delivery for in store delivery type

### DIFF
--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -41,11 +41,13 @@ class DeliveryCarrier(models.Model):
         for vals in vals_list:
             if vals.get('delivery_type') == 'in_store':
                 vals['integration_level'] = 'rate'
+                vals['allow_cash_on_delivery'] = False
         return super().create(vals_list)
 
     def write(self, vals):
         if vals.get('delivery_type') == 'in_store':
             vals['integration_level'] = 'rate'
+            vals['allow_cash_on_delivery'] = False
         return super().write(vals)
 
     # === BUSINESS METHODS ===#

--- a/addons/website_sale_collect/tests/test_click_and_collect_flow.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_flow.py
@@ -39,3 +39,18 @@ class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
         self.env['delivery.carrier'].search([]).active = False
         self.in_store_dm.active = True
         self.start_tour('/', 'website_sale_collect_buy_product_default_location_pick_up_in_store')
+
+    def test_cash_on_delivery_resets_on_in_store_type(self):
+        """
+        Ensure that when a carrier with cash-on-delivery enabled is switched
+        to the 'in_store' delivery type, the 'allow_cash_on_delivery' field
+        is automatically reset to False.
+        """
+        carrier = self.env['delivery.carrier'].create({
+            'name': 'Test Carrier',
+            'allow_cash_on_delivery': True,
+            'delivery_type': 'fixed',
+            'product_id': self.storable_product.id,
+        })
+        carrier.delivery_type = 'in_store'
+        self.assertEqual(carrier.allow_cash_on_delivery, False)


### PR DESCRIPTION
### Issue:
In this issue, `allow_cash_on_delivery` is allowed when delivery type is pick up in store.

#### Steps to reproduce:
1. Create a `fixed_price` delivery method
2. Check `Cash on delivery` checkbox
3. Change the delivery type to `in_store` and configure it
4. Activate cash on delivery payment method
5. Choose a storable ptoduct on the /shop, checkout with a created dm and proceed to payment
6. Observe that you see the 'cash on delivery' pm for pickup in store.

Currently, `allow_cash_on_delivery` is invisible when `delivery_type` is set to `in_store`. However, it's not set to `False`, once the type is changed to `in_store`.

opw-5258535
