### PR TITLE
[FIX] hr: search on user's employee

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -7,6 +7,7 @@ from markupsafe import Markup
 
 from odoo import api, models, fields, _, SUPERUSER_ID
 from odoo.exceptions import AccessError
+from odoo.fields import Domain
 from odoo.tools.misc import clean_context
 from odoo.addons.mail.tools.discuss import Store
 
@@ -58,7 +59,7 @@ class ResUsers(models.Model):
         # So try to enforce the security rules on the field to make sure we do not load employees outside of active companies
         return [('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
 
-    # note: a user can only be linked to one employee per company (see sql constraint in ´hr.employee´)
+    # note: a user can only be linked to one employee per company (see sql constraint in `hr.employee`)
     employee_ids = fields.One2many('hr.employee', 'user_id', string='Related employee', domain=_employee_ids_domain)
     employee_id = fields.Many2one('hr.employee', string="Company employee",
         compute='_compute_company_employee', search='_search_company_employee', store=False)
@@ -277,10 +278,10 @@ class ResUsers(models.Model):
         # If we're going to inject too many `ids`, we fall back on the default behavior
         # to avoid a performance regression.
         IN_MAX = 10_000
-        domain = [('employee_ids', operator, value)]
+        domain = Domain('employee_ids', operator, value)
         user_ids = self.env['res.users'].with_context(active_test=False)._search(domain, limit=IN_MAX).get_result_ids()
         if len(user_ids) < IN_MAX:
-            return [('id', 'in', user_ids)]
+            return Domain('id', 'in', user_ids)
 
         return domain
 

--- a/addons/hr/tests/test_hr_employee_public.py
+++ b/addons/hr/tests/test_hr_employee_public.py
@@ -21,3 +21,7 @@ class TestHrEmployee(TestHrCommon):
     def test_access_related_field_to_hr_employee(self):
         # Check if a related field related to hr_employee is accessible.
         self.env['hr.employee.public'].with_user(self.res_users_without_hr_right).search([("email", "!=", False)])
+
+    def test_access_search_on_users_department(self):
+        User = self.env['res.users'].with_user(self.res_users_without_hr_right)
+        User.search([('employee_id.department_id', '=', 1)])


### PR DESCRIPTION
Searching tasks with domain `user_ids.employee_id.department_id` is failing because of access rights to the `hr.employee` model. There are multiple issues:

First a hack is present to cast a Domain to a list. This was required because the same domain object was used for both `hr.employee` and `hr.employee.public` and was not supported in early versions of the Domain object. This is no longer needed, so we can remove it.

Then the search fails on searching `res.users.employee_ids`. On user model, `employee_id` is translated into a `employee_ids`. Then `department_id` is an inherited field, so it gets transformed into a search on `current_version_id`. However since the user does not have access to `hr.employee`, we run that search on the public model which does not have a `current_version_id` field! We remap that condition to a condition on 'id' which will be simplified.

task-5259549



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
