### PR TITLE
[FIX] l10n_din5008_sale: prevent address duplication in Sale Order

### DIFF
--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -65,7 +65,7 @@
                             </div>
                         </td>
                     </t>
-                    <t t-else="">
+                    <t t-elif="commercial_partner != invoice_partner or commercial_partner != delivery_partner">
                         <t t-if="doc.partner_invoice_id == doc.partner_shipping_id">
                             <td class="shipping_address">
                                 <span class="fw-bold">Invoicing and Shipping Address:</span>


### PR DESCRIPTION
## Issue:
When DIN5008 is selected as the document layout, printing a Sale Order may show the customer address twice

## Cause:
The address is first added by `external_layout_din5008`, then again by `report_saleorder_document`
This duplication only makes sense when the partner address differs from the invoice or delivery address
If the Customer Addresses setting is disabled, displaying it multiple times is unnecessary

## Steps to reproduce:
- Install a company using DIN 5008 (e.g., l10n_de)
- Select the DE company and go to Settings
- Disable `Customer addresses` and ensure the document layout is set to DIN 5008
- Create a Quotation with any customer and product
- Print the PDF → the address appears twice before the fix

opw-5176593