### PR TITLE
[FIX] web: wait for error dialog in tests

### DIFF
--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { unload } from "@odoo/hoot-dom";
+import { unload, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, Deferred, mockSendBeacon } from "@odoo/hoot-mock";
 import {
     contains,
@@ -113,16 +113,14 @@ test("hiding tab multiple times (server error)", async () => {
 
     // simulate a tab switch
     await hideTab();
-    await animationFrame();
-    expect(".o_dialog").toHaveCount(1);
+    await waitFor(".o_dialog");
     expect(".o_dialog .modal-body").toHaveText("Cannot save");
     expect.verifySteps(["save"]);
     expect.verifyErrors(["Cannot save"]);
 
     // simulate another tab switch => should not try to save again
     await hideTab();
-    await animationFrame();
-    expect(".o_dialog").toHaveCount(1);
+    await waitFor(".o_dialog");
     expect.verifySteps([]);
     expect.verifyErrors([]);
 });
@@ -144,8 +142,7 @@ test("hiding tab multiple times (server error) + make another change", async () 
 
     // simulate a tab switch
     await hideTab();
-    await animationFrame();
-    expect(".o_dialog").toHaveCount(1);
+    await waitFor(".o_dialog");
     expect(".o_dialog .modal-body").toHaveText("Cannot save");
     expect.verifySteps(["save"]);
     expect.verifyErrors(["Cannot save"]);
@@ -161,8 +158,7 @@ test("hiding tab multiple times (server error) + make another change", async () 
     // make change and simulate another tab switch
     await contains(".o_field_widget[name=name] input").edit("Mathiew Brown 2");
     await hideTab();
-    await animationFrame();
-    expect(".o_dialog").toHaveCount(1);
+    await waitFor(".o_dialog");
     expect(".o_dialog .modal-body").toHaveText("Cannot save");
     expect.verifySteps(["save"]);
     expect.verifyErrors(["Cannot save"]);


### PR DESCRIPTION
This commit is a followup of [1] which introduced a few tests, but two of them were failing randomly because we didn't correctly wait for error dialogs to be spawned. The `unhandledrejection` event being thrown asynchronously, simply waiting for an animation frame isn't enough. We can only wait for the dialog to be displayed.

[1] https://github.com/odoo/odoo/pull/232523

runbot error~234010

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
