### PR TITLE
[FIX] mail: url paste issue in composer

### DIFF
--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -14,6 +14,7 @@ export class MailComposerPlugin extends Plugin {
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
         bypass_paste_image_files: () => true,
+        create_link_handlers: (linkEl) => (linkEl.target = "_blank"),
         hints: [
             withSequence(1, {
                 selector: `.odoo-editor-editable > ${baseContainerGlobalSelector}:only-child`,

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -4,6 +4,7 @@ import { CORE_PLUGINS } from "@html_editor/plugin_sets";
 import { FeffPlugin } from "@html_editor/main/feff_plugin";
 import { HintPlugin } from "@html_editor/main/hint_plugin";
 import { InlineCodePlugin } from "@html_editor/main/inline_code";
+import { LinkPastePlugin } from "@html_editor/main/link/link_paste_plugin";
 import { LinkPlugin } from "@html_editor/main/link/link_plugin";
 import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
@@ -19,6 +20,7 @@ export const MAIL_CORE_PLUGINS = [
     FeffPlugin,
     HintPlugin,
     InlineCodePlugin,
+    LinkPastePlugin,
     LinkPlugin,
     MailComposerPlugin,
     MentionPlugin,

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1,5 +1,6 @@
 import {
     insertText as htmlInsertText,
+    pasteText,
     tripleClick,
 } from "@html_editor/../tests/_helpers/user_actions";
 
@@ -1661,5 +1662,9 @@ test("parse link correctly in html composer", async () => {
     await contains(editor.editable, { text: "www.google.com", count: 1 });
     await contains(editor.editable.querySelector("a"), { text: "www.google.com", count: 0 });
     await htmlInsertText(editor, " ");
-    await contains(editor.editable.querySelector("a"), { text: "www.google.com" });
+    await contains(editor.editable.querySelector("a[target='_blank']"), { text: "www.google.com" });
+    await press("Enter");
+    await contains(editor.editable, { text: "www.google.com", count: 0 });
+    await pasteText(editor, "www.baidu.com");
+    await contains(editor.editable.querySelector("a[target='_blank']"), { text: "www.baidu.com" });
 });


### PR DESCRIPTION
When pasting a URL in the html composer, the link was not being correctly parsed and converted into a clickable hyperlink.
This commit fixes the issue by ensuring that the LinkPastePlugin is included in the composer plugin set, allowing for proper link detection and conversion.

Also, this commit forced links to open in a new tab when being parsed with LinkPlugin.

task-5259858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
