### PR TITLE
[IMP] xml_import: auto-resolve unique field conflicts during module installation

### DIFF
--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -177,6 +177,9 @@
                 </rng:optional>
             </rng:optional>
             <rng:attribute name="model" />
+            <rng:optional>
+                <rng:attribute name="skip_unique_constraint" />
+            </rng:optional>
             <rng:ref name="env"/>
             <rng:zeroOrMore>
                 <rng:ref name="field" />


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- When installing an industry or demo module, XML data import may fail due to unique constraint violations (e.g., duplicate name fields).
- For example, if an existing record named “Design” already exists and the new XML tries to create another “Design”, installation fails with a IntegrityError.

**Current behavior before PR:**
- XML imports stop with a database integrity error when unique field values (like name or code) already exist.
-  Example: importing Design tag from module fails if “Design” already exists in the database.

**Desired behavior after PR is merged:**
- Introduces support for a new optional attribute skip_unique_constraint on <record> tags.
- When defined, the importer automatically detects unique constraint conflicts on the given field and renames the value by                                                                         appending a numeric suffix until it becomes unique.
- If “Design” already exists, it becomes:
      - “Design (1)”
      - “Design (2)” if needed, and so on.

Tast ID :  [4876395 ](https://www.odoo.com/odoo/project/9285/tasks/4876395)