### PR TITLE
[IMP] web, tools: enable {standard,or}-narrow style for format_list

### DIFF
--- a/addons/web/static/src/core/l10n/utils/format_list.js
+++ b/addons/web/static/src/core/l10n/utils/format_list.js
@@ -1,7 +1,7 @@
 import { user } from "@web/core/user";
 
 /**
- * Convert Unicode TR35-49 list pattern types to ES Intl.ListFormat options
+ * Maps Unicode UTS-35 list pattern types to Intl.ListFormat options
  */
 const LIST_STYLES = {
     standard: {
@@ -12,6 +12,10 @@ const LIST_STYLES = {
         type: "conjunction",
         style: "short",
     },
+    "standard-narrow": {
+        type: "conjunction",
+        style: "narrow",
+    },
     or: {
         type: "disjunction",
         style: "long",
@@ -19,6 +23,10 @@ const LIST_STYLES = {
     "or-short": {
         type: "disjunction",
         style: "short",
+    },
+    "or-narrow": {
+        type: "disjunction",
+        style: "narrow",
     },
     unit: {
         type: "unit",
@@ -37,18 +45,24 @@ const LIST_STYLES = {
 /**
  * Format the items in `list` as a list in a locale-dependent manner with the chosen style.
  *
- * The available styles are defined in the Unicode TR35-49 spec:
+ * The available styles are defined in the Unicode Technical Standard 35:
  * * standard:
  *   A typical "and" list for arbitrary placeholders.
  *   e.g. "January, February, and March"
  * * standard-short:
  *   A short version of an "and" list, suitable for use with short or abbreviated placeholder values.
  *   e.g. "Jan., Feb., and Mar."
+ * * standard-narrow:
+ *   A yet shorter version of a short 'and' list (where possible)
+ *   e.g. "Jan., Feb., Mar."
  * * or:
  *   A typical "or" list for arbitrary placeholders.
  *   e.g. "January, February, or March"
  * * or-short:
  *   A short version of an "or" list.
+ *   e.g. "Jan., Feb., or Mar."
+ *   or-narrow:
+ *   A yet shorter version of a short 'or' list (where possible)
  *   e.g. "Jan., Feb., or Mar."
  * * unit:
  *   A list suitable for wide units.
@@ -60,12 +74,12 @@ const LIST_STYLES = {
  *   A list suitable for narrow units, where space on the screen is very limited.
  *   e.g. "3′ 7″"
  *
- * See https://www.unicode.org/reports/tr35/tr35-49/tr35-general.html#ListPatterns for more details.
+ * See https://www.unicode.org/reports/tr35/tr35-general.html#ListPatterns for more details.
  *
  * @param {string[]} list The array of values to format into a list.
  * @param {Object} [param0]
  * @param {string} [param0.localeCode] The locale to use (e.g. en-US).
- * @param {"standard"|"standard-short"|"or"|"or-short"|"unit"|"unit-short"|"unit-narrow"} [param0.style="standard"] The style to format the list with.
+ * @param {"standard"|"standard-short"|"standard-narrow"|"or"|"or-short"|"or-narrow"|"unit"|"unit-short"|"unit-narrow"} [param0.style="standard"] The style to format the list with.
  * @returns {string} The formatted list.
  */
 export function formatList(list, { localeCode = "", style = "standard" } = {}) {

--- a/addons/web/static/tests/l10n/utils.test.js
+++ b/addons/web/static/tests/l10n/utils.test.js
@@ -30,6 +30,11 @@ describe("formatList", () => {
         expect(formatList(list, { style: "or" })).toBe("A, B, or C");
     });
 
+    test("supports “narrow” style with “standard” type", () => {
+        const list = ["Veni", "vidi", "vici"];
+        expect(formatList(list, { style: "standard-narrow" })).toBe("Veni, vidi, vici");
+    });
+
     test("uses the specified locale", () => {
         const list = ["A", "B", "C"];
         expect(formatList(list, { localeCode: "fr-FR" })).toBe("A, B et C");

--- a/odoo/addons/base/tests/test_i18n.py
+++ b/odoo/addons/base/tests/test_i18n.py
@@ -1,8 +1,7 @@
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import TransactionCase
 from odoo.tools import format_list, py_to_js_locale
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class I18nTest(TransactionCase):
     def test_format_list(self):
         lang = self.env["res.lang"]
@@ -12,6 +11,9 @@ class I18nTest(TransactionCase):
 
         formatted_text = format_list(self.env, ["To be", "Not to be"], "or")
         self.assertEqual(formatted_text, "To be or Not to be", "Should take the style into account.")
+
+        formatted_text = format_list(self.env, ["Veni", "vidi", "vici"], "standard-narrow")
+        self.assertEqual(formatted_text, "Veni, vidi, vici", "Should support “narrow” style with “standard” type.")
 
         lang._activate_lang("fr_FR")
 

--- a/odoo/tools/i18n.py
+++ b/odoo/tools/i18n.py
@@ -25,24 +25,30 @@ XPG_LOCALE_RE = re.compile(
 def format_list(
     env: odoo.api.Environment,
     lst: Iterable,
-    style: Literal["standard", "standard-short", "or", "or-short", "unit", "unit-short", "unit-narrow"] = "standard",
+    style: Literal["standard", "standard-short", "standard-narrow", "or", "or-short", "or-narrow", "unit", "unit-short", "unit-narrow"] = "standard",
     lang_code: str | None = None,
 ) -> str:
     """
     Format the items in `lst` as a list in a locale-dependent manner with the chosen style.
 
-    The available styles are defined by babel according to the Unicode TR35-49 spec:
+    The available styles are defined by babel according to the Unicode Technical Standard #35:
     * standard:
       A typical 'and' list for arbitrary placeholders.
       e.g. "January, February, and March"
     * standard-short:
       A short version of an 'and' list, suitable for use with short or abbreviated placeholder values.
       e.g. "Jan., Feb., and Mar."
+    * standard-narrow:
+      A yet shorter version of a short 'and' list (where possible).
+      e.g. "Jan., Feb., Mar."
     * or:
       A typical 'or' list for arbitrary placeholders.
       e.g. "January, February, or March"
     * or-short:
       A short version of an 'or' list.
+      e.g. "Jan., Feb., or Mar."
+    * or-narrow:
+      A yet shorter version of a short 'or' list (where possible).
       e.g. "Jan., Feb., or Mar."
     * unit:
       A list suitable for wide units.
@@ -54,7 +60,7 @@ def format_list(
       A list suitable for narrow units, where space on the screen is very limited.
       e.g. "3′ 7″"
 
-    See https://www.unicode.org/reports/tr35/tr35-49/tr35-general.html#ListPatterns for more details.
+    See https://www.unicode.org/reports/tr35/tr35-general.html#ListPatterns for more details.
 
     :param env: the current environment.
     :param lst: the iterable of items to format into a list.


### PR DESCRIPTION
Add the missing standard-narrow and or-narrow styles to the list of format_list accepted options.