### PR TITLE
[FIX] l10n_in_ewaybill_stock: make description readonly

### DIFF
--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -133,7 +133,7 @@
                                     <field name="company_currency_id" column_invisible="1"/>
                                     <field name="company_id" column_invisible="1"/>
                                     <field name="product_id" readonly="1"/>
-                                    <field name="description_picking" string="Description" help="Max 100-character description is allowed"/>
+                                    <field name="description_picking" string="Description" help="Max 100-character description is allowed" readonly="1"/>
                                     <field name="quantity" string="Quantity" readonly="1"/>
                                     <field name="ewaybill_price_unit" string="Unit Price"/>
                                     <field name="ewaybill_tax_ids" widget="many2many_tags"/>


### PR DESCRIPTION
This **PR** makes the description on ewaybill stock readonly.

ref - https://github.com/odoo/odoo/pull/228548/commits/285fffe6b0c90b9e37815cb4064b0108a5e8e6ac
