### PR TITLE
[PERF] im_livechat: lazy subscription to looking for help

### DIFF
--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -38,6 +38,15 @@ export class BusBus extends models.Model {
                 if (typeof target === "string") {
                     return channel === target;
                 }
+                if (Array.isArray(target) && Array.isArray(channel)) {
+                    const [target0, target1] = target;
+                    const [channel0, channel1] = channel;
+                    return (
+                        channel0?._name === target0?.model &&
+                        channel0?.id === target0?.id &&
+                        channel1 === target1
+                    );
+                }
                 return channel?._name === target?.model && channel?.id === target?.id;
             })
         );

--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -20,6 +20,5 @@ declare module "models" {
         livechat_status: "in_progress"|"waiting"|"need_help"|undefined;
         matchesSelfExpertise: Readonly<boolean>;
         shadowedBySelf: number;
-        wasLookingForHelp: boolean;
     }
 }

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -9,7 +9,6 @@ declare module "models" {
         goToOldestUnreadLivechatThread: () => boolean;
         has_access_livechat: boolean;
         livechatChannels: ReturnType<Store['makeCachedFetchData']>;
-        livechatLookingForHelp: ReturnType<Store['makeCachedFetchData']>;
         livechatStatusButtons: Readonly<object[]>;
     }
     export interface Thread {

--- a/addons/im_livechat/static/src/core/web/discuss_client_action_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_client_action_patch.js
@@ -7,9 +7,6 @@ patch(DiscussClientAction.prototype, {
         if (this.store.has_access_livechat) {
             this.store.livechatChannels.fetch();
         }
-        if (this.has_access_livechat && !this.discuss.livechatLookingForHelpCategory.hidden) {
-            this.livechatLookingForHelp.fetch();
-        }
         return super.restoreDiscussThread(...arguments);
     },
 });

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -9,7 +9,6 @@ const storePatch = {
     setup() {
         super.setup(...arguments);
         this.livechatChannels = this.makeCachedFetchData("im_livechat.channel");
-        this.livechatLookingForHelp = this.makeCachedFetchData("/im_livechat/looking_for_help");
         this.has_access_livechat = false;
     },
     /**
@@ -19,9 +18,6 @@ const storePatch = {
         super.onStarted(...arguments);
         if (this.discuss.isActive && this.has_access_livechat) {
             this.livechatChannels.fetch();
-        }
-        if (this.has_access_livechat && !this.discuss.livechatLookingForHelpCategory.hidden) {
-            this.livechatLookingForHelp.fetch();
         }
     },
     /** @returns {boolean} Whether the livechat thread changed. */

--- a/addons/im_livechat/static/tests/livechat_test_helpers.js
+++ b/addons/im_livechat/static/tests/livechat_test_helpers.js
@@ -1,3 +1,5 @@
+import { IrWebSocket } from "@im_livechat/../tests/mock_server/mock_models/ir_websocket";
+
 import { mailModels, startServer } from "@mail/../tests/mail_test_helpers";
 import { RatingRating } from "@rating/../tests/mock_server/models/rating_rating";
 import {
@@ -28,6 +30,7 @@ export const livechatModels = {
     LivechatChannel,
     LivechatChannelRule,
     Im_LivechatExpertise,
+    IrWebSocket,
     RatingRating,
     ResPartner,
     ResUsers,

--- a/addons/im_livechat/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/ir_websocket.js
@@ -1,0 +1,23 @@
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+
+import { serverState } from "@web/../tests/web_test_helpers";
+
+export class IrWebSocket extends mailModels.IrWebSocket {
+    /**
+     * @override
+     * @type {typeof busModels.IrWebSocket["prototype"]["_build_bus_channel_list"]}
+     */
+    _build_bus_channel_list(channels) {
+        channels = [...super._build_bus_channel_list(channels)];
+        const result = channels;
+        for (const channel of channels) {
+            if (channel === "im_livechat.looking_for_help") {
+                result.push([
+                    this.env["res.groups"].browse(serverState.groupLivechatId)[0],
+                    "LOOKING_FOR_HELP",
+                ]);
+            }
+        }
+        return result.filter((channel) => channel !== "im_livechat.looking_for_help");
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -21,6 +21,7 @@ declare module "models" {
     }
     export interface Thread {
         _computeDiscussAppCategory: () => undefined|unknown;
+        _computeDisplayInSidebar: () => boolean;
         appAsUnreadChannels: DiscussApp;
         categoryAsThreadWithCounter: DiscussAppCategory;
         createSubChannel: (param0: { initialMessage: Message, name: string }) => Promise<void>;

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -37,11 +37,7 @@ const threadPatch = {
         });
         this.displayInSidebar = fields.Attr(false, {
             compute() {
-                return (
-                    this.displayToSelf ||
-                    this.isLocallyPinned ||
-                    this.sub_channel_ids.some((t) => t.displayInSidebar)
-                );
+                return this._computeDisplayInSidebar();
             },
         });
         this.loadSubChannelsDone = false;
@@ -50,6 +46,13 @@ const threadPatch = {
     },
     get canLeave() {
         return !this.parent_channel_id && super.canLeave;
+    },
+    _computeDisplayInSidebar() {
+        return (
+            this.displayToSelf ||
+            this.isLocallyPinned ||
+            this.sub_channel_ids.some((t) => t.displayInSidebar)
+        );
     },
     _computeDiscussAppCategory() {
         if (this.parent_channel_id) {


### PR DESCRIPTION
Before this commit, every live chat user would receive looking for help update. This commit reduces the dispatching of message by targeting users interessted in the looking for help update.

The looking for help category is folded by default, in which case the user doesn't receive anything related to live chats looking for help.

Once the user accesses discuss, and once the category is opened, updates will be received.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
