### PR TITLE
[FIX] Board: display calendar in My Dashboard

### DIFF
--- a/addons/board/static/src/board_controller.scss
+++ b/addons/board/static/src/board_controller.scss
@@ -31,15 +31,20 @@
 
     > .o_view_controller {
         padding: 0 6px 6px 6px;
-        .o_graph_renderer canvas {
-            height: 300px;
-        }
         .o_content {
             max-height: 80vh;
             overflow: auto;
             > .o_renderer {
                 min-width: 1200px;
             }
+        }
+        // graph view
+        .o_graph_renderer canvas {
+            height: 300px;
+        }
+        // calendar view
+        .o_calendar_wrapper {
+            height: 400px;
         }
     }
 


### PR DESCRIPTION
---
## Short functional explanation of the error
When adding a calendar to a personal dashboard, only the header shows. The calendar itself doesn't show.

## Reproduction Steps
1. Go to calendar and click on the cog next to it.
2. Click on Dashboard > add.
3. Go to the Dashboard app > My Dashboard.

### Expected behavior
The calendar should show under the header.

### Unexpected behavior
Only the header shows.

## Origin of the issue
The calendar wrapper in the CSS style wasn't specified.

---
opw-5242329


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
