### PR TITLE
[FIX] pos_restaurant: table number not appearing on self-order receipts

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/receipt_header_patch.js
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_header_patch.js
@@ -6,14 +6,15 @@ import { patch } from "@web/core/utils/patch";
 patch(ReceiptHeader.prototype, {
     /** @returns {string} */
     get tableName() {
-        if (this.order.table_id && this.order.customer_count) {
+        const table = this.order.table_id || this.order.self_ordering_table_id;
+        if (table && this.order.customer_count) {
             return _t("Table %(number)s, Guests: %(count)s", {
-                number: this.order.table_id.table_number,
+                number: table.table_number,
                 count: this.order.customer_count,
             });
         }
-        if (this.order.table_id) {
-            return _t("Table %(number)s", { number: this.order.table_id.table_number });
+        if (table) {
+            return _t("Table %(number)s", { number: table.table_number });
         }
         return "";
     },

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -36,7 +36,7 @@
     </t>
     <t t-name="pos_restaurant.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('cashier')]" position="after">
-            <t t-if="order.table_id" t-esc="tableName"/>
+            <t t-if="order.table_id or order.self_ordering_table_id" t-esc="tableName"/>
         </xpath>
     </t>
 


### PR DESCRIPTION
**Steps to reproduce:**
* Set up a `POS` with the restaurant module.
* Go to `Configuration → Settings → Self Ordering` and set `QR Menu + Ordering`.
* Set `Service At` to `Table` and `Pay After` to `Meal`.
* Download QR codes from the `Get QR Codes` button in the POS restaurant
  interface.
* Create a self-order by scanning the QR code.
* Print the receipt.

**Observed behavior:**
When a self-order is created, the table number does not appear on the receipt, while orders created from the POS interface correctly display the table number.

**Cause:**
The receipt template only checks `table_id` to display the table number, but self-orders only have `self_ordering_table_id` set.

**Fix:**
Update the receipt header template and logic to also use `self_ordering_table_id` as a fallback when `table_id` is not set, ensuring the table number is correctly displayed on self-order receipts.

opw-5250724
