### PR TITLE
[FIX] web: wait for error dialog in test

### DIFF
--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -6318,7 +6318,7 @@ test(`onchange returns an error`, async () => {
 
     await contains(`.o_field_widget[name=int_field] input`).edit("64");
     expect.verifyErrors(["Some business message"]);
-    expect(`.modal`).toHaveCount(1);
+    await waitFor(`.modal`);
     expect(`.modal-body`).toHaveText(/Some business message/);
     expect(`.o_field_widget[name="int_field"] input`).toHaveValue("9");
 


### PR DESCRIPTION
Before this commit, the test sometimes failed because we didn't wait enough before checking the presence of the error dialog. The `unhandledrejection` event being thrown asynchronously, simply waiting for an animation frame isn't enough. We can only wait for the dialog to be displayed.

runbot error~234017

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
