### PR TITLE
[FIX] mail: use many2one field widget for rotting in list view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -791,7 +791,7 @@
                         options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
                     <field name="recurring_plan" optional="hide" groups="crm.group_use_recurring_revenues"/>
                     <field name="stage_id_color" column_invisible="1"/>
-                    <field name="stage_id" optional="show" widget="badge_rotting" options="{'color_field': 'stage_id_color'}"/>
+                    <field name="stage_id" optional="show" widget="badge_rotting" options="{'no_open': True}"/>
                     <field name="active" column_invisible="True"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="lost_reason_id" optional="hide"/>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -34,7 +34,7 @@
                 <field name="email_from" readonly="1" optional="hide"/>
                 <field name="partner_phone" widget="phone" readonly="1" optional="hide"/>
                 <field name="job_id" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
-                <field name="stage_id" widget="badge_rotting" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
+                <field name="stage_id" widget="badge_rotting" optional="show" column_invisible="context.get('default_talent_pool_ids')" options="{'no_open': True}"/>
                 <field name="priority" widget="priority" nolabel="1" optional="show"/>
                 <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="show"/>

--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
@@ -1,10 +1,7 @@
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import {
-    listBadgeSelectionField,
-    ListBadgeSelectionField,
-} from "@web/views/fields/badge_selection/list_badge_selection_field";
+import { buildM2OFieldDescription, Many2OneField } from "@web/views/fields/many2one/many2one_field";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 export function getRottingDaysTitle(modelName, rotDays) {
@@ -46,8 +43,9 @@ export class KanbanRottingField extends Component {
     }
 }
 
-export class ListBadgeSelectionRotting extends ListBadgeSelectionField {
-    static template = "mail.ListBadgeSelectionRotting";
+export class Many2OneFieldRotting extends Many2OneField {
+    static template = "mail.Many2OneFieldRotting";
+
     setup() {
         super.setup();
         // As this widget is appended to another field's value, we display no additional title to prevent title overlap
@@ -62,6 +60,5 @@ registry.category("fields").add("kanban.rotting", {
 });
 
 registry.category("fields").add("list.badge_rotting", {
-    ...listBadgeSelectionField,
-    component: ListBadgeSelectionRotting,
+    ...buildM2OFieldDescription(Many2OneFieldRotting),
 });

--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.xml
@@ -7,11 +7,13 @@
         </div>
     </t>
 
-    <t t-name="mail.ListBadgeSelectionRotting" t-inherit="web.ListBadgeSelectionField" t-inherit-mode="primary">
-        <t t-else="" position="after">
+    <t t-name="mail.Many2OneFieldRotting">
+        <div class="d-inline-flex">
+            <Many2One t-props="m2oProps"/>
             <span class="badge rounded-pill o_mail_resource_rotting_bg ms-2" t-if="props.record.data.is_rotting">
                 <t t-out="dayCount"/>
-        </span>
-        </t>
+            </span>
+
+        </div>
     </t>
 </templates>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -764,7 +764,7 @@
                     <field name="stage_id_color" column_invisible="1"/>
                     <field name="is_rotting" column_invisible="True"/>
                     <field name="rotting_days" column_invisible="True"/>
-                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="badge_rotting" options="{'color_field': 'stage_id_color'}"/>
+                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="badge_rotting" options="{'no_open': True}"/>
                 </list>
             </field>
         </record>


### PR DESCRIPTION
Before this commit, the rotting feature uses the selection_badge widget to be rendered in the list view. The problem is the selection_badge will do one rpc per project for the tasks displayed in the list view of all tasks to have all available stages when the user wants to update the stage.

This commit changes the widget used to use a custom many2one field widget for rotting in list view to make sure no extra rpc is made.
