### PR TITLE
[IMP] purchase_{stock}: improve UX of purchase order form view

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -146,7 +146,7 @@
                     <button name="button_cancel" invisible="state not in ('draft', 'to approve', 'sent', 'purchase') or locked" string="Cancel" type="object" data-hotkey="x"/>
                     <button name="button_lock" type="object" string="Lock" invisible="locked or state != 'purchase' or not lock_confirmed_po == 'lock'" data-hotkey="l"/>
                     <button name="button_unlock" type="object" string="Unlock" invisible="not locked" groups="purchase.group_purchase_manager" data-hotkey="l"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,sent,purchase" readonly="1"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,purchase" readonly="1"/>
                 </header>
                 <div class="alert alert-warning" role="alert" invisible="not purchase_warning_text">
                     <field name="purchase_warning_text" class="fw-bold"/>
@@ -219,7 +219,7 @@
                         <group>
                             <field name="date_order" invisible="state  == 'purchase'" readonly="state in ['cancel', 'purchase']"/>
                             <label for="date_planned"/>
-                            <div name="date_planned_div" class="o_row">
+                            <div name="date_planned_div">
                                 <field name="date_planned" readonly="state not in ('draft', 'sent', 'to approve', 'purchase')"/>
                             </div>
                             <label for="receipt_reminder_email" class="d-none" groups="purchase.group_send_reminder"/>
@@ -406,15 +406,14 @@
                                 <group name="purchase_info" string="purchase">
                                     <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
+                                    <field name="date_approve" invisible="state not in ('purchase', 'cancel')"/>
                                 </group>
                                 <group name="billing_info" string="billing">
-                                    <field name="date_approve"/>
                                     <field name="invoice_status" invisible="state in ('draft', 'sent', 'to approve', 'cancel')"/>
                                     <field name="fiscal_position_id" options="{'no_create': True}" readonly="invoice_status == 'invoiced' or locked"/>
                                 </group>
                                 <group name="tracking_info" string="tracking">
                                     <field name="origin"/>
-                                    <field name="receipt_status" invisible="state != 'purchase'"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -127,6 +127,8 @@ class PurchaseOrder(models.Model):
                         to_log[order_line] = (order_line.product_qty, pre_order_line_qty[order_line])
                 if to_log:
                     order._log_decrease_ordered_quantity(to_log)
+        if 'priority' in vals:
+            self.picking_ids.filtered(lambda p: p.state not in ('done', 'cancel')).priority = vals['priority']
         return res
 
     # --------------------------------------------------
@@ -396,6 +398,7 @@ class PurchaseOrder(models.Model):
             'company_id': self.company_id.id,
             'state': 'draft',
             'reference_ids': [Command.set(self.reference_ids.ids)],
+            'priority': self.priority,
         }
 
     def _create_picking(self):

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -32,12 +32,9 @@
                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or not is_storable"/>
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
-                <div>
-                    <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state == 'purchase' or not partner_id">
-                        <span invisible="on_time_rate &lt; 0"><field name="on_time_rate" digits="[42, 0]" class="oe_inline"/>% On-Time Delivery</span>
-                        <span invisible="on_time_rate &gt;= 0">No data yet</span>
-                    </button>
-                </div>
+                <button name="%(action_purchase_vendor_delay_report)d" class="oe_link ps-0 pb-0 pt-sm-0" type="action" context="{'search_default_partner_id': partner_id}" invisible="not partner_id or on_time_rate &lt; 0">
+                    <span><field name="on_time_rate" digits="[42, 0]" class="oe_inline"/>% On Time</span>
+                </button>
             </xpath>
             <xpath expr="//field[@name='order_line']/list/field[@name='date_planned']" position="after">
                 <field name="date_promised" optional="hide" column_invisible="parent.state not in ('purchase', 'cancel')"/>
@@ -66,7 +63,7 @@
                 <field name="incoterm_id" readonly="locked"/>
                 <field name="incoterm_location"  readonly="locked"/>
             </xpath>
-            <xpath expr="//page[@name='purchase_delivery_invoice']/group/group[@name='billing_info']/field[@name='date_approve']" position="after">
+            <xpath expr="//group[@name='purchase_info']/field[@name='date_approve']" position="after">
                 <field name="date_promised" invisible="state not in ('purchase', 'cancel')"/>
             </xpath>
             <xpath expr="//div[@name='reminder']" position="after">


### PR DESCRIPTION
Purchase order form adjustments:
- Propagate purchase order priority to related incoming and dropship pickings.
- Do not propagate priority to unrelated transfers.

UX improvements:
- Rebalance the purchase order form layout.
- Move `date_approve` and `invoice_status` from Billing to Purchase.
- Remove `receipt_status` from Tracking (already visible in the form).
- Simplify and reposition the On-Time Delivery rate button.
- Hide the RFQ Sent stage when a PO is confirmed directly.

Task - 5164148