### PR TITLE
[FIX] web: correct list group name colspan calculation

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1128,9 +1128,6 @@ export class ListRenderer extends Component {
             colspan = firstAggregateIndex;
         } else {
             colspan = Math.max(1, this.columns.length - DEFAULT_GROUP_PAGER_COLSPAN);
-            if (this.displayOptionalFields) {
-                colspan++;
-            }
         }
         if (this.hasSelectors) {
             colspan++;

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1938,6 +1938,18 @@ test(`basic grouped list rendering with a date field between two fields with a a
     expect(queryAllTexts(`.o_group_header:eq(0) td`)).toEqual(["-4", "", "-4"]);
 });
 
+test(`basic grouped list rendering 1 col without selector and with optional field`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list><field name="foo"/><field name="bar" optional="hidden"/></list>`,
+        groupBy: ["bar"],
+        allowSelectors: false,
+    });
+    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
+});
+
 test(`basic grouped list rendering 1 col without selector`, async () => {
     await mountView({
         resModel: "foo",
@@ -1991,6 +2003,25 @@ test(`basic grouped list rendering 3 cols without selector`, async () => {
         resModel: "foo",
         type: "list",
         arch: `<list><field name="foo"/><field name="bar"/><field name="text"/></list>`,
+        groupBy: ["bar"],
+        allowSelectors: false,
+    });
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
+    expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
+});
+
+test(`basic grouped list rendering 3 cols without selector and with optional fields`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="bar"/>
+                <field name="text"/>
+                <field name="date" optional="hidden"/>
+            </list>
+        `,
         groupBy: ["bar"],
         allowSelectors: false,
     });


### PR DESCRIPTION
This commit removes the colspan incrementation for optional fields in the group name.

The incrementation was redundant, as the group configuration cog menu <th> is always present in the column for optional fields when the list is grouped. This ensures the colspan value now correctly reflects the actual number of visible columns.

task-5261958
