### PR TITLE
[FIX] mail: correctly restrict mentions in channel to its group

### DIFF
--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -101,7 +101,7 @@ class ResPartner(models.Model):
             *self.env["discuss.channel.member"]._to_store_persona([]),
         ]
         store = Store(members, member_fields).add(partners)
-        store.add(channel, "group_public_id")
+        store.add(channel, Store.One("group_public_id", []))
         if allowed_group:
             for p in partners:
                 store.add(p, {"group_ids": [("ADD", (allowed_group & p.user_ids.all_group_ids).ids)]})

--- a/addons/mail/static/tests/tours/discuss_mention_suggestions_group_restricted_channel.js
+++ b/addons/mail/static/tests/tours/discuss_mention_suggestions_group_restricted_channel.js
@@ -1,0 +1,17 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("discuss_mention_suggestions_group_restricted_channel.js", {
+    steps: () => [
+        { trigger: ".o-mail-Discuss-threadName[title='R&D Channel']" },
+        { trigger: ".o-mail-Composer-input", run: "edit @" },
+        { trigger: ".o-mail-Composer-suggestion:count(3)" },
+        {
+            content: "Suggest channel member not in R&D group",
+            trigger: ".o-mail-Composer-suggestion strong:text(Consultant User)",
+        },
+        {
+            content: "Suggest non-channel member in R&D group",
+            trigger: ".o-mail-Composer-suggestion strong:text(Dev User)",
+        },
+    ],
+});

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -9,6 +9,7 @@ from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest
 from . import test_discuss_channel_member
 from . import test_discuss_mail_presence
+from . import test_discuss_mention_suggestions
 from . import test_discuss_message_update_controller
 from . import test_discuss_reaction_controller
 from . import test_discuss_sub_channels

--- a/addons/mail/tests/discuss/test_discuss_mention_suggestions.py
+++ b/addons/mail/tests/discuss/test_discuss_mention_suggestions.py
@@ -1,0 +1,30 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests.common import HttpCase, new_test_user, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDiscussMentionSuggestions(HttpCase):
+    def test_mention_suggestions_group_restricted_channel(self):
+        user_admin = self.env.ref("base.user_admin")
+        user_group = self.env.ref("base.group_user")
+        rd_group = self.env["res.groups"].create({"name": "R&D Group"})
+        new_test_user(self.env, login="dev", name="Dev User", group_ids=[user_group.id, rd_group.id])
+        # have a user that is not channel member and not in group -> should not be suggested as mention
+        new_test_user(self.env, login="sales", name="Sales User", groups="base.group_user")
+        consultant_user = new_test_user(self.env, login="consultant", name="Consultant User", groups="base.group_user")
+        rd_channel = self.env['discuss.channel'].with_user(user_admin).create({
+            "name": "R&D Channel",
+            "channel_type": "channel",
+            "group_public_id": rd_group.id,
+            "channel_member_ids": [
+                Command.create({"partner_id": consultant_user.partner_id.id}),
+                Command.create({"partner_id": user_admin.partner_id.id}),
+            ],
+        })
+        self.start_tour(
+            f"/odoo/discuss?active_id=discuss.channel_{rd_channel.id}",
+            "discuss_mention_suggestions_group_restricted_channel.js",
+            login="admin",
+        )


### PR DESCRIPTION
Before this commit it would be possible to mention any partner in a discuss channel with an Authorized Group (group_public_id).

Steps to reproduce:
1. Log as Mitchell Admin
2. Open Administrator channel
3. Write "@" in composer to get mentions
4. Observe having non-administrator partners

This happens because we don't send the `group_public_id` record client side (`_field_store_repr` replaces it with the group name), and as such the suggestion service does not correctly filter for partners in the Authorized Group.

This commit fixes the issue by correctly sending the `group_public_id` field of the channel.

task-5258925