### PR TITLE
[FIX] event: set total price in event registration email

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -304,8 +304,8 @@
                         <br/>
                         The order for this ticket has reference <t t-out="object.sale_order_id.name"/>
                         and was placed on <t t-out="object.sale_order_id.date_order.date()"/>
-                        <t t-if="object.sale_order_line_id.price_unit"> for an amount of
-                            <t t-out="object.sale_order_line_id.price_unit" t-options="{'widget': 'monetary', 'display_currency': object.sale_order_line_id.currency_id}"/>
+                        <t t-if="object.sale_order_line_id.price_total"> for an amount of
+                            <t t-out="object.sale_order_line_id.price_total" t-options="{'widget': 'monetary', 'display_currency': object.sale_order_line_id.currency_id}"/>
                         </t>.
                     </div>
                     <div>


### PR DESCRIPTION
Steps to reproduce:

1. Create a new sale order with an event ticket line
2. Apply a 100% discount on the ticket line
3. Confirm the sale order
4. Check on the new attendee created, the mail sent to the attendee.

Current behavior:
The email shows the unit price without the discount applied which can be confusing for the customer as it might look like they need to pay that amount.

After this commit:
The email will just show the confirmation of the registration to the event withouth mentioning the price when the total price is 0.

opw-5122776


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
