### PR TITLE
[FIX] mail: show correct call status in discuss sidebar

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -10,6 +10,8 @@ import { attClassObjectToString } from "@mail/utils/common/format";
 import { CALL_PROMOTE_FULLSCREEN } from "./thread_model_patch";
 
 export const callActionsRegistry = registry.category("discuss.call/actions");
+export const CALL_ICON_DEAFEN = "fa fa-deaf";
+export const CALL_ICON_MUTED = "fa fa-microphone-slash";
 
 /** @typedef {import("@mail/core/common/action").ActionDefinition} ActionDefinition */
 
@@ -42,8 +44,8 @@ export const muteAction = {
     icon: ({ action, store }) =>
         action.isActive
             ? store.rtc.selfSession?.is_deaf
-                ? "fa fa-deaf"
-                : "fa fa-microphone-slash"
+                ? CALL_ICON_DEAFEN
+                : CALL_ICON_MUTED
             : "fa fa-microphone",
     hotkey: "shift+m",
     onSelected: ({ store }) => store.rtc.toggleMicrophone(),
@@ -78,7 +80,7 @@ registerCallAction("deafen", {
     name: ({ store }) => (store.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
     isActive: ({ store }) => store.rtc.selfSession?.is_deaf,
     isTracked: true,
-    icon: ({ action }) => (action.isActive ? "fa fa-deaf" : "fa fa-headphones"),
+    icon: ({ action }) => (action.isActive ? CALL_ICON_DEAFEN : "fa fa-headphones"),
     hotkey: "shift+d",
     onSelected: ({ store }) => store.rtc.toggleDeafen(),
     sequence: 10,

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -1,6 +1,7 @@
 import { Component, useEffect, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { Thread } from "@mail/core/common/thread_model";
+import { CALL_ICON_DEAFEN, CALL_ICON_MUTED } from "@mail/discuss/call/common/call_actions";
 import { AvatarStack } from "@mail/discuss/core/common/avatar_stack";
 import { useHover } from "@mail/utils/common/hooks";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
@@ -27,6 +28,8 @@ export class DiscussSidebarCallParticipants extends Component {
         });
         this.state = useState({ expanded: false });
         this.floating = useDropdownState();
+        this.CALL_ICON_DEAFEN = CALL_ICON_DEAFEN;
+        this.CALL_ICON_MUTED = CALL_ICON_MUTED;
         useEffect(
             (selfSession, compact) => {
                 if (selfSession?.in(this.sessions) && !compact) {

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -78,7 +78,8 @@
                     <t t-set="session" t-value="session"/>
                 </t>
                 <t t-else="">
-                    <span t-if="session.is_muted or session.is_deaf" class="p-1 fa opacity-75" t-att-class="rtc.callActions.find(a => a.id === 'mute').icon"/>
+                    <span t-if="session.is_deaf" class="p-1 fa opacity-75" t-att-class="CALL_ICON_DEAFEN"/>
+                    <span t-elif="session.is_muted" class="p-1 fa opacity-75" t-att-class="CALL_ICON_MUTED"/>
                     <span t-if="session.is_screen_sharing_on" class="o-live bg-danger o-text-white rounded">LIVE</span>
                 </t>
             </div>
@@ -88,8 +89,8 @@
 
     <t t-name="mail.DiscussSidebarCallParticipants.participantShortStatus">
         <span t-if="session?.shortStatus" t-att-class="{
-            [`fa ${rtc.callActions.find(a => a.id === 'mute').icon} opacity-75`]: session.shortStatus === 'mute',
-            [`fa ${rtc.callActions.find(a => a.id === 'deafen').icon} opacity-75`]: session.shortStatus === 'deafen',
+            [`${CALL_ICON_MUTED} opacity-75`]: session.shortStatus === 'mute',
+            [`${CALL_ICON_DEAFEN} opacity-75`]: session.shortStatus === 'deafen',
             'o-live bg-danger o-text-white rounded': session.shortStatus === 'live',
         }"><t t-if="session.shortStatus === 'live'">LIVE</t></span>
     </t>


### PR DESCRIPTION
Before this commit, discuss sidebar call participants had wrong status shown, e.g. when participants are muted it shows non-slashed mic icon instead of slashed mic icon.

Steps to reproduce:
- Start a call without being muted or deafen
- Have another person join the call and mute or deafen => icon shows unslashed mic or headphone

This happens because the slash variants were coupled with active button state of call actions, so was based on current session rather than target session.

This commit fixes the issue by using specific mute and deafen icon when session is either muted or deafen.

Before
<img width="1277" height="406" alt="Screenshot 2025-11-13 at 12 20 08" src="https://github.com/user-attachments/assets/c570d0a4-0ab6-48d8-bab6-b191531b2cb6" />

After
<img width="1276" height="397" alt="Screenshot 2025-11-13 at 12 19 44" src="https://github.com/user-attachments/assets/2d69e942-7726-4c8c-8921-7635df47dc85" />
