### PR TITLE
[FIX] mail: avoid traceback when closing minimized chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <div class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.channel.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': popover.isOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <div t-if="props.chatWindow?.channel" class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.channel.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': popover.isOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !channel.isUnread or channel.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="channel.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="channel.importantCounter"/>
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
@@ -21,7 +21,7 @@
     </t>
 
     <t t-name="mail.ChatBubblePreview">
-        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
+        <div t-if="props.chatWindow?.channel" class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
             <div class="text-truncate base-fs fw-bolder mb-0 mx-2 px-1" t-esc="props.chatWindow.channel.displayName"/>
             <t t-set="message" t-value="channel.newestPersistentOfAllMessage" />
             <div t-if="previewText" class="text-truncate small mx-2 px-1 text-muted">

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -618,3 +618,21 @@ test("Open chat window from command palette with chat hub compact", async () => 
     await click(".o-mail-DiscussCommand", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "John" });
 });
+
+test("Close chat window from bubble while bubble preview is displayed", async () => {
+    const pyEnv = await startServer();
+    const johnId = pyEnv["res.users"].create({ name: "John" });
+    const johnPartnerId = pyEnv["res.partner"].create({ user_ids: [johnId], name: "John" });
+    const chatId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: johnPartnerId }),
+        ],
+        channel_type: "chat",
+    });
+    setupChatHub({ folded: [chatId] });
+    await start();
+    await hover(".o-mail-ChatBubble[name='John']");
+    await click(`.o-mail-ChatBubble[name='John'] .o-mail-ChatBubble-close`);
+    await contains(`.o-mail-ChatBubble[name='John']`, { count: 0 });
+});


### PR DESCRIPTION
Before this commit, closing a minimized chat window could cause a traceback. This happened because the ChatWindow model was deleted before the related channel could be accessed.

This commit fixes the issue by safely guarding the channel.

Task-5255534
