### PR TITLE
[FIX] web: fix crash when using backspace in kanban m2m tags

### DIFF
--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -285,6 +285,8 @@ export class Navigator {
             }
         }
 
+        const focusedIndex = this.items.findIndex((item) => item.el === document.activeElement);
+
         // Focus last item if some where removed
         if (oldItemsLength != this.items.length && this.activeItemIndex >= this.items.length) {
             this.items.at(-1)?.setActive();
@@ -302,6 +304,8 @@ export class Navigator {
                 this.activeItemIndex = index;
                 this.activeItem = this.items[this.activeItemIndex];
             }
+        } else if (focusedIndex >= 0) {
+            this.items[focusedIndex].setActive();
         }
     }
 

--- a/addons/web/static/tests/core/navigation_hook.test.js
+++ b/addons/web/static/tests/core/navigation_hook.test.js
@@ -278,3 +278,30 @@ test("items are focused only on mousemove, not on mouseenter", async () => {
     expect(".three").toHaveClass("focus");
     expect.verifySteps([]); // onMouseEnter is not triggered again
 });
+
+test("set focused element as active item", async () => {
+    class Parent extends Component {
+        static props = [];
+        static template = xml`
+            <div class="container" t-ref="containerRef">
+                <input class="o-navigable one" id="input" t-ref="autofocus"/>
+                <button class="o-navigable two">target two</button>
+                <button class="o-navigable three">target three</button>
+            </div>
+        `;
+
+        setup() {
+            this.inputRef = useAutofocus();
+            useNavigation("containerRef", {
+                onEnabled: (nav) => {
+                    this.navigation = nav;
+                },
+            });
+        }
+    }
+
+    const component = await mountWithCleanup(Parent);
+    expect(component.inputRef.el).toBeFocused();
+    expect(component.navigation.activeItem).not.toBeEmpty();
+    expect(component.navigation.activeItem.el).toBe(component.inputRef.el);
+});


### PR DESCRIPTION
How to reproduce:
- Go to project tasks
- Edit the list of people assigned to a task
- Press backspace

Current behavior:
	Traceback

Expected behavior:
	No traceback

task-5189783