### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: move subscription logic to bridge module

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -88,14 +88,6 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             },
         })
 
-        if invoice.invoice_line_ids._fields.get('deferred_start_date'):
-            line_ids = invoice.invoice_line_ids.filtered(lambda line: line.display_type == 'product' and line.deferred_start_date)
-            if line_ids:
-                document_node['cac:InvoicePeriod'] = {
-                    'cbc:StartDate': {'_text': line_ids[0].deferred_start_date},
-                    'cbc:EndDate': {'_text': line_ids[0].deferred_end_date},
-                }
-
         document_node['cac:OrderReference']['cbc:IssueDate'] = {'_text': invoice.invoice_date}
 
         if invoice.partner_id.l10n_tr_nilvera_customer_status == 'earchive':

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -415,19 +415,6 @@ class AccountMove(models.Model):
 
         return msg, error_codes
 
-    def _l10n_tr_nilvera_einvoice_check_invalid_subscription_dates(self):
-        if 'deferred_start_date' not in self.invoice_line_ids._fields:
-            return False
-
-        # Ensure that either no lines have the start and end dates or all lines have the same start and end dates.
-        lines_to_check = self.invoice_line_ids.filtered(lambda line: line.display_type == 'product')
-        if not (subscription_lines := lines_to_check.filtered('deferred_start_date')):
-            return False
-
-        return len(subscription_lines) != len(lines_to_check) or len(set(subscription_lines.mapped(
-            lambda aml: (aml.deferred_start_date, aml.deferred_end_date))
-        )) > 1
-
     def _l10n_tr_nilvera_einvoice_check_negative_lines(self):
         return any(
             line.display_type not in {'line_note', 'line_section'}

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -114,21 +114,6 @@ class AccountMoveSend(models.AbstractModel):
                 )),
             }
 
-        if tr_invalid_subscription_dates := moves.filtered(
-            lambda move: move._l10n_tr_nilvera_einvoice_check_invalid_subscription_dates()
-        ):
-            alerts["tr_invalid_subscription_dates"] = {
-                'level': 'danger',
-                "message": _(
-                    "The following invoice(s) need to have the same Start Date and End Date "
-                    "on all their respective Invoice Lines."
-                ),
-                "action_text": _("View Invoice(s)"),
-                "action": tr_invalid_subscription_dates._get_records_action(
-                    name=_("Check data on Invoice(s)"),
-                ),
-            }
-
         if invalid_negative_lines := tr_nilvera_moves.filtered(
             lambda move: move._l10n_tr_nilvera_einvoice_check_negative_lines(),
         ):


### PR DESCRIPTION
This PR moves the subscription-handling logic to a dedicated bridge
module in Enterprise. Since the subscription app itself is an
Enterprise feature, keeping the subscription flow in the Community
edition, was inconsistent.

task-5085628
related upgrade PR: https://github.com/odoo/upgrade/pull/8847
related odoo enterprise PR: https://github.com/odoo/enterprise/pull/99382

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr