### PR TITLE
[FIX] link_tracker: clarify error when saving link tracker record

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -74,7 +74,10 @@ class LinkTracker(models.Model):
     @api.depends('code')
     def _compute_short_url(self):
         for tracker in self:
-            tracker.short_url = tools.urls.urljoin(tracker.short_url_host or '', tracker.code or '')
+            try:
+                tracker.short_url = tools.urls.urljoin(tracker.short_url_host or '', tracker.code or '')
+            except ValueError:
+                raise UserError(self.env._("Please enter valid short URL code."))
 
     def _compute_short_url_host(self):
         for tracker in self:


### PR DESCRIPTION
Saving a link tracker record fails when the user enters a URL in the Code field.

Steps to reproduce the error:
- Install ``link_tracker`` module
- Create a new link tracker record with Target Link > Save
- Edit the record and set Code: ``https://demo.com`` > Save

Traceback:
```py
ValueError: Extra URL must use same scheme and host as base, and begin with base path
```

https://github.com/odoo/odoo/blob/af4365421bc7ba990420789c12c98270d723fa1a/addons/link_tracker/models/link_tracker.py#L77
After this commit: https://github.com/odoo/odoo/commit/977e62d91f3e8235e251e9d21b08f53db1856c6b,
When the user sets the code as ``https://demo.com``,
Error will be raised from [1], because the extra URL must use same scheme and host as base,
and must begin with the base path.

[1]: https://github.com/odoo/odoo/blob/af4365421bc7ba990420789c12c98270d723fa1a/odoo/tools/urls.py#L55-L58

sentry-7022131826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
