### PR TITLE
[FIX] web: improve visibility of sample data in list views

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -11,6 +11,7 @@
             <t t-if="showNoContentHelper">
     			<ActionHelper noContentHelp="props.noContentHelp" showRibbon="props.list.model.useSampleModel"/>
             </t>
+            <div t-elif="props.list.model.useSampleModel" class="o_view_nocontent"/>
             <table t-attf-class="o_list_table table table-sm table-hover position-relative mb-0 {{props.list.isGrouped ? 'o_list_table_grouped' : 'o_list_table_ungrouped table-striped'}}" t-ref="table">
                 <thead>
                     <tr>

--- a/addons/web/static/src/views/view.scss
+++ b/addons/web/static/src/views/view.scss
@@ -21,7 +21,7 @@
     background-image:  radial-gradient(
         at 50% 50%,
         #{$o-view-background-color} 0px,
-        #{rgba($o-view-background-color, 0.5)} 100%
+        #{rgba($o-view-background-color, 0.7)} 100%
     );
 
     .o_nocontent_help {


### PR DESCRIPTION
**Steps to reproduce:**
* Create database without demo data.
* Open any list view that displays sample data. Ensure the view contains no actual records. Refresh the page to trigger the sample data display.
* For example: Open the journal items list view in the Accounting module.

**Observed behavior:**
When the view contains no actual records, the sample data is shown at full visibility, making it look like real data and causing confusion.

**Cause:**
When a list view displays sample data but has no help content defined, the sample data appears at full opacity, making it indistinguishable from real data and potentially confusing users.

The blur effect (radial-gradient) is applied via the o_view_nocontent div, which is only rendered when help content exists. 
blur effect added in this commit: [https://github.com/odoo/odoo/commit/6ee090c29f1f4e1745c6cae2d50ea77d3324965b](https://github.com/odoo/odoo/commit/6ee090c29f1f4e1745c6cae2d50ea77d3324965b)

**Fix:**
Added `o_view_nocontent` `div` which, is also rendered when sample data is active, even without help content, so the blur effect is consistently applied.

before:
<img width="1918" height="657" alt="image" src="https://github.com/user-attachments/assets/1955e459-3ef8-4874-96ee-91f5312f2e47" />

after:
<img width="1923" height="682" alt="image" src="https://github.com/user-attachments/assets/7acf539c-27a7-4e19-851c-714cd5258c7d" />


opw-5239503
