### PR TITLE
[IMP] base: warn about invalid module names

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 import logging
 import os
 import platform
+import re
 import shutil
 import typing
 
@@ -331,6 +332,12 @@ class IrModuleModule(models.Model):
         if self:
             self.env.registry.clear_cache('stable')
         return res
+
+    @api.constrains('name')
+    def _check_module_name(self):
+        for m in self:
+            if not re.fullmatch(r'\w+', m.name):
+                _logger.warning("Invalid module name: %r (some features may misbehave)", m.name)
 
     def _get_modules_to_load_domain(self):
         """ Domain to retrieve the modules that should be loaded by the registry. """


### PR DESCRIPTION
When importing modules, they must follow python package naming. This is automatically done for modules containing code: when loading them. For imported modules, we show a warning now. This way, existing modules continue to work, but some features may not properly work (example: importing i18n).



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
