### PR TITLE
[FIX] website_sale: prevent alternative products to be shown when not available

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2523,6 +2523,12 @@
         </div>
     </template>
 
+    <template id="alternative_products_show_if_available" name="Alternative Products Show if Available" inherit_id="website_sale.alternative_products" priority="20">
+        <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_sale_recommended_products']" position="attributes">
+            <attribute name="t-if">product.alternative_product_ids</attribute>
+        </xpath>
+    </template>
+
     <template
         name="Terms and Conditions"
         id="website_sale.product_terms_and_conditions"


### PR DESCRIPTION
### Issue:
In this issue, alternative products will continue to be shown even if the product has no alternative products, due to editing alternative products using studio.

#### To reproduce:
1- Create a product with an at least one alternative product.
2- On product shop page, using studio, edit the description of alternative products.
3- Remove alternative products of the product.
4- As seen, the alternative products section is still shown, even though it is empty.

### Cause:
This is due to `oe_structure` which doesn't copy the `t-if`.
This makes `t-if=product.alternative_product_ids` to be missed in the new inherited view created by studio.

opw-5253884
