### PR TITLE
[FIX] mail: improve message action style

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -17,13 +17,14 @@
 
         &.o-inline {
             &:where(:has(i:first-child:last-child)) {
-                filter: brightness(var(--o-mail-ActionList-Button-opacity));
+                opacity: var(--o-mail-ActionList-Button-opacity);
 
                 &:where(.rounded-circle) {
                     aspect-ratio: 1;
                 }
                 &:hover, &:focus, &:active, &.active, &:focus-visible {
-                    filter: brightness(var(--o-mail-ActionList-Button-opacity--hover));
+                    color: var(--o-mail-ActionList-Button-color--hover);
+                    opacity: var(--o-mail-ActionList-Button-opacity--hover);
                 }
             }
 

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -38,7 +38,7 @@
     .o-mail-ActionList-group {
         gap: map-get($spacers, 3);
 
-        button:not(:hover, &:focus-visible, &:active):not(.btn-success) {
+        button:not(:hover):not(:focus-visible):not(:active):not(.btn-success) {
             --o-mail-ActionList-Button-opacity: 1;
         }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -126,15 +126,18 @@
     &:hover, &.focus, &.show {
         i {
             opacity: 100%;
-            color: var(--mail-Message-actionIconHoveredColor, black);
         }
     }
 }
 
 .o-mail-Message-actions {
-    --o-mail-ActionList-Button-aspect-ratio: 0.65;
-    --o-mail-ActionList-Button-opacity: #{$o-opacity-muted};
+    --o-mail-ActionList-Button-opacity: .35;
     --o-mail-ActionList-Button-opacity--hover: 1;
+    --o-mail-ActionList-Button-color--hover: var(--mail-Message-actionIconHoveredColor, black);
+
+    i {
+        font-size: 1rem;
+    }
 
     .o-mail-Message.o-isMobileOS & i.oi-ellipsis-v {
         opacity: 15%;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -174,7 +174,7 @@
         <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
         <t t-if="isMobileOS and isReverse" t-call="mail.Message.emptyQuickAction"/>
         <div class="d-flex rounded-1 overflow-hidden gap-1" t-att-class="{ 'flex-row-reverse': isReverse }">
-            <ActionList actions="actions" inline="true" fw="false" groupClass="'gap-1'"/>
+            <ActionList actions="actions" inline="true" fw="false"/>
             <t t-foreach="Array.from({ length: quickActionCount - quickActions.length - 1 })" t-as="emptyQuickAction" t-key="emptyQuickAction_index">
                 <t t-call="mail.Message.emptyQuickAction"/>
             </t>


### PR DESCRIPTION
1) increase size, reduce gap

Make icons more readable by being bigger. The gap is reduced so overall this actually takes slightly less horizontal area.

2) More visible hover effect

Hover effect was inexistent due to typo in chat window style leaking to message actions, but still the hover effect was to shy, with 75% => 100% opacity. This is increased to 50% => 100% in addition to true black/white on 100%.

Before / After (white)
<img width="716" height="128" alt="white-before" src="https://github.com/user-attachments/assets/3829b7cb-8e36-4f28-8d20-78ef9aa31a97" />
<img width="723" height="128" alt="white-after" src="https://github.com/user-attachments/assets/79ec373a-c847-4c8a-96da-4582b54bb393" />


Before / After (dark)
<img width="717" height="127" alt="dark-before" src="https://github.com/user-attachments/assets/cdaddee6-8025-46c3-a50b-9c85f9108887" />
<img width="716" height="123" alt="dark-after" src="https://github.com/user-attachments/assets/ddd712b0-407b-427b-b4c6-e3d615b91c27" />
