### PR TITLE
[FIX] web_tour: backward when warn step present in the page

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -54,7 +54,7 @@ export class TourInteractive {
         while (!tempAnchors.length && tempIndex >= 0) {
             tempIndex--;
             tempAction = this.actions.at(tempIndex);
-            if (!tempAction.step.active) {
+            if (!tempAction.step.active || tempAction.event === "warn") {
                 continue;
             }
             tempAnchors = tempAction && this.findTriggers(tempAction.anchor);

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -710,7 +710,7 @@ test("Tour backward when the pointed element disappear and ignore warn step", as
     registry.category("web_tour.tours").add("tour1", {
         steps: () => [
             { trigger: "button.foo", run: "click" },
-            { trigger: "button.bar" },
+            { trigger: "button.foo" },
             { trigger: "button.bar", run: "click" },
         ],
     });
@@ -747,7 +747,7 @@ test("Tour backward when the pointed element disappear and ignore warn step", as
     await contains("button.bar").click();
     await animationFrame();
     expect(".o_tour_pointer").toHaveCount(0);
-    expect.verifySteps(["Step 'button.bar' ignored.", "Step 'button.bar' ignored."]);
+    expect.verifySteps(["Step 'button.foo' ignored.", "Step 'button.foo' ignored."]);
 });
 
 test("Tour started by the URL", async () => {


### PR DESCRIPTION
Before this commit, the backward wasn't ignoring the warn steps. So, if the backward go to the previous step (warn's one) and the trigger is on the page, the tour interactive put the cursor there. But the step is then ignored and go back the step you came from.

Now, the warn's steps are ignored.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
