### PR TITLE
[FIX] hr: use employee_ids instead of employee field

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -12,7 +12,7 @@ class ResPartner(models.Model):
         'hr.employee', 'work_contact_id', string='Employees', groups="hr.group_hr_user",
         help="Related employees based on their private address")
     employees_count = fields.Integer(compute='_compute_employees_count', groups="hr.group_hr_user")
-    employee = fields.Boolean(help="Whether this contact is an Employee.", compute='_compute_employee', store=True, readonly=False)
+    employee = fields.Boolean(help="Whether this contact is an Employee.", compute='_compute_employee', store=True, readonly=False, copy=False)
 
     def _compute_employees_count(self):
         for partner in self:
@@ -67,7 +67,7 @@ class ResPartner(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_contact_rel_employee(self):
-        partners = self.filtered(lambda partner: partner.employee)
+        partners = self.filtered(lambda partner: partner.sudo().employee_ids)
         if len(self) == 1 and len(partners) == 1 and self.id == partners[0].id:
             raise UserError(_('You cannot delete contact that are linked to an employee, please archive them instead.'))
         if partners:


### PR DESCRIPTION
Steps to reproduce:

1. Take or create a contact linked to an employee.
2. Duplicate that contact. (The duplication won't be linked to any employee)
3. Try to delete the duplicated contact.

This behavior was introduced in the commit 834ec2d.

Replace the computed boolean `employee` field with direct `employee_ids` check to ensure we're validating against actual linked employee records.

opw-5209516


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr