### PR TITLE
[IMP] crm_iap_mine: change lead mining provider to dnb

### DIFF
--- a/addons/crm_iap_mine/models/crm_iap_lead_helpers.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_helpers.py
@@ -31,26 +31,29 @@ class CRMHelpers(models.Model):
 
     @api.model
     def lead_vals_from_response(self, lead_type, team_id, tag_ids, user_id, company_data, people_data):
-        country_id = self.env['res.country'].search([('code', '=', company_data['country_code'])]).id
-        website_url = 'https://www.%s' % company_data['domain'] if company_data['domain'] else False
+        country_id = company_data.get('country_id')
+        if not country_id:
+            country_id = self.env['res.country'].search([('code', '=', company_data['country_code'])]).id
+        website_url = 'https://%s' % company_data['domain'] if company_data.get('domain') else False
         lead_vals = {
             # Lead vals from record itself
             'type': lead_type,
             'team_id': team_id,
             'tag_ids': [(6, 0, tag_ids)],
             'user_id': user_id,
-            'reveal_id': company_data['clearbit_id'],
+            'reveal_id': company_data.get('duns') or company_data.get('clearbit_id', ''),
             # Lead vals from data
-            'name': company_data['name'] or company_data['domain'],
-            'partner_name': company_data['legal_name'] or company_data['name'],
+            'name': company_data.get('name', '') or company_data.get('domain', ''),
+            'partner_name': company_data.get('name', ''),
             'email_from': next(iter(company_data.get('email', [])), ''),
-            'phone': company_data['phone'] or (company_data['phone_numbers'] and company_data['phone_numbers'][0]) or '',
+            'phone': company_data.get('phone') or next(iter(company_data.get('phone_numbers', [])), ''),
             'website': website_url,
-            'street': company_data['location'],
-            'city': company_data['city'],
-            'zip': company_data['postal_code'],
+            'street': company_data.get('street') or company_data.get('location', ''),
+            'street2': company_data.get('street2'),
+            'city': company_data.get('city', ''),
+            'zip': company_data.get('zip') or company_data.get('postal_code', ''),
             'country_id': country_id,
-            'state_id': self._find_state_id(company_data['state_code'], country_id),
+            'state_id': self._find_state_id(company_data.get('state_code'), country_id),
         }
 
         # If type is people then add first contact in lead data

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, release
 from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import UserError
 from odoo.tools import is_html_empty
@@ -239,10 +239,15 @@ class CRMLeadMiningRequest(models.Model):
         server_payload = self._prepare_iap_payload()
         reveal_account = self.env['iap.account'].get('reveal')
         dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        reveal_ids = [lead['reveal_id'] for lead in self.env['crm.lead'].search_read([('reveal_id', '!=', False)], ['reveal_id'])]
         params = {
+            'db_uuid': dbuuid,
+            'db_version': release.version,
+            'db_lang': self.env.lang,
             'account_token': reveal_account.account_token,
-            'dbuuid': dbuuid,
-            'data': server_payload
+            'country_code': self.env.company.country_id.code,
+            'query': server_payload,
+            'reveal_ids': reveal_ids
         }
         try:
             response = self._iap_contact_mining(params, timeout=300)
@@ -259,7 +264,7 @@ class CRMLeadMiningRequest(models.Model):
             raise UserError(_("Your request could not be executed: %s", e))
 
     def _iap_contact_mining(self, params, timeout=300):
-        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/iap/clearbit/2/lead_mining_request'
+        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/api/dnb/1/search_by_criteria'
         return iap_tools.iap_jsonrpc(endpoint, params=params, timeout=timeout)
 
     def _create_leads_from_response(self, result):
@@ -268,14 +273,18 @@ class CRMLeadMiningRequest(models.Model):
         lead_vals_list = []
         messages_to_post = {}
         for data in result:
+            country = self.env['res.country'].search([('code', '=', data['country_code'])])
             lead_vals_list.append(self._lead_vals_from_response(data))
 
-            template_values = data['company_data']
+            template_values = data
             template_values.update({
                 'flavor_text': _("Opportunity created by Odoo Lead Generation"),
                 'people_data': data.get('people_data'),
+                'country': country.name,
+                'zip_code': data.get('zip'),
+                'country_id': country.id,
             })
-            messages_to_post[data['company_data']['clearbit_id']] = template_values
+            messages_to_post[data['duns']] = template_values
         leads = self.env['crm.lead'].create(lead_vals_list)
         for lead in leads:
             if messages_to_post.get(lead.reveal_id):
@@ -289,8 +298,8 @@ class CRMLeadMiningRequest(models.Model):
     @api.model
     def _lead_vals_from_response(self, data):
         self.ensure_one()
-        company_data = data.get('company_data')
-        people_data = data.get('people_data')
+        company_data = data
+        people_data = []
         lead_vals = self.env['crm.iap.lead.helpers'].lead_vals_from_response(self.lead_type, self.team_id.id, self.tag_ids.ids, self.user_id.id, company_data, people_data)
         lead_vals['lead_mining_request_id'] = self.id
         return lead_vals

--- a/addons/crm_iap_mine/tests/common.py
+++ b/addons/crm_iap_mine/tests/common.py
@@ -31,7 +31,6 @@ class MockIAPReveal(MockIAPEnrich):
 
         def _iap_contact_mining(params, timeout):
             self.assertMineCallParams(params)
-            self.assertMinePayload(mine, params['data'])
 
             if sim_error and sim_error == 'credit':
                 raise iap_tools.InsufficientCreditError('InsufficientCreditError')
@@ -53,13 +52,7 @@ class MockIAPReveal(MockIAPEnrich):
                 company_data = self._get_iap_company_data(base_name, service='mine')
                 if default_data:
                     company_data.update(default_data)
-                iap_payload['company_data'] = company_data
-
-                if mine.search_type == 'people':
-                    people_data = self._get_iap_contact_data(base_name, service='mine')
-                    iap_payload['people_data'] = people_data
-
-                response.append(iap_payload)
+                response.append(company_data)
 
             return {
                 'data': response,
@@ -71,25 +64,9 @@ class MockIAPReveal(MockIAPEnrich):
             yield
 
     def _get_iap_company_data(self, base_name, service=None, add_values=None):
-        company_data = super(MockIAPReveal, self)._get_iap_company_data(base_name, service=service, add_values=add_values)
-        if service == 'mine':
-            company_data['phone'] = company_data['phone_numbers'][0]
-            company_data['sector'] = 'Sector Info'
+        company_data = super()._get_iap_dnb_company_data(base_name, service=service, add_values=add_values)
         return company_data
 
     def assertMineCallParams(self, params):
         self.assertTrue(bool(params['account_token']))
-        self.assertTrue(bool(params['dbuuid']))
-
-    def assertMinePayload(self, mine, payload):
-        if mine.search_type == 'people':
-            self.assertEqual(payload['contact_number'], mine.contact_number)
-        else:
-            self.assertTrue('contact_number' not in payload)
-        countries = [{
-            'code': country.code,
-            'states': mine.state_ids.filtered(lambda state: state in country.state_ids).mapped('code'),
-        } for country in mine.country_ids]
-        self.assertEqual(payload['countries'], countries)
-        self.assertEqual(payload['lead_number'], mine.lead_number)
-        self.assertEqual(payload['search_type'], mine.search_type)
+        self.assertTrue(bool(params['db_uuid']))

--- a/addons/crm_iap_mine/tests/test_lead_mine.py
+++ b/addons/crm_iap_mine/tests/test_lead_mine.py
@@ -85,20 +85,17 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
             self.assertEqual(lead.team_id, self.sales_team_1)
             self.assertEqual(lead.user_id, self.user_sales_leads)
             # iap
-            self.assertEqual(lead.reveal_id, '123_ClearbitID_%s' % base_name, 'Ensure reveal_id is set to clearbit ID')
-            # clearbit information
-            self.assertEqual(lead.contact_name, 'Contact %s 0' % base_name)
+            self.assertEqual(lead.reveal_id, '123456789', 'Ensure reveal_id is set to Duns')
+            # DnB information
+            self.assertFalse(lead.contact_name)
             self.assertEqual(lead.city, 'Mönchengladbach')
             self.assertEqual(lead.country_id, country_de)
-            self.assertEqual(lead.email_from, 'test.contact.0@%s.example.com' % base_name,
-                             'Lead email should be the one from first contact if search_type people is given')
-            self.assertEqual(lead.function, 'Doing stuff')
             self.assertFalse(lead.partner_id)
-            self.assertEqual(lead.partner_name, '%s GmbH legal_name' % base_name)
-            self.assertEqual(lead.phone, '+4930499193937')
+            self.assertEqual(lead.partner_name, '%s GmbH' % base_name)
+            self.assertEqual(lead.phone, '4930499193937')
             self.assertEqual(lead.state_id, state_de)
             self.assertEqual(lead.street, 'Mennrather Str. 123456')
-            self.assertEqual(lead.website, 'https://www.%s.de' % base_name)
+            self.assertEqual(lead.website, 'https://%s.de' % base_name)
             self.assertEqual(lead.zip, '41179')
 
     @users('user_sales_manager')
@@ -126,17 +123,15 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
             self.assertEqual(lead.team_id, self.sales_team_1)
             self.assertEqual(lead.user_id, self.user_sales_leads)
             # iap
-            self.assertEqual(lead.reveal_id, '123_ClearbitID_%s' % base_name, 'Ensure reveal_id is set to clearbit ID')
-            # clearbit information
+            self.assertEqual(lead.reveal_id, '123456789', 'Ensure reveal_id is set to Duns')
+            # DnB information
             self.assertFalse(lead.contact_name)
             self.assertEqual(lead.city, 'Mönchengladbach')
             self.assertEqual(lead.country_id, country_de)
-            self.assertEqual(lead.email_from, 'info@%s.example.com' % base_name)
-            self.assertFalse(lead.function)
             self.assertFalse(lead.partner_id)
-            self.assertEqual(lead.partner_name, '%s GmbH legal_name' % base_name)
-            self.assertEqual(lead.phone, '+4930499193937')
+            self.assertEqual(lead.partner_name, '%s GmbH' % base_name)
+            self.assertEqual(lead.phone, '4930499193937')
             self.assertEqual(lead.state_id, state_de)
             self.assertEqual(lead.street, 'Mennrather Str. 123456')
-            self.assertEqual(lead.website, 'https://www.%s.de' % base_name)
+            self.assertEqual(lead.website, 'https://%s.de' % base_name)
             self.assertEqual(lead.zip, '41179')

--- a/addons/crm_iap_mine/views/mail_templates.xml
+++ b/addons/crm_iap_mine/views/mail_templates.xml
@@ -3,6 +3,65 @@
 <odoo>
     <template id="enrich_company" inherit_id="iap_mail.enrich_company">
         <xpath expr="//div[hasclass('o_partner_autocomplete_enrich_info')]" position="inside">
+            <div class="col-sm-12 row m-0 p-0">
+                <div t-if="entity_type" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-building text-primary"/>
+                    <b>Company type</b>
+                </div>
+                <div t-if="entity_type" class="my-1 col-sm-9" t-out="entity_type" />
+                <div t-if="vat" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-solid fa-id-card text-primary"/>
+                    <b>Tax ID</b>
+                </div>
+                <div t-if="vat" class="my-1 col-sm-9" t-out="vat" />
+                <div t-if="country" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-address-book text-primary"/>
+                    <b>Address</b>
+                </div>
+                <div class="my-1 col-sm-9">
+                    <div class="o_address_format">
+                        <div t-if="zip_code">
+                            <div t-if="street" class="o_address_street" t-out="street"/>
+                            <div t-if="street2"  class="o_address_street" t-out="street2"/>
+                            <div>
+                                <span t-if="city" t-out="city"/>
+                                <span t-if="zip_code" t-out="zip_code"/>
+                                <span t-if="state" t-out="state"/>
+                                <span t-if="state_name" t-out="state_name"/>
+                            </div>
+                            <div t-if="country" class="o_address_country" t-out="country"/>
+                        </div>
+                    </div>
+                </div>
+                <div t-if="industry_name" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-cube text-primary"/>
+                    <b>Sector</b>
+                </div>
+                <div t-if="industry_name" class="my-1 col-sm-9" t-out="industry_name" />
+                <div t-if="phone" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-phone text-primary"/>
+                    <b>Phone</b>
+                </div>
+                <div t-if="phone" class="col-sm-9">
+                    <a t-attf-href="tel:{{phone}}" t-out="phone" style="font-weight:normal; padding: 2px 0px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                </div>
+                <div t-if="website" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-globe text-primary"/>
+                    <b>Website</b>
+                </div>
+                <div t-if="website" class="col-sm-9">
+                    <a target="_blank" t-attf-href="https://{{website}}" t-out="website" style="font-weight:normal; padding: 2px 0px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                </div>
+                <div t-if="unspsc_codes" class="d-flex my-1 p-0 col-sm-3">
+                    <i class="fa fa-fw me-2 fa-industry text-primary"/>
+                    <b>Industries</b>
+                </div>
+                 <div t-if="unspsc_codes" class="col-sm-9">
+                    <t t-foreach="unspsc_codes" t-as="tag_item">
+                        <label t-out="tag_item[1]" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                    </t>
+                </div>
+            </div>
             <t t-if="people_data">
                 <t t-set="hasPhoneNumbers" t-value="any([people['phone'] for people in people_data])"/>
                 <div style="font-size:16px; margin: 9px 0;">

--- a/addons/iap/tests/common.py
+++ b/addons/iap/tests/common.py
@@ -137,6 +137,34 @@ class MockIAPEnrich(common.TransactionCase):
             'country_name': self.base_de.name,
         }
 
+    def _get_iap_dnb_company_data(self, base_name, service=None, add_values=None):
+        return {
+            'city': 'Mönchengladbach',
+            'country_code': self.base_de.code,
+            'domain': '%s.de' % base_name,
+            'duns': '123456789',
+            'employees': 314,
+            'entity_type': 'private',
+            'industry_code': 'J',
+            'name': '%s GmbH' % base_name,
+            'phone': '4930499193937',
+            'state_code': self.de_state_st.code,
+            'street': 'Mennrather Str. 123456',
+            'unspsc_codes': [
+                [541512, 'Computer Systems Design Services'],
+                [518210, 'Computing Infrastructure Providers, Data Processing, Web Hosting, and Related Services'],
+                [541611, 'Administrative Management and General Management Consulting Services'],
+                [87429902, 'Business management consultant'],
+                [73790200, 'Computer related consulting services'],
+                [73749902, 'Data processing service'],
+                [51, 'Data Processing']
+            ],
+            'vat': '7LRA8',
+            'website': '%s.de' % base_name,
+            'estimated_annual_revenue': '10M USD',
+            'zip': '41179'
+        }
+
     def _get_iap_contact_data(self, base_name, service=None, add_values=None):
         people_data = []
         for index in range(2):

--- a/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
+++ b/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
@@ -187,9 +187,9 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
             else:
                 self.assertFalse(lead.function)
             self.assertFalse(lead.partner_id)
-            self.assertEqual(lead.partner_name, '%s GmbH legal_name' % base_name)
+            self.assertEqual(lead.partner_name, '%s GmbH' % base_name)
             self.assertEqual(lead.phone, '+4930499193937')
             self.assertEqual(lead.state_id, state_de)
             self.assertEqual(lead.street, 'Mennrather Str. 123456')
-            self.assertEqual(lead.website, 'https://www.%s.de' % base_name)
+            self.assertEqual(lead.website, 'https://%s.de' % base_name)
             self.assertEqual(lead.zip, '41179')


### PR DESCRIPTION
Before this commit:
 - Lead mining data was fetched from `clearbit` provider on IAP which is
   now going to be removed for discovery service
After this Commit:
 - Data will now be fetched from `dun_and_bradstreet` provider on IAP
   which we are already using for the `partner_autocomplete`

IAP PR: https://github.com/odoo/iap-apps/pull/1274

task-4873238
