### PR TITLE
[IMP] hr, *: adjust visibility and restructure job sections

### DIFF
--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -21,10 +21,8 @@
                         <notebook>
                             <page string="Details" name="recruitment_page" invisible="1" groups="hr.group_hr_user">
                                 <group>
-                                    <group name="hiring_process" string="Hiring Process">
+                                    <group name="hiring_process" string="Hiring Process" invisible="1">
                                         <field name="user_id" widget="many2one_avatar_user"/>
-                                    </group>
-                                    <group name="job_posting" string="Job Posting">
                                         <label name="no_of_recruitment_label" for="no_of_recruitment"/>
                                         <div class="o_row" name="recruitment_target">
                                             <field name="no_of_recruitment" class="o_hr_narrow_field"/>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -297,6 +297,9 @@
                 <attribute name="invisible">0</attribute>
                 <attribute name="groups">hr_recruitment.group_hr_recruitment_interviewer,hr.group_hr_user</attribute>
             </page>
+            <xpath expr="//group[@name='hiring_process']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
             <group name="hiring_process" position="inside">
                 <field name="interviewer_ids" widget="many2many_tags_avatar"
                     options="{'no_create': True, 'no_create_edit': True}"
@@ -319,7 +322,7 @@
                 </div>
             </group>
 
-            <group name="job_posting" position="inside">
+            <group name="job" position="inside">
                 <field name="expected_degree" groups="hr_recruitment.group_hr_recruitment_interviewer"/>
             </group>
 

--- a/addons/hr_skills/views/hr_job_views.xml
+++ b/addons/hr_skills/views/hr_job_views.xml
@@ -5,9 +5,6 @@
         <field name="model">hr.job</field>
         <field name="inherit_id" ref="hr.view_hr_job_form"/>
         <field name="arch" type="xml">
-            <page name="recruitment_page" position="attributes">
-                <attribute name="invisible">0</attribute>
-            </page>
             <div class="oe_title" position="after">
                 <group id="job_skills">
                     <field
@@ -20,7 +17,7 @@
                     />
                 </group>
             </div>
-            <div name="recruitment_target" position="after">
+            <group name="job" position="inside">
                 <field
                     name="current_job_skill_ids"
                     mode="list"
@@ -35,7 +32,7 @@
                         <field name="color"/>
                     </list>
                 </field>
-            </div>
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
*: hr_recruitment, hr_skills
- Show the Hiring Process section only when the hr_recruitment module is installed.
- Remove the Job Posting section.
- Move Job Posting fields such as recruitment target to the Hiring Process section.
- Move expected skills and expected degree fields to the Job section.
- Display the Details page if the hr_recruitment module is installed.

task-5215960
