### PR TITLE
[FIX] point_of_sale: fix bom variants picking

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -89,9 +89,13 @@ class StockPicking(models.Model):
 
     def _create_move_from_pos_order_lines(self, lines):
         self.ensure_one()
-        lines_by_product = groupby(sorted(lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
+
+        def get_grouping_key(line):
+            return (line.product_id.id, tuple(sorted(line.attribute_value_ids.ids)))
+
+        lines_by_product_and_attrs = groupby(sorted(lines, key=get_grouping_key), key=get_grouping_key)
         move_vals = []
-        for dummy, olines in lines_by_product:
+        for dummy, olines in lines_by_product_and_attrs:
             order_lines = self.env['pos.order.line'].concat(*olines)
             move_vals.append(self._prepare_stock_move_vals(order_lines[0], order_lines))
         moves = self.env['stock.move'].create(move_vals)

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -546,6 +546,135 @@ class TestPosMrp(TestPointOfSaleCommon):
             {'product_id': kit_2.id, 'total_cost': 100.0},
         ])
 
+    def test_never_variant_bom_product_picking(self):
+        self.attribute_1 = self.env['product.attribute'].create({
+            'name': 'Color',
+            'create_variant': 'no_variant',
+            'sequence': 1,
+        })
+
+        # Create attribute values
+        self.value_1_1 = self.env['product.attribute.value'].create({
+            'name': 'Red',
+            'attribute_id': self.attribute_1.id,
+            'sequence': 1,
+        })
+        self.value_1_2 = self.env['product.attribute.value'].create({
+            'name': 'Blue',
+            'attribute_id': self.attribute_1.id,
+            'sequence': 2,
+        })
+
+        # Create the configurable product with attributes
+        self.configurable_product = self.env['product.product'].create({
+            'name': 'Configurable Chair',
+            'is_storable': True,
+            'available_in_pos': True,
+            'list_price': 100,
+        })
+
+        ptal = self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': self.configurable_product.product_tmpl_id.id,
+            'attribute_id': self.attribute_1.id,
+            'value_ids': [Command.set([self.value_1_1.id, self.value_1_2.id])],
+        }])
+
+        # Create the component products
+        self.component_common = self.env['product.product'].create({
+            'name': 'Common Frame',
+            'is_storable': True,
+            'list_price': 50,
+        })
+
+        self.component_red = self.env['product.product'].create({
+            'name': 'Red Cushion',
+            'is_storable': True,
+            'list_price': 20,
+        })
+
+        self.component_blue = self.env['product.product'].create({
+            'name': 'Blue Cushion',
+            'is_storable': True,
+            'list_price': 20,
+        })
+
+        # Create BOM for the configurable product
+        self.bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.configurable_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',  # Kit type
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.component_common.id,
+                    'product_qty': 1.0,
+                }),
+                Command.create({
+                    'product_id': self.component_red.id,
+                    'product_qty': 1.0,
+                    'bom_product_template_attribute_value_ids': [
+                        Command.link(self.configurable_product.product_tmpl_id.attribute_line_ids[0].product_template_value_ids[0].id)
+                    ],
+                }),
+                Command.create({
+                    'product_id': self.component_blue.id,
+                    'product_qty': 1.0,
+                    'bom_product_template_attribute_value_ids': [
+                        Command.link(self.configurable_product.product_tmpl_id.attribute_line_ids[0].product_template_value_ids[1].id)
+                    ],
+                }),
+            ],
+        })
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        pos_order_data = {
+                'amount_paid': 100,
+                'amount_return': 0,
+                'amount_tax': 0,
+                'amount_total': 100,
+                'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+                'fiscal_position_id': False,
+                'lines': [
+                    Command.create({
+                        'attribute_value_ids': [ptal.product_template_value_ids[0].id],
+                        'discount': 0,
+                        'pack_lot_ids': [],
+                        'price_unit': 100.0,
+                        'product_id': self.configurable_product.id,
+                        'price_subtotal': 100.0,
+                        'price_subtotal_incl': 100.0,
+                        'qty': 1,
+                        'tax_ids': [],
+                    }),
+                    Command.create({
+                        'attribute_value_ids': [ptal.product_template_value_ids[1].id],
+                        'discount': 0,
+                        'pack_lot_ids': [],
+                        'price_unit': 100.0,
+                        'product_id': self.configurable_product.id,
+                        'price_subtotal': 100.0,
+                        'price_subtotal_incl': 100.0,
+                        'qty': 1,
+                        'tax_ids': [],
+                        }),
+                ],
+                'name': 'Order 12345-123-1234',
+                'partner_id': False,
+                'session_id': current_session.id,
+                'sequence_number': 2,
+                'payment_ids': [
+                    Command.create({
+                        'amount': 100,
+                        'name': fields.Datetime.now(),
+                        'payment_method_id': self.cash_payment_method.id
+                    })
+                ],
+                'uuid': '12345-123-1234',
+                'last_order_preparation_change': '{}',
+                'user_id': self.env.uid
+            }
+        self.PosOrder.sync_from_ui([pos_order_data])['pos.order'][0]['id']
+        self.assertEqual(len(current_session.picking_ids.move_line_ids), 4)
+
     def test_bom_variant_exclusive_bom_lines(self):
         """This test make sure that the cost is correctly computed when a product has a BoM with lines linked
               to specific variant."""


### PR DESCRIPTION
When selling a bom kit that have some components that applies on specific variants only, the picking was not correctly created. It would only take one kit variant into account, even if you sold 2 kits with different variants.

Steps to reproduce:
-------------------
* Create a product P
* For product P, create an attribute with type "No variant" and values V1 and V2
* Create a BoM Kit for product P, with 3 components C1 C2 and C3
  - C2 applies only for variant V1
  - C3 applies only for variant V2
* Create a POS order with 2 lines of product P:
  - 1 with variant V1
  - 1 with variant V2
* Validate the order and check the created picking
> Observation: Only C1 and C2 are in the picking, C3 is missing

Why the fix:
------------
When creating the picking, the code was grouping the order lines by product only, and not by product variant. Therefore, the 2 lines would be grouped together, and only one of the variant-specific components would be taken into account.

opw-5051289