### PR TITLE
[IMP] mass_mailing, *: add auto-fill snippet plugin

### DIFF
--- a/addons/mass_mailing/static/src/builder/options/record_snapshot_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/record_snapshot_option.xml
@@ -1,0 +1,15 @@
+<templates>
+    <t t-name="mass_mailing.recordSnapshotOption">
+        <BuilderRow label="getModelDisplayName()">
+            <BuilderMany2One
+                action="'selectRecordAction'"
+                model="getElementDataModel()"
+                preview="false"
+                allowUnselect="false"
+                actionParam="{
+                    model: getElementDataModel(),
+                    fragmentKey: getElementFragmentKey(),
+                }"/>
+        </BuilderRow>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
@@ -29,7 +29,7 @@ export class BorderOption3 extends BaseOptionComponent {
 export class BorderOption4 extends BaseOptionComponent {
     static template = "mass_mailing.BorderOption";
     static selector = ".row > div";
-    static exclude = ".o_mail_wrapper_td, .s_image_gallery .row > div";
+    static exclude = ".o_mail_wrapper_td, .s_image_gallery .row > div, .row > .s_record_snapshot";
     static components = { BorderConfigurator };
 }
 

--- a/addons/mass_mailing/static/src/builder/plugins/record_snapshot_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/record_snapshot_option_plugin.js
@@ -1,0 +1,106 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { registry } from "@web/core/registry";
+import { withSequence } from "@html_editor/utils/resource";
+import { BEGIN } from "@html_builder/utils/option_sequence";
+import { _t } from "@web/core/l10n/translation";
+import { renderToFragment } from "@web/core/utils/render";
+
+export class RecordSnapshotPlugin extends Plugin {
+    static id = "recordSnapshot";
+    static shared = ["createFragment"];
+
+    resources = {
+        builder_options: [withSequence(BEGIN, RecordSnapshotOption)],
+        builder_actions: {
+            SelectRecordAction,
+        },
+    };
+
+    /**
+     * Create a filled snippet fragment matching the passed model and ID.
+     * Available fragments are determined by the contents fo the mass_mailing.record-snapshot-snippets registry.
+     */
+    async createFragment(model, id, fragmentKey) {
+        const snippetInfo = registry
+            .category("mass_mailing.record-snapshot-snippet-info")
+            .get(model);
+        const recordData = await this.services.orm.read(model, [id], snippetInfo.fields, {
+            context: snippetInfo.context,
+        });
+        const additionalContext = await snippetInfo.additionalRenderingContext(
+            recordData[0],
+            this.services
+        );
+        const fragmentTemplate = snippetInfo.getSnippetName(fragmentKey);
+        return renderToFragment(fragmentTemplate, {
+            record: recordData[0],
+            ...additionalContext,
+        });
+    }
+}
+
+export class RecordSnapshotOption extends BaseOptionComponent {
+    static template = "mass_mailing.recordSnapshotOption";
+    static selector = ".s_record_snapshot";
+
+    getElementDataModel() {
+        return this.env.getEditingElement().dataset.model;
+    }
+
+    getModelDisplayName() {
+        const model = this.env.getEditingElement().dataset.model;
+        const snippetInfo = registry
+            .category("mass_mailing.record-snapshot-snippet-info")
+            .get(model);
+        return snippetInfo?.modelDisplayName || _t("Record");
+    }
+
+    getElementFragmentKey() {
+        return this.env.getEditingElement().dataset.fragmentKey;
+    }
+}
+
+class SelectRecordAction extends BuilderAction {
+    static dependencies = ["builderOptions", "recordSnapshot"];
+    static id = "selectRecordAction";
+
+    getValue({ editingElement: el }) {
+        if (el.dataset.id) {
+            return JSON.stringify({
+                id: parseInt(el.dataset.id),
+                display_name: el.dataset.displayName,
+                name: el.dataset.name,
+            });
+        }
+        return;
+    }
+
+    async apply({ editingElement: el, value, params }) {
+        value = JSON.parse(value);
+        const fragment = await this.dependencies.recordSnapshot.createFragment(
+            params.model,
+            value.id,
+            params.fragmentKey
+        );
+        const snapshotEl = this.document.createElement("div");
+        snapshotEl.append(fragment);
+        snapshotEl.dataset.model = params.model;
+        snapshotEl.dataset.id = value.id;
+        snapshotEl.dataset.name = value.name;
+        snapshotEl.dataset.displayName = value.display_name;
+
+        // Carry over class list, style and template name from old element
+        snapshotEl.classList.add(...el.classList);
+        snapshotEl.dataset.fragmentKey = params.fragmentKey;
+        snapshotEl.style.cssText = el.style.cssText;
+
+        el.before(snapshotEl);
+        el.remove();
+
+        this.dependencies.builderOptions.updateContainers(snapshotEl);
+    }
+}
+
+registry.category("mass_mailing-plugins").add(RecordSnapshotPlugin.id, RecordSnapshotPlugin);

--- a/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
@@ -197,50 +197,6 @@
     </section>
 </template>
 
-<template id="s_event" name="Event">
-    <section class="s_mail_block_event o_mail_snippet_general bg-100" data-vxml="001">
-        <div class="container">
-            <div class="row align-items-center">
-                <div class="o_mail_no_colorpicker col-md-6 pt32 pb32 col-12">
-                    <div class="card bg-white h-100 rounded" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important;">
-                        <div class="o_not_editable">
-                            <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_event_default_image_1" alt=""/>
-                        </div>
-                        <div class="card-body">
-                            <h3 class="card-title">
-                                <span style="font-size: 18px;">Event One</span>
-                            </h3>
-                            <p><font class="text-o-color-1">25 September 2022 - 4:30 PM</font></p>
-                            <p>London, United Kingdom</p>
-                            <p>
-                                <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                <div class="o_mail_no_colorpicker col-md-6 pt32 pb32 col-12">
-                    <div class="card bg-white h-100 rounded" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important;">
-                        <div class="o_not_editable">
-                            <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_event_default_image_2" alt=""/>
-                        </div>
-                        <div class="card-body">
-                            <h3 class="card-title">
-                                <span style="font-size: 18px">Event Two</span>
-                            </h3>
-                            <p><font class="text-o-color-1">26 September 2022 - 1:30 PM</font></p>
-                            <p>London, United Kingdom</p>
-                            <p>
-                                <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    </section>
-</template>
-
 <template id="s_product_list" name="Items">
     <section class="s_mail_product_list o_mail_snippet_general" data-vxml="001">
         <div class="container pt16">

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -78,7 +78,6 @@
             <t t-snippet="mass_mailing.s_media_list" string="Media List" group="columns"/>
             <t t-snippet="mass_mailing.s_attributes_horizontal" string="Horizontal Attributes" group="columns"/>
             <t t-snippet="mass_mailing.s_numbers" string="Numbers" group="columns"/>
-            <t t-snippet="mass_mailing.s_event" string="Event" group="columns"/>
             <t t-snippet="mass_mailing.s_product_list" string="Items" group="columns"/>
             <t t-snippet="mass_mailing.s_features_grid" string="Features Grid" group="columns"/>
 

--- a/addons/mass_mailing_sale/__manifest__.py
+++ b/addons/mass_mailing_sale/__manifest__.py
@@ -6,8 +6,15 @@
     'summary': 'Add sale order UTM info on mass mailing',
     'description': """UTM and mass mailing on sale orders""",
     'depends': ['sale', 'mass_mailing'],
+    'assets': {
+        'mass_mailing.assets_builder': [
+            'mass_mailing_sale/static/src/builder/**/*',
+        ],
+    },
     'data': [
         'views/mailing_mailing_views.xml',
+        'views/snippets_themes.xml',
+        'views/templates/snippets/s_product_snapshot.xml',
     ],
     'demo': [
         'demo/mailing_mailing.xml',

--- a/addons/mass_mailing_sale/static/src/builder/options/product_snapshot_fragments.xml
+++ b/addons/mass_mailing_sale/static/src/builder/options/product_snapshot_fragments.xml
@@ -1,0 +1,107 @@
+<templates>
+    <t t-name="mass_mailing_sale.s_product_snapshot_columns_fragment">
+        <div class="card rounded h-100" t-att-data-product-id="record.id">
+            <div class="o_not_editable">
+                <img class="img img-fluid o_editable_media rounded mx-auto" style="object-fit: cover; width: 100%;
+                    --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                    t-attf-data-name="{{record.display_name}} Image"
+                    t-attf-src="/web/image/product.template/{{record.id}}/image_1024" t-attf-alt="{{record.name}} Image"
+                    t-attf-data-original-src="/web/image/product.template/{{record.id}}/image_1024"/>
+            </div>
+            <div class="card-body" aria-label="Product information">
+                <h3 class="card-title text-break" t-out="record.name or 'Product Name'"/>
+                <p>
+                    <font style="color: rgb(108, 117, 125)" t-out="record.description_sale or 'Add a description...'"/>
+                </p>
+                <p>
+                    <h3 aria-label="Price information">
+                        <strong>
+                            <t t-out="listPrice"/>
+                        </strong>
+                        <span> </span>
+                        <s t-if="record.standard_price">
+                            <span class="h4-fs">
+                                <font style="color: rgb(108, 117, 125)">
+                                    <t t-out="standardPrice"/>
+                                </font>
+                            </span>
+                        </s>
+                    </h3>
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="#" target="_blank" role="button"><i class="fa fa-cart"/> Buy Now</a>
+                </p>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="mass_mailing_sale.s_product_snapshot_card_fragment">
+        <div>
+            <div class="o_not_editable">
+                <img class="img img-fluid o_editable_media rounded mx-auto" style="width: 100%;
+                    --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                    t-attf-data-name="{{record.display_name}} Image"
+                    t-attf-src="/web/image/product.template/{{record.id}}/image_1024" t-attf-alt="{{record.name}} Image"
+                    t-attf-data-original-src="/web/image/product.template/{{record.id}}/image_1024"/>
+            </div>
+            <div class="text-center pt8">
+                <h3 class="text-break" t-out="record.name or 'Product Name'"/>
+                <p>
+                    <font style="color: rgb(108, 117, 125)" t-out="record.description_sale or 'Add a description...'"/>
+                </p>
+                <h3 aria-label="Price information">
+                    <strong>
+                        <t t-out="listPrice"/>
+                    </strong>
+                    <span> </span>
+                    <s t-if="record.standard_price">
+                        <span class="h4-fs">
+                            <font style="color: rgb(108, 117, 125)">
+                                <t t-out="standardPrice"/>
+                            </font>
+                        </span>
+                    </s>
+                </h3>
+                <p>
+                    <a class="btn btn-primary" href="#" target="_blank" role="button"><i class="fa fa-cart"/> Buy Now</a>
+                </p>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="mass_mailing_sale.s_product_snapshot_aside_fragment">
+        <div class="row align-items-center">
+            <div class="col-md-6 col-12">
+                <div class="o_not_editable">
+                    <img class="img img-fluid o_editable_media rounded mx-auto" style="object-fit: cover;  width: 100%;
+                        --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                        t-attf-data-name="{{record.display_name}} Image"
+                        t-attf-src="/web/image/product.template/{{record.id}}/image_1024" t-attf-alt="{{record.name}} Image"
+                        t-attf-data-original-src="/web/image/product.template/{{record.id}}/image_1024"/>
+                </div>
+            </div>
+            <div class="col-md-6 col-12">
+                <h3 class="text-break" t-out="record.name or 'Product Name'"/>
+                <p>
+                    <font style="color: rgb(108, 117, 125)" t-out="record.description_sale or 'Add a description...'"/>
+                </p>
+                <h3 aria-label="Price information">
+                    <strong>
+                        <t t-out="listPrice"/>
+                    </strong>
+                    <span> </span>
+                    <s t-if="record.standard_price">
+                        <span class="h4-fs">
+                            <font style="color: rgb(108, 117, 125)">
+                                <t t-out="standardPrice"/>
+                            </font>
+                        </span>
+                    </s>
+                </h3>
+                <p>
+                    <a class="btn btn-primary" href="#" target="_blank" role="button"><i class="fa fa-cart"/> Buy Now</a>
+                </p>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/mass_mailing_sale/static/src/builder/options/product_snapshot_snippet_info.js
+++ b/addons/mass_mailing_sale/static/src/builder/options/product_snapshot_snippet_info.js
@@ -1,0 +1,42 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { formatMonetary } from "@web/views/fields/formatters";
+
+export const productSnapshotSnippetInfo = {
+    fields: [
+        "id",
+        "display_name",
+        "name",
+        "description_sale",
+        "list_price",
+        "currency_id",
+        "standard_price",
+    ],
+    get modelDisplayName() {
+        return _t("Product");
+    },
+    getSnippetName: (key) => {
+        switch (key) {
+            case "columns":
+                return "mass_mailing_sale.s_product_snapshot_columns_fragment";
+            case "card":
+                return "mass_mailing_sale.s_product_snapshot_card_fragment";
+            case "aside":
+                return "mass_mailing_sale.s_product_snapshot_aside_fragment";
+        }
+    },
+    additionalRenderingContext: async (record) => ({
+        standardPrice: formatMonetary(record.standard_price, {
+            currencyId: record.currency_id[0],
+            trailingZeros: false,
+        }),
+        listPrice: formatMonetary(record.list_price, {
+            currencyId: record.currency_id[0],
+            trailingZeros: false,
+        }),
+    }),
+};
+
+registry
+    .category("mass_mailing.record-snapshot-snippet-info")
+    .add("product.template", productSnapshotSnippetInfo);

--- a/addons/mass_mailing_sale/views/snippets_themes.xml
+++ b/addons/mass_mailing_sale/views/snippets_themes.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <data>
+        <template id="email_designer_snippets" inherit_id="mass_mailing.email_designer_snippets">
+            <xpath expr="//t[@t-snippet='mass_mailing.s_call_to_action']" position="after">
+                <t t-snippet="mass_mailing_sale.s_product_columns" group="marketing" label="Auto-filled from Product" string="Products List"/>
+                <t t-snippet="mass_mailing_sale.s_product_card" group="marketing" label="Auto-filled from Product" string="Product Card"/>
+                <t t-snippet="mass_mailing_sale.s_product_aside" group="marketing" label="Auto-filled from Product" string="Product Aside"/>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/mass_mailing_sale/views/templates/snippets/s_product_snapshot.xml
+++ b/addons/mass_mailing_sale/views/templates/snippets/s_product_snapshot.xml
@@ -1,0 +1,101 @@
+<odoo>
+    <template id="s_product_columns">
+        <section class="s_mail_block_event o_mail_snippet_general">
+            <div class="container">
+                <div class="row align-items-stretch">
+                    <t t-foreach="[1,2,3]" t-as="key">
+                        <div class="col-md-4 col-12 s_record_snapshot pt16 pb16"
+                            data-model="product.template" data-fragment-key="columns"
+                            style="padding-left: 16px !important; padding-right: 16px !important;">
+                            <div class="card rounded h-100">
+                                <div class="o_not_editable">
+                                    <img class="img img-fluid o_editable_media rounded mx-auto" alt="Example Image" style="object-fit: cover; width: 100%;
+                                        --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                                        t-attf-src="/website_sale/static/src/img/product_previews/product_{{key}}.jpg"
+                                        t-attf-data-original-src="/website_sale/static/src/img/product_previews/product_{{key}}.jpg"/>
+                                </div>
+                                <div class="card-body" aria-label="Product information">
+                                    <h3 class="card-title text-break">Select the products you want to display!</h3>
+                                    <p><font style="color: rgb(108, 117, 125)">Click on this block, then select products using the panel on the right.</font></p>
+                                    <h3 aria-label="Price information">
+                                        <strong>$20</strong>
+                                        <span class="h4-fs">
+                                            <s>
+                                                <font style="color: rgb(108, 117, 125)">$25</font>
+                                            </s>
+                                        </span>
+                                    </h3>
+                                    <p>
+                                        <a class="btn btn-primary" href="#" target="_blank" role="button"><i class="fa fa-cart"/> Buy Now</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+    <template id="s_product_card">
+        <section class="s_text_image o_mail_snippet_general pt24 pb24">
+            <div class="container s_record_snapshot s_text_block o_cc" data-model="product.template" data-fragment-key="card">
+                <div>
+                    <div class="o_not_editable">
+                        <img class="img img-fluid o_editable_media rounded mx-auto" style="width: 65%;
+                            --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                            src="/website_sale/static/src/img/product_previews/product_1.jpg" alt="Example Image"
+                            data-original-src="/website_sale/static/src/img/product_previews/product_1.jpg"/>
+                    </div>
+                    <div class="text-center pt8">
+                        <h3 class="text-break">Select the products you want to display!</h3>
+                        <p><font style="color: rgb(108, 117, 125)">Click on this block, then select products using the panel on the right.</font></p>
+                        <h3 aria-label="Price information">
+                            <strong>$20</strong>
+                            <span class="h4-fs">
+                                <s>
+                                    <font style="color: rgb(108, 117, 125)">$25</font>
+                                </s>
+                            </span>
+                        </h3>
+                        <p>
+                            <a class="btn btn-primary" href="#" target="_blank" role="button"><i class="fa fa-cart"/> Buy Now</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+
+    <template id="s_product_aside">
+        <section class="s_text_image o_mail_snippet_general o_colored_level pt24 pb24">
+            <div class="container s_record_snapshot s_text_block o_cc" contenteditable="true" data-model="product.template" data-fragment-key="aside">
+                <div class="row align-items-center">
+                    <div class="col-md-6 col-12">
+                        <div class="o_not_editable">
+                            <img class="img img-fluid o_editable_media rounded mx-auto" data-name="Example Image" style="object-fit: cover; width: 100%;
+                                --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                                src="/website_sale/static/src/img/product_previews/product_2.jpg"
+                                data-original-src="/website_sale/static/src/img/product_previews/product_2.jpg"/>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-12">
+                        <h3 class="text-break">Select the products you want to display!</h3>
+                        <p><font style="color: rgb(108, 117, 125)">Click on this block, then select products using the panel on the right.</font></p>
+                        <h3 aria-label="Price information">
+                            <strong>$20</strong>
+                            <span class="h4-fs">
+                                <s>
+                                    <font style="color: rgb(108, 117, 125)">$25</font>
+                                </s>
+                            </span>
+                        </h3>
+                        <p>
+                            <a class="btn btn-primary" href="#" target="_blank" role="button"><i class="fa fa-cart"/> Buy Now</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+</odoo>

--- a/addons/website_mass_mailing_event/__manifest__.py
+++ b/addons/website_mass_mailing_event/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    'name': "Mass mailing on website events",
+    'summary': 'Add pre-filled snippets in mass_mailing with an event snapshot',
+    'description': """
+    Add pre-filled event snippets for the mass_mailing html builder, with links to the matching website event page.
+    The snippet is linked to specified events and will load a snapshot of their data to be sent by email.
+    """,
+    'category': 'Marketing/Email Marketing/Website',
+    'depends': ['mass_mailing', 'website_event'],
+    'assets': {
+        'mass_mailing.assets_builder': [
+            'website_mass_mailing_event/static/src/builder/**/*',
+        ],
+    },
+    'data': [
+        'views/snippets_themes.xml',
+        'views/snippets/s_event_snapshot.xml',
+    ],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_fragments.xml
+++ b/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_fragments.xml
@@ -1,0 +1,113 @@
+<templates>
+    <t t-name="website_mass_mailing_event.s_event_snapshot_columns_fragment">
+        <div class="card rounded h-100" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important;">
+            <div class="o_not_editable">
+                <img class="img img-fluid o_editable_media rounded mx-auto" t-attf-data-name="{{record.display_name}} Image"
+                    t-att-src="coverUrl" t-attf-alt="{{record.name}} Image"
+                    t-att-data-original-src="coverUrl"
+                    style="object-fit: cover; width: 100%;
+                    --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"/>
+            </div>
+            <div class="card-body">
+                <h3 class="card-title">
+                    <strong t-out="record.display_name"/>
+                </h3>
+                <p>
+                    <font style="color: rgb(99,99,99);" t-out="record.subtitle or 'Add a description...'"/>
+                </p>
+                <p>
+                    <strong>
+                        <span t-out="dateBegin"/> at
+                        <span t-out="timeBegin"/>
+                    </strong>
+                </p>
+                <p t-if="record.address_id">
+                    <span class="h5-fs">
+                        <t t-call="website_mass_mailing_event.event_address_template" t-call-context="addressData"/>
+                    </span>
+                </p>
+                <p>
+                    <a t-attf-href="{{record.event_share_url}}/register" target="_blank" class="btn btn-primary">Register Now</a>
+                </p>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="website_mass_mailing_event.s_event_snapshot_card_fragment">
+        <div>
+            <div class="o_not_editable">
+                <img class="img img-fluid o_editable_media rounded mx-auto" style="width: 100%;
+                    --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                    t-attf-data-name="{{record.display_name}} Image"
+                    t-att-src="coverUrl" t-attf-alt="{{record.name}} Image"
+                    t-att-data-original-src="coverUrl"/>
+            </div>
+            <div class="text-center pt8">
+                <h3><strong t-out="record.display_name"/></h3>
+                <p>
+                    <font style="color: rgb(99,99,99);" t-out="record.subtitle or 'Add a description...'"/>
+                </p>
+                <p>
+                    <strong>
+                        <span t-out="dateBegin"/> at
+                        <span t-out="timeBegin"/>
+                    </strong>
+                </p>
+                <p t-if="record.address_id">
+                    <span class="h5-fs">
+                        <t t-call="website_mass_mailing_event.event_address_template" t-call-context="addressData"/>
+                    </span>
+                </p>
+                <p>
+                    <a t-attf-href="{{record.event_share_url}}/register" target="_blank" class="btn btn-primary">Register Now</a>
+                </p>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="website_mass_mailing_event.s_event_snapshot_aside_fragment">
+        <div class="row align-items-center">
+            <div class="col-md-6 col-12">
+                <div class="o_not_editable">
+                    <img class="img img-fluid o_editable_media rounded mx-auto" style="object-fit: cover; width: 100%;
+                        --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                        t-att-src="coverUrl" t-attf-alt="{{record.name}} Image"
+                        t-att-data-original-src="coverUrl"/>
+                </div>
+            </div>
+            <div class="col-md-6 col-12">
+                <h3><strong t-out="record.display_name"/></h3>
+                <p>
+                    <font style="color: rgb(99,99,99);" t-out="record.subtitle or 'Add a description...'"/>
+                </p>
+                <p>
+                    <strong>
+                        <span t-out="dateBegin"/> at
+                        <span t-out="timeBegin"/>
+                    </strong>
+                </p>
+                <p t-if="record.address_id">
+                    <span class="h5-fs">
+                        <t t-call="website_mass_mailing_event.event_address_template" t-call-context="addressData"/>
+                    </span>
+                </p>
+                <p>
+                    <a t-attf-href="{{record.event_share_url}}/register" target="_blank" class="btn btn-primary">Register Now</a>
+                </p>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="website_mass_mailing_event.event_address_template">
+        <t t-set="has_city" t-value="address.city"/>
+        <t t-set="has_state" t-value="state and country.state_required"/>
+
+        <span class="fa fa-map-marker"></span> <t t-if="has_city">
+            <t t-out="address.city"/><t t-if="address.country_id">, </t>
+        </t>
+        <t t-if="has_state">
+            <t t-out="state.code"/>,
+        </t>
+        <t t-out="country.name"/>
+    </t>
+</templates>

--- a/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_snippet_info.js
+++ b/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_snippet_info.js
@@ -1,0 +1,85 @@
+import { getBgImageURLFromURL } from "@html_editor/utils/image";
+import { deserializeDateTime } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { formatDateTime } from "@web/views/fields/formatters";
+
+function getEventCoverUrl(coverProperties) {
+    coverProperties = JSON.parse(coverProperties);
+    return (
+        getBgImageURLFromURL(coverProperties["background-image"]) ||
+        "/web/static/img/placeholder.png"
+    );
+}
+
+async function getAddressData(addressId, orm) {
+    const addressData = await orm.read(
+        "res.partner",
+        [addressId],
+        ["city", "country_id", "state_id"]
+    );
+    const countryData = await orm.read(
+        "res.country",
+        [addressData[0].country_id[0]],
+        ["name", "state_required"]
+    );
+    let stateData;
+    if (addressData[0].state_id) {
+        stateData = await orm.read("res.country.state", [addressData[0].state_id[0]], ["code"]);
+    }
+
+    return {
+        address: addressData[0],
+        country: countryData[0],
+        state: stateData && stateData[0],
+    };
+}
+
+export const eventSnapshotSnippetInfo = {
+    fields: [
+        "display_name",
+        "cover_properties",
+        "date_begin",
+        "date_tz",
+        "address_id",
+        "event_share_url",
+    ],
+    get modelDisplayName() {
+        return _t("Event");
+    },
+    getSnippetName: (key) => {
+        switch (key) {
+            case "columns":
+                return "website_mass_mailing_event.s_event_snapshot_columns_fragment";
+            case "card":
+                return "website_mass_mailing_event.s_event_snapshot_card_fragment";
+            case "aside":
+                return "website_mass_mailing_event.s_event_snapshot_event_aside_fragment";
+        }
+    },
+    additionalRenderingContext: async (record, services) => {
+        let addressData;
+        if (record.address_id) {
+            addressData = await getAddressData(record.address_id[0], services.orm);
+        }
+        return {
+            addressData: addressData,
+            dateBegin: formatDateTime(deserializeDateTime(record.date_begin), {
+                showTime: false,
+                format: localization.dateTimeFormat,
+                tz: record.date_tz,
+            }),
+            timeBegin: formatDateTime(deserializeDateTime(record.date_begin), {
+                showDate: false,
+                format: localization.dateTimeFormat,
+                tz: record.date_tz,
+            }),
+            coverUrl: getEventCoverUrl(record.cover_properties),
+        };
+    },
+};
+
+registry
+    .category("mass_mailing.record-snapshot-snippet-info")
+    .add("event.event", eventSnapshotSnippetInfo);

--- a/addons/website_mass_mailing_event/views/snippets/s_event_snapshot.xml
+++ b/addons/website_mass_mailing_event/views/snippets/s_event_snapshot.xml
@@ -1,0 +1,82 @@
+<odoo>
+    <template id="s_event_columns">
+        <section class="s_mail_block_event o_mail_snippet_general">
+            <div class="container">
+                <div class="row align-items-stretch">
+                    <t t-foreach="[1,2]" t-as="key">
+                        <div class="col-md-6 col-12 pt32 pb32 s_record_snapshot"
+                            data-model="event.event" data-fragment-key="columns"
+                            style="padding-left: 16px !important; padding-right: 16px !important;">
+                            <div class="card rounded h-100" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important;">
+                                <div class="o_not_editable">
+                                    <img class="img img-fluid o_editable_media rounded mx-auto" alt="Example Image" style="object-fit: cover; width: 100%;
+                                        --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                                        t-attf-src="/web/image/mass_mailing.s_event_default_image_{{key}}"
+                                        t-attf-data-original-src="/web/image/mass_mailing.s_event_default_image_{{key}}"/>
+                                </div>
+                                <div class="card-body ">
+                                    <h3 class="card-title">
+                                        <strong>Pick an event to promote it.</strong>
+                                    </h3>
+                                    <p><font style="color: rgb(99,99,99);">Click on this block and select your events in the right-hand menu.</font></p>
+                                    <p><font style="color: rgb(99,99,99);">Details will appear here</font></p>
+                                    <p>
+                                        <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+    <template id="s_event_card">
+        <section class="s_text_image o_mail_snippet_general pt24 pb24">
+            <div class="container s_record_snapshot s_text_block o_cc" data-model="event.event" data-fragment-key="card">
+                <div>
+                    <div class="o_not_editable">
+                        <img class="img img-fluid o_editable_media rounded mx-auto" style="width: 100%;
+                            --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                            src="/web/image/mass_mailing.s_event_default_image_2" alt="Example Image"
+                            data-original-src="/web/image/mass_mailing.s_event_default_image_2"/>
+                    </div>
+                    <div class="text-center pt8">
+                        <h3><strong>Pick an event to promote it!</strong></h3>
+                        <p><font style="color: rgb(99,99,99);">Click on this block and select your events in the right-hand menu.</font></p>
+                        <p><font style="color: rgb(99,99,99);">Details will appear here</font></p>
+                        <p>
+                            <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+
+    <template id="s_event_aside">
+        <section class="s_text_image o_mail_snippet_general pt24 pb24">
+            <div class="container s_record_snapshot s_text_block o_cc" data-model="event.event" data-fragment-key="aside">
+                <div class="row align-items-center">
+                    <div class="col-md-6 col-12">
+                        <div class="o_not_editable">
+                            <img class="img img-fluid o_editable_media rounded mx-auto" data-name="Example Image" style="object-fit: cover; width: 100%;
+                                --box-border-bottom-left-radius: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px; --box-border-top-left-radius: 0px;"
+                                src="/web/image/mass_mailing.s_event_default_image_1"
+                                data-original-src="/web/image/mass_mailing.s_event_default_image_1"/>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-12">
+                        <h3><strong>Pick an event to promote it!</strong></h3>
+                        <p><font style="color: rgb(99,99,99);">Click on this block and select your events in the right-hand menu.</font></p>
+                        <p><font style="color: rgb(99,99,99);">Details will appear here</font></p>
+                        <p>
+                            <a href="#" target="_blank" class="btn btn-primary">Register Now</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+</odoo>

--- a/addons/website_mass_mailing_event/views/snippets_themes.xml
+++ b/addons/website_mass_mailing_event/views/snippets_themes.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <data>
+        <template id="email_designer_snippets" inherit_id="mass_mailing.email_designer_snippets">
+            <xpath expr="//t[@t-snippet='mass_mailing.s_call_to_action']" position="after">
+                <t t-snippet="website_mass_mailing_event.s_event_card" group="marketing" label="Auto-filled from Event" string="Event Card"/>
+                <t t-snippet="website_mass_mailing_event.s_event_aside" group="marketing" label="Auto-filled from Event" string="Event Aside"/>
+                <t t-snippet="website_mass_mailing_event.s_event_columns" group="marketing" label="Auto-filled from Event" string="Events List"/>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/website_sale_mass_mailing/__manifest__.py
+++ b/addons/website_sale_mass_mailing/__manifest__.py
@@ -8,7 +8,12 @@
         process.
     """,
     'category': 'Website/Website',
-    'depends': ['website_sale', 'website_mass_mailing'],
+    'depends': ['website_sale', 'website_mass_mailing', 'mass_mailing_sale'],
+    'assets': {
+        'mass_mailing.assets_builder': [
+            'website_sale_mass_mailing/static/src/builder/**/*',
+        ],
+    },
     'data': [
         'views/res_config_settings_views.xml',
         'views/templates.xml',

--- a/addons/website_sale_mass_mailing/static/src/builder/options/product_snapshot_fragments.xml
+++ b/addons/website_sale_mass_mailing/static/src/builder/options/product_snapshot_fragments.xml
@@ -1,0 +1,22 @@
+<templates>
+    <t t-name="s_product_snapshot_columns_fragment"
+        t-inherit="mass_mailing_sale.s_product_snapshot_columns_fragment" t-inherit-mode="extension">
+        <xpath expr="//a[@target='_blank']" position="attributes">
+            <attribute name="t-attf-href">{{record.website_absolute_url or "#"}}</attribute>
+        </xpath>
+    </t>
+    
+    <t t-name="s_product_snapshot_card_fragment"
+        t-inherit="mass_mailing_sale.s_product_snapshot_card_fragment" t-inherit-mode="extension">
+        <xpath expr="//a[@target='_blank']" position="attributes">
+            <attribute name="t-attf-href">{{record.website_absolute_url or "#"}}</attribute>
+        </xpath>
+    </t>
+
+    <t t-name="s_product_snapshot_aside_fragment"
+        t-inherit="mass_mailing_sale.s_product_snapshot_aside_fragment" t-inherit-mode="extension">
+        <xpath expr="//a[@target='_blank']" position="attributes">
+            <attribute name="t-attf-href">{{record.website_absolute_url or "#"}}</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/website_sale_mass_mailing/static/src/builder/options/product_snapshot_snippet_info.js
+++ b/addons/website_sale_mass_mailing/static/src/builder/options/product_snapshot_snippet_info.js
@@ -1,0 +1,3 @@
+import { productSnapshotSnippetInfo } from "@mass_mailing_sale/builder/options/product_snapshot_snippet_info";
+
+productSnapshotSnippetInfo.fields.push("website_absolute_url");


### PR DESCRIPTION
This PR adds a plugin that will manage snippets with dynamic
record content pulled straight from Odoo.

The plugin will fetch record data (such as names and dates) and add
it as a fragment to the snippet. Users will then be able to edit the
fragment at their convenience.

This PR also adds such dynamic snippets for the Event and Product
models.

task-4247666