### PR TITLE
[IMP] account: allow multiple files for export

### DIFF
--- a/addons/account/controllers/download_docs.py
+++ b/addons/account/controllers/download_docs.py
@@ -54,9 +54,9 @@ class AccountDocumentDownloadController(http.Controller):
             if filetype == 'all' and (doc_data := invoice._get_invoice_legal_documents_all(allow_fallback=allow_fallback)):
                 docs_data += doc_data
             elif doc_data := invoice._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback):
-                if (errors := doc_data.get('errors')) and len(invoices) == 1:
+                if len(invoices) == 1 and (errors := [error for data in docs_data for error in data.get('errors', [])]):
                     raise UserError(_("Error while creating XML:\n- %s", '\n- '.join(errors)))
-                docs_data.append(doc_data)
+                docs_data.extend(doc_data)
         if len(docs_data) == 1:
             doc_data = docs_data[0]
             headers = _get_headers(doc_data['filename'], doc_data['filetype'], doc_data['content'])

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6588,13 +6588,15 @@ class AccountMove(models.Model):
         self.ensure_one()
         if filetype == 'pdf':
             if invoice_pdf := self.invoice_pdf_report_id:
-                return {
+                return [{
                     'filename': invoice_pdf.name,
                     'filetype': invoice_pdf.mimetype,
                     'content': invoice_pdf.raw,
-                }
+                }]
             elif allow_fallback:
-                return self._get_invoice_pdf_proforma()
+                return [self._get_invoice_pdf_proforma()]
+
+        return []
 
     def _get_invoice_legal_documents_all(self, allow_fallback=False):
         """ Retrieve the invoice legal attachments: PDF, XML, ...

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -63,22 +63,22 @@ class AccountMove(models.Model):
         self.ensure_one()
         if filetype == 'ubl':
             if ubl_attachment := self.ubl_cii_xml_id:
-                return {
+                return [{
                     'filename': ubl_attachment.name,
                     'filetype': 'xml',
                     'content': ubl_attachment.raw,
-                }
+                }]
             elif allow_fallback:
                 if self.partner_id and (suggested_edi_format := self.commercial_partner_id._get_suggested_ubl_cii_edi_format()):
                     builder = self.env['res.partner']._get_edi_builder(suggested_edi_format)
                     xml_content, errors = builder._export_invoice(self)
                     filename = builder._export_invoice_filename(self)
-                    return {
+                    return [{
                         'filename': filename,
                         'filetype': 'xml',
                         'content': xml_content,
                         'errors': errors,
-                    }
+                    }]
         return super()._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
 
     def get_extra_print_items(self):

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -356,13 +356,14 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon, HttpCase):
         invoice_de = self.init_invoice('out_invoice', partner=german_partner, amounts=[100], taxes=[self.tax_sale_a], post=True)
         invoice_be = self.init_invoice('out_invoice', partner=belgian_partner, amounts=[100], taxes=[self.tax_sale_a], post=True)
         invoice_us = self.init_invoice('out_invoice', partner=us_partner, amounts=[100], taxes=[self.tax_sale_a], post=True)
-        res = [invoice._get_invoice_legal_documents('ubl', allow_fallback=True) for invoice in (invoice_de + invoice_be + invoice_us)]
-        self.assertEqual(len(res), 3)
+        res = [document for invoice in (invoice_de + invoice_be + invoice_us) for document in invoice._get_invoice_legal_documents('ubl', allow_fallback=True)]
+        self.assertEqual(len(res), 2)
         self.assertEqual(res[0].get('filename'), 'INV_2019_00001_ubl_de.xml')
         self.assertEqual(res[1].get('filename'), 'INV_2019_00002_ubl_bis3.xml')
-        self.assertFalse(res[2])
         invoice_be_failing = self.init_invoice('out_invoice', partner=belgian_partner, amounts=[100], post=True)
-        res_errors = invoice_be_failing._get_invoice_legal_documents('ubl', allow_fallback=True)
+        legal_documents = invoice_be_failing._get_invoice_legal_documents('ubl', allow_fallback=True)
+        self.assertEqual(len(legal_documents), 1)
+        res_errors = legal_documents[0]
         self.assertIn("Each invoice line should have at least one tax.", res_errors.get('errors'))
 
     def test_billing_date_in_cii_xml(self):

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -859,11 +859,11 @@ class AccountMove(models.Model):
         self.ensure_one()
         if filetype == 'facturae':
             if facturae_attachment := self.l10n_es_edi_facturae_xml_id:
-                return {
+                return [{
                     'filename': facturae_attachment.name,
                     'filetype': 'xml',
                     'content': facturae_attachment.raw,
-                }
+                }]
         return super()._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
 
     def get_extra_print_items(self):

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -573,7 +573,9 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             })
             invoice.l10n_es_edi_facturae_xml_id = attachment
 
-            self.assertEqual(invoice._get_invoice_legal_documents('facturae'), {
+            legal_documents = invoice._get_invoice_legal_documents('facturae')
+            self.assertEqual(len(legal_documents), 1)
+            self.assertEqual(legal_documents[0], {
                 'filename': attachment.name,
                 'filetype': 'xml',
                 'content': attachment.raw,
@@ -581,8 +583,8 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
             # Test with no XML file
             invoice.l10n_es_edi_facturae_xml_id = False
-            self.assertIsNone(invoice._get_invoice_legal_documents('facturae'),
-                             "Should return None when no XML file exists")
+            self.assertFalse(invoice._get_invoice_legal_documents('facturae'),
+                             "Should return [] when no XML file exists")
 
     def test_download_facturae_xml_batch_scenario(self):
         """ Test Factura-e XML download with multiple invoices. """

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -140,7 +140,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.pos_order_pos0.action_pos_order_invoice()
         attachment_proforma = self.pos_order_pos0.account_move.attachment_ids.filtered(lambda att: "proforma" in att.name)
         self.assertFalse(attachment_proforma)
-        invoice_str = str(self.pos_order_pos0.account_move._get_invoice_legal_documents('pdf', allow_fallback=True).get('content'))
+        legal_documents = self.pos_order_pos0.account_move._get_invoice_legal_documents('pdf', allow_fallback=True)
+        self.assertEqual(len(legal_documents), 1)
+        invoice_str = str(legal_documents[0]['content'])
         self.assertTrue("invoice" in invoice_str)
         self.assertTrue("proforma" not in invoice_str)
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -294,8 +294,9 @@ class TestPointOfSaleFlow(CommonPosTest):
         self.assertEqual(order_3.picking_ids[0].move_ids.mapped('state'), ['done', 'done'])
 
         order_refund_3.action_pos_order_invoice()
-        invoice_pdf_content = str(order_refund_3.account_move._get_invoice_legal_documents(
-            'pdf', allow_fallback=True).get('content'))
+        legal_documents = order_refund_3.account_move._get_invoice_legal_documents('pdf', allow_fallback=True)
+        self.assertEqual(len(legal_documents), 1)
+        invoice_pdf_content = str(legal_documents[0]['content'])
         self.assertTrue("using Cash" in invoice_pdf_content)
         self.assertEqual(order_refund_3.picking_count, 1)
         self.pos_config_usd.current_session_id.action_pos_session_closing_control()

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -699,7 +699,9 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerTax', login="accountman")
 
         # We check the content of the invoice to make sure Product A/B/C only appears only once
-        invoice_pdf_content = str(self.env['pos.order'].search([]).account_move._get_invoice_legal_documents('pdf', allow_fallback=True).get('content'))
+        legal_documents = self.env['pos.order'].search([]).account_move._get_invoice_legal_documents('pdf', allow_fallback=True)
+        self.assertEqual(len(legal_documents), 1)
+        invoice_pdf_content = str(legal_documents[0]['content'])
         self.assertEqual(invoice_pdf_content.count('Product A'), 1)
         self.assertEqual(invoice_pdf_content.count('Product B'), 1)
         self.assertEqual(invoice_pdf_content.count('Product C'), 1)


### PR DESCRIPTION
When calling the `/account/download_invoice_documents` route, it will loop
through all the selected invoices, generating files depending on the filetype.
But custom filetypes only allow to generate 1 document per invoice (because
of the .append), but in some cases, we might want to generate multiple
files per invoice.

This commit replace the .append by .extend, allowing to generate multiple
files for a single invoice, we just need to return a list of files in the
`_get_invoice_legal_documents` method.

Linked:https://github.com/odoo/enterprise/pull/95267

task-5105859
