### PR TITLE
[FIX] hr_expense: skip bank trust validation on expense payments

### DIFF
--- a/addons/hr_expense/models/account_payment.py
+++ b/addons/hr_expense/models/account_payment.py
@@ -16,6 +16,11 @@ class AccountPayment(models.Model):
             payment.outstanding_account_id = payment.expense_ids._get_expense_account_destination()
         super(AccountPayment, self - expense_company_payments)._compute_outstanding_account_id()
 
+    def _compute_show_require_partner_bank(self):
+        expense_payments = self.filtered(lambda pay: pay.move_id.expense_ids)
+        super(AccountPayment, self - expense_payments)._compute_show_require_partner_bank()
+        expense_payments.require_partner_bank_account = False
+
     def write(self, vals):
         trigger_fields = {
             'date', 'amount', 'payment_type', 'partner_type', 'payment_reference',


### PR DESCRIPTION
Steps to reproduce:
- Enable SEPA.
- Configure bank account with IBAN for employee.
- Create an Expense Report with expenses paid by Company.
- Change report Payment Method to SEPA CT.
- Submit to manager and approve.
- Click Post Journal Entries.

Issue:
- Posting company-paid expenses fails with “Invalid Operation”: “To record payments with False, the recipient bank account must be manually validated...”
- The account.payment created by the expense flow is blocked by the bank trust validation.

Cause of the issue:
- The generic SEPA trust rule in account.payment.action_post applies to all outbound payments, including expense-originated payments that merely log already-made payments.
- The expense flow builds a payment without setting a partner_id and often without a trusted partner_bank_id, so the rule always triggers and blocks posting. https://github.com/odoo/odoo/blob/0611a74cb52ca639b683ef158f8b4f2f347d08ad/addons/account/models/account_payment.py#L982-L987
- The hr_expense company-paid flow creates an outbound account.payment tied to the expense. SEPA CT requires a recipient bank account flagged as trusted (allow_out_payment).
- For expense flows, this check is unnecessary and overly strict, as Odoo is only logging the payment for reconciliation, not initiating a new transfer.

opw-5093423


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
