### PR TITLE
[IMP] website_sale*: clean up URL structure

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -355,11 +355,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if filter_by_tags_enabled:
             if tags:
                 post["tags"] = tags
-                tags = {
-                    tag_id
-                    for tag in tags.split(",")
-                    if (tag_id := self.env["ir.http"]._unslug(tag)[1])
-                }
+                unslug = self.env["ir.http"]._unslug
+                tags = {tag_id for tag in tags.split(",") if (tag_id := unslug(tag)[1])}
             else:
                 post["tags"] = None
                 tags = {}

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -99,15 +99,15 @@ class TableCompute:
         return rows
 
 
-def _get_parent_category_route(depth, param_name='_'):
+def _get_parent_category_route(depth, param_name="_"):
     """Recursively build the parent category part of the route."""
     if depth < 1:
-        return ''
-    parent_path = _get_parent_category_route(depth - 1, param_name + '_')
-    return f'{parent_path}/<model("product.public.category"):{param_name}>'
+        return ""
+    parent_path = _get_parent_category_route(depth - 1, param_name + "_")
+    return f"{parent_path}/<model('product.public.category'):{param_name}>"
 
 
-def _get_category_routes(suffix=''):
+def _get_category_routes(suffix=""):
     """Build all category routes with a parent category depth from 0 to 4 (i.e. in addition to the
     current category, we support up to 4 nested parent categories in the route).
 
@@ -117,8 +117,8 @@ def _get_category_routes(suffix=''):
     """
     return [
         (
-            f'{SHOP_PATH}/category{_get_parent_category_route(depth)}'
-            f'/<model("product.public.category"):category>{suffix}'
+            f"{SHOP_PATH}/category{_get_parent_category_route(depth)}"
+            f"/<model('product.public.category'):category>{suffix}"
         )
         for depth in range(5)
     ]
@@ -292,7 +292,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if not request.website.has_ecommerce_access():
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
 
-        post = {k: v for k, v in post.items() if not k.startswith('_')}
+        post = {k: v for k, v in post.items() if not k.startswith("_")}
         is_category_in_query = category and isinstance(category, str)
         category = self._validate_and_get_category(category)
         # TODO: remove support for `category` param in version 20 (or later).
@@ -598,16 +598,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     @route(
         [
-            f'{SHOP_PATH}/product/<model("product.template"):product>',
-            f'{SHOP_PATH}/<model("product.template"):product>',
-            f'{SHOP_PATH}/<model("product.public.category"):category>/<model("product.template"):product>',
+            f"{SHOP_PATH}/product/<model('product.template'):product>",
+            f"{SHOP_PATH}/<model('product.template'):product>",
+            f"{SHOP_PATH}/<model('product.public.category'):category>/<model('product.template'):product>",
         ],
         type="http",
         auth="public",
         website=True,
         sitemap=sitemap_products,
         # Return a 404 instead of a 403 error in case of an access error.
-        handle_params_access_error=lambda e, **kwargs: NotFound.code,
+        handle_params_access_error=lambda e, **_kwargs: NotFound.code,  # noqa: ARG005
     )
     def product(self, product, pricelist=None, **kwargs):
         if not request.website.has_ecommerce_access():
@@ -637,8 +637,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
             self._prepare_product_values(
                 # request context must be given to ensure context updates in overrides are correctly
                 # forwarded to `_get_combination_info` call
-                product.with_context(request.env.context), **kwargs,
-            )
+                product.with_context(request.env.context),
+                **kwargs,
+            ),
         )
 
     @route(
@@ -917,9 +918,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return {
             "attribute_value_images": attribute_value_images,
-            "categories": request.env["product.public.category"].search(
-                [("parent_id", "=", False)]
-            ),
+            "categories": request.env["product.public.category"].search([
+                ("parent_id", "=", False)
+            ]),
             "category": category,
             'original_category': original_category,
             "combination_info": combination_info,
@@ -947,12 +948,15 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             "@context": "https://schema.org",
             "@type": "BreadcrumbList",
-            "itemListElement": [{
-                "@type": "ListItem",
-                "position": i,
-                "name": cat.name,
-                "item": f"{base_url}{cat.website_url}",
-            } for i, cat in enumerate(category.parents_and_self, start=1)],
+            "itemListElement": [
+                {
+                    "@type": "ListItem",
+                    "position": i,
+                    "name": cat.name,
+                    "item": f"{base_url}{cat.website_url}",
+                }
+                for i, cat in enumerate(category.parents_and_self, start=1)
+            ],
         }
 
     @route(

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from datetime import datetime
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from werkzeug import urls
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.urls import url_decode, url_encode, url_parse
 
@@ -31,36 +30,6 @@ from odoo.addons.website_sale.models.website import (
 )
 
 _lt = LazyTranslate(__name__)
-
-
-def handle_product_params_error(_exc, product, category=None, **_kwargs):
-    """Handle access and missing errors related to product or category on the eCommerce.
-
-    This function is intended to prevent access-related exceptions when a user attempts to view a
-    product or category page. It checks if the provided product and category records still exist and
-    are accessible, and then attempts to redirect to a valid fallback route if possible. If no valid
-    route is found, it returns a 404 response code (instead of a 403).
-
-    :param odoo.exceptions.AccessError | odoo.exceptions.MissingError exc: The exception thrown
-            by _check_access `base.models.ir_http._pre_dispatch`.
-    :param product.template product: The product the user is trying to access.
-    :param product.public.category category: The category the user is trying to access, if any.
-    :param dict kwargs: Optional data. This parameter is not used here.
-    :return: A redirect response to a valid shop or product page, or a 404 error code if no valid
-             fallback is found.
-    :rtype: int | Response
-    """
-    product = product.exists()
-    if category:
-        category = category.exists()
-
-    if category and not (product and product.has_access("read")):
-        return request.redirect(WebsiteSale._get_shop_path(category))
-
-    if not category and product and product.has_access("read"):
-        return request.redirect(product._get_product_url())
-
-    return NotFound.code  # 404
 
 
 class TableCompute:
@@ -212,7 +181,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         dom = sitemap_qs2dom(qs, SHOP_PATH, ProductTemplate._rec_name)
         dom &= Domain(website.sale_product_domain())
         for product in ProductTemplate.with_context(prefetch_fields=False).search(dom):
-            loc = f"{SHOP_PATH}/{env['ir.http']._slug(product)}"
+            loc = f'{SHOP_PATH}/product/{env["ir.http"]._slug(product)}'
             if not qs or qs.lower() in loc:
                 yield {"loc": loc}
 
@@ -301,14 +270,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         is_category_in_query = category and isinstance(category, str)
         category = self._validate_and_get_category(category)
-        # If the category is provided as a query parameter (which is deprecated), we redirect to the
-        # "correct" shop URL, where the category has been removed from the query parameters and
-        # added to the path.
+        # TODO: remove support for `category` param in version 20 (or later).
         if is_category_in_query:
-            query = self._get_filtered_query_string(
-                request.httprequest.query_string.decode(), keys_to_remove=["category"]
+            query = request.httprequest.args.to_dict(flat=False)
+            query.pop("category", None)
+            url = urlparse(self._get_shop_path(category, page))
+            return request.redirect(
+                url._replace(query=urlencode(query, doseq=True)).geturl(), code=301
             )
-            return request.redirect(f"{self._get_shop_path(category, page)}?{query}", code=301)
 
         try:
             min_price = float(min_price)
@@ -561,7 +530,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "product_query_params": product_query_params,
             "grouped_attributes_values": grouped_attributes_values,
             "previewed_attribute_values": lazy(
-                lambda: products._get_previewed_attribute_values(category, product_query_params)
+                lambda: products._get_previewed_attribute_values(product_query_params)
             ),
             "pavs_per_attribute": pavs_per_attribute,
         }
@@ -586,6 +555,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     @route(
         [
+            f'{SHOP_PATH}/product/<model("product.template"):product>',
             f'{SHOP_PATH}/<model("product.template"):product>',
             f'{SHOP_PATH}/<model("product.public.category"):category>/<model("product.template"):product>',
         ],
@@ -593,9 +563,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
         auth="public",
         website=True,
         sitemap=sitemap_products,
-        handle_params_access_error=handle_product_params_error,
+        # Return a 404 instead of a 403 error in case of an access error.
+        handle_params_access_error=lambda e, **kwargs: NotFound.code,
     )
-    def product(self, product, category=None, pricelist=None, **kwargs):
+    def product(self, product, pricelist=None, **kwargs):
         if not request.website.has_ecommerce_access():
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
 
@@ -609,34 +580,22 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     )
                 ) from ve
             if not self._apply_selectable_pricelist(pricelist_id):
-                return request.redirect(self._get_shop_path(category))
+                return request.redirect(self._get_shop_path())
 
         request.update_context(website_sale_product_page=True)
-        is_category_in_query = category and isinstance(category, str)
-        category = self._validate_and_get_category(category)
-        query = self._get_filtered_query_string(
-            request.httprequest.query_string.decode(), keys_to_remove=["category"]
-        )
-        # If the product doesn't belong to the category, we redirect to the canonical product URL,
-        # which doesn't include the category.
-        if category and not product.filtered_domain([
-            ("public_categ_ids", "child_of", category.id)
-        ]):
-            return request.redirect(f"{product._get_product_url()}?{query}", code=301)
-        # If the category is provided as a query parameter (which is deprecated), we redirect to the
-        # "correct" shop URL, where the category has been removed from the query parameters and
-        # added to the path.
-        if is_category_in_query:
-            return request.redirect(f"{product._get_product_url(category)}?{query}", code=301)
+        # TODO: remove support for `category` param and path in version 20 (or later).
+        if not request.httprequest.path.startswith(f"{SHOP_PATH}/product/"):
+            query = request.httprequest.args.to_dict(flat=False)
+            query.pop("category", None)
+            return request.redirect(product._get_product_url(query), code=301)
+
         return request.render(
             "website_sale.product",
             self._prepare_product_values(
                 # request context must be given to ensure context updates in overrides are correctly
                 # forwarded to `_get_combination_info` call
-                product.with_context(request.env.context),
-                category,
-                **kwargs,
-            ),
+                product.with_context(request.env.context), **kwargs,
+            )
         )
 
     @route(
@@ -665,24 +624,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             ._get_stream_from(document.ir_attachment_id)
             .get_response(as_attachment=True)
         )
-
-    @route(
-        [f'{SHOP_PATH}/product/<model("product.template"):product>'],
-        type="http",
-        auth="public",
-        website=True,
-        sitemap=False,
-    )
-    def old_product(self, product, category="", **_kwargs):
-        # Compatibility pre-v14
-        # Redirect to the "correct" product URL, which doesn't include `/product`, and where the
-        # category has been removed from the query parameters and added to the path.
-        category = int(category) if str(category).isdigit() else False
-        category = self._validate_and_get_category(category)
-        query = self._get_filtered_query_string(
-            request.httprequest.query_string.decode(), keys_to_remove=["category"]
-        )
-        return request.redirect(f"{product._get_product_url(category)}?{query}", code=301)
 
     @route(["/shop/product/extra-media"], type="jsonrpc", auth="user", website=True)
     def add_product_media(
@@ -879,15 +820,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # In sudo mode to check fields and conditions not accessible to the customer directly.
         return product.sudo()._is_add_to_cart_allowed()
 
-    def _prepare_product_values(self, product, category, **kwargs):
+    def _prepare_product_values(self, product, **kwargs):
         website = request.website
-        ProductCategory = request.env["product.public.category"]
-        original_category = category
-        category = category or product.public_categ_ids[:1]
         markup_data = [
             website._prepare_ecommerce_store_markup_data(),
             product._to_markup_data(website),
         ]
+        category = product.public_categ_ids[:1]
         if category:
             # Add breadcrumb's SEO data.
             markup_data.append(
@@ -895,12 +834,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
             )
 
         if last_attributes_search := request.session.get("attribute_values", []):
-            keep = QueryURL(
-                self._get_shop_path(original_category),
-                attribute_values=last_attributes_search
-            )
+            keep = QueryURL(self._get_shop_path(), attribute_values=last_attributes_search)
         else:
-            keep = QueryURL(self._get_shop_path(original_category))
+            keep = QueryURL(self._get_shop_path())
 
         if attribute_values := kwargs.get("attribute_values", ""):
             attribute_value_ids = {int(i) for i in attribute_values.split(",")}
@@ -932,7 +868,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return {
             "attribute_value_images": attribute_value_images,
-            "categories": ProductCategory.search([("parent_id", "=", False)]),
+            "categories": request.env["product.public.category"].search(
+                [("parent_id", "=", False)]
+            ),
             "category": category,
             'original_category': original_category,
             "combination_info": combination_info,
@@ -2151,23 +2089,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if page:
             path += f"/page/{page}"
         return path
-
-    @staticmethod
-    def _get_filtered_query_string(query_string, keys_to_remove):
-        """Return a filtered copy of the provided query string, where all keys in `keys_to_remove`
-        are removed.
-
-        Note: the query string shouldn't include the leading '?'.
-
-        :param str query_string: The query string to filter.
-        :param list(str) keys_to_remove: The keys to remove from the query string.
-        :return: The filtered query string.
-        :rtype: str
-        """
-        query = urls.url_parse(f"?{query_string}").decode_query()
-        for key in keys_to_remove:
-            query.pop(key, False)
-        return urls.url_encode(query)
 
     @staticmethod
     def _get_attribute_value_dict(attribute_values):

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -293,16 +293,17 @@ class WebsiteSale(payment_portal.PaymentPortal):
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
 
         post = {k: v for k, v in post.items() if not k.startswith("_")}
-        is_category_in_query = category and isinstance(category, str)
+        # TODO: remove support for `category` query param in version 20 (or later).
         category = self._validate_and_get_category(category)
-        # TODO: remove support for `category` param in version 20 (or later).
-        if is_category_in_query and category:
-            query = request.httprequest.args.to_dict(flat=False)
-            query.pop("category", None)
-            url = urlparse(category.website_url + (f"/page/{page}" if page else ""))
-            return request.redirect(
-                url._replace(query=urlencode(query, doseq=True)).geturl(), code=301
-            )
+        if category:
+            path = category.website_url + (f"/page/{page}" if page else "")
+            # Redirect to the correct category URL if needed. There are 2 potential reasons for
+            # redirecting:
+            # - The category was given as a query parameter instead of in the path,
+            # - The category's parents (if any) weren't included in the path.
+            if path != request.httprequest.path:
+                url = urlparse(request.httprequest.url)
+                return request.redirect(url._replace(path=path).geturl(), code=301)
 
         try:
             min_price = float(min_price)
@@ -321,24 +322,30 @@ class WebsiteSale(payment_portal.PaymentPortal):
         gap = website.shop_gap or "16px"
 
         attribute_value_params = self._get_attribute_value_params(post)
-        if not attribute_value_params:
-            # TODO: remove support for `attribute_values` query param in version 20 (or later).
-            attribute_values = request.httprequest.args.getlist("attribute_values")
+        # TODO: remove support for `attribute_values` query param in version 20 (or later).
+        if not attribute_value_params and (
+            attribute_values := request.httprequest.args.getlist("attribute_values")
+        ):
             # Transform the attribute value query params list into a dict.
-            # Before:
-            #     `["1-2,3", "4-5,6"]`
-            # After:
-            #     `{"1": "2,3", "4": "5,6"}`
+            # Before: ["1-2,3", "4-5,6"]
+            # After: {"1": "2,3", "4": "5,6"}
             attribute_value_params = dict([
                 pair.split("-") for pair in attribute_values if pair and pair.count("-") == 1
             ])
-            if attribute_values:
-                # By default, `post` will only contain the first `attribute_values` query param, but
-                # there could be multiple.
-                post["attribute_values"] = attribute_values
         attribute_value_dict = self._get_attribute_value_dict(attribute_value_params)
         attribute_ids = set(attribute_value_dict.keys())
         attribute_value_ids = set(itertools.chain.from_iterable(attribute_value_dict.values()))
+        grouped_attributes_values = (
+            request
+            .env["product.attribute.value"]
+            .browse(attribute_value_ids)
+            .exists()
+            .sorted()
+            .grouped("attribute_id")
+        )
+        if request.httprequest.args.getlist("attribute_values"):
+            redirect_url = self._get_url_with_attribute_values(grouped_attributes_values)
+            return request.redirect(redirect_url, code=301)
         if attribute_value_params:
             request.session["attribute_value_params"] = attribute_value_params
         else:
@@ -348,11 +355,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if filter_by_tags_enabled:
             if tags:
                 post["tags"] = tags
-                tags = {
-                    tag_id
-                    for tag in tags.split(",")
-                    if (tag_id := self.env["ir.http"]._unslug(tag)[1])
-                }
+                unslug = self.env["ir.http"]._unslug
+                tags = {tag_id for tag in tags.split(",") if (tag_id := unslug(tag)[1])}
             else:
                 post["tags"] = None
                 tags = {}
@@ -533,15 +537,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         products_prices = products._get_sales_prices(website)
         product_query_params = self._get_product_query_params(**post)
 
-        grouped_attributes_values = (
-            request
-            .env["product.attribute.value"]
-            .browse(attribute_value_ids)
-            .exists()
-            .sorted()
-            .grouped("attribute_id")
-        )
-
         values = {
             "auto_assign_ribbons": self
             .env["product.ribbon"]
@@ -626,21 +621,20 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 return request.redirect(SHOP_PATH)
 
         request.update_context(website_sale_product_page=True)
-        # TODO: remove support for `category` param and path in version 20 (or later).
+        # TODO: remove support for deprecated paths in version 20 (or later).
         if not request.httprequest.path.startswith(f"{SHOP_PATH}/product/"):
             query = request.httprequest.args.to_dict(flat=False)
-            query.pop("category", None)
             return request.redirect(product._get_product_url(query), code=301)
 
-        return request.render(
-            "website_sale.product",
-            self._prepare_product_values(
-                # request context must be given to ensure context updates in overrides are correctly
-                # forwarded to `_get_combination_info` call
-                product.with_context(request.env.context),
-                **kwargs,
-            ),
+        product_values = self._prepare_product_values(
+            # request context must be given to ensure context updates in overrides are correctly
+            # forwarded to `_get_combination_info` call
+            product.with_context(request.env.context),
+            **kwargs,
         )
+        if "redirect_url" in product_values:
+            return request.redirect(product_values["redirect_url"], code=301)
+        return request.render("website_sale.product", product_values)
 
     @route(
         '/shop/<model("product.template"):product_template>/document/<int:document_id>',
@@ -866,11 +860,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     def _prepare_product_values(self, product, **kwargs):
         website = request.website
+        category = product.public_categ_ids.filtered(
+            lambda categ: categ.can_access_from_current_website()
+        )[:1]
         markup_data = [
             website._prepare_ecommerce_store_markup_data(),
             product._to_markup_data(website),
         ]
-        category = product.public_categ_ids[:1]
         if category:
             # Add breadcrumb's SEO data.
             markup_data.append(
@@ -881,14 +877,22 @@ class WebsiteSale(payment_portal.PaymentPortal):
         attribute_value_params = self._get_attribute_value_params(kwargs)
         attribute_value_dict = self._get_attribute_value_dict(attribute_value_params)
         attribute_value_ids = set(itertools.chain.from_iterable(attribute_value_dict.values()))
-        if not attribute_value_ids:
-            # TODO: remove support for `attribute_values` query param in version 20 (or later).
-            attribute_values = kwargs.get("attribute_values", "")
+        # TODO: remove support for `attribute_values` query param in version 20 (or later).
+        if not attribute_value_ids and (attribute_values := kwargs.get("attribute_values")):
             attribute_value_ids = {
                 int(value_id)
                 for value_id in attribute_values.split(",")
                 if value_id and value_id.isdigit()
             }
+            grouped_attributes_values = (
+                request
+                .env["product.attribute.value"]
+                .browse(attribute_value_ids)
+                .exists()
+                .sorted()
+                .grouped("attribute_id")
+            )
+            return {"redirect_url": self._get_url_with_attribute_values(grouped_attributes_values)}
         if attribute_value_ids:
             combination = product.attribute_line_ids.mapped(
                 lambda ptal: (
@@ -922,7 +926,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 ("parent_id", "=", False)
             ]),
             "category": category,
-            'original_category': original_category,
             "combination_info": combination_info,
             "keep": keep,
             "main_object": product,
@@ -2180,3 +2183,15 @@ class WebsiteSale(payment_portal.PaymentPortal):
             for attr_id, attr_value_ids in filtered_attribute_value_dict.items()
             if attr_value_ids
         }
+
+    def _get_url_with_attribute_values(self, grouped_attributes_values):
+        """Return the current request's URL, but replace the attribute value query params with
+        `grouped_attributes_values` (formatted as query params).
+        """
+        query = request.httprequest.args.to_dict(flat=False)
+        query.pop("attribute_values", None)
+        slug = self.env["ir.http"]._slug
+        for pa, pavs in grouped_attributes_values.items():
+            query[slug(pa)] = ",".join([slug(pav) for pav in pavs])
+        url = urlparse(request.httprequest.url)
+        return url._replace(query=urlencode(query, doseq=True)).geturl()

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -99,6 +99,31 @@ class TableCompute:
         return rows
 
 
+def _get_parent_category_route(depth, param_name='_'):
+    """Recursively build the parent category part of the route."""
+    if depth < 1:
+        return ''
+    parent_path = _get_parent_category_route(depth - 1, param_name + '_')
+    return f'{parent_path}/<model("product.public.category"):{param_name}>'
+
+
+def _get_category_routes(suffix=''):
+    """Build all category routes with a parent category depth from 0 to 4 (i.e. in addition to the
+    current category, we support up to 4 nested parent categories in the route).
+
+    Depths greater than 4 are not supported to avoid having too long URLs.
+
+    The max depth should stay in sync with `ProductPublicCategory._compute_website_url`.
+    """
+    return [
+        (
+            f'{SHOP_PATH}/category{_get_parent_category_route(depth)}'
+            f'/<model("product.public.category"):category>{suffix}'
+        )
+        for depth in range(5)
+    ]
+
+
 class WebsiteSale(payment_portal.PaymentPortal):
     _express_checkout_route = "/shop/express_checkout"
     _express_checkout_delivery_route = "/shop/express/shipping_address_change"
@@ -166,7 +191,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         dom = sitemap_qs2dom(qs, f"{SHOP_PATH}/category", Category._rec_name)
         dom &= website.website_domain()
         for cat in Category.search(dom):
-            loc = f"{SHOP_PATH}/category/{env['ir.http']._slug(cat)}"
+            loc = cat.website_url
             if not qs or qs.lower() in loc:
                 yield {"loc": loc}
 
@@ -181,7 +206,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         dom = sitemap_qs2dom(qs, SHOP_PATH, ProductTemplate._rec_name)
         dom &= Domain(website.sale_product_domain())
         for product in ProductTemplate.with_context(prefetch_fields=False).search(dom):
-            loc = f'{SHOP_PATH}/product/{env["ir.http"]._slug(product)}'
+            loc = product.website_url
             if not qs or qs.lower() in loc:
                 yield {"loc": loc}
 
@@ -252,28 +277,29 @@ class WebsiteSale(payment_portal.PaymentPortal):
         [
             SHOP_PATH,
             f"{SHOP_PATH}/page/<int:page>",
-            f'{SHOP_PATH}/category/<model("product.public.category"):category>',
-            f'{SHOP_PATH}/category/<model("product.public.category"):category>/page/<int:page>',
+            *_get_category_routes(),
+            *_get_category_routes("/page/<int:page>"),
         ],
         type="http",
         auth="public",
         website=True,
         list_as_website_content=_lt("Shop"),
         sitemap=sitemap_shop,
-        # Sends a 404 error in case of any Access error instead of 403.
+        # Return a 404 instead of a 403 error in case of an access error.
         handle_params_access_error=lambda e, **_kwargs: NotFound.code,  # noqa: ARG005
     )
     def shop(self, page=0, category=None, search="", min_price=0.0, max_price=0.0, tags="", **post):
         if not request.website.has_ecommerce_access():
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
 
+        post = {k: v for k, v in post.items() if not k.startswith('_')}
         is_category_in_query = category and isinstance(category, str)
         category = self._validate_and_get_category(category)
         # TODO: remove support for `category` param in version 20 (or later).
-        if is_category_in_query:
+        if is_category_in_query and category:
             query = request.httprequest.args.to_dict(flat=False)
             query.pop("category", None)
-            url = urlparse(self._get_shop_path(category, page))
+            url = urlparse(category.website_url + (f"/page/{page}" if page else ""))
             return request.redirect(
                 url._replace(query=urlencode(query, doseq=True)).geturl(), code=301
             )
@@ -331,7 +357,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 post["tags"] = None
                 tags = {}
 
-        url = self._get_shop_path(category)
+        url = category.website_url if category else SHOP_PATH
         keep = QueryURL(
             url, **self._shop_get_query_url_kwargs(search, min_price, max_price, **post)
         )
@@ -597,7 +623,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     )
                 ) from ve
             if not self._apply_selectable_pricelist(pricelist_id):
-                return request.redirect(self._get_shop_path())
+                return request.redirect(SHOP_PATH)
 
         request.update_context(website_sale_product_page=True)
         # TODO: remove support for `category` param and path in version 20 (or later).
@@ -628,12 +654,12 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         document = request.env["product.document"].browse(document_id).sudo().exists()
         if not document or not document.active:
-            return request.redirect(self._get_shop_path())
+            return request.redirect(SHOP_PATH)
 
         if not document.shown_on_product_page or not (
             document.res_id == product_template.id and document.res_model == "product.template"
         ):
-            return request.redirect(self._get_shop_path())
+            return request.redirect(SHOP_PATH)
 
         return (
             request
@@ -849,7 +875,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             markup_data.append(
                 self._prepare_breadcrumb_markup_data(website.get_base_url(), category)
             )
-        keep = QueryURL(self._get_shop_path(), **request.session.get("attribute_value_params", {}))
+        keep = QueryURL(SHOP_PATH, **request.session.get("attribute_value_params", {}))
 
         attribute_value_params = self._get_attribute_value_params(kwargs)
         attribute_value_dict = self._get_attribute_value_dict(attribute_value_params)
@@ -921,15 +947,12 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             "@context": "https://schema.org",
             "@type": "BreadcrumbList",
-            "itemListElement": [
-                {
-                    "@type": "ListItem",
-                    "position": i,
-                    "name": cat.name,
-                    "item": f"{base_url}{self._get_shop_path(cat)}",
-                }
-                for i, cat in enumerate(category.parents_and_self, start=1)
-            ],
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": i,
+                "name": cat.name,
+                "item": f"{base_url}{cat.website_url}",
+            } for i, cat in enumerate(category.parents_and_self, start=1)],
         }
 
     @route(
@@ -983,7 +1006,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     pass
             redirect_url = decoded_url.replace(query=url_encode(args)).to_url()
 
-        return request.redirect(redirect_url or self._get_shop_path())
+        return request.redirect(redirect_url or SHOP_PATH)
 
     @route("/shop/pricelist", type="http", auth="public", website=True, sitemap=False)
     def pricelist(self, promo, **post):
@@ -1702,7 +1725,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             assert order_sudo.id == request.session.get("sale_last_order_id")
 
         if not order_sudo:
-            return request.redirect(self._get_shop_path())
+            return request.redirect(SHOP_PATH)
 
         errors = self._get_shop_payment_errors(order_sudo) if order_sudo.state != "sale" else []
         if errors:
@@ -1712,7 +1735,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         tx_sudo = order_sudo.get_portal_last_transaction()
         if order_sudo.amount_total and not tx_sudo:
-            return request.redirect(self._get_shop_path())
+            return request.redirect(SHOP_PATH)
 
         if not order_sudo.amount_total and not tx_sudo and order_sudo.state != "sale":
             order_sudo._check_cart_is_ready_to_be_paid()
@@ -1722,7 +1745,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # clean context and session, then redirect to the confirmation page
         request.website.sale_reset()
         if tx_sudo and tx_sudo.state == "draft":
-            return request.redirect(self._get_shop_path())
+            return request.redirect(SHOP_PATH)
 
         return request.redirect("/shop/confirmation")
 
@@ -1746,7 +1769,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             order = request.env["sale.order"].sudo().browse(sale_order_id)
             values = self._prepare_shop_payment_confirmation_values(order)
             return request.render("website_sale.confirmation", values)
-        return request.redirect(self._get_shop_path())
+        return request.redirect(SHOP_PATH)
 
     def _prepare_shop_payment_confirmation_values(self, order):
         """Prepare the dict containing the values to be rendered by the confirmation template.
@@ -1802,7 +1825,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 ("Content-Disposition", content_disposition(filename, "inline")),
             ]
             return request.make_response(pdf, headers=pdfhttpheaders)
-        return request.redirect(self._get_shop_path())
+        return request.redirect(SHOP_PATH)
 
     @route(["/shop/print/invoice"], type="http", auth="public", website=True, sitemap=False)
     def print_invoice(self, **_kwargs):
@@ -1824,7 +1847,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     ("Content-Disposition", content_disposition(filename, "inline")),
                 ]
                 return request.make_response(pdf, headers=pdfhttpheaders)
-        return request.redirect(self._get_shop_path())
+        return request.redirect(SHOP_PATH)
 
     # === CHECK METHODS === #
 
@@ -1858,7 +1881,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if not order_sudo or order_sudo.state != "draft":
             request.session["sale_order_id"] = None
             request.session["sale_transaction_id"] = None
-            return request.redirect(self._get_shop_path())
+            return request.redirect(SHOP_PATH)
 
         # Check that the cart is not empty.
         if not order_sudo.order_line:
@@ -2097,16 +2120,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ) and category.can_access_from_current_website():
             return category
         return ProductCategory
-
-    @staticmethod
-    def _get_shop_path(category=None, page=0):
-        path = SHOP_PATH
-        if category:
-            slug = request.env["ir.http"]._slug
-            path += f"/category/{slug(category)}"
-        if page:
-            path += f"/page/{page}"
-        return path
 
     def _get_attribute_value_params(self, query_params):
         """Extract the attribute value query params from a dict of more general query params.

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -225,14 +225,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def _shop_get_query_url_kwargs(
         self, search, min_price, max_price, order=None, tags=None, **_kwargs
     ):
-        attribute_values = request.session.get("attribute_values", [])
         return {
             "search": search,
             "min_price": min_price,
             "max_price": max_price,
             "order": order,
             "tags": tags,
-            "attribute_values": attribute_values,
+            **request.session.get("attribute_value_params", {}),
         }
 
     def _get_additional_shop_values(self, _values, **_kwargs):
@@ -295,22 +294,39 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ppr = website.shop_ppr or 4
         gap = website.shop_gap or "16px"
 
-        request_args = request.httprequest.args
-        attribute_values = request_args.getlist("attribute_values")
-        attribute_value_dict = self._get_attribute_value_dict(attribute_values)
+        attribute_value_params = self._get_attribute_value_params(post)
+        if not attribute_value_params:
+            # TODO: remove support for `attribute_values` query param in version 20 (or later).
+            attribute_values = request.httprequest.args.getlist("attribute_values")
+            # Transform the attribute value query params list into a dict.
+            # Before:
+            #     `["1-2,3", "4-5,6"]`
+            # After:
+            #     `{"1": "2,3", "4": "5,6"}`
+            attribute_value_params = dict([
+                pair.split("-") for pair in attribute_values if pair and pair.count("-") == 1
+            ])
+            if attribute_values:
+                # By default, `post` will only contain the first `attribute_values` query param, but
+                # there could be multiple.
+                post["attribute_values"] = attribute_values
+        attribute_value_dict = self._get_attribute_value_dict(attribute_value_params)
         attribute_ids = set(attribute_value_dict.keys())
         attribute_value_ids = set(itertools.chain.from_iterable(attribute_value_dict.values()))
-        if attribute_values:
-            request.session["attribute_values"] = attribute_values
-            post["attribute_values"] = attribute_values
+        if attribute_value_params:
+            request.session["attribute_value_params"] = attribute_value_params
         else:
-            request.session.pop("attribute_values", None)
+            request.session.pop("attribute_value_params", None)
 
         filter_by_tags_enabled = website.is_view_active("website_sale.filter_products_tags")
         if filter_by_tags_enabled:
             if tags:
                 post["tags"] = tags
-                tags = {self.env["ir.http"]._unslug(tag)[1] for tag in tags.split(",")}
+                tags = {
+                    tag_id
+                    for tag in tags.split(",")
+                    if (tag_id := self.env["ir.http"]._unslug(tag)[1])
+                }
             else:
                 post["tags"] = None
                 tags = {}
@@ -487,7 +503,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             # Return attributes as recordset of `product.attribute`
             attributes = ProductAttribute.union(pavs_per_attribute.keys())
         else:
-            attributes = ProductAttribute.browse(attribute_ids).sorted()
+            attributes = ProductAttribute.browse(attribute_ids).exists().sorted()
         products_prices = products._get_sales_prices(website)
         product_query_params = self._get_product_query_params(**post)
 
@@ -495,6 +511,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             request
             .env["product.attribute.value"]
             .browse(attribute_value_ids)
+            .exists()
             .sorted()
             .grouped("attribute_id")
         )
@@ -832,14 +849,20 @@ class WebsiteSale(payment_portal.PaymentPortal):
             markup_data.append(
                 self._prepare_breadcrumb_markup_data(website.get_base_url(), category)
             )
+        keep = QueryURL(self._get_shop_path(), **request.session.get("attribute_value_params", {}))
 
-        if last_attributes_search := request.session.get("attribute_values", []):
-            keep = QueryURL(self._get_shop_path(), attribute_values=last_attributes_search)
-        else:
-            keep = QueryURL(self._get_shop_path())
-
-        if attribute_values := kwargs.get("attribute_values", ""):
-            attribute_value_ids = {int(i) for i in attribute_values.split(",")}
+        attribute_value_params = self._get_attribute_value_params(kwargs)
+        attribute_value_dict = self._get_attribute_value_dict(attribute_value_params)
+        attribute_value_ids = set(itertools.chain.from_iterable(attribute_value_dict.values()))
+        if not attribute_value_ids:
+            # TODO: remove support for `attribute_values` query param in version 20 (or later).
+            attribute_values = kwargs.get("attribute_values", "")
+            attribute_value_ids = {
+                int(value_id)
+                for value_id in attribute_values.split(",")
+                if value_id and value_id.isdigit()
+            }
+        if attribute_value_ids:
             combination = product.attribute_line_ids.mapped(
                 lambda ptal: (
                     (
@@ -2059,21 +2082,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
         """Validate and return the `product.public.category` record corresponding to the provided
         category, which can be a record, a record id, or a slug.
 
-        - If no category is provided, return an empty recordset.
-        - If a category is provided, but it doesn't exist or can't be accessed, raise a 404.
-        - If a valid category is provided, return the corresponding record.
+        If the provided category is invalid, non-existing, or inaccessible, return an empty
+        recordset. Otherwise, return the corresponding record.
 
         :param str|product.public.category category: The category to validate and return.
-        :return: The validated category.
+        :return: The validated category, or an empty recordset.
         :rtype: product.public.category
         """
         ProductCategory = request.env["product.public.category"]
-        if (
-            not isinstance(category, ProductCategory.__class__)
-            and category
-            and not str(category).isdigit()
-        ):
-            raise ValidationError(_("Invalid category."))
+        if category and isinstance(category, str) and not category.isdigit():
+            return ProductCategory
         if (
             category := ProductCategory.browse(category and int(category)).exists()
         ) and category.can_access_from_current_website():
@@ -2090,17 +2108,58 @@ class WebsiteSale(payment_portal.PaymentPortal):
             path += f"/page/{page}"
         return path
 
-    @staticmethod
-    def _get_attribute_value_dict(attribute_values):
-        """Parse a list of attribute value query params, and returns a dict grouping attribute
-        value ids by attribute id.
+    def _get_attribute_value_params(self, query_params):
+        """Extract the attribute value query params from a dict of more general query params.
 
-        :param list(str) attribute_values: The list of attribute value query parameters to parse.
-        :return: A dict grouping attribute value ids by attribute id.
+        Attribute value query params are expected to have the following format:
+        `attribute-name-1=attribute-value-name-2,attribute-value-name-3`
+
+        :param dict(str, str) query_params: The more general query params from which to extract the
+            attribute value query params.
+        :return: A dict of attribute value query params.
+        :rtype: dict(str, str)
+        """
+        unslug = self.env["ir.http"]._unslug
+        # Only keep the query params whose key can be unslugged (meaning that the key is an
+        # attribute slug).
+        return {
+            attr: attr_values
+            for attr, attr_values in query_params.items()
+            if unslug(attr)[1] and attr_values
+        }
+
+    def _get_attribute_value_dict(self, attribute_value_params):
+        """Return a dict mapping attribute IDs to lists of attribute value IDs, from a dict of
+        attribute value query params.
+
+        Attribute value query params are expected to have the following format:
+        `attribute-name-1=attribute-value-name-2,attribute-value-name-3`
+
+        This method will ignore any invalid attributes and attribute values (we don't want to raise
+        errors for invalid query params). Moreover, it will only consider the first occurrence of a
+        given attribute (other occurrences are ignored).
+
+        :param dict(str, str) attribute_value_params: The attribute value query params from which to
+            compute the mapping.
+        :return: A dict mapping attribute IDs to lists of attribute value IDs.
         :rtype: dict(int, list(int))
         """
-        attribute_value_pairs = [value.split("-") for value in attribute_values if value]
+        unslug = self.env["ir.http"]._unslug
+        # For each attribute value query param, unslug its key (attribute) and value (attribute
+        # values).
+        attribute_value_dict = {
+            unslug(attr)[1]: [unslug(attr_value)[1] for attr_value in attr_values.split(",")]
+            for attr, attr_values in attribute_value_params.items()
+        }
+        # Only keep the attributes and attribute values that were correctly unslugged.
+        filtered_attribute_value_dict = {
+            attr_id: [attr_value_id for attr_value_id in attr_value_ids if attr_value_id]
+            for attr_id, attr_value_ids in attribute_value_dict.items()
+            if attr_id
+        }
+        # Only keep attributes that have at least one attribute value.
         return {
-            int(pair[0]): [int(value_id) for value_id in pair[1].split(",")]
-            for pair in attribute_value_pairs
+            attr_id: attr_value_ids
+            for attr_id, attr_value_ids in filtered_attribute_value_dict.items()
+            if attr_value_ids
         }

--- a/addons/website_sale/models/ir_http.py
+++ b/addons/website_sale/models/ir_http.py
@@ -33,4 +33,4 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _slug(cls, value: models.BaseModel | tuple[int, str]) -> str:
-        return super()._slug(value.with_context(show_attribute=False))
+        return super()._slug(value.with_context(show_attribute=False, show_parent_categories=False))

--- a/addons/website_sale/models/ir_http.py
+++ b/addons/website_sale/models/ir_http.py
@@ -33,4 +33,8 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _slug(cls, value: models.BaseModel | tuple[int, str]) -> str:
-        return super()._slug(value.with_context(show_attribute=False, show_parent_categories=False))
+        if isinstance(value, models.BaseModel):
+            return super()._slug(
+                value.with_context(show_attribute=False, show_parent_categories=False)
+            )
+        return super()._slug(value)

--- a/addons/website_sale/models/ir_http.py
+++ b/addons/website_sale/models/ir_http.py
@@ -30,3 +30,7 @@ class IrHttp(models.AbstractModel):
         request.cart = lazy(request.website._get_and_cache_current_cart)
         request.fiscal_position = lazy(request.website._get_and_cache_current_fiscal_position)
         request.pricelist = lazy(request.website._get_and_cache_current_pricelist)
+
+    @classmethod
+    def _slug(cls, value: models.BaseModel | tuple[int, str]) -> str:
+        return super()._slug(value.with_context(show_attribute=False))

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import OrderedDict
+from urllib.parse import urlencode, urlparse
 
 from odoo import api, fields, models
 from odoo.http import request
@@ -30,12 +31,15 @@ class ProductProduct(models.Model):
     @api.depends_context("lang")
     @api.depends("product_tmpl_id.website_url", "product_template_attribute_value_ids")
     def _compute_product_website_url(self):
+        slug = self.env["ir.http"]._slug
         for product in self:
-            url = product.product_tmpl_id.website_url
+            url = urlparse(product.product_tmpl_id.website_url)
             if pavs := product.product_template_attribute_value_ids.product_attribute_value_id:
-                pav_ids = [str(pav.id) for pav in pavs]
-                url = f"{url}?attribute_values={','.join(pav_ids)}"
-            product.website_url = url
+                # There's no need to group the PAVs by attribute since a product variant can have
+                # only one PAV per attribute.
+                query_params = {slug(pav.attribute_id): slug(pav) for pav in pavs}
+                url = url._replace(query=urlencode(query_params))
+            product.website_url = url.geturl()
 
     # === BUSINESS METHODS ===#
 

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -131,7 +131,7 @@ class ProductPublicCategory(models.Model):
         By default, parent category names are included, but they can be excluded by setting the
         `show_parent_categories` context key to `False`.
         """
-        if not self.env.context.get('show_parent_categories', True):
+        if not self.env.context.get("show_parent_categories", True):
             super()._compute_display_name()
             return
         for category in self:

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -124,7 +124,16 @@ class ProductPublicCategory(models.Model):
                 category.parents_and_self = category
 
     @api.depends("parents_and_self")
+    @api.depends_context("show_parent_categories")
     def _compute_display_name(self):
+        """Override to include the parent category names in the category's display name.
+
+        By default, parent category names are included, but they can be excluded by setting the
+        `show_parent_categories` context key to `False`.
+        """
+        if not self.env.context.get('show_parent_categories', True):
+            super()._compute_display_name()
+            return
         for category in self:
             category.display_name = " / ".join(
                 category.parents_and_self.mapped(lambda cat: cat.name or self.env._("New"))
@@ -132,11 +141,13 @@ class ProductPublicCategory(models.Model):
 
     def _compute_website_url(self):
         super()._compute_website_url()
+        slug = self.env["ir.http"]._slug
         for category in self:
             if category.id:
-                category.website_url = f"{SHOP_PATH}/category/%s" % self.env["ir.http"]._slug(
-                    category
-                )
+                # Only take the current category and its 4 closest parents to avoid having too long
+                # URLs. This number should stay in sync with the category route computation.
+                category_slugs = [slug(cat) for cat in category.parents_and_self[-5:]]
+                category.website_url = f"{SHOP_PATH}/category/%s" % "/".join(category_slugs)
 
     @api.depends_context("company", "website_id")
     def _compute_has_published_products(self):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1121,14 +1121,19 @@ class ProductTemplate(models.Model):
         url = urlparse(self.website_url)
         query_params = query_params or {}
         if grouped_attributes_values:
-            available_grouped_pavs = self.attribute_line_ids.value_ids.grouped("attribute_id")
-            pavs = [
-                next(pav for pav in pavs if pav in available_grouped_pavs[pa])
+            product_grouped_pavs = self.attribute_line_ids.value_ids.grouped("attribute_id")
+            available_grouped_pavs = {
+                pa: [pav for pav in pavs if pav in product_grouped_pavs[pa]]
                 for pa, pavs in grouped_attributes_values.items()
-                if pa in available_grouped_pavs
-            ]
+                if pa in product_grouped_pavs
+            }
+            compatible_grouped_pavs = {
+                pa: pavs if pa.display_type == "multi" else pavs[:1]
+                for pa, pavs in available_grouped_pavs.items()
+            }
             slug = self.env["ir.http"]._slug
-            query_params.update({slug(pav.attribute_id): slug(pav) for pav in pavs})
+            for pa, pavs in compatible_grouped_pavs.items():
+                query_params[slug(pa)] = ",".join([slug(pav) for pav in pavs])
         if query_params:
             url = url._replace(query=urlencode(query_params, doseq=True))
 

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -309,6 +309,7 @@ class ProductTemplate(models.Model):
         """
         res = defaultdict(dict)
         show_count = 20
+        slug = self.env['ir.http']._slug
         for template in self:
             previewed_ptal = next(
                 (
@@ -331,7 +332,7 @@ class ProductTemplate(models.Model):
                         matching_variant = min(ptav.ptav_product_variant_ids, key=lambda p: p.id)
                         variant_query_params = {
                             **(product_query_params or {}),
-                            "attribute_values": str(ptav.product_attribute_value_id.id),
+                            slug(ptav.attribute_id): slug(ptav.product_attribute_value_id),
                         }
                         previewed_ptavs_data.append({
                             "ptav": ptav,
@@ -888,15 +889,13 @@ class ProductTemplate(models.Model):
                 ("public_categ_ids", "child_of", self.env["ir.http"]._unslug(category)[1])
             ])
         if tags:
-            if isinstance(tags, str):
-                tags = tags.split(",")
-            tags = list(map(int, tags))  # Convert list of strings to list of integers
-            domains.append(
-                Domain.OR([
-                    Domain("product_tag_ids", "in", tags),
-                    Domain("product_variant_ids.additional_product_tag_ids", "in", tags),
-                ])
-            )
+            tags = {
+                tag_id for tag in tags.split(",") if (tag_id := self.env["ir.http"]._unslug(tag)[1])
+            }
+            domains.append(Domain.OR([
+                Domain("product_tag_ids", "in", tags),
+                Domain("product_variant_ids.additional_product_tag_ids", "in", tags),
+            ]))
         if min_price:
             domains.append([("list_price", ">=", min_price)])
         if max_price:
@@ -1121,15 +1120,14 @@ class ProductTemplate(models.Model):
         url = urlparse(self.website_url)
         query_params = query_params or {}
         if grouped_attributes_values:
-            product_grouped_values = self.attribute_line_ids.value_ids.grouped("attribute_id")
-            available_pav_ids = [
-                next(v.id for v in pavs if v in product_grouped_values[pa])
+            available_grouped_pavs = self.attribute_line_ids.value_ids.grouped("attribute_id")
+            pavs = [
+                next(pav for pav in pavs if pav in available_grouped_pavs[pa])
                 for pa, pavs in grouped_attributes_values.items()
-                if pa in product_grouped_values
+                if pa in available_grouped_pavs
             ]
-            available_pav_ids.sort()
-            query_params["attribute_values"] = ",".join(str(i) for i in available_pav_ids)
-
+            slug = self.env["ir.http"]._slug
+            query_params.update({slug(pav.attribute_id): slug(pav) for pav in pavs})
         if query_params:
             url = url._replace(query=urlencode(query_params, doseq=True))
 

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from collections import defaultdict
 
-from werkzeug import urls
+from collections import defaultdict
+from urllib.parse import urlencode, urlparse
 
 from odoo import _, api, fields, models
 from odoo.fields import Domain
@@ -202,7 +202,7 @@ class ProductTemplate(models.Model):
         super()._compute_website_url()
         for product in self:
             if product.id:
-                product.website_url = "/shop/%s" % self.env["ir.http"]._slug(product)
+                product.website_url = "/shop/product/%s" % self.env["ir.http"]._slug(product)
 
     @api.depends("product_variant_ids.default_code")
     def _compute_variants_default_code(self):
@@ -301,7 +301,7 @@ class ProductTemplate(models.Model):
 
         return self._get_possible_variants().sorted(_sort_key_variant)
 
-    def _get_previewed_attribute_values(self, category=None, product_query_params=None):
+    def _get_previewed_attribute_values(self, product_query_params=None):
         """Compute previewed product attribute values for each product in the recordset.
 
         :return: the previewed attribute values per product
@@ -338,9 +338,7 @@ class ProductTemplate(models.Model):
                             "variant_image_url": self.env["website"].image_url(
                                 matching_variant, "image_512"
                             ),
-                            "variant_url": template._get_product_url(
-                                category, variant_query_params
-                            ),
+                            "variant_url": template._get_product_url(variant_query_params),
                         })
 
                     res[template.id] = {
@@ -1117,12 +1115,10 @@ class ProductTemplate(models.Model):
     def _allow_publish_rating_stats(self):  # noqa: PLR6301
         return True
 
-    def _get_product_url(self, category=None, query_params=None, grouped_attributes_values=None):
+    def _get_product_url(self, query_params=None, grouped_attributes_values=None):
         self.ensure_one()
-        slug = self.env["ir.http"]._slug
 
-        url = (category and f"/shop/{slug(category)}/{slug(self)}") or self.website_url
-
+        url = urlparse(self.website_url)
         query_params = query_params or {}
         if grouped_attributes_values:
             product_grouped_values = self.attribute_line_ids.value_ids.grouped("attribute_id")
@@ -1135,9 +1131,9 @@ class ProductTemplate(models.Model):
             query_params["attribute_values"] = ",".join(str(i) for i in available_pav_ids)
 
         if query_params:
-            url = f"{url}?{urls.url_encode(query_params)}"
+            url = url._replace(query=urlencode(query_params, doseq=True))
 
-        return url
+        return url.geturl()
 
     def _can_be_added_to_comparison(self):
         self.ensure_one()

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-
 from collections import defaultdict
 from urllib.parse import urlencode, urlparse
 
@@ -309,7 +308,7 @@ class ProductTemplate(models.Model):
         """
         res = defaultdict(dict)
         show_count = 20
-        slug = self.env['ir.http']._slug
+        slug = self.env["ir.http"]._slug
         for template in self:
             previewed_ptal = next(
                 (
@@ -892,10 +891,12 @@ class ProductTemplate(models.Model):
             tags = {
                 tag_id for tag in tags.split(",") if (tag_id := self.env["ir.http"]._unslug(tag)[1])
             }
-            domains.append(Domain.OR([
-                Domain("product_tag_ids", "in", tags),
-                Domain("product_variant_ids.additional_product_tag_ids", "in", tags),
-            ]))
+            domains.append(
+                Domain.OR([
+                    Domain("product_tag_ids", "in", tags),
+                    Domain("product_variant_ids.additional_product_tag_ids", "in", tags),
+                ])
+            )
         if min_price:
             domains.append([("list_price", ">=", min_price)])
         if max_price:

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -6,8 +6,6 @@ import re
 from urllib.parse import parse_qsl, urlencode, urlsplit
 
 from lxml import etree
-from werkzeug import urls
-from werkzeug.exceptions import NotFound
 
 from odoo import SUPERUSER_ID, api, fields, models
 from odoo.exceptions import AccessError, MissingError

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -1052,27 +1052,6 @@ class Website(models.Model):
         """Return whether the current user is allowed to access eCommerce-related content."""
         return not (self.env.user._is_public() and self.ecommerce_access == "logged_in")
 
-    def _get_canonical_url(self):
-        """Override of `website` to customize the canonical URL for product pages.
-
-        A product page URL can have a category in its path. However, since the page is exactly the
-        same whether the category is present or not, the canonical URL shouldn't include the
-        category.
-        """
-        canonical_url = urls.url_parse(super()._get_canonical_url())
-
-        try:
-            rule = self.env["ir.http"]._match(canonical_url.path)[0].rule
-        except NotFound:
-            rule = None
-        if rule == (
-            '/shop/<model("product.public.category"):category>/<model("product.template"):product>'
-        ):
-            path_parts = canonical_url.path.split("/")
-            path_parts.pop(2)
-            canonical_url = canonical_url.replace(path="/".join(path_parts))
-        return canonical_url.to_url()
-
     def _get_snippet_defaults(self, snippet):
         return super()._get_snippet_defaults(snippet) | const.SNIPPET_DEFAULTS.get(snippet, {})
 

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -4,7 +4,6 @@ import { router } from '@web/core/browser/router';
 import { localization } from '@web/core/l10n/localization';
 import { _t } from '@web/core/l10n/translation';
 import { rpc } from '@web/core/network/rpc';
-import { url } from '@web/core/utils/urls';
 import { memoize, uniqueId } from '@web/core/utils/functions';
 import { KeepLast } from '@web/core/utils/concurrency';
 import { insertThousandsSep } from '@web/core/utils/numbers';
@@ -199,20 +198,26 @@ export class ProductPage extends Interaction {
      */
     _applySearchParams() {
         let params = new URLSearchParams(window.location.search);
-        let attributeValues = params.get('attribute_values')
-        if (!attributeValues) {
-            // TODO remove in 20 (or later): hash support of attribute values
-            params = new URLSearchParams(window.location.hash.substring(1));
-            attributeValues = params.get('attribute_values')
+        let attributeValueIds = Array.from(params.entries())
+            .filter(([attribute, _]) => !!wSaleUtils.unslug(attribute))
+            .map(([_, attributeValue]) => wSaleUtils.unslug(attributeValue));
+        if (!attributeValueIds) {
+            // TODO: remove support for `attribute_values` query param in version 20 (or later).
+            let attributeValues = params.get('attribute_values');
+            if (!attributeValues) {
+                params = new URLSearchParams(window.location.hash.substring(1));
+                attributeValues = params.get('attribute_values');
+            }
+            attributeValueIds = attributeValues?.split(',')?.map(parseInt) ?? [];
         }
-        if (attributeValues) {
-            const attributeValueIds = attributeValues.split(',');
+        attributeValueIds = attributeValueIds.filter(Boolean);
+        if (attributeValueIds.length) {
             const inputs = document.querySelectorAll(
                 'input.js_variant_change, select.js_variant_change option'
             );
             let combinationChanged = false;
             inputs.forEach(element => {
-                if (attributeValueIds.includes(element.dataset.attributeValueId)) {
+                if (attributeValueIds.includes(parseInt(element.dataset.attributeValueId))) {
                     if (element.tagName === 'INPUT' && !element.checked) {
                         element.checked = true;
                         combinationChanged = true;
@@ -235,14 +240,18 @@ export class ProductPage extends Interaction {
         const inputs = document.querySelectorAll(
             'input.js_variant_change:checked, select.js_variant_change option:checked'
         );
-        const attributeIds = Array.from(inputs).map(el => el.dataset.attributeValueId);
-        if (attributeIds.length) {
-            const params = new URLSearchParams(window.location.search);
-            params.set('attribute_values', attributeIds.join(','))
+        const attributeValueSlugs = Array.from(inputs).map(
+            input => input.dataset.slug
+        ).filter(Boolean);
+        const attributeValueParams = wSaleUtils.getAttributeValueParams(attributeValueSlugs);
+        if (attributeValueParams.size) {
+            const url = new URL(window.location);
+            const searchParams = new URLSearchParams({
+                ...Object.fromEntries(wSaleUtils.clearAttributeValueParams(url.searchParams)),
+                ...Object.fromEntries(attributeValueParams),
+            });
             // Avoid adding new entries in session history by replacing the current one
-            history.replaceState(
-                null, '', url(window.location.pathname, Object.fromEntries(params))
-            );
+            history.replaceState(null, '', `${url.pathname}?${searchParams.toString()}`);
         }
     }
 

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -200,7 +200,8 @@ export class ProductPage extends Interaction {
         let params = new URLSearchParams(window.location.search);
         let attributeValueIds = Array.from(params.entries())
             .filter(([attribute, _]) => !!wSaleUtils.unslug(attribute))
-            .map(([_, attributeValue]) => wSaleUtils.unslug(attributeValue));
+            .flatMap(([_, attributeValues]) => attributeValues.split(","))
+            .map(attributeValue => wSaleUtils.unslug(attributeValue));
         if (!attributeValueIds) {
             // TODO: remove support for `attribute_values` query param in version 20 (or later).
             let attributeValues = params.get('attribute_values');

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -58,7 +58,7 @@ export class ShopPage extends Interaction {
         const attributeValueSlugs = Array.from(filters).filter(
             filter => filter.name === 'attribute_value' && filter.value
         ).map(filter => filter.value);
-        const tagIds = Array.from(filters).filter(
+        const tagSlugs = Array.from(filters).filter(
             filter => filter.name === 'tags' && filter.value
         ).map(filter => filter.value);
         const attributeValueParams = wSaleUtils.getAttributeValueParams(attributeValueSlugs);
@@ -68,8 +68,8 @@ export class ShopPage extends Interaction {
             ...Object.fromEntries(attributeValueParams),
         });
         // Aggregate all tags into a single `tags` search param, with duplicates removed.
-        if (tagIds.length) {
-            searchParams.set('tags', [...new Set(tagIds)].join(','));
+        if (tagSlugs.length) {
+            searchParams.set('tags', [...new Set(tagSlugs)].join(','));
         }
         redirect(`${url.pathname}?${searchParams.toString()}`);
     }

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -4,6 +4,7 @@ import { hasTouch, isBrowserFirefox } from '@web/core/browser/feature_detection'
 import { redirect } from '@web/core/utils/urls';
 import { setElementContent } from "@web/core/utils/html";
 import { _t } from "@web/core/l10n/translation";
+import wSaleUtils from "@website_sale/js/website_sale_utils";
 
 export class ShopPage extends Interaction {
     static selector = '.o_wsale_products_page';
@@ -54,31 +55,21 @@ export class ShopPage extends Interaction {
         }
         const form = ev.currentTarget.closest('form');
         const filters = form.querySelectorAll('input:checked, select');
-        const attributeValues = new Map();
-        const tags = new Set();
-        for (const filter of filters) {
-            if (filter.value) {
-                if (filter.name === 'attribute_value') {
-                    // Group attribute value ids by attribute id.
-                    const [attributeId, attributeValueId] = filter.value.split('-');
-                    const valueIds = attributeValues.get(attributeId) ?? new Set();
-                    valueIds.add(attributeValueId);
-                    attributeValues.set(attributeId, valueIds);
-                } else if (filter.name === 'tags') {
-                    tags.add(filter.value);
-                }
-            }
-        }
+        const attributeValueSlugs = Array.from(filters).filter(
+            filter => filter.name === 'attribute_value'
+        ).map(filter => filter.value).filter(Boolean);
+        const tagIds = Array.from(filters).filter(
+            filter => filter.name === 'tags'
+        ).map(filter => filter.value).filter(Boolean);
+        const attributeValueParams = wSaleUtils.getAttributeValueParams(attributeValueSlugs);
         const url = new URL(form.action);
-        const searchParams = url.searchParams;
-        // Aggregate all attribute values belonging to the same attribute into a single
-        // `attribute_values` search param.
-        for (const entry of attributeValues.entries()) {
-            searchParams.append('attribute_values', `${entry[0]}-${[...entry[1]].join(',')}`);
-        }
-        // Aggregate all tags into a single `tags` search param.
-        if (tags.size) {
-            searchParams.set('tags', [...tags].join(','));
+        const searchParams = new URLSearchParams({
+            ...Object.fromEntries(wSaleUtils.clearAttributeValueParams(url.searchParams)),
+            ...Object.fromEntries(attributeValueParams),
+        });
+        // Aggregate all tags into a single `tags` search param, with duplicates removed.
+        if (tagIds.length) {
+            searchParams.set('tags', [...new Set(tagIds)].join(','));
         }
         redirect(`${url.pathname}?${searchParams.toString()}`);
     }

--- a/addons/website_sale/static/src/interactions/shop_page.js
+++ b/addons/website_sale/static/src/interactions/shop_page.js
@@ -56,11 +56,11 @@ export class ShopPage extends Interaction {
         const form = ev.currentTarget.closest('form');
         const filters = form.querySelectorAll('input:checked, select');
         const attributeValueSlugs = Array.from(filters).filter(
-            filter => filter.name === 'attribute_value'
-        ).map(filter => filter.value).filter(Boolean);
-        const tagIds = Array.from(filters).filter(
-            filter => filter.name === 'tags'
-        ).map(filter => filter.value).filter(Boolean);
+            filter => filter.name === 'attribute_value' && filter.value
+        ).map(filter => filter.value);
+        const tagSlugs = Array.from(filters).filter(
+            filter => filter.name === 'tags' && filter.value
+        ).map(filter => filter.value);
         const attributeValueParams = wSaleUtils.getAttributeValueParams(attributeValueSlugs);
         const url = new URL(form.action);
         const searchParams = new URLSearchParams({
@@ -68,8 +68,8 @@ export class ShopPage extends Interaction {
             ...Object.fromEntries(attributeValueParams),
         });
         // Aggregate all tags into a single `tags` search param, with duplicates removed.
-        if (tagIds.length) {
-            searchParams.set('tags', [...new Set(tagIds)].join(','));
+        if (tagSlugs.length) {
+            searchParams.set('tags', [...new Set(tagSlugs)].join(','));
         }
         redirect(`${url.pathname}?${searchParams.toString()}`);
     }

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -118,9 +118,56 @@ function getSelectedAttributeValues(container) {
     )).map(el => parseInt(el.value));
 }
 
+/**
+ * Return a record ID from a slug.
+ *
+ * @param {string} slug - The slug to parse.
+ * @return {undefined|number} - The record ID extracted from the slug, if any.
+ */
+function unslug(slug) {
+    if (!slug) return undefined;
+    return parseInt(slug.split('-').at(-1)) || undefined;
+}
+
+/**
+ * Convert the provided attribute value slugs into search params.
+ *
+ * @param {string[]} attributeValueSlugs - The attribute value slugs to convert.
+ * @return {URLSearchParams} - The search params representing the attribute values.
+ */
+function getAttributeValueParams(attributeValueSlugs) {
+    const attributeValues = new Map();
+    for (const slug of attributeValueSlugs) {
+        // Group attribute values by attribute.
+        const [attribute, attributeValue] = slug.split('/');
+        const values = attributeValues.get(attribute) ?? new Set();
+        values.add(attributeValue);
+        attributeValues.set(attribute, values);
+    }
+    // Aggregate all attribute values belonging to the same attribute into a single search param.
+    return new URLSearchParams(Array.from(attributeValues.entries()).map(
+        ([attribute, attributeValue]) => [attribute, [...attributeValue].join(',')]
+    ));
+}
+
+/**
+ * Filter out any attribute value params from the provided search params.
+ *
+ * @param {URLSearchParams} searchParams - The search params to filter.
+ * @return {URLSearchParams} - The filtered search params.
+ */
+function clearAttributeValueParams(searchParams) {
+    return new URLSearchParams(Array.from(searchParams.entries()).filter(
+        ([attribute, _]) => !unslug(attribute)
+    ));
+}
+
 export default {
     updateCartNavBar: updateCartNavBar,
     showWarning: showWarning,
     getSelectedAttributeValues: getSelectedAttributeValues,
     updateQuickReorderSidebar: updateQuickReorderSidebar,
+    unslug: unslug,
+    getAttributeValueParams: getAttributeValueParams,
+    clearAttributeValueParams: clearAttributeValueParams,
 };

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -146,7 +146,7 @@ function getAttributeValueParams(attributeValueSlugs) {
     }
     // Aggregate all attribute values belonging to the same attribute into a single search param.
     return new URLSearchParams(Array.from(attributeValues.entries()).map(
-        ([attribute, attributeValue]) => [attribute, [...attributeValue].join(',')]
+        ([attribute, values]) => [attribute, [...values].join(',')]
     ));
 }
 

--- a/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
@@ -64,24 +64,17 @@ registry.category("web_tour.tours").add("website_sale.category_page_and_products
             // Wait for at least one shown product
             trigger: "#category_header .s_dynamic_snippet_products:has(.oe_product_image_link)",
             run() {
-                // Fetch the category's id from the url.
-                const productCategoryId = window.location.href.match(
-                    "/shop/category/test-category-(\\d+)"
-                )[1];
                 const productGridEl = document.getElementById("o_wsale_products_grid");
-                const regex = new RegExp(
-                    `^/shop/test-category-${productCategoryId}/[\\w-/]+-(\\d+)$`
-                );
+                const regex = new RegExp(`^/shop/product/[\\w-/]+-(\\d+)$`);
                 const allPageProductIDs = [
                     ...productGridEl.querySelectorAll(".oe_product_image_link"),
-                ].map((el) => el.getAttribute("href").match(regex)[1]);
+                ].map(el => el.getAttribute("href").match(regex)[1]);
 
-                const $shownProductLinks = this.anchor.querySelectorAll(
+                const shownProductLinks = this.anchor.querySelectorAll(
                     ".s_dynamic_snippet_products .oe_product_image_link"
                 );
-                const regex2 = new RegExp(`^/shop/[\\w-/]+-(\\d+)(?:#attribute_values=\\d*)?$`);
-                for (const shownProductLinkEl of $shownProductLinks) {
-                    const productID = shownProductLinkEl.getAttribute("href").match(regex2)[1];
+                for (const shownProductLinkEl of shownProductLinks) {
+                    const productID = shownProductLinkEl.getAttribute("href").match(regex)[1];
                     if (!allPageProductIDs.includes(productID)) {
                         console.error(
                             `The snippet displays a product (${productID}) which does not belong to the current category (${allPageProductIDs})`

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -49,7 +49,7 @@
                                     >
                                         <a
                                             class="py-2 py-lg-0"
-                                            t-att-href="keep('%s/category/%s' % (shop_path, slug(cat)))"
+                                            t-att-href="keep(cat.website_url)"
                                         >
                                             <i
                                                 class="oi oi-chevron-left d-lg-none me-1"
@@ -63,7 +63,7 @@
                                     <span t-field="product.name" />
                                 </li>
                                 <li class="breadcrumb-item d-lg-none">
-                                    <a t-att-href="category and keep('%s/category/%s' % (shop_path, slug(cat))) or keep(shop_path)">
+                                    <a t-att-href="keep(category.website_url or shop_path)">
                                         <i class="oi oi-chevron-left me-2" role="img"/>
                                         <t t-if="category.name" t-out="category.name"/>
                                         <t t-else="" t-call="website_sale.all_products_link_name"/>

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -762,7 +762,7 @@
             <a
                 t-foreach="visible_tags"
                 t-as="tag"
-                t-att-href="is_view_active('website_sale.filter_products_tags') and '/shop?tags=%s' % tag.id or None"
+                t-att-href="is_view_active('website_sale.filter_products_tags') and '/shop?tags=%s' % slug(tag) or None"
                 class="text-decoration-none d-inline-block"
             >
                 <span t-if="tag.image"

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -72,7 +72,6 @@
                             </ol>
                             <div class="d-flex d-md-none gap-2 ms-auto">
                                 <t t-call="website_sale.pricelist_list"/>
-                                <t t-if="original_category" t-set="placeholder" t-valuef.translate="Search in {{original_category.name}}"/>
                                 <t t-call="website.website_search_box_input"
                                     search_type.f="products"
                                     placeholder="placeholder"
@@ -267,6 +266,7 @@
                                         t-att-data-value-name="ptav.name"
                                         t-att-data-attribute-name="attribute.name"
                                         t-att-data-is-custom="ptav.is_custom"
+                                        t-att-data-slug="'%s/%s' % (slug(attribute), slug(ptav.product_attribute_value_id))"
                                     />
                                 </label>
                             </li>
@@ -759,7 +759,7 @@
             <a
                 t-foreach="visible_tags"
                 t-as="tag"
-                t-att-href="is_view_active('website_sale.filter_products_tags') and keep(shop_path, tags=tag.id) or None"
+                t-att-href="is_view_active('website_sale.filter_products_tags') and '/shop?tags=%s' % slug(tag) or None"
                 class="text-decoration-none d-inline-block"
             >
                 <span t-if="tag.image"

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -284,6 +284,7 @@
                                     t-att-data-value-name="ptav.name"
                                     t-att-data-attribute-name="attribute.name"
                                     t-att-data-is-custom="ptav.is_custom"
+                                    t-att-data-slug="'%s/%s' % (slug(attribute), slug(ptav.product_attribute_value_id))"
                                     t-att-selected="ptav in combination">
                                     <span t-field="ptav.name"/>
                                     <t t-call="website_sale.badge_extra_price"/>
@@ -311,7 +312,9 @@
                                                 t-att-data-value-id="ptav.id"
                                                 t-att-data-value-name="ptav.name"
                                                 t-att-data-attribute-name="attribute.name"
-                                                t-att-data-is-custom="ptav.is_custom"/>
+                                                t-att-data-is-custom="ptav.is_custom"
+                                                t-att-data-slug="'%s/%s' % (slug(attribute), slug(ptav.product_attribute_value_id))"
+                                            />
                                             <div class="radio_input_value form-check-label">
                                                 <span t-field="ptav.name"/>
                                                 <t t-call="website_sale.badge_extra_price"/>
@@ -342,6 +345,7 @@
                                         t-att-data-value-name="ptav.name"
                                         t-att-data-attribute-name="attribute.name"
                                         t-att-data-is-custom="ptav.is_custom"
+                                        t-att-data-slug="'%s/%s' % (slug(attribute), slug(ptav.product_attribute_value_id))"
                                         t-att-autocomplete="off"/>
                                     <label class="radio_input_value o_variant_pills_input_value cursor-pointer"
                                            t-att-for="ptav.id">
@@ -380,7 +384,9 @@
                                         t-att-data-value-id="ptav.id"
                                         t-att-data-value-name="ptav.name"
                                         t-att-data-attribute-name="attribute.name"
-                                        t-att-data-is-custom="ptav.is_custom"/>
+                                        t-att-data-is-custom="ptav.is_custom"
+                                        t-att-data-slug="'%s/%s' % (slug(attribute), slug(ptav.product_attribute_value_id))"
+                                      />
                                 </label>
                             </li>
                         </ul>
@@ -409,6 +415,7 @@
                                         t-att-data-value-name="ptav.name"
                                         t-att-data-attribute-name="attribute.name"
                                         t-att-data-is-custom="ptav.is_custom"
+                                        t-att-data-slug="'%s/%s' % (slug(attribute), slug(ptav.product_attribute_value_id))"
                                     />
                                 </label>
                             </li>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -1532,7 +1532,7 @@
                        name="tags"
                        class="form-check-input"
                        t-attf-id="tag_#{tag.id}"
-                       t-att-value="tag.id"
+                       t-att-value="slug(tag)"
                        t-att-checked="'checked' if tag.id in tags else None"
                 />
                 <label class="form-check-label fw-normal" t-attf-for="tag_#{tag.id}" t-field="tag.name"/>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -141,7 +141,7 @@
                     t-attf-class="breadcrumb-item {{cat_index &lt; cat_size - 2 and 'd-none d-lg-inline'}}"
                 >
                     <a
-                        t-att-href="keep('%s/category/%s' % (shop_path, slug(cat)))"
+                        t-att-href="keep(cat.website_url)"
                         t-field="cat.name"
                     />
                 </li>
@@ -1080,7 +1080,7 @@
                         role="presentation"
                     >
                         <a
-                            t-att-href="keep('%s/category/%s' % (shop_path, slug(c)))"
+                            t-att-href="keep(c.website_url)"
                             class="o_wsale_filmstrip_link d-block w-100 h-100 text-decoration-none"
                             draggable="false"
                             role="menuitem"
@@ -1285,7 +1285,7 @@
 
     <template id="website_sale.categorie_link" name="Category Link">
         <a
-            t-att-href="keep('%s/category/%s' % (shop_path, slug(c)))"
+            t-att-href="keep(c.website_url)"
             t-attf-class="{{c.id == category.id and 'text-decoration-underline'}} p-0"
             t-field="c.name"
         />

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -1557,7 +1557,7 @@
                        name="tags"
                        class="form-check-input"
                        t-attf-id="tag_#{tag.id}"
-                       t-att-value="tag.id"
+                       t-att-value="slug(tag)"
                        t-att-checked="'checked' if tag.id in tags else None"
                 />
                 <label class="form-check-label fw-normal" t-attf-for="tag_#{tag.id}" t-field="tag.name"/>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -197,6 +197,10 @@
                 t-set="wsale_has_filters_btn_lg"
                 t-value="opt_wsale_attributes_top"
             />
+            <t
+                t-set="reset_attribute_value_params"
+                t-value="{attr: 0 for attr in request.session.get('attribute_value_params', {}).keys()}"
+            />
 
             <div id="wrap" class="o_wsale_products_page">
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_products_1"/>
@@ -243,7 +247,7 @@
                                     class="py-3 border-bottom"
                                 >
                                     <a
-                                        t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
+                                        t-att-href="keep(**reset_attribute_value_params, tags=0, min_price=0, max_price=0)"
                                         t-attf-class="btn btn-{{navClass}} d-flex align-items-center py-1"
                                         title="Clear Filters"
                                     >
@@ -648,7 +652,7 @@
                 <input type="checkbox"
                        name="attribute_value"
                        class="cursor-pointer"
-                       t-att-value="'%s-%s' % (a.id, v.id)"
+                       t-att-value="'%s/%s' % (slug(a), slug(v))"
                        t-att-checked="'checked' if v.id in attrib_set else None"
                        t-att-title="v.name"
                 />
@@ -664,7 +668,7 @@
                 <input
                     type="checkbox"
                     name="attribute_value"
-                    t-att-value="'%s-%s' % (a.id, v.id)"
+                    t-att-value="'%s/%s' % (slug(a), slug(v))"
                     t-att-checked="'checked' if v.id in attrib_set else None"
                     t-att-title="v.name"
                     class="w-100 h-100 opacity-0 cursor-pointer"
@@ -682,7 +686,7 @@
             <option value="" selected="true">All <t t-out="a.name"/></option>
             <t t-foreach="pavs_per_attribute[a]" t-as="v">
                 <option
-                    t-att-value="'%s-%s' % (a.id,v.id)"
+                    t-att-value="'%s/%s' % (slug(a), slug(v))"
                     t-out="v.name"
                     t-att-selected="v.id in attrib_set"
                 />
@@ -710,7 +714,7 @@
                         name="attribute_value"
                         class="form-check-input"
                         t-att-id="'%s-%s' % (a.id,v.id)"
-                        t-att-value="'%s-%s' % (a.id,v.id)"
+                        t-att-value="'%s/%s' % (slug(a), slug(v))"
                         t-att-checked="v.id in attrib_set"
                     />
                     <label
@@ -737,7 +741,7 @@
                                 name="attribute_value"
                                 class="form-check-input"
                                 t-att-id="'%s-%s' % (a.id,v.id)"
-                                t-att-value="'%s-%s' % (a.id,v.id)"
+                                t-att-value="'%s/%s' % (slug(a), slug(v))"
                                 t-att-checked="v.id in attrib_set"
                             />
                             <label
@@ -788,7 +792,7 @@
                             name="attribute_value"
                             class="form-check-input"
                             t-att-id="'%s-%s' % (a.id,v.id)"
-                            t-att-value="'%s-%s' % (a.id,v.id)"
+                            t-att-value="'%s/%s' % (slug(a), slug(v))"
                             t-att-checked="v.id in attrib_set"
                         />
                         <label
@@ -809,7 +813,7 @@
                 name="attribute_value"
                 class="btn-check"
                 t-att-id="'%s-%s' % (a.id,v.id)"
-                t-att-value="'%s-%s' % (a.id,v.id)"
+                t-att-value="'%s/%s' % (slug(a), slug(v))"
                 t-att-checked="v.id in attrib_set"
                 autocomplete="off"
             />
@@ -828,7 +832,7 @@
         <form
             t-attf-class="js_attributes {{('accordion accordion-flush d-flex flex-column ' + ('border-bottom' if attributes else '')) if isMobile else 'position-relative mb-2'}}"
             method="get"
-            t-att-action="keep(attribute_values=0, tags=0)"
+            t-att-action="keep(**reset_attribute_value_params, tags=0)"
         >
             <t t-foreach="attributes" t-as="a">
                 <t t-set="_status" t-value="'inactive'"/>
@@ -1048,7 +1052,7 @@
             <div class="offcanvas-body d-flex justify-content-between flex-grow-0 border-top overflow-hidden">
                 <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled' }}"
                    t-att-aria-disabled="(not attrib_values and not isFilteringByPrice and not tags) and 'true' or 'false'"
-                   t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
+                   t-att-href="keep(**reset_attribute_value_params, tags=0, min_price=0, max_price=0)"
                    title="Clear Filters">
                     Clear Filters
                 </a>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -458,9 +458,11 @@
                                                     t-att-data-name="product_block_name"
                                                 >
                                                     <div t-attf-class="o_wsale_product_grid_wrapper position-relative h-100 o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
-                                                        <t t-call="website_sale.products_item"
+                                                        <t
+                                                            t-call="website_sale.products_item"
                                                             design_field="website.shop_opt_products_design_classes"
-                                                            product_href="product._get_product_url(category, product_query_params, grouped_attributes_values)"/>
+                                                            product_href="product._get_product_url(product_query_params, grouped_attributes_values)"
+                                                        />
                                                     </div>
                                                 </div>
                                             </t>

--- a/addons/website_sale/templates/snippets/s_mega_menu/big_icons_subtitles.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/big_icons_subtitles.xml
@@ -22,7 +22,7 @@
                         <div class="col-12 col-lg-4">
                             <nav class="nav flex-column w-100">
                                 <a
-                                    t-att-href="'/shop/category/%s' % category.id"
+                                    t-att-href="category.website_url"
                                     class="col-lg-4 nav-link px-2 my-2 rounded text-wrap"
                                 >
                                     <div class="d-flex align-items-center">

--- a/addons/website_sale/templates/snippets/s_mega_menu/cards.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/cards.xml
@@ -17,7 +17,7 @@
                     >
                         <div class="col-12 col-lg-3">
                             <a
-                                t-att-href="'/shop/category/%s' % category.id"
+                                t-att-href="category.website_url"
                                 class="nav-link rounded text-wrap text-center p-3"
                             >
                                 <div class="mb-3 rounded shadow" style="height:80px">

--- a/addons/website_sale/templates/snippets/s_mega_menu/image_menu.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/image_menu.xml
@@ -19,7 +19,7 @@
                         <div class="col-12 col-lg-4 py-2 text-center">
                             <h4>
                                 <a
-                                    t-att-href="'/shop/category/%s' % category.id"
+                                    t-att-href="category.website_url"
                                     class="nav-link p-0 text-black"
                                     t-out="category.name"
                                 />
@@ -28,7 +28,7 @@
                                 <t t-foreach="category.child_id.filtered('has_published_products')"
                                    t-as="sub_category">
                                     <a
-                                        t-att-href="'/shop/category/%s' % sub_category.id"
+                                        t-att-href="sub_category.website_url"
                                         class="nav-link"
                                         t-out="sub_category.name"
                                     />

--- a/addons/website_sale/templates/snippets/s_mega_menu/images_subtitles.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/images_subtitles.xml
@@ -18,7 +18,7 @@
                                 t-as="category"
                             >
                                 <a
-                                    t-att-href="'/shop/category/%s' % category.id"
+                                    t-att-href="category.website_url"
                                     class="col-lg-6 nav-link px-2 rounded text-wrap"
                                 >
                                     <div class="d-flex">

--- a/addons/website_sale/templates/snippets/s_mega_menu/little_icons.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/little_icons.xml
@@ -18,7 +18,7 @@
                                 t-as="category"
                             >
                                 <a
-                                    t-att-href="'/shop/category/%s' % category.id"
+                                    t-att-href="category.website_url"
                                     class="col-lg-4 nav-link px-2 rounded text-wrap"
                                 >
                                     <img

--- a/addons/website_sale/templates/snippets/s_mega_menu/logos.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/logos.xml
@@ -20,7 +20,7 @@
                                 <div class="col-12 col-lg-4 py-2">
                                     <h4>
                                         <a
-                                            t-att-href="'/shop/category/%s' % category.id"
+                                            t-att-href="category.website_url"
                                             class="col-lg-4 nav-link text-black p-0"
                                             t-out="category.name"
                                         />
@@ -29,7 +29,7 @@
                                         <t t-foreach="category.child_id.filtered('has_published_products')"
                                            t-as="sub_category">
                                             <a
-                                                t-att-href="'/shop/category/%s' % sub_category.id"
+                                                t-att-href="sub_category.website_url"
                                                 class="nav-link px-0"
                                                 t-out="sub_category.name"
                                             />

--- a/addons/website_sale/templates/snippets/s_mega_menu/multi_menus.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/multi_menus.xml
@@ -18,7 +18,7 @@
                         <div class="col-12 col-sm py-2 text-center">
                             <h4>
                                 <a
-                                    t-att-href="'/shop/category/%s' % category.id"
+                                    t-att-href="category.website_url"
                                     class="nav-link p-0 text-black"
                                     t-out="category.name"
                                 />
@@ -27,7 +27,7 @@
                                 <t t-foreach="category.child_id.filtered('has_published_products')"
                                    t-as="sub_category">
                                     <a
-                                        t-att-href="'/shop/category/%s' % sub_category.id"
+                                        t-att-href="sub_category.website_url"
                                         class="nav-link"
                                         t-out="sub_category.name"
                                     />

--- a/addons/website_sale/templates/snippets/s_mega_menu/odoo_menu.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/odoo_menu.xml
@@ -18,7 +18,7 @@
                         <div class="col-12 col-lg-3 pt16 pb24">
                             <h4 class="h5 fw-bold mt-0">
                                 <a
-                                    t-att-href="'/shop/category/%s' % category.id"
+                                    t-att-href="category.website_url"
                                     class="nav-link p-0 text-black"
                                     t-out="category.name"
                                 />
@@ -32,7 +32,7 @@
                                 <t t-foreach="category.child_id.filtered('has_published_products')"
                                    t-as="sub_category">
                                     <a
-                                        t-att-href="'/shop/category/%s' % sub_category.id"
+                                        t-att-href="sub_category.website_url"
                                         class="nav-link px-0"
                                         t-out="sub_category.name"/>
                                 </t>

--- a/addons/website_sale/templates/snippets/s_mega_menu/thumbnails.xml
+++ b/addons/website_sale/templates/snippets/s_mega_menu/thumbnails.xml
@@ -22,7 +22,7 @@
                         </t>
                         <div class="col-6 col-lg-2 text-center py-2">
                             <a
-                                t-att-href="'/shop/category/%s' % category.id"
+                                t-att-href="category.website_url"
                                 class="nav-link p-0"
                             >
                                 <img

--- a/addons/website_sale/tests/test_google_merchant_center.py
+++ b/addons/website_sale/tests/test_google_merchant_center.py
@@ -102,16 +102,23 @@ class TestWebsiteSaleGMC(WebsiteSaleGMCCommon, HttpCase):
     def test_gmc_items_link_redirects_to_correct_product_case_specific_pricelist(self):
         self.gmc_feed.pricelist_id = self.eur_pricelist
         self.update_items()
+        slug = self.env['ir.http']._slug
 
         for product in self.red_sofa + self.blue_sofa:
             response = self.url_open(self.items[product]["link"])
 
             self.assertEqual(200, response.status_code)
             url = urlparse(product.website_url)
-            ptav_ids = product.product_template_attribute_value_ids.product_attribute_value_id.ids
+            attribute_values = (
+                product.product_template_attribute_value_ids.product_attribute_value_id
+            )
+            attribute_value_params = [
+                f"{slug(attribute_value.attribute_id)}={slug(attribute_value)}"
+                for attribute_value in attribute_values
+            ]
             self.assertURLEqual(
                 f"{url.path}"
-                f"?attribute_values={','.join(str(i) for i in ptav_ids)}"
+                f"?{'&'.join(attribute_value_params)}"
                 f"&pricelist={self.eur_pricelist.id}"
                 f"#{url.fragment}",
                 response.url,

--- a/addons/website_sale/tests/test_google_merchant_center.py
+++ b/addons/website_sale/tests/test_google_merchant_center.py
@@ -102,7 +102,7 @@ class TestWebsiteSaleGMC(WebsiteSaleGMCCommon, HttpCase):
     def test_gmc_items_link_redirects_to_correct_product_case_specific_pricelist(self):
         self.gmc_feed.pricelist_id = self.eur_pricelist
         self.update_items()
-        slug = self.env['ir.http']._slug
+        slug = self.env["ir.http"]._slug
 
         for product in self.red_sofa + self.blue_sofa:
             response = self.url_open(self.items[product]["link"])

--- a/addons/website_sale/tests/test_mail.py
+++ b/addons/website_sale/tests/test_mail.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import odoo
+
 from odoo import SUPERUSER_ID, fields
 from odoo.tests import tagged
 
@@ -64,7 +65,7 @@ class TestWebsiteSaleMail(HttpCaseWithUserPortal):
             "website_published": True,
         })
         url = f"/mail/view?model=product.template&res_id={product_template.id}"
-        shop_url = f"/shop/test-product-template-{product_template.id}"
+        shop_url = f"/shop/product/test-product-template-{product_template.id}"
 
         with self.subTest(user="admin"):
             self.authenticate("admin", "admin")

--- a/addons/website_sale/tests/test_mail.py
+++ b/addons/website_sale/tests/test_mail.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import odoo
-
 from odoo import SUPERUSER_ID, fields
 from odoo.tests import tagged
 

--- a/addons/website_sale/tests/test_product_configurator.py
+++ b/addons/website_sale/tests/test_product_configurator.py
@@ -445,9 +445,7 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
         main_product.attribute_line_ids[1].product_template_value_ids[0].ptav_active = False
         with self.mock_request():
             product_values = self.pc_controller._prepare_product_values(
-                main_product,
-                self.env["product.public.category"],
-                attribute_values=str(attribute_single.value_ids.id),
+                main_product, attribute_values=str(attribute_single.value_ids.id)
             )
         is_combination_possible = product_values["combination_info"]["is_combination_possible"]
         combination_product_id = product_values["combination_info"]["product_id"]

--- a/addons/website_sale/tests/test_product_configurator.py
+++ b/addons/website_sale/tests/test_product_configurator.py
@@ -8,7 +8,7 @@ from odoo.tests import HttpCase, tagged
 from odoo.addons.website_sale.controllers.product_configurator import (
     WebsiteSaleProductConfiguratorController,
 )
-from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 
 
 @tagged("post_install", "-at_install")
@@ -445,36 +445,9 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
         main_product.attribute_line_ids[1].product_template_value_ids[0].ptav_active = False
         with self.mock_request():
             product_values = self.pc_controller._prepare_product_values(
-                main_product, attribute_values=str(attribute_single.value_ids.id)
+                main_product, **{str(attribute_single.id): str(attribute_single.value_ids.id)}
             )
         is_combination_possible = product_values["combination_info"]["is_combination_possible"]
         combination_product_id = product_values["combination_info"]["product_id"]
         self.assertTrue(is_combination_possible)
         self.assertTrue(self.env["product.product"].browse(combination_product_id).active)
-
-    def test_product_page_search_scope_respects_navigation_context(self):
-        """
-        Ensure that search scope depends on how the user accessed the product page.
-
-        - Direct access to a product → search must be global (/shop)
-        - Access via category → search must be category-scoped
-        """
-        product_tmpl = self.product.product_tmpl_id
-        public_category = self.env['product.public.category'].create({
-            'name': 'Test Public Category',
-        })
-        product_tmpl.public_categ_ids = [Command.set([public_category.id])]
-
-        with MockRequest(self.env, website=self.website):
-            values = self.pc_controller._prepare_product_values(
-                product_tmpl,
-                category=None,
-            )
-        self.assertNotIn('/category', values['keep'].path)
-
-        with MockRequest(self.env, website=self.website):
-            values = self.pc_controller._prepare_product_values(
-                product_tmpl,
-                category=public_category,
-            )
-        self.assertIn('/category', values['keep'].path)

--- a/addons/website_sale/tests/test_shop_redirects.py
+++ b/addons/website_sale/tests/test_shop_redirects.py
@@ -10,53 +10,42 @@ from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 @tagged("post_install", "-at_install")
 class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
     def test_website_sale_shop_redirects(self):
-        category_a = self.env["product.public.category"].create({"name": "Category A"})
-        category_b = self.env["product.public.category"].create({"name": "Category B"})
+        test_category = self.env["product.public.category"].create({'name': "Test category"})
         test_product = self.env["product.template"].create({
             "name": "Test product",
-            "public_categ_ids": [Command.link(category_a.id)],
+            "public_categ_ids": [Command.link(test_category.id)],
             "website_published": True,
         })
-        # Add a different published product to category B so that it is accessible to public users
-        self._create_product(website_published=True, public_categ_ids=[Command.link(category_b.id)])
 
         slug = self.env["ir.http"]._slug
 
         response = self.url_open(
-            f"/shop?category={category_a.id}&some-key=some-value", allow_redirects=False
+            f"/shop?category={test_category.id}&some-key=some-value", allow_redirects=False
         )
         self.assertEqual(response.status_code, 301)
         self.assertURLEqual(
             response.headers.get("Location"),
-            f"/shop/category/{slug(category_a)}?some-key=some-value",
+            f"/shop/category/{slug(test_category)}?some-key=some-value",
         )
 
         response = self.url_open(
-            f"/shop/product/{slug(test_product)}?category={category_a.id}&some-key=some-value",
+            f"/shop/{slug(test_product)}?category={test_category.id}&some-key=some-value",
             allow_redirects=False,
         )
         self.assertEqual(response.status_code, 301)
         self.assertURLEqual(
             response.headers.get("Location"),
-            f"/shop/{slug(category_a)}/{slug(test_product)}?some-key=some-value",
+            f"/shop/product/{slug(test_product)}?some-key=some-value",
         )
 
         response = self.url_open(
-            f"/shop/product/{slug(test_product)}?category=test&some-key=some-value",
+            f"/shop/{slug(test_category)}/{slug(test_product)}?some-key=some-value",
             allow_redirects=False,
         )
         self.assertEqual(response.status_code, 301)
         self.assertURLEqual(
-            response.headers.get("Location"), f"/shop/{slug(test_product)}?some-key=some-value"
-        )
-
-        response = self.url_open(
-            f"/shop/{slug(category_b)}/{slug(test_product)}?some-key=some-value",
-            allow_redirects=False,
-        )
-        self.assertEqual(response.status_code, 301)
-        self.assertURLEqual(
-            response.headers.get("Location"), f"/shop/{slug(test_product)}?some-key=some-value"
+            response.headers.get("Location"),
+            f"/shop/product/{slug(test_product)}?some-key=some-value",
         )
 
     def test_ecommerce_product_page_url_unpublished_product(self):
@@ -65,7 +54,7 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
             "name": "Access Product",
             "is_published": False,
         })
-        url = f"{SHOP_PATH}/{accessory_product.id}"
+        url = f"{SHOP_PATH}/product/{accessory_product.id}"
         res = self.url_open(url)
         self.assertEqual(len(res.history), 0, "Unpublished products shouldn't redirect.")
         self.assertURLEqual(res.url, url, "Unpublished products shouldn't slug the URL.")
@@ -77,56 +66,3 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
         res = self.url_open(url)
 
         self.assertEqual(res.status_code, 404, "Invalid category should return a 404.")
-
-    def test_ecommerce_product_page_url_invalid_category(self):
-        # Invalid category should redirect to the canonical product page.
-        accessory_product = self.env["product.template"].create({
-            "name": "Access Product",
-            "is_published": True,
-        })
-        url = f"{SHOP_PATH}/999999/{accessory_product.id}"
-        res = self.url_open(url)
-
-        self.assertEqual(
-            len(res.history),
-            1,
-            "Invalid category with valid product should only redirect once to the product page.",
-        )
-        self.assertEqual(
-            res.history[0].status_code,
-            303,
-            "Invalid category with valid product should redirect to the product page.",
-        )
-        good_url = f"{SHOP_PATH}/{self.env['ir.http']._slug(accessory_product)}"
-        self.assertURLEqual(res.url, good_url)
-
-    def test_ecommerce_category_page_url_unpublished_product(self):
-        # Unpublished product should redirect to the canonical category page (if category provided).
-        category = self.env["product.public.category"].create({"name": "Test Category"})
-        # Add a different published product to category so that it is accessible to public users
-        self.env["product.template"].create({
-            "name": "Test Product",
-            "is_published": True,
-            "public_categ_ids": [Command.link(category.id)],
-        })
-        accessory_product = self.env["product.template"].create({
-            "name": "Access Product",
-            "public_categ_ids": [Command.link(category.id)],
-        })
-        accessory_product.is_published = False
-        url = f"{SHOP_PATH}/{category.id}/{accessory_product.id}"
-        res = self.url_open(url)
-
-        self.assertEqual(
-            len(res.history),
-            1,
-            "Unpublished product with valid category should only redirect once to the category"
-            " page.",
-        )
-        self.assertEqual(
-            res.history[0].status_code,
-            303,
-            "Unpublished product with valid category should redirect to the category page.",
-        )
-        good_url = f"{SHOP_PATH}/category/{self.env['ir.http']._slug(category)}"
-        self.assertURLEqual(res.url, good_url)

--- a/addons/website_sale/tests/test_shop_redirects.py
+++ b/addons/website_sale/tests/test_shop_redirects.py
@@ -10,7 +10,7 @@ from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 @tagged("post_install", "-at_install")
 class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
     def test_website_sale_shop_redirects(self):
-        test_category = self.env["product.public.category"].create({'name': "Test category"})
+        test_category = self.env["product.public.category"].create({"name": "Test category"})
         test_product = self.env["product.template"].create({
             "name": "Test product",
             "public_categ_ids": [Command.link(test_category.id)],

--- a/addons/website_sale/tests/test_shop_redirects.py
+++ b/addons/website_sale/tests/test_shop_redirects.py
@@ -25,7 +25,7 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
         self.assertEqual(response.status_code, 301)
         self.assertURLEqual(
             response.headers.get("Location"),
-            f"/shop/category/{slug(test_category)}?some-key=some-value",
+            f"/shop/category/{slug(test_category)}?category={test_category.id}&some-key=some-value",
         )
 
         response = self.url_open(
@@ -35,7 +35,7 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
         self.assertEqual(response.status_code, 301)
         self.assertURLEqual(
             response.headers.get("Location"),
-            f"/shop/product/{slug(test_product)}?some-key=some-value",
+            f"/shop/product/{slug(test_product)}?category={test_category.id}&some-key=some-value",
         )
 
         response = self.url_open(

--- a/addons/website_sale/tests/test_sitemap.py
+++ b/addons/website_sale/tests/test_sitemap.py
@@ -37,15 +37,23 @@ class TestSitemap(HttpCase):
 
     def test_01_shop_route_sitemap(self):
         resp = self.url_open("/sitemap.xml")
-        level2_url = "/shop/category/level-0-level-1-level-2-%s" % self.cats[2].id
+        level2_url = "/shop/category/level-0-%s/level-1-%s/level-2-%s" % (
+            self.cats[0].id,
+            self.cats[1].id,
+            self.cats[2].id,
+        )
         self.assertIn(
             level2_url,
             resp.text,
             "Category entry in sitemap should be prefixed by its parent hierarchy.",
         )
-        level2A_url = "/shop/category/level-0-level-1-level-2a-%s" % self.cats[3].id
+        level2a_url = "/shop/category/level-0-%s/level-1-%s/level-2a-%s" % (
+            self.cats[0].id,
+            self.cats[1].id,
+            self.cats[3].id,
+        )
         self.assertNotIn(
-            level2A_url,
+            level2a_url,
             resp.text,
             "Category entry with no active products should not be listed in sitemap.",
         )

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -7,9 +7,10 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSaleCollect(WebsiteSale):
-    def _prepare_product_values(self, product, category, **kwargs):
+
+    def _prepare_product_values(self, product, **kwargs):
         """Override of `website_sale` to configure the Click & Collect Availability widget."""
-        res = super()._prepare_product_values(product, category, **kwargs)
+        res = super()._prepare_product_values(product, **kwargs)
         if in_store_dm_sudo := request.website.sudo().in_store_dm_id:
             order_sudo = request.cart
             selected_location_data = {}

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -7,7 +7,6 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSaleCollect(WebsiteSale):
-
     def _prepare_product_values(self, product, **kwargs):
         """Override of `website_sale` to configure the Click & Collect Availability widget."""
         res = super()._prepare_product_values(product, **kwargs)

--- a/addons/website_sale_stock/controllers/website_sale.py
+++ b/addons/website_sale_stock/controllers/website_sale.py
@@ -6,8 +6,8 @@ from odoo.addons.website_sale.controllers import main
 
 
 class WebsiteSale(main.WebsiteSale):
-    def _prepare_product_values(self, product, category, **kwargs):
-        values = super()._prepare_product_values(product, category, **kwargs)
+    def _prepare_product_values(self, product, **kwargs):
+        values = super()._prepare_product_values(product, **kwargs)
         # We need the user mail to prefill the back of stock notification, so we put it in the value
         # that will be sent
         values["user_email"] = request.env.user.email or request.session.get(


### PR DESCRIPTION
- **Clean up the product page path**
  Insert `/product` between `/shop` and the product slug (to make it clear that
  we're on the product page), and remove the category slug (so that the
  breadcrumbs are always the same, no matter which category the user selected on
  the shop page).
- **Clean up the category page path**
  If a category has parents, don't include them in the path's slug. Instead, use
  a separate path segment for the category and each parent. E.g.
  ```
  /shop/category/desks-components-10
  ```
  becomes
  ```
  /shop/category/desks-1/components-10
  ```
- **Clean up the attribute value query params**
  On the shop page, the attribute values were encoded as follows:
  ```
  attribute_values={attribute_id}-{attribute_value_1_id},{attribute_value_2_id}
  ```
  On the product page, the attribute values were encoded as follows:
  ```
  attribute_values={attribute_value_1_id},{attribute_value_2_id}
  ```
  The attribute values were not only encoded differently (which is confusing), but
  also unreadable (since we were showing integer ids).

  Now, the attribute values are encoded as follows, both on the shop and product
  pages:
  ```
  {attribute_slug}={attribute_value_1_slug},{attribute_value_2_slug}
  ```
  This addresses both issues pointed out above.
- **Clean up the tags query param**
  Use slugs instead of ids.
- **Ensure that invalid query params don't result in errors**
  Validate query params for attribute values and tags more thoroughly before using
  them.

task-5129517
Enterprise PR: https://github.com/odoo/enterprise/pull/99710