### PR TITLE
[FIX] stock: use edited lot_ids from picking form

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -603,7 +603,7 @@ Please change the quantity done or the rounding precision in your settings.""",
 
     def _set_lot_ids(self):
         for move in self:
-            if move.state == 'assigned' and all(ml.lot_id for ml in move.move_line_ids):
+            if move.state == 'assigned' and all(ml.lot_id in move.lot_ids for ml in move.move_line_ids):
                 continue
             move_lines_commands = []
             mls = move.move_line_ids

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6592,3 +6592,39 @@ class TestStockMove(TestStockCommon):
         self.assertEqual(backorder.move_ids.product_uom_qty, 6)
         self.assertEqual(backorder.move_ids.quantity, 6)
         self.assertEqual(backorder.move_ids.state, 'assigned')
+
+    def test_edit_serial_number_from_move(self):
+        """
+        This test verifies that when a move is assigned an initial serial number,
+        and the user manually replaces it with another available one before
+        validation, the system correctly updates the serial number on both the
+        stock move and the move line. It also ensures that the updated serial
+        number is preserved after validating the picking.
+        """
+        lot1 = self.env['stock.lot'].create({
+            'product_id': self.product_serial.id,
+        })
+        lot2 = self.env['stock.lot'].create({
+            'product_id': self.product_serial.id,
+        })
+        self.env['stock.quant']._update_available_quantity(self.product_serial, self.stock_location, 1, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(self.product_serial, self.stock_location, 1, lot_id=lot2)
+        picking = self.env['stock.picking'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            'move_ids': [Command.create({
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+                'product_id': self.product_serial.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        picking.action_confirm()
+        self.assertEqual(picking.move_ids.state, 'assigned')
+        self.assertEqual(picking.move_ids.lot_ids, lot1)
+        picking.move_ids.lot_ids = lot2
+        self.assertEqual(picking.move_ids.lot_ids, lot2)
+        self.assertEqual(picking.move_line_ids.lot_id, lot2)
+        picking.button_validate()
+        self.assertEqual(picking.move_ids.lot_ids, lot2)


### PR DESCRIPTION
In the stock.picking form, we can modify the `lot_id` of the product we deliver to the customers. Since 19.0, the edited `lot_id` wasn't saved properly, leading to the original `lot_id` being used when confirming the delivery.

### Steps to reproduce:

1. Install the Stock (`stock`) app.
2. Enable the *Lots & Serial Numbers* traceability settings.
3. Create a product tracked *By Unique Serial Number*
4. Create a quotation with a line that includes the product tracked by unique serial number
5. Confirm the quotation
6. Click on the *Delivery* smart button
7. Display the *Serial Numbers* column in the list view
8. Update the Serial Number of the product (remove the original serial number, then add a new one)
9. Click *Validate*, or *Save manually* and reload the page
10. The Serial Number set in step 8 is replaced by the original one

The condition at the start of the `StockMove._set_lot_ids` method was preventing the `stock.move.line` from being updated. In the context of this issue, at the moment of execution, the `stock.move.line` still has the original `lot_id`, but it should be updated to the `lot_id` set by the user. This update does not occur because of the condition.

https://github.com/odoo/odoo/blob/af4365421bc7ba990420789c12c98270d723fa1a/addons/stock/models/stock_move.py#L606-L607

After applying this fix, the serial number set by the user is correctly saved and used when clicking the *Validate* button on the stock picking form.

opw-5169690