### PR TITLE
[FIX] sale_project: add default search on SO shown when we open project

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -869,8 +869,8 @@ class ProjectProject(models.Model):
         if self.env.context.get("from_sale_order_action"):
             context = dict(action.get("context", {}))
             context.pop("search_default_open_tasks", None)
-            if self.sale_order_id:
-                context["search_default_sale_order_id"] = self.sale_order_id.id
+            if sale_order_id := self.env.context.get('default_reinvoiced_sale_order_id') or self.reinvoiced_sale_order_id.id:
+                context["search_default_sale_order_id"] = sale_order_id
             if not self.sale_order_id:
                 sale_order = self.env["sale.order"].browse(self.env.context.get("active_id"))
                 context["default_sale_order_id"] = sale_order.id


### PR DESCRIPTION
Before this commit, when the user clicks on x projects and x tasks stat button in the sale order form view and that SO is linked to some task and more than one project, the user will be redirected in kanban view of projects and when he will click on a project, he will see all tasks linked to that project instead of seeing the tasks linked to SO inside that project.

This commit makes sure a default search is added in the tasks views when the user open a project from an SO to be sure the user will first see the tasks linked to that SO.

