### PR TITLE
[FIX] sale: prevent changing the product on combo item lines

### DIFF
--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -71,7 +71,7 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
     isCellReadonly(column, record) {
         return super.isCellReadonly(column, record) || (
             this.isComboItem(record)
-                && ![this.titleField, 'tax_id', 'qty_delivered'].includes(column.name)
+                && !['name', 'tax_id', 'qty_delivered'].includes(column.name)
         );
     }
 

--- a/addons/sale/static/src/js/tours/tour_utils.js
+++ b/addons/sale/static/src/js/tours/tour_utils.js
@@ -63,16 +63,18 @@ function clickSomewhereElse() {
     ]
 }
 
-function checkSOLDescriptionContains(productName, text) {
+function checkSOLDescriptionContains(productName, text, { isReadonly = false } = {}) {
     // currently must be called after exiting the edit mode on the SOL
     // TODO in the future: handle edit mode and look directly into the textarea value
+    const productSelector = isReadonly
+        ? `a:contains("${productName}")` : `span:contains("${productName}")`;
     if (!text) {
         return {
-            trigger: `span:contains("${productName}")`,
+            trigger: productSelector,
         }
     }
     return {
-        trigger: `span:contains("${productName}") ~ textarea`,
+        trigger: `${productSelector} ~ textarea`,
     }
 }
 

--- a/addons/sale/static/tests/tours/sale_combo_configurator.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator.js
@@ -53,7 +53,7 @@ registry
             ...comboConfiguratorTourUtils.saveConfigurator(),
             tourUtils.checkSOLDescriptionContains("Combo product x 3"),
             tourUtils.checkSOLDescriptionContains(
-                "Product A1", "No variant attribute: B: Some custom value"
+                "Product A1", "No variant attribute: B: Some custom value", { isReadonly: true }
             ),
             tourUtils.checkSOLDescriptionContains("Product B2"),
             {


### PR DESCRIPTION
This was initially allowed so that the user could edit the description on combo item lines (since both the product and description fields are displayed in a single column). However, users seem to abuse this (see https://github.com/odoo/odoo/pull/234090).

For information, the description can still be edited, but to do so, the user must first hide the `Product` and `Product variant` columns (which can be shown again after making the necessary changes).
