### PR TITLE
[FIX] mail, *: demonstrate the available canned responses in portal

### DIFF
--- a/addons/im_livechat/static/src/core/web/suggestion_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/suggestion_service_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(SuggestionService.prototype, {
     /** @override */
-    getSupportedDelimiters(thread) {
+    getSupportedDelimiters(thread, env) {
         const res = super.getSupportedDelimiters(...arguments);
         return thread.channel_type === "livechat"
             ? res.filter((delimiter) => delimiter.at(0) !== "#")

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -100,7 +100,10 @@ export class UseSuggestion {
         if (this.search.position !== undefined && this.search.position < start) {
             candidatePositions.push(this.search.position);
         }
-        const supportedDelimiters = this.suggestionService.getSupportedDelimiters(this.thread);
+        const supportedDelimiters = this.suggestionService.getSupportedDelimiters(
+            this.thread,
+            this.comp.env
+        );
         for (const candidatePosition of candidatePositions) {
             if (candidatePosition < 0 || candidatePosition >= text.length) {
                 continue;

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -28,7 +28,7 @@ export class SuggestionService {
      * @param {import('models').Thread} thread
      * @returns {Array<[string, number, number]>}
      */
-    getSupportedDelimiters(thread) {
+    getSupportedDelimiters(thread, env) {
         return [["@"], ["#"], ["::"], [":", undefined, 2]];
     }
 

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -8,8 +8,8 @@ const commandRegistry = registry.category("discuss.channel_commands");
 
 /** @type {SuggestionService} */
 const suggestionServicePatch = {
-    getSupportedDelimiters(thread) {
-        const res = super.getSupportedDelimiters(thread);
+    getSupportedDelimiters(thread, env) {
+        const res = super.getSupportedDelimiters(...arguments);
         return thread?.model === "discuss.channel" ? [...res, ["/", 0]] : res;
     },
     /**

--- a/addons/portal/static/src/chatter/frontend/composer_patch.js
+++ b/addons/portal/static/src/chatter/frontend/composer_patch.js
@@ -3,13 +3,6 @@ import { Composer } from "@mail/core/common/composer";
 import { patch } from "@web/core/utils/patch";
 
 patch(Composer.prototype, {
-    setup() {
-        super.setup();
-        if (this.env.inFrontendPortalChatter) {
-            this.suggestion = undefined;
-        }
-    },
-
     get showComposerAvatar() {
         return super.showComposerAvatar || (this.compact && this.props.composer.portalComment);
     },

--- a/addons/portal/static/src/chatter/frontend/suggestion_service_patch.js
+++ b/addons/portal/static/src/chatter/frontend/suggestion_service_patch.js
@@ -1,0 +1,14 @@
+import { SuggestionService } from "@mail/core/common/suggestion_service";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {SuggestionService} */
+const suggestionServicePatch = {
+    getSupportedDelimiters(thread, env) {
+        if (env?.inFrontendPortalChatter) {
+            return [["::"]];
+        }
+        return super.getSupportedDelimiters(...arguments);
+    },
+};
+patch(SuggestionService.prototype, suggestionServicePatch);

--- a/addons/project/static/src/project_sharing/chatter/chatter_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/chatter_patch.js
@@ -12,8 +12,9 @@ patch(Chatter.prototype, {
         });
         this.orm = useService("orm");
         useSubEnv({
+            // 'inFrontendPortalChatter' is specific to the frontend portal chatters 
+            // and should not be set to 'true' in the project sharing chatter environment.
             projectSharingId: this.props.projectSharingId,
-            inFrontendPortalChatter: true,
         });
     },
 

--- a/addons/project/static/src/project_sharing/chatter/composer_actions_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/composer_actions_patch.js
@@ -1,0 +1,11 @@
+import { patch } from "@web/core/utils/patch";
+import { composerActionsInternal } from "@mail/core/common/composer_actions";
+
+patch(composerActionsInternal, {
+    condition(component, id, action) {
+        if (id === "open-full-composer" && component.env.projectSharingId) {
+            return false;
+        }
+        return super.condition(component, id, action);
+    },
+});

--- a/addons/test_mail_full/static/tests/tours/portal_composer_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/portal_composer_actions_tour.js
@@ -1,0 +1,34 @@
+import { registry } from "@web/core/registry";
+
+const cannedResponseButtonSelector = "button[title='Insert a Canned response']";
+
+registry.category("web_tour.tours").add("portal_composer_actions_tour_internal_user", {
+    steps: () => [
+        {
+            trigger: `#chatterRoot:shadow .o-mail-Composer ${cannedResponseButtonSelector}`,
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Composer-input",
+            run() {
+                if (this.anchor.value !== "::") {
+                    console.error(
+                        "Clicking on the canned response button should insert the '::' into the composer."
+                    );
+                }
+            },
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Composer-suggestion:contains(Hello, how may I help you?)",
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("portal_composer_actions_tour_portal_user", {
+    steps: () => [
+        {
+            trigger: `#chatterRoot:shadow .o-mail-Composer:not(:has(${cannedResponseButtonSelector}))`,
+        },
+    ],
+});

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -50,3 +50,14 @@ class TestUIPortal(TestPortal):
             f"/my/test_portal_rating_records/{record_rating.id}?token={record_rating._portal_ensure_token()}",
             "portal_rating_tour",
         )
+
+    def test_composer_actions_portal(self):
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}",
+            "portal_composer_actions_tour_internal_user",
+            login=self.user_employee.login,
+        )
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}?token={self.record_portal._portal_ensure_token()}",
+            "portal_composer_actions_tour_portal_user",
+        )


### PR DESCRIPTION
*: im_livechat, portal, project, test_mail_full

PR #192953 introduces a composer action for canned responses. The feature is
available in portal for internal users but since `suggestion` is disabled in
portal, this feature doesn't work properly.
In preparation for supporting `::` delimiter in portal, the incorrect fix in PR
#231360 has been reverted. `inFrontendPortalChatter` is specific to portal
frontend and should not be set to `true` in the project sharing environment.
Instead of the mentioned fix, a similar fix from PR #231441 has been backported.

task-5262349