### PR TITLE
[FIX] mass_mailing: fix history operations for conditionally visible snippets

### DIFF
--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -180,7 +180,7 @@ class AttributeAction extends BuilderAction {
     }
 }
 
-class DataAttributeAction extends BuilderAction {
+export class DataAttributeAction extends BuilderAction {
     static id = "dataAttributeAction";
     getValue({ editingElement, params: { mainParam: attributeName } = {} }) {
         if (!/(^color|Color)($|(?=[A-Z]))/.test(attributeName)) {

--- a/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.js
+++ b/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.js
@@ -66,7 +66,7 @@ export class SnippetVisibilityOption extends BaseOptionComponent {
                         this.state.domain.toJson()
                     );
                     this.parseTree(newDomain);
-                    this.historyPlugin.addStep();
+                    this.config.onChange?.({ isPreviewing: false });
                 },
             },
             {

--- a/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.xml
@@ -1,9 +1,9 @@
 <templates>
     <t t-name="mass_mailing.VisibilityOption">
         <BuilderRow label.translate="Visibility">
-            <BuilderSelect dataAttributeAction="'filterDomain'">
-                <BuilderSelectItem dataAttributeActionValue="''">Always Visible</BuilderSelectItem>
-                <BuilderSelectItem dataAttributeActionValue="this.stringifiedDomain" id="'show_domain_selector'">Conditionally</BuilderSelectItem>
+            <BuilderSelect action="'dataAttributeChangeAction'" actionParam="'filterDomain'">
+                <BuilderSelectItem actionValue="''">Always Visible</BuilderSelectItem>
+                <BuilderSelectItem actionValue="this.stringifiedDomain" id="'show_domain_selector'">Conditionally</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
         <BuilderContext t-if="this.isActiveItem('show_domain_selector')">

--- a/addons/mass_mailing/static/src/builder/plugins/snippet_visibility_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/snippet_visibility_option_plugin.js
@@ -3,13 +3,24 @@ import { registry } from "@web/core/registry";
 import { SnippetVisibilityOption } from "../options/snippet_visibility_option";
 import { withSequence } from "@html_editor/utils/resource";
 import { effect } from "@web/core/utils/reactive";
+import { DataAttributeAction } from "@html_builder/core/core_builder_action_plugin";
+
+class DataAttributeChangeAction extends DataAttributeAction {
+    static id = "dataAttributeChangeAction";
+    apply(context) {
+        super.apply(context);
+        this.config.onChange?.(context);
+    }
+}
 
 class SnippetVisibilityPlugin extends Plugin {
     static id = "mass_mailing.SnippetVisibility";
     static shared = ["getModel"];
 
     resources = {
+        builder_actions: { DataAttributeChangeAction },
         builder_options: [withSequence(Infinity, SnippetVisibilityOption)],
+        system_attributes: "data-filter-domain",
     };
     setup() {
         this.mailingModelId = this.config.record.data.mailing_model_id.id;
@@ -34,7 +45,7 @@ class SnippetVisibilityPlugin extends Plugin {
     resetFilterDomains() {
         const filteredElements = this.editable.querySelectorAll("[data-filter-domain]");
         filteredElements.forEach((el) => el.removeAttribute("data-filter-domain"));
-        this.dispatchTo("trigger_dom_updated");
+        this.config.onChange?.({ isPreviewing: false });
     }
 }
 

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -313,7 +313,7 @@ describe("field HTML", () => {
         await runAllTimers();
         const section = queryAny(":iframe section");
         section.dataset.filterDomain = JSON.stringify([["id", "=", 1]]);
-        htmlField.editor.shared["history"].addStep();
+        htmlField.editor.config.onChange({ isPreviewing: false });
         await click(section);
         await waitFor(".hb-row .hb-row-label span:contains(Domain)");
         expect(queryOne(".hb-row span.fa-filter + span").textContent.toLowerCase()).toBe("id = 1");


### PR DESCRIPTION
There is an issue with conditionally visible snippets in `mass_mailing` where a user is able to undo in the editor the reset of a filter caused by a recipient model change.

How to reproduce:
- Create a mass_mailing and add a conditional display rule on a snippet
- Change the recipient model
- undo, then redo

Issue:
- The rule appears again on the element, even though the model still has the new value. The domain is invalid, since it applied only on the previous model

Resolution:
- Make the `data-filter-domain` a `system_attribute` so it is not registered in the editor history. To inform the view that there was a change, `onChange` is called directly when the attribute value changes.

task-5263043
