### PR TITLE
[FIX] mass_mailing: fix infinite scrolling and ghost paragraphs

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -138,6 +138,7 @@
             'mass_mailing/static/src/xml/mailing_portal_subscription_form.xml',
         ],
         'web.assets_backend': [
+            'mass_mailing/static/src/editor/**/*',
             'mass_mailing/static/src/fields/**/*',
             'mass_mailing/static/src/themes/**/*',
             'mass_mailing/static/src/iframe/**/*',

--- a/addons/mass_mailing/static/src/editor/plugins/mass_mailing_contenteditable_plugin.js
+++ b/addons/mass_mailing/static/src/editor/plugins/mass_mailing_contenteditable_plugin.js
@@ -1,0 +1,25 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+export class MassMailingContenteditablePlugin extends Plugin {
+    static id = "massMailingContenteditablePlugin";
+    resources = {
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+    };
+
+    setup() {
+        const layoutEditable = this.editable.querySelector(".o_layout .o_mail_no_options");
+        if (layoutEditable) {
+            this.editable.setAttribute("contenteditable", "false");
+            layoutEditable.setAttribute("contenteditable", "true");
+        }
+    }
+
+    cleanForSave({ root: clone }) {
+        clone.querySelector(".o_layout .o_mail_no_options")?.removeAttribute("contenteditable");
+    }
+}
+
+registry
+    .category("basic-editor-plugins")
+    .add(MassMailingContenteditablePlugin.id, MassMailingContenteditablePlugin);

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -256,7 +256,11 @@ export class MassMailingHtmlField extends HtmlField {
         return {
             ...config,
             onEditorReady: () => this.commitChanges(),
-            Plugins: [...MAIN_EDITOR_PLUGINS, ...DYNAMIC_PLACEHOLDER_PLUGINS],
+            Plugins: [
+                ...MAIN_EDITOR_PLUGINS,
+                ...DYNAMIC_PLACEHOLDER_PLUGINS,
+                ...registry.category("basic-editor-plugins").getAll(),
+            ],
         };
     }
 

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -30,8 +30,6 @@ div.col:not([align]) {
 // ===== Layout =====
 .o_layout {
     overflow: hidden;
-    box-sizing: content-box;
-    min-height: 100%;
 
     > .o_mail_wrapper {
         width: 100%;

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -350,7 +350,7 @@ describe("field HTML", () => {
         expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);
         // editable basic
         await contains(`.o_pager_next`).click();
-        await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_basic_theme", {
+        await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_basic_theme:only-child", {
             timeout: 3000,
         });
         expect(getPagerValue()).toEqual([2]);
@@ -358,7 +358,7 @@ describe("field HTML", () => {
         expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);
         // editable builder
         await contains(`.o_pager_next`).click();
-        await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_empty_theme", {
+        await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_empty_theme:only-child", {
             timeout: 3000,
         });
         expect(getPagerValue()).toEqual([3]);
@@ -366,9 +366,10 @@ describe("field HTML", () => {
         expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(1);
         // readonly default
         await contains(`.o_pager_next`).click();
-        await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_default_theme", {
-            timeout: 3000,
-        });
+        await waitFor(
+            ".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_default_theme:only-child",
+            { timeout: 3000 }
+        );
         expect(getPagerValue()).toEqual([1]);
         expect(htmlField.state.activeTheme).toBe("default");
         expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);


### PR DESCRIPTION
This [commit] introduced 2 issues in `mass_mailing`:
- when creating a mailing with the basic editor, it adds an empty paragraph above the `o_layout` block, even thought the entire mailing content should be enclosed inside the `o_layout` block.
- when sending such an email (with the wrong paragraph) and consulting the readonly value in the `mass_mailing` Form view, the view started growing indefinitely.

How to reproduce:
- create a mailing using the basic editor and send the email
- open the mailing in readonly

Issues:
- there is a paragraph outside the `o_layout` element in the DOM
- the page scrolls indefinitely because `o_layout` has `min-height: 100%`.

Resolution:
- don't force `o_layout` to have a `min-height`, which will prevent the infinite scrolling for mailing that were sent with a wrongly placed paragraph.
- configure the mailing so that the editable element has `contenteditable="false"`, and the element with `o_mail_no_options` coming from the basic template gets `contenteditable="true"` so that the editor is informed that the user is only allowed to edit the content of that node, not the outside of it, which will prevent the empty paragraph insertion.

[commit]: https://github.com/odoo/odoo/commit/edf7f7bb0c62978640c181eccb4934855d5d872d

task-5263045
