### PR TITLE
[FIX] account: prevent the div `journal_div` from being displayed empty

### DIFF
--- a/addons/account/static/src/css/account.css
+++ b/addons/account/static/src/css/account.css
@@ -72,3 +72,7 @@
         margin-left: 2px;
     }
 }
+
+.o_account_move_form_view .o_cell:has(>div[name="journal_div"]:empty) {
+    display: none !important;
+}


### PR DESCRIPTION
### Issue:
In a certain case, the div `journal_div` has nothing inside and is displayed. This causes the form view to be offsetted.

### Steps to reproduce:
- Install "l10n_ar" and switch to an Argentinian company
- The user must not have the group `base.group_multi_currency`
	- Settings > Currencies and deactivate the USD
- Make sure you only have one Sales journal
- Create an invoice
- The field 'Result' is offsetted

### Cause:
The div `journal_div` is constructed like this:
```xml
<div name="journal_div" class="d-flex">
    <field name="journal_id"
           invisible="not show_journal"/>
    <div name="currency_div"
         groups="base.group_multi_currency">
       ...
    </div>
</div>
```
In the case `show_journal = False` and the user doesn't have the group `base.group_multi_currency`, then `journal_div` is empty, but it's still displayed.

It will take the place of a label, this means that the next field label will be in the "input" column and its input in the "label" column.

### Solution:
We need to not display the `div` when `show_journal = False` AND the user doesn't have the group `base.group_multi_currency`. This is not possible.

A possible fix would be to add a non-stored computed field just like `show_journal` to show or not the div.

This commit chose to fix this with CSS: do not display `journal_div` if it's empty. This is also more secure in the case where a customization added things in the div.

Before this commit:
<img width="1048" height="273" alt="image" src="https://github.com/user-attachments/assets/04062527-ee8d-463c-9768-72f0680c922d" />

After this commit:
<img width="1052" height="221" alt="image" src="https://github.com/user-attachments/assets/30b4f169-f4c0-485f-b895-b8d33bfd1fa6" />


opw-5221931