### PR TITLE
[FIX] web_editor: avoid traceback on empty div rows

### DIFF
--- a/addons/web_editor/static/src/js/common/column_layout_mixin.js
+++ b/addons/web_editor/static/src/js/common/column_layout_mixin.js
@@ -11,7 +11,7 @@ export const ColumnLayoutMixin = {
      * @returns {integer|string} number of columns or "custom"
      */
     _getNbColumns(columnEls, isMobile) {
-        if (!columnEls) {
+        if (!columnEls || !columnEls[0]) {
             return 0;
         }
         if (this._areColsCustomized(columnEls, isMobile)) {
@@ -82,6 +82,9 @@ export const ColumnLayoutMixin = {
      * @returns {boolean}
      */
     _areColsCustomized(columnEls, isMobile) {
+        if (!columnEls || !columnEls[0]) {
+            return false;
+        }
         const resolutionModifier = isMobile ? "" : "lg-";
         const colRegex = new RegExp(`(?:^|\\s+)col-${resolutionModifier}(\\d{1,2})(?!\\S)`);
         const colSize = parseInt(columnEls[0].className.match(colRegex)?.[1] || 12);


### PR DESCRIPTION
When a .row div was empty, the _areColsCustomized function was called with an empty HTMLCollection. This caused a traceback when the function tried to access columnEls[0].

This commit adds a safety check to _getNbColumns for avoiding extra calls to _areColsCustomized when columnEls is empty. And we also add a similar check to _areColsCustomized for safety, since it's also being called through the _computeWidgetVisibility.

opw-5121738

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
