### PR TITLE
[FIX] account: Bank statement first line index compute

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -27,7 +27,7 @@ class AccountBankStatement(models.Model):
     )
 
     date = fields.Date(
-        compute='_compute_date_index', store=True,
+        compute='_compute_date', store=True,
         index=True,
     )
 
@@ -36,7 +36,7 @@ class AccountBankStatement(models.Model):
     # keeping this order is important because the validity of the statements are based on their order
     first_line_index = fields.Char(
         comodel_name='account.bank.statement.line',
-        compute='_compute_date_index', store=True,
+        compute='_compute_first_line_index', store=True,
     )
 
     balance_start = fields.Monetary(
@@ -123,12 +123,18 @@ class AccountBankStatement(models.Model):
             stmt.name = name +_("Statement %(date)s", date=stmt.date or fields.Date.to_date(stmt.create_date))
 
     @api.depends('line_ids.internal_index', 'line_ids.state')
-    def _compute_date_index(self):
+    def _compute_first_line_index(self):
         for stmt in self:
             # When we create lines manually from the form view, they don't have any `internal_index` set yet.
             sorted_lines = stmt.line_ids.filtered("internal_index").sorted('internal_index')
             stmt.first_line_index = sorted_lines[:1].internal_index
-            stmt.date = sorted_lines.filtered(lambda l: l.state == 'posted')[-1:].date
+
+    @api.depends('line_ids.internal_index', 'line_ids.state')
+    def _compute_date(self):
+        for statement in self:
+            # When we create lines manually from the form view, they don't have any `internal_index` set yet.
+            sorted_lines = statement.line_ids.filtered('internal_index').sorted('internal_index')
+            statement.date = sorted_lines.filtered(lambda l: l.state == 'posted')[-1:].date
 
     @api.depends('create_date')
     def _compute_balance_start(self):


### PR DESCRIPTION
Ensure proper computation of first_line_index when line.internal_index or line.state changes.

Previously, the computation of first_line_index was grouped with the date computation. However, due to a specific ORM behavior, the compute method is not
triggered when one of the computed fields (in this case, the date) is provided in the create values.
As a result, first_line_index could remain falsy,
leading to an incorrect balance in the bank journal.

no task id


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
