### PR TITLE
[FIX] l10n_es_edi_tbai: fix fechaOperation

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -106,7 +106,7 @@
                 </t>
             </CabeceraFactura>
             <DatosFactura t-if="is_emission">
-                <FechaOperacion t-if="invoice.delivery_date and format_date(invoice.invoice_date) != format_date(invoice.delivery_date)" t-out="format_date(invoice.delivery_date)"/>
+                <FechaOperacion t-if="invoice.delivery_date and format_date(datetime_now) != format_date(invoice.delivery_date)" t-out="format_date(invoice.delivery_date)"/>
                 <DescripcionFactura t-out="invoice.invoice_origin and invoice.invoice_origin[:250] or 'manual'"/>
                 <DetallesFactura>
                     <IDDetalleFactura t-foreach="invoice_lines" t-as="line_values">

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -469,3 +469,89 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
   </HuellaTBAI>
 </T:TicketBai>
 """
+
+    L10N_ES_TBAI_FECHA_OPERACION = """<?xml version='1.0'?>
+<T:TicketBai xmlns:etsi="http://uri.etsi.org/01903/v1.3.2#" xmlns:T="urn:ticketbai:emision" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <Cabecera>
+    <IDVersionTBAI>1.2</IDVersionTBAI>
+  </Cabecera>
+  <Sujetos>
+    <Emisor>
+      <NIF>___ignore___</NIF>
+      <ApellidosNombreRazonSocial>EUS Company</ApellidosNombreRazonSocial>
+    </Emisor>
+    <Destinatarios>
+      <IDDestinatario>
+        <IDOtro>
+          <IDType>02</IDType>
+          <ID>BE0477472701</ID>
+        </IDOtro>
+        <ApellidosNombreRazonSocial>&amp;@&#224;&#193;$&#163;&#8364;&#232;&#234;&#200;&#202;&#246;&#212;&#199;&#231;&#161;&#8539;&#8482;&#179;</ApellidosNombreRazonSocial>
+        <CodigoPostal>___ignore___</CodigoPostal>
+        <Direccion>___ignore___</Direccion>
+      </IDDestinatario>
+    </Destinatarios>
+    <VariosDestinatarios>N</VariosDestinatarios>
+    <EmitidaPorTercerosODestinatario>N</EmitidaPorTercerosODestinatario>
+  </Sujetos>
+  <Factura>
+    <CabeceraFactura>
+      <SerieFactura>INVTEST</SerieFactura>
+      <NumFactura>01</NumFactura>
+      <FechaExpedicionFactura>01-01-2025</FechaExpedicionFactura>
+      <HoraExpedicionFactura>___ignore___</HoraExpedicionFactura>
+      <FacturaSimplificada>N</FacturaSimplificada>
+    </CabeceraFactura>
+    <DatosFactura>
+      <FechaOperacion>01-01-2022</FechaOperacion>
+      <DescripcionFactura>manual</DescripcionFactura>
+      <DetallesFactura>
+        <IDDetalleFactura>
+          <DescripcionDetalle>producta</DescripcionDetalle>
+          <Cantidad>5.00000000</Cantidad>
+          <ImporteUnitario>1000.00000000</ImporteUnitario>
+          <Descuento>1000.00000000</Descuento>
+          <ImporteTotal>4840.00000000</ImporteTotal>
+        </IDDetalleFactura>
+      </DetallesFactura>
+      <ImporteTotalFactura>4840.00</ImporteTotalFactura>
+      <Claves>
+        <IDClave>
+          <ClaveRegimenIvaOpTrascendencia>01</ClaveRegimenIvaOpTrascendencia>
+        </IDClave>
+      </Claves>
+    </DatosFactura>
+    <TipoDesglose>
+      <DesgloseTipoOperacion>
+        <Entrega>
+          <Sujeta>
+            <NoExenta>
+              <DetalleNoExenta>
+                <TipoNoExenta>S1</TipoNoExenta>
+                <DesgloseIVA>
+                  <DetalleIVA>
+                    <BaseImponible>4000.00</BaseImponible>
+                    <TipoImpositivo>21.00</TipoImpositivo>
+                    <CuotaImpuesto>840.00</CuotaImpuesto>
+                  </DetalleIVA>
+                </DesgloseIVA>
+              </DetalleNoExenta>
+            </NoExenta>
+          </Sujeta>
+        </Entrega>
+      </DesgloseTipoOperacion>
+    </TipoDesglose>
+  </Factura>
+  <HuellaTBAI>
+    <Software>
+      <LicenciaTBAI>___ignore___</LicenciaTBAI>
+      <EntidadDesarrolladora>
+        <NIF>___ignore___</NIF>
+      </EntidadDesarrolladora>
+      <Nombre>___ignore___</Nombre>
+      <Version>___ignore___</Version>
+    </Software>
+    <NumSerieDispositivo>___ignore___</NumSerieDispositivo>
+  </HuellaTBAI>
+</T:TicketBai>
+"""

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -241,3 +241,17 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             xml_doc.remove(xml_doc.find("Signature", namespaces=NS_MAP))
             xml_expected = etree.fromstring(super().L10N_ES_TBAI_CREDIT_NOTE_XML_POST)
             self.assertXmlTreeEqual(xml_doc, xml_expected)
+
+    def test_xml_tree_fecha_operacion(self):
+        """
+        Test that when the invoice_date and delivery date are in the past but are the same
+        FechaOperacion appears in the xml since it is still different from
+        the date the xml is generated (FechaExpedicionFactura)
+        """
+        self.out_invoice.delivery_date = self.out_invoice.invoice_date
+
+        with freeze_time(self.frozen_today):
+            xml_doc = self.edi_format._get_l10n_es_tbai_invoice_xml(self.out_invoice, cancel=False)[self.out_invoice]['xml_file']
+            xml_doc.remove(xml_doc.find("Signature", namespaces=NS_MAP))
+            xml_expected = etree.fromstring(super().L10N_ES_TBAI_FECHA_OPERACION)
+            self.assertXmlTreeEqual(xml_doc, xml_expected)


### PR DESCRIPTION
**[FIX] l10n_es_edi_tbai: fix FechaOperacion**

With l10n_es_tbai:

- Create an invoice with an `invoice_date` and `delivery_date` that are the same and earlier than today.  
- In the generated TBAI XML, `FechaOperacion` is missing.

In the TBAI XML, `FechaExpedicionFactura` corresponds to the date on which the XML is generated.  
`FechaOperacion` corresponds to the `delivery_date` and should appear whenever it differs from the issue date.

The TicketBAI specs define `FechaOperacion` as:  
> “Date on which the transaction was carried out, whenever it differs from the issue date.”

So when the invoice date and delivery date are equal but set in the past, `FechaOperacion` is not generated, even though it should be.

opw-4477135



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
