### PR TITLE
[FIX] mail: view image in full-size in message list

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -1,6 +1,12 @@
 .o-mail-AttachmentContainer {
-    width: 13em;
-    height: 10em;
+    &.o-inMessage.o-isImage {
+        min-width: 13em;
+        min-height: 10em;
+    }
+    &:not(.o-inMessage.o-isImage) {
+        width: 13em;
+        height: 10em;
+    }
     background-color: $gray-200;
 
     @include media-breakpoint-down(sm) {
@@ -30,6 +36,10 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
     line-height: 1.25;
+}
+
+.o-mail-AttachmentImage.o-inMessage {
+    max-height: 300px;
 }
 
 .o-viewable {

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -14,8 +14,10 @@
                      class="o-mail-AttachmentContainer d-flex border position-relative rounded-3"
                      t-att-title="attachment.name ? attachment.name : undefined"
                      t-att-class="{
-                        'o-viewable': attachment.isViewable,
+                        'o-inMessage': env.inMessage,
+                        'o-isImage': attachment.isImage,
                         'o-isUploading opacity-25': attachment.uploading,
+                        'o-viewable': attachment.isViewable,
                     }"
                      tabindex="0"
                      t-att-data-mimetype="attachment.mimetype"
@@ -28,11 +30,12 @@
                         src="getImageUrl(attachment)"
                         paused="attachment.gifPaused"
                         alt="attachment.name"
-                        class="'o-mail-AttachmentImage img img-fluid object-fit-cover w-100 rounded-3'"
+                        class="'o-mail-AttachmentImage img img-fluid w-100 rounded-3 ' + (env.inMessage ? 'object-fit-contain o-inMessage' : 'object-fit-cover')"
                     />
                     <img
                         t-elif="attachment.isImage"
-                        class="o-mail-AttachmentImage img img-fluid object-fit-cover w-100 rounded-3"
+                        class="o-mail-AttachmentImage img img-fluid w-100 rounded-3"
+                        t-att-class="{ 'object-fit-contain o-inMessage': env.inMessage, 'object-fit-cover': !env.inMessage }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"
                         t-on-load="onImageLoaded"

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -22,6 +22,7 @@ import {
     useEffect,
     useRef,
     useState,
+    useSubEnv,
 } from "@odoo/owl";
 
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
@@ -129,10 +130,10 @@ export class Message extends Component {
         this.ui = useService("ui");
         this.openReactionMenu = this.openReactionMenu.bind(this);
         this.optionsDropdown = useDropdownState();
+        useSubEnv({ inMessage: true });
         useChildSubEnv({
             message: this.props.message,
             alignedRight: this.isAlignedRight,
-            inMessage: true,
         });
         onMounted(() => {
             if (this.shadowBody.el) {


### PR DESCRIPTION
Before this commit, images attached to a message had their preview cropped and forced people to view with file viewer.

This square and cropped visual looks good in contexts other than message, e.g. chatter attachment list. In message, however, most of the time people want to share images and be able to see whole content just from preview.

This commit fixes the issue by making image preview of message see whole content.

Task-5259604

Before
<img width="1360" height="788" alt="Screenshot 2025-11-13 at 17 49 30" src="https://github.com/user-attachments/assets/d84c245e-2501-4e5b-9e32-10f0ae882b7e" />

After
<img width="1366" height="831" alt="Screenshot 2025-11-13 at 17 49 39" src="https://github.com/user-attachments/assets/ce27f9eb-1f9a-4802-9590-fa69e8c40140" />
