### PR TITLE
[FIX] hr_holidays : Count public leaves when reevaluating

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -60,11 +60,11 @@ class CalendarLeaves(models.Model):
 
         previous_durations = leaves.mapped('number_of_days')
         previous_states = leaves.mapped('state')
+        self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leaves)
+        self.env.add_to_compute(self.env['hr.leave']._fields['duration_display'], leaves)
         leaves.sudo().write({
             'state': 'confirm',
         })
-        self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leaves)
-        self.env.add_to_compute(self.env['hr.leave']._fields['duration_display'], leaves)
         sick_time_status = self.env.ref('hr_holidays.holiday_status_sl', raise_if_not_found=False)
         leaves_to_recreate = self.env['hr.leave']
         for previous_duration, leave, state in zip(previous_durations, leaves, previous_states):

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -254,3 +254,52 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         }
         for day, value in expected.items():
             self.assertEqual(flex_days.get(day), value, f"Day {day} should be {'unusual' if value else 'normal'}")
+
+    def test_public_holidays_for_consecutive_allocations(self):
+        employee = self.employee_emp
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+        })
+        self.env['hr.leave.allocation'].create([
+            {
+                'name': '2025 allocation',
+                'holiday_status_id': leave_type.id,
+                'number_of_days': 20,
+                'employee_id': employee.id,
+                'state': 'confirm',
+                'date_from': date(2025, 1, 1),
+                'date_to': date(2025, 12, 31),
+            },
+            {
+                'name': '2026 allocation',
+                'holiday_status_id': leave_type.id,
+                'number_of_days': 20,
+                'employee_id': employee.id,
+                'state': 'confirm',
+                'date_from': date(2026, 1, 1),
+                'date_to': date(2026, 12, 31),
+            }
+        ]).action_validate()
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Holiday 1 week',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': datetime(2025, 12, 8, 7, 0),
+            'request_date_to': datetime(2026, 1, 3, 18, 0),
+        })
+        leave.action_validate()
+
+        self.assertEqual(leave.number_of_days, 20, "Number of days should be 20")
+
+        public_holiday = self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': datetime(2025, 12, 31, 23, 0, 0),
+            'date_to': datetime(2026, 1, 1, 22, 59, 59),
+        })
+
+        self.assertTrue(public_holiday)
+        self.assertEqual(leave.number_of_days, 19, "Number of days should be 19 as one day has been granted back to the"
+                                                   "the employee for the public holiday")


### PR DESCRIPTION
### Steps to reproduce:
	- Install Time off apps
	- Create two consecutive allocations (e.g. one for 2025 and one for 2026)
	- Create a leave that overlap with the two allocation (e.g. from 8th Dec to 3rd Jan)
	- Create a public holiday at the beginning of the second allocation (e.g. on 1st Jan 2026)

### Cause:
When we are checking the leave duration after having a public holiday the  will return the attendance without
the public holidays duration so when subtracting the attendance duration from the leave duration we will have a remaining amout equals to the public holiday duration and it will be considered as excess days.

https://github.com/odoo/odoo/blob/06e47d8601ba56b1650eeaeef71ebd7a4af39b8b/addons/hr_holidays/models/hr_employee_base.py#L228-L230

https://github.com/odoo/odoo/blob/06e47d8601ba56b1650eeaeef71ebd7a4af39b8b/addons/hr_holidays/models/hr_employee_base.py#L246-L254

### Fix:
We compute the leave duration before confirming it instead of computed them after

opw-5006119
