### PR TITLE
[FIX] sale: allow searching products by seller code

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -517,7 +517,10 @@
                                                 invisible="state not in ['draft', 'sent'] or not is_product_archived"
                                             />
                                             <field name="product_id"
-                                                context="{'default_uom_id': product_uom_id}"
+                                                context="{
+                                                    'default_uom_id': product_uom_id,
+                                                    'partner_id': parent.partner_id,
+                                                }"
                                                 readonly="not product_updatable"
                                                 required="not display_type and not is_downpayment"
                                                 force_save="1"
@@ -628,6 +631,7 @@
                                     context="{
                                         'default_lst_price': price_unit,
                                         'default_uom_id': product_uom_id,
+                                        'partner_id': parent.partner_id,
                                     }"
                                     optional="hide"
                                     widget="sol_product_many2one"/>
@@ -638,6 +642,7 @@
                                     context="{
                                         'default_list_price': price_unit,
                                         'default_uom_id': product_uom_id,
+                                        'partner_id': parent.partner_id,
                                     }"
                                     optional="show"
                                     widget="sol_product_many2one"


### PR DESCRIPTION
Commit 6e69b1d4a357bf236695a2ed5b09fd62de911872 cleaned up SO views and removed some context fields from the product_id and product_template_id fields which were in fact used in the `_search_display_name` override of the related models.

This commit brings back those values to allow finding products by their seller product name or code.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
