### PR TITLE
[FIX] {,purchase_}stock,stock_picking_batch: generate correct svl whe…

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -111,6 +111,13 @@ class StockMove(models.Model):
             qty_received -= self.product_uom._compute_quantity(
                 self.quantity, self.purchase_line_id.product_uom, rounding_method='HALF-UP'
             )
+            batch_moves = self._get_batch_moves()
+            for move in batch_moves:
+                if move == self or move.state != 'done' or move.purchase_line_id != self.purchase_line_id:
+                    continue
+                qty_received -= move.product_uom._compute_quantity(
+                    move.quantity, self.purchase_line_id.product_uom, rounding_method='HALF-UP'
+                )
         return qty_received
 
     def _get_currency_convert_date(self):

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3809,3 +3809,40 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             {'debit': 0.0, 'credit': 100.0, 'reconciled': True},
             {'debit': 100.0, 'credit': 0.0, 'reconciled': True},
         ])
+
+    def test_PO_ordered_quantity_invoice_batch_svl(self):
+        if not self.env["ir.module.module"].search([("name", "=", "stock_picking_batch"), ("state", "=", "installed")]):
+            self.skipTest("stock_picking_batch module is required for this test")
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        self.product1.purchase_method = 'purchase'
+        self.product1.standard_price = 1.0
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [
+                Command.create({
+                    'name': self.product1.name,
+                    'product_id': self.product1.id,
+                    'product_qty': 50.0,
+                    'price_unit': 1.0,
+                }),
+            ],
+        })
+        po.button_confirm()
+        self._bill(po)
+        receipt_1 = po.picking_ids[0]
+        receipt_1.move_ids.quantity = 20
+        receipt_1.action_split_transfer()
+        receipt_1 = po.picking_ids[0]
+        receipt_2 = po.picking_ids[1]
+        batch = self.env['stock.picking.batch'].create({
+            'name': 'Batch 1',
+            'company_id': self.env.company.id,
+            'picking_ids': [Command.link(receipt_1.id), Command.link(receipt_2.id)]
+        })
+        batch.action_done()
+        self.assertRecordValues(batch.picking_ids.move_ids.stock_valuation_layer_ids.sorted('quantity'), [
+            {'quantity': 20.0, 'unit_cost': 1.0, 'value': 20},
+            {'quantity': 30.0, 'unit_cost': 1.0, 'value': 30},
+        ])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2584,3 +2584,8 @@ Please change the quantity done or the rounding precision of your unit of measur
         return self.location_dest_id.usage in ('customer', 'supplier') or (
             self.location_dest_id.usage == 'transit' and not self.location_dest_id.company_id
         )
+
+    def _get_batch_moves(self):
+        """ Overridden in stock_picking_batch to return the move of the batch
+        """
+        return self.env['stock.move']

--- a/addons/stock_picking_batch/models/stock_move.py
+++ b/addons/stock_picking_batch/models/stock_move.py
@@ -40,3 +40,9 @@ class StockMove(models.Model):
     def _action_assign(self, force_qty=False):
         super()._action_assign(force_qty=force_qty)
         self.move_line_ids._auto_wave()
+
+    def _get_batch_moves(self):
+        moves = super()._get_batch_moves()
+        if self.picking_id.batch_id:
+            moves |= self.picking_id.batch_id.move_ids
+        return moves


### PR DESCRIPTION
…n batch billed on ordered qty

**Problem:**
When the picking of a purchase order (of a product billed on ordered quantity) is split into different
moves and put in a batch, at batch validation, svls are created with the wrong values.

 **Steps to reproduce:**
    - enable "Batch, Wave & Cluster Transfers" settings
    - create a storable product with a standard price of 1
    - set the category as avco
    - in the Purchase tab select the control policy as
    "on ordered quantities"
    - create and confirm a purchase order for 50 of this product
    - on the Receipt, change the quantity to 20 and split the
    picking
    - go back the the PO and create and confirm a bill for
    the full amount
    - click on the receipt smart button
    - select the two pickings and then the 'Action' button
    - select add to batch
    - check 'new batch transfer' and confirm
    - open the batch and validate it
    - open stock valuation
    
**Current behavior:**
    the newly created svls have total values of
    50 and 50.10

**Expected behavior:**
    it should be 20 and 30
    
**Cause of the issue:**
When the batch is validated, _action_done is called 
on the two stock moves.
https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/stock/models/stock_picking.py#L1258
In the stock_account override: 
- first the super method is called
As a consequence the state of the two moves becomes 'done'
and the qty_received of the linked purchase order line becomes 50.
- then product_price_update_before_done is called before creating
the svls.

Inside product_price_update_before_done we call _get_price_unit.
In the purchase_stock override of _get_price_unit : 
- because the super method of action_done was already called, 
qty_received of the purchase order line is 50, so _get_qty_received_without_self
will return 30. 
https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/purchase_stock/models/stock_move.py#L50
So received_qty is 30 and later remaining_qty will be 20
https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/purchase_stock/models/stock_move.py#L86
- but because no svl was created yet receipt_value will stay 0 and later 
remaining_value will be 50
https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/purchase_stock/models/stock_move.py#L55-L63
Therefore price_unit will be 2.5 (50/20) instead of 1 

**fix**
We do not take into account the move(s) of the 
same batch in the remaining value (because svls are not created yet)
so we should not  take them into account in the remaining quantity.

opw-5179581
