### PR TITLE
[REF] hr: _get_calendar_periods will take dates instead of datetime and ignore timezone

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -118,20 +118,23 @@ class HrEmployee(models.Model):
         lookahead_days = [7, 30, 90, 180, 365, 730]
         work_intervals = None
         for lookahead_day in lookahead_days:
-            periods = self._get_calendar_periods(dt, dt + timedelta(days=lookahead_day))
+            periods = self._get_calendar_periods(dt.date(), dt.date() + timedelta(days=lookahead_day))
             if not periods:
                 calendar = self.resource_calendar_id or self.company_id.resource_calendar_id
                 work_intervals = calendar._work_intervals_batch(
                     dt, dt + timedelta(days=lookahead_day), resources=self.resource_id)
             else:
-                for period in periods[self]:
-                    start, end, calendar = period
+                for start, end, calendar in periods[self]:
                     calendar = calendar or self.company_id.resource_calendar_id
+                    ctz = ZoneInfo(calendar.tz)
                     work_intervals = calendar._work_intervals_batch(
-                        start, end, resources=self.resource_id)
+                        datetime.combine(start, time.min, ctz),
+                        datetime.combine(end, time.max, ctz),
+                        resources=self.resource_id)
             if work_intervals.get(self.resource_id.id) and work_intervals[self.resource_id.id]._items:
                 # return start time of the earliest interval
                 return work_intervals[self.resource_id.id]._items[0][0]
+        return None
 
     def _compute_leave_status(self):
         # Used SUPERUSER_ID to forcefully get status of other user's leave, to bypass record rule


### PR DESCRIPTION
This change is done as the function _get_calendar_periods takes datetimes with timezones when they are not needed and immediately converted into dates with overwritten times and timezones.

task-5186744

