### PR TITLE
[FIX] account: deduplicate res.partner fiscal_country_codes

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -358,7 +358,7 @@ class ResPartner(models.Model):
             country_codes = allowed_companies.mapped('account_fiscal_country_id.code')
             if record.country_code:
                 country_codes.append(record.country_code)
-            record.fiscal_country_codes = ",".join(country_codes)
+            record.fiscal_country_codes = ",".join(set(country_codes))
 
     @property
     def _order(self):


### PR DESCRIPTION
Recently we started considering `country_code` as part of the `fiscal_country_codes` [1]. Because of this, the field can now contain duplicates. If your active company is a US one, and you set United States as the country on the partner you end up with `US,US`.

It breaks some (admittedly fragile) invisible conditions on the `res.partner` form view [2]. Although we could fix those conditions, it would require everyone to update the module, and having duplicate country codes in `fiscal_country_codes` field doesn't serve any purpose anyway.

[1] https://github.com/odoo/odoo/pull/229584
[2] https://github.com/odoo/enterprise/pull/62615

opw-5248844
opw-5241556
