### PR TITLE
[FIX] l10n_vn_edi_viettel: Add index on sinvoice.symbol.invoice_template_id (inverse One2many field)

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/sinvoice.py
+++ b/addons/l10n_vn_edi_viettel/models/sinvoice.py
@@ -84,6 +84,7 @@ class L10n_Vn_Edi_ViettelSinvoiceSymbol(models.Model):
     invoice_template_id = fields.Many2one(
         comodel_name='l10n_vn_edi_viettel.sinvoice.template',
         required=True,
+        index=True,
     )
 
     _name_template_uniq = models.Constraint(


### PR DESCRIPTION
TestIndex.test_enforce_index_on_one2many_inverse Traceback (most recent call last):

AssertionError: The following fields should be indexed with a btree index, as they are inverse of an One2many field:
- if the field is sparse -> 'btree_not_null'
- if the field is Required or low fraction of False/NULL values -> True or 'btree'
- if not sure -> 'btree_not_null': l10n_vn_edi_viettel.sinvoice.symbol.invoice_template_id (inverse of l10n_vn_edi_viettel.sinvoice.template.invoice_symbols_ids)






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
