### PR TITLE
[FIX] pos_loyalty: prevent double negation in reward domain

### DIFF
--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -62,7 +62,7 @@ class LoyaltyReward(models.Model):
 
             if field and field.type == 'many2one' and operator in ('ilike', 'not ilike'):
                 comodel = self.env[field.comodel_name]
-                matching_ids = list(comodel._search([('display_name', operator, value)]))
+                matching_ids = list(comodel._search([('display_name', 'ilike', value)]))
 
                 new_operator = 'in' if operator == 'ilike' else 'not in'
                 domain[index] = [field_name, new_operator, matching_ids]

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -223,6 +223,12 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardPro
             ProductScreen.clickDisplayedProduct("Product B"),
             ProductScreen.selectedOrderlineHas("Product B", "1.00", "50.00"),
             PosLoyalty.orderTotalIs("40.00"),
+
+            ProductScreen.clickControlButton("Reward"),
+            SelectionPopup.has("10$ on your order - Product B - Saleable", { run: "click" }),
+            ProductScreen.clickControlButton("Reward"),
+            SelectionPopup.has("10$ on your order - Product B - Not Saleable", { run: "click" }),
+            PosLoyalty.orderTotalIs("30.00"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1307,6 +1307,37 @@ class TestUi(TestPointOfSaleHttpCommon):
             'pos_config_ids': [Command.link(self.main_pos_config.id)],
         })
 
+        # Adding a third program whose first reward should not be applied during the Tour
+        # Its purpose is to confirm that the 'not ilike' logic is properly converted into 'in'
+        self.env['loyalty.program'].create({
+            'name': 'Discount on Specific Products - Product B',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'minimum_qty': 1,
+                'reward_point_amount': 2,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'required_points': 1,
+                'description': '10$ on your order - Product B - Not Saleable',
+                'discount_mode': 'per_order',
+                'discount': 10,
+                'discount_applicability': 'specific',
+                'discount_product_domain': '["&", ("categ_id", "not ilike", "Saleable"), ("name", "=", "Product B")]',
+            }),
+            (0, 0, {
+                'reward_type': 'discount',
+                'required_points': 1,
+                'description': '10$ on your order - Product B - Saleable',
+                'discount_mode': 'per_order',
+                'discount': 10,
+                'discount_applicability': 'specific',
+                'discount_product_domain': '["&", ("categ_id", "ilike", "Saleable"), ("name", "=", "Product B")]',
+            })],
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+        })
         self.main_pos_config.open_ui()
         self.start_pos_tour("PosLoyaltySpecificDiscountWithRewardProductDomainTour")
 


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a loyalty program;
2. Create a reward;
3. Add a Product domain to the reward containing the `not ilike` operator;
4. Load the POS;
5. Try to trigger the Loyalty program;
6. The Reward is not applied when the domain is satisfied

Issue
-----
Loyalty Program rewards containing `not ilike`-based product domains are not applied when they should.

Cause
-----
The `_replace_ilike_with_in` function in loyalty_reward.py converts the `ilike` and `not ilike` operators by first fetching the records that very the domain with the operator used, and then by replacing the domain by `in` or `not in` with the returned records ids. This is problematic as in the case of `not ilike`, it leads to a double negation.

Example
-----
For `ilike`: `['categ_id', 'ilike', 'service']`
-> Search for all categories that contain "service": `_search([('display_name', 'ilike', 'service')])` 
-> Return new domain `['categ_id', 'in', matching_ids]`
Which is correct.

For `not ilike`: `['categ_id', 'not ilike', 'service']`
-> Search for all categories that **do not contain** "service": `_search([('display_name', 'not ilike', 'service')])`
-> Return new domain `['categ_id', 'not in', matching_ids]`
Which is incorrect, as the matching_ids are already the ids that are not like "service". (i.e., *categ_id not in the categories that do not contain "service"* <=> *categ_id in the categories that contain "service"*, opposite of what is expected.)

Solution
--------
1. Perform the initial search with `ilike` for both operators

opw-5182818

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
