### PR TITLE
[FIX] hr_holiday, hr_work_holiday: prevent traceback when reloading page in Studio

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -33,6 +33,7 @@ class HrEmployee(models.Model):
         return {
             'name': _('Time Off Dashboard'),
             'type': 'ir.actions.act_window',
+            'path': 'time-off',
             'res_model': 'hr.leave',
             'views': [[self.env.ref('hr_holidays.hr_leave_employee_view_dashboard').id, 'calendar']],
             'domain': [('employee_id', 'in', self.ids)],

--- a/addons/hr_work_entry/models/hr_employee.py
+++ b/addons/hr_work_entry/models/hr_employee.py
@@ -34,6 +34,7 @@ class HrEmployee(models.Model):
             'name': _('%s work entries', self.display_name),
             'view_mode': 'calendar,list,form',
             'res_model': 'hr.work.entry',
+            'path': 'work-entries',
             'context': ctx,
             'domain': [('employee_id', '=', self.id)],
         }


### PR DESCRIPTION
**Verison:**
- saas-18.2

**Steps to reproduce:**
- Go to an employee form view.
- Click on the WorkEntries smart button.
- Open Studio.
- Reload page.

**Issue:**
- A traceback appears after reloading the page in Studio.

**Cause:**
- The smart button URL uses the model name hr.work.entry, but Studio’s service_action expects a path without dots. Because the action cannot be loaded correctly, the view breaks and triggers the traceback.

**Solution:**
- Return the proper path instead of the model name so that the action loads correctly. This prevents the error when reloading the page.

task-5236317

