### PR TITLE
[FIX] l10n_latam_base: add guatemala to latamid group

### DIFF
--- a/addons/l10n_latam_base/data/res_country_group.xml
+++ b/addons/l10n_latam_base/data/res_country_group.xml
@@ -6,7 +6,7 @@
             <field name="code">LATAMID</field>
             <field name="country_ids" eval="[Command.set([
                 ref('base.ar'),ref('base.br'),ref('base.cl'),ref('base.co'),
-                ref('base.ec'),ref('base.pe'),ref('base.uy')])]"/>
+                ref('base.ec'),ref('base.pe'),ref('base.uy'),ref('base.gt')])]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
Step to reproduce:
- install `l10n_gt_edi` with demo
- switch to GT company
- open a record from contacts

Observation:
- partner form is missing the Identification Type field

Cause:
- after this commit [1] , Identification Type is now conditional. It only appear in other localizations when the type is not is_vat and the allowed company is not a LATAM company.

Fix:
- As Guatemala is a latam, we add it in LATAMID group

[1]:https://github.com/odoo/odoo/commit/bc742ad449c704cf9324e569e73aa1e919238dda

opw-5234916

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
