### PR TITLE
[IMP] im_livechat: add transcript download button to info panel

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -3,6 +3,7 @@ import { Thread } from "@mail/core/common/thread_model";
 
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
+import { url } from "@web/core/utils/urls";
 
 patch(Thread.prototype, {
     setup() {
@@ -77,6 +78,11 @@ patch(Thread.prototype, {
             ? _t("This livechat conversation has ended")
             : "";
     },
+
+    get transcriptUrl() {
+        return url(`/im_livechat/download_transcript/${this.id}`);
+    },
+
     /**
      * @override
      * @param {import("models").Persona} persona

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -51,6 +51,7 @@
             <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Send conversation</h6>
                 <TranscriptSender thread="props.thread"/>
+                <a class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="pe-2 fa fa-download"/>Download</a>
             </div>
         </ActionPanel>
     </t>

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.js
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.js
@@ -51,8 +51,9 @@ export class FeedbackPanel extends Component {
         );
     }
 
+    /** @deprecated use `thread.transcriptUrl` instead */
     get transcriptUrl() {
-        return url(`/im_livechat/download_transcript/${this.props.thread.id}`);
+        return this.props.thread.transcriptUrl;
     }
 
     onClickSendFeedback() {

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -28,7 +28,7 @@
         <div class="d-flex gap-2 justify-content-center">
             <button class="btn btn-outline-secondary" t-on-click="props.onClickClose">Close</button>
             <button t-if="allowNewSession" class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
-            <a t-if="store.can_download_transcript" class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="transcriptUrl"><i class="fa fa-download"/></a>
+            <a t-if="store.can_download_transcript" class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="fa fa-download"/></a>
         </div>
     </div>
 </div>

--- a/addons/im_livechat/static/src/embed/cors/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/thread_model_patch.js
@@ -1,14 +1,14 @@
+import { Thread } from "@mail/core/common/thread_model";
 import { expirableStorage } from "@im_livechat/core/common/expirable_storage";
-import { FeedbackPanel } from "@im_livechat/embed/common/feedback_panel/feedback_panel";
 import { GUEST_TOKEN_STORAGE_KEY } from "@im_livechat/embed/common/store_service_patch";
 
 import { patch } from "@web/core/utils/patch";
 import { url } from "@web/core/utils/urls";
 
-patch(FeedbackPanel.prototype, {
+patch(Thread.prototype, {
     get transcriptUrl() {
         const guestToken = expirableStorage.getItem(GUEST_TOKEN_STORAGE_KEY);
-        return url(`/im_livechat/cors/download_transcript/${this.props.thread.id}`, {
+        return url(`/im_livechat/cors/download_transcript/${this.id}`, {
             guest_token: guestToken,
         });
     },


### PR DESCRIPTION
Previously, the 'Download Transcript' button was only visible to visitors at the end of a live chat session. This limitation caused confusion since internal users could not download the conversation transcript from the interface.

This PR adds the 'download transcript' button to the info panel, ensuring it is accessible from within the chat session as well.

Task-5262296


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
