### PR TITLE
[FIX][17.0] website_slides: Sidebar category not visible in full screen view

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -108,7 +108,7 @@
             <i class="fa fa-fw fa-caret-left" role="img"/>
             <i class="fa fa-fw fa-caret-down" role="img"/>
         </a>
-        <ul t-attf-class="o_wslides_fs_sidebar_section_slides position-relative px-0 pb-1 my-0 mx-n3 collapse #{'show' if category_collapsed else ''}"
+        <ul t-attf-class="o_wslides_fs_sidebar_section_slides position-relative px-0 pb-1 my-0 mx-n3 collapse #{'show' if (not category or category_collapsed) else ''}"
             t-attf-id="collapse-#{category.id if category else 0}">
             <t t-set="is_member" t-value="current_slide.channel_id.is_member"/>
             <t t-set="can_access_channel" t-value="is_member or current_slide.channel_id.can_publish"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

fix(website_slides): sidebar not visible when category is Uncategorized in fullscreen mode

Issue:
- When `category` is empty (Uncategorized), the sidebar category section
  is collapsed by default in fullscreen mode.
- No toggle button is shown, so users cannot expand the sidebar.
- As a result, slide navigation is broken for Uncategorized items.

Fix:
- Adjust conditional class binding to ensure the "show" class is applied
  when category is empty.
- The sidebar now appears and can be toggled normally in fullscreen mode
  for the Uncategorized case.


<img width="1909" height="1026" alt="Screenshot 2025-11-14 at 1 48 23 PM" src="https://github.com/user-attachments/assets/9a0903be-efe1-4728-8d99-d6d7be709cc6" />


<img width="1916" height="1039" alt="Screenshot 2025-11-14 at 1 40 18 PM" src="https://github.com/user-attachments/assets/f8f27cb7-041e-491f-b0ce-d1d8bc99d394" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
