### PR TITLE
[FIX] spreadsheet: sort pivot dimensions

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -753,11 +753,12 @@ export class OdooPivotModel extends PivotModel {
         const allGroupBys = params.groupingSets.flat();
         const order = columns
             .concat(rows)
-            .filter(
-                (dimension) =>
-                    dimension.order && allGroupBys.includes(dimension.nameWithGranularity)
+            .filter((dimension) => allGroupBys.includes(dimension.nameWithGranularity))
+            .map((dimension) =>
+                dimension.order
+                    ? `${dimension.nameWithGranularity} ${dimension.order}`
+                    : dimension.nameWithGranularity
             )
-            .map((dimension) => `${dimension.nameWithGranularity} ${dimension.order}`)
             .join(",");
         params.kwargs.order = order;
 


### PR DESCRIPTION
Since the introduction of grouping sets, the order of dimensions was incorrect as soon as an order was set on a dimensions: all the dimensions without order were ignored.

Steps to reproduce:
- Go to Subscriptions > Reporting > MRR Breakdown
- Go the pivot view and group by Event Date and Salesperson
- Insert in spreadsheet
- Replace all the static formulas by a dynamic PIVOT(1)
- Sort the Salesperson dimension by "Descending" => the dates are not sorted

This commit fixes the issue by ensuring that all dimensions are included in the order parameter sent to the backend.

Task: 5263233

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
