### PR TITLE
[FIX] point_of_sale, pos_self_order: combo parent line price incl also zero

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -194,7 +194,7 @@ export class PosOrderAccounting extends Base {
         this.amount_return = this.change; // Already rounded by the getter
         this.lines.forEach((line) => {
             line.price_subtotal = line.priceExcl;
-            line.price_subtotal_incl = line.displayPrice;
+            line.price_subtotal_incl = line.priceIncl;
         });
     }
     /**

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -204,6 +204,25 @@ test("sendDraftOrderToServer", async () => {
     expect(store.models["pos.order"].length).toBe(1);
 });
 
+describe("setOrderPrices", () => {
+    test("Combo products order", async () => {
+        const store = await setupSelfPosEnv();
+        await addComboProduct(store);
+
+        store.currentOrder.setOrderPrices();
+        const [parentLine, comboLine1, comboLine2] = store.currentOrder.lines;
+
+        expect(parentLine.price_subtotal).toBe(0);
+        expect(parentLine.price_subtotal_incl).toBe(0);
+
+        expect(comboLine1.price_subtotal).toBe(1500);
+        expect(comboLine1.price_subtotal_incl).toBe(1875);
+
+        expect(comboLine2.price_subtotal).toBe(200);
+        expect(comboLine2.price_subtotal_incl).toBe(250);
+    });
+});
+
 describe("cancelOrder", () => {
     test("Normal cancel order", async () => {
         const store = await setupSelfPosEnv();


### PR DESCRIPTION
Steps to reproduce
------------------
In pos self order, choose a combo product and checkout.
Notice that the price shown on the "success" screen is double the combo
price.

Why it's happening
------------------
When displaying the order price, we sum the `price_subtotal_incl` of all
its lines. In a combo order, for each combo product, we have a combo
parent line and its children lines. We rely on `price_subtotal_incl` of
the combo parent line to be 0, and the price thus will be the sum of
`price_subtotal_incl` of the children combo lines.

After https://github.com/odoo/odoo/commit/9538698f13d5763b49b00f4c06a1a2afc0d6b39e, we are setting the combo line's `price_subtotal_incl` to
the sum of the price of its children, so it's no longer 0 making the
calculation wrong, i.e. it's summing twice the price.

The Fix
-------
We now set the `price_subtotal_incl` to `priceIncl` and not to
`displayPrice` anymore. Which makes sure a combo parent line has 0
price.

opw-5247554
