### PR TITLE
[IMP] pos_restaurant: Improve user scenario to configure "self_ordering_mode"

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -403,6 +403,12 @@ class PosConfig(models.Model):
             'self_ordering_mode': 'kiosk',
         })
 
+    def _load_restaurant_demo_data(self, with_demo_data=True):
+        self.ensure_one()
+        super()._load_restaurant_demo_data(with_demo_data)
+        if with_demo_data:
+            self.self_ordering_mode = 'mobile'
+
     def _generate_single_qr_code__(self, url):  # noqa: PLW3201
         qr = qrcode.QRCode(
             version=1,


### PR DESCRIPTION
The goal of this PR is to improve the onboarding experience for users setting up a POS Restaurant for the first time. 

Previously, when a user loaded sample data in a POS Restaurant, the Self-Ordering mode was not configured automatically. With this update, loading sample data now automatically sets the Self-Ordering mode to "QR menu + Ordering".

task : 5130571
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
