### PR TITLE
[IMP] sale_service: show customer name in gantt popover

### DIFF
--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -55,7 +55,7 @@ class SaleOrderLine(models.Model):
         return super()._auto_init()
 
     def _additional_name_per_id(self):
-        name_per_id = super()._additional_name_per_id() if not self.env.context.get('hide_partner_ref') else {}
+        name_per_id = super()._additional_name_per_id() if (not self.env.context.get('hide_partner_ref') or len(self) == 1) else {}
         if not self.env.context.get('with_price_unit'):
             return name_per_id
 


### PR DESCRIPTION
Before this PR:
---
- When hide_partner_ref context flag was true , _additional_name_per_id() returned empty dict for all reads , blocking customer names in all scenarios
- Gantt popover lost customer information even when partner_id field was not displayed separately

After this PR:
---
- Single-record reads bypass hide_partner_ref check and preserve customer name.
- Grouped views continue to respect hide_partner_ref to prevent duplication when partner_id is shown.
- Planning Gantt popover now display customer information inline with sale order line

Technical details:
---
The hide_partner_ref context flag prevents _additional_name_per_id() from adding customer names to sale line display_name. This is correct for grouped/kanban views where partner_id is displayed separately but incorrect for single-record reads where the customer context is essential.

This change adds a recordset length check: single records bypass the flag, while batch operations continue to respect it for de-duplication purposes.

Related : https://github.com/odoo/odoo/pull/105470

task - 5140117