### PR TITLE
[FIX] im_livechat, mail: missing bus subscription for non-member channels

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -19,6 +19,7 @@ declare module "models" {
         livechat_expertise_ids: LivechatExpertise[];
         livechat_status: "in_progress"|"waiting"|"need_help"|undefined;
         matchesSelfExpertise: Readonly<boolean>;
+        shadowedBySelf: number;
         wasLookingForHelp: boolean;
     }
 }

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -34,7 +34,7 @@ patch(Thread.prototype, {
                 }
             },
         });
-        this.shadowedBySelf = false;
+        this.shadowedBySelf = 0;
         this.wasLookingForHelp = false;
     },
     get canLeave() {
@@ -130,6 +130,9 @@ patch(Thread.prototype, {
         if (this.store.env.services.ui.isSmall && this.channel_type === "livechat") {
             this.store.discuss.activeTab = "livechat";
         }
+    },
+    get shouldSubscribeToBusChannel() {
+        return super.shouldSubscribeToBusChannel || Boolean(this.shadowedBySelf);
     },
     async leaveChannel({ force = false } = {}) {
         if (

--- a/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
@@ -1,7 +1,28 @@
-import { registry } from "@web/core/registry";
+import { whenReady } from "@odoo/owl";
 
+import { registry } from "@web/core/registry";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+
+let firstChannelId;
 registry.category("web_tour.tours").add("im_livechat_session_history_open", {
     steps: () => [
+        {
+            trigger: "body",
+            async run() {
+                await whenReady();
+                const busService = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
+                patchWithCleanup(busService, {
+                    addChannel(channel) {
+                        document.body.classList.add(`o-bus-channel-${channel}`);
+                        return super.addChannel(...arguments);
+                    },
+                    deleteChannel(channel) {
+                        document.body.classList.remove(`o-bus-channel-${channel}`);
+                        return super.deleteChannel(...arguments);
+                    },
+                });
+            },
+        },
         {
             trigger: ".o_switch_view[data-tooltip='List']",
             run: "click",
@@ -12,6 +33,13 @@ registry.category("web_tour.tours").add("im_livechat_session_history_open", {
         },
         {
             trigger: ".o-mail-Message-content:contains('Test Channel 2 Msg')",
+            async run({ waitFor }) {
+                firstChannelId =
+                    odoo.__WOWL_DEBUG__.root.env.services.action.currentController.state.resId;
+                await waitFor(`body.o-bus-channel-discuss\\.channel_${firstChannelId}`, {
+                    timeout: 3000,
+                });
+            },
         },
         {
             trigger: ".oi-chevron-right",
@@ -19,6 +47,16 @@ registry.category("web_tour.tours").add("im_livechat_session_history_open", {
         },
         {
             trigger: ".o-mail-Message-content:contains('Test Channel 1 Msg')",
+            async run({ waitFor }) {
+                await waitFor(`body:not(.o-bus-channel-discuss\\.channel_${firstChannelId})`, {
+                    timeout: 3000,
+                });
+                const channelId =
+                    odoo.__WOWL_DEBUG__.root.env.services.action.currentController.state.resId;
+                await waitFor(`body.o-bus-channel-discuss\\.channel_${channelId}`, {
+                    trimeout: 3000,
+                });
+            },
         },
     ],
 });

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -13,6 +13,7 @@ declare module "models" {
         autoOpenChatWindowOnNewMessage: Readonly<boolean>;
         inChathubOnNewMessage: Readonly<boolean>;
         notifyMessageToUser: (message: Message) => Promise<void>;
+        notifyWhenOutOfFocus: Readonly<boolean>;
         setActiveURL: () => void;
         setAsDiscussThread: (pushState: boolean) => void;
         unpin: () => Promise<void>;

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -17,6 +17,8 @@ declare module "models" {
         activity_counter_bus_id: number;
         activityCounter: number;
         activityGroups: Object[];
+        computeGlobalCounter: () => number;
+        globalCounter: number;
         history: Thread;
         inbox: Thread;
         onLinkFollowed: (fromThread: Thread) => void;
@@ -24,6 +26,7 @@ declare module "models" {
         scheduleActivity: (resModel: string, resIds: number[], defaultActivityTypeId: number|undefined) => Promise<void>;
         starred: Thread;
         unstarAll: () => Promise<void>;
+        updateAppBadge: () => void;
     }
     export interface Thread {
         activities: Activity[];

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -69,6 +69,7 @@ declare module "models" {
         otherTypingMembers: ChannelMember[];
         scrollUnread: boolean;
         self_member_id: ChannelMember;
+        shouldSubscribeToBusChannel: Readonly<boolean>;
         showCorrespondentCountry: Readonly<boolean>;
         showUnreadBanner: Readonly<boolean>;
         toggleBusSubscription: boolean;

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -28,7 +28,6 @@ declare module "models" {
         displayInSidebar: boolean;
         from_message_id: Message;
         hasSubChannelFeature: Readonly<boolean>;
-        isBusSubscribed: boolean;
         lastSubChannelLoaded: Thread|null;
         loadMoreSubChannels: (param0: { searchTerm: string }) => Promise<Thread[]|undefined>;
         loadSubChannelsDone: boolean;

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -25,7 +25,6 @@ const threadPatch = {
                 return this._computeDiscussAppCategory();
             },
         });
-        this.isBusSubscribed = false;
         this.from_message_id = fields.One("mail.message");
         this.parent_channel_id = fields.One("Thread", {
             onDelete() {
@@ -65,12 +64,6 @@ const threadPatch = {
     },
     get allowCalls() {
         return super.allowCalls && !this.parent_channel_id;
-    },
-    delete() {
-        if (this.model === "discuss.channel") {
-            this.store.env.services.bus_service.deleteChannel(this.busChannel);
-        }
-        super.delete(...arguments);
     },
     get hasSubChannelFeature() {
         return ["channel", "group"].includes(this.channel_type);
@@ -132,17 +125,6 @@ const threadPatch = {
         super.onPinStateUpdated();
         if (this.self_member_id?.is_pinned) {
             this.isLocallyPinned = false;
-        }
-        if (this.isLocallyPinned) {
-            if (!this.isBusSubscribed) {
-                this.store.env.services["bus_service"].addChannel(this.busChannel);
-                this.isBusSubscribed = true;
-            }
-        } else {
-            if (this.isBusSubscribed) {
-                this.store.env.services["bus_service"].deleteChannel(this.busChannel);
-                this.isBusSubscribed = false;
-            }
         }
         if (!this.self_member_id?.is_pinned && !this.isLocallyPinned) {
             this.sub_channel_ids.forEach((c) => (c.isLocallyPinned = false));

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -1,6 +1,7 @@
 import { reactive } from "@odoo/owl";
 import { memoize } from "@web/core/utils/functions";
 import { rpc } from "@web/core/network/rpc";
+import { effect } from "@web/core/utils/reactive";
 
 export function assignDefined(obj, data, keys = Object.keys(data)) {
     for (const key of keys) {
@@ -231,3 +232,31 @@ export const hasHardwareAcceleration = memoize(() => {
     }
     return true;
 });
+
+/**
+ * Runs a reactive effect whenever the dependencies change. The effect receives
+ * the current values returned by `dependencies`. If the effect returns a
+ * cleanup function, it is run before the next execution.
+ *
+ * @template {object[]} T
+ * @param {Object} options
+ * @param {(…dependencies: any[]) => void | (() => void)} options.effect The
+ *        effect callback. May return a cleanup function.
+ * @param {(…args: [...T]) => any[]} options.dependencies Returns an array of
+ *        values to track. The effect is called only if these values change.
+ * @param {[...T]} options.reactiveTargets Objects that the effect depends on.
+ */
+export function effectWithCleanup({ effect: effectFn, dependencies, reactiveTargets }) {
+    let cleanup;
+    let prevDependencies;
+    effect((...deps) => {
+        const nextDependencies = dependencies(...deps);
+        const changed =
+            !prevDependencies || nextDependencies.some((v, i) => v !== prevDependencies[i]);
+        if (changed) {
+            cleanup?.();
+            cleanup = effectFn(...nextDependencies);
+            prevDependencies = [...nextDependencies];
+        }
+    }, reactiveTargets);
+}

--- a/addons/mail/static/tests/discuss/core/bus_subscription.test.js
+++ b/addons/mail/static/tests/discuss/core/bus_subscription.test.js
@@ -1,0 +1,111 @@
+import { waitForChannels } from "@bus/../tests/bus_test_helpers";
+import { onWebsocketEvent } from "@bus/../tests/mock_websocket";
+
+import {
+    click,
+    contains,
+    defineMailModels,
+    insertText,
+    openDiscuss,
+    setupChatHub,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+
+import { describe, edit, expect, mockDate, press, test } from "@odoo/hoot";
+
+import { Command } from "@web/../tests/web_test_helpers";
+
+defineMailModels();
+
+describe.current.tags("desktop");
+
+test("bus subscription updated when joining/leaving thread as non member", async () => {
+    const pyEnv = await startServer();
+    const johnUser = pyEnv["res.users"].create({ name: "John" });
+    const johnPartner = pyEnv["res.partner"].create({ name: "John", user_ids: [johnUser] });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [Command.create({ partner_id: johnPartner })],
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
+    await click("button", { text: "Leave Conversation" });
+    await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
+});
+
+test("bus subscription updated when opening/closing chat window as a non member", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [],
+        name: "Sales",
+    });
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await contains(".o-mail-ChatWindow", { text: "Sales" });
+    await waitForChannels([`discuss.channel_${channelId}`]);
+    await click("[title*='Close Chat Window']", {
+        parent: [".o-mail-ChatWindow", { text: "Sales" }],
+    });
+    await contains(".o-mail-ChatWindow", { count: 0, text: "Sales" });
+    await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
+    await press(["control", "k"]);
+    await click(".o_command_palette_search input");
+    await edit("@");
+    await click(".o-mail-DiscussCommand", { text: "Sales" });
+    await waitForChannels([`discuss.channel_${channelId}`]);
+});
+
+test("bus subscription updated when joining locally pinned thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [],
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
+    await click("[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", {
+        text: "Mitchell Admin",
+    });
+    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
+    await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
+});
+
+test("bus subscription is refreshed when channel is joined", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create([{ name: "General" }, { name: "Sales" }]);
+    onWebsocketEvent("subscribe", () => expect.step("subscribe"));
+    const later = luxon.DateTime.now().plus({ seconds: 2 });
+    mockDate(
+        `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
+    );
+    await start();
+    await expect.waitForSteps(["subscribe"]);
+    await openDiscuss();
+    await expect.waitForSteps([]);
+    await click("input[placeholder='Search conversations']");
+    await insertText("input[placeholder='Search a conversation']", "new channel");
+    await expect.waitForSteps(["subscribe"]);
+});
+
+test("bus subscription is refreshed when channel is left", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
+    onWebsocketEvent("subscribe", () => expect.step("subscribe"));
+    const later = luxon.DateTime.now().plus({ seconds: 2 });
+    mockDate(
+        `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
+    );
+    await start();
+    await expect.waitForSteps(["subscribe"]);
+    await openDiscuss();
+    await expect.waitForSteps([]);
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:contains('Leave Channel')");
+    await expect.waitForSteps(["subscribe"]);
+});

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -3,15 +3,13 @@ import {
     click,
     contains,
     defineMailModels,
-    insertText,
     openDiscuss,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-dom";
-import { mockDate } from "@odoo/hoot-mock";
-import { asyncStep, makeMockEnv, waitForSteps } from "@web/../tests/web_test_helpers";
+import { makeMockEnv } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -52,38 +50,4 @@ test("subscribe to presence channels according to store data", async () => {
     await expect.waitForSteps([
         "subscribe - [odoo-presence-mail.guest_1-token,odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
     ]);
-});
-
-test("bus subscription is refreshed when channel is joined", async () => {
-    const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create([{ name: "General" }, { name: "Sales" }]);
-    onWebsocketEvent("subscribe", () => asyncStep("subscribe"));
-    const later = luxon.DateTime.now().plus({ seconds: 2 });
-    mockDate(
-        `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
-    );
-    await start();
-    await waitForSteps(["subscribe"]);
-    await openDiscuss();
-    await waitForSteps([]);
-    await click("input[placeholder='Search conversations']");
-    await insertText("input[placeholder='Search a conversation']", "new channel");
-    await waitForSteps(["subscribe"]);
-});
-
-test("bus subscription is refreshed when channel is left", async () => {
-    const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General" });
-    onWebsocketEvent("subscribe", () => asyncStep("subscribe"));
-    const later = luxon.DateTime.now().plus({ seconds: 2 });
-    mockDate(
-        `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
-    );
-    await start();
-    await waitForSteps(["subscribe"]);
-    await openDiscuss();
-    await waitForSteps([]);
-    await click("[title='Channel Actions']");
-    await click(".o-dropdown-item:contains('Leave Channel')");
-    await waitForSteps(["subscribe"]);
 });

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -1,6 +1,5 @@
-import { waitForChannels, waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
+import { waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
 import {
-    click,
     contains,
     defineMailModels,
     openDiscuss,
@@ -8,78 +7,14 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { tick } from "@odoo/hoot-mock";
 import { EventBus } from "@odoo/owl";
-import { Command, patchWithCleanup, withUser, mockService } from "@web/../tests/web_test_helpers";
+import { Command, mockService, patchWithCleanup, withUser } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 
 import { rpc } from "@web/core/network/rpc";
 
 describe.current.tags("desktop");
 defineMailModels();
-
-test("bus subscription updated when joining/leaving thread as non member", async () => {
-    const pyEnv = await startServer();
-    const johnUser = pyEnv["res.users"].create({ name: "John" });
-    const johnPartner = pyEnv["res.partner"].create({ name: "John", user_ids: [johnUser] });
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [Command.create({ partner_id: johnPartner })],
-        name: "General",
-    });
-    await start();
-    await openDiscuss(channelId);
-    await waitForChannels([`discuss.channel_${channelId}`]);
-    await click("[title='Channel Actions']");
-    await click(".o-dropdown-item:contains('Leave Channel')");
-    await click("button", { text: "Leave Conversation" });
-    await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
-});
-
-test("bus subscription updated when joining locally pinned thread", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [],
-        name: "General",
-    });
-    await start();
-    await openDiscuss(channelId);
-    await waitForChannels([`discuss.channel_${channelId}`]);
-    await click("[title='Invite People']");
-    await click(".o-discuss-ChannelInvitation-selectable", {
-        text: "Mitchell Admin",
-    });
-    await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");
-    await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
-});
-
-test.skip("bus subscription kept after receiving a message as non member", async () => {
-    const pyEnv = await startServer();
-    const johnUser = pyEnv["res.users"].create({ name: "John" });
-    const johnPartner = pyEnv["res.partner"].create({ name: "John", user_ids: [johnUser] });
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [Command.create({ partner_id: johnPartner })],
-        name: "General",
-    });
-    await start();
-    await Promise.all([openDiscuss(channelId), waitUntilSubscribe(`discuss.channel_${channelId}`)]);
-    await withUser(johnUser, () =>
-        rpc("/mail/message/post", {
-            post_data: { body: "Hello!", message_type: "comment" },
-            thread_id: channelId,
-            thread_model: "discuss.channel",
-        })
-    );
-    await contains(".o-mail-Message", { text: "Hello!" });
-    await tick();
-    await withUser(johnUser, () =>
-        rpc("/mail/message/post", {
-            post_data: { body: "Goodbye!", message_type: "comment" },
-            thread_id: channelId,
-            thread_model: "discuss.channel",
-        })
-    );
-    await contains(".o-mail-Message", { text: "Goodbye!" });
-});
 
 test("open channel in discuss from push notification", async () => {
     patchWithCleanup(window.navigator, {


### PR DESCRIPTION
Discuss subscribes to channel the user is not a member of when it is displayed in the side bar or when `thread.open` is called.

However, all flows are not covered. For example, chat hub opens chat windows without calling `thread.open`. So does the command palette.

We shouldn't rely on specific flows, but instead detect when the correct conditions are met.

This commit fixes this issue by adding a field on thread, that determines whether the subscription is required. When this field update, so does the bus subscription.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
