### PR TITLE
[IMP] im_livechat,*: improve customer values quality

### DIFF
--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -57,9 +57,12 @@ class ChatbotScriptStep(models.Model):
         customer_values = self._chatbot_prepare_customer_values(
             discuss_channel, create_partner=False, update_partner=True)
         if self.env.user._is_public():
+            country = customer_values.get('country', False)
             create_values = {
                 'email_from': customer_values['email'],
                 'phone': customer_values['phone'],
+                'lang_id': customer_values["lang"].id,
+                'country_id': country.get('id', False) if country else False,
             }
         else:
             create_values = {"partner_id": self.env.user.partner_id.id}

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -75,7 +75,9 @@ class LivechatChatbotScriptController(http.Controller):
             return None
         # sudo: discuss.channel - updating current step on the channel is allowed
         discuss_channel.sudo().chatbot_current_step_id = next_step.id
-        step_data = next_step._process_step(discuss_channel)
+        step_data = next_step.with_context(
+            lang=chatbot_language, country_code=request.geoip.country_code
+        )._process_step(discuss_channel)
         posted_message = step_data["message"]
         store.add(posted_message, "_store_message_fields")
         store.add(next_step, "_store_script_step_fields")

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -155,19 +155,20 @@ class LivechatController(http.Controller):
                 ),
             )
         else:
+            lang = request.env["res.lang"].search(
+                [("code", "=", request.cookies.get("frontend_lang"))]
+            )
             if request.env.user._is_public():
                 guest = guest.sudo()._get_or_create_guest(
                     guest_name=self._get_guest_name(),
                     country_code=request.geoip.country_code,
                     timezone=request.env["mail.guest"]._get_timezone_from_request(request),
+                    lang=lang,
                 )
                 livechat_channel = livechat_channel.with_context(guest=guest)
                 request.update_context(guest=guest)
             channel_vals = livechat_channel._get_livechat_discuss_channel_vals(**operator_info)
             channel_vals.update(**persisted_channel_params)
-            lang = request.env["res.lang"].search(
-                [("code", "=", request.cookies.get("frontend_lang"))]
-            )
             channel_vals.update({"country_id": country.id, "livechat_lang_id": lang.id})
             channel = request.env['discuss.channel'].with_context(
                 lang=request.env['chatbot.script']._get_chatbot_language()

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -156,7 +156,13 @@ class ChatbotCase(common.HttpCase):
         })
 
     def _post_answer_and_trigger_next_step(
-        self, discuss_channel, body=None, email=None, phone=None, chatbot_script_answer=None
+        self,
+        discuss_channel,
+        body=None,
+        email=None,
+        phone=None,
+        chatbot_script_answer=None,
+        trigger_cookies=None,
     ):
         data = self.make_jsonrpc_request(
             "/mail/message/post",
@@ -184,4 +190,6 @@ class ChatbotCase(common.HttpCase):
                     "selected_answer_id": chatbot_script_answer.id,
                 },
             )
-        self.make_jsonrpc_request("/chatbot/step/trigger", {"channel_id": discuss_channel.id})
+        self.make_jsonrpc_request(
+            "/chatbot/step/trigger", {"channel_id": discuss_channel.id}, cookies=trigger_cookies
+        )

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -67,12 +67,12 @@ class MailGuest(models.Model):
             return guest.sudo(False).with_context(guest=guest)
         return self.env['mail.guest']
 
-    def _get_or_create_guest(self, *, guest_name, country_code, timezone):
+    def _get_or_create_guest(self, *, guest_name, country_code, timezone, lang=None):
         if not (guest := self._get_guest_from_context()):
             guest = self.create(
                 {
                     "country_id": self.env["res.country"].search([("code", "=", country_code)]).id,
-                    "lang": get_lang(self.env).code,
+                    "lang": (lang if lang else get_lang(self.env)).code,
                     "name": guest_name,
                     "timezone": timezone,
                 }

--- a/addons/website_livechat/models/chatbot_script_step.py
+++ b/addons/website_livechat/models/chatbot_script_step.py
@@ -15,6 +15,7 @@ class ChatbotScriptStep(models.Model):
                 values['email'] = visitor_sudo.email
             if not values.get('phone') and visitor_sudo.mobile:
                 values['phone'] = visitor_sudo.mobile
-            values['country'] = {'id': visitor_sudo.country_id} if visitor_sudo.country_id else False
+            if visitor_sudo.country_id:
+                values['country'] = {'id': visitor_sudo.country_id}
 
         return values


### PR DESCRIPTION
*: crm_livechat,website_livechat

Previously, some values like language or country were not properly set on partners/guest and therefore not given to helpdesk tickets or crm leads.

Now, the values are directly set on the partner/guest and then given (if necessary) to the different objects created.

task-4423648

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
