### PR TITLE
[FIX] base_import_module: Improve error visibility when running `odoo-bin deploy`

### DIFF
--- a/addons/base_import_module/controllers/main.py
+++ b/addons/base_import_module/controllers/main.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 import functools
+import logging
+import traceback
 
 from odoo import _
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.http import Controller, route, request, Response
+
+_logger = logging.getLogger(__name__)
 
 
 class ImportModule(Controller):
@@ -11,14 +15,26 @@ class ImportModule(Controller):
         '/base_import_module/login_upload',
         type='http', auth='none', methods=['POST'], csrf=False, save_session=False)
     def login_upload(self, login, password, force='', mod_file=None, **kw):
+
         try:
             if not request.db:
                 raise Exception(_("Could not select database '%s'", request.db))
+
             credential = {'login': login, 'password': password, 'type': 'password'}
             request.session.authenticate(request.env, credential)
-            # request.env.uid is None in case of MFA
+
             if request.env.uid and request.env.user._is_admin():
-                return request.env['ir.module.module']._import_zipfile(mod_file, force=force == '1')[0]
+                return request.env['ir.module.module']._import_zipfile(
+                    mod_file, force=force == '1'
+                )[0]
+
             raise AccessError(_("Only administrators can upload a module"))
+
+        except UserError as e:
+            # return clean error to client
+            return Response(response=str(e), status=400)
+
         except Exception as e:
-            return Response(response=str(e), status=500)
+            # log full traceback
+            _logger.error("Deploy failed:\n%s", traceback.format_exc())
+            return Response(response="Server error: %s" % str(e), status=500)

--- a/doc/cla/individual/rajgohel0312.md
+++ b/doc/cla/individual/rajgohel0312.md
@@ -1,0 +1,11 @@
+India, 2025-11-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Raj Gohel rajgohel2018@gmail.com https://github.com/Rajgohel0312


### PR DESCRIPTION
When running `odoo-bin deploy`, Odoo returns a vague 500 error when a module
fails to import. The server also hides the real traceback because the logging
line in the controller is incorrect.

Current line:
    _logger.warning("Response", res)
This triggers a logging TypeError.

Fix:
    - log full traceback using _logger.exception(...)
    - return the actual error in the HTTP response

This makes debugging easier and matches expected behaviour.
Fixes: #227857
