### PR TITLE
[IMP] HR: consistent naming for Contract Type

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -37,7 +37,7 @@ class HrJob(models.Model):
     allowed_user_ids = fields.Many2many('res.users', compute='_compute_allowed_user_ids', readonly=True)
     department_id = fields.Many2one('hr.department', string='Department', check_company=True, tracking=True, index='btree_not_null')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, tracking=True)
-    contract_type_id = fields.Many2one('hr.contract.type', string='Employment Type', tracking=True)
+    contract_type_id = fields.Many2one('hr.contract.type', string='Contract Type', tracking=True)
 
     _name_company_uniq = models.Constraint(
         'unique(name, company_id, department_id)',

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -26,7 +26,7 @@
                                         <label name="no_of_recruitment_label" for="no_of_recruitment"/>
                                         <div class="o_row" name="recruitment_target">
                                             <field name="no_of_recruitment" class="o_hr_narrow_field"/>
-                                            <span>new employees</span>
+                                            <span>employees</span>
                                         </div>
                                     </group>
                                     <group name="job" string="Job">
@@ -91,7 +91,7 @@
                     <group>
                         <filter string="Department" name="department" domain="[]" context="{'group_by': 'department_id'}"/>
                         <filter string="Company" name="company" domain="[]" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
-                        <filter string="Employment Type" name="employment_type" domain="[]" context="{'group_by': 'contract_type_id'}"/>
+                        <filter string="Contract Type" name="contract_type" domain="[]" context="{'group_by': 'contract_type_id'}"/>
                     </group>
                 </search>
             </field>


### PR DESCRIPTION
- renamed the instances of Employment Type to be Contract Type to be more consistent with other places

task-id: 5167551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
