### PR TITLE
[FIX] pos_viva_wallet: wrong payment line used on payment confirmation

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -135,7 +135,8 @@ class PosPaymentMethod(models.Model):
         pos_session_sudo = self.env["pos.session"].browse(int(data.get('pos_session_id', False)))
         if pos_session_sudo:
             pos_session_sudo.config_id._notify('VIVA_WALLET_LATEST_RESPONSE', {
-                'config_id': pos_session_sudo.config_id.id
+                'config_id': pos_session_sudo.config_id.id,
+                'session_id': data.get('sessionId'),
             })
 
     def _load_pos_data_fields(self, config_id):

--- a/addons/pos_viva_wallet/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_viva_wallet/static/src/overrides/models/pos_payment.js
@@ -1,0 +1,12 @@
+import { PosPayment } from "@point_of_sale/app/models/pos_payment";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosPayment.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.uiState = {
+            ...(this.uiState ?? {}),
+            vivaSessionId: null,
+        };
+    },
+});

--- a/addons/pos_viva_wallet/static/src/overrides/pos_store.js
+++ b/addons/pos_viva_wallet/static/src/overrides/pos_store.js
@@ -4,11 +4,21 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 patch(PosStore.prototype, {
     async setup() {
         await super.setup(...arguments);
-        this.data.connectWebSocket("VIVA_WALLET_LATEST_RESPONSE", () => {
-            const pendingLine = this.getPendingPaymentLine("viva_wallet");
+        this.data.connectWebSocket("VIVA_WALLET_LATEST_RESPONSE", (payload) => {
+            if (payload.config_id === this.config.id) {
+                const paymentLine = this.models["pos.payment"].find(
+                    (line) => line.uiState.vivaSessionId === payload.session_id
+                );
 
-            if (pendingLine) {
-                pendingLine.payment_method_id.payment_terminal.handleVivaWalletStatusResponse();
+                if (
+                    paymentLine &&
+                    !paymentLine.is_done() &&
+                    paymentLine.get_payment_status() !== "retry"
+                ) {
+                    paymentLine.payment_method_id.payment_terminal.handleVivaWalletStatusResponse(
+                        paymentLine
+                    );
+                }
             }
         });
     },


### PR DESCRIPTION
This commit fixes various issues when using Viva Wallet, including the following:
- When two Viva Wallet terminals had a payment in process at the same time in the same POS, one of the payments would fail on Odoo even when it succeeded on the terminal.
- When a previous Viva Wallet payment was stuck (never completed or failed), trying to make a new payment would mistakenly affect that previous order instead of the new order.
- When refreshing the page during a payment, it becomes stuck and never confirms or fails.

To fix these issues, there are two main changes:
1. Stop using the `getPendingPaymentLine` method to retrieve the Viva Wallet payment line. This method is flawed as it assumes there is only one pending payment at a time.
2. Store the Viva session ID for a payment in the payment line's UI state, instead of on the plain JS object. This allows it to persist after a refresh.

opw-5226966
opw-5248178

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
