### PR TITLE
[FIX] hr: prevent traceback when loading template in debug mode

### DIFF
--- a/addons/hr/static/src/js/contract_template_button.js
+++ b/addons/hr/static/src/js/contract_template_button.js
@@ -12,11 +12,12 @@ class TemplateSelectionPopover extends Component {
         close: Function,
         onSelect: Function,
         record: Object,
+        fieldProps: Object,
     };
 
     setup() {
         this.state = useState({ 
-            selectedTemplate: null,
+            selectedTemplate: false,
         });
     }
 


### PR DESCRIPTION
**Version:**
- master

**Steps to reproduce:**
- Open the Employee view
- Navigate to the Payroll page
- Click “Load Template”

**Issue:**
Loading a payroll template in debug mode triggers a traceback.

**Cause:**
- Props were not correctly defined, and useState initialized with null instead of a boolean.

**Fix:**
- Correct props definition.
- Initialize useState with false instead of null.

Task-5264364


