### PR TITLE
[FIX] snailmail: extract report (re)generation functions

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -129,13 +129,24 @@ class SnailmailLetter(models.Model):
             self.attachment_id.check('read')
         return res
 
+    def _generate_report_pdf(self, report):
+        obj = self.env[self.model].browse(self.res_id)
+        if report.print_report_name:
+            report_name = safe_eval(report.print_report_name, {'object': obj})
+        elif report.attachment:
+            report_name = safe_eval(report.attachment, {'object': obj})
+        else:
+            report_name = 'Document'
+        filename = "%s.%s" % (report_name, "pdf")
+        pdf_bin = self.env['ir.actions.report'].with_context(snailmail_layout=not self.cover, lang='en_US')._render_qweb_pdf(report, self.res_id)[0]
+        return filename, pdf_bin
+
     def _fetch_attachment(self):
         """
         This method will check if we have any existent attachement matching the model
         and res_ids and create them if not found.
         """
         self.ensure_one()
-        obj = self.env[self.model].browse(self.res_id)
         if not self.attachment_id:
             report = self.report_template
             if not report:
@@ -145,17 +156,11 @@ class SnailmailLetter(models.Model):
                     return False
                 else:
                     self.write({'report_template': report.id})
-            if report.print_report_name:
-                report_name = safe_eval(report.print_report_name, {'object': obj})
-            elif report.attachment:
-                report_name = safe_eval(report.attachment, {'object': obj})
-            else:
-                report_name = 'Document'
-            filename = "%s.%s" % (report_name, "pdf")
             paperformat = report.get_paperformat()
             if (paperformat.format == 'custom' and paperformat.page_width != 210 and paperformat.page_height != 297) or paperformat.format != 'A4':
                 raise UserError(_("Please use an A4 Paper format."))
-            pdf_bin, unused_filetype = self.env['ir.actions.report'].with_context(snailmail_layout=not self.cover, lang='en_US')._render_qweb_pdf(report, self.res_id)
+
+            filename, pdf_bin = self._generate_report_pdf(report)
             pdf_bin = self._overwrite_margins(pdf_bin)
             if self.cover:
                 pdf_bin = self._append_cover_page(pdf_bin)

--- a/addons/snailmail/wizard/snailmail_letter_format_error.py
+++ b/addons/snailmail/wizard/snailmail_letter_format_error.py
@@ -13,15 +13,17 @@ class SnailmailLetterFormatError(models.TransientModel):
         default=lambda self: self.env.company.snailmail_cover,
     )
 
-    def update_resend_action(self):
-        self.env.company.write({'snailmail_cover': self.snailmail_cover})
-        letters_to_resend = self.message_id.letter_ids
+    def _resend_letters(self, letters_to_resend):
         for letter in letters_to_resend:
             old_attachment = letter.attachment_id
             letter.attachment_id = False
             old_attachment.unlink()
             letter.write({'cover': self.snailmail_cover})
             letter.snailmail_print()
+
+    def update_resend_action(self):
+        self.env.company.write({'snailmail_cover': self.snailmail_cover})
+        self._resend_letters(self.message_id.letter_ids)
 
     def cancel_letter_action(self):
         self.message_id.cancel_letter()


### PR DESCRIPTION
#### [FIX] snailmail: extract report PDF generation function
We extract a function `_generate_report_pdf` from `_fetch_attachment`
to create the report PDF (and its filename).
The resulting PDF's margins are fixed and a cover page is added to it
after the function is called in `_fetch_attachment`.

The new function is extended in the related enterprise commit to generate the
followup report inside `_fetch_attachment` (when sent via snailmail).
This way it will respect the cover page option and page layout / size requirements.
(See the related enterprise PR for more details.)

#### [FIX] snailmail: extract letter resending function

We extract a function `_resend_letters` from the `update_resend_action`.
It handles the regeneration of letters after the cover option has been updated.
This way the resending logic can easily extended to adjust the logic depending
on attributes of the letter.

The new function is extended in the related enterprise commit to disable
the resending for followup report letters.
This is necessary because the followup report requires special options
to be generated that are not available at the point of the regeneration.

#### references

opw-5160121
opw-5209504
opw-5226366