### PR TITLE
[FIX] purchase: avoid rounding error for catalog packs

### DIFF
--- a/addons/purchase/static/src/product_catalog/kanban_record.js
+++ b/addons/purchase/static/src/product_catalog/kanban_record.js
@@ -3,6 +3,7 @@ import { ProductCatalogKanbanRecord } from "@product/product_catalog/kanban_reco
 import { ProductCatalogPurchaseOrderLine } from "./purchase_order_line/purchase_order_line";
 import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
+import { formatFloat } from "@web/views/fields/formatters";
 import { useSubEnv } from "@odoo/owl";
 
 patch(ProductCatalogKanbanRecord.prototype, {
@@ -31,7 +32,7 @@ patch(ProductCatalogKanbanRecord.prototype, {
 
     async updatePackagingQuantity(packaging) {
         const productPackagingQty =
-            Math.floor(this.productCatalogData.quantity / packaging.qty) + 1;
+            Math.floor(parseFloat(formatFloat(this.productCatalogData.quantity / packaging.qty))) + 1;
         this.productCatalogData.quantity = productPackagingQty * packaging.qty;
         const price = await this.rpc("/product/catalog/update_order_line_info", {
             order_id: this.env.orderId,


### PR DESCRIPTION
Issue
-----
Clicking the "pack" button in the catalog sometimes seems not to work and the product quantity remains unchanged.

Steps to reproduce
-----
- Enable packagings in settings
- Create a product
	- Set a vendor "Mom"
	- Add a packaging of some decimal number, eg 22.68
- Create a new purchase from "Mom"
- Open the catalog
- Click the product once
- Click the "pack" button 4 times (# of clicks required depends on the pack amount)
> The last click did not increase the product quantity

Cause
-----
Javascript floats are sometimes an approximation of the value rather than the value itself. This means that when we do

https://github.com/odoo/odoo/blob/0611a74cb52ca639b683ef158f8b4f2f347d08ad/addons/purchase/static/src/product_catalog/kanban_record.js#L33-L34

the flooring might sometimes get a close approximation and end up flooring down the packaging quantity.

In our example, `this.productCatalogData.quantity` should be `68.04` but is actually `68.03999999999999`. This leads to

`this.productCatalogData.quantity / packaging.qty` == `2.9999999999999996`

`Math.floor` then rounds it down to 2 so we end up with 2 + 1 = 3, which is the current packaging quantity so nothing changes.

-----
Ticket:
opw-5130865
