### PR TITLE
[IMP] mail: improve call preview and invitation UX

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_invitation.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.js
@@ -99,6 +99,11 @@ export class CallInvitation extends Component {
                         if (this.state.hasMicrophone) {
                             this.state.activateMicrophone++;
                         }
+                        if (this.state.showCameraPreview) {
+                            this.props.channel.self_member_id?.cancelInvitationTimeout();
+                        } else {
+                            this.props.channel.self_member_id?.startInvitationTimeout();
+                        }
                     },
                     tags: () => [ACTION_TAGS.CALL_LAYOUT],
                 },
@@ -117,13 +122,6 @@ export class CallInvitation extends Component {
 
     get inviter() {
         return this.props.channel.self_member_id?.rtc_inviting_session_id?.channel_member_id;
-    }
-
-    get incomingCallText() {
-        if (this.props.channel.channel_type === "chat" || !this.inviter) {
-            return _t("Incoming call");
-        }
-        return _t("Incoming call from %(inviter)s", { inviter: this.inviter.name });
     }
 
     /** @param {{ microphone?: boolean, camera?: boolean }} settings */

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -13,10 +13,10 @@
                             </div>
                             <div class="ms-2 me-3 flex-grow-1 overflow-hidden">
                                 <p class="o-discuss-CallInvitation-channelName m-0 fw-bold small text-truncate" t-esc="props.channel.displayName"/>
-                                <p class="o-discuss-CallInvitation-description m-0 fst-italic smaller text-truncate pe-1" t-esc="incomingCallText"/>
+                                <p class="o-discuss-CallInvitation-description m-0 fst-italic smaller text-truncate pe-1">Incoming call...</p>
                             </div>
                         </div>
-                        <div class="d-flex align-items-center flex-shrink-0">
+                        <div class="d-flex align-items-center flex-shrink-0 gap-2">
                             <ActionList actions="acceptOrRejectActions" inline="true" hasBtnBg="true"/>
                             <ActionList actions="otherActions" inline="true"/>
                         </div>

--- a/addons/mail/static/src/discuss/call/common/call_preview.js
+++ b/addons/mail/static/src/discuss/call/common/call_preview.js
@@ -130,12 +130,12 @@ export class CallPreview extends Component {
     get actions() {
         const cameraOnActionUpdated = {
             ...cameraOnAction,
-            name: () => (this.state.videoStream ? _t("Stop camera") : _t("Turn camera on")),
             isActive: () => this.state.videoStream,
+            name: ({ action }) => (action.isActive ? _t("Stop camera") : _t("Turn camera on")),
             onSelected: () => this.toggleCamera(),
             tags: (...args) => {
                 const tags = cameraOnAction.tags?.(...args) ?? [];
-                if (!args[0].action.isActive) {
+                if (!args[0].action.isActive && this.rtc.cameraPermission !== "granted") {
                     tags.push(ACTION_TAGS.DANGER);
                 }
                 return tags;

--- a/addons/mail/static/src/discuss/call/common/call_preview.xml
+++ b/addons/mail/static/src/discuss/call/common/call_preview.xml
@@ -2,9 +2,25 @@
 <templates xml:space="preserve">
     <t t-name="mail.CallPreview">
         <div class="o-mail-CallPreview ratio ratio-16x9">
-            <div class="bg-dark">
-                <video class="object-fit-cover h-100 w-100" autoplay="" style="background-color: rgba(0, 0, 0, 0.5);" t-ref="video"/>
-                <div class="position-absolute bottom-0 mb-3 w-100 d-flex justify-content-center">
+            <div t-att-class="{'bg-dark': env.inWelcomePage}">
+                <video t-if="state.videoStream" class="object-fit-cover h-100 w-100 position-relative z-0" autoplay="" t-ref="video"/>
+                <div t-else="" class="position-absolute top-0 start-0 end-0 bottom-0 d-flex flex-column align-items-center justify-content-center text-center px-3 z-1" t-att-class="{'text-white': env.inWelcomePage}">
+                    <t t-if="env.inWelcomePage and rtc.cameraPermission !== 'granted'">
+                        <span class="fs-3">Do you want people to see and hear you in the meeting?</span>
+                        <button class="btn btn-primary mt-3" t-on-click="() => this.toggleCamera()">Allow Microphone and Camera</button>
+                    </t>
+                    <t t-else="">
+                        <div class="d-flex flex-column align-items-center" t-att-class="{'mb-4': !env.inWelcomePage}">
+                            <i class="fa fa-camera fa-4x mb-2 opacity-50"/>
+                            <span class="fs-4 fw-bold">No Camera Preview</span>
+                            <small class="opacity-50">
+                                <t t-if="rtc.cameraPermission !== 'granted'">Please allow access in your browser settings.</t>
+                                <t t-else="">Turn on your camera to see the preview.</t>
+                            </small>
+                        </div>
+                    </t>
+                </div>
+                <div class="position-absolute bottom-0 mb-3 w-100 d-flex justify-content-center z-2">
                     <ActionList actions="actions" inline="true" hasBtnBg="true"/>
                 </div>
             </div>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -22,6 +22,7 @@ import {
     CROSS_TAB_CLIENT_MESSAGE,
     CROSS_TAB_HOST_MESSAGE,
 } from "@mail/discuss/call/common/rtc_service";
+import { ChannelMember } from "@mail/discuss/core/common/channel_member_model";
 
 import { beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
 import { advanceTime, hover, manuallyDispatchProgrammaticEvent, queryFirst } from "@odoo/hoot-dom";
@@ -744,6 +745,28 @@ test("automatically cancel incoming call after some time", async () => {
     await openDiscuss(channelId);
     await contains(".o-discuss-CallInvitation");
     await advanceTime(30_000);
+    await contains(".o-discuss-CallInvitation", { count: 0 });
+});
+
+test("Should not auto-cancel incoming call when camera preview is open", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const [memberId] = pyEnv["discuss.channel.member"].search([["channel_id", "=", channelId]]);
+    const rtcSessionId = pyEnv["discuss.channel.rtc.session"].create({
+        channel_member_id: memberId,
+        channel_id: channelId,
+    });
+    pyEnv["discuss.channel.member"].write([memberId], { rtc_inviting_session_id: rtcSessionId });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-CallInvitation");
+    await advanceTime(ChannelMember.CANCEL_CALL_INVITE_DELAY - 5000);
+    await contains(".o-discuss-CallInvitation");
+    await click(".o-mail-ActionList-button[title='Show camera preview']");
+    await advanceTime(ChannelMember.CANCEL_CALL_INVITE_DELAY - 5000); // Call should not auto-cancel while preview is open
+    await contains(".o-discuss-CallInvitation");
+    await click(".o-mail-ActionList-button[title='Hide camera preview']");
+    await advanceTime(ChannelMember.CANCEL_CALL_INVITE_DELAY); // Timer restarts when the preview closes, and the call should auto-cancel after 30s.
     await contains(".o-discuss-CallInvitation", { count: 0 });
 });
 

--- a/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
+++ b/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
@@ -18,8 +18,7 @@ registry.category("web_tour.tours").add("discuss_call_invitation.js", {
                     ".o-discuss-CallInvitation-channelName:contains('bob (base.group_user) and john (base.group_user)')",
             },
             {
-                trigger:
-                    ".o-discuss-CallInvitation-description:contains('Incoming call from bob (base.group_user)')",
+                trigger: ".o-discuss-CallInvitation-description:contains('Incoming call...')",
             },
             {
                 trigger: ".o-discuss-CallInvitation-cameraPreview:not(:visible)",


### PR DESCRIPTION
**Purpose of this PR:**

Before this commit, the call preview and invitation interfaces had various UX and visual inconsistencies:
- No fallback message was shown when video preview was unavailable (camera off or access not granted), 
  leaving the preview area visually empty.
- The call invitation auto-dismissed after 30 seconds, interrupting adjusting their audio or video settings.
- Disabled mic and camera buttons used inconsistent red tones.
- The call invitation showed redundant info like` 'Incoming call Mitchell Admin'` when the channel name
 already displayed participant names.

This commit introduces the following improvements:
- Adds a clear message when video preview is unavailable.
- Stops the invitation auto-dismiss timeout when camera preview is opened, preventing unexpected dismissal 
 while users adjust their settings.
- Aligns red tone for disabled mic and camera icons with the design system.
- Adds left margin to the `toggle-camera-preview` action for uniform alignment.
- Simplifies call invitation text to `'Incoming call'` since participant names are already shown in the channel name.


**Call Invitations:**
When access not granted:
<img width="1160" height="432" alt="image" src="https://github.com/user-attachments/assets/ea03b3ae-6f90-46ef-9a98-ef13a59c2936" />
 
When camera turned off:
<img width="1166" height="392" alt="image" src="https://github.com/user-attachments/assets/a6428f21-694d-4354-93ea-15192fabebc5" />

**Welcome Page:**
When access not granted:
 <img width="1503" height="501" alt="image" src="https://github.com/user-attachments/assets/6cd31ffb-b7d0-48e1-80e9-9c59dfdf84eb" />

When camera turned off:
<img width="1381" height="470" alt="image" src="https://github.com/user-attachments/assets/521eed7d-8112-4f26-83a2-866b8ea01c1e" />


task-5380264