### PR TITLE
[FIX] payment_adyen: skip amount validation for 3ds challenge flow

### DIFF
--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -313,9 +313,9 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'adyen':
             return super()._extract_amount_data(payment_data)
 
-        # Redirection payments don't have the amount or currency in their payment_data, but
-        # processing them results in a pending transaction anyway.
-        if payment_data.get('action', {}).get('type') == 'redirect':
+        # Redirection payments and 3DS challenges don't have the amount or currency in their
+        # payment_data, but processing them results in a pending transaction anyway.
+        if payment_data.get('action', {}).get('type') in ['redirect', 'threeDS2']:
             return None  # Skip the validation
 
         amount_data = payment_data.get('amount', {})


### PR DESCRIPTION
When Adyen request a 3DS challenge for the payment, we should not enforce amount and currency validation at that time (no amount are provided in the Adyen response).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
