### PR TITLE
[FIX] web: avoid crash when action.views is undefined in calendar popup

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -439,7 +439,10 @@ export function makeActionManager(env, router = _router) {
             action.target = action.target || "current";
         }
         if (action.type === "ir.actions.act_window") {
-            action.views = [...action.views.map((v) => [v[0], v[1]])]; // manipulate a copy to keep cached action unmodified
+            if (!action.views || !Array.isArray(action.views)) {
+                action.views = [[false, "form"]];
+            }
+            action.views = [...action.views.map((v) => [v[0], v[1]])];
             action.controllers = {};
             if (action.views.every((v) => ["form", "search"].includes(v[1]))) {
                 action.views = action.views.filter((v) => v[1] === "form");


### PR DESCRIPTION
When opening certain activity items from the Activity Calendar popover,
the backend may return an `ir.actions.act_window` without the `views` key.

The frontend then executes:

    action.views.map(...)

which raises:

    TypeError: Cannot read properties of undefined (reading 'map')

This commit adds a safe fallback:

    if (!action.views) {
        action.views = [[false, "form"]];
    }

so that the action always has a valid view definition. This prevents the
client-side crash and ensures the record opens normally.

Steps to reproduce:
1. Go to Activities → Calendar
2. Click on different activity items to open the popover
3. Click the "View" button
4. Some records trigger the JS error instead of opening

After this fix, affected actions correctly open a form view without error.

This issue is reproducible on the official Odoo demo (demo.odoo.com).