### PR TITLE
[IMP] website_sale_collect: auto-publish the "Pay on Site" provider

### DIFF
--- a/addons/website_sale_collect/data/payment_provider_data.xml
+++ b/addons/website_sale_collect/data/payment_provider_data.xml
@@ -6,6 +6,7 @@
         <field name="module_id" ref="base.module_website_sale_collect"/>
         <field name="code">custom</field>
         <field name="state">enabled</field>
+        <field name="is_published">True</field>
         <field name="custom_mode">on_site</field>
         <field name="payment_method_ids"
                eval="[(6, 0, [


### PR DESCRIPTION
As of commit 397b9c26, the "Pick up in store" delivery method supporting Click & Collect is automatically published when created if existing warehouses are found. However, the associated "Pay on Site" payment provider was enabled but left unpublished, requiring users to manually publish it to allow on-site payment in the Click & Collect flow.

This commit auto-publishes the "Pay on Site" payment provider when it is created, even if the "Pick up in store" delivery method could not be published, as customers won't be able to use the former to pay anyway.
