### PR TITLE
[FIX] website_livechat: ongoing recent conversations in info list

### DIFF
--- a/addons/website/static/tests/mock_server/website_livechat_mock_server.js
+++ b/addons/website/static/tests/mock_server/website_livechat_mock_server.js
@@ -1,0 +1,25 @@
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(mailDataHelpers, {
+    _process_request_for_internal_user(store, name, params) {
+        super._process_request_for_internal_user(...arguments);
+        if (name === "/im_livechat/session/data") {
+            const DiscussChannel = this.env["discuss.channel"];
+            const WebsiteVisitor = this.env["website.visitor"];
+            const [channel] = DiscussChannel.browse(params.channel_id);
+            const channelIds = DiscussChannel.search(
+                [
+                    ["channel_type", "=", "livechat"],
+                    ["livechat_visitor_id", "=", channel.livechat_visitor_id],
+                ],
+                0,
+                5
+            );
+            store._add_record_fields(WebsiteVisitor.browse(channel.livechat_visitor_id), {
+                discuss_channel_ids: mailDataHelpers.Store.many(DiscussChannel.browse(channelIds)),
+            });
+        }
+    },
+});

--- a/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.js
+++ b/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.js
@@ -1,22 +1,20 @@
 import { LivechatChannelInfoList } from "@im_livechat/core/web/livechat_channel_info_list";
+
+import { compareDatetime } from "@mail/utils/common/misc";
+
 import { formatDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-/** @type {import("models").ChannelMember} */
+/** @type {LivechatChannelInfoList} */
 const livechatChannelInfoListPatch = {
     get recentConversations() {
         return (this.props.thread.livechat_visitor_id?.discuss_channel_ids ?? [])
             .filter((channel) => channel.notEq(this.props.thread))
-            .sort((t1, t2) => {
-                if (t1.livechat_end_dt && !t2.livechat_end_dt) {
-                    return 1;
-                }
-                if (!t1.livechat_end_dt && t2.livechat_end_dt) {
-                    return -1;
-                }
-                return t1.livechat_end_dt.diff(t2.livechat_end_dt) > 0 ? -1 : 1;
-            });
+            .sort(
+                (t1, t2) =>
+                    compareDatetime(t2.last_interest_dt, t1.last_interest_dt) || t2.id - t1.id
+            );
     },
     CLOSED_ON_TEXT(thread) {
         return _t("(closed on: %(date)s)", { date: formatDateTime(thread.livechat_end_dt) });

--- a/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.xml
@@ -23,7 +23,7 @@
                 <div class="btn btn-group o-rounded-bubble d-flex flex-column w-100 p-0 m-0" style="gap: 1px;">
                     <a
                         t-foreach="recentConversations" t-as="thread" t-key="thread.localId"
-                        class="btn btn-sm btn-secondary btn-group-item d-flex align-items-center justify-content-start gap-1 w-100 m-0 px-3 py-1"
+                        class="o-livechat-LivechatChannelInfoList-recentConversation btn btn-sm btn-secondary btn-group-item d-flex align-items-center justify-content-start gap-1 w-100 m-0 px-3 py-1"
                         t-attf-href="/odoo/discuss?active_id={{thread.model}}_{{thread.id}}"
                         target="_blank"
                         t-att-class="{


### PR DESCRIPTION
Live chat shows recent conversations with a customer in the info panel. Chats are sorted by end date. However, some conversations could still be ongoing. This is not taken into account in the sort function and can lead to a crash. This commit fixes the issue.

opw-5263335

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
