### PR TITLE
[FIX] hr_attendance: prevent error when user tries to checkout

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -43,8 +43,8 @@ class HrAttendance(http.Controller):
                 'kiosk_delay': employee.company_id.attendance_kiosk_delay * 1000,
                 'attendance': {'check_in': employee.last_attendance_id.check_in,
                                'check_out': employee.last_attendance_id.check_out},
-                'overtime_today': request.env['hr.attendance.overtime.line'].sudo().search([
-                    ('employee_id', '=', employee.id), ('date', '=', datetime.date.today())]).duration or 0,
+                'overtime_today': sum(request.env['hr.attendance.overtime.line'].sudo().search([
+                    ('employee_id', '=', employee.id), ('date', '=', datetime.date.today())]).mapped('duration')) or 0,
                 'use_pin': employee.company_id.attendance_kiosk_use_pin,
                 'display_overtime': employee.company_id.hr_attendance_display_overtime,
                 'device_tracking_enabled': employee.company_id.attendance_device_tracking,

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -3,12 +3,12 @@ from datetime import date, datetime
 from freezegun import freeze_time
 
 from odoo import Command
-from odoo.tests import Form, new_test_user
-from odoo.tests.common import tagged, TransactionCase
+from odoo.tests import Form, HttpCase, new_test_user
+from odoo.tests.common import tagged
 
 
 @tagged('hr_attendance_overtime')
-class TestHrAttendanceOvertime(TransactionCase):
+class TestHrAttendanceOvertime(HttpCase):
     """ Tests for overtime """
 
     @classmethod
@@ -1032,3 +1032,24 @@ class TestHrAttendanceOvertime(TransactionCase):
 
         self.assertEqual(ruleset.rule_ids.timing_type, 'work_days',
                  "Employee work Timing type should default to 'work_days' when not set.")
+
+    def test_employee_overtime_with_multiple_attendance_lines(self):
+        """Validate that multiple overtime lines for today are summed correctly
+        and that the entire attendance_employee_data response is consistent.
+        """
+        for _ in range(2):
+            self.env['hr.attendance.overtime.line'].create({
+                'employee_id': self.employee.id,
+                'date': date.today(),
+                'duration': 5,
+            })
+        token = self.employee.company_id.attendance_kiosk_key
+        response = self.make_jsonrpc_request(
+            '/hr_attendance/attendance_employee_data',
+            {'token': token, 'employee_id': self.employee.id},
+        )
+        self.assertEqual(response.get('hours_previously_today'), 0)
+        self.assertEqual(response.get('hours_today'), 0)
+        self.assertEqual(response.get('last_attendance_worked_hours'), 0)
+        self.assertEqual(response.get('overtime_today'), 10)
+        self.assertEqual(response.get('total_overtime'), 10)


### PR DESCRIPTION
The system raises an error when a user attempts to checkout through any method.

Steps to produce:
- Install hr_attendance without demo.
- Settings  > Under Work Organization > set schedule with 0 working hours.([Example])
- Employees > Administrator > under settings > set Overtime Ruleset as `Default Ruleset`.
- Now to attendance > kiosk > do checkin - checkout server time.

Error:
`ValueError: Expected singleton: hr.attendance.overtime.line(171, 172, 173)`

Cause:
- [Here], the system retrieves the attendance duration for today and assumes it exists in only one record. However, multiple attendance records can exist for the same day.

Solution:
- This fix updates the logic to compute the sum of all attendance durations for that employee for today, instead of expecting a single record.

[Example]: https://drive.google.com/file/d/12cdXOHtE11ytCBotVr6FDszK7xHndbm_/view?usp=sharing

[Here]https://github.com/odoo/odoo/blob/e387c4a706a7d24b437e75c3d5970e5786626dc9/addons/hr_attendance/controllers/main.py#L46-L47

sentry-7024592646
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
