### PR TITLE
[IMP] mail: limit invite people autofocus to active context

### DIFF
--- a/addons/mail/static/tests/discuss/call/call_permissions.test.js
+++ b/addons/mail/static/tests/discuss/call/call_permissions.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     defineMailModels,
     mockGetMedia,
+    mockPermissionsPrompt,
     openDiscuss,
     start,
     startServer,
@@ -10,24 +11,8 @@ import {
 
 import { describe, test } from "@odoo/hoot";
 
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
-import { browser } from "@web/core/browser/browser";
-
 describe.current.tags("desktop");
 defineMailModels();
-
-function mockPermissionsPrompt() {
-    patchWithCleanup(browser.navigator.permissions, {
-        async query() {
-            return {
-                state: "prompt",
-                addEventListener: () => {},
-                removeEventListener: () => {},
-                onchange: null,
-            };
-        },
-    });
-}
 
 test("Starting a video call asks for permissions", async () => {
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     defineMailModels,
     insertText,
+    mockPermissionsPrompt,
     openDiscuss,
     setupChatHub,
     start,
@@ -222,4 +223,14 @@ test("invite user to self chat opens DM chat with user", async () => {
     await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner" });
     await click("button:contains('Go to Conversation'):enabled");
     await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "TestPartner" });
+});
+
+test("invite input not focused when there is an active dialog", async () => {
+    await startServer();
+    mockPermissionsPrompt();
+    await start();
+    await openDiscuss();
+    await click("button[title='New Meeting']");
+    await contains(".o-discuss-ChannelInvitation-search");
+    await contains("button:focus", { text: "Use Camera" });
 });

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -992,3 +992,16 @@ export function patchVoiceMessageAudio() {
     });
     return res;
 }
+
+export function mockPermissionsPrompt() {
+    patchWithCleanup(browser.navigator.permissions, {
+        async query() {
+            return {
+                state: "prompt",
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                onchange: null,
+            };
+        },
+    });
+}


### PR DESCRIPTION
**Purpose of this PR:**

Focus the invite input only when it exists and the UI marks the panel as active, so it no longer steals focus from dialogs such as the call-permission dialog.

Part of task-[5227387](https://www.odoo.com/odoo/project/1519/tasks/5227387)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
