### PR TITLE
[FIX] html_builder: ensure background shapes compatibility

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
@@ -208,7 +208,12 @@ export class BackgroundShapeOptionPlugin extends Plugin {
             shapeAnimationSpeed: "0",
         };
         const json = editingElement.dataset.oeShapeData;
-        return json ? Object.assign(defaultData, JSON.parse(json.replace(/'/g, '"'))) : defaultData;
+        if (json) {
+            Object.assign(defaultData, JSON.parse(json.replace(/'/g, '"')));
+            // Compatibility with old shapes.
+            defaultData.shape = defaultData.shape.replace("web_editor", "html_builder");
+        }
+        return defaultData;
     }
     /**
      * Returns the src of the shape corresponding to the current parameters.
@@ -313,14 +318,17 @@ export class BackgroundShapeOptionPlugin extends Plugin {
         return backgroundShapesDefinition;
     }
     getBackgroundShapes() {
-        const entries = Object.values(this.getBackgroundShapeGroups())
-            .map((x) =>
-                Object.values(x.subgroups)
-                    .map((x) => Object.entries(x.shapes))
-                    .flat()
-            )
-            .flat();
-        return Object.fromEntries(entries);
+        if (!this.backgroundShapesById) {
+            const entries = Object.values(this.getBackgroundShapeGroups())
+                .map((x) =>
+                    Object.values(x.subgroups)
+                        .map((x) => Object.entries(x.shapes))
+                        .flat()
+                )
+                .flat();
+            this.backgroundShapesById = Object.fromEntries(entries);
+        }
+        return this.backgroundShapesById;
     }
 }
 

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -455,3 +455,17 @@ test("change background size", async () => {
     expect(widthInput).toHaveValue("1", { message: "minimum value is 1" });
     expect(section).toHaveStyle("background-size: 1px");
 });
+
+test("background shape detection is compatible with previous ones (web_editor)", async () => {
+    await setupWebsiteBuilder(`
+        <section data-oe-shape-data='{"shape":"web_editor/Connections/01","flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            AAAA
+        </section>`);
+    await contains(":iframe section").click();
+    expect("div[data-label='Shape'] button:first-of-type").toHaveText("Connections 01");
+    await contains("div[data-label='Shape'] button:first-of-type").click();
+    expect("button.active[data-action-id='setBackgroundShape']").toHaveAttribute(
+        "data-action-value",
+        "html_builder/Connections/01"
+    );
+});


### PR DESCRIPTION
After website builder refactoring [1], background shapes were moved from `web_editor` to `html_builder` [2], this causes the applied shape to be shown as "None" if it was done before the move.

Additionally, `getBackgroundShapes` method was generating the shapes map on every call. We now store the generated shapes map to prevent unnecessary recalculation.

Steps to reproduce:
- Add a section with a shape in a page using an old shape (e.g. in 18.3).
- Copy the HTML code of this section.
- Paste this HTML code into a page in 19.0.
- Click the section.
- The shape option shows "None".

task-5263013

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[2]: https://github.com/odoo/odoo/commit/2feed24b9e44e9dd4d218afdcae07b127d1e201d