### PR TITLE
[FIX] web: Add opacity back to sample data

### DIFF
--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -332,6 +332,7 @@
 
 // Sample data
 @mixin o-sample-data-disabled {
+    opacity: 0.06;
     pointer-events: none;
     user-select: none;
 }

--- a/addons/web/static/src/views/view.scss
+++ b/addons/web/static/src/views/view.scss
@@ -18,11 +18,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-image:  radial-gradient(
-        at 50% 50%,
-        #{$o-view-background-color} 0px,
-        #{rgba($o-view-background-color, 0.5)} 100%
-    );
 
     .o_nocontent_help {
         @include o-nocontent-empty;


### PR DESCRIPTION
The opacity effect was removed from Sample Data in #233205 and caused issue when sample data are present without an ActionHelper.

This commit reverts these changes.
