### PR TITLE
[FIX] hr_holidays: set 1 day off for flexible schedule

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -606,7 +606,7 @@ Versions:
                     else:
                         hours = (leave.date_to - leave.date_from).total_seconds() / 3600
                     if not leave.request_unit_hours and not public_holidays:
-                        days = 1 if not leave.request_unit_half else 0.5
+                        days = 1 if not leave.request_unit_half or leave.request_date_from_period != leave.request_date_to_period else 0.5
                     else:
                         days = hours / 24
                 elif leave.leave_type_request_unit == 'day' and check_leave_type:

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -2123,3 +2123,32 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_req_form.holiday_status_id = self.holidays_type_hours
 
         self.assertFalse(leave_req_form.date_to)
+
+    def test_flexible_schedule_full_day_off(self):
+        """this tests checks that if the morning and afternoon have been selected as time off and the schedule type of
+        the employee is flexible, the time considered off is a full day."""
+        calendar = self.env['resource.calendar'].sudo().create({
+            'company_id': False,
+            'name': 'Flexible 40h/week',
+            'tz': 'UTC',
+            'hours_per_day': 8.0,
+            'full_time_required_hours': 40.0,
+            'flexible_hours': True,
+            'schedule_type': 'flexible',
+        })
+        self.employee_hruser.write({
+            'is_flexible': True,
+            'resource_calendar_id': calendar.id
+        })
+        flex_leave = self.env['hr.leave'].create({
+            'name': "Full Day Leave",
+            'employee_id': self.employee_hruser.id,
+            'holiday_status_id': self.holidays_type_half.id,
+            'request_date_from': "2025-08-29",
+            'request_date_to': "2025-08-29",
+            'request_date_from_period': 'am',
+            'request_date_to_period': 'pm',
+        })
+
+        leave = flex_leave._get_durations()
+        self.assertEqual(leave[flex_leave.id][0], 1, "The total leaves should be 1.")


### PR DESCRIPTION
---
## Short functional explanation of the error
When setting an employee's schedule as flexible, and entering a time off entry of one day (morning + afternoon for a specific date), the amount of time considered is 1 day.

## Reproduction Steps
1. Go to Time off. Click on the tab Configuration > time off types > extra time off. You should see 2 smart buttons: Allocations and Time off.
2. Click on Allocations > New, and allocate a few days off for a specific employee. Make sure that this employee's schedule is flexible by checking the tab Payroll on his profile: the working hours type should be flexible.
3. Go back to Extra Time Off and click on the Time Off smart button > new.
4. Set the corresponding employee. Set an end date equal to a start date, and for the day period, set it from morning to afternoon.

### Expected behavior
The computed amount of days off should be equal to 1.

### Unexpected behavior
The computed amount of days off equals 0.5.

## Origin of the issue
When the employee doesn't require a leave of type hours, and the leave is computed in half days, if only one say has been selected the code will automatically set the duration of the day off as 0.5 days:
https://github.com/odoo/odoo/blob/7d9f7637c83b8ae3d0f0ca42b41edb6a3ea68349/addons/hr_holidays/models/hr_leave.py#L608-L609 Hence we need to specify a condtion to take this use case into consideration.

__
opw-5214449

