### PR TITLE
[PERF] bus: do not use registry to dispatch notifications

### DIFF
--- a/addons/bus/__init__.py
+++ b/addons/bus/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from . import models
+from . import session_helpers
 from . import controllers
 from . import websocket

--- a/addons/bus/session_helpers.py
+++ b/addons/bus/session_helpers.py
@@ -1,0 +1,70 @@
+import hashlib
+import hmac
+import time
+
+from odoo.api import Environment
+from odoo.modules.registry import Registry
+from odoo.sql_db import SQL
+from odoo.tools.lru import LRU
+from odoo.tools.misc import consteq
+
+_query_params_by_user = LRU(8192)
+
+
+def _get_session_token_query_params(cr, session):
+    """
+    Retrieve the session token query parameters like
+    `res.users@_get_session_token_query_params`, but with caching to avoid building the
+    full registry. The cache is invalidated when `registry.registry_sequence` has changed.
+    """
+    cache_key = (cr.dbname, session.uid)
+    if cached_value := _query_params_by_user.get(cache_key):
+        cr.execute('SELECT MAX(id) FROM orm_signaling_registry')
+        if cached_value['registry_sequence'] == cr.fetchone()[0]:
+            return cached_value['query_params']
+    Registry(cr.dbname).check_signaling()
+    env = new_env(cr, session)
+    params = env.user._get_session_token_query_params()
+    _query_params_by_user[cache_key] = {
+        'registry_sequence': env.registry.registry_sequence,
+        'query_params': params,
+    }
+    return params
+
+
+def check_session(cr, session):
+    session._delete_old_sessions()
+    if 'deletion_time' in session and session['deletion_time'] <= time.time():
+        return False
+    query_params = _get_session_token_query_params(cr, session)
+    cr.execute(
+        SQL(
+            'SELECT %(select)s FROM %(from)s %(joins)s WHERE %(where)s GROUP BY %(group_by)s',
+            **query_params,
+        ),
+    )
+    if cr.rowcount != 1:
+        return False
+    row = cr.fetchone()
+    key_tuple = tuple(
+        (col.name, row[i]) for i, col in enumerate(cr.description) if row[i] is not None
+    )
+    key = str(key_tuple).encode()
+    token = hmac.new(key, session.sid.encode(), hashlib.sha256).hexdigest()
+    return consteq(token, session.session_token)
+
+
+def new_env(cr, session, *, set_lang=False):
+    """
+    Create a new environment. Make sure the transaction has a `default_env` and
+    if requested, set the language of the user in the context.
+    """
+    uid = session.uid
+    ctx = dict(session.context, lang=None)  # lang is not guaranteed to be correct
+    env = Environment(cr, uid, ctx)
+    if set_lang:
+        lang = env['res.lang']._get_code(ctx['lang'])
+        env = env(context=dict(ctx, lang=lang))
+    if not env.transaction.default_env:
+        env.transaction.default_env = env
+    return env

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_ir_model
 from . import test_ir_websocket
 from . import test_notify
 from . import test_websocket_caryall
+from . import test_websocket_check_session
 from . import test_close_websocket_after_tour
 from . import test_websocket_controller
 from . import test_websocket_rate_limiting

--- a/addons/bus/tests/test_websocket_check_session.py
+++ b/addons/bus/tests/test_websocket_check_session.py
@@ -1,0 +1,44 @@
+import time
+from datetime import timedelta
+from unittest.mock import patch
+
+from freezegun import freeze_time
+
+from odoo.tests import HttpCase, new_test_user
+
+from ..session_helpers import _get_session_token_query_params, check_session
+
+
+class TestWebsocketCheckSession(HttpCase):
+    def test_check_session_deletion_time(self):
+        bob = new_test_user(self.env, "bob", groups="base.group_user")
+        self.authenticate(bob.login, bob.password)
+        with freeze_time() as frozen_time:
+            self.session["deletion_time"] = time.time() + 3600
+            self.assertTrue(check_session(self.env.cr, self.session))
+            frozen_time.tick(delta=timedelta(hours=2))
+            self.assertFalse(check_session(self.env.cr, self.session))
+
+    def test_check_session_token_field_changes(self):
+        bob = new_test_user(self.env, "bob", groups="base.group_user")
+        self.authenticate(bob.login, bob.password)
+        self.assertTrue(check_session(self.env.cr, self.session))
+        bob.password = "bob_new_password"
+        self.assertFalse(check_session(self.env.cr, self.session))
+
+    def test_update_cache_when_registry_changes(self):
+        bob = new_test_user(self.env, "bob", groups="base.group_user")
+        self.authenticate(bob.login, bob.password)
+        bob_query_params = _get_session_token_query_params(self.env.cr, self.session)
+        self.assertIs(
+            bob_query_params, _get_session_token_query_params(self.env.cr, self.session)
+        )
+        jane = new_test_user(self.env, "jane", groups="base.group_user")
+        self.authenticate(jane.login, jane.password)
+        current_registry_sequence = self.env.registry.registry_sequence
+        # Signaling is patched during test, simulate first entry coming from an old registry.
+        with patch.object(self.env.registry, "registry_sequence", current_registry_sequence - 1):
+            jane_query_params = _get_session_token_query_params(self.env.cr, self.session)
+        next_jane_query_params = _get_session_token_query_params(self.env.cr, self.session)
+        self.assertIsNot(jane_query_params, next_jane_query_params)
+        self.assertIs(next_jane_query_params, _get_session_token_query_params(self.env.cr, self.session))

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -5,35 +5,36 @@ import hashlib
 import json
 import logging
 import os
-import psycopg2
 import random
+import selectors
 import socket
 import struct
-import selectors
 import threading
 import time
 from collections import defaultdict, deque
 from contextlib import closing, suppress
 from enum import IntEnum
 from itertools import count
-from psycopg2.pool import PoolError
 from queue import PriorityQueue
 from urllib.parse import urlparse
 from weakref import WeakSet
 
-from werkzeug.local import LocalStack
+import psycopg2
+from psycopg2.pool import PoolError
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
+from werkzeug.local import LocalStack
 
 import odoo
 from odoo import modules
-from .models.bus import dispatch
-from .session_helpers import check_session, new_env
-from odoo.http import root, Request, Response, SessionExpiredException, get_default_session
+from odoo.http import Request, Response, SessionExpiredException, get_default_session, root
 from odoo.modules.registry import Registry
 from odoo.service import model as service_model
 from odoo.service.server import CommonServer
 from odoo.tools import config
+
+from .models.bus import dispatch
+from .session_helpers import check_session, new_env
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -26,13 +26,13 @@ from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
 
 import odoo
-from odoo import api, modules
+from odoo import modules
 from .models.bus import dispatch
+from .session_helpers import check_session, new_env
 from odoo.http import root, Request, Response, SessionExpiredException, get_default_session
 from odoo.modules.registry import Registry
 from odoo.service import model as service_model
 from odoo.service.server import CommonServer
-from odoo.service.security import check_session
 from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
@@ -620,7 +620,7 @@ class Websocket:
         dispatch.unsubscribe(self)
         self._trigger_lifecycle_event(LifecycleEvent.CLOSE)
         with acquire_cursor(self._db) as cr:
-            env = self.new_env(cr, self._session)
+            env = new_env(cr, self._session)
             env["ir.websocket"]._on_websocket_closed(self._cookies)
 
     def _handle_control_frame(self, frame):
@@ -697,7 +697,7 @@ class Websocket:
         if not self.__event_callbacks[event_type]:
             return
         with closing(acquire_cursor(self._db)) as cr:
-            env = self.new_env(cr, self._session, set_lang=True)
+            env = new_env(cr, self._session, set_lang=True)
             for callback in self.__event_callbacks[event_type]:
                 try:
                     service_model.retrying(functools.partial(callback, env, self), env)
@@ -726,8 +726,7 @@ class Websocket:
         if session.uid is None:
             return
         with acquire_cursor(session.db) as cr:
-            env = self.new_env(cr, session)
-            if not check_session(session, env):
+            if not check_session(cr, session):
                 raise SessionExpiredException()
 
     def _send_control_command(self, command, data=None):
@@ -754,7 +753,7 @@ class Websocket:
     def _dispatch_bus_notifications(self):
         self._waiting_for_dispatch = False
         with acquire_cursor(self._session.db) as cr:
-            env = self.new_env(cr, self._session)
+            env = new_env(cr, self._session)
             notifications = env['bus.bus']._poll(
                 self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
             )
@@ -783,23 +782,6 @@ class Websocket:
                 self._last_notif_sent_id = self._notif_history[last_index][0]
                 self._notif_history = self._notif_history[last_index + 1 :]
             self._send(notifications)
-
-    def new_env(self, cr, session, *, set_lang=False):
-        """
-        Create a new environment.
-        Make sure the transaction has a `default_env` and if requested, set the
-        language of the user in the context.
-        """
-        uid = session.uid
-        # lang is not guaranteed to be correct, set None
-        ctx = dict(session.context, lang=None)
-        env = api.Environment(cr, uid, ctx)
-        if set_lang:
-            lang = env['res.lang']._get_code(ctx['lang'])
-            env = env(context=dict(ctx, lang=lang))
-        if not env.transaction.default_env:
-            env.transaction.default_env = env
-        return env
 
 
 class TimeoutManager:
@@ -913,7 +895,7 @@ class WebsocketRequest:
             raise InvalidDatabaseException() from exc
 
         with closing(acquire_cursor(self.db)) as cr:
-            self.env = self.ws.new_env(cr, self.session, set_lang=True)
+            self.env = new_env(cr, self.session, set_lang=True)
             service_model.retrying(
                 functools.partial(self._serve_ir_websocket, event_name, data),
                 self.env,

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -33,7 +33,7 @@ from odoo.service import model as service_model
 from odoo.service.server import CommonServer
 from odoo.tools import config
 
-from .models.bus import dispatch
+from .models.bus import dispatch, fetch_bus_notifications
 from .session_helpers import check_session, new_env
 
 _logger = logging.getLogger(__name__)
@@ -754,9 +754,8 @@ class Websocket:
     def _dispatch_bus_notifications(self):
         self._waiting_for_dispatch = False
         with acquire_cursor(self._session.db) as cr:
-            env = new_env(cr, self._session)
-            notifications = env['bus.bus']._poll(
-                self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
+            notifications = fetch_bus_notifications(
+                cr, self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
             )
             if not notifications:
                 return

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -708,6 +708,28 @@ class Websocket:
                         exc_info=True
                     )
 
+    def _assert_session_validity(self):
+        """Ensure the current session exists and validate it using
+        `check_session`.
+
+        :raises: SessionExpiredException if the session does not exist or fails
+          validation.
+
+        """
+        session = root.session_store.get(self._session.sid)
+        if not session:
+            raise SessionExpiredException()
+        if 'next_sid' in session:
+            self._session = root.session_store.get(session['next_sid'])
+            self._assert_session_validity()
+            return
+        if session.uid is None:
+            return
+        with acquire_cursor(session.db) as cr:
+            env = self.new_env(cr, session)
+            if not check_session(session, env):
+                raise SessionExpiredException()
+
     def _send_control_command(self, command, data=None):
         """Send a command to the websocket event loop.
 
@@ -724,57 +746,43 @@ class Websocket:
         """
         match command:
             case ControlCommand.DISPATCH:
+                self._assert_session_validity()
                 self._dispatch_bus_notifications()
             case ControlCommand.CLOSE:
                 self._disconnect(data['code'], data.get('reason'))
 
     def _dispatch_bus_notifications(self):
-        """
-        Dispatch notifications related to the registered channels. If
-        the session is expired, close the connection with the
-        `SESSION_EXPIRED` close code. If no cursor can be acquired,
-        close the connection with the `TRY_LATER` close code.
-        """
-        session = root.session_store.get(self._session.sid)
-        if not session:
-            raise SessionExpiredException()
-        if 'next_sid' in session:
-            self._session = root.session_store.get(session['next_sid'])
-            return self._dispatch_bus_notifications()
-         # Mark the notification request as processed.
         self._waiting_for_dispatch = False
-        with acquire_cursor(session.db) as cr:
-            env = self.new_env(cr, session)
-            if session.uid is not None and not check_session(session, env):
-                raise SessionExpiredException()
-            notifications = env["bus.bus"]._poll(
+        with acquire_cursor(self._session.db) as cr:
+            env = self.new_env(cr, self._session)
+            notifications = env['bus.bus']._poll(
                 self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
             )
-        if not notifications:
-            return
-        for notif in notifications:
-            bisect.insort(self._notif_history, (notif["id"], time.time()), key=lambda x: x[0])
-        # Discard all the smallest notification ids that have expired and
-        # increment the last id accordingly. History can only be trimmed of ids
-        # that are below the new last id otherwise some notifications might be
-        # dispatched again.
-        # For example, if the theshold is 10s, and the state is:
-        # last id 2, history [(3, 8s), (6, 10s), (7, 7s)]
-        # If 6 is removed because it is above the threshold, the next query will
-        # be (id > 2 AND id NOT IN (3, 7)) which will fetch 6 again.
-        # 6 can only be removed after 3 reaches the threshold and is removed as
-        # well, and if 4 appears in the meantime, 3 can be removed but 6 will
-        # have to wait for 4 to reach the threshold as well.
-        last_index = -1
-        for i, notif in enumerate(self._notif_history):
-            if time.time() - notif[1] > self.MAX_NOTIFICATION_HISTORY_SEC:
-                last_index = i
-            else:
-                break
-        if last_index != -1:
-            self._last_notif_sent_id = self._notif_history[last_index][0]
-            self._notif_history = self._notif_history[last_index + 1 :]
-        self._send(notifications)
+            if not notifications:
+                return
+            for notif in notifications:
+                bisect.insort(self._notif_history, (notif['id'], time.time()), key=lambda x: x[0])
+            # Discard all the smallest notification ids that have expired and
+            # increment the last id accordingly. History can only be trimmed of ids
+            # that are below the new last id otherwise some notifications might be
+            # dispatched again.
+            # For example, if the theshold is 10s, and the state is:
+            # last id 2, history [(3, 8s), (6, 10s), (7, 7s)]
+            # If 6 is removed because it is above the threshold, the next query will
+            # be (id > 2 AND id NOT IN (3, 7)) which will fetch 6 again.
+            # 6 can only be removed after 3 reaches the threshold and is removed as
+            # well, and if 4 appears in the meantime, 3 can be removed but 6 will
+            # have to wait for 4 to reach the threshold as well.
+            last_index = -1
+            for i, notif in enumerate(self._notif_history):
+                if time.time() - notif[1] > self.MAX_NOTIFICATION_HISTORY_SEC:
+                    last_index = i
+                else:
+                    break
+            if last_index != -1:
+                self._last_notif_sent_id = self._notif_history[last_index][0]
+                self._notif_history = self._notif_history[last_index + 1 :]
+            self._send(notifications)
 
     def new_env(self, cr, session, *, set_lang=False):
         """


### PR DESCRIPTION
This PR aims to make the bus faster and more efficient. When there
are more databases than what the LRU cache can hold, the gevent
worker struggles to keep notifications flowing. Each incoming or
outgoing message requires a registry, which is highly inefficient.
Many notifications need to build the registry from scratch (since they
don't fit in the cache), blocking a cursor for a long time and
preventing other greenlets from waking up.

This PR removes the need to build an environment for outgoing
messages:
- Notifications are fetched directly with an SQL query.
- The result of `_get_session_token_query_params`
is cached, allowing to check session validity with a direct query.

Note that dispatching bus notifications won't update `res.device`
anymore, which is considered acceptable.