### PR TITLE
[IMP] project_todo: hide “View Task” button for portal users in emails

### DIFF
--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -46,3 +46,15 @@ class ProjectTask(models.Model):
             (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_calendar"), "calendar"),
             (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_activity"), "activity"),
         ]
+
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        groups = super()._notify_get_recipients_groups(
+            message, model_description, msg_vals=msg_vals
+        )
+        self.ensure_one()
+        if not self.project_id:
+            for group_name, _group_method, group_data in groups:
+                if group_name == 'portal':
+                    group_data['has_button_access'] = False
+
+        return groups

--- a/addons/project_todo/tests/__init__.py
+++ b/addons/project_todo/tests/__init__.py
@@ -2,6 +2,7 @@
 
 from . import test_access_rights
 from . import test_mail_activity_todo_create
+from . import test_todo_mail_features
 from . import test_todo_onboarding_for_users
 from . import test_mail_activity_systray_counter
 from . import test_project_tags

--- a/addons/project_todo/tests/test_todo_mail_features.py
+++ b/addons/project_todo/tests/test_todo_mail_features.py
@@ -1,0 +1,68 @@
+from odoo import Command
+from odoo.tests import tagged, new_test_user
+
+from odoo.addons.mail.tests.common import MailCommon
+
+
+@tagged('post_install', '-at_install')
+class TestTodoMailFeatures(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.portal_user = new_test_user(
+            cls.env,
+            login='portal_user_test',
+            groups='base.group_portal',
+            name='Portal User'
+        )
+        cls.internal_user = new_test_user(
+            cls.env,
+            login='internal_user_test',
+            groups='project.group_project_user',
+            name='Internal User'
+        )
+        cls.todo = cls.env['project.task'].create({
+            'name': 'Test Private To-Do',
+            'project_id': False,
+            'user_ids': [Command.link(cls.internal_user.id)],
+        })
+
+    def test_view_task_button_visibility(self):
+        """
+        Test that when a To-Do sends a notification:
+        1. Internal User (who has access) receives the 'View Task' button.
+        2. Portal User does NOT receive the 'View Task' button.
+        """
+
+        self.todo.message_subscribe(partner_ids=[
+            self.portal_user.partner_id.id,
+            self.internal_user.partner_id.id,
+        ])
+        with self.mock_mail_gateway():
+            self.todo.message_post(
+                body='Test message content',
+                message_type='comment',
+                subtype_xmlid='mail.mt_comment',
+            )
+
+        portal_email = self._new_mails.filtered(
+            lambda m: self.portal_user.partner_id in m.recipient_ids
+        )
+        internal_email = self._new_mails.filtered(
+            lambda m: self.internal_user.partner_id in m.recipient_ids
+        )
+
+        self.assertTrue(internal_email, "Internal user should have received an email")
+        self.assertIn(
+            'View Task',
+            internal_email.body_html,
+            "The email to the internal user SHOULD contain the 'View Task' button"
+        )
+
+        self.assertTrue(portal_email, "Portal user should have received an email")
+        self.assertNotIn(
+            'View Task',
+            portal_email.body_html,
+            "The email to the portal user should NOT contain the 'View Task' button"
+        )


### PR DESCRIPTION
This commit hides the “View Task” button from To-Do notification emails sent to portal users. Since portal users do not have access to view To-Dos, the button is no longer displayed for them.

task-4908548

