### PR TITLE
[FIX] iot_box_image: update requirements for trixie compatibility

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -1,14 +1,14 @@
 cryptocode==0.1
 evdev==1.6.0; sys_platform == "linux"
-freezegun==1.2.1
+freezegun==1.2.1 ; python_version < '3.13'
 gatt
 ghostscript==0.7; sys_platform == "win32"
 netifaces==0.11.0; sys_platform == "win32"
-num2words==0.5.13
-polib
+num2words==0.5.13 ; python_version < '3.13'
+polib ; python_version < '3.13'
 pycups; sys_platform == "linux"
-PyKCS11==1.5.16
-PyPDF2==1.26.0
+PyKCS11==1.5.16 ; python_version < '3.13'
+PyPDF2==1.26.0 ; python_version < '3.13'
 pysmb==1.2.9.1
 pyusb; sys_platform == "linux"
 python-escpos==3.1
@@ -16,9 +16,9 @@ RPi.GPIO; sys_platform == "linux"
 rjsmin==1.1.0
 schedule==1.2.1
 screeninfo==0.8.1
-urllib3==1.26.5
+urllib3==1.26.5 ; python_version < '3.13'
 v4l2; sys_platform == "linux"
 vcgencmd; sys_platform == "linux"
-websocket-client==1.6.3
-Werkzeug==2.0.2
-zeep==4.2.1
+websocket-client==1.9.0
+Werkzeug==2.0.2 ; python_version < '3.13'
+zeep==4.2.1 ; python_version < '3.13'


### PR DESCRIPTION
This commit stops installing the following packages when using Python 3.13 on the IoT box (they are already installed via apt):
- num2words
- polib
- freezegun
- PyKCS11
- PyPDF2
- urllib3
- zeep

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
