### PR TITLE
[FIX] purchase: recompute qty_invoiced on canceled invoice

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -154,8 +154,7 @@ class PurchaseOrderLine(models.Model):
     def _compute_qty_invoiced(self):
         invoiced_quantities = self._prepare_qty_invoiced()
         for line in self:
-            if not line.qty_invoiced or line in invoiced_quantities:
-                line.qty_invoiced = invoiced_quantities[line]
+            line.qty_invoiced = invoiced_quantities[line]
 
             # compute qty_to_invoice
             if line.order_id.state == 'purchase':

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -153,6 +153,12 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             self.assertEqual(line.qty_to_invoice, 0.0)
             self.assertEqual(line.qty_invoiced, 5)
 
+        purchase_order.invoice_ids.button_cancel()
+        self.assertEqual(purchase_order.invoice_status, "to invoice")
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_to_invoice, 5)
+            self.assertEqual(line.qty_invoiced, 0.0)
+
     def test_vendor_bill_ordered(self):
         """Test if a order of product invoiced by ordered quantity can be
         correctly invoiced."""


### PR DESCRIPTION
Since 81f25bc57b8433a65bf33950c64dc7582240a229, `_compute_qty_invoiced` was not resetting the field to zero when the linked invoice was canceled, resulting in purchase orders remaining in status `invoiced` even if there was no invoice any more.

With this commit, we always write the qty_invoiced on the purchase order line, and the status is recomputed accordingly.

Source: post odoo.com migration feedback