### PR TITLE
[FIX] payment_xendit: fix "amount" must be integer error.

### DIFF
--- a/addons/payment_xendit/static/src/js/payment_form.js
+++ b/addons/payment_xendit/static/src/js/payment_form.js
@@ -133,7 +133,7 @@ paymentForm.include({
                     // charging.
                     if (processingValues['should_tokenize']) {
                         Xendit.card.createAuthentication({
-                            amount: processingValues.amount,
+                            amount: processingValues['rounded_amount'],
                             token_id: token.id
                         }, (err, result) => {
                             this._xenditHandleResponse(err, result, processingValues, 'auth')


### PR DESCRIPTION
When trying to pay a subscription (tokenization enforced) in IDR with a card that require the 3DS flow in Xendit, the following error is raised:

`"amount" must be an integer.`

So following 46166e25f049, when creating then token authentication we must use the rounded amount (introduced by b3f4e08cea6c) to meet Xendit specific currencies requirements.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
