### PR TITLE
[FIX] mail: handle mentions without base container

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -350,6 +350,7 @@ $o-mail-utilities: map-merge(
 }
 
 a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention, a.o_message_redirect_transformed {
+    user-select: none;
     border-radius: $btn-border-radius-sm;
     padding: 0rem 0.1rem;
     margin: 0rem 0.0875rem;

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -3,7 +3,7 @@ import { generateThreadMentionElement } from "@mail/utils/common/format";
 
 export class MentionPlugin extends Plugin {
     static id = "mention";
-    static dependencies = ["selection", "history"];
+    static dependencies = ["baseContainer", "selection", "history", "protectedNode"];
     resources = {
         selectionchange_handlers: this.detectMentions.bind(this),
     };
@@ -24,6 +24,14 @@ export class MentionPlugin extends Plugin {
                     this.dependencies.history.addStep();
                 },
             },
+            {
+                selector: "a.o_mail_redirect",
+                checker: () => true,
+            },
+            {
+                selector: "a.o-discuss-mention",
+                checker: () => true,
+            },
         ];
     }
 
@@ -40,7 +48,24 @@ export class MentionPlugin extends Plugin {
             )
                 .filter(({ isValid }) => isValid)
                 .map(({ el }) => el);
+            this.prepareValidMentionLinks(validMentionLinks);
             validMentionsHandler?.(validMentionLinks);
+        }
+    }
+
+    prepareValidMentionLinks(validMentionLinks) {
+        for (const el of validMentionLinks) {
+            this.dependencies.protectedNode.setProtectingNode(el, true);
+            // if el's parent is odoo-editor-editable, which happens when the html is computed or set with setContent,
+            // considering the mention blocks are protected and not editable.
+            // This will lead to issues where the mention cannot be deleted or edited properly.
+            // In this case, we wrap the mention with a base container.
+            if (el.parentElement === this.editable) {
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                baseContainer.appendChild(el.cloneNode(true));
+                this.editable.replaceChild(baseContainer, el);
+                this.dependencies.history.addStep();
+            }
         }
     }
 

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -12,6 +12,7 @@ import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 
 import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
 import { MentionPlugin } from "@mail/core/common/plugin/mention_plugin";
+import { ProtectedNodePlugin } from "@html_editor/core/protected_node_plugin";
 
 export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
@@ -24,6 +25,7 @@ export const MAIL_CORE_PLUGINS = [
     LinkPlugin,
     MailComposerPlugin,
     MentionPlugin,
+    ProtectedNodePlugin,
     ShortCutPlugin,
     TabulationPlugin,
 ];

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -181,6 +181,7 @@ function generateMentionElement({ className, id, model, text }) {
         class: className,
         "data-oe-id": id,
         "data-oe-model": model,
+        "data-oe-protected": "true",
         target: "_blank",
         contenteditable: "false",
     });
@@ -213,6 +214,7 @@ export function generateSpecialMentionElement(label) {
     const link = document.createElement("a");
     setAttributes(link, {
         class: "o-discuss-mention",
+        "data-oe-protected": "true",
         contenteditable: "false",
     });
     link.textContent = `@${label}`;


### PR DESCRIPTION
In some cases, mentions can be inserted directly into the editable area without being wrapped in a base container. This can lead to issues when trying to edit or delete the mention, as the mention is a protected node.

This commit updates the MentionPlugin to ensure that any mentions found directly under the editable area are wrapped in a base container.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
