### PR TITLE
[REF] web: move shareUrl to community and in the router

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -239,6 +239,21 @@ function urlToState(urlObj) {
     return state;
 }
 
+async function shareUrl() {
+    // avoid exposing /scoped_app urls to the user and replace them with /odoo when possible
+    const url = browser.location.href.replace("/scoped_app", "/odoo");
+    await browser.navigator
+        .share({
+            url,
+            title: document.title,
+        })
+        .catch((e) => {
+            if (!(e instanceof DOMException && e.name === "AbortError")) {
+                throw e;
+            }
+        });
+}
+
 let state;
 let pushTimeout;
 let pushArgs;
@@ -263,6 +278,9 @@ export function startRouter() {
     };
     _lockedKeys = new Set(["debug", "lang"]);
     _hiddenKeysFromUrl = new Set([...PATH_KEYS, "actionStack"]);
+    if (browser.navigator.share) {
+        router.shareUrl = shareUrl;
+    }
 }
 
 /**

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.js
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.js
@@ -2,6 +2,12 @@ import { registry } from "@web/core/registry";
 import { Transition } from "@web/core/transition";
 import { user } from "@web/core/user";
 import { useBus } from "@web/core/utils/hooks";
+import {
+    isAndroidApp,
+    isDisplayStandalone,
+    isIosApp,
+} from "@web/core/browser/feature_detection";
+import { router } from "@web/core/browser/router";
 import { BurgerUserMenu } from "./burger_user_menu/burger_user_menu";
 import { MobileSwitchCompanyMenu } from "./mobile_switch_company_menu/mobile_switch_company_menu";
 
@@ -29,6 +35,8 @@ export class BurgerMenu extends Component {
             isBurgerOpened: false,
         });
         this.swipeStartX = null;
+        this.router = router;
+        this.isDisplayStandalone = isDisplayStandalone() || isAndroidApp() || isIosApp();
         useBus(this.env.bus, "HOME-MENU:TOGGLED", () => {
             this._closeBurger();
         });
@@ -57,6 +65,9 @@ export class BurgerMenu extends Component {
         }
         this._closeBurger();
         this.swipeStartX = null;
+    }
+    _shareUrl() {
+        router.shareUrl();
     }
 }
 

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -19,7 +19,10 @@
               <img class="o_burger_menu_avatar o_image_24_cover rounded" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
               <span class="o_burger_menu_username px-2"><t t-esc="user.name"/></span>
             </small>
-            <button class="o_sidebar_close oi oi-close btn d-flex align-items-center h-100 bg-transparent border-0 fs-2 text-reset" aria-label="Close menu" title="Close menu" t-on-click.stop="_closeBurger"/>
+            <div class="d-flex align-items-center h-100 bg-transparent">
+                <button t-if="this.router.shareUrl and this.isDisplayStandalone" class="o_sidebar_share fa fa-share-alt btn border-0 fs-5 text-reset" aria-label="Share URL" title="Share URL" t-on-click.stop="() => this._shareUrl()"/>
+                <button class="o_sidebar_close oi oi-close btn border-0 fs-3 text-reset" aria-label="Close menu" title="Close menu" t-on-click.stop="() => this._closeBurger()"/>
+            </div>
         </div>
         <nav class="o_burger_menu_content flex-grow-1 flex-shrink-1 overflow-auto o_burger_menu_app">
           <MobileSwitchCompanyMenu t-if="user.allowedCompanies.length > 1" />

--- a/addons/web/static/src/webclient/user_menu/user_menu.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu.js
@@ -27,7 +27,6 @@ export class UserMenu extends Component {
         const sortedItems = userMenuRegistry
             .getAll()
             .map((element) => element(this.env))
-            .filter((element) => (element.show ? element.show() : true))
             .sort((x, y) => {
                 const xSeq = x.sequence ? x.sequence : 100;
                 const ySeq = y.sequence ? y.sequence : 100;

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -1,9 +1,10 @@
 import { Component, markup } from "@odoo/owl";
-import { isMacOS } from "@web/core/browser/feature_detection";
+import { isDisplayStandalone, isMacOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { session } from "@web/session";
+import { router } from "@web/core/browser/router";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
 import { post } from "@web/core/network/http_service";
@@ -92,7 +93,7 @@ export function odooAccountItem(env) {
 function installPWAItem(env) {
     let description = _t("Install App");
     let callback = () => env.services.pwa.show();
-    let show = () => env.services.pwa.isAvailable;
+    let hide = !env.services.pwa.isAvailable;
     const currentApp = env.services.menu.getCurrentApp();
     if (currentApp && ["barcode", "field-service", "shop-floor"].includes(currentApp.actionPath)) {
         // While the feature could work with all apps, we have decided to only
@@ -106,14 +107,14 @@ function installPWAItem(env) {
                 )}`
             );
         };
-        show = () => !env.services.pwa.isScopedApp;
+        hide = env.services.pwa.isScopedApp;
     }
     return {
         type: "item",
         id: "install_pwa",
         description,
         callback,
-        show,
+        hide,
         sequence: 65,
     };
 }
@@ -136,6 +137,21 @@ function logOutItem(env) {
     };
 }
 
+export function shareUrlMenuItem(env) {
+    return {
+        type: "item",
+        hide: !router.shareUrl || env.isSmall || !isDisplayStandalone(),
+        id: "share_url",
+        description: markup`
+            <div class="d-flex align-items-center justify-content-between w-100">
+                <span>${_t("Share")}</span>
+                <span class="fa fa-share-alt"></span>
+            </div>`,
+        callback: router.shareUrl,
+        sequence: 25,
+    };
+}
+
 registry
     .category("user_menuitems")
     .add("support", supportItem)
@@ -144,4 +160,5 @@ registry
     .add("preferences", preferencesItem)
     .add("odoo_account", odooAccountItem)
     .add("install_pwa", installPWAItem)
-    .add("log_out", logOutItem);
+    .add("log_out", logOutItem)
+    .add("share_url", shareUrlMenuItem);


### PR DESCRIPTION
This commit moves the shareUrl feature for the PWA available in community. Since the standalone mode is available in community, it is no longer useful to have dedicated enterprise patches that add the feature to the user menu or the BurgerMenu on small screens.

Also, to have a common and simple way to access the feature, the shareUrl function has been moved in the router, if the feature is available on the browser, instead of relying in the implementations of the share feature to make sure the feature that is available before putting an item in the menu. This could allow other ways to open the share dialog by just calling it from the router.

Finally, an usused argument 'show' can be removed. It was redundant, since 'hide' argument was already present, and there was no longer any usecase for 'show', since we've recently changed the behavior to use 'hide' instead for the 'Share URL' item.

Tests have been moved as well in community.