### PR TITLE
[FIX] website: check filter exitance before rendering

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -421,7 +421,9 @@ class Website(Home):
             dynamic_filter_sudo = dynamic_filter_sudo.search(
                 Domain('id', '=', filter_id) & request.website.website_domain()
             )
-        return dynamic_filter_sudo._render(**kwargs) or []
+        single_record_filter = kwargs.get('limit') == 1 and kwargs.get('res_model') and kwargs.get('res_id')
+        dynamic_filter_found = single_record_filter or dynamic_filter_sudo
+        return dynamic_filter_sudo._render(**kwargs) if dynamic_filter_found else []
 
     @http.route('/website/snippet/options_filters', type='jsonrpc', auth='user', website=True, readonly=True)
     def get_dynamic_snippet_filters(self, model_name=None, search_domain=None):


### PR DESCRIPTION
**Patch description:**
- Following commit: odoo/odoo@e3b062e5d3820ddfcee2eb669f21edc0c53c3330 the behavior of dynamic snippet rendering changed.

- Previously (up to v18.4), the system first checked whether the dynamic filter existed before calling `_render` on it. After the referenced commit, `get_dynamic_filter` attempts to find the filter and immediately calls `_render`, even if the filter record is missing. diff: https://github.com/odoo/odoo/commit/e3b062e5d3820ddfcee2eb669f21edc0c53c3330#diff-d41b2dc5ff6fd6a303373f86e1af97d055db315ccc431749b4ffac1488dea119R416-R423

**Steps to reproduce:**
- Create a v19 db and install `website_sale`
- Add a dynamic snippet (e.g., Product Catalog) to the website homepage.
- Uninstall `website_sale`
- Install `website_sale` again
- Open the website homepage and then editor
- Traceback:
```py
  File "/home/odoo/odoo/odoo/addons/website/controllers/main.py", line 424, in get_dynamic_filter
    return dynamic_filter_sudo._render(**kwargs) or []
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/addons/website/models/website_snippet_filter.py", line 78, in _render
    records = self._prepare_sample(limit, res_model=res_model)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/addons/website/models/website_snippet_filter.py", line 183, in _prepare_sample
    records = self._prepare_sample_records(length, **options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/addons/website/models/website_snippet_filter.py", line 201, in _prepare_sample_records
    model = self.env[(self.model_name or options.get('res_model'))]
            ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/odoo/orm/environments.py", line 107, in __getitem__
    return self.registry[model_name](self, (), ())
           ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/odoo/orm/registry.py", line 322, in __getitem__
    return self.models[model_name]
           ~~~~~~~~~~~^^^^^^^^^^^^
KeyError: None
```

The issue occurs because the snippet’s `data-filter-id` refers to a filter record that gets deleted when `website_sale` is uninstalled. Upon reinstalling, new filter records are created with new IDs. The old snippet still references the deleted ID,
so in `get_dynamic_filter` when searching with `filter_id` returns no record.

Despite `_render` having an `self.ensure_one()` check, the mentioned commit changed it to `self and self.ensure_one()`, allowing a null/empty recordset to pass through and causing rendering issues.

This fix restores the proper behavior by verifying the filter’s existence before rendering.

opw - 5163214, 5248474


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
