### PR TITLE
[FIX] point_of_sale, pos_sale: handle pos refunds amounts in reports

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -259,6 +259,32 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("refund_multiple_products_amounts_compliance", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            inLeftSide([
+                ...["2"].map(Numpad.click),
+                ...ProductScreen.selectedOrderlineHasDirect("Test Product", "2", "20"),
+            ]),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            ...ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("001"),
+            ProductScreen.clickNumpad("2"),
+            TicketScreen.confirmRefund(),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("LotTour", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1556,6 +1556,28 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
 
+    def test_refund_multiple_products_amounts_compliance(self):
+        test_product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'list_price': 10.00,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'refund_multiple_products_amounts_compliance', login="pos_user")
+
+        refund_order = current_session.order_ids.filtered(lambda order: order.is_refund)
+        self.assertEqual(refund_order.lines[0].price_subtotal, 2 * test_product.list_price)
+        total_cash_payment = sum(current_session.mapped('order_ids.payment_ids').filtered(
+            lambda payment: payment.payment_method_id.type == 'cash').mapped('amount')
+        )
+        current_session.post_closing_cash_details(total_cash_payment)
+        current_session.close_session_from_ui()
+        self.assertEqual(current_session.state, 'closed')
+
     def test_product_combo_price(self):
         """ Check that the combo has the expected price """
         self.desk_organizer.product_variant_id.write({"lst_price": 7})

--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -38,11 +38,11 @@ class SaleReport(models.Model):
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
             AS price_unit,
-            SUM(l.price_subtotal_incl)
+            SUM(SIGN(l.qty) * SIGN(l.price_unit) * ABS(l.price_subtotal_incl))
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
             AS price_total,
-            SUM(l.price_subtotal)
+            SUM(SIGN(l.qty) * SIGN(l.price_unit) * ABS(l.price_subtotal))
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
             AS price_subtotal,


### PR DESCRIPTION
## Versions
19.0+

## Issue
Positive totals for refunds lead to miscalculation and wrong data in the sales report. A PoS order line and its refund should lead to a $0 total.

## Steps to reproduce
*In the PoS app*
- Open a register:
  - Sell 2 units of any product and process payment by cash;
  - Validate payment;
  - Navigate to "Orders" tab and filter on "Paid" orders (instead of "Active"):
    - Select your latest order and refund 2 items;
    - Process refund by cash and validate; *In the Sales app*
- Go to "Reporting > Sales" and change for list view:
  - Display "Untaxed total" column;
  - Filter on 2 last lines (by date and hour):
    - The refund line has positive values for "Untaxed Total" and "Total column";
    - The refund line has a "Untaxed Total" equal to the "Unit Price" but should be multiplied by the quantity;
    - The bold totals are not equal to 0 for "Untaxed Total" and "Total" columns.

## Cause
Commit c5d4e4f73ac0474675414ee89555028b370f8e30 refactored all PoS taxes logic and there were some forgotten parts.

opw-5241438