### PR TITLE
[FIX] iot_box_builder: allow local network access on IoT box Chromium

### DIFF
--- a/setup/iot_box_builder/overwrite_after_init/etc/chromium/policies/managed/local_access.json
+++ b/setup/iot_box_builder/overwrite_after_init/etc/chromium/policies/managed/local_access.json
@@ -1,0 +1,3 @@
+{
+  "LocalNetworkAccessAllowedForUrls": ["*"]
+}


### PR DESCRIPTION
Chromium 142 added a permission prompt whenever a page tries to access something on the local network (including localhost). This causes an issue on the IoT box as it is intended to be used without user input, but in some cases (such as using it as a Customer Display in the POS) the local network permission prompt can appear.

The fix is to add a policy file to allow local network access by default. This prevents the popup from ever appearing, and the local requests work as expected.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
