### PR TITLE
[FIX] html_editor, mass_mailing: apply data-selection-placeholder style

### DIFF
--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.scss
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.scss
@@ -5,7 +5,10 @@
 
 *[data-selection-placeholder] {
     height: 0;
-    margin: 0 0 -1px; // Compensate for the border.
+    // margin-bottom is set to -1px to compensate for the border, important
+    // is necessary to prevent other more specific selector from overriding
+    // the margin.
+    margin: 0 0 -1px !important;
     border-top: solid transparent 1px;
     caret-color: transparent;
     position: relative;

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -125,6 +125,9 @@
         # during html conversion, specific to the builder
         'mass_mailing.assets_inside_builder_iframe': [
             ('include', 'html_builder.assets_inside_builder_iframe'),
+            # TODO ABD: fix bundles usages so that html_editor files don't
+            # have to be cherry picked individually.
+            'html_editor/static/src/main/selection_placeholder_plugin.scss',
             'mass_mailing/static/src/builder/**/*.inside.scss'
         ],
         'mass_mailing.iframe_add_dialog': [


### PR DESCRIPTION
This [commit] introduced an issue in `mass_mailing` where
`[data-selection-placeholder]` paragraph take up vertical space when they were
not designed to.

How to reproduce:
- create a new mass_mailing
- add the snippet "pricelist"

Issue:
- Horizontal lines have extra blank space around them (empty
  `[data-selection-placeholder]` paragraphs

Resolution:
- Use the related style asset for these nodes from html_editor, and add
  `!important` on the margin-bottom style property value, to ensure that the
  Design Tab does not override it.
- Since `mass_mailing` does not use `web.assets_frontend` anymore, files from
  new features in the `html_editor` may not automatically be included in
  `mass_mailing` bundles. A future task will refactor assets bundles so that
  this problem does not occur again.

[commit]: https://github.com/odoo/odoo/commit/edf7f7bb0c62978640c181eccb4934855d5d872d

task-5265692