### PR TITLE
[FIX] l10n_es_edi_facturae: ensure withhold value to be positive

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -446,7 +446,7 @@ class AccountMove(models.Model):
             is_withholding = tax.amount < 0.0
             tax_data = self._l10n_es_edi_facturae_get_tax_node_from_tax_data({**values, 'grouping_key': tax})
             invoice_values['TaxesWithheld' if is_withholding else 'TaxOutputs'].append(tax_data)
-            invoice_values['TotalTaxesWithheld' if is_withholding else 'TotalTaxOutputs'] += values['tax_amount_currency']
+            invoice_values['TotalTaxesWithheld' if is_withholding else 'TotalTaxOutputs'] += abs(values['tax_amount_currency'])
 
         invoice_values['TotalGrossAmountBeforeTaxes'] = (
             invoice_values['TotalGrossAmount']

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_withhold.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_withhold.xml
@@ -1,0 +1,211 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<fac:Facturae xmlns:fac="http://www.facturae.gob.es/formato/Versiones/Facturaev3_2_2.xml">
+  <FileHeader>
+    <SchemaVersion>3.2.2</SchemaVersion>
+    <Modality>I</Modality>
+    <InvoiceIssuerType>EM</InvoiceIssuerType>
+    <Batch>
+      <BatchIdentifier>INV/2023/00001</BatchIdentifier>
+      <InvoicesCount>1</InvoicesCount>
+      <TotalInvoicesAmount>
+        <TotalAmount>85.00</TotalAmount>
+      </TotalInvoicesAmount>
+      <TotalOutstandingAmount>
+        <TotalAmount>85.00</TotalAmount>
+      </TotalOutstandingAmount>
+      <TotalExecutableAmount>
+        <TotalAmount>85.00</TotalAmount>
+      </TotalExecutableAmount>
+      <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
+    </Batch>
+  </FileHeader>
+  <Parties>
+    <SellerParty>
+      <TaxIdentification>
+        <PersonTypeCode>J</PersonTypeCode>
+        <ResidenceTypeCode>R</ResidenceTypeCode>
+        <TaxIdentificationNumber>ES59962470K</TaxIdentificationNumber>
+      </TaxIdentification>
+      <LegalEntity>
+        <CorporateName>company_1_data</CorporateName>
+        <TradeName>company_1_data</TradeName>
+        <AddressInSpain>
+          <Address>C. de Embajadores, 68-116</Address>
+          <PostCode>12345</PostCode>
+          <Town>Madrid</Town>
+          <Province>Madrid</Province>
+          <CountryCode>ESP</CountryCode>
+        </AddressInSpain>
+      </LegalEntity>
+    </SellerParty>
+    <BuyerParty>
+      <TaxIdentification>
+        <PersonTypeCode>F</PersonTypeCode>
+        <ResidenceTypeCode>U</ResidenceTypeCode>
+        <TaxIdentificationNumber>BE0477472701</TaxIdentificationNumber>
+      </TaxIdentification>
+      <Individual>
+        <Name>UNKNOWN</Name>
+        <FirstSurname>UNKNOWN</FirstSurname>
+        <OverseasAddress>
+          <Address>Rue de Bruxelles, 15000</Address>
+          <PostCodeAndTown>5000 Namur</PostCodeAndTown>
+          <Province>Belgium</Province>
+          <CountryCode>BEL</CountryCode>
+        </OverseasAddress>
+      </Individual>
+    </BuyerParty>
+  </Parties>
+  <Invoices>
+    <Invoice>
+      <InvoiceHeader>
+        <InvoiceNumber>INV/2023/00001</InvoiceNumber>
+        <InvoiceDocumentType>FC</InvoiceDocumentType>
+        <InvoiceClass>OO</InvoiceClass>
+      </InvoiceHeader>
+      <InvoiceIssueData>
+        <IssueDate>2023-01-01</IssueDate>
+        <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
+        <TaxCurrencyCode>EUR</TaxCurrencyCode>
+        <LanguageName>en</LanguageName>
+      </InvoiceIssueData>
+      <TaxesWithheld>
+        <Tax>
+          <TaxTypeCode>04</TaxTypeCode>
+          <TaxRate>15.000</TaxRate>
+          <TaxableBase>
+            <TotalAmount>100.00</TotalAmount>
+          </TaxableBase>
+          <TaxAmount>
+            <TotalAmount>15.00</TotalAmount>
+          </TaxAmount>
+        </Tax>
+      </TaxesWithheld>
+      <InvoiceTotals>
+        <TotalGrossAmount>100.00</TotalGrossAmount>
+        <TotalGrossAmountBeforeTaxes>100.00</TotalGrossAmountBeforeTaxes>
+        <TotalTaxOutputs>0.00</TotalTaxOutputs>
+        <TotalTaxesWithheld>15.00</TotalTaxesWithheld>
+        <InvoiceTotal>85.00</InvoiceTotal>
+        <TotalOutstandingAmount>85.00</TotalOutstandingAmount>
+        <TotalExecutableAmount>85.00</TotalExecutableAmount>
+      </InvoiceTotals>
+      <Items>
+        <InvoiceLine>
+          <FileDate>2023-01-01</FileDate>
+          <ItemDescription>product_a</ItemDescription>
+          <Quantity>1.0</Quantity>
+          <UnitOfMeasure>01</UnitOfMeasure>
+          <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
+          <TotalCost>100.00000000</TotalCost>
+          <GrossAmount>100.00000000</GrossAmount>
+          <TaxesWithheld>
+            <Tax>
+              <TaxTypeCode>04</TaxTypeCode>
+              <TaxRate>15.000</TaxRate>
+              <TaxableBase>
+                <TotalAmount>100.00</TotalAmount>
+              </TaxableBase>
+              <TaxAmount>
+                <TotalAmount>15.00</TotalAmount>
+              </TaxAmount>
+            </Tax>
+          </TaxesWithheld>
+        </InvoiceLine>
+      </Items>
+      <PaymentDetails>
+        <Installment>
+          <InstallmentDueDate>2023-01-01</InstallmentDueDate>
+          <InstallmentAmount>85.00</InstallmentAmount>
+          <PaymentMeans>04</PaymentMeans>
+          <AccountToBeCredited>
+            <IBAN>ES9121000418450200051332</IBAN>
+            <BIC>CAIXESBBXXX</BIC>
+          </AccountToBeCredited>
+        </Installment>
+      </PaymentDetails>
+    </Invoice>
+  </Invoices>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="___ignore___">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference Type="http://www.w3.org/2000/09/xmldsig#Object" URI="___ignore___" Id="___ignore___">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>___ignore___</ds:DigestValue>
+      </ds:Reference>
+      <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="___ignore___">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>___ignore___</ds:DigestValue>
+      </ds:Reference>
+      <ds:Reference URI="___ignore___">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>___ignore___</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>___ignore___</ds:SignatureValue>
+    <ds:KeyInfo Id="___ignore___">
+      <ds:X509Data>
+        <ds:X509Certificate>___ignore___</ds:X509Certificate>
+      </ds:X509Data>
+      <ds:KeyValue>
+        <ds:RSAKeyValue>
+          <ds:Modulus>___ignore___</ds:Modulus>
+          <ds:Exponent>___ignore___</ds:Exponent>
+        </ds:RSAKeyValue>
+      </ds:KeyValue>
+    </ds:KeyInfo>
+    <ds:Object>
+      <xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Target="___ignore___">
+        <xades:SignedProperties Id="___ignore___">
+          <xades:SignedSignatureProperties>
+            <xades:SigningTime>___ignore___</xades:SigningTime>
+            <xades:SigningCertificate>
+              <xades:Cert>
+                <xades:CertDigest>
+                  <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                  <ds:DigestValue>___ignore___</ds:DigestValue>
+                </xades:CertDigest>
+                <xades:IssuerSerial>
+                  <ds:X509IssuerName>___ignore___</ds:X509IssuerName>
+                  <ds:X509SerialNumber>___ignore___</ds:X509SerialNumber>
+                </xades:IssuerSerial>
+              </xades:Cert>
+            </xades:SigningCertificate>
+            <xades:SignaturePolicyIdentifier>
+              <xades:SignaturePolicyId>
+                <xades:SigPolicyId>
+                  <xades:Identifier>http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf</xades:Identifier>
+                  <xades:Description>Política de firma electrónica para facturación electrónica con formato Facturae</xades:Description>
+                </xades:SigPolicyId>
+                <xades:SigPolicyHash>
+                  <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                  <ds:DigestValue>___ignore___</ds:DigestValue>
+                </xades:SigPolicyHash>
+                <xades:SigPolicyQualifiers>
+                  <xades:SigPolicyQualifier>
+                    <xades:SPURI>http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf</xades:SPURI>
+                  </xades:SigPolicyQualifier>
+                </xades:SigPolicyQualifiers>
+              </xades:SignaturePolicyId>
+            </xades:SignaturePolicyIdentifier>
+          </xades:SignedSignatureProperties>
+          <xades:SignedDataObjectProperties>
+            <xades:DataObjectFormat ObjectReference="___ignore___">
+              <xades:Description/>
+              <xades:ObjectIdentifier>
+                <xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+                <xades:Description/>
+              </xades:ObjectIdentifier>
+              <xades:MimeType>text/xml</xades:MimeType>
+              <xades:Encoding/>
+            </xades:DataObjectFormat>
+          </xades:SignedDataObjectProperties>
+        </xades:SignedProperties>
+      </xades:QualifyingProperties>
+    </ds:Object>
+  </ds:Signature>
+</fac:Facturae>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -253,6 +253,37 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
             self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)
 
+    def test_out_invoice_withhold(self):
+        """
+        The Tax Withhold must be positive in the generated xml
+        """
+        with freeze_time(self.frozen_today):
+            withhold_tax = self.env['account.tax'].create({
+                'name': "15% WHI (Test)",
+                'company_id': self.company_data['company'].id,
+                'amount': -15.0,
+                'price_include_override': 'tax_excluded',
+                'l10n_es_edi_facturae_tax_type': '04',
+            })
+
+            invoice = self.create_invoice(
+                partner_id=self.partner_a.id,
+                move_type='out_invoice',
+                invoice_line_ids=[
+                    {'price_unit': 100, 'quantity': 1.0, 'tax_ids': [withhold_tax.id]},
+                ],
+            )
+            invoice.action_post()
+
+            generated_file, errors = invoice._l10n_es_edi_facturae_render_facturae()
+            self.assertFalse(errors)
+            self.assertTrue(generated_file)
+
+            with file_open("l10n_es_edi_facturae/tests/data/expected_out_invoice_withhold.xml", "rt") as f:
+                expected_xml = lxml.etree.fromstring(f.read().encode())
+
+            self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)
+
     def test_refund_invoice(self):
         random.seed(42)
         # We need to patch dates and uuid to ensure the signature's consistency


### PR DESCRIPTION
## Issue:
The `TotalTaxesWithhold` field in the exported XML could be negative, causing FACE to reject the document.

## Cause:
A previous change (https://github.com/odoo/odoo/pull/229236) added `values['tax_amount_currency']` to `TotalTaxesWithhold` without converting it to a positive value: https://github.com/odoo/odoo/blob/88b7ee6d9d2a7fe96512da0a7eaf8efcf9020ee1/addons/l10n_es_edi_facturae/models/account_move.py#L449

## Steps to reproduce:
- Install `l10n_es_edi_facturae`
- With the ES company, create an invoice with a product and a withholding tax (e.g., 15% WHI)
- Confirm the invoice and Send (Facturae)
- Open the XML attached in the chatter
- Observe that `TotalTaxesWithhold` is negative

opw-5220205