### PR TITLE
[FIX] web: list: do not crash with sample data and real groups

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -6,7 +6,7 @@ import { Domain } from "@web/core/domain";
 import { WarningDialog } from "@web/core/errors/error_dialogs";
 import { rpcBus } from "@web/core/network/rpc";
 import { shallowEqual } from "@web/core/utils/arrays";
-import { pick } from "@web/core/utils/objects";
+import { deepCopy, pick } from "@web/core/utils/objects";
 import { Deferred, KeepLast, Mutex } from "@web/core/utils/concurrency";
 import { orderByToString } from "@web/search/utils/order_by";
 import { Model } from "../model";
@@ -160,6 +160,7 @@ export class RelationalModel extends Model {
         this.specialDataCaches = markRaw(params.state?.specialDataCaches || {});
         this.useSendBeaconToSaveUrgently = params.useSendBeaconToSaveUrgently || false;
         this.withCache = this.constructor.withCache && this.env.config?.cache;
+        this.initialSampleGroups = undefined; // real groups to populate with sample records
 
         this._urgentSave = false;
     }
@@ -190,6 +191,9 @@ export class RelationalModel extends Model {
      * @type {Model["load"]}
      */
     async load(params = {}) {
+        if (this.orm.isSample && this.initialSampleGroups?.length) {
+            this.orm.setGroups(this.initialSampleGroups);
+        }
         const config = this._getNextConfig(this.config, params);
         if (!this.isReady) {
             // We want the control panel to be displayed directly, without waiting for data to be
@@ -854,6 +858,16 @@ export class RelationalModel extends Model {
             context: { read_group_expand: true, ...config.context },
         };
         const orm = cache ? this.orm.cache(cache) : this.orm;
-        return orm.webReadGroup(config.resModel, config.domain, config.groupBy, aggregates, params);
+        const result = await orm.webReadGroup(
+            config.resModel,
+            config.domain,
+            config.groupBy,
+            aggregates,
+            params
+        );
+        if (!this.initialSampleGroups) {
+            this.initialSampleGroups = deepCopy(result.groups);
+        }
+        return result;
     }
 }

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -76,39 +76,16 @@ export class KanbanController extends Component {
         const { Model, archInfo } = this.props;
 
         class KanbanSampleModel extends Model {
-            setup() {
-                super.setup(...arguments);
-                this.initialSampleGroups = undefined;
-            }
-
             /**
              * @override
              */
             hasData() {
-                if (this.root.groups) {
-                    if (!this.root.groups.length) {
-                        // While we don't have any data, we want to display the column quick create and
-                        // example background. Return true so that we don't get sample data instead
-                        return true;
-                    }
-                    return this.root.groups.some((group) => group.hasData);
+                if (this.root.groups && !this.root.groups.length) {
+                    // While we don't have any data, we want to display the column quick create and
+                    // example background. Return true so that we don't get sample data instead
+                    return true;
                 }
                 return super.hasData();
-            }
-
-            async load() {
-                if (this.orm.isSample && this.initialSampleGroups) {
-                    this.orm.setGroups(this.initialSampleGroups);
-                }
-                return super.load(...arguments);
-            }
-
-            async _webReadGroup() {
-                const result = await super._webReadGroup(...arguments);
-                if (!this.initialSampleGroups) {
-                    this.initialSampleGroups = JSON.parse(JSON.stringify(result.groups));
-                }
-                return result;
             }
 
             removeSampleDataInGroups() {

--- a/addons/web/static/tests/model/sample_server.test.js
+++ b/addons/web/static/tests/model/sample_server.test.js
@@ -411,21 +411,4 @@ describe("RPC calls", () => {
         const ids = new Array(16).fill(0).map((_, index) => index + 1);
         expect(result[0]["id:array_agg"]).toEqual(ids);
     });
-
-    test("'web_read_group': records on unfolded group", async () => {
-        const server = new DeterministicSampleServer("hobbit", fields.hobbit);
-        server.setExistingGroups([
-            { profession: "gardener", count: 0 },
-            { profession: "brewer", count: 0 },
-        ]);
-        const result = await server.mockRpc({
-            method: "web_read_group",
-            model: "hobbit",
-            groupBy: ["profession"],
-            aggregates: [],
-            opening_info: [{ folded: false }, { folded: true }],
-        });
-        expect(result.groups[0].__records).toEqual([]);
-        expect("__records" in result.groups[1]).toBe(false);
-    });
 });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -7393,7 +7393,7 @@ test("kanban with sample data grouped by m2o and existing groups", async () => {
                 __extra_domain: [["product_id", "=", "3"]],
             },
         ],
-        length: 2,
+        length: 1,
     }));
 
     await mountView({
@@ -7415,6 +7415,43 @@ test("kanban with sample data grouped by m2o and existing groups", async () => {
     expect(".o_kanban_group:first .o_column_title").toHaveText("hello");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(16);
     expect(".o_kanban_record").toHaveText("hello");
+});
+
+test(`kanban grouped by m2o with sample data with more than 5 real groups`, async () => {
+    Partner._records = [];
+    onRpc("web_read_group", () => ({
+        // simulate 6, empty, real groups
+        groups: [1, 2, 3, 4, 5, 6].map((id) => ({
+            __count: 0,
+            __records: [],
+            product_id: [id, `Value ${id}`],
+            __extra_domain: [["product_id", "=", id]],
+        })),
+        length: 6,
+    }));
+
+    await mountView({
+        resModel: "partner",
+        type: "kanban",
+        arch: `
+            <kanban sample="1">
+                <templates>
+                    <div t-name="card">
+                        <field name="product_id"/>
+                    </div>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+    expect(".o_content").toHaveClass("o_view_sample_data");
+    expect(queryAllTexts(`.o_kanban_group .o_column_title`)).toEqual([
+        "Value 1",
+        "Value 2",
+        "Value 3",
+        "Value 4",
+        "Value 5",
+        "Value 6",
+    ]);
 });
 
 test.tags("desktop");

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7442,6 +7442,38 @@ test(`click on header in empty list with sample data`, async () => {
     });
 });
 
+test(`list grouped by m2o with sample data with more than 5 real groups`, async () => {
+    Foo._records = [];
+    onRpc("web_read_group", () => ({
+        // simulate 6, empty, real groups
+        groups: [1, 2, 3, 4, 5, 6].map((id) => ({
+            __count: 0,
+            __records: [],
+            m2o: [id, `Value ${id}`],
+            __extra_domain: [["m2o", "=", id]],
+        })),
+        length: 6,
+    }));
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list sample="1"><field name="foo"/></list>`,
+        groupBy: ["m2o"],
+    });
+    expect(`.o_list_view .o_content`).toHaveClass("o_view_sample_data");
+    expect(`.o_list_table`).toHaveCount(1);
+    expect(`.o_group_header`).toHaveCount(6);
+    expect(queryAllTexts(`.o_group_header`)).toEqual([
+        "Value 1 (3)",
+        "Value 2 (3)",
+        "Value 3 (3)",
+        "Value 4 (3)",
+        "Value 5 (2)",
+        "Value 6 (2)",
+    ]);
+});
+
 test.tags("desktop");
 test(`non empty editable list with sample data: delete all records`, async () => {
     await mountView({


### PR DESCRIPTION
This commit reverts PR [1] which attempted to fix an issue with grouped list views with sample data. The issue occured when the web_read_group returned real groups that are all empty. When this happened, the model kept and relied on the real groups information, in particular which groups are open ("folded" flag).

In kanban, this works fine because we use those real groups in the sample server, and populate them with sample records. However, we didn't do that for the list view, for an obscure reason. As a consequence, in list, we sometimes received sample groups that matched the real ones (same id, when grouped by many2one), so we re-used the real group information (i.e. the folded flag). We were then manipulating groups that we believed to be open, i.e. to have a `records` key, whereas the fake read group done by the sample server returned groups without that `records` key, leading to a crash.

PR [1] tried to fix web_read_group in the SampleServer, to take into account the `opening_info` and return a `__records` key for opened groups. However, the fix crashed if there were more open real groups than sample groups (i.e. 5).

This commit fixes the issue by generalizing the kanban logic to the list, i.e. by moving it to the RelationalModel. From now on, both kanban and list will use the real groups, and fill them with sample data if necessary.

In master, we'll go even further by allowing to manipulate those groups (e.g. edit, create new...) like we do in kanban.

[1] https://github.com/odoo/odoo/pull/226253

Issue reported on the feedback pad after migrating odoo.com to v19

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
