### PR TITLE
[FIX] sale_pdf_quote_builder: allow extra documents on confirmed orders

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -5,7 +5,7 @@ import io
 import json
 
 from odoo import _, api, models
-from odoo.tools import format_amount, format_date, format_datetime, pdf
+from odoo.tools import format_amount, format_date, format_datetime, pdf, str2bool
 from odoo.tools.pdf import (
     NameObject,
     NumberObject,
@@ -24,17 +24,15 @@ class IrActionsReport(models.Model):
         if self._get_report(report_ref).report_name != 'sale.report_saleorder':
             return result
 
+        ICP = self.env['ir.config_parameter'].sudo()
+        always_include = str2bool(ICP.get_param('sale.always_include_selected_documents'))
         orders = self.env['sale.order'].browse(res_ids)
 
         for order in orders:
             if (
-                order.state == 'sale'
-                or order.id not in result
-                or 'stream' not in result[order.id]
+                (order.state != 'sale' or always_include)
+                and (initial_stream := result.get(order.id, {}).get('stream'))
             ):
-                continue
-            initial_stream = result[order.id]['stream']
-            if initial_stream:
                 quotation_documents = order.quotation_document_ids
                 headers = quotation_documents.filtered(lambda doc: doc.document_type == 'header')
                 footers = quotation_documents - headers

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.js
@@ -26,6 +26,15 @@ export class CustomContentKanbanLikeWidget extends Component {
         useEffect((saleOrderTemplate) => {
             this.updateState();
         }, () => [this.props.record.data.sale_order_template_id]);
+
+        // Make quotation tab readonly on confirmation
+        useEffect((saleOrderState) => {
+            if (saleOrderState === 'sale') {
+                this.props.readonly = true;
+                this.props.record.save(); // trigger refresh to update form
+            }
+        }, () => [this.props.record.data.state]);
+
     }
 
     async updateState() {
@@ -79,6 +88,9 @@ export class CustomContentKanbanLikeWidget extends Component {
     }
 
     async saveProductDocument(lineId, docId, isSelected) {
+        if (this.props.readonly) {
+            return;
+        }
         const sol = this.props.record.data.order_line.records.find(
             sol => sol.resId === lineId
         );
@@ -95,6 +107,9 @@ export class CustomContentKanbanLikeWidget extends Component {
     };
 
     async saveQuotationDocument(docId, isSelected) {
+        if (this.props.readonly) {
+            return;
+        }
         if (isSelected) {
             await this.props.record.update({
                 quotation_document_ids: [

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.xml
@@ -55,6 +55,7 @@
                             doc.is_selected = !doc.is_selected;
                             save(id, doc.id, doc.is_selected);
                         }"
+                        t-att-disabled="props.readonly"
                     />
                     <label
                         class="btn btn-secondary m-1"
@@ -82,6 +83,7 @@
                             name="formField.name"
                             value="formField.value"
                             onChange="(value) => { formField.value = value; this.updateJson(); }"
+                            readonly="!!props.readonly"
                         />
                     </t>
                 </div>

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.js
@@ -8,6 +8,7 @@ export class CustomFieldCard extends Component {
         name: String,
         value: String,
         onChange: Function,
+        readonly: { type: Boolean, optional: true },
     };
 
     setup() {

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.xml
@@ -10,8 +10,10 @@
                         t-ref="customFieldCardTextArea"
                         t-model.lazy="this.props.value"
                         t-on-change="(ev) => { this.props.onChange(this.props.value) }"
-                        t-att-placeholder="this.placeholder"
+                        t-att-placeholder="!props.readonly &amp;&amp; this.placeholder"
+                        t-att-readonly="props.readonly"
                         class="customFieldCardTextArea form-control overflow-y-hidden"
+                        t-att-class="{ 'text-muted': !props.value || props.readonly }"
                     />
                 </span>
             </div>


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Add product documents, headers or footers to a quotation;
2. confirm quotation;
3. print quotation.

Issue
-----
Extra documents aren't added to the PDF, even though they show up as selected in the quotation builder.

Cause
-----
As of commit b02f53d, any quotation documents linked to a sales order are simply ignored for confirmed orders.

Solution
--------
Add a `sale.always_include_selected_documents` config parameter, allowing users to keep including the selected documents on confirmed orders.

opw-5242743