### PR TITLE
[IMP] web: increase darkmode focus state contrast

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -105,6 +105,12 @@ $component-active-bg: $o-component-active-bg !default;
 
 $caret-width: 4px !default;
 
+$focus-ring-width: .25rem !default;
+$focus-ring-opacity: .5 !default;
+$focus-ring-color: rgba($o-component-active-border, $focus-ring-opacity) !default;
+$focus-ring-blur: 0 !default;
+$focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width * .5 $o-component-active-border, 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color !default;
+
 // Typography
 //
 // Font, line-height, and color for body text, headings, and more.

--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -10,6 +10,7 @@
 
 .btn {
     --#{$variable-prefix}btn-disabled-border-color: transparent;
+    --#{$prefix}btn-focus-box-shadow: #{$focus-ring-box-shadow};
 }
 
 // 1. Render buttons defined in '$o-btns-bs-override' and '$o-btns-bs-outline-override'


### PR DESCRIPTION
The focus states on buttons are inconsistent and sometimes hard to see
(eg. darkmode secondary buttons)

Defines the focus-ring-* variables to make the focus state use `o-component-active-border` everywhere.

This PR makes the buttons use the `focus-ring-box-shadow` instead of the default `--btn-focus-box-shadow-rgb` with the .5 opacity.

Enterprise PR: https://github.com/odoo/enterprise/pull/99537

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
