### PR TITLE
[FIX] mail: reduce eye fatigue when using discuss in white theme

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -73,7 +73,7 @@
                         }"/>
                         <Wysiwyg t-if="composerService.htmlEnabled" class="'w-100 text-break overflow-auto'" config="this.wysiwygConfig" onLoad.bind="onLoadWysiwyg"/>
                         <t t-else="">
-                                <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin text-body user-select-auto"
+                                <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin o-discuss-text-body user-select-auto"
                                 t-att-class="inputClasses"
                                 t-ref="textarea"
                                 t-on-keydown="onKeydown"

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -10,6 +10,10 @@ a.o-discuss-mention {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%));
 }
 
+.o-discuss-text-body {
+    color: $o-main-text-color;
+}
+
 .o-secondary {
     --o-secondary: #{$o-gray-700};
 }

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -82,6 +82,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     opacity: $hr-opacity / 2;
 }
 
+.o-discuss-text-body {
+    color: $gray-700;
+}
+
 .o-discuss-badge, .o-discuss-badgeShape {
     &, & .o-innerBadge {
         display: flex;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -78,7 +78,7 @@
                                                     <path class="o-mail-Message-bubbleTailBg" fill="currentColor" d="M 2, 1 L 5, 7 V 1 z"/>
                                                 </svg>
                                             </div>
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block text-body" t-att-class="{
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block o-discuss-text-body" t-att-class="{
                                                 'w-100': isEditing,
                                                 'o-rounded-bubble': message.bubbleColor and props.squashed,
                                                 'o-rounded-bottom-bubble': message.bubbleColor and !props.squashed,


### PR DESCRIPTION
Main text color in white theme was increased from gray-700 to gray-900, increasing the overall contrast of the web client [1].

This change, in addition to reducing the color of message bubble, has the effect to increase contrast of message list by a lot in white theme, which leads to complain of eyes being hurt.

This commit reduces the black level of message text content color in white theme, to match text color as it was before [1].

[1]: https://github.com/odoo/odoo/pull/209125

Part of Task-5265246

Before
<img width="958" height="678" alt="before" src="https://github.com/user-attachments/assets/eee192fd-b24f-450e-85cc-2b97cae28b22" />


After
<img width="959" height="680" alt="after" src="https://github.com/user-attachments/assets/1955e515-9f43-4394-b32a-63fbfe213f6f" />
