### PR TITLE
[FIX] payment_flutterwave: singularize transaction references

### DIFF
--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -219,7 +219,7 @@
                type="base64"
                file="payment_flutterwave/static/description/icon.png"/>
         <field name="module_id" ref="base.module_payment_flutterwave"/>
-        <!-- https://developer.flutterwave.com/docs/collecting-payments/payment-methods/ -->
+        <!-- https://developer.flutterwave.com/v3.0.0/docs/payment-methods -->
         <field name="payment_method_ids"
                eval="[Command.set([
                          ref('payment.payment_method_card'),

--- a/addons/payment_flutterwave/README.md
+++ b/addons/payment_flutterwave/README.md
@@ -2,7 +2,7 @@
 
 ## Technical details
 
-API: [Flutterwave standard](https://developer.flutterwave.com/docs/collecting-payments/standard/)
+API: [Flutterwave standard](https://developer.flutterwave.com/v3.0.0/docs/flutterwave-standard-1)
 version `3`
 
 This module integrates Flutterwave using the generic payment with redirection flow based on form
@@ -26,7 +26,7 @@ submission provided by the `payment` module.
 
 ## Testing instructions
 
-https://developer.flutterwave.com/docs/integration-guides/testing-helpers
+https://developer.flutterwave.com/v3.0.0/docs/testing
 
 ### MasterCard
 

--- a/addons/payment_flutterwave/tests/test_payment_transaction.py
+++ b/addons/payment_flutterwave/tests/test_payment_transaction.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+from freezegun import freeze_time
+
 from odoo.tests import tagged
 from odoo.tools import mute_logger
 
@@ -10,6 +12,12 @@ from odoo.addons.payment_flutterwave.tests.common import FlutterwaveCommon
 
 @tagged('post_install', '-at_install')
 class TestPaymentTransaction(FlutterwaveCommon):
+
+    @freeze_time('2011-11-02 12:00:21')  # Freeze time for consistent singularization behavior.
+    def test_reference_is_singularized(self):
+        """Test that transaction references are unique at the provider level."""
+        reference = self.env['payment.transaction']._compute_reference(self.flutterwave.code)
+        self.assertEqual(reference, 'tx-20111102120021')
 
     def test_no_item_missing_from_rendering_values(self):
         """ Test that the rendered values are conform to the transaction fields. """


### PR DESCRIPTION
The `/payments` endpoint of the Flutterwave v3.0.0 API expects unique `tx_ref` parameters (matching Odoo's payment transaction `reference` field) to be passed. This is guaranteed by a UNIQUE() SQL constraint in Odoo, but testing sometimes involves dropping the database, leading to transaction references being repeated at the provider level for a given merchant account.

This commit singularizes all transaction references by suffixing them with the current timestamp, ensuring that the `tx_ref` API parameter remains unique across transaction reference sequences.
