### PR TITLE
[FIX] website: allow user to translate a field

### DIFF
--- a/addons/html_builder/static/src/core/core_setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/core_setup_editor_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 
 export class CoreSetupEditorPlugin extends Plugin {
+    // TODO: remove in master
     static id = "core_setup_editor_plugin";
     resources = {
         o_editable_selectors: "[data-oe-model]",

--- a/addons/website/static/src/builder/plugins/translate_setup_editor_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_setup_editor_plugin.js
@@ -1,8 +1,9 @@
 import { Plugin } from "@html_editor/plugin";
 
 export class TranslateSetupEditorPlugin extends Plugin {
+    // TODO: remove in master
     static id = "translate_setup_editor_plugin";
     resources = {
-        o_editable_selectors: "[data-oe-model][data-oe-translation-source-sha]",
+        o_editable_selectors: "[data-oe-model]",
     };
 }

--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -69,6 +69,7 @@ export class TranslationPlugin extends Plugin {
             for (const editableEl of editableEls) {
                 if (editableEl.querySelectorAll(editableElSelector).length) {
                     editableEl.setAttribute("data-oe-readonly", "true");
+                    editableEl.classList.remove("o_editable", "o_editable_attribute");
                 }
             }
             return true;


### PR DESCRIPTION
[FIX] html_builder, website: allow user to translate a field

Steps to reproduce the problem:
- With french installed on a website, go to `/fr/shop`.
- Enter in translate mode.

-> You can not edit product names.

The problem is that since [1], regular fields are not translatable. This
commit does two things:
- It modifies the `o_editable_selectors` selector in edit mode to allow
translation of regular fields.
- Because we revert the logic of [1], the problem that was solved by
this commit (translation of a mega menu item) still has to be fixed. To
do so, the `o_editable` or `o_editable_attribute` is removed when
setting the `data-oe-readonly` attribute on cascaded branded elements.
The idea is to follow the same logic than in the `SetupEditorPlugin`
where elements with the `data-oe-readonly` attribute are filtered before
adding the `o_editable` class.

task-5265949

[1]: https://github.com/odoo/odoo/commit/d4d428ff1d5be46135973aa806f206a1076bfcf7