### PR TITLE
[FIX] bus: ensure consistent events when closing handshake is incomplete

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -499,6 +499,7 @@ export class WebsocketWorker {
             this._onWebsocketClose(
                 new CloseEvent("close", { code: WEBSOCKET_CLOSE_CODES.CLOSING_HANDSHAKE_ABORTED })
             );
+            this.websocket = null;
             return;
         }
         this._updateState(WORKER_STATE.CONNECTING);


### PR DESCRIPTION
In [1], the websoket worker was updated to properly trigger disconnect/reconnecting/reconnect event when calling `_start` with a socket stuck in the closing state. Calling close will trigger a call to `_retryConnectionWithDelay` thus calling `_start` again.

However, we need to clear the websocket as well otherwise it will still be in the closing state, preventing reconnect.

[1]: https://github.com/odoo/odoo/pull/235623

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
