### PR TITLE
[FIX] stock: remove interwarehouse on partner locations

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -65,11 +65,6 @@ class ResCompany(models.Model):
 
             company.write({'internal_transit_location_id': location.id})
 
-            company.partner_id.with_company(company).write({
-                'property_stock_customer': location.id,
-                'property_stock_supplier': location.id,
-            })
-
     def _create_inventory_loss_location(self):
         for company in self:
             inventory_loss_location = self.env['stock.location'].create({


### PR DESCRIPTION
Currently when you set the partner on your warehouse it will set their customer and vendor location to interwarehouse transit. It's an issue with subcontracting since it will broke the rules and there is no reason to update them. So we remove thi feature

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
