### PR TITLE
[FIX] hr_attendance: overflow style in new employee dialog

### DIFF
--- a/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.xml
+++ b/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_attendance.NewEmployeeDialog" owl="1">
-        <Dialog title="props.title" footer="props.footer" bodyClass="'overflow-visible'">
+        <Dialog title="props.title" footer="props.footer" bodyClass="'overflow-visible'" contentClass="'overflow-visible'">
             <div class="p-3">
                 <div class="mb-3">
                     <label class="form-label">Create the name of the new employee below</label>


### PR DESCRIPTION
This commit fixes the style of the drop-down menu in the new employee dialog in hr attendance by adding `overflow-visible` to the contentClass prop of the Dialog component.

task-526548

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
