### PR TITLE
[FIX] account: Remove non-modular unit test.

### DIFF
--- a/addons/account_audit_trail/tests/test_audit_trail.py
+++ b/addons/account_audit_trail/tests/test_audit_trail.py
@@ -43,28 +43,6 @@ class TestAuditTrail(AccountTestInvoicingCommon):
                 expected
             )
 
-    def test_can_reset_deferred_invoice(self):
-        customer = self.env['res.partner'].create({'name': 'Rob Odoo'})
-        invoice = self.env['account.move'].create({
-            'invoice_date': '2025-09-01',
-            'invoice_date_due': '2025-09-01',
-            'invoice_line_ids': [
-                (0, 0, {'name': 'Line1',
-                        'price_unit': 100.0,
-                        'deferred_start_date': '2025-09-01',
-                        'deferred_end_date': '2025-12-31',
-                       }
-                ),
-            ],
-            'move_type': 'out_invoice',
-            'name': 'INVOICE_00001',
-            'partner_id': customer.id,
-        })
-
-        for i in range(4):
-            invoice.action_post()
-            invoice.button_draft()
-
     def test_can_unlink_draft(self):
         self.move.unlink()
 


### PR DESCRIPTION
The unit test `test_can_reset_deferred_invoice()` has several issues.

1. It should be in the `account_audit_trail` module, as the test requires this module. [Unit test documentation: modules](https://www.odoo.com/documentation/19.0/developer/tutorials/unit_tests.html#modules).
2. The test references fields from the Enterprise module `account_accountant`, `account.move.line.deferred_start_date` and `account.move.line.deferred_end_date`. This causes build tests to fail.

As such, the test should be removed now and replaced later if necessary.

Fixes [PR 235223](https://github.com/odoo/odoo/pull/235223)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
