### PR TITLE
[FIX] website: keep image gallery indicators contrast

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -175,8 +175,12 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
         // Since there is no versioning for this snippet we use the last version
         // of "website.gallery.slideshow" called "website.s_image_gallery_mirror"
         if (this.$target[0].dataset.vcss === '002') {
-            let carouselEl = this.$target[0].querySelector('.carousel');
-            params.colorContrast  = carouselEl && carouselEl.classList.contains('carousel-dark') ? 'carousel-dark' : ' ';
+            const carouselEl = this.$target[0].querySelector(".carousel");
+            const addImagesEl = this.$target[0].querySelector(".o_add_images");
+            const isCarouselDark = carouselEl
+                ? carouselEl.classList.contains("carousel-dark")
+                : addImagesEl?.hasAttribute("data-carousel-dark");
+            params.colorContrast = isCarouselDark ? "carousel-dark" : " ";
         }
         let $slideshow = $(renderToElement('website.s_image_gallery_mirror', params));
         const carouselItemEls = $slideshow[0].querySelectorAll(".carousel-item");
@@ -561,6 +565,9 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
             style: 'cursor: pointer;',
             text: _t(" Add Images"),
         });
+        if (this.$target[0].querySelector(".carousel-dark")) {
+            $text[0].dataset.carouselDark = "";
+        }
         const $icon = $('<i>', {
             class: ' fa fa-plus-circle',
         });


### PR DESCRIPTION
Steps to reproduce:

- Drag and drop an “image gallery” snippet.
- Click the “remove all” button in the options.
- Add 3 new images to the image gallery.
- Indicators and arrows become white (and therefore not visible on a light background).

The issue is that the class used to determine whether the indicators should be dark is located on the carousel element, but once the snippet is emptied of images, this carousel element no longer exists. As a result, the contrast of the indicators is computed while this element is missing, causing the issue.

task-5261756
