### PR TITLE
[FIX] web: avoid truncating event title in calendar view

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
@@ -10,7 +10,7 @@
                 <span class="d-none d-lg-inline fc-time" t-esc="startTime" />
                 <t> </t>
             </t>
-            <div class="o_event_title text-truncate" t-out="title"/>
+            <div class="o_event_title" t-out="title"/>
     </t>
 
     <t t-name="web.CalendarCommonRendererHeader">


### PR DESCRIPTION
Before this commit, when the user goes to a calendar view in day to check what he have to do. He cannot see the event title properly in his mobile phone since the title is truncated.

This commit makes sure the event title is not truncated to clearly see the whole event title.

Before the fix:

<img width="1172" height="802" alt="image" src="https://github.com/user-attachments/assets/f85a4a03-89a3-48c8-bda7-38e72854ce1f" />

After the fix:

<img width="1179" height="808" alt="image" src="https://github.com/user-attachments/assets/7b0b31ba-10f5-412b-837b-8399c78c5bac" />

