### PR TITLE
[FIX] website: fix Hoot builder tests for Firefox

### DIFF
--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -150,6 +150,13 @@ export async function setupWebsiteBuilder(
             originalIframeLoaded = this.iframeLoaded;
             this.iframeLoaded = iframeLoaded;
         },
+        // Override for Firefox. Chrome doesn't load the initial iframe and
+        // never goes through this method. As Firefox does, it means it re-
+        // assigns `this.publicRootReady` to a deferred that is never resolved
+        // in tests, which prevents any Hoot builder test from working.
+        // Reimplement this method the day interactions within the iframe work
+        // with Hoot.
+        preparePublicRootReady() {},
         async loadAssetsEditBundle() {
             // To instantiate interactions in the iframe test we need to
             // load the edit and frontend bundle in it. The problem is that


### PR DESCRIPTION
In the website builder test suite, Chrome doesn't load the initial iframe (we load a dummy iframe instead) and never goes through `preparePublicRootReady` from the `WebsiteBuilderClientAction`. On the contrary, Firefox does load the initial iframe. We already have a partial fix for it in the html_builder test helpers (see `originalIframeLoaded`), but it stopped working at some point. As Firefox loads the iframe and goes through `preparePublicRootReady`, it re-assigns `this.publicRootReady` to a deferred that is never resolved in tests, which prevents any Hoot builder test from working.

Solution: completely override `preparePublicRootReady` with an empty method in tests.

task-5266212