### PR TITLE
[IMP] orm: fields.Binary stores bytes

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -421,12 +421,12 @@ class AccountMoveLine(models.Model):
     deductible_amount = fields.Float("Deductibility", default=100)
 
     # === Invoice sync fields === #
-    term_key = fields.Binary(compute='_compute_term_key', exportable=False)
-    epd_key = fields.Binary(compute='_compute_epd_key', exportable=False)
-    epd_needed = fields.Binary(compute='_compute_epd_needed', exportable=False)
+    term_key = fields.Json(compute='_compute_term_key', exportable=False)
+    epd_key = fields.Json(compute='_compute_epd_key', exportable=False)
+    epd_needed = fields.Json(compute='_compute_epd_needed', exportable=False)
     epd_dirty = fields.Boolean(compute='_compute_epd_needed')
-    discount_allocation_key = fields.Binary(compute='_compute_discount_allocation_key', exportable=False)
-    discount_allocation_needed = fields.Binary(compute='_compute_discount_allocation_needed', exportable=False)
+    discount_allocation_key = fields.Json(compute='_compute_discount_allocation_key', exportable=False)
+    discount_allocation_needed = fields.Json(compute='_compute_discount_allocation_needed', exportable=False)
     discount_allocation_dirty = fields.Boolean(compute='_compute_discount_allocation_needed')
 
     # === Analytic fields === #
@@ -1094,7 +1094,12 @@ class AccountMoveLine(models.Model):
                 })
                 dist = distribution_totals[key]
                 total = sum(dist.values()) or 1  # avoid division by zero
-                discount_allocation_needed[key] = frozendict({
+                key_needed = frozendict({
+                    'move_id': line.move_id._origin.id,
+                    'account_id': account._origin.id,
+                    'currency_rate': line.currency_rate,
+                }) if not line.move_id.id else key
+                discount_allocation_needed[key_needed] = frozendict({
                     'display_type': 'discount',
                     'name': _("Discount"),
                     'amount_currency': amount,
@@ -1103,7 +1108,7 @@ class AccountMoveLine(models.Model):
                         for account_id, value in dist.items()
                     }
                 })
-            line.discount_allocation_needed = discount_allocation_needed
+            line.discount_allocation_needed = list(discount_allocation_needed.items())
 
     @api.depends('tax_ids', 'account_id', 'company_id')
     def _compute_epd_key(self):
@@ -1141,8 +1146,8 @@ class AccountMoveLine(models.Model):
             taxes = line.tax_ids.filtered(lambda t: t.amount_type != 'fixed')
             epd_needed_vals = epd_needed.setdefault(
                 frozendict({
-                    'move_id': line.move_id.id,
-                    'account_id': line.account_id.id,
+                    'move_id': line.move_id._origin.id,
+                    'account_id': line.account_id._origin.id,
                     'analytic_distribution': line.analytic_distribution,
                     'tax_ids': [Command.set(taxes.ids)],
                     'display_type': 'epd',
@@ -1161,8 +1166,8 @@ class AccountMoveLine(models.Model):
             epd_needed_vals['balance'] -= balance
             epd_needed_vals = epd_needed.setdefault(
                 frozendict({
-                    'move_id': line.move_id.id,
-                    'account_id': line.account_id.id,
+                    'move_id': line.move_id._origin.id,
+                    'account_id': line.account_id._origin.id,
                     'display_type': 'epd',
                 }),
                 {
@@ -1174,7 +1179,7 @@ class AccountMoveLine(models.Model):
             )
             epd_needed_vals['amount_currency'] += amount_currency
             epd_needed_vals['balance'] += balance
-            line.epd_needed = {k: frozendict(v) for k, v in epd_needed.items()}
+            line.epd_needed = list(epd_needed.items())
 
     @api.depends('move_id.move_type', 'balance', 'tax_repartition_line_id', 'tax_ids')
     def _compute_is_refund(self):
@@ -1205,7 +1210,7 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.display_type == 'payment_term':
                 line.term_key = frozendict({
-                    'move_id': line.move_id.id,
+                    'move_id': line.move_id._origin.id,
                     'date_maturity': fields.Date.to_date(line.date_maturity),
                     'discount_date': line.discount_date,
                 })

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -4952,7 +4952,7 @@ class AccountTaxRepartitionLine(models.Model):
         compute='_compute_use_in_tax_closing', store=True, readonly=False, precompute=True,
     )
 
-    tag_ids_domain = fields.Binary(string="tag domain", help="Dynamic domain used for the tag that can be set on tax", compute="_compute_tag_ids_domain")
+    tag_ids_domain = fields.Json(string="tag domain", help="Dynamic domain used for the tag that can be set on tax", compute="_compute_tag_ids_domain")
 
     @api.depends('company_id.multi_vat_foreign_country_ids', 'company_id.account_fiscal_country_id')
     def _compute_tag_ids_domain(self):

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -121,6 +121,7 @@ class AccountChartTemplate(models.AbstractModel):
         return {
             name: template
             for mapping in modules.mapped('account_templates')
+            if mapping
             for name, template in mapping.items()
             if get_all or template['visible']
         }

--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -24,7 +24,7 @@ TEMPLATE_REGISTER = {}
 class IrModuleModule(models.Model):
     _inherit = "ir.module.module"
 
-    account_templates = fields.Binary(compute='_compute_account_templates', exportable=False)
+    account_templates = fields.Json(compute='_compute_account_templates', exportable=False)
 
     @api.depends('state')
     def _compute_account_templates(self):
@@ -119,7 +119,12 @@ class IrModuleModule(models.Model):
             del self.env.registry._auto_install_template
 
     def module_uninstall(self):
-        unlinked_templates = [code for template in self.mapped('account_templates') for code in template]
+        unlinked_templates = [
+            code
+            for template in self.mapped('account_templates')
+            if template
+            for code in template
+        ]
         if unlinked_templates:
             companies = self.env['res.company'].search([
                 ('chart_template', 'in', unlinked_templates),

--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -78,7 +78,7 @@ export class AccountPaymentField extends Component {
 
 export const accountPaymentField = {
     component: AccountPaymentField,
-    supportedTypes: ["binary"],
+    supportedTypes: ["json"],
 };
 
 registry.category("fields").add("payment", accountPaymentField);

--- a/addons/account_payment/wizards/account_payment_register.py
+++ b/addons/account_payment/wizards/account_payment_register.py
@@ -41,7 +41,8 @@ class AccountPaymentRegister(models.TransientModel):
                 and not provider.capture_manually
             ):
                 token_partners = wizard.partner_id
-                lines_partners = wizard.batches[0]['lines'].move_id.partner_id
+                batch = wizard._get_batches()[0]
+                lines_partners = batch['lines'].move_id.partner_id
                 if len(lines_partners) == 1:
                     token_partners |= lines_partners
                 wizard.suitable_payment_token_ids = self.env['payment.token'].sudo().search(

--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -1,6 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from markupsafe import Markup
-
 from odoo import Command, models, fields, api, _
 from odoo.exceptions import ValidationError
 from odoo.tools.misc import frozendict
@@ -77,19 +75,19 @@ class AccountMove(models.Model):
         for move in self:
             if move.expense_ids and 'company_account' in move.expense_ids.mapped('payment_mode'):
                 term_lines = move.line_ids.filtered(lambda l: l.display_type != 'payment_term')
-                move.needed_terms = {
+                move.needed_terms = [(
                     frozendict(
                         {
                             "move_id": move.id,
                             "date_maturity": fields.Date.context_today(move.expense_ids),
                         }
-                    ): {
+                    ), {
                         "balance": -sum(term_lines.mapped("balance")),
                         "amount_currency": -sum(term_lines.mapped("amount_currency")),
                         "name": "",
                         "account_id": move.expense_ids._get_expense_account_destination(),
                     }
-                }
+                )]
 
     def _prepare_product_base_line_for_taxes_computation(self, product_line):
         # EXTENDS 'account'

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -31,7 +31,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
         compute="_compute_duplicate_applicant_ids",
         store=True, readonly=False,
     )
-    duplicate_applicant_ids_domain = fields.Binary(compute="_compute_duplicate_applicant_ids_domain")
+    duplicate_applicant_ids_domain = fields.Json(compute="_compute_duplicate_applicant_ids_domain")
     attachment_ids = fields.Many2many(
         'ir.attachment', string='Attachments',
         compute="_compute_from_template_id", readonly=False, store=True, bypass_search_access=True,
@@ -69,7 +69,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
                 & Domain('id', 'not in', self.applicant_ids.ids)
                 & Domain('application_status', 'not in', ['hired', 'refused', 'archived'])
             )
-            wizard.duplicate_applicant_ids_domain = domain
+            wizard.duplicate_applicant_ids_domain = list(domain)
             wizard.duplicates_count = self.env['hr.applicant'].search_count(wizard.duplicate_applicant_ids_domain)
 
     @api.depends('duplicates', 'duplicate_applicant_ids_domain')

--- a/addons/l10n_account_withholding_tax/wizards/account_payment_register.py
+++ b/addons/l10n_account_withholding_tax/wizards/account_payment_register.py
@@ -140,7 +140,7 @@ class AccountPaymentRegister(models.TransientModel):
 
             # Compute the lines themselves once; when opening the wizard.
             if not wizard.withholding_line_ids:
-                batch = wizard.batches[0]
+                batch = wizard._get_batches()[0]
                 base_lines = []
                 for move in batch['lines'].move_id:
                     move_base_lines, _move_tax_lines = move._get_rounded_base_and_tax_lines()
@@ -231,7 +231,7 @@ class AccountPaymentRegister(models.TransientModel):
         if not self.can_edit_wizard:
             return 0.0
 
-        moves = self.batches[0]['lines'].move_id  # Use the move to get the TOTAL amount, including all installment.
+        moves = self._get_batches()[0]['lines'].move_id  # Use the move to get the TOTAL amount, including all installment.
         wizard_curr = self.currency_id
         comp_curr = self.company_currency_id
 

--- a/addons/l10n_account_withholding_tax/wizards/account_payment_register_withholding_line.py
+++ b/addons/l10n_account_withholding_tax/wizards/account_payment_register_withholding_line.py
@@ -48,7 +48,7 @@ class AccountPaymentRegisterWithholdingLine(models.TransientModel):
                 lines.comodel_percentage_paid_factor = 0.0
                 continue
 
-            total_amounts_to_pay = wizard._get_total_amounts_to_pay(wizard.batches)
+            total_amounts_to_pay = wizard._get_total_amounts_to_pay(wizard._get_batches())
             moves_total_amount = wizard._get_total_amount_in_wizard_currency()
             if total_amounts_to_pay['full_amount']:
                 # We need to care about partial payment; for example if paid in two times.

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -272,7 +272,8 @@ class AccountMove(models.Model):
         # OVERRIDE 'account'
         super()._compute_tax_totals()
         for move in self:
-            if move.tax_totals and move._get_name_invoice_report() == 'l10n_cl.report_invoice_document':
+            if (tax_totals := move.tax_totals) and move._get_name_invoice_report() == 'l10n_cl.report_invoice_document':
                 # Disable the recap of tax totals in company currency at the bottom right of the invoice,
                 # since this info is already present in our custom tax totals grid.
-                move.tax_totals['display_in_company_currency'] = False
+                tax_totals['display_in_company_currency'] = False
+                move.tax_totals = tax_totals

--- a/addons/l10n_id/models/account_move.py
+++ b/addons/l10n_id/models/account_move.py
@@ -124,7 +124,8 @@ class AccountMove(models.Model):
             # for every tax group component with non-luxury tax group, we adjust the base amount and adjust the display to
             # show base amount
             change_tax_base = False
-            for subtotal in move.tax_totals["subtotals"]:
+            tax_totals = move.tax_totals
+            for subtotal in tax_totals["subtotals"]:
                 for tax_group in subtotal["tax_groups"]:
                     if tax_group["id"] == non_luxury_tax_group.id:
                         tax_group.update({
@@ -134,4 +135,5 @@ class AccountMove(models.Model):
                         })
                         change_tax_base = True
             if change_tax_base:
-                move.tax_totals["same_tax_base"] = False
+                tax_totals["same_tax_base"] = False
+                move.tax_totals = tax_totals

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
 import json
 import logging
 import re
@@ -130,7 +129,7 @@ class L10nInEwaybill(models.Model):
         ("error", "Error")],
         string="Blocking Level", readonly=True)
 
-    content = fields.Binary(compute='_compute_content', compute_sudo=True)
+    content = fields.Json(compute='_compute_content', compute_sudo=True)
     cancel_reason = fields.Selection(selection=[
         ("1", "Duplicate"),
         ("2", "Data Entry Mistake"),
@@ -257,7 +256,7 @@ class L10nInEwaybill(models.Model):
                 ewaybill_json = ewaybill._ewaybill_generate_direct_json()
             else:
                 ewaybill_json = {}
-            ewaybill.content = base64.b64encode(json.dumps(ewaybill_json).encode())
+            ewaybill.content = ewaybill_json
 
     @api.depends('name', 'state')
     def _compute_display_name(self):

--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -1,8 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
-import json
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.addons.l10n_in_ewaybill.tools.ewaybill_api import EWayBillApi, EWayBillError
@@ -59,7 +56,7 @@ class L10nInEwaybill(models.Model):
         irn_ewaybill = self.filtered('is_process_through_irn')
         for ewaybill in irn_ewaybill:
             ewaybill_json = ewaybill._ewaybill_generate_irn_json()
-            ewaybill.content = base64.b64encode(json.dumps(ewaybill_json).encode())
+            ewaybill.content = ewaybill_json
         super(L10nInEwaybill, self - irn_ewaybill)._compute_content()
 
     def action_generate_ewaybill(self):

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -63,15 +63,16 @@ class AccountMove(models.Model):
         """Add pos_payment_name field in the reconciled vals to be able to show the payment method in the invoice."""
         super()._compute_payments_widget_reconciled_info()
         for move in self:
-            if move.invoice_payments_widget:
+            if widget := move.invoice_payments_widget:
                 if move.state == 'posted' and move.is_invoice(include_receipts=True):
                     reconciled_partials = move._get_all_reconciled_invoice_partials()
                     for i, reconciled_partial in enumerate(reconciled_partials):
                         counterpart_line = reconciled_partial['aml']
                         pos_payment = counterpart_line.move_id.sudo().pos_payment_ids[:1]
-                        move.invoice_payments_widget['content'][i].update({
+                        widget['content'][i].update({
                             'pos_payment_name': pos_payment.payment_method_id.name,
                         })
+                        move.invoice_payments_widget = widget
 
     def _compute_amount(self):
         super()._compute_amount()

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -344,7 +344,7 @@ class SaleOrder(models.Model):
         compute='_compute_tax_country_id',
         # Avoid access error on fiscal position when reading a sale order with company != user.company_ids
         compute_sudo=True)  # used to filter available taxes depending on the fiscal country and position
-    tax_totals = fields.Binary(compute='_compute_tax_totals', exportable=False)
+    tax_totals = fields.Json(compute='_compute_tax_totals', exportable=False)
     terms_type = fields.Selection(related='company_id.terms_type')
     type_name = fields.Char(string="Type Name", compute='_compute_type_name')
 

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1074,13 +1074,6 @@ class TestOrmModel_Binary(models.Model):
     binary_x_filename2 = fields.Char()
     binary_related_store = fields.Binary("Binary Related Store", related='binary', store=True, readonly=False)
     binary_related_no_store = fields.Binary("Binary Related No Store", related='binary', store=False, readonly=False)
-    binary_computed = fields.Binary(compute='_compute_binary')
-
-    @api.depends('binary')
-    def _compute_binary(self):
-        # arbitrary value: 'bin_size' must have no effect
-        for record in self:
-            record.binary_computed = [(record.id, bool(record.binary))]
 
 
 class TestOrmModel_Image(models.Model):
@@ -2500,10 +2493,6 @@ class BinaryTest(models.Model):
 
     img = fields.Image()
     bin1 = fields.Binary()
-    bin2 = fields.Binary(compute="_compute_bin2")
-
-    def _compute_bin2(self):
-        self.bin2 = {}
 
 
 class CalendarTest(models.Model):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -2992,16 +2992,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         assertBinaryValue(record_no_bin_size, binary_value)
         assertBinaryValue(record_bin_size, binary_size)
 
-        # check computed binary field with arbitrary Python value
-        record = self.env['test_orm.model_binary'].create({})
-        record_no_bin_size = record.with_context(bin_size=False)
-        record_bin_size = record.with_context(bin_size=True)
-
-        expected_value = [(record.id, False)]
-        self.assertEqual(record.binary_computed, expected_value)
-        self.assertEqual(record_no_bin_size.binary_computed, expected_value)
-        self.assertEqual(record_bin_size.binary_computed, expected_value)
-
     def test_95_binary_bin_size_write(self):
         binary_value = base64.b64encode(b'content')
         binary_size = b'7.00 bytes'

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -96,22 +96,25 @@ class Binary(Field):
         return self._get_cache(record_no_bin_size.env)[record.id]
 
     def convert_to_cache(self, value, record, validate=True):
-        if isinstance(value, _BINARY):
-            return bytes(value)
+        if isinstance(value, bytes):
+            return value
+        if value is False or value is None:
+            return None
         if isinstance(value, str):
             # the cache must contain bytes or memoryview, but sometimes a string
             # is given when assigning a binary field (test `TestFileSeparator`)
             return value.encode()
-        if isinstance(value, int) and \
-                (record.env.context.get('bin_size') or
-                 record.env.context.get('bin_size_' + self.name)):
-            # If the client requests only the size of the field, we return that
-            # instead of the content. Presumably a separate request will be done
-            # to read the actual content, if necessary.
-            value = human_size(value)
-            # human_size can return False (-> None) or a string (-> encoded)
-            return value.encode() if value else None
-        return None if value is False else value
+        if record.env.context.get('bin_size') or record.env.context.get('bin_size_' + self.name):
+            if isinstance(value, int):
+                # If the client requests only the size of the field, we return that
+                # instead of the content. Presumably a separate request will be done
+                # to read the actual content, if necessary.
+                value = human_size(value)
+                # human_size can return False (-> None) or a string (-> encoded)
+                return value.encode() if value else None
+            # keep bin_size as is
+            return value
+        return bytes(value)
 
     def convert_to_record(self, value, record):
         if isinstance(value, _BINARY):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The field is used to sometimes some mutable data because the `convert_to_cache` does not force a particular type. That hack is used in multiple places where instead json files (or another form of cache) could be used.

Current behavior before PR:
```py
res.binary_field = val = {}
res.binary_field["ok"] = 4
assert "ok" in val
```

Desired behavior after PR is merged:
```py
res.binary_field = {}  # fail because not bytes (or like bytes)
```

https://github.com/odoo/enterprise/pull/99567
task-4251301

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
