### PR TITLE
[FIX] payment_worldline: fix Bancontact payment w/ challenge flow

### DIFF
--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -301,7 +301,7 @@ class PaymentTransaction(models.Model):
             raise ValidationError("Worldline: " + _("Received data with missing payment state."))
 
         if status in const.PAYMENT_STATUS_MAPPING['pending']:
-            if status == 'AUTHORIZATION_REQUESTED':
+            if status == 'AUTHORIZATION_REQUESTED' and self.operation in ('online_token', 'offline'):
                 self._set_error("Worldline: " + status)
             elif self.operation == 'validation' \
                  and status in {'PENDING_CAPTURE', 'CAPTURE_REQUESTED'} \


### PR DESCRIPTION
When paying with Bancontact, in case a 3DS validation is required (challenge flow), Wordline will send a webhook (see below) to indicate that an external (asynchronous) validation was requested.

Example of recevied webhook:
```
{
  'apiFullVersion': 'v1.1',
  'apiVersion': 'v1',
  ...
  'payment': {
     'status': 'AUTHORIZATION_REQUESTED',
      'statusOutput': {
        'isAuthorized': False,
        'isCancellable': False,
        'isRefundable': False,
        'statusCategory': 'PENDING_CONNECT_OR_3RD_PARTY',
        'statusCode': 51
      }
   },
 'type': 'payment.authorization_requested'
}
```

Since efc2788dfccd, when receiving such webhook we set the transaction as error then force the user flow to `redirect`; this was done to handle payment w/ token (`online_token`) where a 3DS challenge is still required.

But for Bancontact - which is non-tokenizable - we will always be in the "redirect" mode, so we must keep the transaction as `pending`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
