### PR TITLE
[FIX] mail: can add message reaction in mobile

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -10,11 +10,6 @@
     &.o-mobile {
         margin-right: $o-mail-ChatHub-bubblesMargin + 5px;
         --mail-ChatHub-bubbles-bottomLift: 35px;
-
-        body:has(.o-mail-Discuss):not(:has(.o-mail-ChatWindow)) &, body:has(.o-mail-MessagingMenu):not(:has(.o-mail-ChatWindow)) &  {
-            --mail-ChatHub-bubbles-bottomLift: 65px;
-            z-index: $zindex-modal + 5;
-        }
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -2,6 +2,9 @@
     width: $o-mail-ChatWindow-width;
 
     z-index: $zindex-sticky;
+    &.o-mobile {
+        z-index: $zindex-sticky - 2 !important;
+    }
     &:not(.o-mobile) {
         --border-opacity: .15;
         height: Min(95vh, $o-mail-ChatWindow-width * 15 / 9)

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -49,7 +49,10 @@ export class ChatWindow extends Record {
     });
 
     computeCanShow() {
-        return !this.store.discuss?.isActive || this.store.env.services.ui.isSmall;
+        if (this.store.env.services.ui.isSmall) {
+            return !this.hubAsFolded || !this.store.discuss?.isActive;
+        }
+        return !this.store.discuss?.isActive;
     }
 
     async close(options = {}) {

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <template xml:space="preserve">
     <t t-name="mail.MessageReactionList">
-        <Dropdown state="preview" position="'top-middle'" menuClass="'mt-1 overflow-visible ' + store.discussDropdownMenuClass(this)" manual="true">
+        <Dropdown state="preview" position="'top-middle'" menuClass="'mt-1 overflow-visible ' + store.discussDropdownMenuClass(this)" manual="true" bottomSheet="false">
             <t t-call="mail.MessageReactionList.button" />
             <t t-set-slot="content">
                 <t t-call="mail.MessageReactionList.preview"/>

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -26,6 +26,7 @@ export class QuickReactionMenu extends Component {
     setup() {
         this.toggle = useRef("toggle");
         this.store = useService("mail.store");
+        this.ui = useService("ui");
         this.picker = useEmojiPicker(
             null,
             { onSelect: this.toggleReaction.bind(this), class: "overflow-hidden rounded-2" },
@@ -79,11 +80,15 @@ export class QuickReactionMenu extends Component {
         if (!this.store.emojiLoader.isLoaded) {
             loadEmoji();
         }
-        this.picker.close();
-        if (this.dropdown.isOpen) {
-            this.dropdown.close();
+        if (this.ui.isSmall) {
+            this.props.action.onSelected();
         } else {
-            this.dropdown.open();
+            this.picker.close();
+            if (this.dropdown.isOpen) {
+                this.dropdown.close();
+            } else {
+                this.dropdown.open();
+            }
         }
     }
 

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.QuickReactionMenu">
-        <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'" navigationOptions="navigationOptions" bottomSheet="false">
-            <button class="btn border-0 o-p-0_5 o-inline o-mail-QuickReactionMenu-toggler" t-att-class="attClass" t-att-title="props.action.name" t-att-aria-label="props.action.name" t-on-click="onClick">
-                <i t-att-class="props.action.icon"/>
-            </button>
+        <t t-if="ui.isSmall" t-call="mail.QuickReactionMenu.toggler"/>
+        <Dropdown t-else="" state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'" navigationOptions="navigationOptions" bottomSheet="false">
+            <t t-call="mail.QuickReactionMenu.toggler"/>
             <t t-set-slot="content">
                 <div class="o-mail-QuickReactionMenu d-flex align-items-center o-px-0_5 bg-100 border border-secondary o-rounded-bubble shadow-sm gap-1" t-ref="toggle">
                     <button t-foreach="mostFrequentEmojis" t-as="emoji" t-key="emoji" class="o-mail-QuickReactionMenu-emoji o-mail-QuickReactionMenu-popEffect o-navigable d-flex justify-content-center align-items-center o-rounded-bubble btn lh-1 p-1" t-att-class="{ 'bg-secondary': reactedBySelf(emoji) }" t-att-title="getEmojiShortcode(emoji)" t-on-click="() => this.toggleReaction(emoji)">
@@ -16,5 +15,11 @@
                 </div>
             </t>
         </Dropdown>
+    </t>
+
+    <t t-name="mail.QuickReactionMenu.toggler">
+        <button class="btn border-0 o-p-0_5 o-inline o-mail-QuickReactionMenu-toggler" t-att-class="attClass" t-att-title="props.action.name" t-att-aria-label="props.action.name" t-on-click="onClick">
+            <i t-att-class="props.action.icon"/>
+        </button>
     </t>
 </templates>

--- a/addons/mail/static/tests/mail_shared_tests.js
+++ b/addons/mail/static/tests/mail_shared_tests.js
@@ -1,0 +1,35 @@
+import { click, contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { expect, mockTouch, mockUserAgent, queryFirst } from "@odoo/hoot";
+
+export async function mailCanAddMessageReactionMobile() {
+    mockTouch(true);
+    mockUserAgent("android");
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        body: "Hello world",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { text: "Hello world" });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-dropdown-item:contains('Add a Reaction')");
+    await contains(".o-overlay-item:has(.modal .o-EmojiPicker)");
+    const emojiPickerZIndex = parseInt(
+        getComputedStyle(queryFirst(".o-overlay-item:has(.modal .o-EmojiPicker)")).zIndex
+    );
+    const chatWindowZIndex = parseInt(getComputedStyle(queryFirst(".o-mail-ChatWindow")).zIndex);
+    expect(chatWindowZIndex).toBeLessThan(emojiPickerZIndex, {
+        message: "emoji picker modal should be above chat window",
+    });
+    await click(".modal .o-EmojiPicker .o-Emoji:contains('😀')");
+    await contains(".o-mail-MessageReaction:contains('😀')");
+    // Can quickly add new reactions
+    await click(".o-mail-MessageReactions button[title='Add a Reaction']");
+    await click(".modal .o-EmojiPicker .o-Emoji:contains('🤣')");
+    await contains(".o-mail-MessageReaction:contains('🤣')");
+    await contains(".o-mail-MessageReaction:contains('😀')");
+}


### PR DESCRIPTION
[FIX] mail: can add message reaction in mobile

Before this commit, mobile uses could not practically add reactions.

Steps to reproduce:
- open a discuss conversation on mobile device
- post a message
- click on "..."
- click on "Add a reaction"
=> No emoji picker is shown.

This happens because the emoji picker opens in a modal in mobile. The modal has a z-index lower than chat window, and because of this it is actually shown below the chat window.

The chat window being above modal is sometimes desirable, like for AI chat windows triggered from a modal in desktop, but sometimes the opposite is desirable, like in mobile. Chat window had z-index for desktop use of above modal, but in mobile the opposite is desirable.

This commit fixes the issue by reducing the chat window z-index in mobile, so that modals are above chat windows.

Note that current desktop style for chat window being necessarily above modals is not exactly correct, but this is a tricker part to fix therefore this PR focuses on the immediate usability issue in mobile that makes using any modal in chat window unusable.

Task-5208322
Task-5261880

This PR also disables the showing of chat bubbles in discuss app similarly to the desktop counter-part.

Task-4607436

https://github.com/odoo/enterprise/pull/99588