### PR TITLE
[FIX] hr, *: restrict employee form tab and buttons based on access rights

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -89,7 +89,7 @@
                 <form string="Employee" js_class="hr_employee_form" duplicate="false">
                     <header groups="hr.group_hr_user">
                         <button string="Create User" name="action_create_user" type="object"
-                                class="btn btn-primary" invisible="user_id" groups="hr.group_hr_user"
+                                class="btn btn-primary" invisible="user_id" groups="base.group_erp_manager"
                                 context="{'default_create_employee': True}"/>
                         <button name="%(plan_wizard_action)d" string="Launch Plan" type="action"
                             groups="hr.group_hr_user" invisible="not active or not id" context="{'sort_by_responsible': True}"/>

--- a/addons/hr/views/hr_version_views.xml
+++ b/addons/hr/views/hr_version_views.xml
@@ -80,8 +80,8 @@
                             ('contract_date_start', '>', 'today'),
                         ]"/>
                 <separator />
-                <filter string="Contract Start Date" name="contract_date_start" date="contract_date_start"/>
-                <filter string="Contract End Date" name="contract_date_end" date="contract_date_end"/>
+                <filter string="Contract Start Date" name="contract_date_start" date="contract_date_start" groups="hr.group_hr_manager"/>
+                <filter string="Contract End Date" name="contract_date_end" date="contract_date_end" groups="hr.group_hr_manager"/>
                 <separator />
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -9,7 +9,7 @@
             <button name="action_open_versions" position="before">
                 <field name="has_work_entries" invisible="1"/>
                 <button invisible="not has_work_entries" type="object" class="oe_stat_button" id="open_work_entries"
-                    icon="fa-calendar" name="action_open_work_entries">
+                    icon="fa-calendar" name="action_open_work_entries" groups="hr.group_hr_manager">
                     <div class="o_stat_info">
                             <span class="o_stat_text">
                             Work Entries


### PR DESCRIPTION
* = hr_work_entry

Steps to reproduce:
- Install 'hr' and 'hr_work_entry'.
- Log in as an HR Officer.
- Open an employee form and click:
  - 'Create User'
  - 'Work Entries' smart button
  - 'History' smart button

Cause:
- 'Create User' was visible to HR Officers, but only users with Settings rights
  ('base.group_erp_manager') can create 'res.users', causing an AccessError.
- The 'Work Entries' and 'History buttons were visible to HR Officers, but
  fields  as 'contract_date_start' which only HR Managers can read when
  payroll is not installed.

Fix:
- Restricted 'Create User' to 'base.group_erp_manager'.
- Limited the 'History' smart button to 'hr.group_hr_manager'.
- Limited the 'Work Entries' smart button to 'hr.group_hr_manager'.

Task - 5188997