### PR TITLE
[FIX] html_editor: add end tags to element except void elements

### DIFF
--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -31,8 +31,8 @@ export function initElementForEdition(element, options = {}) {
 }
 
 /**
- * Properly close common XML-like self-closing elements to avoid HTML parsing
- * issues.
+ * Converts XML-style self-closing tags (e.g., <div/> <span/> <t/>) into proper
+ * HTML start/end tag pairs, except for true HTML void elements.
  *
  * @param {string} content
  * @returns {string}
@@ -41,9 +41,11 @@ export function fixInvalidHTML(content) {
     if (!content) {
         return content;
     }
-    // TODO: improve the regex to support nodes with data-attributes containing
-    // `/` and `>` characters.
-    const regex = /<\s*(a|strong|t|span)[^<]*?\/\s*>/g;
+    // Match self-closing tags EXCEPT HTML void elements.
+    // We do not use selfClosingElementTags because it includes XML-only tags
+    // such as <t>, which must not be treated as void in HTML.
+    const regex =
+        /<\s*(?!area\b|base\b|br\b|col\b|embed\b|hr\b|img\b|input\b|link\b|meta\b|param\b|source\b|track\b|wbr\b)([a-zA-Z0-9:-]+)\s*((?:(?:\s+[\w:-]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?)*))\s*\/>/g;
     return content.replace(regex, (match, g0) => match.replace(/\/\s*>/, `></${g0}>`));
 }
 


### PR DESCRIPTION
**Step to Reproduce:**
- install Subscription (with demo data)
- try to edit `Subscription: Payment Reminder` email template

**Observation:**
- Traceback for faulty template


**Cause**
For outgoing mails, we are using output_method = 'xml' when normalizing html content
https://github.com/odoo/odoo/blob/cb5176df98490ef04c0aac481f010bd2ac2f2424/odoo/orm/fields_textual.py#L580-L587

when this content is parsed using DOMParser in browser, 

https://github.com/odoo/odoo/blob/cb5176df98490ef04c0aac481f010bd2ac2f2424/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js#L61-L63

we might get different result.
For a very basic template like this:
```
<div>
    <t t-if="ctx.get('error')">
        <pre t-out="ctx['error'] or ''" />.
    </t>
    <t t-else="">
        <span>some text</span>
    </t>
</div>
```
when parsed using Domparser(), return a faulty template:
```
<div>
    <t t-if="ctx.get('error')">
        <pre t-out="ctx['error'] or ''">.
        <t t-else="">
            <span>some text</span>
    </t>
</pre>
    </t>
</div>
```

Issue roots because of use of self-closing tags, which are valid for xml but not for html

**Fix:**
- we forcefully replace all self-closing tags(which are not void elements)  with a closing tag.
- see  list of void elements https://developer.mozilla.org/en-US/docs/Glossary/Void_element



opw-5234345


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
