### PR TITLE
[FIX] point_of_sale: correct computation of price_subtotal in POS orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -193,7 +193,7 @@ export class PosOrderAccounting extends Base {
         this.amount_total = this.currency.round(this.priceIncl);
         this.amount_return = this.change; // Already rounded by the getter
         this.lines.forEach((line) => {
-            line.price_subtotal = line.displayPriceUnit;
+            line.price_subtotal = line.priceExcl;
             line.price_subtotal_incl = line.displayPrice;
         });
     }

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -466,11 +466,11 @@ describe("pos_store.js", () => {
             expect(order.amount_tax).toEqual(2.85);
             expect(order.lines[0].qty).toEqual(3);
             expect(order.lines[0].price_unit).toEqual(3);
-            expect(order.lines[0].price_subtotal).toEqual(3);
+            expect(order.lines[0].price_subtotal).toEqual(9);
             expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
             expect(order.lines[1].qty).toEqual(2);
             expect(order.lines[1].price_unit).toEqual(3);
-            expect(order.lines[1].price_subtotal).toEqual(3);
+            expect(order.lines[1].price_subtotal).toEqual(6);
             expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
 
             order.is_refund = true;
@@ -481,11 +481,11 @@ describe("pos_store.js", () => {
             expect(order.amount_tax).toEqual(-2.85);
             expect(order.lines[0].qty).toEqual(-3);
             expect(order.lines[0].price_unit).toEqual(3);
-            expect(order.lines[0].price_subtotal).toEqual(3);
+            expect(order.lines[0].price_subtotal).toEqual(9);
             expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
             expect(order.lines[1].qty).toEqual(-2);
             expect(order.lines[1].price_unit).toEqual(3);
-            expect(order.lines[1].price_subtotal).toEqual(3);
+            expect(order.lines[1].price_subtotal).toEqual(6);
             expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
         });
     });


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **Point of Sale** module with demo data.
* Open the POS interface and create a new order.
* Add a product that has **taxes applied** and set its quantity to more than one.
* Confirm the order by proceeding to payment and Validate payment.
* Go to the backend: **Point of Sale → Orders → Orders**.
* Open the created order and check the value displayed under **Tax Excl**.

**Issue:**
* The **Tax Excl** field shows the *unit price* of the product instead of the *subtotal without tax*.

- *Example -*
 *Unit Price*: 10
 *Quantity*: 3
 *Tax*: 10%

**Expected Value -** 
**Tax Excl**(price_subtotal) : 30
**Tax Incl**(price_subtotal_incl): 33

**Current Value -** 
**Tax Excl**(price_subtotal) : 3
**Tax Incl**(price_subtotal_incl): 33

**Cause:**
* The POS code incorrectly assigns `price_subtotal` using the displayed unit price
 instead of the actual tax-excluded subtotal.

**Fix:**
* Assign `price_subtotal` using the correct **PriceExcl** value so the subtotal
 without tax is accurately reflected.

---
opw-5252340

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
