### PR TITLE
[IMP] point_of_sale: hide payment status when remaining/change is zero

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
@@ -54,11 +54,11 @@ export class PaymentScreenStatus extends Component {
     }
 
     get statusText() {
-        if (!this.isRemaining) {
-            return _t("Change");
-        } else {
-            return _t("Remaining");
-        }
+        return this.isRemaining ? _t("Remaining") : _t("Change");
+    }
+
+    get showStatus() {
+        return Boolean(this.order.remainingDue || this.order.change);
     }
 
     get amountText() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
@@ -5,7 +5,7 @@
         <div t-if="props.order.payment_ids.length == 0" class="d-flex justify-content-center align-items-center text-center fs-4 flex-grow-1">
             Please select a payment method
         </div>
-        <section t-else="" t-attf-class="paymentlines-container border-top pt-3 {{ !isComplete ? 'text-danger' : 'text-success'}}">
+        <section t-elif="this.currentTip.amount > 0 or showStatus" t-attf-class="paymentlines-container border-top pt-3 {{ !isComplete ? 'text-danger' : 'text-success'}}">
             <div t-if="this.currentTip.amount > 0" class="tip-container d-flex flex-lg-row justify-content-between align-items-center fs-2 mb-2 text-dark position-relative">
                 <span class="label pe-2" t-esc="tipLabel" />
                 <span class="align-self-end me-5 pe-5">
@@ -15,7 +15,7 @@
                     <i class="fa fa-info-circle mx-2 px-3 fs-4" data-tooltip="The tip is already included inside the payment lines" />
                 </div>
             </div>
-            <div class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2">
+            <div t-if="showStatus" class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2">
                 <div class="payment-status-amount d-flex justify-content-between flex-grow-1">
                     <span class="label pe-2" t-out="statusText" />
                     <span class="amount align-self-end me-5 pe-5" t-att-amount="amountText" t-att-class="{ 'highlight text-danger fw-bolder': !isComplete }">

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -267,10 +267,15 @@ export function isInvoiceOptionSelected() {
  * @param {String} amount
  */
 export function remainingIs(amount) {
+    const step = `.payment-status-amount .amount:contains("${amount}")`;
+    // If amount is 0 we do NOT show the payment status on the PaymentScreen
+    if (!parseFloat(amount)) {
+        return [{ trigger: negate(step) }];
+    }
     return [
         {
             content: `remaining amount is ${amount}`,
-            trigger: `.payment-status-amount .amount:contains("${amount}")`,
+            trigger: step,
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -750,7 +750,6 @@ registry.category("web_tour.tours").add("test_no_kitchen_confirmation_for_deposi
             },
             PaymentScreen.clickNumpad("+10"),
             PaymentScreen.fillPaymentLineAmountMobile("bank", "10.0"),
-            PaymentScreen.changeIs("0"),
             PaymentScreen.clickValidate(),
             Dialog.is("The order is empty"),
             Dialog.confirm("Yes"),


### PR DESCRIPTION
Before this commit :
---------------
- Payment screen always showed Remaining or Change even when the amount was 0.

After this commit :
---------------------------
- Payment screen no longer shows the status section when the amount is 0.
--------------------

Task-5266175
