### PR TITLE
[IMP] web,*: support hide_trailing_zeros option in statinfo widget

### DIFF
--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -109,7 +109,7 @@
                         type="object" icon="fa-credit-card" invisible="not purchase_ok" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value d-flex gap-1">
-                                <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline"/>
+                                <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
                                 <field name="uom_name"  class="oe_inline" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Purchased</span>
@@ -130,7 +130,7 @@
                         type="object" icon="fa-credit-card" invisible="not purchase_ok" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value d-flex gap-1">
-                                <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline"/>
+                                <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
                                 <field name="uom_name"  class="oe_inline" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Purchased</span>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -54,7 +54,7 @@
                     invisible="not sale_ok">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value d-flex gap-1">
-                            <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline"/>
+                            <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
                             <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                         </span>
                         <span class="o_stat_text">Sold</span>
@@ -78,7 +78,7 @@
                     invisible="not sale_ok">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value d-flex gap-1">
-                            <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline"/>
+                            <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
                             <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                         </span>
                         <span class="o_stat_text">Sold</span>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -327,16 +327,16 @@
                                 <div class="d-flex flex-row gap-1 ms-1">
                                     <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
                                         <span class="o_stat_value">
-                                            <field name="qty_available" widget="statinfo" nolabel="1"/>
+                                            <field name="qty_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                         <span class="o_stat_value" invisible="virtual_available != 0">
-                                            <field name="virtual_available" nolabel="1"/>
+                                            <field name="virtual_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                         <span class="o_stat_value text-info" invisible="virtual_available &lt;= 0">
-                                            <field name="virtual_available" nolabel="1"/>
+                                            <field name="virtual_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                         <span class="o_stat_value text-danger" invisible="virtual_available &gt;= 0">
-                                            <field name="virtual_available" nolabel="1"/>
+                                            <field name="virtual_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                     </div>
                                     <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
@@ -444,16 +444,16 @@
                                 <div class="d-flex flex-row gap-1 ms-1">
                                     <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
                                         <span class="o_stat_value">
-                                            <field name="qty_available" widget="statinfo" nolabel="1"/>
+                                            <field name="qty_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                         <span class="o_stat_value" invisible="virtual_available != 0">
-                                            <field name="virtual_available" nolabel="1"/>
+                                            <field name="virtual_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                         <span class="o_stat_value text-info" invisible="virtual_available &lt;= 0">
-                                            <field name="virtual_available" nolabel="1"/>
+                                            <field name="virtual_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                         <span class="o_stat_value text-danger" invisible="virtual_available &gt;= 0">
-                                            <field name="virtual_available" nolabel="1"/>
+                                            <field name="virtual_available" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
                                         </span>
                                     </div>
                                     <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">

--- a/addons/web/static/src/views/fields/stat_info/stat_info_field.js
+++ b/addons/web/static/src/views/fields/stat_info/stat_info_field.js
@@ -14,6 +14,10 @@ export class StatInfoField extends Component {
         noLabel: { type: Boolean, optional: true },
         digits: { type: Array, optional: true },
         string: { type: String, optional: true },
+        trailingZeros: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        trailingZeros: true,
     };
 
     get formattedValue() {
@@ -22,6 +26,7 @@ export class StatInfoField extends Component {
         return formatter(this.props.record.data[this.props.name], {
             digits: this.props.digits,
             field,
+            trailingZeros: this.props.trailingZeros,
         });
     }
     get label() {
@@ -41,6 +46,12 @@ export const statInfoField = {
             type: "field",
             availableTypes: ["char"],
         },
+        {
+            label: _t("Hide trailing zeros"),
+            name: "hide_trailing_zeros",
+            type: "boolean",
+            help: _t("Hide zeros to the right of the last non-zero digit, e.g. 1.20 becomes 1.2"),
+        },
     ],
     supportedTypes: ["float", "integer", "monetary", "char", "one2many", "many2one"],
     isEmpty: () => false,
@@ -59,6 +70,7 @@ export const statInfoField = {
             labelField: options.label_field,
             noLabel: exprToBoolean(attrs.nolabel),
             string,
+            trailingZeros: !options.hide_trailing_zeros,
         };
     },
 };

--- a/addons/web/static/tests/views/fields/stat_info_field.test.js
+++ b/addons/web/static/tests/views/fields/stat_info_field.test.js
@@ -5,9 +5,10 @@ class Partner extends models.Model {
     foo = fields.Char({ default: "My little Foo Value" });
     int_field = fields.Integer({ string: "int_field" });
     qux = fields.Float({ digits: [16, 1] });
+    bar = fields.Float({ string: "Float field" });
     monetary = fields.Monetary({ currency_field: "" });
 
-    _records = [{ id: 1, foo: "yop", int_field: 10, qux: 0.44444, monetary: 9.999999 }];
+    _records = [{ id: 1, foo: "yop", int_field: 10, qux: 0.44444, bar: 9.1, monetary: 9.999999 }];
 }
 
 defineModels([Partner]);
@@ -38,6 +39,25 @@ test("StatInfoField formats decimal precision", async () => {
     });
     expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(1)").toHaveText("10.00", {
         message: "Currency decimal precision should be 2",
+    });
+});
+
+test("StatInfoField with 'hide_trailing_zeros' option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <button class="oe_stat_button" name="items" icon="fa-gear">
+                    <field name="bar" widget="statinfo" options="{'hide_trailing_zeros': true}" />
+                </button>
+            </form>
+        `,
+    });
+
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("9.1", {
+        message: "Value would show 9.10 without the option enabled",
     });
 });
 


### PR DESCRIPTION
*=purchase,sale,stock

Previously, unnecessary trailing zeros were shown in the 
statinfo widget and there was no option to hide them.

After this commit, the widget supports the 'hide_trailing_zeros' 
option to hide those zeros.

Also added this option in statinfo fields of product views.

Documentation PR: https://github.com/odoo/documentation/pull/15366

task-5238438

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
