### PR TITLE
[FIX] account: hide 'Export ZIP' on invoices that are not sent

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6767,7 +6767,7 @@ class AccountMove(models.Model):
     def get_extra_print_items(self):
         """ Helper to dynamically add items in the 'Print' menu of list and form of account.move.
         """
-        if posted_moves := self.filtered(lambda m: m.state == 'posted'):
+        if posted_moves := self.filtered(lambda m: m.state == 'posted' and m.is_move_sent):
             return [
                 {
                     'key': 'download_all',


### PR DESCRIPTION
**Steps to reproduce:**
* Install the *Accounting* module.
* Create a customer invoice.
* Post the invoice.
* Click the *gear* icon → **Print** → **Export ZIP**.
* Observe that the  invoice opens a blank page.

**Issue:**
* Clicking **Export ZIP** on an unsent invoice opens a blank page.

**Cause:**
* The `account.move.send` model returns an empty dataset when the invoice is not sent,
 leading to an empty export result.

**Fix:**
* Add a condition to display **Export ZIP** only when the invoice has been sent.

---
opw-5245483

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
