### PR TITLE
[FIX] website: fix default website filter in website search view

### DIFF
--- a/addons/website/static/src/components/views/page_search_model.js
+++ b/addons/website/static/src/components/views/page_search_model.js
@@ -48,7 +48,7 @@ export class PageSearchModel extends SearchModel {
             const websiteDomain =
                 this.resModel === "website.page"
                     ? [["id", "in", websitePageIds[website.id] || []]]
-                    : [["website_id", "in", [false, website.id]]];
+                    : ["|", ["website_id", "=", false], ["website_id", "=", website.id]];
 
             return {
                 name: `website_${website.id}`,


### PR DESCRIPTION
The current default filter in the website search view displays `Invalid record ID` when the `website_id` is set to `False`. 

<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/8b4db134-7a4e-40e5-b836-1d8f1c059be4" />


This commit aims to establish the correct domain for the default website filter, allowing it to be set to both `False` and the current `website_id`.

<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/86c9d1a6-4e0f-427b-979a-dba835c2fb0b" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
