### PR TITLE
[FIX] account: set copy=False on date fields in account.payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -15,7 +15,7 @@ class AccountPayment(models.Model):
 
     # == Business fields ==
     name = fields.Char(string="Number", compute='_compute_name', store=True)
-    date = fields.Date(default=fields.Date.context_today, required=True, tracking=True)
+    date = fields.Date(default=fields.Date.context_today, required=True, tracking=True, copy=False)
     move_id = fields.Many2one(
         comodel_name='account.move',
         string='Journal Entry',


### PR DESCRIPTION
This commit sets copy=False on these fields to ensure new duplicated payments start with empty or system-generated dates.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
