### PR TITLE
[IMP] hr_holidays: add hooks

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -144,3 +144,10 @@ class HrEmployee(models.Model):
             return 0
         calendars = self._get_calendars(date_from)
         return calendars[self.id].hours_per_day if calendars[self.id] else 24
+
+    def _is_time_off_manager(self):
+        """
+        Returns True if the current user is a leave manager of the employee of the leave.
+        Used as a hook for other apps.
+        """
+        return self.leave_manager_id == self.env.user

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -839,16 +839,16 @@ class HolidaysAllocation(models.Model):
             if state == 'confirm' or is_manager or val_type == 'no_validation':
                 continue
 
-            if not is_officer and self.env.user != allocation.employee_id.leave_manager_id:
+            if not is_officer and not allocation.employee_id._is_time_off_manager():
                 raise UserError(_('Only %s\'s Time Off Approver, a time off Officer/Responsible or Administrator can approve or refuse allocation requests.') % (allocation.employee_id.name))
 
             # both -> 1st approver and 2nd officer
-            if (val_type == 'manager' or state == 'validate1') and self.env.user != allocation.employee_id.leave_manager_id:
+            if (val_type == 'manager' or state == 'validate1') and not allocation.employee_id._is_time_off_manager():
                 raise UserError(_('You must be either %s\'s Time Off Approver or Time off Administrator to validate this allocation request.') % (allocation.employee_id.name))
             if (val_type == 'both' and state == 'validate' or val_type == 'hr') and not is_officer:
                 raise UserError(_('Only a time off Officer/Responsible or Administrator can approve or refuse allocation requests.'))
 
-            if is_officer or self.env.user == allocation.employee_id.leave_manager_id:
+            if is_officer or allocation.employee_id._is_time_off_manager():
                 # use ir.rule based first access check: department, members, ... (see security.xml)
                 allocation.check_access('write')
 


### PR DESCRIPTION
By adding this hooks, it is easier in the future to add extra modules This module might add several approvers or back-up approvers.

Current behavior before PR: there is no way to add backup approvers

Desired behavior after PR is merged: By bypassing the functionality to a function, it is easier to add extra changes.

On 19 and master, the behavior is different, but I can open a PR for that.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
