### PR TITLE
[FIX] spreadsheet: add day granularity when no date global filter is set 

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_feature_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_feature_plugin.js
@@ -6,35 +6,13 @@ export class OdooChartFeaturePlugin extends OdooUIPlugin {
     static getters = /** @type {const} */ (["getAvailableChartGranularities"]);
 
     overwrittenGranularities = {};
+    granularityOptionsCache = {};
 
     handle(cmd) {
         switch (cmd.type) {
             case "SET_GLOBAL_FILTER_VALUE": {
-                if (!this.getters.isDashboard()) {
-                    return;
-                }
-                const filterId = cmd.id;
-                const globalFilter = this.getters.getGlobalFilter(filterId);
-                if (globalFilter.type === "date") {
-                    const charts = this.getters.getOdooChartIds();
-                    for (const chartId of charts) {
-                        const { fieldName, granularity } =
-                            this.getters.getChartGranularity(chartId);
-                        const fieldMatching = this.getters.getChartFieldMatch(chartId)[filterId];
-                        const bestGranularity = getBestGranularity(cmd.value, fieldMatching);
-                        const validGranularities = getValidGranularities(cmd.value);
-                        if (
-                            fieldMatching?.chain === fieldName &&
-                            !validGranularities.includes(this.overwrittenGranularities[chartId]) &&
-                            bestGranularity !== granularity
-                        ) {
-                            this.dispatch("UPDATE_CHART_GRANULARITY", {
-                                chartId,
-                                granularity: bestGranularity,
-                            });
-                            this.overwrittenGranularities[chartId] = undefined;
-                        }
-                    }
+                if (this.getters.isDashboard()) {
+                    this._onGlobalFilterChange(cmd);
                 }
                 break;
             }
@@ -47,38 +25,73 @@ export class OdooChartFeaturePlugin extends OdooUIPlugin {
     }
 
     getAvailableChartGranularities(chartId) {
-        const definition = this.getters.getChartDefinition(chartId);
-        if (!definition.type.startsWith("odoo_")) {
-            return [];
+        if (this.granularityOptionsCache[chartId]) {
+            return this.granularityOptionsCache[chartId];
         }
-        const { granularity } = this.getters.getChartGranularity(chartId);
+        const { granularity, fieldName } = this.getters.getChartGranularity(chartId);
         if (!granularity) {
             return [];
         }
-        const filterId = this._getChartHorizontalAxisFilter(chartId);
-        const currentFilterValue = filterId
-            ? this.getters.getGlobalFilterValue(filterId)
-            : undefined;
-        const all = [
+        const allGranularities = [
+            { value: "hour", label: _t("Hours") },
             { value: "day", label: _t("Days") },
             { value: "week", label: _t("Weeks") },
             { value: "month", label: _t("Months") },
             { value: "quarter", label: _t("Quarters") },
             { value: "year", label: _t("Years") },
         ];
+        const filterId = this._getChartHorizontalAxisFilter(chartId, fieldName);
         const matching = this.getters.getOdooChartFieldMatching(chartId, filterId);
-        if (matching?.type === "datetime") {
-            all.unshift({ value: "hour", label: _t("Hours") });
+        if (matching?.type !== "datetime") {
+            allGranularities.shift();
         }
-        const validGranularities = getValidGranularities(currentFilterValue);
-        return all.filter(
-            ({ value }) => validGranularities.includes(value) || value === granularity
-        );
+        const currentFilterValue = filterId
+            ? this.getters.getGlobalFilterValue(filterId)
+            : undefined;
+        const allowed = getValidGranularities(currentFilterValue);
+        const available = allGranularities.filter(({ value }) => allowed.includes(value));
+
+        this.granularityOptionsCache[chartId] = available;
+        return available;
+    }
+
+    _onGlobalFilterChange(cmd) {
+        const filterId = cmd.id;
+        const globalFilter = this.getters.getGlobalFilter(filterId);
+        if (globalFilter.type !== "date") {
+            return;
+        }
+        for (const chartId of this.getters.getOdooChartIds()) {
+            const { fieldName, granularity: currentGranularity } =
+                this.getters.getChartGranularity(chartId);
+            const fieldMatching = this.getters.getChartFieldMatch(chartId)[filterId];
+            const bestGranularity = getBestGranularity(cmd.value, fieldMatching);
+            const validGranularities = getValidGranularities(cmd.value);
+            const shouldAutoUpdate =
+                fieldMatching?.chain === fieldName &&
+                !validGranularities.includes(this.overwrittenGranularities[chartId]) &&
+                bestGranularity !== currentGranularity;
+
+            if (shouldAutoUpdate) {
+                this.dispatch("UPDATE_CHART_GRANULARITY", {
+                    chartId,
+                    granularity: bestGranularity,
+                });
+                this.overwrittenGranularities[chartId] = undefined;
+            }
+            if (currentGranularity) {
+                this.granularityOptionsCache[chartId] = undefined;
+            }
+        }
     }
 
     _updateChartGranularity(chartId, granularity) {
         const definition = this.getters.getChartDefinition(chartId);
         const { fieldName } = this.getters.getChartGranularity(chartId);
+        const newGroupBy = [
+            `${fieldName}:${granularity}`,
+            ...definition.searchParams.groupBy.slice(1),
+        ];
         this.dispatch("UPDATE_CHART", {
             chartId,
             figureId: this.getters.getFigureIdFromChartId(chartId),
@@ -87,24 +100,17 @@ export class OdooChartFeaturePlugin extends OdooUIPlugin {
                 // I don't know why it's in both searchParams and metaData.
                 searchParams: {
                     ...definition.searchParams,
-                    groupBy: [
-                        `${fieldName}:${granularity}`,
-                        ...definition.searchParams.groupBy.slice(1),
-                    ],
+                    groupBy: newGroupBy,
                 },
                 metaData: {
                     ...definition.metaData,
-                    groupBy: [
-                        `${fieldName}:${granularity}`,
-                        ...definition.metaData.groupBy.slice(1),
-                    ],
+                    groupBy: newGroupBy,
                 },
             },
         });
     }
 
-    _getChartHorizontalAxisFilter(chartId) {
-        const { fieldName } = this.getters.getChartGranularity(chartId);
+    _getChartHorizontalAxisFilter(chartId, fieldName) {
         for (const filter of this.getters.getGlobalFilters()) {
             const matching = this.getters.getOdooChartFieldMatching(chartId, filter.id);
             if (matching?.chain === fieldName) {

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -64,7 +64,7 @@ export function getBestGranularity(dateFilterValue, fieldMatching) {
  */
 export function getValidGranularities(dateFilterValue) {
     if (!dateFilterValue) {
-        return ["week", "month", "quarter", "year"];
+        return ["day", "week", "month", "quarter", "year"];
     }
     const { from, to } = getDateRange(dateFilterValue);
     const numberOfDays = Math.round(to.diff(from, "days").days);

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -1536,6 +1536,7 @@ test("available granularities without filter", async () => {
     const chartId = model.getters.getChartIds(sheetId)[0];
 
     expect(model.getters.getAvailableChartGranularities(chartId).map((g) => g.value)).toEqual([
+        "day",
         "week",
         "month",
         "quarter",
@@ -1584,6 +1585,7 @@ test("available granularities with a date filter", async () => {
     );
     model.updateMode("dashboard");
     expect(model.getters.getAvailableChartGranularities(chartId).map((g) => g.value)).toEqual([
+        "day",
         "week",
         "month",
         "quarter",
@@ -1632,6 +1634,7 @@ test("hour is an available granularity with a filtered datetime field", async ()
     );
     model.updateMode("dashboard");
     expect(model.getters.getAvailableChartGranularities(chartId).map((g) => g.value)).toEqual([
+        "day",
         "week",
         "month",
         "quarter",


### PR DESCRIPTION
## Description

Current behavior before PR:
- Day granularity was not added when no date global filter was defined.
- Charts inserted from graph view with default day granularity behaved
  incorrectly. When switching from day to week granularity, day would
  disappear from the available options.
- Granularities were recomputed on every call, causing repeated work.


Desired behavior after PR is merged:
- Day granularity is now added to the available granularities when no
  date global filter is set.
- Granularities are cached per chart, avoiding repeated computation.
- Redundant code paths were cleaned up to simplify the logic.

Task: [5155481](https://www.odoo.com/odoo/project/2328/tasks/5155481)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
