### PR TITLE
[FIX] l10n_id: Fix xpath issue on l10n_id_qris fields

### DIFF
--- a/addons/l10n_id/views/res_bank.xml
+++ b/addons/l10n_id/views/res_bank.xml
@@ -6,7 +6,7 @@
         <field name="model">res.partner.bank</field>
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='currency_id']" position="after">
+            <xpath expr="//field[@name='allow_out_payment']/parent::group" position="inside">
                 <field name="l10n_id_qris_api_key" invisible="country_code != 'ID'"/>
                 <field name="l10n_id_qris_mid" invisible="country_code != 'ID'" />
             </xpath>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This issue occurs because the XPath targeting the `currency_id` field is placed inside a `<div>` that becomes invisible under certain conditions. The `view_partner_bank_form_inherit_hr` view is loaded first due to its sequence, and the `l10n_id` view is applied afterward, causing the QRIS fields to be inserted into that hidden `<div>` from `view_partner_bank_form_inherit_hr`.

**Current behavior before PR:**
The fields l10n_id_qris_api_key and l10n_id_qris_mid are not visible.

**Desired behavior after PR is merged:**
The fields l10n_id_qris_api_key and l10n_id_qris_mid are visible by changing XPath target

Task: [5247678](https://www.odoo.com/odoo/project.task/5247678)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
