### PR TITLE
[FIX] stock_account : ensure correct mapping of move_id using lot_id field

### DIFF
--- a/addons/stock_account/models/product_value.py
+++ b/addons/stock_account/models/product_value.py
@@ -83,7 +83,7 @@ class ProductValue(models.Model):
             else:
                 product_ids.add(vals['product_id'])
         if lot_ids:
-            move_ids.update(self.env['stock.move'].search([('lot_id', 'in', lot_ids)]).ids)
+            move_ids.update(self.env['stock.move.line'].search([('lot_id', 'in', lot_ids)]).move_id.ids)
         products = self.env['product.product'].browse(product_ids)
         if products:
             moves_by_product = products._get_remaining_moves()


### PR DESCRIPTION
**Steps to Reproduce the Issue**:

1. Install the following apps in version 19.0 database:
   * stock_account
2. Go to Settings → enable Lots & Serial Numbers.
3. Open the Inventory app, then go to Products and create a new product
with the following configuration:
   * Product Type: Goods
   * Track Inventory: By Unique Serial Number
   * Inventory tab: Enable Valuation by Lot/Serial
   * General Information tab: Create a new Product Category with:
     * Costing Method: AVCO (Average Cost)
4. Go to Products → Lots/Serial Numbers.
5. Create a new Lot/Serial Number and select the product you just created, then
click Save.
6. Now update the Cost in the Lot/Serial Number form and click Save again.
7. You will now encounter the trackback error.

**Description:**

In the [commit](odoo@22b9e1a#diff-2623d0e4c393b65afe1c6d00f55af80d19f022aaeb0da0e5e173e37a84138159R42) The `lot_id` is written but in `stock.move` model there is `lot_ids` [field]((https://github.com/odoo/odoo/blob/6496653de3c9bb2a3cde8e38fdda8fb7abe27713/addons/stock/models/stock_move.py#L189)) so it gives error `keyerror`.
Now i have used [`lot_id`](https://github.com/odoo/odoo/blob/9333df06e15134df92efed765cf95db38c0dfede/addons/stock/models/stock_move_line.py#L48) field of `stock.move.line` for mapping the `move_id` so that after price adjustment correct move value is set.

opw-[5266457](https://www.odoo.com/odoo/project/70/tasks/5266457)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
