### PR TITLE
[IMP] Prevent user from reseting invoice in draft while pos session is ongoing

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -112,11 +112,11 @@ class AccountMove(models.Model):
     def button_draft(self):
         if self.sudo().pos_order_ids.filtered(lambda o: o.session_id.state != 'closed'):
             self.env.user._bus_send("simple_notification", {
-                'type': 'warning',
-                'title': _("Warning: Invoice Reset Risk"),
-                'message': _("This invoice is linked to a POS Order, resetting it to draft prevents closing the session. You should rather refund the order or create a credit note."),
+                'type': 'danger',
+                'message': _("You can't reset this invoice to draft because the POS session is still open. Please close the ongoing session first, then try again."),
                 'sticky': True,
             })
+            return False
         return super().button_draft()
 
     @api.model

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -411,13 +411,12 @@ class TestPointOfSaleFlow(CommonPosTest):
         with patch.object(self.env.registry['bus.bus'], '_sendone') as mock_send:
             invoice.button_draft()
             mock_send.assert_called_with(self.env.user.partner_id, 'simple_notification', {
-                'type': 'warning',
-                'title': "Warning: Invoice Reset Risk",
-                'message': "This invoice is linked to a POS Order, resetting it to draft prevents closing the session. You should rather refund the order or create a credit note.",
+                'type': 'danger',
+                'message': "You can't reset this invoice to draft because the POS session is still open. Please close the ongoing session first, then try again.",
                 'sticky': True,
             })
 
-        invoice.action_post()
+        self.assertEqual(invoice.state, 'posted')
 
         self.assertAlmostEqual(invoice.amount_total, order.amount_total, places=2)
 

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1049,16 +1049,9 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         invoice = pos_order.account_move
         self.assertEqual(invoice.state, 'posted')
 
-        # when clicking on cancel button
+        # when clicking on draft button, it must keep posted because if the pos is open
+        # we cannot cancel the invoice.
         invoice.button_draft()
-        self.assertEqual(invoice.state, 'draft')
-        invoice.button_cancel()
-        self.assertEqual(invoice.state, 'cancel')
-
-        # when clicking on confirm button
-        invoice.button_draft()
-        self.assertEqual(invoice.state, 'draft')
-        invoice.action_post()
         self.assertEqual(invoice.state, 'posted')
 
     def test_pos_order_and_invoice_amounts(self):


### PR DESCRIPTION
Before this commit, when trying to reset to draft an invoice linked to a POS order with an ongoing session, a warning notification was sent but the action was still performed.

Now, the user is prevented from doing so and an error notification is sent instead.

task: 5265836

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
