### PR TITLE
[FIX] website_sale, adding website_id in portal controller

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -2125,7 +2125,12 @@ class CustomerPortal(sale_portal.CustomerPortal):
         :return: The payment-specific values.
         :rtype: dict
         """
-        website_id = website_id or order_sudo.website_id.id
+        if not website_id:
+            if order_sudo.website_id:
+                website_id = order_sudo.website_id.id
+            elif request.website:
+                website_id = request.website.id
+
         return super()._get_payment_values(order_sudo, website_id=website_id, **kwargs)
 
     def _sale_reorder_get_line_context(self):

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_delivery_controller
 from . import test_delivery_express_checkout_flows
 from . import test_delivery_ui
 from . import test_express_checkout_flows
+from . import test_main_controller
 from . import test_sale_order
 from . import test_sale_process
 from . import test_sitemap

--- a/addons/website_sale/tests/test_main_controller.py
+++ b/addons/website_sale/tests/test_main_controller.py
@@ -1,0 +1,52 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+from odoo.tests import tagged
+
+from odoo.addons.payment.models.payment_provider import PaymentProvider
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.addons.sale.tests.common import SaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestPaymentProviderVisibility(PaymentHttpCommon, SaleCommon):
+
+    def test_payment_provider_visibility_with_portal(self):
+        """Check providers availability on the sales portal.
+
+        The current website must be considered to filter the providers.
+        """
+        website_portal = self.env['website'].get_current_website()
+        website_shop = self.env['website'].create({'name': "Shop Website"})
+
+        base_url = self.env['ir.config_parameter'].sudo().get_base_url()
+        website_portal.write({'domain': base_url})
+
+        self.provider.write({'website_id': website_portal.id})
+        restricted_provider = self.env['payment.provider'].sudo().search([('name', '=', 'Demo')])
+        restricted_provider.write({'state': 'test', 'website_id': website_shop.id})
+
+        url_so = self.sale_order.get_portal_url()
+        portal_url = f"{website_portal.domain}{url_so}"
+
+        with patch(
+            'odoo.addons.website_payment.models.payment_provider.PaymentProvider._get_compatible_providers',
+            side_effect=lambda *args, **kwargs: PaymentProvider._get_compatible_providers(
+                self.env['payment.provider'], *args, **kwargs
+            ),
+        ) as mock_method:
+            self.url_open(portal_url, allow_redirects=True)
+
+            mock_method.assert_called_once()
+            self.assertEqual(mock_method.call_args.kwargs['website_id'], website_portal.id)
+
+        providers = self.env['payment.provider']._get_compatible_providers(
+            *mock_method.call_args.args, **mock_method.call_args.kwargs
+        )
+
+        self.assertIn(self.provider.id, providers.ids, "The visible provider should be visible.")
+
+        self.assertNotIn(
+            restricted_provider.id, providers.ids, "The restricted provider shouldn't be visible."
+        )


### PR DESCRIPTION
[FIX] website_sale, adding website_id in portal controller

Version: 17.0+e

Steps to reproduce
------------------
The database has two different websites.

A payment provider is enabled for just one of them (website1).

When a sale order is created on the sales app and the customer accesses it in its portal on the website2, he is able to pay with the payment provider which is only enabled on website1.

The problem also occurs when previewing the customer’s portal view.

Why it's happening
------------------
When accessing an order via “/my/orders/<int:order\_id>”, the portal_order_page method calls _get_compatible_providers without passing the website_id. The overriding logic in website_payment then defaults to considering all activated payment methods as compatible, regardless of website restrictions.

As no website_id is provided, the overriding method from the payment_provider extension in website_payment module considers every activated payment methods as compatible.

The Fix
-------
We now add the current website's id to the method if none has been added before.


opw-5172444, “Payment provider visible on sales order portal"


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
