### PR TITLE
[FIX] pos_loyalty: Ensure postSyncAllOrders is awaited

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1183,7 +1183,7 @@ export class PosStore extends Reactive {
 
     // There for override
     async preSyncAllOrders(orders) {}
-    postSyncAllOrders(orders) {}
+    async postSyncAllOrders(orders) {}
     async syncAllOrders(options = {}) {
         const { orderToCreate, orderToUpdate } = this.getPendingOrder();
         let orders = options.orders || [...orderToCreate, ...orderToUpdate];
@@ -1241,7 +1241,7 @@ export class PosStore extends Reactive {
                     }
                 }
 
-                this.postSyncAllOrders(newData["pos.order"]);
+                await this.postSyncAllOrders(newData["pos.order"]);
                 this.removePendingOrder(order);
                 syncedOrders.push(...newData["pos.order"]);
                 order.clearCommands();

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -758,8 +758,8 @@ patch(PosStore.prototype, {
             );
         }
     },
-    postSyncAllOrders(orders) {
-        super.postSyncAllOrders(orders);
+    async postSyncAllOrders(orders) {
+        await super.postSyncAllOrders(orders);
 
         for (const order of orders) {
             for (const line of order.lines) {
@@ -780,7 +780,7 @@ patch(PosStore.prototype, {
                     });
                 }
             }
-            this._postProcessLoyalty(order);
+            await this._postProcessLoyalty(order);
         }
     },
     async _postProcessLoyalty(order) {


### PR DESCRIPTION
Before this commit, it was possible that double gift cards were created when syncing orders with preparation display. This was due to the fact that the postSyncAllOrders method was not awaited, leading to duplicate processing of loyalty when calling syncAllOrders twice.

opw-5246407

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
