### PR TITLE
[FIX] web: avoid error when platform key is removed from navigator

### DIFF
--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -38,9 +38,13 @@ export function isAndroid() {
 }
 
 export function isIOS() {
+    let isIOSPlatform = false;
+    if ("platform" in browser.navigator) {
+        isIOSPlatform = browser.navigator.platform === "MacIntel";
+    }
     return (
         /(iPad|iPhone|iPod)/i.test(browser.navigator.userAgent) ||
-        (browser.navigator.platform === "MacIntel" && maxTouchPoints() > 1)
+        (isIOSPlatform && maxTouchPoints() > 1)
     );
 }
 


### PR DESCRIPTION
This commit uses "Feature detection" to avoid some error when the platform key is not available from navigator.

> The platform property indicates the platform/OS the browser is running on.
> Theoretically this information is useful for detecting the browser and serving code to work around browser-specific bugs or lack of feature support. However, this is unreliable and is not recommended for the reasons given in User-Agent reduction and Browser detection using the user agent.
> Feature detection is a much more reliable strategy.

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Testing/Feature_detection

task-4420689

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
