### PR TITLE
[FIX] html_editor: select single cell from backward

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -673,8 +673,8 @@ export class TablePlugin extends Plugin {
             // Do not prevent default when there is a text in cell.
             if (focusNode.nodeType === Node.TEXT_NODE) {
                 const textNodes = descendants(startTd).filter(isTextNode);
-                const lastTextChild = textNodes.pop();
-                const firstTextChild = textNodes.shift();
+                const lastTextChild = textNodes[textNodes.length - 1];
+                const firstTextChild = textNodes[0];
                 const isAtTextBoundary = {
                     ArrowRight: nodeSize(focusNode) === focusOffset && focusNode === lastTextChild,
                     ArrowLeft: focusOffset === 0 && focusNode === firstTextChild,

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1641,6 +1641,53 @@ describe("symmetrical selection", () => {
             </table>`
         );
     });
+
+    test("select single cell containing text when pressing shift + arrow key backward", async () => {
+        const { el } = await setupEditor(
+            unformat(
+                `<table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td>ab</td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>`
+            )
+        );
+
+        const secondTd = el.querySelectorAll("td")[1];
+        setSelection({
+            anchorNode: secondTd,
+            anchorOffset: nodeSize(secondTd),
+            focusNode: secondTd,
+            focusOffset: 0,
+        }); // <td>]ab[</td>
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td><br></td><td class="o_selected_td">]ab[</td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">]<br></td><td class="o_selected_td">ab[</td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+    });
 });
 
 describe("single cell selection", () => {


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- In an m × n table, type some text inside a cell.
- Place the cursor at the end of the text.
- Hold Shift and repeatedly press ArrowLeft until the entire cell becomes selected.

Once the cell content is fully selected, the cell itself is selected along with its adjacent cell, instead of only the current cell.

**Desired behavior after PR:**

After selecting all text, the current cell alone should become selected. Pressing Shift + ArrowLeft again should then extend the selection to the adjacent cell.

task-5268801



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
