### PR TITLE
[FIX] web: Hoot - setInputFile in shadow roots

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/events.js
+++ b/addons/web/static/lib/hoot-dom/helpers/events.js
@@ -793,8 +793,9 @@ function registerButton(eventInit, toggle) {
  * @param {Event} ev
  */
 function registerFileInput({ target }) {
-    if (getTag(target) === "input" && target.type === "file") {
-        runTime.fileInput = target;
+    const actualTarget = target.shadowRoot ? target.shadowRoot.activeElement : target;
+    if (getTag(actualTarget) === "input" && actualTarget.type === "file") {
+        runTime.fileInput = actualTarget;
     } else {
         runTime.fileInput = null;
     }

--- a/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
@@ -1434,6 +1434,24 @@ describe(parseUrl(import.meta.url), () => {
         expect("input").toHaveValue(/file\.txt/);
     });
 
+    test("setInputFiles: shadow root", async () => {
+        await mountForTest(/* xml */ `
+            <div class="container" />
+        `);
+
+        const shadow = queryOne(".container").attachShadow({
+            mode: "open",
+        });
+        const input = document.createElement("input");
+        input.type = "file";
+        shadow.appendChild(input);
+
+        await click(".container:shadow input");
+        await setInputFiles(new File([""], "file.txt"));
+
+        expect(".container:shadow input").toHaveValue(/file\.txt/);
+    });
+
     test("setInputRange: basic case and events", async () => {
         await mountForTest(/* xml */ `<input type="range" min="10" max="40" />`);
 


### PR DESCRIPTION
Before this commit, using 'setInputFile' after interacting with an element contained in any shadow root would not work ("no input has been interacted with" error).

This commit allows the listeners responsible for detecting clicks/focus on file inputs to handle the shadow root cases properly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
