### PR TITLE
[FIX] account: Make bill date required

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3,7 +3,7 @@
 import ast
 import calendar
 from collections import Counter, defaultdict
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, nullcontext
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
 from hashlib import sha256
@@ -5446,13 +5446,14 @@ class AccountMove(models.Model):
 
             # Handle case when the invoice_date is not set. In that case, the invoice_date is set at today and then,
             # lines are recomputed accordingly (if the user didnt' change the rate manually)
-            if not invoice.invoice_date and invoice.is_invoice(include_receipts=True):
-                if invoice.invoice_currency_rate != invoice.expected_currency_rate:
+            if not invoice.invoice_date:
+                if invoice.is_sale_document(include_receipts=True):
+                    is_manual_rate = invoice.invoice_currency_rate != invoice.expected_currency_rate
                     # keep the rate set by the user
-                    with self.env.protecting([self._fields['invoice_currency_rate']], invoice):
+                    with self.env.protecting([self._fields['invoice_currency_rate']], invoice) if is_manual_rate else nullcontext():
                         invoice.invoice_date = fields.Date.context_today(self)
-                else:
-                    invoice.invoice_date = fields.Date.context_today(self)
+                elif invoice.is_purchase_document(include_receipts=True):
+                    validation_msgs.add(_("The Bill/Refund date is required to validate this document."))
 
         for move in self:
             if move.state in ['posted', 'cancel']:

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
-from odoo import Command
+from odoo import Command, fields
 
 from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 
@@ -102,6 +102,7 @@ class TestUi(AccountTestInvoicingHttpCommon):
         move = self.env['account.move'].create({
             'move_type': 'in_invoice',
             'partner_id': partner.id,
+            'invoice_date': fields.Date.today(),
             'line_ids': [Command.create({'name': "T-shirt", 'deductible_amount': 50.0})],
         })
         move.action_post()

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1035,7 +1035,7 @@
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"/>
                                 <field name="invoice_date" nolabel="1" options="{'warn_future': true}"
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
-                                       readonly="state != 'draft'" placeholder="Today"/>
+                                       readonly="state != 'draft'"/>
 
                                 <field name="date" string="Accounting Date"
                                        invisible="move_type in ('out_invoice', 'out_refund', 'out_receipt') and not quick_edit_mode and not (state == 'posted' and date != invoice_date)"

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -626,6 +626,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             'company_id': self.env.company.id,
             'partner_id': self.valid_partner.id,
             'date': '2023-01-01',
+            'invoice_date': '2023-01-01',
             'ref': 'Test vendor bill reference',
             'invoice_line_ids': [
                 (0, 0, {
@@ -679,6 +680,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             'company_id': self.env.company.id,
             'partner_id': self.valid_partner.id,
             'date': '2023-01-01',
+            'invoice_date': '2023-01-01',
             'ref': 'Test vendor bill reference',
             'invoice_line_ids': [
                 (0, 0, {

--- a/addons/stock_account/tests/common.py
+++ b/addons/stock_account/tests/common.py
@@ -1,4 +1,4 @@
-from odoo import Command
+from odoo import Command, fields
 from odoo.tools.misc import clean_context
 from odoo.tests import Form
 from odoo.addons.base.tests.common import BaseCommon
@@ -19,6 +19,7 @@ class TestStockValuationCommon(BaseCommon):
         invoice_vals = {
             "partner_id": self.vendor.id,
             "move_type": move_type,
+            "invoice_date": fields.Date.today(),
             "invoice_line_ids": [],
         }
         if kwargs.get('reversed_entry_id'):


### PR DESCRIPTION
Defaulting the bill date to today (behavior since 19.0) is error-prone for accounting (e.g., VAT periods,
deductibility) as the bill date rarely matches the posting date.

This commit restores the validation error if the date is empty on vendor bills, forcing a user to enter
the correct date.

task-5214234



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
