### PR TITLE
[FIX] web: center image_field buttons

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.scss
+++ b/addons/web/static/src/views/fields/image/image_field.scss
@@ -3,6 +3,9 @@
 
     button {
         transition: opacity ease 400ms;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         width: 26px;
         height: 26px;
     }


### PR DESCRIPTION
The buttons in image_field are not centered vertically. Since it's a custom sized button, using flex is reliable (it's now centered on both flex axis).

Note: Done in SCSS instead of utilities because the flex is there to compensate the custom size set in SCSS (easier to maintain) + there could be injected buttons in the component.

task-5258887


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
