### PR TITLE
[FIX] hr_attendance: Officer/Admin gets Traceback while Onboarding

### DIFF
--- a/addons/hr_attendance/static/src/views/attendance_helper_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.js
@@ -13,8 +13,9 @@ export class AttendanceActionHelper extends Component {
             hasDemoData: false,
         });
         onWillStart(async () => {
+            this.isHrUser = await user.hasGroup("hr.group_hr_user");
             this.hasAttendanceRight = await user.hasGroup("hr_attendance.group_hr_attendance_user");
-            if (this.hasAttendanceRight){
+            if (this.hasAttendanceRight && this.isHrUser){
                 this.state.hasDemoData = await this.orm.call("hr.attendance", "has_demo_data", []);
             }
         });

--- a/addons/hr_attendance/static/src/views/attendance_helper_view.xml
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.xml
@@ -3,7 +3,7 @@
     <t t-name="hr_attendance.AttendanceActionHelper">
         <div class="o_view_nocontent">
             <div class="o_nocontent_help">
-                <t t-if="hasAttendanceRight">
+                <t t-if="hasAttendanceRight and isHrUser">
                     <t t-if="env.isSmall">
                         <t t-call="hr_attendance.AttendanceActionHelperMobileScreen"/>
                     </t>

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -493,6 +493,6 @@
 
     <menuitem id="menu_hr_attendance_configuration" name="Configuration" parent="menu_hr_attendance_root" sequence="99" groups="hr_attendance.group_hr_attendance_manager"/>
 
-    <menuitem id="menu_hr_attendance_onboarding" name="Onboarding" action="action_try_kiosk" parent="menu_hr_attendance_configuration" sequence="100"/>
+    <menuitem id="menu_hr_attendance_onboarding" name="Onboarding" action="action_try_kiosk" parent="menu_hr_attendance_configuration" sequence="100" groups="hr.group_hr_user"/>
 
 </odoo>


### PR DESCRIPTION
# Issue
Getting a traceback when trying to access the onboarding menu with just Attendance: Officer access right.
# Steps to reproduce
1. Log in with a demo user, with just Attendance: Officer access right.
2. Navigate to Attendances app, and yes, you don't see Configuration, but still you can access the Onboarding menu by typing some random text on search.
3. Now, navigate to the Onboarding menu, and try setting a badge of an employee
4. You get a traceback.
# Fix
Attendance: Officer/Admin without Employee rights (either Officer/Admin) will not be able to access the Attendances Onboarding menu. Only the user with both the rights can access it.

task-5267189

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
