### PR TITLE
[IMP] account: allow to mass edit journal in invoice list view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -529,6 +529,7 @@
                     <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" groups="base.group_user" string="Vendor" />
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" groups="base.group_user" string="Customer" />
+                    <field name="journal_id" optional="hide"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" readonly="state != 'draft'" string="Invoice Date" decoration-warning="abnormal_date_warning"/>
                     <field name="date" optional="hide" string="Accounting Date" readonly="state in ['cancel', 'posted']"/>


### PR DESCRIPTION
Since 19.1 [1], it's possible to mass edit invoices in list view. Let's add the journal in optional=hide to allow user to easily mass edit journal. Note that this only works when invoices are in draft. This is particularly usefull for Peppol since all invoices will arrive in the same journal.

[1]: https://github.com/odoo/odoo/commit/af368c872fcbdd952dffde47abcdc7d1fd02f298
task-id: 4815773