### PR TITLE
[PERF] point_of_sale: optimize loading of product configurator popup

### DIFF
--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -69,4 +69,4 @@ class ProductTemplateAttributeExclusion(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['value_ids']
+        return ['product_template_attribute_value_id', 'value_ids']

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
@@ -5,9 +5,9 @@ export class ProductTemplateAttributeValue extends Base {
     static pythonModel = "product.template.attribute.value";
 
     get exclusions() {
-        const values = this.models["product.template.attribute.value"].filter((value) =>
-            value.exclude_for.some(({ value_ids }) => value_ids.some(({ id }) => id === this.id))
-        );
+        const values = this.models["product.template.attribute.exclusion"]
+            .filter(({ value_ids }) => value_ids.some(({ id }) => id === this.id))
+            .map((exclusion) => exclusion.product_template_attribute_value_id);
 
         return [...this.exclude_for.flatMap(({ value_ids }) => value_ids), ...values];
     }


### PR DESCRIPTION
Before this commit, to compute the exclusions of a ptav, it would loop through all ptav records to find those that exclude the current one. This could be slow when there are many attributes and values.

opw-5230890

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
