### PR TITLE
[FIX] purchase: correct unit price and discount when adding POL via catalog

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1043,7 +1043,8 @@ class PurchaseOrder(models.Model):
                 uom_id=pol.product_uom)
             if seller:
                 # Fix the PO line's price on the seller's one.
-                pol.price_unit = seller.price_discounted
+                pol.price_unit = seller.price
+                pol.discount = seller.discount
         return pol.price_unit_discounted
 
     def _create_update_date_activity(self, updated_dates):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -953,3 +953,26 @@ class TestPurchase(AccountTestInvoicingCommon):
             self.env['base'].get_base_url(), message.mail_ids.body_html,
             "Mail shouldn't link to the base URL",
         )
+
+    def test_product_price_on_purchase_order_view_catalog(self):
+        """
+        Ensure vendor price & discount from supplierinfo are applied
+        properly when using the vendor catalog popup.
+        """
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'price': 100,
+                    'discount': 10,
+                })
+            ]
+        })
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        purchase_order._update_order_line_info(product.id, 1)
+        self.assertRecordValues(purchase_order.order_line, [
+            {'price_unit': 100, 'discount': 10, 'price_unit_discounted': 90},
+        ])


### PR DESCRIPTION
**Steps to reproduce:**

- Install the `purchase_stock` module.
- Create a product and configure a Vendor Pricelist for a vendor.
Include a discount on the vendor pricelist line.
- Create a Purchase Order for the same vendor.
- In the Purchase Order, add a Purchase Order Line using 
the catalog (vendor catalog popup) and add a configured product.

**Observed behavior:**
- The unit price on the Purchase Order Line becomes vendor `unit price − discount`
The `discount` field remains empty, causing incorrect price calculations.

---
**Example**
---

Product-A  - > Vendor Price list - > Vendor - > Test Vendor, Unit price = 100 and discount 10

- Create PO with `Test Vendor` and add a Product to POL via catalog then

 **Current behavior:**
Product - A , qty - >1, unit price -> 90, discount->0% , subtotal ->90 

 **Expected behavior :**
Product-A , qty->1, unit_price->100, discount->10%, subtotal->90

---

**Cause:**
- The catalog selection applies the vendor pricelist discount directly to 
the unit price instead of populating the discount field.

**Fix:**
- Use the vendor pricelist's price as the `unit_price` and apply 
vendor pricelist discount to the discount field on the Purchase Order Line.

---
`NOTE` - This issue is resolved from version 18.2, In this [Commit](https://github.com/odoo/odoo/pull/227695/commits/6b91f393353bcdaeed076d58dcac3149ed587e77#diff-1281da5f4d0a3daaf162a2e6456469537d1b74b8034437783c9c717307aa8fcd)

---
opw-5217345

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
