### PR TITLE
[FIX] account, l10n_gcc_invoice: Fix illegal tag in report_invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -439,11 +439,17 @@
                                         <div t-if='o.show_payment_term_details' id="total_payment_term_details_table" class="row">
                                             <div t-attf-class="#{'col-10' if report_type != 'html' else 'col-sm-10 col-md-9'}">
                                                 <t t-if="o._is_eligible_for_early_payment_discount(o.currency_id,o.invoice_date)">
-                                                    <td>
+                                                    <!--
+                                                        This is required in stable to void breaking xpath to show_payment_term_details//td,
+                                                        which is illegal because a td cannot be alone.
+                                                        To be removed in master.
+                                                    -->
+                                                    <table class="d-none"><tbody><tr><td/></tr></tbody></table>
+                                                    <div id="early_payment_discount">
                                                         <span t-options='{"widget": "monetary", "display_currency": o.currency_id}'
                                                               t-out="o.invoice_payment_term_id._get_amount_due_after_discount(o.amount_total, o.amount_tax)">30.00</span> due if paid before
                                                         <span t-out="o.invoice_payment_term_id._get_last_discount_date_formatted(o.invoice_date)">2024-01-01</span>
-                                                    </td>
+                                                    </div>
                                                 </t>
                                                 <t t-if="len(payment_term_details) > 1" t-foreach="payment_term_details" t-as="term">
                                                     <div>
@@ -504,6 +510,7 @@
                                 <div class="text-muted mb-3" t-attf-style="#{'text-align:justify;text-justify:inter-word;' if o.company_id.terms_type != 'html' else ''}" t-if="not is_html_empty(o.narration)" name="comment">
                                     <span t-field="o.narration"/>
                                 </div>
+                                <div class="oe_structure"></div>
                             </div>
                         </div>
                     </div>

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -181,6 +181,18 @@
                     <span t-out="o_sec.invoice_payment_term_id._get_last_discount_date_formatted(o_sec.invoice_date)" dir="ltr">2024-01-01</span>
                 </td>
             </xpath>
+             <xpath expr="//div[@id='total_payment_term_details_table']//div[@id='early_payment_discount']" position="before">
+                <div name="td_payment_term_ar" t-if="display_in_ar" t-translation="off">
+                    <span t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}'
+                          t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax)" dir="rtl">30.00</span> المبلغ المستحق إذا تم الدفع قبل
+                    <span t-out="o_sec.invoice_payment_term_id._get_last_discount_date_formatted(o_sec.invoice_date)" dir="rtl">2024-01-01</span>
+                </div>
+                <div name="td_payment_term_en" t-if="display_in_en" t-translation="off">
+                    <span t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}'
+                          t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax)" dir="ltr">30.00</span> due if paid before
+                    <span t-out="o_sec.invoice_payment_term_id._get_last_discount_date_formatted(o_sec.invoice_date)" dir="ltr">2024-01-01</span>
+                </div>
+            </xpath>
             <xpath expr="//div[@id='total_payment_term_details_table']//t[2]" position="before">
                 <t name="div_payment_term_ar" t-if="len(payment_term_details_sec) > 1 and display_in_ar" t-foreach="payment_term_details_sec" t-as="term" t-translation="off">
                     <div dir="rtl">


### PR DESCRIPTION
This commit fixes an issue from report_invoice_document.
In the “show_payment_term_details” t-if, there was a single td
containing the `invoice_payment_term_id`.

In another module, `l10n_gcc_invoice`, we use this td in the following
xpath:
```xml
<xpath expr="//div[@id='total_payment_term_details_table']//td" position="before">
```
The problem is that a td cannot be used outside of a table, which will
cause incorrect HTML to be generated and therefore prevent Studio from
working on it.

One solution would be to replace the incorrect td with div, add a class
`early_payment_discount` to it, and create a new customization that
would target this time
```xml
<xpath expr="//div[@id='total_payment_term_details_table']//div[@id='early_payment_discount']" position="before">
```

In order not to break the current customization targeting the old
incorrect td, we keep it but this time in a correct `table/tbody/tr/`
and we do not display it in the final report.
This will be removed in master.

A new `oe_structure` has also been added below the Terms to allow people
who want to add a field below to do so, as this is currently not
possible. The only way to do this is to add a modification to the terms,
which will only be displayed if this field is not empty because it is in
a t-if.

opw-5248145
opw-5879285
opw-5410727
opw-5476981
opw-5381578
opw-5369618
opw-5485437
opw-5498946
opw-5331519