### PR TITLE
[IMP] web,*: make tests with error dialogs more robust

### DIFF
--- a/addons/base_automation/static/tests/base_automation_error_dialog.test.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.test.js
@@ -1,6 +1,7 @@
 import { BaseAutomationErrorDialog } from "@base_automation/base_automation_error_dialog";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import {
     makeServerError,
@@ -85,7 +86,7 @@ test("display automation rule id and name in Error dialog", async () => {
     });
     await mountWithCleanup(MainComponentsContainer);
     Promise.reject(error);
-    await animationFrame();
+    await waitFor(".modal");
     expect.verifyErrors(["Message"]);
     expect.verifySteps(["error setup"]);
     expect(".modal-body p.mt-2").toHaveText(

--- a/addons/web/static/tests/core/dialog_service.test.js
+++ b/addons/web/static/tests/core/dialog_service.test.js
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach } from "@odoo/hoot";
+import { test, expect, beforeEach, waitFor } from "@odoo/hoot";
 import { click, press, queryAll, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { getService, mountWithCleanup } from "@web/../tests/web_test_helpers";
@@ -198,8 +198,7 @@ test("dialog component crashes", async () => {
     }
 
     getService("dialog").add(FailingDialog);
-    await animationFrame();
-
+    await waitFor(".o_error_dialog");
     expect(".modal .o_error_dialog").toHaveCount(1);
     expect.verifyErrors(["Error: Some Error"]);
 });

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -2633,6 +2633,7 @@ test("failing quick create on a many2one because ValidationError", async () => {
 
 test("failing quick create on a many2one", async () => {
     expect.assertions(3);
+    expect.errors(1);
     Product._views = {
         form: '<form><field name="name" /></form>',
     };
@@ -2648,7 +2649,6 @@ test("failing quick create on a many2one", async () => {
 
     await contains(".o_field_widget[name='product_id'] input").edit("abcd", { confirm: false });
     await runAllTimers();
-    expect.errors(1);
     await contains(".o_field_widget[name='product_id'] .o_m2o_dropdown_option_create").click();
     await animationFrame(); // wait for the error service
     expect.verifyErrors(["RPC_ERROR"]);

--- a/addons/web/static/tests/webclient/actions/misc.test.js
+++ b/addons/web/static/tests/webclient/actions/misc.test.js
@@ -292,7 +292,7 @@ test("properly handle case when action id does not exist", async () => {
     expect.errors(1);
     await mountWithCleanup(WebClient);
     getService("action").doAction(4448);
-    await animationFrame();
+    await waitFor(".o_error_dialog");
     expect.verifyErrors(["RPC_ERROR"]);
     expect(`.modal .o_error_dialog`).toHaveCount(1);
     expect(".o_error_dialog .modal-body").toHaveText("The action 4448 does not exist");
@@ -302,7 +302,7 @@ test("properly handle case when action path does not exist", async () => {
     expect.errors(1);
     await mountWithCleanup(WebClient);
     getService("action").doAction("plop");
-    await animationFrame();
+    await waitFor(".o_error_dialog");
     expect.verifyErrors(["RPC_ERROR"]);
     expect(`.modal .o_error_dialog`).toHaveCount(1);
     expect(".o_error_dialog .modal-body").toHaveText('The action "plop" does not exist');
@@ -312,7 +312,7 @@ test("properly handle case when action xmlId does not exist", async () => {
     expect.errors(1);
     await mountWithCleanup(WebClient);
     getService("action").doAction("not.found.action");
-    await animationFrame();
+    await waitFor(".o_error_dialog");
     expect.verifyErrors(["RPC_ERROR"]);
     expect(`.modal .o_error_dialog`).toHaveCount(1);
     expect(".o_error_dialog .modal-body").toHaveText(

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -13,6 +13,7 @@ import { animationFrame, Deferred, mockSendBeacon, mockTouch, runAllTimers } fro
 import {
     clickModalButton,
     clickSave,
+    contains,
     defineActions,
     defineModels,
     editSearch,
@@ -1267,10 +1268,8 @@ test("click on save button which throws an error", async () => {
     expect(".o_form_button_save").toHaveCount(1);
     expect(".o_form_button_save").toHaveProperty("disabled", false);
 
-    await click(".o_field_boolean input[type='checkbox']");
-    await animationFrame();
-    await click(".o_form_button_save");
-    await animationFrame();
+    await contains(".o_field_boolean input[type='checkbox']").click();
+    await contains(".o_form_button_save").click();
     // error are caught asynchronously, so we have to wait for an extra animationFrame, for the error dialog to be mounted
     await animationFrame();
     expect.verifyErrors(["RPC_ERROR"]);


### PR DESCRIPTION
*base_automation

The `unhandledrejection` event is triggered asynchronously in JS. Once this event is triggered, the error is handled and an error dialog might be displayed, depending on the type or error being thrown. In several tests, after throwing an error, we only waited for an animation frame before asserting the presence of the error dialog. This only works if the `unhandledrejection` event is fired before the next animation frame, which isn't guaranteed. When it is not the case, the test fails because the error dialog is not there yet.

We already had to fix that kind of issues multiple times, after impacted tests were caught failing non deterministically on runbot (e.g. [1][2][3]).

This commit fixes several other occurrences of the faulty pattern, which haven't been spotted yet but could have non deterministically failed as well.

[1] https://github.com/odoo/odoo/pull/178491
[2] https://github.com/odoo/odoo/pull/235446
[3] https://github.com/odoo/odoo/pull/235464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
