### PR TITLE
[FIX] mail: fix poll result text overflow and icon alignment

### DIFF
--- a/addons/mail/static/src/core/common/poll_result.xml
+++ b/addons/mail/static/src/core/common/poll_result.xml
@@ -3,8 +3,8 @@
     <t t-name="mail.PollResult">
         <div class="w-100">
             <div class="o-mail-PollResult card border border-secondary rounded shadow-sm my-2 p-2 w-100">
-                <div class="d-flex gap-1 align-items-center fw-bold text-muted card-title small">
-                    <i class="oi oi-view-cohort"/>
+                <div class="d-flex gap-1 align-items-start fw-bold text-muted text-break card-title small">
+                    <i class="oi oi-view-cohort mt-1"/>
                     <span t-out="props.poll.pollClosedText"/>
                 </div>
                 <div class="card-body text-muted d-flex gap-2 align-items-center p-0 ms-3">


### PR DESCRIPTION
**Current behavior before PR:**
Before this PR, long poll names would overflow the poll result card boundaries, and the `oi-view-cohort` icon would become vertically centered instead of top-aligned.

**Desired behavior after PR is merged:**
This PR resolves the text overflow issue and ensures the icon remains properly aligned at the top with the poll text.

Before:
<img width="1455" height="647" alt="image" src="https://github.com/user-attachments/assets/52ca374b-7d24-4c4c-a58b-eebe22a65bc6" />

After:
<img width="640" height="617" alt="image" src="https://github.com/user-attachments/assets/706783f7-c64a-4a7e-bc4c-df3c1d9dd1de" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
