### PR TITLE
[REM] hr_{work_entry,}_holidays: drop mode field in multi-generate wizards

### DIFF
--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -72,25 +72,9 @@ class TestAllocations(TestHrHolidaysCommon):
             'request_unit': 'day',
         })
 
-    def test_allocation_whole_company(self):
-        company_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
-            'name': 'Bank Holiday',
-            'allocation_mode': 'company',
-            'company_id': self.company.id,
-            'holiday_status_id': self.leave_type.id,
-            'duration': 2,
-            'allocation_type': 'regular',
-        })
-
-        company_allocation.action_generate_allocations()
-
-        num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id)])
-        self.assertEqual(num_of_allocations, 1)
-
     def test_allocation_multi_employee(self):
         employee_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'employee',
             'employee_ids': [(4, self.employee.id), (4, self.employee_emp.id)],
             'holiday_status_id': self.leave_type.id,
             'duration': 2,
@@ -98,21 +82,6 @@ class TestAllocations(TestHrHolidaysCommon):
         })
 
         employee_allocation.action_generate_allocations()
-
-        num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id)])
-        self.assertEqual(num_of_allocations, 1)
-
-    def test_allocation_department(self):
-        department_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
-            'name': 'Bank Holiday',
-            'allocation_mode': 'department',
-            'department_id': self.department.id,
-            'holiday_status_id': self.leave_type.id,
-            'duration': 2,
-            'allocation_type': 'regular',
-        })
-
-        department_allocation.action_generate_allocations()
 
         num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id)])
         self.assertEqual(num_of_allocations, 1)
@@ -137,21 +106,6 @@ class TestAllocations(TestHrHolidaysCommon):
             'allocation_type': 'regular',
         })
         allocation_wizard.action_generate_allocations()
-
-    def test_allocation_category(self):
-        category_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
-            'name': 'Bank Holiday',
-            'allocation_mode': 'category',
-            'category_id': self.category_tag.id,
-            'holiday_status_id': self.leave_type.id,
-            'duration': 2,
-            'allocation_type': 'regular',
-        })
-
-        category_allocation.action_generate_allocations()
-
-        num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id)])
-        self.assertEqual(num_of_allocations, 1)
 
     def test_allocation_request_day(self):
         self.leave_type.write({
@@ -217,7 +171,6 @@ class TestAllocations(TestHrHolidaysCommon):
 
         hour_type_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
             'name': 'Hours Allocation',
-            'allocation_mode': 'employee',
             'employee_ids': [(4, self.employee.id), (4, self.employee_emp.id)],
             'holiday_status_id': self.leave_type.id,
             'duration': 10,

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -49,7 +49,7 @@ class TestCompanyLeave(TransactionCase):
         # Add a company leave on the second day.
         # Check that leave is split into 2.
 
-        leave = self.env['hr.leave'].create({
+        self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
             'holiday_status_id': self.paid_time_off.id,
@@ -59,7 +59,6 @@ class TestCompanyLeave(TransactionCase):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.bank_holiday.id,
             'date_from': date(2020, 1, 8),
@@ -103,7 +102,6 @@ class TestCompanyLeave(TransactionCase):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.bank_holiday.id,
             'date_from': date(2020, 1, 8),
@@ -150,7 +148,6 @@ class TestCompanyLeave(TransactionCase):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.bank_holiday.id,
             'date_from': date(2020, 1, 7),
@@ -187,7 +184,6 @@ class TestCompanyLeave(TransactionCase):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.bank_holiday.id,
             'date_from': date(2020, 1, 9),
@@ -235,7 +231,6 @@ class TestCompanyLeave(TransactionCase):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.bank_holiday.id,
             'date_from': date(2020, 1, 10),
@@ -278,7 +273,6 @@ class TestCompanyLeave(TransactionCase):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Bank Holiday',
-            'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.bank_holiday.id,
             'date_from': date(2020, 4, 2),

--- a/addons/hr_holidays/tests/test_working_hours.py
+++ b/addons/hr_holidays/tests/test_working_hours.py
@@ -84,7 +84,6 @@ class TestWorkingHours(TestHrCalendarCommon):
 
         company_leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'holiday from monday to tuesday',
-            'allocation_mode': 'company',
             'company_id': self.company_A.id,
             'holiday_status_id': self.leave_type.id,
             'date_from': date(2023, 12, 25),

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
@@ -5,11 +5,7 @@
         <field name="arch" type="xml">
             <form string="Generate time off allocations for multiple employees">
                     <group>
-                        <field name="allocation_mode" string="Grant" groups="hr_holidays.group_hr_holidays_user"/>
-                        <field name="employee_ids" invisible="allocation_mode != 'employee'" widget="many2many_avatar_employee" placeholder="All Employees"/>
-                        <field name="company_id" invisible="allocation_mode != 'company'"/>
-                        <field name="department_id" invisible="allocation_mode != 'department'" required="allocation_mode == 'department'"/>
-                        <field name="category_id" invisible="allocation_mode != 'category'" required="allocation_mode == 'category'"/>
+                        <field name="employee_ids" widget="many2many_avatar_employee" placeholder="All Employees"/>
                         <field name="holiday_status_id"/>
                         <field name="allocation_type" widget="radio"/>
                         <field name="unit_of_measure" invisible="1"/>

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
@@ -6,12 +6,7 @@
             <form string="Generate time off for multiple employees">
                 <group>
                     <field name="holiday_status_id" class="w-100"/>
-                    <field name="allocation_mode" string="Mode" groups="hr_holidays.group_hr_holidays_user"/>
-                    <field name="employee_ids" invisible="allocation_mode != 'employee'" 
-                    widget="many2many_avatar_employee" placeholder="Everyone"/>
-                    <field name="company_id" invisible="allocation_mode != 'company'"/>
-                    <field name="department_id" invisible="allocation_mode != 'department'" required="allocation_mode == 'department'"/>
-                    <field name="category_id" invisible="allocation_mode != 'category'" required="allocation_mode == 'category'"/>
+                    <field name="employee_ids" widget="many2many_avatar_employee" placeholder="All Employees"/>
                     <label for="date_from" string="Dates"/>
                     <field
                         name="date_from"

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -113,7 +113,6 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertEqual(len(work_entries.work_entry_type_id), 1)
         leave = self.env['hr.leave.generate.multi.wizard'].create({
             'name': 'Holiday!!!',
-            'allocation_mode': 'company',
             'company_id': self.env.company.id,
             'holiday_status_id': self.leave_type.id,
             'date_from': datetime(2022, 8, 8),


### PR DESCRIPTION
This commit removes the `allocation_mode`, `department_id`, and `category_id` fields from the `hr.leave.generate.multi.wizard` and `hr.leave.allocation.generate.multi.wizard` models, as well as all related logic. Tests have been updated accordingly to reflect these changes.

task-5265508

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
