### PR TITLE
[FIX] base: remove useless attributes when loading view from file

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -117,7 +117,10 @@ def get_view_arch_from_file(filepath, xmlid):
 
         elif node.tag == 'template':
             # The following dom operations has been copied from convert.py's _tag_template()
+            # TODO: Refactor from file method and code conversion method. Ideally, this method
+            # should be refactored to use a common logic as _tag_template() or utilize a common AST.
             if not node.get('inherit_id'):
+                node.attrib.clear()
                 node.set('t-name', xmlid)
                 node.tag = 't'
             else:


### PR DESCRIPTION
Issue: When use `--dev-mode=xml`, the "Unknown directives or unused attributes" warning appear because the loading file from installation or update is different than the `get_view_arch_from_file` method. There is an inconsistency between the two mechanisms.

The fix removes the specific attributes that were causing the 'Unknown directives or unused attributes' warning during file loading, aligning the output with the expected format.

TODO: Refactor from file method and code conversion method. Ideally, this method should be refactored to use a common logic as _tag_template() or utilize a common AST.
