### PR TITLE
[FIX] web: correct scss variables missing in colorpicker

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -1,11 +1,7 @@
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
 import { usePopover } from "@web/core/popover/popover_hook";
-import {
-    isCSSColor,
-    isColorGradient,
-    normalizeCSSColor,
-} from "@web/core/utils/colors";
+import { isCSSColor, isColorGradient, normalizeCSSColor } from "@web/core/utils/colors";
 import { cookie } from "@web/core/browser/cookie";
 import { POSITION_BUS } from "../position/position_hook";
 import { registry } from "../registry";
@@ -26,6 +22,8 @@ export const DEFAULT_GRAYSCALES = {
     solid: ["black", "900", "800", "600", "400", "200", "100", "white"],
 };
 
+// These CSS variables are defined in html_editor.
+// Using ColorPicker without html_editor installed is extremely unlikely.
 export const DEFAULT_THEME_COLOR_VARS = [
     "o-color-1",
     "o-color-2",

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -1,3 +1,8 @@
+$o-we-toolbar-bg: #FFF !default;
+$o-we-toolbar-color-text: #2b2b33 !default; // Same as $o-we-bg-light
+$o-we-item-spacing: 8px !default;
+$o-we-color-success: #00ff9e !default;
+
 .o_font_color_selector {
     @include o-input-number-no-arrows();
     --bg: #{$o-we-toolbar-bg};
@@ -86,12 +91,4 @@
         font-family: FontAwesome;
         color: $o-we-color-success;
     }
-}
-
-// Extend bootstrap to create background and text utilities for some colors
-@for $index from 1 through 5 {
-    $-color-name: 'o-color-#{$index}';
-    $-color: map-get($colors, $-color-name);
-    @include bg-variant(".bg-#{$-color-name}", $-color);
-    @include text-emphasis-variant(".text-#{$-color-name}", $-color);
 }

--- a/addons/web/static/src/scss/secondary_variables.scss
+++ b/addons/web/static/src/scss/secondary_variables.scss
@@ -42,10 +42,5 @@ $o-caret-down: url("data:image/svg+xml," +
     "<polygon fill='%23#{str-slice(#{$o-main-text-color}, 2)}' points='3.5 4 7 0 0 0'/>" +
 "</svg>");
 
-// Used in color picker and web_editor toolbar
-// TODO: move to color_picker.scss when web_editor is removed
-$o-we-toolbar-bg: #FFF !default;
-$o-we-toolbar-color-text: #2b2b33 !default; // Same as $o-we-bg-light
-
 $o-bubble-color-size: $o-font-size-base;
 $o-bubble-color-size-xl: $o-font-size-base * 1.36;


### PR DESCRIPTION
Some scss variables used in color_picker.scss were defined in html_editor, thus breaking assets if html_editor was not installed.

Steps to reproduce:
- Create a new database
- Uninstall html_editor
- Scss assets are broken

task-5230908

Issue: https://github.com/odoo/odoo/issues/234507