### PR TITLE
[IMP] web: no spam notifications

### DIFF
--- a/addons/web/static/src/core/notifications/notification_service.js
+++ b/addons/web/static/src/core/notifications/notification_service.js
@@ -50,6 +50,11 @@ export const notificationService = {
                 props,
                 onClose: options.onClose,
             };
+            for (const [notifId, notif] of Object.entries(notifications)) {
+                if (notif.props.message.toString() === notification.props.message.toString()) {
+                    close(notifId);
+                }
+            }
             notifications[id] = notification;
             return closeFn;
         }

--- a/addons/web/static/tests/core/notifications/notifications.test.js
+++ b/addons/web/static/tests/core/notifications/notifications.test.js
@@ -313,3 +313,37 @@ test("notification autocloses after a specified delay", async () => {
     await animationFrame();
     expect(".o_notification").toHaveCount(0);
 });
+
+test("no spam notifications", async () => {
+    await makeMockEnv();
+    const { Component: NotificationContainer, props } = registry
+        .category("main_components")
+        .get("NotificationContainer");
+
+    await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
+    getService("notification").add("my notification");
+    getService("notification").add("my notification");
+    getService("notification").add("my notification");
+    getService("notification").add("my notification");
+    getService("notification").add("my notification");
+    await waitFor(".o_notification");
+
+    expect(".o_notification").toHaveCount(1);
+});
+
+test("no spam markup'd notifications", async () => {
+    await makeMockEnv();
+    const { Component: NotificationContainer, props } = registry
+        .category("main_components")
+        .get("NotificationContainer");
+
+    await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
+    getService("notification").add(markup("<i>my notification</i>"));
+    getService("notification").add(markup("<i>my notification</i>"));
+    getService("notification").add(markup("<i>my notification</i>"));
+    getService("notification").add(markup("<i>my notification</i>"));
+    getService("notification").add(markup("<i>my notification</i>"));
+    await waitFor(".o_notification");
+
+    expect(".o_notification").toHaveCount(1);
+});

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -12055,10 +12055,7 @@ test(`multi edit list view: mousedown on "Discard" with invalid field`, async ()
 
     await pointerUp(".o_control_panel");
     await animationFrame();
-    // FIXME: Hoot incorrectly triggers"change" events *after* the blur instead of
-    // *before*, causing the internals of the list controller/renderer to dispatch
-    // 2 notifications.
-    expect(`.o_notification`).toHaveCount(2);
+    expect(`.o_notification`).toHaveCount(1);
     expect(`.o_data_row:eq(0) .o_data_cell`).toHaveText("10");
 });
 

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -1271,8 +1271,8 @@ test("cannot create cyclic", async () => {
         "Josephine\nAlbert",
         "Louis\nJosephine",
     ]);
-    expect(".o_notification").toHaveCount(2);
-    expect(".o_notification_bar.bg-danger").toHaveCount(2);
+    expect(".o_notification").toHaveCount(1);
+    expect(".o_notification_bar.bg-danger").toHaveCount(1);
 
     await contains(".o_hierarchy_node:eq(0)").dragAndDrop(".o_hierarchy_row:eq(2)");
     expect(".o_hierarchy_row").toHaveCount(3);
@@ -1283,8 +1283,8 @@ test("cannot create cyclic", async () => {
         "Josephine\nAlbert",
         "Louis\nJosephine",
     ]);
-    expect(".o_notification").toHaveCount(3);
-    expect(".o_notification_bar.bg-danger").toHaveCount(3);
+    expect(".o_notification").toHaveCount(1);
+    expect(".o_notification_bar.bg-danger").toHaveCount(1);
 
     expect.verifySteps([]);
 });

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -256,7 +256,6 @@ test("Use the sidebar 'create anchor' buttons", async () => {
     expect(":iframe section.third").not.toHaveAttribute("id");
     expect(":iframe section.third").not.toHaveAttribute("data-anchor");
 
-    await contains(notificationCloseSelector).click();
     // Column without title nor data-name should use the default name for column
     await contains(":iframe section.fourth div.row div").click();
     await animationFrame();


### PR DESCRIPTION
Before this commit you could have many notifications with the same content showing on the screen.

Now, if a notification is showing the same content than another one, then the previous one is closed.

TASK-ID: 5269619



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
