### PR TITLE
[FIX] website_sale: get correct element when fetching ecom categories

### DIFF
--- a/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
@@ -38,7 +38,7 @@ export class ToggleFetchEcomCategoriesAction extends BuilderAction {
             editingElement,
             true
         );
-        const cls = [...editingElement.firstElementChild.classList].find((cls) =>
+        const cls = [...editingElement.querySelector("section").classList].find((cls) =>
             cls.startsWith("s_mega_menu_")
         );
         const templateKey = `${module}${cls}`;


### PR DESCRIPTION
When we toggle the e-commerce categories in the mega menu option, an
error occurs. This happens because the  `toggleFetchEcomCategories`
action gets the first child of the editing element, which used to be the
section we target, but after this [commit] has added the selection placeholder,
the section is no longer the first child.

Steps to see the issue:
- Open website and create a mega menu
- Start the edit mode
- Click on the mega menu you just created
- Toggle eCommerce categories in the 'Mega Menu' options container

-> We receive an error: `Template not found: 'website_sale.undefined'
(website: None)`

[commit]: https://github.com/odoo/odoo/commit/edf7f7bb0c62978640c181e

task-5268995
