### PR TITLE
[FIX] mail: unwanted border on background blur toggle button

### DIFF
--- a/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
@@ -10,7 +10,7 @@
                 <div class="flex-grow-1"/>
                 <DeviceSelect kind="'videoinput'"/>
             </label>
-            <div t-if="!isBrowserSafari()" class="btn d-flex gap-2" t-on-click="() => store.settings.useBlur = !store.settings.useBlur">
+            <div t-if="!isBrowserSafari()" class="btn border-transparent d-flex gap-2" t-on-click="() => store.settings.useBlur = !store.settings.useBlur">
                 <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer gap-2">
                     <i class="fa fa-fw fa-photo"/><span class="text-truncate text-wrap">Blur background</span>
                 </label>


### PR DESCRIPTION
**Current behavior before PR:**
The background blur toggle button in the call video settings dropdown shows an unintended border when clicked.

**Desired behavior after PR is merged:**
The background blur toggle button in the call video settings dropdown no longer shows border when clicked.

Before:
<img width="463" height="203" alt="image" src="https://github.com/user-attachments/assets/ffc42a8d-3d07-480d-84ba-5959e7bf723d" />

After:
<img width="398" height="205" alt="image" src="https://github.com/user-attachments/assets/01cc4883-b6e0-4e23-b400-45c4373ef77e" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
