### PR TITLE
[FIX]  hr: indicate that employees without a pay category will be excluded from pay runs

### DIFF
--- a/addons/hr/views/hr_contract_template_views.xml
+++ b/addons/hr/views/hr_contract_template_views.xml
@@ -31,7 +31,7 @@
                                         <div name="wage_period_label">/ month</div>
                                     </div>
                                     <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"/>
-                                    <field name="structure_type_id" string="Pay Category" placeholder="Pay Category"
+                                    <field name="structure_type_id" string="Pay Category" placeholder="Employee will be excluded from Pay Runs"
                                             domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
 
                                     <separator name="schedule" string="Schedule"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -342,7 +342,7 @@
                                         </div>
                                         <field name="employee_type"/>
                                         <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"/>
-                                        <field name="structure_type_id" string="Pay Category" placeholder="Pay Category"
+                                        <field name="structure_type_id" string="Pay Category" placeholder="Employee will be excluded from Pay Runs"
                                                 domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
 
                                         <separator name="schedule" string="Schedule"/>


### PR DESCRIPTION
The pay run field is now optional on employee profiles and contract templates, and therefore such employees are not included in pay runs. This commit makes the placeholder for the field indicate that the employee will be excluded from pay runs.

Task-5237800
