### PR TITLE
[IMP] mail: warning when mentioning a large group of people

### DIFF
--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -155,7 +155,7 @@ class ResPartner(models.Model):
                 store.add(p, {"group_ids": [("ADD", (allowed_group & p.user_ids.all_group_ids).ids)]})
         try:
             roles = self.env["res.role"].search([("name", "ilike", search)], limit=8)
-            store.add(roles, ["name"])
+            store.add(roles, ["name", "user_ids_count"])
         except AccessError:
             pass
         return store.get_result()

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -300,7 +300,7 @@ class ResPartner(models.Model):
         )
         try:
             roles = self.env["res.role"].search([("name", "ilike", search)], limit=8)
-            store.add(roles, "name")
+            store.add(roles, ["name", "user_ids_count"])
         except AccessError:
             pass
         return store.get_result()

--- a/addons/mail/models/res_role.py
+++ b/addons/mail/models/res_role.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResRole(models.Model):
@@ -13,5 +13,16 @@ class ResRole(models.Model):
 
     name = fields.Char(required=True)
     user_ids = fields.Many2many("res.users", relation="res_role_res_users_rel", string="Users")
+    user_ids_count = fields.Integer(compute="_compute_user_ids_count")
 
     _unique_name = models.UniqueIndex("(name)", "A role with the same name already exists.")
+
+    @api.depends("user_ids")
+    def _compute_user_ids_count(self):
+        user_count_by_role = dict(
+            self.env["res.users"]._read_group(
+                [("role_ids", "in", self.ids)], ["role_ids"], ["__count"],
+            ),
+        )
+        for role in self:
+            role.user_ids_count = user_count_by_role.get(role, 0)

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -51,6 +51,8 @@ export class ResPartner extends webModels.ResPartner {
 
         /** @type {import("mock_models").ResUsers} */
         const ResUsers = this.env["res.users"];
+        /** @type {import("mock_models").ResRole} */
+        const ResRole = this.env["res.role"];
 
         search = search.toLowerCase();
         /**
@@ -102,11 +104,11 @@ export class ResPartner extends webModels.ResPartner {
         const store = new mailDataHelpers.Store(
             this.browse(mainMatchingPartnerIds.concat(extraMatchingPartnerIds))
         );
-        const roleIds = this.env["res.role"].search(
+        const roleIds = ResRole.search(
             [["name", "ilike", search || ""]],
             makeKwArgs({ limit: limit || 8 })
         );
-        store.add("res.role", this.env["res.role"]._read_format(roleIds, ["name"], false));
+        store.add(ResRole.browse(roleIds), makeKwArgs({ fields: ["name", "user_ids_count"] }));
 
         return store.get_result();
     }
@@ -126,6 +128,8 @@ export class ResPartner extends webModels.ResPartner {
         const DiscussChannelMember = this.env["discuss.channel.member"];
         /** @type {import("mock_models").ResUsers} */
         const ResUsers = this.env["res.users"];
+        /** @type {import("mock_models").ResRole} */
+        const ResRole = this.env["res.role"];
         /** @type {import("mock_models").DiscussChannel} */
         const channel = this.env["discuss.channel"].browse(channel_id)[0];
         const searchLower = search.toLowerCase();
@@ -176,11 +180,11 @@ export class ResPartner extends webModels.ResPartner {
             };
             store.add(this.browse(partnerId), data);
         }
-        const roleIds = this.env["res.role"].search(
+        const roleIds = ResRole.search(
             [["name", "ilike", searchLower || ""]],
             makeKwArgs({ limit: limit || 8 })
         );
-        store.add("res.role", this.env["res.role"]._read_format(roleIds, ["name"], false));
+        store.add(ResRole.browse(roleIds), makeKwArgs({ fields: ["name", "user_ids_count"] }));
         return store.get_result();
     }
 

--- a/addons/mail/static/tests/mock_server/mock_models/res_role.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_role.js
@@ -4,4 +4,12 @@ export class ResRole extends models.ServerModel {
     _name = "res.role";
 
     name = fields.Char();
+    user_ids = fields.Many2many({ relation: "res.users" });
+    user_ids_count = fields.Integer({ compute: "_compute_user_ids_count" });
+
+    _compute_user_ids_count() {
+        for (const role of this) {
+            role.user_ids_count = role.user_ids.length;
+        }
+    }
 }


### PR DESCRIPTION
This commit introduces a warning that alerts the user before sending a message which would mention more than 50 users.
This is done to avoid possible spam or embarrassing situations by making users aware of how many users they are about to notify.

task-5232714