### PR TITLE
[FIX] account: manage empty attachments in document import mixin

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -109,7 +109,7 @@ def split_etree_on_tag(tree, tag):
 
 
 def extract_pdf_embedded_files(filename, content):
-    with io.BytesIO(content or b'') as buffer:
+    with io.BytesIO(content) as buffer:
         try:
             pdf_reader = OdooPdfFileReader(buffer, strict=False)
         except Exception as e:  # noqa: BLE001
@@ -436,7 +436,7 @@ class AccountDocumentImportMixin(models.AbstractModel):
         for attachment in attachments:
             file_data = {
                 'name': attachment.name,
-                'raw': attachment.raw,
+                'raw': attachment.raw or b'',
                 'mimetype': attachment.mimetype,
                 'origin_attachment': attachment,
                 'attachment': attachment,
@@ -506,7 +506,7 @@ class AccountDocumentImportMixin(models.AbstractModel):
             for filename, content in extract_pdf_embedded_files(file_data['name'], file_data['raw']):
                 embedded_file_data = {
                     'name': filename,
-                    'raw': content,
+                    'raw': content or b'',
                     'mimetype': guess_mimetype(content),
                     'attachment': None,
                     'origin_attachment': file_data['origin_attachment'],


### PR DESCRIPTION
Previous fix[^1] was not fixing the issue deep enough and similar issues were spotted by the new test.

runbot-234029

[^1]: d6716bae8954637876f98a9695d25387512b157d
