### PR TITLE
[FIX] hr_attendance: add comparison type in overtime rule (fall behin…

### DIFF
--- a/addons/hr_attendance/__init__.py
+++ b/addons/hr_attendance/__init__.py
@@ -2,6 +2,7 @@
 
 from . import controllers
 from . import models
+from . import wizard
 
 
 def post_init_hook(env):

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -20,6 +20,7 @@ actions(Check in/Check out) performed by them.
         'data/hr_attendance_data.xml',
         'security/hr_attendance_security.xml',
         'security/ir.model.access.csv',
+        'wizard/hr_attendance_absence_management_views.xml',
         'data/hr_attendance_overtime_ruleset_data.xml',
         'data/hr_attendance_overtime_rule_data.xml',
         'views/hr_attendance_view.xml',

--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -38,6 +38,11 @@ class HrAttendanceOvertimeLine(models.Model):
 
     rule_ids = fields.Many2many("hr.attendance.overtime.rule", string="Applied Rules")
 
+    quantity_comparison = fields.Selection([
+        ('exceed', 'Exceed'),
+        ('fall_behind', 'Fall behind')
+    ], string="Quantity Comparison")
+
     # in payroll: rate, work_entry_type
     # in time_off: convertible_to_time_off
 

--- a/addons/hr_attendance/static/src/views/absence_wizard_hook.js
+++ b/addons/hr_attendance/static/src/views/absence_wizard_hook.js
@@ -1,0 +1,22 @@
+/** @odoo-module **/
+
+import { useService } from "@web/core/utils/hooks";
+
+export function useAbsenceManagementWizard() {
+    const action = useService("action");
+
+    return (rulesetId, ruleId) => {
+        action.doAction({
+            name: "Absence Management Wizard",
+            type: "ir.actions.act_window",
+            res_model: "hr.attendance.absence.management.wizard",
+            views: [[false, "form"]],
+            view_mode: "form",
+            target: "new",
+            context: {
+                default_ruleset_id: rulesetId,
+                default_rule_id: ruleId,
+            },
+        });
+    };
+}

--- a/addons/hr_attendance/static/src/views/overtime_rule_form.js
+++ b/addons/hr_attendance/static/src/views/overtime_rule_form.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import { formView } from "@web/views/form/form_view";
+import { registry } from "@web/core/registry";
+import { FormController } from "@web/views/form/form_controller";
+import { useAbsenceManagementWizard } from "@hr_attendance/views/absence_wizard_hook";
+
+console.log("loaded but not binding")
+export class OvertimeRuleFormController extends FormController {
+
+    setup() {
+        console.log("🎉 OvertimeRuleFormController SETUP called!");
+        super.setup()
+        this.openAbsenceWizard = useAbsenceManagementWizard();
+    }
+
+    async saveRecord() {
+        const result = await super.saveRecord()
+
+        const rule = this.model.root.data;
+
+        if (rule.quantity_comparison === "fall_behind") {
+            this.openAbsenceWizard(rule.ruleset_id[0], rule.id);
+        }
+
+        return result;
+    }
+}
+
+registry.category("views").add("overtime_rule_form_view", {
+    ...formView,
+    Controller: OvertimeRuleFormController,
+});

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -26,7 +26,8 @@
                                 <span colspan="2" class="d-flex gap-1" invisible="base_off != 'quantity'">
                                     <label for="quantity_period" string="If the worked hours on a"/>
                                     <field style="width:10ch" nolabel="1" name="quantity_period"/>
-                                    <label for="expected_hours_from_contract" string="exceed"/>
+                                    <!-- <label for="expected_hours_from_contract" string="exceed"/> -->
+                                    <field style="width:10ch" nolabel="1" name="quantity_comparison"/>
                                     <field class="w-auto" name="expected_hours_from_contract" nolabel="1" widget="boolean_radio" options="{
                                         'yes_label_element_id': 'expected_hours_from_contract_yes',
                                         'no_label_element_id': 'expected_hours_from_contract_no'
@@ -34,12 +35,14 @@
                                     <template id="expected_hours_from_contract_yes">the amount defined on the contract</template>
                                     <template id="expected_hours_from_contract_no">a specific duration</template>
                                 </span>
-                                <label for="expected_hours" string="Duration to exceed:" invisible="base_off != 'quantity' or expected_hours_from_contract"/>
+                                <!-- <label for="expected_hours" string="Duration to exceed:" invisible="base_off != 'quantity' or expected_hours_from_contract"/> -->
+                                <field name="expected_hours_label" nolabel="1" readonly="1" invisible="base_off != 'quantity' or expected_hours_from_contract"/>
                                 <span name="expected_hours" class="fw-bold" invisible="base_off != 'quantity' or expected_hours_from_contract">
                                     <field name="expected_hours" widget="float_time" style="width:10ch"/>
                                     hours
                                 </span>
-                                <field name="employer_tolerance" widget="float_time" string="With a tolerance in favor of the employer of"/>
+                                <field name="employer_tolerance" widget="float_time" string="With a tolerance in favor of the employer of" invisible="quantity_comparison == 'fall_behind'"/>
+                                <field name="employee_tolerance" widget="float_time" string="With a tolerance in favor of the employee of" invisible="quantity_comparison == 'exceed'"/>
                                 <!-- TIMING -->
                                 <field name="timing_type" widget="radio" string="If the employee works" invisible="base_off != 'timing'"/>
                                 <span class="fw-bold" invisible="base_off != 'timing' or timing_type not in ['work_days', 'non_work_days']">Between</span>
@@ -55,12 +58,17 @@
                                 string="Action" 
                                 style="grid-template-columns:max-content 1fr"
                             >
-                                <span colspan="2" class="mb-3 fw-bold">The hours will be considered extra and submitted to approval.</span>
-                                                <label for="paid" string="Pay extra hours"/>
-                                <span class="d-flex gap-1" name="paid">
+                                <span colspan="2" class="mb-3 fw-bold" invisible="quantity_comparison == 'fall_behind'">The hours will be considered extra and submitted to approval. If approved, they will be added to your pool of Extra Hours.</span>
+                                <span colspan="2" class="mb-3 fw-bold" invisible="quantity_comparison == 'exceed'">The hours will be considered extra and submitted to approval. If approved, they will be subtracted from your pool of Extra Hours.</span>
+                                                <label for="paid" string="Pay extra hours" invisible="quantity_comparison == 'fall_behind'"/>
+                                <span class="d-flex gap-1" name="paid" invisible="quantity_comparison == 'fall_behind'">
                                     <field class="w-auto" nolabel="1" name="paid"/>
                                     <label for="amount_rate" string="with a rate of" invisible="not paid"/>
                                     <field name="amount_rate" style="width:10ch" widget="percentage" invisible="not paid"/>
+                                </span>
+                                <label for="set_missing_hours" string="Set missing hours" invisible="quantity_comparison == 'exceed'"/>
+                                <span class="d-flex gap-1" name="paid" invisible="quantity_comparison == 'exceed'">
+                                    <field class="w-auto" nolabel="1" name="set_missing_hours"/>
                                 </span>
                             </group>
                         </page>

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -6,7 +6,7 @@
         <field name="name">hr.attendance.overtime.rule.form</field>
         <field name="model">hr.attendance.overtime.rule</field>
         <field name="arch" type="xml">
-            <form>
+            <form js_class="overtime_rule_form_view">
                 <sheet>
                     <div class="oe_title">
                         <label for="name" string="Rule Name"/>

--- a/addons/hr_attendance/wizard/__init__.py
+++ b/addons/hr_attendance/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_attendance_absence_management

--- a/addons/hr_attendance/wizard/hr_attendance_absence_management.py
+++ b/addons/hr_attendance/wizard/hr_attendance_absence_management.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class HrAttendanceAbsenceManagement(models.TransientModel):
+    _name = 'hr.attendance.absence.management.wizard'
+    _description = 'Recommendation when fall-behind rule is saved without Absence Management'
+
+    ruleset_id = fields.Many2one('hr.attendance.overtime.ruleset', string='Ruleset')
+    rule_id = fields.Many2one('hr.attendance.overtime.rule', string='Rule')
+
+    def action_confirm_and_activate(self):
+        settings = self.env['res.config.settings'].create({
+            'company_id': self.env.company.id,
+            'absence_management': True,
+        }).execute()
+
+        return {'type': 'ir.actions.act_window_close'}
+
+    def action_confirm_without_activate(self):
+        return {'type': 'ir.actions.act_window_close'}
+
+    def action_discard(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.attendance.overtime.rule',
+            'view_mode': 'form',
+            'res_id': self.rule_id.id,
+            'target': 'current',
+        }

--- a/addons/hr_attendance/wizard/hr_attendance_absence_management_views.xml
+++ b/addons/hr_attendance/wizard/hr_attendance_absence_management_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_attendance_absence_management_wizard_form" model="ir.ui.view">
+        <field name="name">hr.attendance.absence.management.wizard.form</field>
+        <field name="model">hr.attendance.absence.management.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Absence Management Recommended">
+                <group>
+                    <p>
+                        To obtain best results, we suggest to activate the Absence Management feature. It will create missing attendance records for days where the expected attendances have not been made at all.
+                    </p>
+                </group>
+                <footer>
+                    <button name="action_confirm_and_activate"
+                        string="Confirm &amp; Activate the Settings"
+                        type="object"
+                        class="btn-primary"/>
+                    <button name="action_confirm_without_activate"
+                        string="Confirm but don't activate the Settings"
+                        type="object"
+                        class="btn-primary"/>
+                    <button name="action_discard"
+                        string="Discard"
+                        type="object"
+                        class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_hr_attendance_absence_management" model="ir.actions.act_window">
+        <field name="name">Absence Management Recommendation</field>
+        <field name="res_model">hr.attendance.absence.management.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>

--- a/addons/hr_holidays_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance_overtime.py
@@ -8,3 +8,4 @@ class HrAttendanceOvertimeLine(models.Model):
     _inherit = 'hr.attendance.overtime.line'
 
     compensable_as_leave = fields.Boolean("Compensable as Time Off")
+    deduct_as_leave = fields.Boolean("Deductable from Time Off")

--- a/addons/hr_holidays_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance_overtime_rule.py
@@ -9,16 +9,19 @@ class HrAttendanceOvertimeRule(models.Model):
     _inherit = 'hr.attendance.overtime.rule'
 
     compensable_as_leave = fields.Boolean("Give back as time off", default=False)
+    deduct_as_leave = fields.Boolean("Take back as time off", default=False)
 
     def _extra_overtime_vals(self):
         if not self:
             return {
                 **super()._extra_overtime_vals(),
                 'compensable_as_leave': False,
+                'deduct_as_leave': False,
             }
 
         res = super()._extra_overtime_vals()
         res['compensable_as_leave'] = any(self.mapped('compensable_as_leave'))
+        res['deduct_as_leave'] = any(self.mapped('deduct_as_leave'))
         if self.ruleset_id.rate_combination_mode == 'sum' and any(self.mapped('paid')):
             combined_rate = 1.0
             combined_rate += sum(r.amount_rate - 1.0 for r in self.filtered(

--- a/addons/hr_holidays_attendance/views/hr_attendance_overtime_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_attendance_overtime_views.xml
@@ -17,7 +17,8 @@
         <field name="inherit_id" ref="hr_attendance.hr_attendance_overtime_rule_view_form"/>
         <field name="arch" type="xml">
             <group name="action_section" position="inside">
-                <field name="compensable_as_leave"/>
+                <field name="compensable_as_leave" invisible="quantity_comparison == 'fall_behind'"/>
+                <field name="deduct_as_leave" invisible="quantity_comparison == 'exceed'"/>
             </group>
         </field>
     </record>


### PR DESCRIPTION
Introduced a new field quantity_comparison allowing attendance overtime rules to compare expected hours using either exceed or fall_behind logic. Updated the overtime rule form view to display the new comparison selector and extended the overtime value generation logic to include the selected comparison type for downstream processing.

Implemented support for undertime handling: when a rule is configured with quantity_comparison = 'fall_behind', the system now generates negative overtime lines and correctly subtracts the corresponding hours from the employee’s Extra Hours pool.

Example:

1. Day 1 — Employee works 2 hours extra: Rule: quantity_comparison = 'exceed' Action: System creates an overtime line for +2.0 h and adds 2.0 h to the employee’s Extra Hours pool. Resulting pool: +2.0 h

2. Day 2 — Employee works 1 hour less than expected: Rule: quantity_comparison = 'fall_behind' Action: System creates a deductable overtime line for 1.0 h (undertime) and subtracts 1.0 h from the Extra Hours pool. Resulting pool: +1.0 h

3. Final state: Extra Hours pool after both days = +1.0 h (2.0 added − 1.0 deducted)

task-5159254

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
