### PR TITLE
[FIX] im_livechat: custom im status should not impact agent availability

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -164,7 +164,8 @@ class Im_LivechatChannel(models.Model):
 
         def is_available(user, channel):
             return (
-                ("online" in user.im_status or "busy" in user.im_status)
+                #  sudo - res.users: can access agent presence to determine if they are available.
+                user.sudo().presence_ids.status == "online"
                 and (
                     channel.max_sessions_mode == "unlimited"
                     or counts.get((user.partner_id, channel), 0) < channel.max_sessions
@@ -196,7 +197,8 @@ class Im_LivechatChannel(models.Model):
         for channel in self:
             active_users = users if users is not None else channel.user_ids
             if filter_online:
-                active_users = active_users.filtered(lambda u: "online" in u.im_status or "busy" in u.im_status)
+                # sudo - res.users: can access agent presence to determine if they are available.
+                active_users = active_users.filtered(lambda u: u.sudo().presence_ids.status == "online")
             user_domain |= Domain(
                 [
                     ("partner_id", "in", active_users.partner_id.ids),

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -384,23 +384,6 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
                 livechat_channels[1]: operator,
             },
         )
-        operator.manual_im_status = "busy"
-        self.assertEqual(
-            livechat_channels._get_available_operators_by_livechat_channel(operator),
-            {
-                livechat_channels[0]: self.env["res.users"],
-                livechat_channels[1]: operator,
-            },
-        )
-        operator.manual_im_status = False
-        operator.presence_ids.status = "away"
-        self.assertEqual(
-            livechat_channels._get_available_operators_by_livechat_channel(operator),
-            {
-                livechat_channels[0]: self.env["res.users"],
-                livechat_channels[1]: self.env["res.users"],
-            },
-        )
         operator.presence_ids.status = "offline"
         self.assertEqual(
             livechat_channels._get_available_operators_by_livechat_channel(operator),
@@ -480,3 +463,22 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
         chat.livechat_end_dt = fields.Datetime.now()
         chat.flush_recordset(["livechat_end_dt"])
         self.assertEqual(first_operator, livechat_channel._get_operator())
+
+    def test_agent_availability_not_affected_by_custom_im_status(self):
+        agent = self._create_operator()
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Livechat Channel",
+                "user_ids": [agent.id],
+            }
+        )
+        self.assertEqual(agent.presence_ids.status, "online")
+        self.assertEqual(agent, livechat_channel._get_operator())
+        agent.manual_im_status = "busy"
+        self.assertEqual(agent, livechat_channel._get_operator())
+        agent.manual_im_status = "away"
+        self.assertEqual(agent, livechat_channel._get_operator())
+        agent.manual_im_status = "offline"
+        self.assertEqual(agent, livechat_channel._get_operator())
+        agent.presence_ids.status = "away"
+        self.assertEqual(self.env["res.users"], livechat_channel._get_operator())


### PR DESCRIPTION
Since 19.0, users can set their im status (online/away/busy/offline). Because of this, some agents are considered unavailable while they actually are online.

The intent is to prevent assignation when an agent is *really* unavailable. Custom IM status shouldn't interfere with assignation.

This commit ensures we only consider *real* IM status to determine if an agent is available.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
