### PR TITLE
[FIX] pos_sale: correct price_unit for non groupable UoM

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -164,12 +164,14 @@ patch(PosStore.prototype, {
             const product_unit = line.product_id.uom_id;
             if (product_unit && !product_unit.is_pos_groupable) {
                 let remaining_quantity = newLine.qty;
+                const priceUnit = newLine.price_unit;
                 newLine.delete();
                 while (!this.env.utils.floatIsZero(remaining_quantity)) {
                     const splitted_line = this.models["pos.order.line"].create({
                         ...newLineValues,
                     });
                     splitted_line.set_quantity(Math.min(remaining_quantity, 1.0), true);
+                    splitted_line.set_unit_price(priceUnit);
                     splitted_line.set_discount(line.discount);
                     remaining_quantity -= splitted_line.qty;
                 }

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -214,6 +214,16 @@ registry.category("web_tour.tours").add("PoSSaleOrderWithDownpayment", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_settle_so_with_non_pos_groupable_uom", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.selectedOrderlineHas("Pomme de Terre", "0.5", "5.00"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
     steps: () =>
         [

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -672,6 +672,36 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             order_line = order_line.with_context(lang=partner_test.lang)
             self.assertIn(format_date(order_line.env, order_line.order_id.date_order), order_line.name)
 
+    def test_settle_so_with_non_pos_groupable_uom(self):
+        """
+        For products with a non-groupable PoS UoM (e.g., Kg), ensure that when a SO
+        uses another UoM (e.g., g), the PoS correctly displays the quantity converted
+        back to the original UoM.
+        """
+        self.component_kg = self.env['product.product'].create({
+            'name': 'Pomme de Terre',
+            'is_storable': True,
+            'available_in_pos': True,
+            'taxes_id': False,
+            'lst_price': 10.0,
+            'uom_id': self.env.ref('uom.product_uom_kgm').id,
+            'uom_po_id': self.env.ref('uom.product_uom_kgm').id,
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': self.component_kg.id,
+                'name': self.component_kg.name,
+                'product_uom_qty': 500,
+                'product_uom': self.env.ref('uom.product_uom_gram').id,
+                'price_unit': 0.01,
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.start_pos_tour('test_settle_so_with_non_pos_groupable_uom')
+
     def test_settle_so_with_pos_downpayment(self):
         so = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,


### PR DESCRIPTION
Steps to reproduce
------------------
1. Create a product with a UoM that is non groupable in PoS
2. Make a sale order with that product having a UoM that is based on the
   UoM of the first steps. If the UoM in the first step was Kg for
   intsance, use Gram (g) here.
3. Confirm the order, and settle it in PoS.

Notice that the price of that order in PoS is not correct.

Why it's happening
------------------
When settling the PoS order, we first convert the sale_order's line UoM
(g) to the original product UoM (kg), and we update the quantity
accordingly (in this example by dividing by 1000).
https://github.com/odoo/odoo/blob/fcc5a90d2d5754923676b11031e37f52729402fd/addons/pos_sale/static/src/overrides/models/pos_store.js#L94-L96
So this step updates both the qty and the unit_price.
https://github.com/odoo/odoo/blob/fcc5a90d2d5754923676b11031e37f52729402fd/addons/pos_sale/static/src/overrides/models/pos_store.js#L160-L161

However, when the UoM is not groupable, we split the lines by taking
into consideration the updated qty, but we still use the old price_unit,
which creates an inconsitency and wrong calculations.

The fix
-------
When splitting the lines, we're just supposed to change the qty per line
to max 1, but we're not supposed to change the price per unit for this
qty. We now use the updated `price_unit` to have a correct math.

opw-5232571