### PR TITLE
[FIX] pos_stripe: display backend validation errors on the frontend

### DIFF
--- a/addons/pos_stripe/static/src/app/payment_stripe.js
+++ b/addons/pos_stripe/static/src/app/payment_stripe.js
@@ -20,7 +20,7 @@ export class PaymentStripe extends PaymentInterface {
     async stripeFetchConnectionToken() {
         // Do not cache or hardcode the ConnectionToken.
         try {
-            const data = await this.pos.data.silentCall(
+            const data = await this.pos.data.call(
                 "pos.payment.method",
                 "stripe_connection_token",
                 []
@@ -237,7 +237,7 @@ export class PaymentStripe extends PaymentInterface {
 
     async capturePaymentStripe(paymentIntentId, amount = null, context = {}) {
         try {
-            const data = await this.pos.data.silentCall(
+            const data = await this.pos.data.call(
                 "pos.payment.method",
                 "stripe_capture_payment",
                 [paymentIntentId],
@@ -259,11 +259,10 @@ export class PaymentStripe extends PaymentInterface {
 
     async fetchPaymentIntentClientSecret(payment_method, amount) {
         try {
-            const data = await this.pos.data.silentCall(
-                "pos.payment.method",
-                "stripe_payment_intent",
-                [[payment_method.id], amount]
-            );
+            const data = await this.pos.data.call("pos.payment.method", "stripe_payment_intent", [
+                [payment_method.id],
+                amount,
+            ]);
             if (data.error) {
                 throw data.error;
             }


### PR DESCRIPTION
Before this commit:
===================
Previously, Stripe-related RPC calls used `silentCall`, which suppresses backend errors and prevents them from being displayed in the POS UI. As a result, users were unable to see important validation or API failure messages coming from the server

After this commit:
======================
Use `call` instead of `silentCall`. Using `call` allows backend exceptions and validation errors to be propagated to the POS frontend, ensuring that the user receives clear feedback when a Stripe request fails.

Task-4976972

