### PR TITLE
[FIX] website_sale: use tax display settings for cart notification

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -460,6 +460,13 @@ class Cart(PaymentPortal):
         if not lines:
             return {}
 
+        if order.website_id.show_line_subtotals_tax_selection == 'tax_included':
+            def get_unit_price(line):
+                return line.currency_id.round(line.price_total / line.product_uom_qty)
+        else:
+            def get_unit_price(line):
+                return line.price_unit
+
         return {
             'currency_id': order.currency_id.id,
             'lines': [
@@ -470,7 +477,7 @@ class Cart(PaymentPortal):
                     'name': line._get_line_header(),
                     'combination_name': line._get_combination_name(),
                     'description': line._get_sale_order_line_multiline_description_variants(),
-                    'price_total': line.price_unit * added_qty_per_line[line.id],
+                    'price_total': get_unit_price(line) * added_qty_per_line[line.id],
                     **self._get_additional_cart_notification_information(line),
                 } for line in lines
             ],

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
         },
         {
             content: "check the price of 1 website_sale_cart_notification_product_1",
-            trigger: '.toast-body div:contains("$ 1,000.00")',
+            trigger: '.toast-body div:contains("$ 1,150.00")',
         },
         ...tourUtils.searchProduct("website_sale_cart_notification_product_2", { select: true }),
         {
@@ -48,7 +48,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
         },
         {
             content: "check the price of 3 website_sale_cart_notification_product_2",
-            trigger: '.toast-body div:contains("$ 15,000.00")',
+            trigger: '.toast-body div:contains("$ 17,250.00")',
         },
         {
             content: "Go To Cart",
@@ -85,7 +85,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification_qty_and_
         },
         {
             content: "check the price of 1 website_sale_cart_notification_product_1",
-            trigger: '.toast-body div:contains("$ 1,000.00")',
+            trigger: '.toast-body div:contains("$ 1,150.00")',
         },
         // Again add same product
         {
@@ -104,7 +104,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification_qty_and_
         },
         {
             content: "check that price total only showing total of newly added quantity",
-            trigger: '.toast-body div:contains("$ 3,000.00")',
+            trigger: '.toast-body div:contains("$ 3,450.00")',
         },
     ],
 });


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Set website preference to display taxes price-included;
2. add a product to your cart.

Issue
-----
The notification displays the product's price tax-excluded.

Cause
-----
Commit 8dac8f3 updated the cart notification to display the amount of the recently added quantity, instead of the product's total amount. It did this by removing the check on `show_line_subtotals_tax_selection` and simply display the line's `price_unit` times the added quantity.

Solution
--------
If `show_line_subtotals_tax_selection` is set to `tax_included`, calculate a tax-inclusive unit price by dividing the line's total by the line's quantity.

opw-5214094