### PR TITLE
[FIX] base, web: Use sessions.max_inactivity_seconds when it's possible

### DIFF
--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -46,7 +46,7 @@ class Session(http.Controller):
                 http.root.session_store.rotate(request.session, env)
                 request.future_response.set_cookie(
                     'session_id', request.session.sid,
-                    max_age=http.SESSION_LIFETIME, httponly=True
+                    max_age=http.get_session_max_inactivity(env), httponly=True
                 )
             return env['ir.http'].session_info()
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -273,9 +273,7 @@ class IrHttp(models.AbstractModel):
     def _gc_sessions(self):
         if os.getenv("ODOO_SKIP_GC_SESSIONS"):
             return
-        ICP = self.env["ir.config_parameter"]
-        max_lifetime = int(ICP.get_param('sessions.max_inactivity_seconds', http.SESSION_LIFETIME))
-        http.root.session_store.vacuum(max_lifetime=max_lifetime)
+        http.root.session_store.vacuum(max_lifetime=http.get_session_max_inactivity(self.env))
 
     @api.model
     def get_translations_for_webclient(self, modules, lang):

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -2,15 +2,20 @@
 
 import datetime
 import json
-import pytz
-from urllib.parse import urlencode
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
+from urllib.parse import urlencode
+
+import pytz
+from freezegun import freeze_time
 
 import odoo
+from odoo.http import SESSION_LIFETIME
 from odoo.tests import get_db_name, tagged
-from odoo.tools import mute_logger
-from .test_common import TestHttpBase
+from odoo.tools import config, lazy_property, mute_logger
 
+from .test_common import TestHttpBase
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 GEOIP_ODOO_FARM_2 = {
     'city': 'Ramillies',
@@ -226,3 +231,76 @@ class TestHttpSession(TestHttpBase):
             r"called ignoring args {('session_id', 'debug'|'debug', 'session_id')}$"
         )
         self.assertEqual(admin_session.debug, '1')
+
+
+class TestSessionStore(HttpCaseWithUserDemo):
+    def setUp(self):
+        super().setUp()
+        self.tmpdir = TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+        lazy_property.reset_all(odoo.http.root)
+        self.addCleanup(lazy_property.reset_all, odoo.http.root)
+        patcher = patch.dict(config.options, {'data_dir': self.tmpdir.name})
+        self.startPatcher(patcher)
+
+    @mute_logger('odoo.http')
+    def test01_session_nan(self):
+        self.env['ir.config_parameter'].set_param('sessions.max_inactivity_seconds', 'adminCantSetupThisValueLikeANormalPerson')
+
+        with self.assertLogs('odoo.http', level='WARNING') as logs:
+            self.assertEqual(odoo.http.get_session_max_inactivity(self.env), SESSION_LIFETIME)
+            self.assertEqual(logs.output[0], "WARNING:odoo.http:Invalid value for 'sessions.max_inactivity_seconds', using default value.")
+
+    @mute_logger('odoo.http')
+    def test02_session_lifetime_1week(self):
+        # default lifetime is 1 week
+        with freeze_time() as freeze:
+            session = self.authenticate(None, None)
+
+            freeze.tick(delta=datetime.timedelta(seconds=SESSION_LIFETIME - 1))
+            self.env['ir.http']._gc_sessions()
+            session_from_store = odoo.http.root.session_store.get(session.sid)
+            self.assertEqual(session.sid, session_from_store.sid, "the session should still be valid")
+
+            freeze.tick(delta=datetime.timedelta(seconds=2))
+            self.env['ir.http']._gc_sessions()
+            session_from_store = odoo.http.root.session_store.get(session.sid)
+            self.assertNotEqual(session.sid, session_from_store.sid, "the old session as been removed")
+
+    @mute_logger('odoo.http')
+    def test03_session_lifetime_1min(self):
+        # changing the lifetime to 1 minute
+        self.env['ir.config_parameter'].set_param('sessions.max_inactivity_seconds', 60)
+        with freeze_time() as freeze:
+            session = self.authenticate(None, None)
+
+            freeze.tick(delta=datetime.timedelta(seconds=59))
+            self.env['ir.http']._gc_sessions()
+            session_from_store = odoo.http.root.session_store.get(session.sid)
+            self.assertEqual(session.sid, session_from_store.sid, "the session should still be valid")
+
+            freeze.tick(delta=datetime.timedelta(seconds=2))
+            self.env['ir.http']._gc_sessions()
+            session_from_store = odoo.http.root.session_store.get(session.sid)
+            self.assertNotEqual(session.sid, session_from_store.sid, "the old session as been removed")
+
+    @mute_logger('odoo.http')
+    def test04_session_lifetime_nodb(self):
+        # in case of requesting session in a no db scenario
+        self.env['ir.config_parameter'].set_param('sessions.max_inactivity_seconds', SESSION_LIFETIME // 2)
+        with freeze_time() as freeze:
+            self.authenticate(None, None)
+            res = TestHttpBase.nodb_url_open(self, '/')
+            res.raise_for_status()
+            session = res.cookies.get('session_id')
+
+            freeze.tick(delta=datetime.timedelta(seconds=(SESSION_LIFETIME // 2) - 1))
+            self.env['ir.http']._gc_sessions()
+            session_from_store = odoo.http.root.session_store.get(session)
+            self.assertEqual(session, session_from_store.sid, "the session should still be valid")
+
+            freeze.tick(delta=datetime.timedelta(seconds=2))
+            self.env['ir.http']._gc_sessions()
+            session_from_store = odoo.http.root.session_store.get(session)
+            self.assertNotEqual(session, session_from_store.sid, "the old session as been removed")


### PR DESCRIPTION
When adding the session_id cookie, we usually set it to expires after odoo.http.SESSION_LIFETIME seconds (at the moment: 7 days). At the same time the "sessions.max_inactivity_seconds" ir.config_paramater is used to remove old sessions from the session store. We suggest to better align the two options, to also use the "sessions.max_inactivity_seconds" ICP when we are in the context of a database and when the option is set to a valid value, and to only fallback on odoo.http.SESSION_LIFETIME otherwise.

opw-3716924
opw-5237642
task-5263937

Backport-of: 99f96049a895e7336ab19356649a46db51c012ce
