### PR TITLE
[FIX] point_of_sale: broken receipt attachment in email

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/send_receipt_popup/send_receipt_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/send_receipt_popup/send_receipt_popup.js
@@ -51,7 +51,7 @@ export class SendReceiptPopup extends Component {
     }
 
     async generateTicketImage(basicReceipt = false) {
-        await this.renderer.toJpeg(
+        return await this.renderer.toJpeg(
             OrderReceipt,
             {
                 order: this.order,

--- a/addons/point_of_sale/static/tests/unit/components/popup/send_receipt_popup.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/popup/send_receipt_popup.test.js
@@ -1,0 +1,19 @@
+import { test, expect } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { SendReceiptPopup } from "@point_of_sale/app/components/popups/send_receipt_popup/send_receipt_popup";
+import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+test("generateTicketImage returns renderer output", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+
+    const comp = await mountWithCleanup(SendReceiptPopup, {
+        props: { order, close: () => {} },
+    });
+
+    const result = await comp.generateTicketImage();
+    expect(result).not.toBeEmpty();
+});


### PR DESCRIPTION
Steps to reproduce
------------
- Open register and create an order.
- Send the receipt by email.
- Check the backend order log
- Receipt attachment is broken.

Issue
-------------
Sending a receipt created a broken attachment because the generated ticket image was not correctly returned.

Fix
---------
Return receipt image properly so the email and backend order show a correct attachment.

--------
Task-5269024
