### PR TITLE
[FIX] im_livechat: restrict emailing transcript to internal users

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -245,10 +245,10 @@ class LivechatController(http.Controller):
     @http.route("/im_livechat/email_livechat_transcript", type="jsonrpc", auth="user")
     @add_guest_to_context
     def email_livechat_transcript(self, channel_id, email):
+        if not request.env.user._is_internal():
+            raise NotFound()
         if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
-            channel._email_livechat_transcript(
-                email if not request.env.user.share else request.env.user.email,
-            )
+            channel._email_livechat_transcript(email)
 
     @http.route("/im_livechat/download_transcript/<int:channel_id>", type="http", auth="public")
     @add_guest_to_context

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -21,7 +21,7 @@
             <textarea t-model="state.feedback" class="form-control my-2" placeholder="Explain your note"/>
             <button class="btn btn-primary align-self-end" t-on-click="onClickSendFeedback">Send</button>
         </div>
-        <label class="mb-5 w-100" t-if="store.self_partner">
+        <label class="mb-5 w-100" t-if="store.self_partner?.main_user_id?.share === false">
             Receive a copy of this conversation
             <TranscriptSender thread="props.thread" disableOnSend="true"/>
         </label>

--- a/addons/im_livechat/static/tests/embed/transcript_sender.test.js
+++ b/addons/im_livechat/static/tests/embed/transcript_sender.test.js
@@ -56,27 +56,3 @@ test("send failed", async () => {
     await click("button[data-action='sendTranscript']:enabled");
     await contains(".form-text", { text: "An error occurred. Please try again." });
 });
-
-test("portal user send", async () => {
-    const pyEnv = await startServer();
-    await loadDefaultEmbedConfig();
-    onRpcBefore("/im_livechat/email_livechat_transcript", () => expect.step(`send_transcript`));
-    pyEnv["res.users"].create({
-        partner_id: pyEnv["res.partner"].create({ email: "portal@kombat.com", name: "Portal" }),
-        login: "portal",
-        password: "portal",
-        share: true,
-    });
-    await start({ authenticateAs: { login: "portal", password: "portal" } });
-    await click(".o-livechat-LivechatButton");
-    await insertText(".o-mail-Composer-input", "Hello World!");
-    triggerHotkey("Enter");
-    await contains(".o-mail-Thread:not([data-transient])");
-    await click(".o-mail-ChatWindow-header [title*='Close']");
-    await click(".o-livechat-CloseConfirmation-leave");
-    await contains("label", { text: "Receive a copy of this conversation" });
-    await contains("input:disabled", { value: "portal@kombat.com" });
-    await click("button[data-action='sendTranscript']:enabled");
-    await contains(".form-text", { text: "The conversation was sent." });
-    await expect.waitForSteps(["send_transcript"]);
-});

--- a/addons/im_livechat/tests/test_transcript.py
+++ b/addons/im_livechat/tests/test_transcript.py
@@ -1,11 +1,11 @@
-from odoo.tests.common import tagged
+from odoo.tests.common import JsonRpcException, tagged
 from odoo.tools import mute_logger
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 
 
 @tagged("-at_install", "post_install")
-class TestImLivechatTranscript(TestImLivechatCommon, HttpCaseWithUserDemo):
+class TestImLivechatTranscript(TestImLivechatCommon, HttpCaseWithUserDemo, HttpCaseWithUserPortal):
     def test_download_transcript(self):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
@@ -27,3 +27,15 @@ class TestImLivechatTranscript(TestImLivechatCommon, HttpCaseWithUserDemo):
         with mute_logger("odoo.http"):
             res = self.url_open(f"/im_livechat/download_transcript/{data['channel_id']}")
         self.assertEqual(res.status_code, 404)
+
+    def test_email_transcript_portal_user(self):
+        self.authenticate(self.user_portal.login, self.user_portal.login)
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {"channel_id": self.livechat_channel.id},
+        )
+        with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
+            self.make_jsonrpc_request(
+                "/im_livechat/email_livechat_transcript",
+                {"channel_id": data["channel_id"], "email": self.partner_portal.email},
+            )


### PR DESCRIPTION
This commit restricts the possibility of emailing a transcript of the live chat conversation to internal users.

task-5262277