### PR TITLE
[FIX] website: support lastmod for non-dated record

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1571,7 +1571,9 @@ class Website(models.Model):
             record = {'loc': page['url'], 'id': page['id'], 'name': page['name']}
             if page.view_id.priority != 16:
                 record['priority'] = min(round(page.view_id.priority / 32.0, 1), 1)
-            record['lastmod'] = max(page.write_date, page.view_write_date).date()
+            last_dates = [d for d in (page.write_date, page.view_write_date) if d]
+            if last_dates:
+                record['lastmod'] = max(last_dates).date()
             yield record
 
         # ==== CONTROLLERS ====


### PR DESCRIPTION
In some cases, write_date can be Falsy, causing the sitemap to crash with:
> '>' not supported between instances of 'datetime.datetime' and 'bool'

Restore previous behavior, if there is no write_date, the lastmod key is not set.
