### PR TITLE
[FIX] website: make Alt+A shortcut open translation mode from frontend

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -381,7 +381,8 @@ export class WebsiteBuilderClientAction extends Component {
             this.websiteService.context.showResourceEditor = false;
         }
         this.websiteService.pageDocument = this.websiteContent.el.contentDocument;
-        if (this.translation) {
+        const url = new URL(this.websiteService.contentWindow.location.href);
+        if (url.searchParams.has("edit_translations")) {
             deleteQueryParam("edit_translations", this.websiteService.contentWindow, true);
         }
 

--- a/addons/website/static/src/js/content/redirect.js
+++ b/addons/website/static/src/js/content/redirect.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.addEventListener("keydown", ev => {
                 if (ev.key === "a" && ev.altKey) {
                     currentUrl.searchParams.set('enable_editor', 1);
+                    currentUrl.searchParams.set("edit_translations", 1);
                     window.location.replace(currentUrl.href);
                 }
             }, true);

--- a/addons/website/static/tests/tours/alt_a.js
+++ b/addons/website/static/tests/tours/alt_a.js
@@ -1,0 +1,60 @@
+import { registry } from "@web/core/registry";
+
+function pressAltA() {
+    return {
+        content: "Press Alt+a",
+        trigger: "body",
+        run: "press Alt+a",
+        expectUnloadPage: true,
+    };
+}
+
+function searchParamsCheck() {
+    return {
+        content: "Check URL does not contain edit_translations or enable_editor",
+        trigger: "body",
+        run: () => {
+            const urlParams = new URLSearchParams(window.location.search);
+            if (urlParams.has("edit_translations") || urlParams.has("enable_editor")) {
+                throw new Error(
+                    "URL should not contain edit_translations or enable_editor after reload"
+                );
+            }
+        },
+    };
+}
+
+registry.category("web_tour.tours").add("alt_a_edit", {
+    url: "/",
+    steps: () => [
+        pressAltA(),
+        {
+            content: "Check that the sidebar is in edit mode",
+            trigger: ".o_builder_sidebar_open .o-tab-content #snippet_groups",
+        },
+        {
+            content: "Check that the iframe is in edit mode",
+            trigger:
+                ":iframe html[data-editable='1']:not([data-translatable='1'][data-edit_translations='1'])",
+        },
+        searchParamsCheck(),
+    ],
+});
+
+registry.category("web_tour.tours").add("alt_a_translation", {
+    url: "/fr",
+    steps: () => [
+        pressAltA(),
+        {
+            content: "Check that the sidebar is in translate mode",
+            trigger:
+                ".o_builder_sidebar_open .o-tab-content:contains(Select content on your page to translate it.)",
+        },
+        {
+            content: "Check that the iframe is in translate mode",
+            trigger:
+                ":iframe html[data-translatable='1'][data-edit_translations='1']:not([data-editable='1'])",
+        },
+        searchParamsCheck(),
+    ],
+});

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -730,3 +730,30 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_website_edit_megamenu_visibility(self):
         self.start_tour("/", 'edit_megamenu_visibility', login='admin')
+
+    def test_alt_a_edit(self):
+        lang_en = self.env.ref('base.lang_en')
+        self.env.ref('website.default_website').write({
+            'default_lang_id': lang_en.id,
+            'language_ids': [Command.link(lang_en.id)],
+        })
+        self.start_tour('/', 'alt_a_edit', login='admin')
+
+    def add_fr_language_to_website(self):
+        lang_en = self.env.ref('base.lang_en')
+        lang_fr = self.env.ref('base.lang_fr')
+        self.env['res.lang']._activate_lang(lang_fr.code)
+        self.env.ref('website.default_website').write({
+            'default_lang_id': lang_en.id,
+            'language_ids': [Command.link(lang_en.id), Command.link(lang_fr.id)],
+        })
+
+    def test_alt_a_with_foreign_language(self):
+        self.add_fr_language_to_website()
+        self.start_tour('/', 'alt_a_translation', login='admin')
+
+    def test_alt_a_not_on_foreign_language_page(self):
+        self.add_fr_language_to_website()
+        # It should go in edit mode if we are not on the FR page even if FR is
+        # available
+        self.start_tour('/', 'alt_a_edit', login='admin')


### PR DESCRIPTION
__Before this commit:__
1. Add a 2nd language to your site
2. Show the website homepage in the 2nd language and be outside the admin backend (no admin navbar at the top of the page)
3. Press Alt+A (the shortcut to open the builder) => The builder opens, but it is unusable. The builder options are the translation options, but the iframe is not in a translatable state.

__Cause:__
Pressing Alt+A outside the admin backend just [adds `enable_editor=1` in the URL][1]. When the page is displayed in the 2nd language `data-translatable` is included in the metadata so the translation mode opens. However the iframe relies on the `edit_translations` search param being set to include the translation branding (i.e. `data-oe-translation-source-sha`) which is not the case after pressing Alt+A.

__The fix:__
Add `edit_translations` when pressing Alt+A in any case. If the page is translatable, the translation mode will correclty open, otherwise it will be ignored and the edit mode will open instead.

NB: By doing this, we bypass the checks in [`attemptStartTranslate`][2] therefore a user who doesn't have the proper access rights will still be able to open the translation mode but they will not be able to do anything. Using those checks would add too much complexity to the code in regards to how niche the feature is anyway.

[1]: https://github.com/odoo/odoo/blob/d985ec2e9b61b5e6c36a278654d526aaa5b512e2/addons/website/static/src/js/content/redirect.js#L33
[2]: https://github.com/odoo/odoo/blob/d985ec2e9b61b5e6c36a278654d526aaa5b512e2/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js#L54

task-5125700
