### PR TITLE
[FIX] hw_drivers: revert pdf fit page

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -115,7 +115,7 @@ class PrinterDriver(Driver):
             printer = self.device_name
 
             args = [
-                "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT", "-dPDFFitPage",
+                "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
                 "-q",
                 "-sDEVICE#mswinpr2",
                 f'-sOutputFile#%printer%{printer}',


### PR DESCRIPTION
Adding the argument "-dPDFFitPage" in the printer driver for the windows IoT broke the alignment when printing PDF labels on Zebra printers.

Issue introduced in #232866

opw-5220275

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
