### PR TITLE
[FIX] mail: make `record.exists()`  reactive

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -389,7 +389,7 @@ export class Record {
     }
 
     exists() {
-        return !this._[IS_DELETED_SYM];
+        return !this[IS_DELETED_SYM];
     }
 
     /** @param {Record} record */

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -9,7 +9,6 @@ import { RecordUses } from "./record_uses";
 
 export class RecordInternal {
     [IS_RECORD_SYM] = true;
-    [IS_DELETED_SYM] = false;
     // Note: state of fields in Maps rather than object is intentional for improved performance.
     /**
      * For computed field, determines whether the field is computing its value.
@@ -150,7 +149,7 @@ export class RecordInternal {
     }
 
     requestCompute(record, fieldName, { force = false } = {}) {
-        if (record._[IS_DELETED_SYM]) {
+        if (record[IS_DELETED_SYM]) {
             return;
         }
         const Model = record.Model;
@@ -169,7 +168,7 @@ export class RecordInternal {
         }
     }
     requestSort(record, fieldName, { force } = {}) {
-        if (record._[IS_DELETED_SYM]) {
+        if (record[IS_DELETED_SYM]) {
             return;
         }
         const Model = record.Model;

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -124,7 +124,7 @@ export class StoreInternal extends RecordInternal {
                 /** @type {import("./record").Record} */
                 const [record] = params;
                 record._[IS_DELETING_SYM] = true;
-                record._[IS_DELETED_SYM] = true;
+                record._proxy[IS_DELETED_SYM] = true;
                 delete record.Model.records[record.localId];
                 if (!this.RHD_QUEUE.has(record)) {
                     this.RHD_QUEUE.set(record, true);
@@ -189,7 +189,10 @@ export class StoreInternal extends RecordInternal {
      * @param {Object} vals
      */
     updateFields(record, vals) {
-        for (const [fieldName, value] of Object.entries(vals)) {
+        const fieldEntries = Object.entries(vals).concat(
+            Object.getOwnPropertySymbols(vals).map((sym) => [sym, vals[sym]])
+        );
+        for (const [fieldName, value] of fieldEntries) {
             if (!record.Model._.fields.get(fieldName) || record.Model._.fieldsAttr.get(fieldName)) {
                 this.updateAttr(record, fieldName, value);
             } else {


### PR DESCRIPTION
The `exists` function of mail records is not reactive. Indeed, it uses a symbol, stored on the proxy internal field which is not observed.

This commit fixes the issue by storing it on the record and ensuring we write on the full proxy when the record is deleted.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
