### PR TITLE
[FIX] payment_mollie: update linked and default payment methods

### DIFF
--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -271,7 +271,6 @@
                          ref('payment.payment_method_paypal'),
                          ref('payment.payment_method_paysafecard'),
                          ref('payment.payment_method_p24'),
-                         ref('payment.payment_method_sofort'),
                          ref('payment.payment_method_twint'),
                      ])]"
         />

--- a/addons/payment_mollie/const.py
+++ b/addons/payment_mollie/const.py
@@ -51,7 +51,6 @@ SUPPORTED_CURRENCIES = [
 DEFAULT_PAYMENT_METHODS_CODES = [
     # Primary payment methods.
     'card',
-    'ideal',
     # Brand payment methods.
     'visa',
     'mastercard',


### PR DESCRIPTION
**[FIX] payment_mollie: remove iDEAL from the default payment methods**

When a new Mollie account is created, it only accepts card payments out of the box. In Odoo, both the Cards and iDEAL payment methods were activated by default upon enabling the payment provider, while iDEAL required manual activation from Mollie's dashboard.

---

**[FIX] payment_mollie: remove Sofort from the linked payment methods**

See https://help.mollie.com/hc/en-us/articles/20904206772626-SOFORT-Deprecation-30-September-2024ard.