### PR TITLE
[FIX] event_product: ensure error gets raised in test by using a form

### DIFF
--- a/addons/event_product/tests/test_event_product.py
+++ b/addons/event_product/tests/test_event_product.py
@@ -1,5 +1,5 @@
 from odoo.exceptions import ValidationError
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 from odoo.addons.event_product.tests.common import TestEventProductCommon
 
@@ -20,4 +20,5 @@ class TestEventProduct(TestEventProductCommon):
         with self.assertRaises(ValidationError):
             self.event_product.service_tracking = 'no'
         with self.assertRaises(ValidationError):
-            self.event_product.type = 'consu'
+            with Form(self.event_product) as product_form:
+                product_form.type = 'consu'


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a minimal database with `event_product` installed;
2. run `:TestEventProduct.test_ensure_event_service_tracking`.

Issue
-----
> FAIL: TestEventProduct.test_ensure_event_service_tracking
> AssertionError: ValidationError not raised

Cause
-----
The test works as expected with `sale_project` installed due to a `write` override of `product.product`, setting the `service_tracking` to 'no' if `type` is no longer 'service': https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/sale_project/models/product_product.py#L25-L30

This change still occurs without `sale_project` installed, but via the `_compute_service_tracking` method defined in `product`: https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/product/models/product_template.py#L181-L183

As this value is set via a compute method instead of `write`, the `_check_event_ticket_service_tracking` method isn't triggered, and no error is raised.

Solution
--------
Simulate a front-end flow by changing the `type` to 'consu' on a product form. This way, the constraint method does get triggered as expected.

runbot-234024