### PR TITLE
[IMP] sale: filter for products previously purchased by customer in catalog

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1484,6 +1484,7 @@ class SaleOrder(models.Model):
     def _get_action_add_from_catalog_extra_context(self):
         return {
             **super()._get_action_add_from_catalog_extra_context(),
+            'order_customer_id': self.partner_id.id,
             'product_catalog_currency_id': self.currency_id.id,
             'product_catalog_digits': self.order_line._fields['price_unit'].get_digits(self.env),
             'show_sections': bool(self.id),

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -163,6 +163,14 @@
         <field name="inherit_id" ref="product.product_view_search_catalog"/>
         <field name="model">product.product</field>
         <field name="arch" type="xml">
+            <filter name="favorites" position="after">
+                <filter
+                    string="Previously bought"
+                    name="products_previously_bought_by_customer"
+                    domain="[('previously_bought_by_customer', '=', True)]"
+                    invisible="context.get('active_model', '') != 'sale.order.line'"
+                />
+            </filter>
             <filter name="goods" position="after">
                 <filter string="In the Order"
                         invisible="context.get('active_model', '') != 'sale.order.line'"


### PR DESCRIPTION
Prior to this commit:
- The product catalog did not provide a way to prioritize or filter products
  based on a customer’s past purchases.

Post this commit:
- A new filter is introduced to identify products previously bought by the
  selected customer, allowing the catalog to filter those products accordingly.

task-5187283