### PR TITLE
[IMP] html_editor: allow replacement multiple times

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -64,6 +64,7 @@ export class FormatPlugin extends Plugin {
         "insertAndSelectZws",
         "mergeAdjacentInlines",
         "formatSelection",
+        "removeFormats",
     ];
     /** @type {import("plugins").EditorResources} */
     resources = {


### PR DESCRIPTION
Before this commit, it was only possible to replace a piece of text once in the HTML editor through the AI draft. The second time you clicked on the "Use this" button, the text wouldn't be replaced but appended to the right of the previously replaced text.

In this change we made some changes to the HTML editor's DOM plugin to allow multiple replacements of the same piece of text. Namely, we allow to optionally pass a selection object to the insert function which will then be replaced.

We also edit the delete plugin so if we are replacing text that begun with bold, any lingering <strong> tags will be deleted with they are empty after deletion.

task-4762525


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
