### PR TITLE
[IMP] product,stock: translate prod. category name

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -33,7 +33,7 @@ class StockMoveLine(models.Model):
         'uom.uom', 'Unit', required=True, domain="[('id', 'in', allowed_uom_ids)]",
         compute="_compute_uom_id", store=True, readonly=False, precompute=True,
     )
-    product_category_name = fields.Char(related="product_id.categ_id.complete_name", string="Product Category")
+    product_category_id = fields.Many2one(related="product_id.categ_id", string="Product Category")
     quantity = fields.Float(
         'Quantity', digits='Product Unit', copy=False, store=True,
         compute='_compute_quantity', readonly=False)

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -131,7 +131,7 @@
                 <field name="product_id"/>
                 <field name="picking_id" string="Transfer"/>
                 <field name="reference" string="Reference"/>
-                <field name="product_category_name" string="Category"/>
+                <field name="product_category_id" string="Category"/>
                 <field name="lot_id" string="Lot/Serial Number" groups="stock.group_production_lot"/>
                 <field name="package_id" string="Source Package" groups="stock.group_tracking_lot"/>
                 <field name="result_package_id" string="Destination Package" groups="stock.group_tracking_lot"/>
@@ -159,7 +159,7 @@
                     <filter string="Date" name="by_date" domain="[]" context="{'group_by': 'date'}"/>
                     <filter string="Transfers" name="by_picking" domain="[]" context="{'group_by': 'picking_id'}"/>
                     <filter string="Location" name="by_location" domain="[]" context="{'group_by': 'location_id'}"/>
-                    <filter string="Category" name="by_category" domain="[]" context="{'group_by': 'product_category_name'}"/>
+                    <filter string="Category" name="by_category" domain="[]" context="{'group_by': 'product_category_id'}"/>
                 </group>
             </search>
         </field>
@@ -207,7 +207,7 @@
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
             <pivot string="Moves History">
-                <field name="product_category_name" type="col"/>
+                <field name="product_category_id" type="col"/>
                 <field name="date" interval="month" type="row"/>
             </pivot>
         </field>


### PR DESCRIPTION
Product category names are not translated since 13.0 (https://github.com/odoo/odoo/commit/322618a69c8870835e0e4ea785b7268a16d14f67) because it didn't work with the stored complete_name field.

By not storing the complete_name, we can allow the category name to be translatable again. This is useful because product categories are shared between different companies, so in the case of having multiple companies with multiple languages, without translation, your only choices are to either use the same language for product categories across the different companies or have multiple versions of the same category for each company in each language and having all of these visible in all your companies.

Enterprise PR: https://github.com/odoo/enterprise/pull/99689
Upgrade PR: https://github.com/odoo/upgrade/pull/9279

task-4804824
