### PR TITLE
[FIX] html_editor, *: fix editor/builder/website Plugins documentation

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -26,7 +26,7 @@ declare module "plugins" {
     import { mark_color_level_selector_params } from "@html_builder/plugins/background_option/background_option_plugin";
     import { is_movable_selector } from "@html_builder/core/move_plugin";
     import { content_editable_selectors, content_not_editable_selectors } from "@html_builder/core/builder_content_editable_plugin";
-    import { builder_actions } from "@html_builder/core/builder_actions_plugin";
+    import { builder_actions, BuilderActionsShared } from "@html_builder/core/builder_actions_plugin";
     import { so_content_addition_selector, so_snippet_addition_selector } from "@html_builder/core/dropzone_selector_plugin";
     import { fontCssVariables } from "@html_builder/plugins/font/font_plugin";
     import { apply_custom_css_style } from "@html_builder/core/core_builder_action_plugin";

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -9,11 +9,11 @@ import { OptionsContainer } from "@html_builder/sidebar/option_container";
 /** @typedef {import("@html_builder/core/utils").BaseOptionComponent} BaseOptionComponent */
 /** @typedef {import("@odoo/owl").Component} Component */
 /** @typedef {import("plugins").CSSSelector} CSSSelector */
-/** @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString */
+/** @typedef {import("plugins").TranslatedString} TranslatedString */
 /**
  * @typedef {{
  *        class: string;
- *        title: LazyTranslatedString;
+ *        title: TranslatedString;
  *        handler: () => Promise<void>;
  *        disabledReason?: string;
  * }} BuilderButtonDescriptor

--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -9,7 +9,7 @@ declare module "plugins" {
     import { DialogShared } from "@html_editor/core/dialog_plugin";
     import { after_insert_handlers, before_insert_processors, before_set_tag_handlers, DomShared, node_to_insert_processors, system_attributes, system_classes, system_style_properties } from "@html_editor/core/dom_plugin";
     import { format_class_predicates, format_selection_handlers, FormatShared, has_format_predicates, remove_all_formats_handlers } from "@html_editor/core/format_plugin";
-    import { attribute_change_handlers, attribute_change_processors, before_add_step_handlers, before_filter_mutation_record_handlers, content_updated_handlers, external_step_added_handlers, handleNewRecords, history_cleaned_handlers, history_reset_from_steps_handlers, history_reset_handlers, HistoryShared, post_redo_handlers, restore_savepoint_handlers, savable_mutation_record_predicates, serializable_descendants_processors, step_added_handlers } from "@html_editor/core/history_plugin";
+    import { attribute_change_handlers, attribute_change_processors, before_add_step_handlers, before_filter_mutation_record_handlers, content_updated_handlers, external_step_added_handlers, handleNewRecords, history_cleaned_handlers, history_reset_from_steps_handlers, history_reset_handlers, HistoryShared, post_redo_handlers, post_undo_handlers, restore_savepoint_handlers, savable_mutation_record_predicates, serializable_descendants_processors, step_added_handlers } from "@html_editor/core/history_plugin";
     import { beforeinput_handlers, input_handlers } from "@html_editor/core/input_plugin";
     import { before_line_break_handlers, insert_line_break_element_overrides, LineBreakShared } from "@html_editor/core/line_break_plugin";
     import { OverlayShared } from "@html_editor/core/overlay_plugin";
@@ -51,9 +51,11 @@ declare module "plugins" {
     import { DynamicPlaceholderShared } from "@html_editor/others/dynamic_placeholder_plugin";
     import { EmbeddedComponentShared, mount_component_handlers, post_mount_component_handlers } from "@html_editor/others/embedded_component_plugin";
 
+    import { _t } from "@web/core/l10n/translation.js";
+
     /* Misc */
     export interface CSSSelector extends String {}
-    export interface LazyTranslatedString extends String {}
+    export type TranslatedString = ReturnType<typeof _t>
 
     /** Plugin */
     export type PluginConstructor = (typeof Plugin) & {

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -36,11 +36,11 @@ import { FontSizeSelector } from "./font_size_selector";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { weakMemoize } from "@html_editor/utils/functions";
 
-/** @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString */
+/** @typedef {import("plugins").TranslatedString} TranslatedString */
 
 /**
  * @typedef {((insertedNode: Node) => insertedNode)[]} before_insert_within_pre_processors
- * @typedef {{ name: LazyTranslatedString; tagName: string; extraClass?: string; }[]} font_items
+ * @typedef {{ name: TranslatedString; tagName: string; extraClass?: string; }[]} font_items
  */
 
 export const fontSizeItems = [

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -8,7 +8,7 @@ import { closestBlock } from "../utils/blocks";
  * @typedef {import("@html_editor/editor").EditorContext} EditorContext
  * @typedef {import("@html_editor/core/selection_plugin").SelectionData} SelectionData
  * @typedef {import("plugins").CSSSelector} CSSSelector
- * @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString
+ * @typedef {import("plugins").TranslatedString} TranslatedString
  */
 
 /**
@@ -16,7 +16,7 @@ import { closestBlock } from "../utils/blocks";
  *   selectionData: SelectionData,
  *   editable: EditorContext["editable"]
  * ) => HTMLElement[] | NodeList)[]} hint_targets_providers
- * @typedef {{ selector: CSSSelector; text: LazyTranslatedString; }[]} hints
+ * @typedef {{ selector: CSSSelector; text: TranslatedString; }[]} hints
  */
 
 export class HintPlugin extends Plugin {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -31,7 +31,7 @@ import { FORMATTABLE_TAGS } from "@html_editor/utils/formatting";
  *
  * @typedef {{
  *      id: "DOCUMENTS" | "ICONS" | "IMAGES" | "VIDEOS";
- *      title: import("plugins").LazyTranslatedString;
+ *      title: import("plugins").TranslatedString;
  *      Component: import("@odoo/owl").Component;
  *      sequence: number;
  *  }[]} media_dialog_extra_tabs

--- a/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
@@ -4,11 +4,11 @@ import { registry } from "@web/core/registry";
 import { SearchbarOption } from "./searchbar_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
-/** @typedef {import("plugins").LazyTranslatedString} LazyTranslatedString */
+/** @typedef {import("plugins").TranslatedString} TranslatedString */
 
 /**
  * @typedef {{
- *      label: LazyTranslatedString;
+ *      label: TranslatedString;
  *      orderBy: string;
  *      dependency?: string;
  *      id?: string;
@@ -33,7 +33,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
  */
 /**
  * @typedef {{
- *      label: LazyTranslatedString;
+ *      label: TranslatedString;
  *      dataAttribute: string;
  *      dependency: string;
  * }[]} searchbar_option_display_items

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -28,7 +28,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 /**
  * @typedef { Object } SocialMediaInfo
  * @property { boolean } [recorded] whether the social media is one from the orm
- * @property { string|Markup|LazyTranslatedString } label
+ * @property { import("plugins").TranslatedString } label
  * @property { string } iconClass the icon class to use for the social media
  * @property { RegExp } [extraHostnameRegex] a regex for host names that belongs to this social media, but are not catch by the default mechanism
  */

--- a/addons/website_blog/static/src/@types/plugins.d.ts
+++ b/addons/website_blog/static/src/@types/plugins.d.ts
@@ -1,5 +1,5 @@
 declare module "plugins" {
-    import { DynamicSnippetBlogPostsOptionShared } from "../website_builder/dynamic_snippet_blog_posts_option_plugin";
+    import { DynamicSnippetBlogPostsOptionShared } from "addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin";
 
     interface SharedMethods {
         dynamicSnippetBlogPostsOption: DynamicSnippetBlogPostsOptionShared;


### PR DESCRIPTION
*: html_builder, website, website_blog

As commits [18ed09d], [9d9ae7c] and [d4df17b] introduced documentation for the Plugins in the modules html_editor / html_builder / website, a few elements were not properly imported. This commit fixes that.

[18ed09d]: https://github.com/odoo/odoo/commit/18ed09dd97988362f9b97eb344beb896b5c0bf13
[9d9ae7c]: https://github.com/odoo/odoo/commit/9d9ae7c95dbb8e91f81235a40493600210b906a7
[d4df17b]: https://github.com/odoo/odoo/commit/d4df17bacfee069d595d52c91a274d875dd231d1

task-5249231