### PR TITLE
[FIX] web: maintain consistent column widths in Kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -208,7 +208,7 @@
         .o_kanban_group,
         .o_column_quick_create:not(.o_quick_create_folded) {
             &:not(.o_column_folded) {
-                flex-grow: 1;
+                flex: 1 1;
                 min-width: var(--KanbanGroup-width);
             }
             max-width: var(--KanbanGroup-max-width);


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/odoo/odoo/pull/204103/commits/48d6904b78ee6b067dcf49de5f1ef99c421260c3 with adaptive column sizing. Previously, content-heavy columns would take more space than lighter columns, causing flickering during record drag-and-drop.

Columns now retain adaptive sizing while ensuring all columns in the Kanban share the same resulting width.

task-5266223
