### PR TITLE
[FIX] web: statusbar field: correctly render stages in dropdown

### DIFF
--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -73,10 +73,11 @@ export class StatusBarField extends Component {
             this.render();
         };
 
-        useEffect(
-            () => status === "shouldAdjust" && adjust(),
-            () => [status]
-        );
+        useEffect(() => {
+            if (status === "shouldAdjust") {
+                adjust();
+            }
+        });
 
         let forceRecomputeItems = false;
         onWillRender(() => {

--- a/addons/web/static/tests/views/fields/statusbar_field.test.js
+++ b/addons/web/static/tests/views/fields/statusbar_field.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { expect, resize, test } from "@odoo/hoot";
 import {
     click,
     Deferred,
@@ -1165,4 +1165,97 @@ test("cache: update current status if it changed", async () => {
     // updated when the rpc returns
     expect(".o_last_breadcrumb_item").toHaveText("second record");
     expect('.o_statusbar_status button[data-value="1"]').toHaveClass("o_arrow_button_current");
+});
+
+test("[adjust] statusbar with a lot of stages, click to change stage", async () => {
+    // force the window width and define long stage names s.t. at most 3 stages can be displayed
+    resize({ width: 800 });
+    class Stage extends models.Model {
+        name = fields.Char();
+        _records = Array.from(Array(6).keys()).map((i) => {
+            const id = i + 1;
+            return { id, name: `Stage with very long name ${id}` };
+        });
+    }
+    defineModels([Stage]);
+    Partner._fields.stage_id = { type: "many2one", relation: "stage" };
+    Partner._records[0].stage_id = 3;
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <header>
+                    <field name="stage_id" widget="statusbar" options="{'clickable': 1}" />
+                </header>
+            </form>
+        `,
+    });
+
+    // initial rendering: there should be a dropdown before and a dropdown after
+    expect(".o_statusbar_status button:visible.dropdown-toggle").toHaveCount(2);
+    expect(queryAllTexts(".o_statusbar_status button:visible:not(.dropdown-toggle)")).toEqual([
+        "Stage with very long name 4",
+        "Stage with very long name 3",
+        "Stage with very long name 2",
+    ]);
+    expect(".o_statusbar_status button[data-value='3']").toHaveClass("o_arrow_button_current");
+    await contains(".o_statusbar_status .o_last").click();
+    expect(queryAllTexts(".o-dropdown-item")).toEqual(["Stage with very long name 1"]);
+    await contains(".o_statusbar_status .o_first").click();
+    expect(queryAllTexts(".o-dropdown-item")).toEqual([
+        "Stage with very long name 5",
+        "Stage with very long name 6",
+    ]);
+
+    // choose the next value: there should still be one dropdown before and one after
+    await contains(".o_statusbar_status button[data-value='4']").click();
+    expect(".o_statusbar_status button:visible.dropdown-toggle").toHaveCount(2);
+    expect(queryAllTexts(".o_statusbar_status button:visible:not(.dropdown-toggle)")).toEqual([
+        "Stage with very long name 5",
+        "Stage with very long name 4",
+        "Stage with very long name 3",
+    ]);
+    expect(".o_statusbar_status button[data-value='4']").toHaveClass("o_arrow_button_current");
+    await contains(".o_statusbar_status .o_last").click();
+    expect(queryAllTexts(".o-dropdown-item")).toEqual([
+        "Stage with very long name 1",
+        "Stage with very long name 2",
+    ]);
+    await contains(".o_statusbar_status .o_first").click();
+    expect(queryAllTexts(".o-dropdown-item")).toEqual(["Stage with very long name 6"]);
+
+    // choose the next value: there should only be a dropdown before
+    await contains(".o_statusbar_status button[data-value='5']").click();
+    expect(".o_statusbar_status button:visible.dropdown-toggle").toHaveCount(1);
+    expect(queryAllTexts(".o_statusbar_status button:visible:not(.dropdown-toggle)")).toEqual([
+        "Stage with very long name 6",
+        "Stage with very long name 5",
+        "Stage with very long name 4",
+    ]);
+    expect(".o_statusbar_status button[data-value='5']").toHaveClass("o_arrow_button_current");
+    await contains(".o_statusbar_status .o_last").click();
+    expect(queryAllTexts(".o-dropdown-item")).toEqual([
+        "Stage with very long name 1",
+        "Stage with very long name 2",
+        "Stage with very long name 3",
+    ]);
+
+    // select the first item from the dropdown before => there should only be a dropdown after
+    await contains(".o-dropdown-item:first").click();
+    expect(".o_statusbar_status button:visible.dropdown-toggle").toHaveCount(1);
+    expect(queryAllTexts(".o_statusbar_status button:visible:not(.dropdown-toggle)")).toEqual([
+        "Stage with very long name 3",
+        "Stage with very long name 2",
+        "Stage with very long name 1",
+    ]);
+    expect(".o_statusbar_status button[data-value='1']").toHaveClass("o_arrow_button_current");
+    await contains(".o_statusbar_status .o_first").click();
+    expect(queryAllTexts(".o-dropdown-item")).toEqual([
+        "Stage with very long name 4",
+        "Stage with very long name 5",
+        "Stage with very long name 6",
+    ]);
 });


### PR DESCRIPTION
Since PR [1], there was an issue with the statusbar field and the way it put overflowing items into dropdowns (cf. adjust function). Have a form view with a statusbar field and enough items s.t. they don't all fit in the screen. The widget implements a logic to put the first and/or last overflowing items into dropdowns (one before the displayed items, one after).

Before this commit, if the user clicked on an item to select it as new value, the state of the widget was incorrect, leading to dropdowns being displayed, but empty (and items being unavailable, as they are hidden, but not displayed in the dropdown).

This was due to a `useEffect` with an incorrect dependency: if two consecutive renderings were done with the `shouldAdjust` status (which is possible since [1] and the introduction of the `forceRecomputeItems` flag), the dependency didn't change and the callback of `useEffect` was not called, leading to items not being processed.

[1] https://github.com/odoo/odoo/pull/230548

opw~5232448

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
