### PR TITLE
[IMP] account_peppol: display Peppol mode in settings

### DIFF
--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -10,6 +10,9 @@
                     <div class="o_setting_right_pane border-0">
                         <div invisible="account_peppol_proxy_state not in ('sender', 'receiver', 'smp_registration')">
                             Your Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/> <field name="account_peppol_proxy_state" class="oe_inline o_form_label text-lowercase" readonly="1"/> invoices and credit notes.
+                            <span class="ps-2" invisible="account_peppol_edi_mode == 'prod'">
+                                (<field class="oe_inline o_form_label text-uppercase" name="account_peppol_edi_mode" />)
+                            </span>
                         </div>
                         <div invisible="account_peppol_proxy_state != 'rejected'">
                             You registration has been rejected, the reason has been sent to you via email.


### PR DESCRIPTION
Before this PR :
The Peppol settings section in the settings page did not show the current mode (demo/test/prod). 
Users had no clear indication of the active mode, which could lead to mistakes.

After this PR :
A small label is now displayed in the Peppol settings section to clearly indicate the current mode when not in production.

task-5149768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
