### PR TITLE
[FIX] website: activate url autocomplete for ReplaceMediaOption

### DIFF
--- a/addons/website/static/src/builder/plugins/image/replace_media_option.xml
+++ b/addons/website/static/src/builder/plugins/image/replace_media_option.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-inherit="html_builder.ReplaceMediaOption" t-inherit-mode="extension">
+    <xpath expr="//BuilderRow[@label.translate='Your URL']//BuilderUrlPicker" position="replace">
+        <WebsiteUrlPicker title.translate="Your URL"
+            action="'setUrl'"
+            inputClasses="'o_we_large'"
+            placeholder.translate="www.example.com"/>
+    </xpath>
+</t>
+
+</templates>


### PR DESCRIPTION
This commit extends the default BuilderUrlPicker by WebsiteUrlPicker for ReplaceMediaOption to enable URL suggestions/autocomplete.

Steps to reproduce:
- Drop a snippet with an image
- Click on the image
- Click on the chain icon next to "Replace" button
- Type in "Your URL" field
- No url suggestion or autocomplete

task-5090136