### PR TITLE
[FIX] html_builder, website: prevent dropping form snippet inside a form

### DIFF
--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -146,6 +146,10 @@ export class DropZonePlugin extends Plugin {
 
         // Prevent dropping an element into another one.
         // (e.g. ToC inside another ToC)
+        const hasForm = snippetEl.matches("form") || !!snippetEl.querySelector("form");
+        if (hasForm && !selectorExcludeAncestor.includes("form")) {
+            selectorExcludeAncestor.push("form");
+        }
         if (selectorExcludeAncestor.length) {
             const excludeAncestor = selectorExcludeAncestor.join(",");
             selectorSiblings = selectorSiblings.filter((el) => !el.closest(excludeAncestor));

--- a/addons/website/static/src/builder/plugins/form/form_field_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_field_option.js
@@ -8,6 +8,7 @@ import {
     getMultipleInputs,
     isFieldCustom,
     getCurrentFieldInputEl,
+    getModelName,
 } from "./utils";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 
@@ -32,7 +33,7 @@ export class FormFieldOption extends BaseOptionComponent {
             valueList: null,
         });
         this.domState = useDomState((el) => {
-            const modelName = el.closest("form")?.dataset.model_name;
+            const modelName = getModelName(el.closest("form"));
             const fieldName = getFieldName(el);
             return {
                 elDataset: { ...el.dataset },

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -403,7 +403,7 @@ export class FormOptionPlugin extends Plugin {
     }
     async fetchAuthorizedFields(formEl) {
         // Combine model and fields into cache key.
-        const model = formEl.dataset.model_name;
+        const model = getModelName(formEl);
         const propertyOrigins = {};
         const parts = [model];
         for (const hiddenInputEl of [...formEl.querySelectorAll("input[type=hidden]")].sort(


### PR DESCRIPTION
When a snippet containing a `<form>` (e.g. “Contact us” form) is dropped
inside an existing form element, the inner form is invalid HTML
(see [1]).

Steps to reproduce:
===================
1- Go to a Shop page and open a Product page.
2- Drag and drop a “Contact us” form snippet inside the existing product
form (e.g. in description_ecommerce, which is an HTML field with
`sanitize_form=False`).
3- Save the page, re-enter edit mode.
4- Click on any field of the inserted “Contact us” form.
→ traceback.

Cause:
======
HTML does not support nested `<form>` elements.
As soon as the browser parses the dropped snippet inside an existing
`<form>`, it normalizes the DOM and strips or moves the inner `<form>`
tag, keeping only its contents. The inner form therefore loses its
attributes (action, method, data-model_name, etc.).
When editing a field, `fetchAuthorizedFields` needs the form’s model it
used to rely directly on `formEl.dataset.model_name`, which is missing
in this broken structure, causing a crash.

Solution:
========
Prevent dropping the snippets that contain a form inside another form,
by filtering out the `selectorSiblings/Children` (which are used to make
the dropzones appear) that are in forms, when they are dragged.

This commit also uses the `getModelName(formEl)` helper wherever we need
the form model instead of accessing `dataset.model_name` directly.

[1]: https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/How_to_structure_a_web_form

opw-5256576