### PR TITLE
[FIX] api_doc: band-aid for badly renamed fields

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -138,6 +138,7 @@ class DocController(http.Controller):
                     field.name: {'string': field.field_description}
                     for field in ir_model.field_id
                     # sorted(ir_model.field_id, key=partial(sort_key_field, modules, Model))
+                    if field.name in Model._fields  # band-aid, see task 5172546
                     if Model._has_field_access(Model._fields[field.name], 'read')
                 },
                 'methods': [

--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -101,6 +101,8 @@ class DocController(http.Controller):
         # TODO: gzip
         filename = f'odoo-doc-index-{db_registry_sequence}-{unique}.json'
         index_attach = self.env['ir.attachment'].sudo().search([('name', '=', filename)], limit=1)
+        if not use_cache:
+            modules, models = self._doc_index()
         if not index_attach:
             # No cache, generate the index and save it.
             modules, models = self._doc_index()


### PR DESCRIPTION
Steps to reproduce:

1. Install studio and contact (the bug is in the ORM, but studio/contact make it easy to reproduce).
2. Add a field (regular one, text/checkbox/...) on a partner form view with studio. Note its auto generated "old" name.
3. Rename the field via studio Note its new name.
4. Go to /doc, traceback `Key error: "old name" not in Model._fields`.
5. Go to "technical/database structure/fields" in ?debug=1 mode.
6. Search for "x_studio" `[("x_studio", "in", "name")]`

On "partner" you only see a single field, with the new name. On "user" you see two fields, one with the old name and another with the new name.

The problem is that when renaming the field, the ORM renamed (replaced) the old field by the new one on partner, reflected the change by adding a new field on res.users (inherits) but failed to remove the old field on res.users.

The traceback in /doc is only a symptom of the above problem. In this work we are adding a band-aid to skip badly renamed fields. It doesn't solve the root problem but it makes it possible to use /doc again until the actual bug is solved.

task-5172546
