### PR TITLE
[IMP] payment_mollie: tokenization support

### DIFF
--- a/addons/payment_mollie/README.md
+++ b/addons/payment_mollie/README.md
@@ -2,7 +2,9 @@
 
 ## Technical details
 
-API: [Payments API](https://docs.mollie.com/reference/v2/payments-api/create-payment) version `2`
+API:
+- [Payments API](https://docs.mollie.com/reference/v2/payments-api/create-payment) version `2`
+- [Customers API](https://docs.mollie.com/reference/v2/customers-api/create-customer) version `1`
 
 This module integrates Mollie using the generic payment with redirection flow based on form
 submission provided by the `payment` module.

--- a/addons/payment_mollie/data/payment_provider_data.xml
+++ b/addons/payment_mollie/data/payment_provider_data.xml
@@ -4,6 +4,7 @@
     <record id="payment.payment_provider_mollie" model="payment.provider">
         <field name="code">mollie</field>
         <field name="redirect_form_view_id" ref="payment.generic_redirect_form"/>
+        <field name="allow_tokenization">True</field>
     </record>
 
 </odoo>

--- a/addons/payment_mollie/models/__init__.py
+++ b/addons/payment_mollie/models/__init__.py
@@ -1,3 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import payment_provider, payment_transaction
+from . import payment_provider, payment_token, payment_transaction

--- a/addons/payment_mollie/models/payment_provider.py
+++ b/addons/payment_mollie/models/payment_provider.py
@@ -25,6 +25,11 @@ class PaymentProvider(models.Model):
 
     # === COMPUTE METHODS === #
 
+    def _compute_feature_support_fields(self):
+        """Override of `payment` to enable additional features."""
+        super()._compute_feature_support_fields()
+        self.filtered(lambda p: p.code == "mollie").support_tokenization = True
+
     def _get_supported_currencies(self):
         """Override of `payment` to return the supported currencies."""
         supported_currencies = super()._get_supported_currencies()

--- a/addons/payment_mollie/models/payment_token.py
+++ b/addons/payment_mollie/models/payment_token.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class PaymentToken(models.Model):
+    _inherit = "payment.token"
+
+    mollie_customer_id = fields.Char(string="Mollie Customer ID", readonly=True)

--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -60,7 +60,7 @@ class PaymentTransaction(models.Model):
             self.currency_id.name, self.currency_id.decimal_places
         )
 
-        return {
+        payload = {
             "description": self.reference,
             "amount": {
                 "currency": self.currency_id.name,
@@ -92,6 +92,30 @@ class PaymentTransaction(models.Model):
                 }
             ],
         }
+        if self.token_id:
+            payload["sequenceType"] = "recurring"
+            payload["customerId"] = self.token_id.mollie_customer_id
+            payload["mandateId"] = self.token_id.provider_ref
+            payload.pop("method")
+        elif self.tokenize:
+            payload["sequenceType"] = "first"
+            payload["customerId"] = self._mollie_create_customer()
+        else:
+            payload["sequenceType"] = "oneoff"
+        return payload
+
+    def _mollie_create_customer(self):
+        """Create a Mollie customer.
+
+        Note: exceptions are intentionally left to bubble up to
+        `_get_specific_rendering_values` to ensure more accurate error messages.
+
+        :return: The Mollie customer ID.
+        :rtype: str
+        """
+        payload = {"name": self.partner_name, "email": self.partner_email}
+        response = self._send_api_request("POST", "/customers", json=payload)
+        return response["id"]
 
     def _mollie_prepare_billing_address_payload(self):
         """Return correctly formatted billing address payload.
@@ -110,6 +134,15 @@ class PaymentTransaction(models.Model):
             "email": self.partner_email or "",
         }
 
+    def _send_payment_request(self):
+        """Override of `payment` to send a token payment request to Mollie."""
+        if self.provider_code != "mollie":
+            return super()._send_payment_request()
+
+        payload = self._mollie_prepare_payment_request_payload()
+        payment_data = self._send_api_request("POST", "/payments", json=payload)
+        self._process("mollie", payment_data)
+
     @api.model
     def _extract_reference(self, provider_code, payment_data):
         """Override of `payment` to extract the reference from the payment data."""
@@ -122,6 +155,9 @@ class PaymentTransaction(models.Model):
         if self.provider_code != "mollie":
             super()._apply_updates(payment_data)
             return
+
+        # Update the provider reference.
+        self.provider_reference = payment_data["id"]
 
         # Update the payment method.
         payment_method_type = payment_data.get("method", "")
@@ -159,3 +195,23 @@ class PaymentTransaction(models.Model):
         amount = amount_data.get("value")
         currency_code = amount_data.get("currency")
         return {"amount": float(amount), "currency_code": currency_code}
+
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to extract the token values from the payment data."""
+        if self.provider_code != "mollie":
+            return super()._extract_token_values(payment_data)
+
+        mandate_id = payment_data.get("mandateId")
+        customer_id = payment_data.get("customerId")
+        if not mandate_id or not customer_id:
+            _logger.warning(
+                "Tried to tokenize with missing mandate_id (%s) or customer_id (%s)",
+                mandate_id,
+                customer_id,
+            )
+            return {}
+
+        token_values = {"provider_ref": mandate_id, "mollie_customer_id": customer_id}
+        if card_number := payment_data.get("details", {}).get("cardNumber"):
+            token_values["payment_details"] = card_number[-4:]
+        return token_values

--- a/addons/payment_mollie/tests/test_mollie.py
+++ b/addons/payment_mollie/tests/test_mollie.py
@@ -33,6 +33,63 @@ class MollieTest(MollieCommon, PaymentHttpCommon):
         )
         self.assertEqual(payload["description"], tx.reference)
 
+    def test_payload_preparation_in_payment_with_tokenize(self):
+        """Test that tokenization requests create a customer and set a 'first' sequence without a
+        mandate ID."""
+        tx = self._create_transaction("redirect", tokenize=True)
+        with patch.object(
+            self.env.registry["payment.transaction"],
+            "_mollie_create_customer",
+            return_value="cst_test987",
+        ):
+            payload = tx._mollie_prepare_payment_request_payload()
+
+        expected_payload = {"sequenceType": "first", "customerId": "cst_test987"}
+        for key, value in expected_payload.items():
+            self.assertEqual(payload.get(key), value)
+        self.assertNotIn("mandateId", payload)
+
+    def test_payload_preparation_in_payment_with_token(self):
+        """Test that using a saved token produces a recurring payload with customer and mandate IDs
+        and no method."""
+        token = self._create_token(mollie_customer_id="cst_test987")
+        tx = self._create_transaction("redirect", token_id=token.id)
+
+        payload = tx._mollie_prepare_payment_request_payload()
+
+        expected_payload = {
+            "sequenceType": "recurring",
+            "customerId": "cst_test987",
+            "mandateId": "provider Ref (TEST)",
+        }
+        for key, value in expected_payload.items():
+            self.assertEqual(payload.get(key), value)
+        self.assertNotIn("method", payload)
+
+    def test_payload_preparation_in_oneoff_payment(self):
+        """Test that a payment without tokenization or token is configured as a one-off sequence."""
+        tx = self._create_transaction("redirect")
+        payload = tx._mollie_prepare_payment_request_payload()
+        self.assertEqual(payload.get("sequenceType"), "oneoff")
+
+    def test_extract_token_values_maps_fields_correctly(self):
+        """Test that the token values are extracted correctly from the payment data."""
+        tx = self._create_transaction("direct")
+        payment_data = {
+            "customerId": "cst_test987",
+            "details": {"cardNumber": "4242"},
+            "mandateId": "provider Ref (TEST)",
+        }
+        token_values = tx._extract_token_values(payment_data)
+        self.assertDictEqual(
+            token_values,
+            {
+                "payment_details": "4242",
+                "provider_ref": "provider Ref (TEST)",
+                "mollie_customer_id": "cst_test987",
+            },
+        )
+
     @mute_logger(
         "odoo.addons.payment_mollie.controllers.main",
         "odoo.addons.payment_mollie.models.payment_transaction",
@@ -46,6 +103,7 @@ class MollieTest(MollieCommon, PaymentHttpCommon):
             return_value={
                 "status": "paid",
                 "amount": {"value": str(self.amount), "currency": self.currency.name},
+                "id": "provider Ref (TEST)",
             },
         ):
             self._make_http_post_request(url, data=self.payment_data)


### PR DESCRIPTION
Enable tokenization for Mollie by exposing save payment details checkbox
and generating payment.token records from Mollie mandates.
This allows customers to store their payment method for future use.

task-5249290