### PR TITLE
[FIX] l10n_eu_oss: wrong call to self in loop

### DIFF
--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -92,7 +92,7 @@ class Company(models.Model):
                             ], order='sequence,id desc', limit=1)
                             foreign_tax_copy_name = existing_foreign_tax and _('%(tax_name)s (Copy)', tax_name=existing_foreign_tax.name)
 
-                            extra_fields = self._get_country_specific_account_tax_fields()
+                            extra_fields = company._get_country_specific_account_tax_fields()
                             foreign_taxes[tax_amount] = self.env['account.tax'].create({
                                 'name': foreign_tax_copy_name or foreign_tax_name,
                                 'amount': tax_amount,


### PR DESCRIPTION
To reproduce:
- Activate multiple companies in the selector
- Enable OSS on the active company
- Click the refresh mapping button ===> Traceback, because a function expects to be called on a single company and is instead called on all the active companies.

