### PR TITLE
[FIX] mail: push to talk should be released on stop keydown

### DIFF
--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -5,9 +5,16 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 
+/** In object so it's patchable */
+export const pttExtensionServiceInternal = {
+    onAnswerIsEnabled(pttService) {
+        pttService.isEnabled = true;
+    },
+};
+
 export const pttExtensionHookService = {
     start(env) {
-        const INITIAL_RELEASE_TIMEOUT = 500;
+        const INITIAL_RELEASE_TIMEOUT = 750;
         const COMMON_RELEASE_TIMEOUT = 200;
         // https://chromewebstore.google.com/detail/discuss-push-to-talk/mdiacebcbkmjjlpclnbcgiepgifcnpmg
         const EXT_ID = "mdiacebcbkmjjlpclnbcgiepgifcnpmg";
@@ -76,7 +83,7 @@ export const pttExtensionHookService = {
                     }
                     break;
                 case "answer-is-enabled":
-                    self.isEnabled = true;
+                    pttExtensionServiceInternal.onAnswerIsEnabled(self);
                     break;
             }
         });

--- a/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
+++ b/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
@@ -9,8 +9,9 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
+import { pttExtensionServiceInternal } from "@mail/discuss/call/common/ptt_extension_service";
 import { describe, test } from "@odoo/hoot";
-import { mockService } from "@web/../tests/web_test_helpers";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -19,9 +20,9 @@ test("display banner when ptt extension is not enabled", async () => {
     mockGetMedia();
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    mockService("discuss.ptt_extension", {
-        get isEnabled() {
-            return false;
+    patchWithCleanup(pttExtensionServiceInternal, {
+        onAnswerIsEnabled(pttService) {
+            pttService.isEnabled = false;
         },
     });
     patchUiSize({ size: SIZES.SM });


### PR DESCRIPTION
Before this commit, when using push-to-talk in a discuss call, sometimes the push-to-talk was kept on although user had it released.

Steps to reproduce:
- do not use discuss extensions' push-to-talk key
- start a call
- enable push-to-talk with chosen shortcut
- press and hold the push-to-talk key
- switch to another browser tab while keeping the push-to-talk key pressed (e.g. alt-tab while holding push-to-talk)
- release push-to-talk key
=> Even after a long time and coming back to the call tab, the push to talk is still on

This happens because the release of push to talk is designed with keyup intercepted on the call tab. While this happens most of the time, sometimes the keyup is triggered outside of call tab and never in call tab, thus the push-to-talk is not released.

This commit fixes the issue by triggering a push-to-talk release when unfocusing the tab.

task-[4707634](https://www.odoo.com/odoo/project/1519/tasks/4707634)