### PR TITLE
[FIX] mail: delete mention correctly

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -285,6 +285,16 @@ export class SelectionPlugin extends Plugin {
         const container = selection && closestElement(selection.anchorNode, containerSelector);
         const [anchorNode, anchorOffset] = getDeepestPosition(container, 0);
         const [focusNode, focusOffset] = getDeepestPosition(container, nodeSize(container));
+        if (
+            this.delegateTo("select_all_overrides", {
+                anchorNode,
+                anchorOffset,
+                focusNode,
+                focusOffset,
+            })
+        ) {
+            return;
+        }
         this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
     }
 

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1668,3 +1668,88 @@ test("parse link correctly in html composer", async () => {
     await pasteText(editor, "www.baidu.com");
     await contains(editor.editable.querySelector("a[target='_blank']"), { text: "www.baidu.com" });
 });
+
+test.tags("html composer");
+test("mentions can be correctly selected with ctrl+A and deleted", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    // partner beginning of the message
+    await htmlInsertText(editor, "@admin");
+    await click(".o-mail-NavigableList-item", { text: "Mitchell Admin" });
+    await contains(editor.editable, { text: "@Mitchell Admin" });
+    await htmlInsertText(editor, " Hello");
+    await contains(editor.editable, { textContent: "@Mitchell Admin Hello" });
+    await focus(editor.editable);
+    await press("Control+a");
+    await press("Backspace");
+    await contains(editor.editable, { textContent: "" });
+
+    // thread with an icon beginning of the message
+    await htmlInsertText(editor, "#general");
+    await click(".o-mail-NavigableList-item", { text: "General" });
+    await contains(editor.editable, { text: "General" });
+    await contains(editor.editable.querySelector("i.fa-hashtag"));
+    await htmlInsertText(editor, " Hello");
+    await contains(editor.editable, { textContent: "General Hello" });
+    await focus(editor.editable);
+    await press("Control+a");
+    await press("Backspace");
+    await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
+    await contains(editor.editable, { textContent: "" });
+
+    //partner in the middle of the message
+    await htmlInsertText(editor, "Hello @admin");
+    await click(".o-mail-NavigableList-item", { text: "Mitchell Admin" });
+    await contains(editor.editable, { text: "@Mitchell Admin" });
+    await htmlInsertText(editor, " nice to meet you!");
+    await contains(editor.editable, { textContent: "Hello @Mitchell Admin nice to meet you!" });
+    await focus(editor.editable);
+    await press("Control+a");
+    await press("Backspace");
+    await contains(editor.editable, { textContent: "" });
+
+    // thread with an icon in the middle of the message
+    await htmlInsertText(editor, "Hello #general");
+    await click(".o-mail-NavigableList-item", { text: "General" });
+    await contains(editor.editable, { text: "General" });
+    await contains(editor.editable.querySelector("i.fa-hashtag"));
+    await htmlInsertText(editor, " nice to meet you!");
+    await contains(editor.editable, { textContent: "Hello  General nice to meet you!" });
+    await focus(editor.editable);
+    await press("Control+a");
+    await press("Backspace");
+    await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
+    await contains(editor.editable, { textContent: "" });
+
+    //partner at the end of the message
+    await htmlInsertText(editor, "Hello @admin");
+    await click(".o-mail-NavigableList-item", { text: "Mitchell Admin" });
+    await contains(editor.editable, { text: "@Mitchell Admin" });
+    await focus(editor.editable);
+    await press("Control+a");
+    await press("Backspace");
+    await contains(editor.editable, { textContent: "" });
+
+    // thread with an icon at the end of the message
+    await htmlInsertText(editor, "Hello #general");
+    await click(".o-mail-NavigableList-item", { text: "General" });
+    await contains(editor.editable, { text: "General" });
+    await contains(editor.editable.querySelector("i.fa-hashtag"));
+    await focus(editor.editable);
+    await press("Control+a");
+    await press("Backspace");
+    await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
+    await contains(editor.editable, { textContent: "" });
+});


### PR DESCRIPTION
currently, when selecting all content (ctrl+A) in the html composer and deleting it (Backspace), if there is a mention in the content, only the text part of the selection is deleted, the rest remains.

To reproduce:
1. mention a partner in the html composer, type some text after.
2. selecting all content (ctrl+A) and delete it (Backspace).
3. only one character will be deleted, the rest remains.

This is the select all selects the deepest text nodes, meaning that the ndoe in the mention link will be selected. However, it is inside a protected node, so will lead to this issue.

This commit fixes the issue by overriding the select all behavior when the selection contains protected nodes, to select the whole protected node instead of its content.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
