### PR TITLE
[FIX] event: Ensure consistency of company between event and tickets

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Events Organization',
-    'version': '1.9',
+    'version': '1.10',
     'website': 'https://www.odoo.com/app/events',
     'category': 'Marketing/Events',
     'summary': 'Trainings, Conferences, Meetings, Exhibitions, Registrations',

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -205,6 +205,20 @@ class EventEvent(models.Model):
     specific_question_ids = fields.Many2many('event.question', 'event_event_event_question_rel',
         string='Specific Questions', domain=[('once_per_order', '=', False)])
 
+    @api.constrains('company_id', 'event_ticket_ids')
+    def _check_consistent_company_id(self):
+        if len(self.env.companies) == 1:
+            return
+        problematic_tickets = self.event_ticket_ids.filtered(
+            lambda r: r.product_id.company_id != self.company_id
+        )
+        if problematic_tickets:
+            raise ValidationError(
+                _("User Error: You can't include tickets (ids: %s) belonging to a different company than the company of the event (ids: %s)")
+                % (", ".join(str(t.id) for t in problematic_tickets),
+                   ", ".join(str(t.id) for t in self))
+            )
+
     def _compute_use_barcode(self):
         use_barcode = self.env['ir.config_parameter'].sudo().get_bool('event.use_event_barcode')
         for record in self:

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -50,9 +50,9 @@ class EventEventTicket(models.Model):
     color = fields.Char('Color', default="#875A7B")
 
     @api.depends('company_id', 'product_id', 'event_id')
-    def create(self, vals):
-        res = super().create(vals)
-        if len(self.env.companies) > 1 and any(k in vals for k in ('company_id', 'product_id', 'event_id')):
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        if len(self.env.companies) > 1 and any(k in vals_list for k in ('company_id', 'product_id', 'event_id')):
             res.event_id._check_consistent_company_id()
         return res
 

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -49,6 +49,13 @@ class EventEventTicket(models.Model):
     # reports
     color = fields.Char('Color', default="#875A7B")
 
+    @api.depends('company_id', 'product_id', 'event_id')
+    def create(self, vals):
+        res = super().create(vals)
+        if len(self.env.companies) > 1 and any(k in vals for k in ('company_id', 'product_id', 'event_id')):
+            res.event_id._check_consistent_company_id()
+        return res
+
     @api.depends('end_sale_datetime', 'event_id.date_tz')
     def _compute_is_expired(self):
         for ticket in self:

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -49,7 +49,6 @@ class EventEventTicket(models.Model):
     # reports
     color = fields.Char('Color', default="#875A7B")
 
-    @api.depends('company_id', 'product_id', 'event_id')
     def create(self, vals_list):
         res = super().create(vals_list)
         if len(self.env.companies) > 1 and any(k in vals_list for k in ('company_id', 'product_id', 'event_id')):

--- a/addons/event/tests/__init__.py
+++ b/addons/event/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_event_internals
 from . import test_event_mail_schedule
 from . import test_event_slot
 from . import test_mailing
+from . import test_event_tickets_multi_company

--- a/addons/event/tests/test_event_tickets_multi_company.py
+++ b/addons/event/tests/test_event_tickets_multi_company.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo.addons.event.tests.common import EventCase
+from odoo.exceptions import ValidationError
+
+
+class TestEventTicketsMultiCompany(EventCase):
+
+    def test_event_tickets_multi_company(self):
+        eur_cur = self.env.ref('base.EUR')
+        company_eur = self.env['res.company'].create({
+            'name': 'EUR Company',
+            'currency_id': eur_cur.id,
+        })
+        company_us = self.env.company
+        product_us, product_eur = self.env['product.product'].create([{
+            'name': 'Ticket US',
+            'type': 'service',
+            'service_tracking': 'event',
+            'list_price': 10,
+            'company_id': company_us.id,
+        }, {
+            'name': 'Ticket EUR',
+            'type': 'service',
+            'service_tracking': 'event',
+            'list_price': 10,
+            'company_id': company_eur.id,
+        }])
+        test_event = self.env['event.event'].create({
+            'date_begin': datetime.now() + relativedelta(days=-1),
+            'date_end': datetime.now() + relativedelta(days=1),
+            'name': 'Test Event',
+            'company_id': company_us.id,
+        })
+        self.env['event.event.ticket'].create({
+            'name': 'US ticket',
+            'event_id': test_event.id,
+            'product_id': product_us.id,
+        })
+        # include a eur ticket on us company
+        with self.assertRaises(ValidationError):
+            self.env['event.event.ticket'].create({
+                'name': 'EUR ticket',
+                'event_id': test_event.id,
+                'product_id': product_eur.id,
+            })
+        # attempt to change the company of the event to eur - should raise an error due to a us ticket already included on the event
+        with self.assertRaises(ValidationError):
+            test_event.write({'company_id': company_eur})
+        # attempt to change the company of the us product
+        with self.assertRaises(ValidationError):
+            product_us.write({'company_id': company_eur.id})

--- a/addons/event/tests/test_event_tickets_multi_company.py
+++ b/addons/event/tests/test_event_tickets_multi_company.py
@@ -27,7 +27,7 @@ class TestEventTicketsMultiCompany(EventCase):
             'list_price': 10,
             'company_id': company_eur.id,
         }])
-        test_event = self.env['event.event'].create({
+        event_us = self.env['event.event'].create({
             'date_begin': datetime.now() + relativedelta(days=-1),
             'date_end': datetime.now() + relativedelta(days=1),
             'name': 'Test Event',
@@ -35,19 +35,19 @@ class TestEventTicketsMultiCompany(EventCase):
         })
         self.env['event.event.ticket'].create({
             'name': 'US ticket',
-            'event_id': test_event.id,
+            'event_id': event_us.id,
             'product_id': product_us.id,
         })
         # include a eur ticket on us company
         with self.assertRaises(ValidationError):
             self.env['event.event.ticket'].create({
                 'name': 'EUR ticket',
-                'event_id': test_event.id,
+                'event_id': event_us.id,
                 'product_id': product_eur.id,
             })
         # attempt to change the company of the event to eur - should raise an error due to a us ticket already included on the event
         with self.assertRaises(ValidationError):
-            test_event.write({'company_id': company_eur})
+            event_us.write({'company_id': company_eur})
         # attempt to change the company of the us product
         with self.assertRaises(ValidationError):
             product_us.write({'company_id': company_eur.id})

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -539,6 +539,11 @@ class ProductTemplate(models.Model):
                 'image_128',
                 'can_image_1024_be_zoomed',
             ])
+        if len(self.env.companies) > 1 and 'company_id' in vals:
+            tickets = self.env['event.event.ticket'].sudo().search([
+                ('product_id', '=', self.ids),
+            ])
+            tickets.event_id._check_consistent_company_id()
         for product_template in self:
             if "type" in vals and vals.get("type") != "combo":
                 product_template.combo_ids = False

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -540,10 +540,14 @@ class ProductTemplate(models.Model):
                 'can_image_1024_be_zoomed',
             ])
         if len(self.env.companies) > 1 and 'company_id' in vals:
-            tickets = self.env['event.event.ticket'].sudo().search([
-                ('product_id.id', '=', self.product_variant_ids.id),
-            ])
-            tickets.event_id._check_consistent_company_id()
+            tickets = []
+            for variant in self.product_variant_ids:
+                tickets += self.env['event.event.ticket'].sudo().search([
+                    ('product_id.id', '=', variant.id),
+                ])
+            if tickets:
+                for ticket in tickets:
+                    ticket.event_id._check_consistent_company_id()
         for product_template in self:
             if "type" in vals and vals.get("type") != "combo":
                 product_template.combo_ids = False

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -541,7 +541,7 @@ class ProductTemplate(models.Model):
             ])
         if len(self.env.companies) > 1 and 'company_id' in vals:
             tickets = self.env['event.event.ticket'].sudo().search([
-                ('product_id', '=', self.product_variant_ids),
+                ('product_id.id', '=', self.product_variant_ids.id),
             ])
             tickets.event_id._check_consistent_company_id()
         for product_template in self:

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -541,7 +541,7 @@ class ProductTemplate(models.Model):
             ])
         if len(self.env.companies) > 1 and 'company_id' in vals:
             tickets = self.env['event.event.ticket'].sudo().search([
-                ('product_id', '=', self.ids),
+                ('product_id', '=', self.product_variant_ids),
             ])
             tickets.event_id._check_consistent_company_id()
         for product_template in self:


### PR DESCRIPTION
For mulit-company environments,the _check_consistent_company_id method prevents the addition of tickets belonging to a different company than the one listed on the event. It also prevents the modification of the company_id field on the event if there are tickets which belong a different company than the new value of company_id.

task~4720354

Description of the issue/feature this PR addresses:

Current behavior before PR: Tickets could be added to events regardless of the company associated with the ticket product or the company of the event. This results in a display issue on the event registration form.

Desired behavior after PR is merged: Ensure that the companies match between the ticket products and the event.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
