### PR TITLE
[FIX] mrp_subcontracting: Create missing locations also during upgrade

### DIFF
--- a/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml
+++ b/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <data noupdate="0">
+        <function model="res.company" name="_create_missing_subcontracting_location"/>
+    </data>
     <data noupdate="1">
         <record id="route_resupply_subcontractor_mto" model='stock.route'>
             <field name="name">Resupply Subcontractor on Order</field>
             <field name="company_id"></field>
             <field name="sequence">15</field>
         </record>
-        <function model="res.company" name="_create_missing_subcontracting_location" />
         <function model="stock.warehouse" name="write">
             <value model="stock.warehouse" eval="obj().env['stock.warehouse'].search([]).ids"/>
             <value eval="{'subcontracting_to_resupply': True}"/>


### PR DESCRIPTION
During an upgrade, it could happen that some companies are created before this module is loaded. That means the override of `_create_per_company_locations` is not called and the company is created with an empty `subcontracting_location_id`.

That can lead later to issues as that value was not expected to be empty.

To reproduce:
- On 16, install `onboarding`[^1], `l10n_de`, `mrp_subcontracting` with demo data.
- Upgrade to 17. Module `l10n_de` will have created a company with empty subcontracting location.
- Upgrade to 18. The upgrade will break during a call to `_create_or_update_sequences_and_picking_types` in `stock` because of the empty value.
[^1]: onboarding is necessary to ensure l10n_de is loaded before mrp_subcontracting because of the dependencies.