### PR TITLE
[FIX] mail: fix test 'can add message reaction (mobile)'

### DIFF
--- a/addons/mail/static/tests/mail_shared_tests.js
+++ b/addons/mail/static/tests/mail_shared_tests.js
@@ -6,16 +6,25 @@ export async function mailCanAddMessageReactionMobile() {
     mockUserAgent("android");
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.message"].create({
-        body: "Hello world",
-        res_id: channelId,
-        message_type: "comment",
-        model: "discuss.channel",
-    });
+    pyEnv["mail.message"].create([
+        {
+            body: "Hello world",
+            res_id: channelId,
+            message_type: "comment",
+            model: "discuss.channel",
+        },
+        {
+            body: "Hello Odoo",
+            res_id: channelId,
+            message_type: "comment",
+            model: "discuss.channel",
+        },
+    ]);
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Message", { text: "Hello world" });
-    await click(".o-mail-Message [title='Expand']");
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message:contains('Hello world')");
+    await click(".o-mail-Message:contains('Hello world') [title='Expand']");
     await click(".o-dropdown-item:contains('Add a Reaction')");
     await contains(".o-overlay-item:has(.modal .o-EmojiPicker)");
     const emojiPickerZIndex = parseInt(

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -439,7 +439,7 @@ export class MailMessage extends models.ServerModel {
         ]);
         let reaction_group = mailDataHelpers.Store.many(
             MailMessageReaction.browse(reactions),
-            "ADD"
+            makeKwArgs({ mode: "ADD" })
         );
         if (reactions.length === 0) {
             reaction_group = [["DELETE", { message: this.browse(id), content: content }]];


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/235852

Test was recently unskipped for test coverage of the fix, but there were non-deterministic failures of this test on runbot:
```
Failed to find 1 of ".o-mail-MessageReaction:contains('😀')" (Timeout of 3 seconds). Found 0 instead.
```

This happens because conversation has a single message, and the last message is fetched twice: once at init_messaging of the pinned conversation, and another one when loading the message list. The test was awaiting presence of message before adding reactions, but while adding a reaction it's possible to have 2nd fetch of message overwriting the message reactions from a prior `ADD`, leading to failed assertion below that there's no message reactions.

This commit fixes the issue by awaiting the whole message list render thanks to awaiting the 2 messages on UI and not just the 1st one.

Also the to_store format of message reaction was poorly formatted, which lead to "ADD" command being treated as a "REPLACE" instead. This commit also fixes this issue, as the client-side code of message reaction is designed to receive "ADD" commands.