### PR TITLE
[FIX] product: prevent infinite loop in cartesian product generation

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1298,6 +1298,11 @@ class ProductTemplate(models.Model):
                 # reset current line, and then go to previous line
                 value_index_per_line[line_index] = - 1
                 line_index -= 1
+
+                # skip backwards over any empty lines
+                while line_index > 0 and len(product_template_attribute_values_per_line[line_index]) == 0:
+                    line_index -= 1
+
                 continue
             else:
                 # we're done if we must reset first line


### PR DESCRIPTION
ISSUE:

When generating product variant combinations, the cartesian product algorithm enters an infinite loop whenever the attribute lines follow the pattern: non-empty → empty → non-empty. In this case, the DFS backtracking logic incorrectly returns to the empty middle line, which always forwards execution to the next line instead of propagating the backtrack upward. This causes the search to oscillate between the empty line and the deeper non-empty line, never allowing the first line to advance to its next value and repeatedly yielding the same combinations.

FIX:

This fix introduces a minimal, localized change: during backtracking, the algorithm now skips backward over empty attribute lines until it reaches a line that actually has selectable values (or reaches the root). This preserves all existing behavior, avoids altering the core iteration logic, and ensures that the DFS always makes progress and terminates properly.

The change avoids modifying exclusion logic or altering the order of generated combinations. It simply ensures that empty intermediate lines do not trap the state machine in a loop.

opw-5231175
