### PR TITLE
[FIX] sale_stock: prevent error when adding product in sale order

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -192,6 +192,7 @@ class StockPicking(models.Model):
     def _set_sale_id(self):
         if self.reference_ids:
             if self.sale_id:
+                self.reference_ids.sale_ids = [Command.unlink(so.id) for so in self.reference_ids.sale_ids]
                 self.reference_ids.sale_ids = [Command.link(self.sale_id.id)]
             else:
                 sale_order = self.move_ids.sale_line_id.order_id


### PR DESCRIPTION
The system crashes with an error when a user tries to add a new product to a Sale Order that is already confirmed.

**Steps to produce:**
- Install `Sales and stock` module without demo data.
- Make SO with customer and product and confirm the SO.
- Duplicate the SO and confirm it also.
- Now go to first SO > delivery > Additional info > change the sale order to second one.
- Then go to second SO > delivery > open the delivery where source document as second order > Additional info > change the sale order to first one. (Basically, we manually swap the pickings.)
- Go to the first SO and add new product and click on save.

**Error:**
`ValueError: Wrong value for stock.picking.sale_id: sale.order(3784, 3727)`

**Cause:**
- At [1], The domain used in the search returns two pickings, but because `limit=1` is applied, only the first picking is returned. which is not the one we want.
- The domain conditions match both pickings, which causes the wrong picking to be selected.
- At [2], When updating the `reference_ids`, the new sale order reference is added, but the previous sale order references are not removed.

**Solution:**
- This PR ensures that all previous sale order references are removed from `reference_ids` before adding the new one.
- This prevents multiple sale orders from being linked at once and ensures the correct picking is selected.

[1]https://github.com/odoo/odoo/blob/0313a5e47cfa3f338bd80ac25becd09862f0e11c/addons/stock/models/stock_move.py#L1389-L1390
[2]https://github.com/odoo/odoo/blob/0313a5e47cfa3f338bd80ac25becd09862f0e11c/addons/sale_stock/models/stock.py#L194-L195

**sentry-7013716337**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
