### PR TITLE
[FIX] hr: prevent error when clicking the New Contract button

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -3,7 +3,7 @@
     <t t-name="hr.ButtonNewContract">
         <span class="w-100 d-flex justify-content-end">
             <button class="btn btn-link p-0 o_field_widget text-end w-auto" t-on-click="onClickNewContractBtn"
-                    t-ref="datetime-picker-target-new-contract" t-if="props.record.data.contract_date_start">New Contract</button>
+                    t-ref="datetime-picker-target-new-contract" t-if="props.record.resId and props.record.data.contract_date_start">New Contract</button>
         </span>
     </t>
 </template>


### PR DESCRIPTION
Currently, an error occurs when the user clicks the New Contract button.

Steps to Reproduce ([Video](https://drive.google.com/file/d/11xSVGvMLJSvEfnHjixquP94wH29eVqMT/view)):

 - Install the `hr` module.
 - Go to `Employees` > click `New` > do not fill in the employee name.
 - In the `Payroll` section, set the contract `start and end dates`.
 - Click `New Contract` and select a date outside that date range.

`IndexError: tuple index out of range`

This error occurs because the user clicks the New Contract button before the employee record is created. Since the employee is not created, the employee ID is False. Then it attempts to create a contract with this False ID [1]. When the system tries to find the employee’s version using this False ID, no version is found, raise the error [2].

This commit ensures that the Add Contract button is visible after the employee record is created.

[1]- https://github.com/odoo/odoo/blob/bf0e135d55136dd6f263d281a09b7f4d08d7fc5b/addons/hr/static/src/components/button_new_contract/button_new_contract.js#L45-L48

[2]- https://github.com/odoo/odoo/blob/bf0e135d55136dd6f263d281a09b7f4d08d7fc5b/addons/hr/models/hr_employee.py#L554

sentry-7033637685


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
