### PR TITLE
[FIX] website_crm_partner_assign: authorise post message

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -9,6 +9,7 @@ from odoo.exceptions import AccessDenied, AccessError, UserError
 
 class CrmLead(models.Model):
     _inherit = "crm.lead"
+    _mail_post_access = 'read'
 
     partner_latitude = fields.Float('Geo Latitude', digits=(10, 7))
     partner_longitude = fields.Float('Geo Longitude', digits=(10, 7))

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -11,6 +11,7 @@ from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_crm_partner_assign.controllers.main import (
@@ -201,6 +202,17 @@ class TestPartnerLeadPortal(TestCrmCommon):
             'email_from': email_2,
         })
         self.assertEqual(test_partner.email, email_2, 'Adress email on the partner must be updated')
+
+        # Portal user must be able to write to the thread
+        old_message_ids = opportunity.message_ids
+        with MockRequest(self.env(user=self.user_portal)):
+            res = ThreadController().mail_message_post(
+                "crm.lead",
+                opportunity.id,
+                {"body": "Test message"},
+            )
+        new_message_ids = opportunity.message_ids - old_message_ids
+        self.assertEqual(res['message_id'], new_message_ids.id)
 
     def test_portal_mixin_url(self):
         record_action = self.lead_portal._get_access_action(access_uid=self.user_portal.id)


### PR DESCRIPTION
When we want to post a message, we check that the user has access to the thread, i.e. we check access for the `crm.lead` record with the `write` operation.

It is therefore necessary for the group portal to be able to post message on the `crm.lead` record (opportunity) he can read by adding `_mail_post_access` with the `read` operation.