### PR TITLE
[WIP][FIX] base_import: allow import records to work for client actions

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -96,7 +96,7 @@ export class ImportAction extends Component {
         if (!this.action) {
             return this.env.config.historyBack();
         }
-        if (this.action.type !== "ir.actions.act_window") {
+        if (!["ir.actions.act_window", "ir.actions.client"].includes(this.action.type)) {
             return this.actionService.restore(this.actionService.currentController.jsId);
         }
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install mrp_mps
2. Go to Inventory > Operations > Procurement > MPS
3. Click "Toggle search panel"(▼)
4. Click “Import Records”

Issue:
------
Nothing happens when clicking “Import Records”.

Cause:
------
After this 646bee6, initialization moved to `onWillStart()`, but it only runs
when the current action type is `ir.actions.act_window`. MPS triggers
the import from a [client action](https://github.com/odoo/enterprise/blob/142d86ad89435cd0751e9865ff62e8263a67e060/mrp_mps/views/mrp_mps_menu_views.xml#L4-L9), so the condition returns early and [get_import_templates](https://github.com/odoo/odoo/blob/f272eb19813be4254fd461ec21f1cc47e8834559/addons/base_import/static/src/import_model.js#L238) never loads.

Solution:
---------
Allow initialization for client actions as well, same as window actions.

Reference: MPS(Master Production Schedule)

opw-5248073



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
