### PR TITLE
[FIX] point_of_sale: correct config_id reference in cash move popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -64,7 +64,7 @@ export class CashMovePopup extends Component {
         const order = this.pos.models["pos.order"].create({
             session_id: this.session,
             company_id: this.company,
-            config_id: this.config,
+            config_id: this.pos.config,
             user_id: this.user,
             ticket_code: "",
             tracking_number: "",


### PR DESCRIPTION
Before this commit, the cash move popup created an order that missing the config_id field, leading to potential issues in receipt printing.

opw-5251257

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
