### PR TITLE
[FIX] web: Fix sync issue with updated datetime picker values issue

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -504,12 +504,12 @@ export const datetimePickerService = {
                         const oldStringProps = stringProps;
 
                         stringProps = stringifyProps(nextProps);
-                        lastAppliedStringValue = stringProps.value;
-
-                        if (shallowEqual(oldStringProps, stringProps)) {
+                        
+                        if (shallowEqual(oldStringProps, stringProps) && stringProps.value === lastAppliedStringValue) {
                             return;
                         }
-
+                        
+                        lastAppliedStringValue = stringProps.value;
                         inputsChanged = ensureArray(nextProps.value).map(() => false);
 
                         for (const [key, value] of Object.entries(nextProps)) {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -11905,6 +11905,27 @@ test(`only re-render necessary fields after change (with onchange)`, async () =>
     expect.verifySteps(["[Field int_field] onPatched", "[IntegerField int_field] onPatched"]);
 });
 
+test(`datetimepicker re-renders when date field is cleared`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="date"/>
+            </form>
+        `,
+        resId: 2,
+    });
+    expect(`.o_field_widget[name=date] input`).toHaveCount(1);
+    
+    await contains(`.o_field_widget[name=date] input`).edit("01/15/2025");
+    expect(`.o_field_widget[name=date] input`).not.toHaveValue("");
+
+    await contains(`.o_field_widget[name=date] input`).clear();
+    
+    expect(`.o_field_widget[name=date] input`).toHaveValue("");
+});
+
 test(`widget update several fields including an x2m`, async () => {
     Partner._onChanges = {
         name() {},


### PR DESCRIPTION
- Updated the datetimepicker service, ensuring changes to sync with backend.

Steps to reproduce:
- Install the Employee app.
- Go on an employee with a contract date start and contract date end.
- Remove the contract date start.

Issue:
The contract start date appears in the input field even after removing on the value on frontend, but once saved, the backend correctly stores it as False.

Cause:
When the UI updates, the condition check fails, preventing a rerender and leaving the field value unchanged. This issue stems from PR #227321.

Fix:
Fixed the condition so value changes are detected accurately, allowing the UI to re-render as expected.

task-5231971

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
