### PR TITLE
[FIX] l10n_*: fix installation issue for many localizations

### DIFF
--- a/addons/l10n_bh/__manifest__.py
+++ b/addons/l10n_bh/__manifest__.py
@@ -19,6 +19,7 @@ Activates:
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'data': [
         'data/tax_report_full.xml',
         'data/tax_report_simplified.xml',

--- a/addons/l10n_iq/__manifest__.py
+++ b/addons/l10n_iq/__manifest__.py
@@ -15,6 +15,7 @@ Activates:
     "depends": [
         "account",
     ],
+    "auto_install": ["account"],
     "data": ["data/res.country.state.csv"],
     "demo": ["demo/demo_company.xml"],
     "license": "LGPL-3",

--- a/addons/l10n_jo/__manifest__.py
+++ b/addons/l10n_jo/__manifest__.py
@@ -23,6 +23,7 @@ Activates:
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml',
     ],

--- a/addons/l10n_kw/__manifest__.py
+++ b/addons/l10n_kw/__manifest__.py
@@ -13,6 +13,7 @@ Activates:
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'demo': [
         'demo/demo_company.xml',
     ],

--- a/addons/l10n_mu_account/__manifest__.py
+++ b/addons/l10n_mu_account/__manifest__.py
@@ -16,6 +16,7 @@ This is the base module to manage the accounting chart for the Republic of Mauri
     "depends": [
         "account",
     ],
+    "auto_install": ["account"],
     "data": [
         "data/tax_report-mu.xml",
         "views/report_invoice.xml",

--- a/addons/l10n_ng/__manifest__.py
+++ b/addons/l10n_ng/__manifest__.py
@@ -11,7 +11,11 @@ Nigerian localization.
     'icon': '/account/static/description/l10n.png',
     'countries': ['ng'],
     'category': 'Accounting/Localizations/Account Charts',
-    'depends': ['base_vat'],
+    'depends': [
+        'account',
+        'base_vat',
+    ],
+    'auto_install': ['account'],
     'data': [
         'data/tax_report.xml',
         'data/withholding_vat_report.xml',

--- a/addons/l10n_pk/__manifest__.py
+++ b/addons/l10n_pk/__manifest__.py
@@ -19,6 +19,7 @@ Activates:
 - Withholding Tax Report
     """,
     'depends': ['account'],
+    'auto_install': ['account'],
     'data': [
         'data/res.country.state.csv',
         'data/account_tax_vat_report.xml',

--- a/addons/l10n_qa/__manifest__.py
+++ b/addons/l10n_qa/__manifest__.py
@@ -13,6 +13,7 @@ Activates:
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'demo': [
         'demo/demo_company.xml',
     ],

--- a/addons/l10n_tz_account/__manifest__.py
+++ b/addons/l10n_tz_account/__manifest__.py
@@ -8,6 +8,7 @@
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'description': """
     Tanzanian localisation containing:
     - COA

--- a/addons/l10n_zm_account/__manifest__.py
+++ b/addons/l10n_zm_account/__manifest__.py
@@ -17,6 +17,7 @@ This is the basic Zambian localization necessary to run Odoo in ZM:
     "depends": [
         "account",
     ],
+    "auto_install": ["account"],
     "data": [
         "data/account_tax_report_data.xml",
         "views/report_invoice.xml",


### PR DESCRIPTION
Steps to reproduce:
1. Install 'accountant'
2. Create a new company without a country and switch to that company
3. Accounting > Configuration > Fiscal Localization
4. Select Mauritius and save

Issue:
It gives a traceback: KeyError: 'mu'

Cause:
'auto_install' is not present in the manifest file.

Solution:
Add 'auto_install': ['account'] in the manifest as it is done in other localization modules.

opw-5231064