### PR TITLE
[FIX] hr_recruitment: fix save email to partner_id of hr_applicant

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -238,11 +238,11 @@ class HrApplicant(models.Model):
                         email_normalized: {'lang': self.env.lang}
                     },
                 )
-            if applicant.partner_name and not applicant.partner_id.name:
+            if applicant.partner_name and applicant.partner_name != applicant.partner_id.name:
                 applicant.partner_id.name = applicant.partner_name
-            if email_normalized and not applicant.partner_id.email:
+            if email_normalized and email_normalized != applicant.partner_id.email:
                 applicant.partner_id.email = applicant.email_from
-            if applicant.partner_phone and not applicant.partner_id.phone:
+            if applicant.partner_phone and applicant.partner_phone != applicant.partner_id.phone:
                 applicant.partner_id.phone = applicant.partner_phone
 
     @api.depends("email_normalized", "partner_phone_sanitized", "linkedin_profile")

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -444,3 +444,17 @@ class TestRecruitment(TransactionCase):
 
         job._compute_activities()
         self.assertEqual(job.activities_today, 0)
+
+    def test_applicant_modify_email_number(self):
+        applicant = self.env['hr.applicant'].create({
+            'partner_name': 'Mary Applicant',
+            'email_from': 'applicant@example.com',
+            'partner_phone': '123456789',
+        })
+        self.assertEqual(applicant.partner_id.email, 'applicant@example.com', "Email should have been set on the partner.")
+        self.assertEqual(applicant.partner_id.phone, '123456789', "Phone should have been set on the partner.")
+
+        applicant.email_from = 'applicant_diff@example.com'
+        self.assertEqual(applicant.partner_id.email, 'applicant_diff@example.com', "Email should have been updated on the partner.")
+        applicant.partner_phone = '987654321'
+        self.assertEqual(applicant.partner_id.phone, '987654321', "Phone should have been updated on the partner.")


### PR DESCRIPTION
Steps to reproduce:
1- Create a job position and then create an applicant for the position with an email address. 2- Change email from the applicant form.
3- Use the chatter to send an email.
4- As seen, both old email and new email address are used as recipient addresses which shouldn't be the case.

The cause was that it failed to save the new email on the partner_id associated to the hr_applicant. This was fixed by modifying the inverse function to allow the values to be modified even if already existant.

task-5269650
