### PR TITLE
[FIX] orm: fields.Json stable

### DIFF
--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -6,7 +6,7 @@ import typing
 
 from psycopg2.extras import Json as PsycopgJson
 
-from odoo.tools import SQL
+from odoo.tools import SQL, json_default
 
 from .fields import Field
 from .identifiers import IdType
@@ -54,8 +54,8 @@ class Boolean(Field[bool]):
 
 class Json(Field):
     """ JSON Field that contain unstructured information in jsonb PostgreSQL column.
-    This field is still in beta
-    Some features have not been implemented and won't be implemented in stable versions, including:
+
+    Some features won't be implemented, including:
     * searching
     * indexing
     * mutating the values.
@@ -71,10 +71,12 @@ class Json(Field):
     def convert_to_cache(self, value, record, validate=True):
         if not value:
             return None
-        return json.loads(json.dumps(value))
+        return json.loads(json.dumps(value, ensure_ascii=False, default=json_default))
 
     def convert_to_column(self, value, record, values=None, validate=True):
-        if not value:
+        if validate:
+            value = self.convert_to_cache(value, record)
+        if value is None:
             return None
         return PsycopgJson(value)
 


### PR DESCRIPTION
The field did not change for quite some time. It mainly serves as a way of storing and retrieving some unstructured data.
Use default serialization function when assiging values to Json fields.

Some business code may assign domains or frozendicts to json fields. That should not fail.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
