### PR TITLE
[FIX] account: Improve error message in _check_balanced()

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2448,7 +2448,8 @@ class AccountMove(models.Model):
             error_msg = _("The following entries are unbalanced:\n\n")
             for move in unbalanced_moves:
                 error_msg += f"  - {self.browse(move[0]).name}\n"
-                raise UserError(error_msg)
+
+            raise UserError(error_msg)
 
     def _get_unbalanced_moves(self, container):
         moves = container['records'].filtered(lambda move: move.line_ids)


### PR DESCRIPTION
The commit 3467b5971423f70581c6be2caf7f8a8d86ee70f1 intended to improve the error message in `_check_balanced()` by tailoring it based on the number of affected entries.

However, in the case of multiple affected entries, the error was raised after the first iteration, preventing the full list of unbalanced entries from being collected and displayed to the user.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
