### PR TITLE
[FIX] payment_authorize: prevent error when paying with authorize

### DIFF
--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -160,6 +160,9 @@ class PaymentTransaction(models.Model):
         tx_details = AuthorizeAPI(self.provider_id).get_transaction_details(
             payment_data.get('response', {}).get('x_trans_id')
         )
+        if 'err_code' in tx_details:  # Transaction details are missing when an API error occurs.
+            return None  # Skip the validation
+
         amount = tx_details.get('transaction', {}).get('authAmount')
         # Authorize supports only one currency per account.
         currency = self.provider_id.available_currency_ids  # The currency has not been removed from the provider.


### PR DESCRIPTION
Currently an error occurs when a user tries to pay using Authorize.net, and Authorize.net returns an error in the response.

**Steps to replicate:**
* Install `website_sale` and `payment_authorize` with demo.
* Setup the payment provider Authorize.net with valid credentials.
* Add the product to your cart, proceed to checkout, then use and save the payment details from [1] and complete the purchase.
* Repeat the checkout process after replacing the `API Login ID` with an invalid value, and then pay using the saved payment details.

**Error:**
`TypeError: float() argument must be a string or a real number, not 'NoneType'`

**Root cause:**
* The error happens because after the API request at [2], an error response causes `tx_details` to have no `transaction` key, as shown in [3]. This makes the amount at [4] become `None`, which then triggers an error at [5] when Python tries to convert `None` to `float`.
* As noted in the Authorize.net forums (see [6], [7], [8], [9]), the `E00040 'record not found'` error can appear when Authorize.net has synchronization issues on their end.

**Solution:**
* Show the error, change the transaction’s status to ‘error’, and save the error message on the transaction.

[1]:
https://developer.mastercard.com/unified-checkout-solutions/documentation/testing/test_data/ 
[2]:
https://github.com/odoo/odoo/blob/f272eb19813be4254fd461ec21f1cc47e8834559/addons/payment_authorize/models/payment_transaction.py#L160 
[3]:
https://drive.google.com/file/d/1JrXkKzRRTbpjZ8l0kJsX5SIg-kS-P5tv/view?usp=sharing 
[4]:
https://github.com/odoo/odoo/blob/f272eb19813be4254fd461ec21f1cc47e8834559/addons/payment_authorize/models/payment_transaction.py#L163 
[5]:
https://github.com/odoo/odoo/blob/f272eb19813be4254fd461ec21f1cc47e8834559/addons/payment_authorize/models/payment_transaction.py#L167 
[6]:
https://community.developer.cybersource.com/t5/Integration-and-Testing/E00040-The-record-cannot-be-found-right-after-profile-create/m-p/55106#M30039 
[7]:
https://community.developer.cybersource.com/t5/Integration-and-Testing/E00040-when-Creating-Subscription-from-Customer-Profile/m-p/59597#M34176
[8]:
https://stackoverflow.com/questions/67506179/authorize-net-shows-e00040-when-creating-subscription-from-customer-profile 
[9]:
https://community.developer.cybersource.com/t5/Integration-and-Testing/quot-E00040-The-record-cannot-be-found-quot-when-creating/td-p/62409

sentry-7021997195