### PR TITLE
[FIX] pos_loyalty: print giftcard report

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -855,7 +855,7 @@ patch(PosStore.prototype, {
             }
             if (payload.coupon_report) {
                 for (const [actionId, active_ids] of Object.entries(payload.coupon_report)) {
-                    await this.report.doAction(actionId, active_ids);
+                    await this.env.services.report.doAction(actionId, active_ids);
                 }
                 order.has_pdf_gift_card = Object.keys(payload.coupon_report).length > 0;
             }

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -529,6 +529,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.env.ref('loyalty.gift_card_product_50').product_tmpl_id.write({'active': True})
         # Create gift card program
         gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+        gift_card_program.pos_report_print_id = self.env.ref('loyalty.report_gift_card')
         # Run the tour to create a gift card
         self.start_pos_tour("GiftCardProgramTour1")
         # Check that gift cards are created


### PR DESCRIPTION
Current behavior:
-----------------
A traceback occurs upon validation of an order that contains a giftcard.

Steps to reproduce:
-------------------
* Open shop
* Add giftcard to the order
* Go to pay the order
* Select a payment method and validate
> Observation: A traceback occurs, giftcard report not downloaded

Why the fix:
------------
It seems like when this code was forwarded some uses this.env.services.report and some just this.report.
https://github.com/odoo/odoo/commit/246515874e863b72626da11a4f5151599b0fa7b5

18.0 has already been changed to use this.env.services.reports and was not merged forward because 18.2 was already using this.env.services.reports. However we need to fix the version pat 18.2 using this.report.

opw-5261898