### PR TITLE
[FIX] l10n_latam_invoice_document: load `l10n_latam_use_documents` for LATAM templates

### DIFF
--- a/addons/l10n_ar/models/res_company.py
+++ b/addons/l10n_ar/models/res_company.py
@@ -33,7 +33,7 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Argentinean localization use documents """
         self.ensure_one()
-        return self.account_fiscal_country_id.code == "AR" or super()._localization_use_documents()
+        return self.chart_template in {'ar_base', 'ar_ex', 'ar_ri'} or super()._localization_use_documents()
 
     def write(self, vals):
         if 'l10n_ar_afip_responsibility_type_id' in vals:

--- a/addons/l10n_br/models/res_company.py
+++ b/addons/l10n_br/models/res_company.py
@@ -15,4 +15,4 @@ class ResCompany(models.Model):
 
     def _localization_use_documents(self):
         self.ensure_one()
-        return self.account_fiscal_country_id.code == "BR" or super()._localization_use_documents()
+        return self.chart_template == 'br' or super()._localization_use_documents()

--- a/addons/l10n_cl/models/res_company.py
+++ b/addons/l10n_cl/models/res_company.py
@@ -12,4 +12,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Chilean localization use documents """
         self.ensure_one()
-        return self.account_fiscal_country_id.code == "CL" or super()._localization_use_documents()
+        return self.chart_template == 'cl' or super()._localization_use_documents()

--- a/addons/l10n_ec/models/res_company.py
+++ b/addons/l10n_ec/models/res_company.py
@@ -7,4 +7,4 @@ class ResCompany(models.Model):
 
     def _localization_use_documents(self):
         self.ensure_one()
-        return self.account_fiscal_country_id.code == "EC" or super(ResCompany, self)._localization_use_documents()
+        return self.chart_template == 'ec' or super()._localization_use_documents()

--- a/addons/l10n_pe/models/res_company.py
+++ b/addons/l10n_pe/models/res_company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         # OVERRIDE
         self.ensure_one()
-        return self.account_fiscal_country_id.code == "PE" or super()._localization_use_documents()
+        return self.chart_template == 'pe' or super()._localization_use_documents()

--- a/addons/l10n_uy/models/res_company.py
+++ b/addons/l10n_uy/models/res_company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Uruguayan localization use documents """
         self.ensure_one()
-        return self.account_fiscal_country_id.code == "UY" or super()._localization_use_documents()
+        return self.chart_template == 'uy' or super()._localization_use_documents()


### PR DESCRIPTION
### Issue:
During the loading of fiscal position data for LATAMs the option "Use Documents" on Journals is not set-up.

### Steps to reproduce:
- Install 'l10n_ar'
- Settings > Accounting
- Make sure the "Fiscal Localization" have a value (not Argentina)
- Change the "Fiscal Localization" to "Argentine - Generic Chart of Accounts [...]"
- Go in Accounting > Configuration > Journals
- Click on "Ventas Preimpreso"
- The journal don't have "Use Documents" ticked but it should

### Cause:
When loading the data, `_get_chart_template_data()` calls `_get_ar_base_res_company()` and `_get_latam_document_account_journal()`.

The first one returns the data to change `res.company.account_fiscal_country_id` to `base.ar`. The second one [checks](https://github.com/odoo/odoo/blob/26a5384af0af8fc6e6b5a10bea277f937e2b3481/addons/l10n_latam_invoice_document/models/account_chart_template.py#L12) that [`self.env.company.account_fiscal_country_id.code == "AR"`](https://github.com/odoo/odoo/blob/d985ec2e9b61b5e6c36a278654d526aaa5b512e2/addons/l10n_ar/models/res_company.py#L36) before returning the data to change `l10n_latam_use_documents` to `True`. As `res.company.account_fiscal_country_id` has not been updated, it's not Argentina during the check and `_get_latam_document_account_journal()` returns nothing.

### Solution:
When loading the template, we cannot use `res.company.account_fiscal_country_id` to know if we are in LATAM or not. So instead we check on `chart_template`.

opw-5221931