### PR TITLE
[FIX] l10n_hu_edi: stop sending region element in edi as it is not mandatory

### DIFF
--- a/addons/l10n_hu_edi/data/template_invoice.xml
+++ b/addons/l10n_hu_edi/data/template_invoice.xml
@@ -112,7 +112,6 @@
     <template id="nav_online_invoice_xml_3_0_simple_address" xmlns:base="http://schemas.nav.gov.hu/OSA/3.0/base">
         <base:simpleAddress>
             <base:countryCode t-out="partner.country_code"/>
-            <base:region t-if="partner.state_id" t-out="partner.state_id.name"/>
             <base:postalCode t-out="partner.zip"/>
             <base:city t-out="partner.city"/>
             <base:additionalAddressDetail t-out="partner.street"/>


### PR DESCRIPTION
Purpose: According to documentation, in region tag in address details, we need
to send that county's province code as per the ISO 3166-2 alpha 2 standard.
E.g. 'HU-BU'. But we were sending state's name E.g. 'Budapest'. But since region
tag is not mandatory for edi, we choose not to send that.

Before this commit: In region tag, state's name was sent.

After this commit: We stopped sending region tag.

EDI Documentation(page-87): https://onlineszamla.nav.gov.hu/files/container/download/2025.10.09.%20EN_Online%20Invoice%20System%203.0%20Interface%20Specification%20.pdf

task-5270199