### PR TITLE
[FIX] payment: correct label on clipboard button in payment link wizard

### DIFF
--- a/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
+++ b/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
@@ -22,6 +22,10 @@ class PaymentWizardCopyClipboardButtonField extends CopyClipboardButtonField {
 const paymentWizardCopyClipboardButtonField = {
     ...copyClipboardButtonField,
     component: PaymentWizardCopyClipboardButtonField,
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...copyClipboardButtonField.extractProps(fieldInfo, dynamicInfo),
+        string: fieldInfo.string,
+    }),
 };
 
 registry

--- a/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
+++ b/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
@@ -32,7 +32,7 @@ QUnit.module("Payment", {
 });
 
 QUnit.test("copy link immediatly after entering the amount", async (assert) => {
-    assert.expect(2);
+    assert.expect(3);
 
     await makeView({
         serverData,
@@ -65,6 +65,11 @@ QUnit.test("copy link immediatly after entering the amount", async (assert) => {
         },
     });
 
+    assert.strictEqual(
+        target.querySelector(".o_clipboard_button").textContent,
+        "Generate and Copy Payment Link",
+        "The clipboard button should show the correct label"
+    );
     // not awaiting the events
     editInput(target, ".o_field_widget[name=amount] input", "13");
 


### PR DESCRIPTION
Steps to reproduce:
1. Install sale_management
2. Create a sale order and confirm it
3. Open the Generate a Payment Link wizard from the cog menu

Issue:
The button in the wizard displays “Copy” instead of “Generate a Payment Link”.

Cause:
The custom paymentWizardCopyClipboardButtonField widget did not forward the field’s string to its component props, causing the default "Copy" label to be used.

Solution:
Forward the string prop in the widget’s extractProps implementation.

opw-5224112