### PR TITLE
[IMP] website_sale_autocomplete: allow to change the type of search for the google_places api

### DIFF
--- a/addons/website_sale_autocomplete/controllers/main.py
+++ b/addons/website_sale_autocomplete/controllers/main.py
@@ -73,11 +73,12 @@ class AutoCompleteController(http.Controller):
                 'session_id': session_id
             }
 
+        types = request.context.get('types', 'address')
         params = {
             'key': api_key,
             'fields': 'formatted_address,name',
             'inputtype': 'textquery',
-            'types': 'address',
+            'types': types,
             'input': partial_address
         }
         if country_code:

--- a/doc/cla/individual/pencherek.md
+++ b/doc/cla/individual/pencherek.md
@@ -1,0 +1,11 @@
+Switzerland, 2025.11.18
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Noah Pencherek noah@pencherek.ch https://github.com/pencherek


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We use the google search autocomplete for completing our clients informations in the application Contact, but for some reasons almost all the times the autocomplete was not working, it was not able to find an address (the same query worked on google search engine).
Current behavior before PR:
On trying to search the business of a client by name, most of the time no result found.
Desired behavior after PR is merged:
I would be able to change the base behaviour of the google search api with a custom module by changing the parameter of the method, by changing the types from "address" to "geocode|establishment".
This change will change nothing for thoses who don't need this improvement, because the old comportement was kept as a default parameter.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
