### PR TITLE
[REM] stock_account,.*_stock,point_of_sale: remove unused method

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -33,14 +33,6 @@ class AccountMove(models.Model):
             if move.pos_session_ids:
                 move.always_tax_exigible = True
 
-    def _stock_account_get_last_step_stock_moves(self):
-        stock_moves = super(AccountMove, self)._stock_account_get_last_step_stock_moves()
-        for invoice in self.filtered(lambda x: x.move_type == 'out_invoice'):
-            stock_moves += invoice.sudo().mapped('pos_order_ids.picking_ids.move_ids').filtered(lambda x: x.state == 'done' and x.location_dest_id.usage == 'customer')
-        for invoice in self.filtered(lambda x: x.move_type == 'out_refund'):
-            stock_moves += invoice.sudo().mapped('pos_order_ids.picking_ids.move_ids').filtered(lambda x: x.state == 'done' and x.location_id.usage == 'customer')
-        return stock_moves
-
 
     def _get_invoiced_lot_values(self):
         self.ensure_one()

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -122,16 +122,6 @@ class AccountMove(models.Model):
 
         return super()._post(soft)
 
-    def _stock_account_get_last_step_stock_moves(self):
-        """ Overridden from stock_account.
-        Returns the stock moves associated to this invoice."""
-        rslt = super()._stock_account_get_last_step_stock_moves()
-        for invoice in self.filtered(lambda x: x.move_type == 'in_invoice'):
-            rslt += invoice.mapped('invoice_line_ids.purchase_line_id.move_ids').filtered(lambda x: x.state == 'done' and x.location_id.usage == 'supplier')
-        for invoice in self.filtered(lambda x: x.move_type == 'in_refund'):
-            rslt += invoice.mapped('invoice_line_ids.purchase_line_id.move_ids').filtered(lambda x: x.state == 'done' and x.location_dest_id.usage == 'supplier')
-        return rslt
-
     @api.depends('purchase_id')
     def _compute_incoterm_location(self):
         super()._compute_incoterm_location()

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -9,23 +9,6 @@ from odoo.tools.misc import formatLang
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    def _stock_account_get_last_step_stock_moves(self):
-        """ Overridden from stock_account.
-        Returns the stock moves associated to this invoice."""
-        rslt = super()._stock_account_get_last_step_stock_moves()
-        for invoice in self:
-            if invoice.move_type not in ['out_invoice', 'out_refund']:
-                continue
-            if (invoice.move_type == 'out_invoice' or (
-                invoice.move_type == 'out_refund' and any(invoice.invoice_line_ids.sale_line_ids.mapped('is_downpayment')))
-            ):
-                rslt += invoice.mapped('invoice_line_ids.sale_line_ids.move_ids').filtered(lambda x: x.state == 'done' and x.location_dest_id.usage == 'customer')
-            else:
-                rslt += invoice.mapped('reversed_entry_id.invoice_line_ids.sale_line_ids.move_ids').filtered(lambda x: x.state == 'done' and x.location_id.usage == 'customer')
-                # Add refunds generated from the SO
-                rslt += invoice.mapped('invoice_line_ids.sale_line_ids.move_ids').filtered(lambda x: x.state == 'done' and x.location_id.usage == 'customer')
-        return rslt
-
     def _get_invoiced_lot_values(self):
         """ Get and prepare data to show a table of invoiced lot on the invoice's report. """
         self.ensure_one()

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -164,8 +164,5 @@ class AccountMove(models.Model):
         """
         return self.env.context
 
-    def _get_related_stock_moves(self):
-        return self.env['stock.move']
-
     def _get_invoiced_lot_values(self):
         return []


### PR DESCRIPTION
`_stock_account_get_last_step_stock_moves` is not used and is an override of a method that has been changed.
The new name of the method is unused (_get_related_stock_moves) and is removed too.

(the last use of `_get_related_stock_moves` got removed in https://github.com/odoo/enterprise/commit/57a18e6fb58d8b5decdff9fbe7e628e8155987c1 because the whole class was not used and was not working properly anymore)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
