### PR TITLE
[REF] base, web: company_logo as attachment

### DIFF
--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -264,43 +264,28 @@ class Binary(http.Controller):
         imgname = 'logo'
         imgext = '.png'
         dbname = request.db
-        uid = (request.session.uid if dbname else None) or odoo.SUPERUSER_ID
 
         if not dbname:
             response = http.Stream.from_path(file_path('web/static/img/logo.png')).get_response()
         else:
             try:
-                company = int(kw['company']) if kw and kw.get('company') else False
-                if company:
-                    request.env.cr.execute("""
-                        SELECT logo_web, write_date
-                          FROM res_company
-                         WHERE id = %s
-                    """, (company,))
+                attachment = request.env(user=request.session.uid or odoo.api.SUPERUSER_ID, su=True)['ir.attachment']
+                if company_id := (kw or {}).get('company'):
+                    company_ids = [int(company_id)]
                 else:
-                    request.env.cr.execute("""
-                        SELECT c.logo_web, c.write_date
-                          FROM res_users u
-                     LEFT JOIN res_company c
-                            ON c.id = u.company_id
-                         WHERE u.id = %s
-                    """, (uid,))
-                row = request.env.cr.fetchone()
-                if row and row[0]:
-                    image_base64 = base64.b64decode(row[0])
-                    image_data = io.BytesIO(image_base64)
-                    mimetype = guess_mimetype(image_base64, default='image/png')
-                    imgext = '.' + mimetype.split('/')[1]
-                    if imgext == '.svg+xml':
-                        imgext = '.svg'
-                    response = send_file(
-                        image_data,
-                        request.httprequest.environ,
-                        download_name=imgname + imgext,
-                        mimetype=mimetype,
-                        last_modified=row[1],
-                        response_class=Response,
-                    )
+                    # keeping a single query
+                    company_ids = attachment.env.user._as_query(ordered=False).subselect('company_id')
+                attachment = attachment.search_fetch([
+                    ('res_model', '=', 'res.company'),
+                    ('res_field', '=', 'logo_web'),
+                    ('res_id', 'in', company_ids),
+                ], limit=1)
+                if attachment:
+                    stream = attachment._to_http_stream()
+                    download_ext = '.svg' if '/svg' in attachment.mimetype else imgext
+                    stream.download_name = f'{imgname}{download_ext}'
+                    stream.public = True
+                    response = stream.get_response()
                 else:
                     response = http.Stream.from_path(file_path('web/static/img/nologo.png')).get_response()
             except Exception:

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -52,9 +52,7 @@ class ResCompany(models.Model):
     company_details = fields.Html(string='Company Details', translate=True, help="Header text displayed at the top of all reports.")
     is_company_details_empty = fields.Boolean(compute='_compute_empty_company_details')
     logo = fields.Binary(related='partner_id.image_1920', default=_get_logo, string="Company Logo", readonly=False)
-    # logo_web: do not store in attachments, since the image is retrieved in SQL for
-    # performance reasons (see addons/web/controllers/main.py, Binary.company_logo)
-    logo_web = fields.Binary(compute='_compute_logo_web', store=True, attachment=False)
+    logo_web = fields.Binary(compute='_compute_logo_web', store=True)
     uses_default_logo = fields.Boolean(compute='_compute_uses_default_logo', store=True)
     currency_id = fields.Many2one('res.currency', string='Currency', required=True, default=lambda self: self._default_currency_id())
     user_ids = fields.Many2many('res.users', 'res_company_users_rel', 'cid', 'user_id', string='Accepted Users')


### PR DESCRIPTION
Avoid storing the data in the field. Performance reasons from 2015 have changed: fields are base64-encoded which adds overhead and attachments may be streamed directly by the web server and the mimetype is stored as well. We just keep it one query.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
