### PR TITLE
[IMP] mail, im_livechat: clarify external access and improve email invite UX

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -1005,3 +1005,6 @@ class DiscussChannel(models.Model):
                     "operatorFound": True,
                 },
             ).bus_send()
+
+    def _allow_invite_by_email(self):
+        return self.channel_type == "livechat" or super()._allow_invite_by_email()

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -111,5 +111,8 @@ const discussChannelPatch = {
         }
         return super.showImStatus;
     },
+    get allow_invite_by_email() {
+        return this.channel_type === "livechat" || super.allow_invite_by_email;
+    },
 };
 patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1341,7 +1341,7 @@ class DiscussChannel(models.Model):
         return channel
 
     def _allow_invite_by_email(self):
-        return self.channel_type == "group" or (
+        return self.channel_type in ("group", "chat") or (
             self.channel_type == "channel" and not self.group_public_id
         )
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -240,8 +240,11 @@ export class Thread extends Record {
     }
 
     get accessRestrictedToGroupText() {
-        if (!this.group_public_id?.full_name) {
+        if (this.channel?.channel_type === "chat") {
             return false;
+        }
+        if (!this.group_public_id?.full_name) {
+            return _t("Accessible to anyone with the link");
         }
         return _t('Access restricted to group "%(groupFullName)s"', {
             groupFullName: this.group_public_id.full_name,

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.scss
@@ -40,3 +40,12 @@
     position: sticky;
     bottom: - map-get($spacers, 2); // Ignore p-2 class of ActionPanel
 }
+
+.o-discuss-ChannelInvitation-iconContainer {
+    margin-top: 1px;
+}
+
+.o-discuss-ChannelInvitation-iconPlus {
+    top: -4px;
+    right: -5px;
+}

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,7 +11,13 @@
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.channel }">
             <t t-if="store.self_user">
-                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
+                <div class="position-relative">
+                    <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
+                    <div t-if="props.channel?.allow_invite_by_email" class="o-discuss-ChannelInvitation-iconContainer position-absolute top-50 end-0 translate-middle-y me-2 smaller opacity-50" data-tooltip="Type email to invite">
+                        <i class="fa fa-envelope-o fa-lg"/>
+                        <i class="fa fa-plus-circle o-discuss-ChannelInvitation-iconPlus position-absolute bg-white rounded-circle"/>
+                    </div>
+                </div>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 and state.selectableEmails.length === 0 }">
                     <div t-if="selectablePartners.length === 0 and state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
                         <t t-if="props.channel">No people found to invite.</t>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -88,6 +88,7 @@ export class DiscussChannel extends Record {
     get allow_invite_by_email() {
         return (
             this.channel_type === "group" ||
+            this.channel_type == "chat" ||
             (this.channel_type === "channel" && !this.group_public_id)
         );
     }

--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -10,7 +10,7 @@ registry.category("web_tour.tours").add("discuss.invite_by_email", {
             run: "click",
         },
         {
-            trigger: ".o-discuss-ChannelInvitation-search[placeholder='Invite people or email']",
+            trigger: ".o-discuss-ChannelInvitation-search[placeholder='Enter name or email']",
             run: "edit john@test.com",
         },
         {

--- a/addons/mail/tests/discuss/test_discuss_channel_invite.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_invite.py
@@ -82,7 +82,7 @@ class TestDiscussChannelInvite(HttpCase, MailCommon):
                 "group_public_id": self.env.ref("base.group_user").id,
             }
         )
-        for channel in [chat, private_channel]:
+        for channel in private_channel:
             with self.assertRaises(UserError) as exc:
                 channel.invite_by_email(["some@email.com"])
             self.assertEqual(
@@ -90,7 +90,7 @@ class TestDiscussChannelInvite(HttpCase, MailCommon):
                 f"Inviting by email is not allowed for this channel type ({channel.channel_type}).",
             )
         with self.mock_mail_gateway():
-            for channel in [group_chat, public_channel]:
+            for channel in [chat, group_chat, public_channel]:
                 channel.invite_by_email(["some@email.com"])
                 self.assertMailMail(
                     self.env["res.partner"],
@@ -166,13 +166,13 @@ class TestDiscussChannelInvite(HttpCase, MailCommon):
             ),
             # Channel types that do not allow inviting by email, not selectable.
             *product(
-                [chat, private_channel],
+                private_channel,
                 ["bob@odoo.com", "alfred@odoo.com", "jane@odoo.com"],
                 [False],
             ),
             # Channel types that allow inviting by email, valid email, selectable.
             *product(
-                [group_chat, public_channel],
+                [chat, group_chat, public_channel],
                 ["bob@odoo.com", "alfred@odoo.com", "jane@odoo.com"],
                 [True],
             ),


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------
Users often did not realize that conversations could be joined by external people.
There was no clear indication when a conversation was accessible to anyone with the link.
Additionally, the email invitation option in the invitation panel was not very discoverable,
causing users to overlook the ability to invite external participants by email.

**Current behavior before PR:**
---------------------------------
- No message is shown when a conversation is publicly accessible through the share link.
- External invitations are not allowed from live chat or direct messages.
- The invitation panel uses the placeholder “Invite people or email”, which does not make the email option obvious.
- There is no icon or tooltip to guide users toward using email for invitations.

**Desired behavior after PR is merged:**
-----------------------------------------
- A clear message is displayed under the share link when the conversation is accessible to anyone with the link.
- External invitations are allowed from live chat and direct messages.
- The placeholder is updated to “Enter name or email” for better clarity.
- An envelope plus icon is added, showing a “Type email to invite” tooltip on hover to improve discoverability.

**Task:** 5135950
**Related Enterprise PR:** https://github.com/odoo/enterprise/pull/99769

envelope plus icon:
<img width="477" height="336" alt="image" src="https://github.com/user-attachments/assets/5511cfab-5035-4e22-97e6-d9b3b7623177" />
<img width="722" height="283" alt="image" src="https://github.com/user-attachments/assets/90678cd6-4423-4d8c-b38e-0eefb84a16c5" />







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
