### PR TITLE
[IMP] resource: avoid creating resource from resource leaves

### DIFF
--- a/addons/resource/views/resource_calendar_leaves_views.xml
+++ b/addons/resource/views/resource_calendar_leaves_views.xml
@@ -43,7 +43,7 @@
                         <field name="name" string="Reason"/>
                         <field name="calendar_id"/>
                         <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" invisible="not calendar_id"/>
-                        <field name="resource_id"/>
+                        <field name="resource_id" options="{'no_create': True}"/>
                     </group>
                     <group name="leave_dates">
                        <field name="date_from"/>


### PR DESCRIPTION
Purpose
=======
Remove the possibility to create a resource from the resource leaves form view (by clicking on the "Search more" of the resource field and then clicking on "New").

Specification
=============
Creating resources this way leads to misunderstandings, especially in modules using the resource.mixin like appointment where users think they're creating an appointment resource when they're actually creating a basic resource.

Globally seems also weird to add a leave to a not yet created resource.

=> Adding the no_create option on the resource field in the resource leave form view to prevent any resource creation from this view.

Task-5079021


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
