### PR TITLE
[IMP] hr: remove contract_wage field and use method instead

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -208,7 +208,6 @@ class HrEmployee(models.Model):
     contract_date_start = fields.Date(readonly=False, related="version_id.contract_date_start", inherited=True, groups="hr.group_hr_manager")
     contract_date_end = fields.Date(readonly=False, related="version_id.contract_date_end", inherited=True, groups="hr.group_hr_manager")
     trial_date_end = fields.Date(readonly=False, related="version_id.trial_date_end", inherited=True, groups="hr.group_hr_manager")
-    contract_wage = fields.Monetary(related="version_id.contract_wage", inherited=True, groups="hr.group_hr_manager")
     date_start = fields.Date(related='version_id.date_start', inherited=True, groups="hr.group_hr_manager")
     date_end = fields.Date(related='version_id.date_end', inherited=True, groups="hr.group_hr_manager")
     is_current = fields.Boolean(related='version_id.is_current', inherited=True, groups="hr.group_hr_manager")

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -168,7 +168,6 @@ class HrVersion(models.Model):
     currency_id = fields.Many2one(string="Currency", related='company_id.currency_id', readonly=True)
     wage = fields.Monetary('Wage', tracking=True, help="Employee's monthly gross wage.", aggregator="avg",
                            groups="hr.group_hr_manager")
-    contract_wage = fields.Monetary('Contract Wage', compute='_compute_contract_wage', groups="hr.group_hr_manager")
     # [XBO] TODO: remove me in master
     company_country_id = fields.Many2one('res.country', string="Company country",
                                          related='company_id.country_id', readonly=True)
@@ -451,11 +450,6 @@ class HrVersion(models.Model):
                 for field, value in contract_template_vals.items()
                 if field in whitelist and not self.env['hr.version']._fields[field].related
         }
-
-    @api.depends('wage')
-    def _compute_contract_wage(self):
-        for version in self:
-            version.contract_wage = version._get_contract_wage()
 
     def _get_contract_wage(self):
         if not self:

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -648,7 +648,6 @@ class TestHrVersion(TestHrCommon):
             "active_employee",
             "activity_ids",
             "company_country_id",
-            "contract_wage",
             "country_code",
             "create_date",
             "create_uid",


### PR DESCRIPTION
contract_wage field is just a shortcut field that calls _get_contract_wage() to get the wage from the correct wage field in function of the context.

In the process of merging and cleaning the multiple wage field that exists in hr and payroll, this field can be deleted, and each time it was used, the _get_contract_wage() method is used instead.

Task-5125864