### PR TITLE
[FIX] mrp,{purchase,sale}_stock,stock: handle assigning multiple stock reference

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -3126,12 +3126,14 @@ class MrpProduction(models.Model):
             res = OrderedSet(topological_sort(self.fields_get(res, ('depends'))))
         return res
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _add_reference(self, reference):
-        """ link the given reference to the list of references. """
+        """ link the given references to the list of references. """
         self.ensure_one()
-        self.reference_ids = [Command.link(reference.id)]
+        self.reference_ids = [Command.link(stock_reference.id) for stock_reference in reference]
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _remove_reference(self, reference):
-        """ remove the given reference to the list of references. """
+        """ remove the given references from the list of references. """
         self.ensure_one()
-        self.reference_ids = [Command.unlink(reference.id)]
+        self.reference_ids = [Command.unlink(stock_reference.id) for stock_reference in reference]

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -453,12 +453,14 @@ class PurchaseOrder(models.Model):
         res["suggested_qty"] = product.suggested_qty
         return res
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _add_reference(self, reference):
-        """ link the given reference to the list of references. """
+        """ link the given references to the list of references. """
         self.ensure_one()
-        self.reference_ids = [Command.link(reference.id)]
+        self.reference_ids = [Command.link(stock_reference.id) for stock_reference in reference]
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _remove_reference(self, reference):
-        """ remove the given reference to the list of references. """
+        """ remove the given references from the list of references. """
         self.ensure_one()
-        self.reference_ids = [Command.unlink(reference.id)]
+        self.reference_ids = [Command.unlink(stock_reference.id) for stock_reference in reference]

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -323,12 +323,14 @@ class SaleOrder(models.Model):
     def _is_display_stock_in_catalog(self):
         return True
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _add_reference(self, reference):
-        """ link the given reference to the list of references. """
+        """ link the given references to the list of references. """
         self.ensure_one()
-        self.stock_reference_ids = [Command.link(reference.id)]
+        self.stock_reference_ids = [Command.link(stock_reference.id) for stock_reference in reference]
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _remove_reference(self, reference):
-        """ remove the given reference to the list of references. """
+        """ remove the given references from the list of references. """
         self.ensure_one()
-        self.stock_reference_ids = [Command.unlink(reference.id)]
+        self.stock_reference_ids = [Command.unlink(stock_reference.id) for stock_reference in reference]

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -2096,15 +2096,17 @@ class StockPicking(models.Model):
         self.ensure_one()
         return self.state == 'done'
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _add_reference(self, reference=False):
-        """ link the given reference to the list of references. """
+        """ link the given references to the list of references. """
         self.ensure_one()
-        self.move_ids.reference_ids = [Command.link(reference.id)]
+        self.move_ids.reference_ids = [Command.link(stock_reference.id) for stock_reference in reference]
 
+    # TODO: rename the parameter from reference to references in master for improved readability
     def _remove_reference(self, reference):
-        """ remove the given reference to the list of references. """
+        """ remove the given references from the list of references. """
         self.ensure_one()
-        self.move_ids.reference_ids = [Command.unlink(reference.id)]
+        self.move_ids.reference_ids = [Command.unlink(stock_reference.id) for stock_reference in reference]
 
     def _prepare_entire_pack_move_line_vals(self, packages):
         """ Prepares the move line values for every packages within packages and their children that contain products.


### PR DESCRIPTION
Currently an error occurs when there are multiple stock references of same name, and user assigns references on Reception report.

Steps to replicate:
- Install `sale_stock`.
- Load Demo data from Settings.
- From settings, check `Reception Report`.
- Go to Operations > Reference > S00004 > Duplicate it (from the form view).
- Open Receipts > WH/IN/00002 > Allocation (Smart button) > Click 'Assign All' or the S00004 line.

Error:
```
File "/home/odoo/odoo18/community/addons/stock/report/report_stock_reception.py", line 271, in action_assign
    self._action_assign(in_move, out)
  File "/home/odoo/odoo18/community/addons/stock/report/report_stock_reception.py", line 343, in _action_assign
    in_move._get_source_document()._add_reference(out_ref)
  File "/home/odoo/odoo18/community/addons/stock/models/stock_picking.py", line 2102, in _add_reference
    self.move_ids.reference_ids = [Command.link(reference.id)]
  File "/home/odoo/odoo18/community/odoo/orm/fields_misc.py", line 112, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: stock.reference(3, 19)
```

Cause:
- As the user duplicated the record, there were two records received in the variable `reference` at [1] that caused the expected singleton error.

Solution:
- The methods `_add_reference()` and `_remove_reference()` can now handle multiple reference records.

[1]: https://github.com/odoo/odoo/blob/4b2154870eebcce449f53d8f593386ae6af04a83/addons/sale_stock/models/sale_order.py#L329

sentry-6982131891
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
