### PR TITLE
[IMP] l10n_in: move TDS Section field before Base Amount Field

### DIFF
--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
@@ -22,7 +22,6 @@
                     <group>
                         <group id="header_left_group">
                             <field name="date" string="Entry Date"/>
-                            <field name="base" widget="monetary" options="{'currency_field': 'currency_id'}" required="True"/>
                             <label for="tax_id" string="TDS Section"/>
                             <div>
                                 <field name="tax_id" class="oe_inline" domain="[('l10n_in_tax_type', '=', l10n_in_tds_tax_type)]" required="True"
@@ -34,6 +33,7 @@
                                        invisible="tds_deduction == 'normal'"
                                 />
                             </div>
+                            <field name="base" widget="monetary" options="{'currency_field': 'currency_id'}" required="True"/>
                             <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="currency_id" invisible="1"/> <!-- used to display the currency symbol -->
                             <field name="related_move_id" invisible="1"/> <!-- used to compute the l10n_in_tds_tax_type -->


### PR DESCRIPTION
Before this commit:
- In the TDS Entry wizard the Base Amount field appeared before the TDS Section field, causing users to enter a manual amount that later changed once the TDS Section is selected, since base amount is computed based on it.

After this commit:
- The TDS Section field is now placed before the Base Amount field to ensure a predictable input flow.

task-5312252

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
