### PR TITLE
[IMP] l10n_in_pos: show correct tax columns on POS receipt

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
@@ -37,16 +37,16 @@
                 <tr>
                     <th class="text-center">HSN Code</th>
                     <th class="text-center">Rate%</th>
-                    <th class="text-center">CGST</th>
-                    <th class="text-center">SGST</th>
+                    <th class="text-center" t-if="l10n_in_hsn_summary.has_gst">CGST</th>
+                    <th class="text-center" t-if="l10n_in_hsn_summary.has_gst">SGST</th>
                     <th class="text-center" t-if="l10n_in_hsn_summary.has_igst">IGST</th>
                     <th class="text-center" t-if="l10n_in_hsn_summary.has_cess">CESS</th>
                 </tr>
                 <tr t-foreach="l10n_in_hsn_summary.items" t-as="item" t-key="item_index">
                     <td class="text-center" t-out="item.l10n_in_hsn_code"/>
                     <td class="text-center"><t t-out="item.rate"/> %</td>
-                    <td class="text-center" t-out="item.tax_amount_cgst"/>
-                    <td class="text-center" t-out="item.tax_amount_sgst"/>
+                    <td class="text-center" t-if="l10n_in_hsn_summary.has_gst" t-out="item.tax_amount_cgst"/>
+                    <td class="text-center" t-if="l10n_in_hsn_summary.has_gst" t-out="item.tax_amount_sgst"/>
                     <td class="text-center" t-if="l10n_in_hsn_summary.has_igst" t-out="item.tax_amount_igst"/>
                     <td class="text-center" t-if="l10n_in_hsn_summary.has_cess" t-out="item.tax_amount_cess"/>
                 </tr>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- The POS receipt shows CGST, SGST, and IGST together, even when IGST is applicable.
- This is incorrect because only CGST+SGST or IGST should be displayed, not all three.

Current behavior before PR:
- The receipt always displays CGST, SGST, and IGST columns at the same time.
<img width="250" height="400" alt="image" src="https://github.com/user-attachments/assets/5c8487c7-c497-4c82-ad80-8cf0e98fbf38" />

Desired behavior after PR is merged:
- The receipt shows only the correct tax columns based on the transaction:
  - Shows CGST and SGST when GST applies.
  - Shows IGST when IGST applies.
<img width="250" height="400" alt="image" src="https://github.com/user-attachments/assets/68d2fb58-9e15-4861-a71f-ccb2d978e544" />

Changes implemented in this commit:
- Added `t-if="l10n_in_hsn_summary.has_gst"` to CGST and SGST headers.
- Added the same condition to CGST and SGST values in the item rows.


task-5268935

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
