### PR TITLE
[IMP] website, website_sale: improve search with missing-word tolerance

### DIFF
--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -303,3 +303,14 @@ class TestAutoComplete(TransactionCase):
         suggestions = self._autocomplete("week-end")
         self.assertEqual(1, len(suggestions['results']), "All results must be present")
         self.assertFalse(suggestions['fuzzy_search'], "Expects an exact match")
+
+    def test_10_multiple_word_search(self):
+        """ Ensures partial word match is used when search contains multiple words """
+        suggestions = self._autocomplete("results page")
+        self.assertEqual(1, suggestions['results_count'], "Test data contains one exact match")
+        suggestions = self._autocomplete("results no_match_1")
+        self.assertEqual(0, suggestions['results_count'], "Test data contains no exact match")
+        suggestions = self._autocomplete("results page no_match")
+        self.assertEqual(1, suggestions['results_count'], "Test data contains one exact match")
+        suggestions = self._autocomplete("results no_match_1 no_match_2")
+        self.assertEqual(0, suggestions['results_count'], "Test data contains no exact match")

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -370,7 +370,7 @@ export function searchProduct(productName, { select = false } = {}) {
     if (select) {
         steps.push({
             content: `Select ${productName}`,
-            trigger: `.oe_product_cart:first a:text(${productName})`,
+            trigger: `.oe_product_cart a:text(${productName})`,
             run: "click",
             expectUnloadPage: true,
         });


### PR DESCRIPTION
Search results are no longer limited to exact matches of all search
terms. If user looking for "XX YY ZZ", it should display resource
named "XX ZZ" as well.

When a query contains more than 2 words, a threshold-based matching
strategy is applied so that relevant results are still returned even
if some words are missing.

The allowed number of missing words depends on the query length:
- 1 or 2 words: all words must match
- 3 to 5 words: one word may be missing
- More than 5 words: up to two words may be missing

This keeps short searches strict while allowing flexibility for longer
queries.

task-5264301

Co-authored-by: Divyesh Vyas <divy@odoo.com>