### PR TITLE
[FIX] mail: restrict invite input autofocus

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -1,11 +1,11 @@
 import { ImStatus } from "@mail/core/common/im_status";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
-import { Component, onMounted, onWillStart, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 import { useSequential } from "@mail/utils/common/hooks";
 import { _t } from "@web/core/l10n/translation";
-import { useService } from "@web/core/utils/hooks";
+import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 
 export class ChannelInvitation extends Component {
@@ -28,8 +28,6 @@ export class ChannelInvitation extends Component {
         this.rtc = useService("discuss.rtc");
         this.notification = useService("notification");
         this.suggestionService = useService("mail.suggestion");
-        this.ui = useService("ui");
-        this.inputRef = useRef("input");
         this.sequential = useSequential();
         this.state = useState({
             searchResultCount: 0,
@@ -44,24 +42,12 @@ export class ChannelInvitation extends Component {
             this.fetchPartnersToInvite.bind(this),
             250
         );
+        this.inputRef = useAutofocus({ refName: "input" });
         onWillStart(() => {
             if (this.store.self_partner) {
                 this.fetchPartnersToInvite();
             }
         });
-        onMounted(() => {
-            if (this.store.self_partner && this.props.thread) {
-                this.inputRef.el.focus();
-            }
-        });
-        useEffect(
-            () => {
-                if (this.props.autofocus) {
-                    this.inputRef.el?.focus();
-                }
-            },
-            () => [this.props.autofocus]
-        );
     }
 
     get selectablePartners() {

--- a/addons/mail/static/tests/discuss/call/call_permissions.test.js
+++ b/addons/mail/static/tests/discuss/call/call_permissions.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     defineMailModels,
     mockGetMedia,
+    mockPermissionsPrompt,
     openDiscuss,
     start,
     startServer,
@@ -10,24 +11,8 @@ import {
 
 import { describe, test } from "@odoo/hoot";
 
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
-import { browser } from "@web/core/browser/browser";
-
 describe.current.tags("desktop");
 defineMailModels();
-
-function mockPermissionsPrompt() {
-    patchWithCleanup(browser.navigator.permissions, {
-        async query() {
-            return {
-                state: "prompt",
-                addEventListener: () => {},
-                removeEventListener: () => {},
-                onchange: null,
-            };
-        },
-    });
-}
 
 test("Starting a video call asks for permissions", async () => {
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -3,12 +3,14 @@ import {
     contains,
     defineMailModels,
     insertText,
+    mockPermissionsPrompt,
     openDiscuss,
     setupChatHub,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
 import { Command, getService, serverState, withUser } from "@web/../tests/web_test_helpers";
 
@@ -244,4 +246,15 @@ test("Invite sidebar action has the correct title for group chats", async () => 
     await click("button[title='Chat Actions']");
     await click(".o-dropdown-item", { text: "Invite People" });
     await contains(".modal-title", { text: "Mitchell Admin and Demo" });
+});
+
+test("Active dialog retains focus over invite input", async () => {
+    await startServer();
+    mockPermissionsPrompt();
+    await start();
+    await openDiscuss();
+    await click("button[title='New Meeting']");
+    await animationFrame();
+    await contains(".o-discuss-ChannelInvitation");
+    await contains("button:focus", { text: "Use Camera" });
 });

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -980,6 +980,19 @@ export function patchVoiceMessageAudio() {
     return res;
 }
 
+export function mockPermissionsPrompt() {
+    patchWithCleanup(browser.navigator.permissions, {
+        async query() {
+            return {
+                state: "prompt",
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                onchange: null,
+            };
+        },
+    });
+}
+
 /**
  * Assert IM status on chat bubble and chat window of given `conversationName` with `count`.
  * The conversation should be present as a bubble initially, becomes open and folded again


### PR DESCRIPTION
**Current behavior before PR:**

- The invite input always tried to autofocus, in turn stealing focus from dialogs like the call-permission dialog.

**Desired behavior after PR is merged:**

- Autofocus only when the input exists and the context is active.
- Moved `mockPermissionsPrompt` to `mail_test_helpers`.

**Part of task-**[5227387](https://www.odoo.com/odoo/project/1519/tasks/5227387)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
