### PR TITLE
[FIX] rating, portal_rating: move the override to the correct folder

### DIFF
--- a/addons/portal_rating/controllers/portal_chatter.py
+++ b/addons/portal_rating/controllers/portal_chatter.py
@@ -6,6 +6,10 @@ from odoo.addons.portal.controllers import mail
 
 
 class PortalChatter(mail.PortalChatter):
+    def _get_non_empty_message_domain(self):
+        return expression.OR(
+            [super()._get_non_empty_message_domain(), [("rating_value", "!=", False)]]
+        )
 
     def _setup_portal_message_fetch_extra_domain(self, data):
         domains = [super()._setup_portal_message_fetch_extra_domain(data)]

--- a/addons/rating/controllers/portal_chatter.py
+++ b/addons/rating/controllers/portal_chatter.py
@@ -1,13 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.osv import expression
-
 from odoo.addons.portal.controllers import mail
 
 
 class PortalChatter(mail.PortalChatter):
-
-    def _get_non_empty_message_domain(self):
-        return expression.OR(
-            [super()._get_non_empty_message_domain(), [("rating_value", "!=", False)]]
-        )
+    pass


### PR DESCRIPTION
Since #234356, `_get_allowed_message_post_params` method of the `PortalChatter` has been overridden in the `rating` module. As the `rating` has no dependency on the portal, the current change moves this override to the `portal_rating`
 module.
