### PR TITLE
[FIX] sale_management: prevent negative quantities for optional products

### DIFF
--- a/addons/sale_management/controllers/portal.py
+++ b/addons/sale_management/controllers/portal.py
@@ -41,7 +41,7 @@ class CustomerPortal(portal.CustomerPortal):
             quantity = input_quantity
         else:
             number = -1 if remove else 1
-            quantity = order_line.product_uom_qty + number
+            quantity = max((order_line.product_uom_qty + number), 0)
 
         if order_line.product_type == 'combo':
             # for combo products, we update the quantities of the combo items too


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **Sale Management** module with demo data.
* Create a Quotation and set the *Quotation Template* to **Office Furniture**.
* Open the **Preview** mode of the quotation.
* Scroll to the bottom where **Optional Products** are listed.
* Increase the quantity of an optional product from the initial value of zero.
* Rapidly click the **minus (-)** button multiple times.

**Observed behavior:**
* The quantity of an optional product goes below zero when the **minus button** is clicked rapidly.

**Cause:**
https://github.com/odoo/odoo/blob/5ab45d45073463495e517aca9fd061415a73e893/addons/sale_management/views/sale_portal_templates.xml#L9-L16

* The decrease button is bound using classes that is not updated in 
the DOM after quantity changes rapidly.  As a result, rapid clicks continue triggering 
the handler on the outdated element, causing multiple unexpected decrease 
events and allowing the quantity to become negative.

**Fix:**
* Add a guard to prevent the quantity from dropping below zero, 
ensuring the minimum quantity always remains zero.

---
opw-5250851

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
