### PR TITLE
[FIX] website_sale: sitemap gen. when public categ. have archived products

### DIFF
--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -110,7 +110,7 @@ class ProductPublicCategory(models.Model):
     @api.depends('product_tmpl_ids.is_published', 'child_id.has_published_products')
     def _compute_has_published_products(self):
         grouped_product_templates = self.env['product.template']._read_group(
-            domain=[('public_categ_ids', 'in', self.ids), ('is_published', '=', True)],
+            domain=[('public_categ_ids', 'in', self.ids), ('is_published', '=', True), ('active', '=', True)],
             groupby=['public_categ_ids']
         )
         published_category_ids = {group[0].id for group in grouped_product_templates}
@@ -134,7 +134,7 @@ class ProductPublicCategory(models.Model):
         if operator != 'in':
             return NotImplemented
         published_categ_ids = self._search(
-            [('product_tmpl_ids.is_published', 'in', True)]
+            [('product_tmpl_ids', 'any', [('is_published', '=', True), ('active', '=', True)])]
         ).get_result_ids()
         # Note that if the `value` is False, the ORM will invert the domain below
         return [

--- a/addons/website_sale/tests/test_sitemap.py
+++ b/addons/website_sale/tests/test_sitemap.py
@@ -16,7 +16,10 @@ class TestSitemap(HttpCase):
             'name': 'Level 1',
         }, {
             'name': 'Level 2',
+        }, {
+            'name': 'Level 2A',
         }])
+        self.cats[3].parent_id = self.cats[1].id
         self.cats[2].parent_id = self.cats[1].id
         self.cats[1].parent_id = self.cats[0].id
         # 'Level 2' cetegory must have at least one published product to be visible by public users
@@ -26,8 +29,18 @@ class TestSitemap(HttpCase):
             'public_categ_ids': [Command.link(self.cats[2].id)],
             'is_published': True,
         })
+        # 'Level 2A' category will contains only archived products, so should be hidden to public users
+        prodA = self.env['product.product'].create({
+            'name': 'Dummy product A',
+            'list_price': 100.0,
+            'public_categ_ids': [Command.link(self.cats[3].id)],
+            'is_published': True,
+        })
+        prodA.product_tmpl_id.active = False
 
     def test_01_shop_route_sitemap(self):
         resp = self.url_open('/sitemap.xml')
         level2_url = '/shop/category/level-0-level-1-level-2-%s' % self.cats[2].id
         self.assertIn(level2_url, resp.text, "Category entry in sitemap should be prefixed by its parent hierarchy.")
+        level2A_url = '/shop/category/level-0-level-1-level-2a-%s' % self.cats[3].id
+        self.assertNotIn(level2A_url, resp.text, "Category entry with no active products should not be listed in sitemap.")


### PR DESCRIPTION
To reproduce:
    
- Connect as "admin"
- Go to "Website / eCommerce / Products / eCommerce Category"
- Create a new category "Test With Archived Products"
- Go to "Website / eCommerce / Products"
- Create a product:
   - name it "Test Archived"
   - in "Sales" tab, under "eCommerce Shop" section, set category to:
         "Test With Archived Products"
   - then archive the product
    
- Clear the sitemap attachment and go to /sitemap.xml
    
The sitemap has an entry for "Test With Archived Products" but it should should not be visible as there are only archived products for that category.
    
 Since odoo/odoo@d3fd767b0568, access rules domain are always optimized with `active_test=False`, so ensure we only return public category that have active products.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
