### PR TITLE
[FIX] project_forecast: fix weeks comparison

### DIFF
--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -296,7 +296,7 @@ class ResourceResource(models.Model):
         locale = babel_locale_parse(get_lang(self.env).code)
         week_start_date = weekstart(locale, start)
         week_end_date = weekend(locale, end)
-        end_week = weeknumber(locale, week_end_date)[1]
+        end_year, end_week = weeknumber(locale, week_end_date)
 
         min_start_date = week_start_date + relativedelta(hour=0, minute=0, second=0, microsecond=0)
         max_end_date = week_end_date + relativedelta(days=1, hour=0, minute=0, second=0, microsecond=0)
@@ -334,9 +334,10 @@ class ResourceResource(models.Model):
                 if day >= start_day and day <= end_day:
                     resource_hours_per_day[resource.id][day] = day_working_hours
 
-                week = weeknumber(babel_locale_parse(locale), day)
-                if week[1] <= end_week:
-                    resource_hours_per_week[resource.id][week] = min(resource.calendar_id.full_time_required_hours, day_working_hours + resource_hours_per_week[resource.id][week])
+                year_week = weeknumber(babel_locale_parse(locale), day)
+                year, week = year_week
+                if (year < end_year) or (year == end_year and week <= end_week):
+                    resource_hours_per_week[resource.id][year_week] = min(resource.calendar_id.full_time_required_hours, day_working_hours + resource_hours_per_week[resource.id][year_week])
 
         for calendar, resources in calendar_resources.items():
             domain = [('calendar_id', '=', False)] if not calendar else None

--- a/addons/resource/tests/test_flexible_resource_calendar.py
+++ b/addons/resource/tests/test_flexible_resource_calendar.py
@@ -9,47 +9,49 @@ UTC = pytz.timezone('UTC')
 
 class TestFlexibleResourceCalendar(TransactionCase):
 
-    def test_flexible_resource_work_intervals(self):
-        flex_calendar = self.env['resource.calendar'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.flex_calendar = cls.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'tz': 'UTC',
             'hours_per_day': 8.0,
             'flexible_hours': True,
         })
 
-        fully_flex_resource, flex_resource = self.env['resource.resource'].create([{
+        cls.fully_flex_resource, cls.flex_resource = cls.env['resource.resource'].create([{
             'name': 'Wade Wilson',
             'calendar_id': False,
             'tz': 'UTC',
         }, {
             'name': 'Wade Wilson',
-            'calendar_id': flex_calendar.id,
+            'calendar_id': cls.flex_calendar.id,
             'tz': 'UTC',
         }])
 
-        self.env['resource.calendar.leaves'].create([
+        cls.env['resource.calendar.leaves'].create([
             {
-                'resource_id': flex_resource.id,
+                'resource_id': cls.flex_resource.id,
                 'date_from': datetime(2025, 7, 29, 8),
                 'date_to': datetime(2025, 7, 29, 17),
             },
             {
-                'resource_id': flex_resource.id,
+                'resource_id': cls.flex_resource.id,
                 'date_from': datetime(2025, 7, 31, 8),
                 'date_to': datetime(2025, 8, 1, 17),
             },
             {
-                'resource_id': fully_flex_resource.id,
+                'resource_id': cls.fully_flex_resource.id,
                 'date_from': datetime(2025, 7, 29, 8),
                 'date_to': datetime(2025, 7, 29, 17),
             },
             {
-                'resource_id': fully_flex_resource.id,
+                'resource_id': cls.fully_flex_resource.id,
                 'date_from': datetime(2025, 7, 31, 8),
                 'date_to': datetime(2025, 8, 1, 17),
             },
             {
-                'calendar_id': flex_calendar.id,
+                'calendar_id': cls.flex_calendar.id,
                 'date_from': datetime(2025, 8, 4, 8),
                 'date_to': datetime(2025, 8, 4, 17),
             },
@@ -60,14 +62,16 @@ class TestFlexibleResourceCalendar(TransactionCase):
             },
         ])
 
+        cls.resources = cls.flex_resource | cls.fully_flex_resource
+
+    def test_flexible_resource_work_intervals(self):
         start_dt = datetime(2025, 7, 28).astimezone(UTC)
         end_dt = datetime(2025, 8, 3, 17, 0).astimezone(UTC)
 
-        resources = flex_resource | fully_flex_resource
-        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        work_intervals, hours_per_day, hours_per_week = self.resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
 
         self.maxDiff = None
-        for resource in resources:
+        for resource in self.resources:
             self.assertEqual(work_intervals[resource.id]._items, [
                 (datetime(2025, 7, 28, 0, 0, tzinfo=UTC), datetime(2025, 7, 28, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
                 (datetime(2025, 7, 30, 0, 0, tzinfo=UTC), datetime(2025, 7, 30, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
@@ -75,7 +79,7 @@ class TestFlexibleResourceCalendar(TransactionCase):
                 (datetime(2025, 8, 3, 0, 0, tzinfo=UTC), datetime(2025, 8, 3, 17, tzinfo=UTC), self.env['resource.calendar.attendance']),
             ], "resource not available on 29, 31 and 01, for other days, resource can do his hours at any moment of the day (from 00:00:00 to 23:59:59)")
 
-        self.assertDictEqual(hours_per_day[flex_resource.id], {
+        self.assertDictEqual(hours_per_day[self.flex_resource.id], {
             date(2025, 7, 28): 8.0,
             date(2025, 7, 29): 0.0,
             date(2025, 7, 30): 8.0,
@@ -84,20 +88,30 @@ class TestFlexibleResourceCalendar(TransactionCase):
             date(2025, 8, 2): 8.0,
             date(2025, 8, 3): 8.0,
         }, "0 hours when the resource is not available, hours_per_day from the calendar for working days")
-        self.assertDictEqual(hours_per_week[flex_resource.id], {
+        self.assertDictEqual(hours_per_week[self.flex_resource.id], {
             (2025, 31): 16.0,
             (2025, 32): 24.0,
         }, "3 days off (24 hours), remaining 16h, 2 days off (16 hours) for second week")
 
-        self.assertTrue(fully_flex_resource.id not in hours_per_day and fully_flex_resource not in hours_per_week, "no daily and weekly limit")
+        self.assertTrue(self.fully_flex_resource.id not in hours_per_day and self.fully_flex_resource not in hours_per_week, "no daily and weekly limit")
 
         start_dt = datetime(2025, 8, 4).astimezone(UTC)
         end_dt = datetime(2025, 8, 5, 17, 0).astimezone(UTC)
 
-        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        work_intervals, hours_per_day, hours_per_week = self.resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
 
-        self.assertEqual(work_intervals[flex_resource.id]._items, [], "flex calendar have a public holidays on day 4, and there's a public holiday on day 5 for all calendars")
+        self.assertEqual(work_intervals[self.flex_resource.id]._items, [], "flex calendar have a public holidays on day 4, and there's a public holiday on day 5 for all calendars")
 
-        self.assertEqual(work_intervals[fully_flex_resource.id]._items, [
+        self.assertEqual(work_intervals[self.fully_flex_resource.id]._items, [
             (datetime(2025, 8, 4, 0, 0, tzinfo=UTC), datetime(2025, 8, 4, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
         ], "fully flex resource doesn't have a calendar, he should not follow the flex calendar public holiday, he follows holidays without a calendar")
+
+    def test_hours_per_week_for_different_years(self):
+        start_dt = datetime(2025, 12, 26).astimezone(UTC)
+        end_dt = datetime(2026, 1, 1, 17).astimezone(UTC)
+
+        _, _, hours_per_week = self.resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        self.assertDictEqual(hours_per_week[self.flex_resource.id], {
+            (2025, 52): 40.0,
+            (2026, 1): 40.0,
+        }, "weeks are well computed when ")


### PR DESCRIPTION
Steps to reproduce:
1- install project_forecast
2- run test_creating_a_planning_shift_with_flexible_hours_allocated_hours_are_correct => test fail

Source:
When slots span across multiple years (e.g., 2019 → 2026), https://github.com/odoo/odoo/blob/f8f72b15598576f5870e49879e96fc5c127a6100/addons/resource/models/resource_resource.py#L338 this comparison  becomes invalid, it compares week numbers only, ignoring the year. For instance, week 23 of 2019 is considered after week 18 of 2026.

Fix:
compare year and week