### PR TITLE
[FIX] *: support for pylint 4

### DIFF
--- a/addons/hw_escpos/controllers/main.py
+++ b/addons/hw_escpos/controllers/main.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+# pylint: skip-file
 
 from __future__ import print_function
 import logging

--- a/addons/hw_escpos/escpos/escpos.py
+++ b/addons/hw_escpos/escpos/escpos.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: skip-file
 
 from __future__ import print_function
 import base64

--- a/addons/hw_escpos/escpos/printer.py
+++ b/addons/hw_escpos/escpos/printer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# pylint: skip-file
 
 from __future__ import print_function
 import serial

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -641,6 +641,8 @@ class TestMailMail(MailCommon):
         # SMTP sending issues
         with self.mock_mail_gateway():
             _send_current = self.send_email_mocked.side_effect
+            self.addCleanup(setattr, self.send_email_mocked, 'side_effect', _send_current)
+
             self._reset_data()
             mail.write({'email_to': 'test@example.com'})
 
@@ -648,9 +650,7 @@ class TestMailMail(MailCommon):
             for error, error_class in [
                     (smtplib.SMTPServerDisconnected("Some exception"), smtplib.SMTPServerDisconnected),
                     (MemoryError("Some exception"), MemoryError)]:
-                def _send_email(*args, **kwargs):
-                    raise error
-                self.send_email_mocked.side_effect = _send_email
+                self.send_email_mocked.side_effect = error
 
                 with self.assertRaises(error_class):
                     mail.send(raise_exception=False)
@@ -666,9 +666,7 @@ class TestMailMail(MailCommon):
             for error, msg in [
                     (MailDeliveryException("Some exception"), 'Some exception'),
                     (ValueError("Unexpected issue"), 'Unexpected issue')]:
-                def _send_email(*args, **kwargs):
-                    raise error
-                self.send_email_mocked.side_effect = _send_email
+                self.send_email_mocked.side_effect = error
 
                 self._reset_data()
                 mail.send(raise_exception=False)
@@ -678,8 +676,6 @@ class TestMailMail(MailCommon):
                 self.assertEqual(notification.failure_reason, msg)
                 self.assertEqual(notification.failure_type, 'unknown', 'Mail: generic failure type')
                 self.assertEqual(notification.notification_status, 'exception')
-
-            self.send_email_mocked.side_effect = _send_current
 
     def test_mail_mail_values_misc(self):
         """ Test various values on mail.mail, notably default values """

--- a/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
@@ -5,11 +5,7 @@ from collections import deque
 from contextlib import ExitStack
 from typing import Optional
 
-import astroid
-try:
-    from astroid import NodeNG
-except ImportError:
-    from astroid.node_classes import NodeNG
+from astroid import nodes
 
 import pylint.interfaces
 from pylint.checkers import BaseChecker, utils
@@ -35,10 +31,10 @@ FUNCTION_WHITELIST = [
 
 func_call = {}
 func_called_for_query = []
-root_call: contextvars.ContextVar[Optional[astroid.Call]] =\
+root_call: contextvars.ContextVar[Optional[nodes.Call]] =\
     contextvars.ContextVar('root_call', default=None)
 @contextlib.contextmanager
-def push_call(node: astroid.Call):
+def push_call(node: nodes.Call):
     with ExitStack() as s:
         if root_call.get() is None:
             t = root_call.set(node)
@@ -72,36 +68,36 @@ class OdooBaseChecker(BaseChecker):
         return node.file
     def _get_return_node(self, node):
         ret = []
-        nodes = deque([node])
-        while nodes:
-            node = nodes.popleft()
-            if isinstance(node, astroid.Return):
+        q = deque([node])
+        while q:
+            node = q.popleft()
+            if isinstance(node, nodes.Return):
                 ret.append(node)
             else:
-                nodes.extend(node.get_children())
+                q.extend(node.get_children())
         return ret
 
     def _is_asserted(self, node): # If there is an assert on the value of the node, it's very likely to be safe
-        asserted = deque((assert_.test for assert_ in node.scope().nodes_of_class(astroid.Assert)))
+        asserted = deque(assert_.test for assert_ in node.scope().nodes_of_class(nodes.Assert))
         while asserted:
             n = asserted.popleft()
-            if isinstance(n, astroid.Name) and n.name == node.name:
+            if isinstance(n, nodes.Name) and n.name == node.name:
                 return True
             else:
                 asserted.extend(n.get_children())
         return False
 
     def _get_attribute_chain(self, node):
-        if isinstance(node, astroid.Attribute):
+        if isinstance(node, nodes.Attribute):
             return self._get_attribute_chain(node.expr) + '.' + node.attrname
-        elif isinstance(node, astroid.Name):
+        elif isinstance(node, nodes.Name):
             return node.name
-        elif isinstance(node, astroid.Call):
+        elif isinstance(node, nodes.Call):
             return self._get_attribute_chain(node.func)
         return '' #FIXME
 
     def _evaluate_function_call(self, node, args_allowed, position):
-        name = node.func.attrname if isinstance(node.func, astroid.Attribute) else node.func.name
+        name = node.func.attrname if isinstance(node.func, nodes.Attribute) else node.func.name
         if name == node.scope().name:
             return True
         if  name not in func_called_for_query:
@@ -116,13 +112,13 @@ class OdooBaseChecker(BaseChecker):
                         return False
         return True
 
-    def _is_fstring_cst(self, node: astroid.JoinedStr, args_allowed=False, position=None):
+    def _is_fstring_cst(self, node: nodes.JoinedStr, args_allowed=False, position=None):
         # an fstring is constant if all its FormattedValue are constant, or
         # are access to private attributes (nb: whitelist?)
         return self.all_const((
             node.value for node in node.values
-            if isinstance(node, astroid.FormattedValue)
-            if not (isinstance(node.value, astroid.Attribute) and node.value.attrname.startswith('_'))
+            if isinstance(node, nodes.FormattedValue)
+            if not (isinstance(node.value, nodes.Attribute) and node.value.attrname.startswith('_'))
         ),
             args_allowed=args_allowed,
             position=position
@@ -134,70 +130,68 @@ class OdooBaseChecker(BaseChecker):
             for node in nodes
         )
 
-    def _is_constexpr(self, node: NodeNG, args_allowed=False, position=None):
-        if isinstance(node, astroid.Const): # astroid.const is always safe
+    def _is_constexpr(self, node: nodes.NodeNG, args_allowed=False, position=None):
+        if isinstance(node, nodes.Const):  # nodes.const is always safe
             return True
-        elif isinstance(node, (astroid.List, astroid.Set)):
+        elif isinstance(node, (nodes.List, nodes.Set)):
             return self.all_const(node.elts, args_allowed=args_allowed)
-        elif isinstance(node, astroid.Tuple):
+        elif isinstance(node, nodes.Tuple):
             if position is None:
                 return self.all_const(node.elts, args_allowed=args_allowed)
             else:
                 return self._is_constexpr(node.elts[position], args_allowed=args_allowed)
-        elif isinstance(node, astroid.Dict):
+        elif isinstance(node, nodes.Dict):
             return all(
                 self._is_constexpr(k, args_allowed=args_allowed) and self._is_constexpr(v, args_allowed=args_allowed)
                 for k, v in node.items
             )
-        elif isinstance(node, astroid.Starred):
+        elif isinstance(node, nodes.Starred):
             return self._is_constexpr(node.value, args_allowed=args_allowed, position=position)
-        elif isinstance(node, astroid.BinOp): # recusively infer both side of the operation. Failing if either side is not inferable
+        elif isinstance(node, nodes.BinOp):  # recusively infer both side of the operation. Failing if either side is not inferable
             left_operand = self._is_constexpr(node.left, args_allowed=args_allowed)
             # This case allows to always consider a string formatted with %d to be safe
             if node.op == '%' and \
-                isinstance(node.left, astroid.Const) and \
+                isinstance(node.left, nodes.Const) and \
                 node.left.pytype() == 'builtins.str' and \
                 '%d' in node.left.value and \
                 not '%s' in node.left.value:
                 return True
             right_operand = self._is_constexpr(node.right, args_allowed=args_allowed)
             return left_operand and right_operand
-        elif isinstance(node, astroid.Name) or isinstance(node, astroid.AssignName): # Variable: find the assignement instruction in the AST and infer its value.
-            assignements = node.lookup(node.name)
+        elif isinstance(node, (nodes.Name, nodes.AssignName)):  # Variable: find the assignement instruction in the AST and infer its value.
+            assignment = node.lookup(node.name)
             assigned_node = []
-            for n in assignements[1]: #assignement[0] contains the scope, so assignment[1] contains the assignement nodes
-                if isinstance(n.parent, astroid.FunctionDef):
+            for n in assignment[1]:  # assignment[0] contains the scope, so assignment[1] contains the assignement nodes
+                if isinstance(n.parent, (nodes.FunctionDef, nodes.Arguments)):
                     assigned_node += [args_allowed]
-                elif isinstance(n.parent, astroid.Arguments):
-                    assigned_node += [args_allowed]
-                elif isinstance(n.parent, astroid.Tuple): # multi assign a,b = (a,b)
+                elif isinstance(n.parent, nodes.Tuple):  # multi assign a,b = (a,b)
                     statement = n.statement()
-                    if isinstance(statement, astroid.For):
+                    if isinstance(statement, nodes.For):
                         assigned_node += [self._is_constexpr(statement.iter, args_allowed=args_allowed)]
-                    elif isinstance(statement, astroid.Assign):
+                    elif isinstance(statement, nodes.Assign):
                         assigned_node += [self._is_constexpr(statement.value, args_allowed=args_allowed, position=n.parent.elts.index(n))]
                     else:
                         raise TypeError(f"Expected statement Assign or For, got {statement}")
-                elif isinstance(n.parent, astroid.For):
+                elif isinstance(n.parent, nodes.For):
                     assigned_node.append(self._is_constexpr(n.parent.iter, args_allowed=args_allowed))
-                elif isinstance(n.parent, astroid.AugAssign):
+                elif isinstance(n.parent, nodes.AugAssign):
                     left = self._is_constexpr(n.parent.target, args_allowed=args_allowed)
                     right = self._is_constexpr(n.parent.value, args_allowed=args_allowed)
                     assigned_node.append(left and right)
-                elif isinstance(n.parent, astroid.Module):
+                elif isinstance(n.parent, nodes.Module):
                     return True
                 else:
-                    if isinstance(n.parent, astroid.Comprehension):
+                    if isinstance(n.parent, nodes.Comprehension):
                         assigned_node += [self._is_constexpr(n.parent.iter, args_allowed=args_allowed)]
                     else:
                         assigned_node += [self._is_constexpr(n.parent.value, args_allowed=args_allowed)]
             if assigned_node and all(assigned_node):
                 return True
             return self._is_asserted(node)
-        elif isinstance(node, astroid.JoinedStr):
+        elif isinstance(node, nodes.JoinedStr):
             return self._is_fstring_cst(node, args_allowed)
-        elif isinstance(node, astroid.Call):
-            if isinstance(node.func, astroid.Attribute):
+        elif isinstance(node, nodes.Call):
+            if isinstance(node.func, nodes.Attribute):
                 if node.func.attrname == 'append':
                     return self._is_constexpr(node.args[0])
                 elif node.func.attrname == 'format':
@@ -208,16 +202,16 @@ class OdooBaseChecker(BaseChecker):
                     )
             with push_call(node):
                 return self._evaluate_function_call(node, args_allowed=args_allowed, position=position)
-        elif isinstance(node, astroid.IfExp):
+        elif isinstance(node, nodes.IfExp):
             body = self._is_constexpr(node.body, args_allowed=args_allowed)
             orelse = self._is_constexpr(node.orelse, args_allowed=args_allowed)
             return body and orelse
-        elif isinstance(node, astroid.Subscript):
+        elif isinstance(node, nodes.Subscript):
             return self._is_constexpr(node.value, args_allowed=args_allowed)
-        elif isinstance(node, astroid.BoolOp):
+        elif isinstance(node, nodes.BoolOp):
             return self.all_const(node.values, args_allowed=args_allowed)
 
-        elif isinstance(node, astroid.Attribute):
+        elif isinstance(node, nodes.Attribute):
             attr_chain = self._get_attribute_chain(node)
             while attr_chain:
                 if attr_chain in ATTRIBUTE_WHITELIST or attr_chain.startswith('_'):
@@ -232,20 +226,17 @@ class OdooBaseChecker(BaseChecker):
     def _get_cursor_name(self, node):
         expr_list = []
         node_expr = node.expr
-        while isinstance(node_expr, astroid.Attribute):
+        while isinstance(node_expr, nodes.Attribute):
             expr_list.insert(0, node_expr.attrname)
             node_expr = node_expr.expr
-        if isinstance(node_expr, astroid.Name):
+        if isinstance(node_expr, nodes.Name):
             expr_list.insert(0, node_expr.name)
         cursor_name = '.'.join(expr_list)
         return cursor_name
 
-    def _allowable(self, node):
-        """
-        :type node: NodeNG
-        """
+    def _allowable(self, node: nodes.NodeNG) -> bool:
         scope = node.scope()
-        if isinstance(scope, astroid.FunctionDef) and (scope.name.startswith("_") or scope.name == 'init'):
+        if isinstance(scope, nodes.FunctionDef) and (scope.name.startswith("_") or scope.name == 'init'):
             return True
 
         infered = utils.safe_infer(node)
@@ -256,27 +247,27 @@ class OdooBaseChecker(BaseChecker):
         if self._is_constexpr(node):  # If we can infer the value at compile time, it cannot be injected
             return True
 
-        if isinstance(node, astroid.Call):
+        if isinstance(node, nodes.Call):
             node = node.func
         # self._thing is OK (mostly self._table), self._thing() also because
         # it's a common pattern of reports (self._select, self._group_by, ...)
-        return (isinstance(node, astroid.Attribute)
-            and isinstance(node.expr, astroid.Name)
+        return (isinstance(node, nodes.Attribute)
+            and isinstance(node.expr, nodes.Name)
             and node.attrname.startswith('_')
         )
 
-    def _check_concatenation(self, node):
+    def _check_concatenation(self, node: nodes.NodeNG) -> bool | None:
         node = self.resolve(node)
 
         if self._allowable(node):
             return False
 
-        if isinstance(node, astroid.BinOp) and node.op in ('%', '+'):
-            if isinstance(node.right, astroid.Tuple):
+        if isinstance(node, nodes.BinOp) and node.op in ('%', '+'):
+            if isinstance(node.right, nodes.Tuple):
                 # execute("..." % (self._table, thing))
                 if not all(map(self._allowable, node.right.elts)):
                     return True
-            elif isinstance(node.right, astroid.Dict):
+            elif isinstance(node.right, nodes.Dict):
                 # execute("..." % {'table': self._table}
                 if not all(self._allowable(v) for _, v in node.right.items):
                     return True
@@ -299,8 +290,8 @@ class OdooBaseChecker(BaseChecker):
             return self._check_concatenation(node.left)
 
         # check execute("...".format(self._table, table=self._table))
-        if isinstance(node, astroid.Call) \
-                and isinstance(node.func, astroid.Attribute) \
+        if isinstance(node, nodes.Call) \
+                and isinstance(node.func, nodes.Attribute) \
                 and node.func.attrname == 'format':
 
             return not (
@@ -309,18 +300,20 @@ class OdooBaseChecker(BaseChecker):
             )
 
         # check execute(f'foo {...}')
-        if isinstance(node, astroid.JoinedStr):
+        if isinstance(node, nodes.JoinedStr):
             return not all(
                 self._allowable(formatted.value)
-                for formatted in node.nodes_of_class(astroid.FormattedValue)
+                for formatted in node.nodes_of_class(nodes.FormattedValue)
             )
+
+        return None
 
     def resolve(self, node):
         # if node is a variable, find how it was built
-        if isinstance(node, astroid.Name):
+        if isinstance(node, nodes.Name):
             for target in node.lookup(node.name)[1]:
                 # could also be e.g. arguments (if the source is a function parameter)
-                if isinstance(target.parent, astroid.Assign):
+                if isinstance(target.parent, nodes.Assign):
                     # FIXME: handle multiple results (e.g. conditional assignment)
                     return target.parent.value
         # otherwise just return the original node for checking
@@ -332,8 +325,8 @@ class OdooBaseChecker(BaseChecker):
         current_file_bname = os.path.basename(self.linter.current_file)
         if not (
             # .execute() or .executemany()
-            isinstance(node, astroid.Call) and node.args and
-            isinstance(node.func, astroid.Attribute) and
+            isinstance(node, nodes.Call) and node.args and
+            isinstance(node.func, nodes.Attribute) and
             node.func.attrname in ('execute', 'executemany') and
             # cursor expr (see above)
             self._get_cursor_name(node.func) in DFTL_CURSOR_EXPR and

--- a/odoo/addons/test_lint/tests/_pylint_path_setup.py
+++ b/odoo/addons/test_lint/tests/_pylint_path_setup.py
@@ -42,8 +42,8 @@ class AddonsPackageFinder(spec.Finder):
     forcefully discovered as namespace packages since otherwise they get
     discovered as directory packages.
     """
+    @staticmethod
     def find_module(
-        self,
         modname: str,
         module_parts: Sequence[str],
         processed: list[str],

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -2,10 +2,11 @@ import json
 import os
 import tempfile
 import unittest
-
 from contextlib import contextmanager
 from subprocess import run, PIPE
 from textwrap import dedent
+
+import astroid
 
 from odoo import tools
 from odoo.tests.common import TransactionCase
@@ -129,7 +130,7 @@ class TestSqlLint(TransactionCase):
         self.linter.current_file = 'dummy.py' # should not be prefixed by test
         checker = _odoo_checker_sql_injection.OdooBaseChecker(self.linter)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test(): 
             arg = "test"
             arg = arg + arg
@@ -139,7 +140,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function9(self,arg):
             my_injection_variable= "aaa" % arg #Uninferable
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -148,7 +149,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function10(self):
             my_injection_variable= "aaa" + "aaa" #Const
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -156,7 +157,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function11(self, arg):
             my_injection_variable= "aaaaaaaa" + arg #Uninferable
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -165,7 +166,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function12(self):
             arg1 = "a"
             arg2 = "b" + arg1
@@ -178,7 +179,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function1(self, arg):
             my_injection_variable= f"aaaaa{arg}aaa" #Uninferable
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -186,7 +187,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function2(self):
             arg = 'bbb'
             my_injection_variable= f"aaaaa{arg}aaa" #Uninferable
@@ -195,7 +196,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function3(self, arg):
             my_injection_variable= "aaaaaaaa".format() # Const
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -203,7 +204,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function4(self, arg):
             my_injection_variable= "aaaaaaaa {test}".format(test="aaa") 
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -211,7 +212,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function5(self):
             arg = 'aaa'
             my_injection_variable= "aaaaaaaa {test}".format(test=arg) #Uninferable
@@ -220,7 +221,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function6(self,arg):
             my_injection_variable= "aaaaaaaa {test}".format(test="aaa" + arg) #Uninferable
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -228,7 +229,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function7(self):
             arg = "aaa"
             my_injection_variable= "aaaaaaaa {test}".format(test="aaa" + arg) #Const
@@ -237,7 +238,7 @@ class TestSqlLint(TransactionCase):
         with self.assertNoMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function8(self):
             global arg
             my_injection_variable= "aaaaaaaa {test}".format(test="aaa" + arg) #Uninferable
@@ -246,18 +247,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        #TODO
-        #node = _odoo_checker_sql_injection.astroid.extract_node("""
-        #def test_function(self):
-        #    def test():
-        #        return "hello world"
-        #    my_injection_variable= "aaaaaaaa {test}".format(test=test()) #Const
-        #    self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
-        #""")
-        #with self.assertNoMessages():
-        #    checker.visit_call(node)
-
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function9(self,arg):
             my_injection_variable= "aaa" % arg
             self.env.cr.execute('select * from hello where id = %s' % my_injection_variable) #@
@@ -266,7 +256,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test_function10(self,arg):
             if_else_variable = "aaa" if arg else "bbb" # the two choice of a condition are constant, this is not injectable
             self.env.cr.execute('select * from hello where id = %s' % if_else_variable) #@
@@ -275,7 +265,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def _search_phone_mobile_search(self, operator, value):
   
             condition = 'IS NULL' if operator == '=' else 'IS NOT NULL'
@@ -290,7 +280,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test1(self):
             operator = 'aaa' 
             value = 'bbb'
@@ -300,7 +290,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test2(self):
             operator = 'aaa' 
             operator += 'bbb'
@@ -309,14 +299,14 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def test3(self):
             self.env.cr.execute(f'{self._table}') #@
         """)
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def _init_column(self, column_name):
             query = f'UPDATE "{self._table}" SET "{column_name}" = %s WHERE "{column_name}" IS NULL'
             self._cr.execute(query, (value,)) #@
@@ -324,7 +314,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def _init_column1(self, column_name):
             query = 'SELECT %(var1)s FROM %(var2)s WHERE %(var3)s' % {'var1': 'field_name','var2': 'table_name','var3': 'where_clause'}
             self._cr.execute(query) #@
@@ -332,7 +322,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def _graph_data(self, start_date, end_date):
 
             query = '''SELECT %(x_query)s as x_value, %(y_query)s as y_value
@@ -371,34 +361,34 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def first_fun():
             anycall() #@
             return 'a'
         """)
         with self.assertMessages():
             checker.visit_call(node)
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def second_fun(value):
             anycall() #@
             return value
         """)
         with self.assertMessages():
             checker.visit_call(node)
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def injectable():
             cr.execute(first_fun())#@
         """)
         with self.assertMessages():
             checker.visit_call(node)
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def injectable1():
             cr.execute(second_fun('aaaaa'))#@
         """)
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def injectable2(var):
             a = ['a','b']
             cr.execute('a'.join(a))#@
@@ -406,21 +396,21 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def return_tuple(var):
             return 'a',var
         """)
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def injectable4(var):
             a, _ =  return_tuple(var)
             cr.execute(a)#@
         """)
         with self.assertMessages():
             checker.visit_call(node)
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def not_injectable5(var):
             star = ('defined','constant','string')
             cr.execute(*star)#@
@@ -428,7 +418,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages():
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def injectable6(var):
             star = ('defined','variable','string',var)
             cr.execute(*star)#@
@@ -436,7 +426,7 @@ class TestSqlLint(TransactionCase):
         with self.assertMessages("sql-injection"):
             checker.visit_call(node)
 
-        node = _odoo_checker_sql_injection.astroid.extract_node("""
+        node = astroid.extract_node("""
         def formatNumber(var):
             cr.execute('LIMIT %d'  % var)#@
         """)


### PR DESCRIPTION
- astroid 4 deprecates toplevel exports of nodes, thankfully that was never actually necessary so we can just import that unconditionally
- remove support for pre-jammy pylint / astroid, specifically `astroid.nodes` was added in astroid 2.7.0 and `astroid.node_classes` deprecated then and removed in 3.0, this can affect Bullseye users as it shipped with astroid 2.5
- Astroid 4 changes `spec.Finder.find_module` in order to cache it (pylint-dev/astroid#2509), we can just make our method static for all versions as we don't need `self` anyway.
- The mail test triggers `function-redefined` (E0102), fix it.
- Skip the escpos script thing which triggers a bunch of `undefined-variable` (E0602) false positives.
