### PR TITLE
[FIX] pos_self_order: remove stale table reference after table transfer

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -44,6 +44,12 @@ class PosOrder(models.Model):
         ('kiosk', 'Self-Order Kiosk')
     ])
 
+    def write(self, vals):
+        if 'table_id' in vals and self.self_ordering_table_id:
+            # Clear stale self-order table link when the order is transferred to a new table.
+            vals['self_ordering_table_id'] = vals['table_id']
+        return super().write(vals)
+
     @api.model
     def _load_pos_self_data_domain(self, data, config):
         return [('id', '=', False)]

--- a/addons/pos_self_order/static/tests/pos/pos_self_order_tour.js
+++ b/addons/pos_self_order/static/tests/pos/pos_self_order_tour.js
@@ -3,6 +3,7 @@ import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/produc
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_pos_self_order_preparation_changes", {
@@ -14,6 +15,25 @@ registry.category("web_tour.tours").add("test_pos_self_order_preparation_changes
             TicketScreen.selectOrder("Self-order"),
             TicketScreen.loadSelectedOrder(),
             ProductScreen.isShown(),
+            ProductScreen.orderlinesHaveNoChange(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_pos_self_order_table_transfer", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            FloorScreen.clickTable("1"),
+            ProductScreen.isShown(),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("2"),
+            ProductScreen.isShown(),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("1"),
+            ProductScreen.orderIsEmpty(),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("2"),
             ProductScreen.orderlinesHaveNoChange(),
         ].flat(),
 });

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -314,3 +314,48 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         })
 
         self.start_tour(self_route, "test_self_order_table_sharing-meal_mode")
+
+    def test_pos_self_order_table_transfer(self):
+        """
+        Verify that transferring a POS order to a new table clears
+        `self_ordering_table_id`, preventing the order from remaining linked
+        to the original self-order table.
+        """
+
+        self.browser_size = '1366x768'
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'meal',
+            'self_ordering_service_mode': 'table',
+            'floor_ids': [(6, 0, [self.pos_main_floor.id])],
+        })
+
+        self.pos_main_floor.write({
+            'table_ids': [(0, 0, {
+                'table_number': '2',
+            })],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+
+        self.env['pos.order'].create({
+            'session_id': self.pos_config.current_session_id.id,
+            'self_ordering_table_id': self.pos_main_floor.table_ids[0].id,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'amount_paid': 0.0,
+            'lines': [(0, 0, {
+                'qty': 1,
+                'product_id': self.cola.id,
+                'price_unit': self.cola.lst_price,
+                'price_subtotal': self.cola.lst_price,
+                'price_subtotal_incl': self.cola.lst_price,
+            })],
+        })
+
+        self.start_tour('/pos/ui?config_id=%d' % self.pos_config.id, 'test_pos_self_order_table_transfer', login='pos_user')
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.self_ordering_table_id, order.table_id)


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **Restaurant** and **pos_self_order** modules.
* Go to **POS → Dashboard → Mobile Menu** and create a self-order linked to its table.
* Open the created order in the POS interface.
* Click the **three dots** menu, choose **Transfer / Merge**, and select a different table as the destination.
* Open the floor plan and inspect both the original and the transferred tables.

**Observed behavior:**
* The same order appears on both the original and the destination tables.
* The `self_ordering_table_id` field still points to the initial table even after the transfer.

**Cause:**
* The transfer operation updates only `table_id`. The `self_ordering_table_id`, which stores the initial self-order table reference, is not reset, causing the order to remain incorrectly linked to the original table.

**Fix:**
* Update the `write` logic to clear `self_ordering_table_id` whenever `table_id` is changed to a new table.

opw-5250671
