### PR TITLE
[FIX] mail: message mentions in Html composer

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -33,7 +33,7 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { createElementWithContent } from "@web/core/utils/html";
-import { getOrigin, url } from "@web/core/utils/urls";
+import { url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
@@ -444,16 +444,8 @@ export class Message extends Component {
         editedEl?.replaceChildren(renderToElement("mail.Message.edited"));
         const channelLinks = bodyEl.querySelectorAll("a.o_channel_redirect");
         this.store.handleValidChannelMention(Array.from(channelLinks));
-        for (const el of bodyEl.querySelectorAll(".o_message_redirect")) {
-            // only transform links targetting the same database
-            if (el.getAttribute("href")?.startsWith(getOrigin())) {
-                const message = this.store["mail.message"].get(el.dataset.oeId);
-                if (message?.thread?.displayName) {
-                    el.classList.add("o_message_redirect_transformed");
-                    el.replaceChildren(renderToElement("mail.Message.messageLink", { message }));
-                }
-            }
-        }
+        const messageLinks = bodyEl.querySelectorAll("a.o_message_redirect");
+        this.store.prettifyMessageMentions(Array.from(messageLinks));
     }
 
     getAuthorAttClass() {

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -3,6 +3,7 @@ import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
+import { messageUrlRegExp } from "@mail/utils/common/format";
 
 /**
  * This plugin works with the composer used in Discuss, ChatWindow and Chatter.
@@ -10,7 +11,7 @@ import { withSequence } from "@html_editor/utils/resource";
  */
 export class MailComposerPlugin extends Plugin {
     static id = "mail_composer";
-    static dependencies = ["clipboard", "hint", "input", "selection"];
+    static dependencies = ["clipboard", "hint", "input", "link", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
         bypass_paste_image_files: () => true,
@@ -35,6 +36,7 @@ export class MailComposerPlugin extends Plugin {
             }
         },
         input_handlers: this.config.composerPluginDependencies.onInput.bind(this),
+        paste_text_overrides: this.handlePasteText.bind(this),
     };
 
     setup() {
@@ -53,5 +55,14 @@ export class MailComposerPlugin extends Plugin {
             "focusout",
             this.config.composerPluginDependencies.onFocusout
         );
+    }
+
+    handlePasteText(selection, text) {
+        const messageMatch = messageUrlRegExp.exec(text);
+        if (!messageMatch) {
+            return false;
+        }
+        this.dependencies.link.insertLink(text, text);
+        return true;
     }
 }

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -3,6 +3,7 @@ import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
+import { messageUrlRegExp } from "@mail/utils/common/format";
 
 const ALLOWED_TAGS = [
     "A",
@@ -28,7 +29,7 @@ const PRESERVED_CLASSNAMES = new Set(["o_mail_redirect", "o_channel_redirect", "
  */
 export class MailComposerPlugin extends Plugin {
     static id = "mail_composer";
-    static dependencies = ["clipboard", "dom", "hint", "history", "input", "selection"];
+    static dependencies = ["clipboard", "dom", "hint", "history", "input", "link", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
         bypass_paste_image_files: () => true,
@@ -54,6 +55,7 @@ export class MailComposerPlugin extends Plugin {
             }
         },
         input_handlers: this.config.composerPluginDependencies.onInput.bind(this),
+        paste_text_overrides: this.handlePasteText.bind(this),
     };
 
     setup() {
@@ -105,6 +107,15 @@ export class MailComposerPlugin extends Plugin {
         [...sanitizedFragment.childNodes].forEach(removeStyle);
         this.dependencies.dom.insert(sanitizedFragment);
         this.dependencies.history.addStep();
+        return true;
+    }
+
+    handlePasteText(selection, text) {
+        const messageMatch = messageUrlRegExp.exec(text);
+        if (!messageMatch) {
+            return false;
+        }
+        this.dependencies.link.insertLink(text, text);
         return true;
     }
 }

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { generateThreadMentionElement } from "@mail/utils/common/format";
+import { generateThreadMentionElement, messageUrlRegExp } from "@mail/utils/common/format";
+import { setAttributes } from "@web/core/utils/xml";
 
 export class MentionPlugin extends Plugin {
     static id = "mention";
@@ -67,6 +68,16 @@ export class MentionPlugin extends Plugin {
                 selector: "a.o-discuss-mention",
                 checker: (el) => true,
             },
+            {
+                selector: 'a[href*="mail/message/"]',
+                checker: (el) => this.isValidMessageMentionElement(el),
+                validMentionsHandler: (messageLinks) => {
+                    this.prepareValidMessageMentions(messageLinks);
+                    if (this.store.prettifyMessageMentions(messageLinks)) {
+                        this.dependencies.history.addStep();
+                    }
+                },
+            }
         ];
     }
 
@@ -101,6 +112,31 @@ export class MentionPlugin extends Plugin {
                 this.dependencies.history.addStep();
             }
         }
+    }
+
+    /**
+     * @param {HTMLElement} element
+     * @returns {boolean}
+     */
+    isValidMessageMentionElement(el) {
+        return messageUrlRegExp.exec(el.getAttribute("href"));
+    }
+
+    /**
+     * @param {HTMLElement[]} messageLinks
+     */
+    prepareValidMessageMentions(messageLinks) {
+        messageLinks.forEach((el) => {
+            const messageMatch = messageUrlRegExp.exec(el.getAttribute("href"));
+            setAttributes(el, {
+                class: "o_message_redirect",
+                "data-oe-id": messageMatch[1],
+                "data-oe-model": "mail.message",
+                "data-oe-protected": "true",
+                contenteditable: "false",
+                target: false,
+            });
+        });
     }
 
     async isValidChannelMentionElement(el) {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -583,6 +583,32 @@ export class Store extends BaseStore {
         }
     }
 
+    /**
+     * @param {HTMLElement[]} messageLinks
+     * @returns {boolean} whether at least one mention was updated
+     */
+    prettifyMessageMentions(messageLinks) {
+        let changed = false;
+        for (const linkEl of messageLinks) {
+            const href = linkEl.getAttribute("href");
+            if (href?.startsWith(getOrigin())) {
+                const message = this["mail.message"].get(Number(linkEl.dataset.oeId));
+                if (message?.thread?.displayName) {
+                    const messageLinkElement = renderToElement("mail.Message.messageLink", {
+                        message,
+                    });
+                    if (messageLinkElement.innerHTML === linkEl.innerHTML) {
+                        continue;
+                    }
+                    linkEl.classList.add("o_message_redirect_transformed");
+                    linkEl.replaceChildren(messageLinkElement);
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
     getMentionsFromText(
         body,
         { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [], thread } = {}

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -584,6 +584,32 @@ export class Store extends BaseStore {
         }
     }
 
+    /**
+     * @param {HTMLElement[]} messageLinks
+     * @returns {boolean} whether at least one mention was updated
+     */
+    prettifyMessageMentions(messageLinks) {
+        let changed = false;
+        for (const linkEl of messageLinks) {
+            const href = linkEl.getAttribute("href");
+            if (href?.startsWith(getOrigin())) {
+                const message = this["mail.message"].get(Number(linkEl.dataset.oeId));
+                if (message?.thread?.displayName) {
+                    const messageLinkElement = renderToElement("mail.Message.messageLink", {
+                        message,
+                    });
+                    if (messageLinkElement.innerHTML === linkEl.innerHTML) {
+                        continue;
+                    }
+                    linkEl.classList.add("o_message_redirect_transformed");
+                    linkEl.replaceChildren(messageLinkElement);
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
     getMentionsFromText(
         body,
         { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [], thread } = {}

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -19,7 +19,7 @@ import { setAttributes } from "@web/core/utils/xml";
 
 const urlRegexp =
     /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{1,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|[.]*[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
-const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/(\\d+)$`);
+export const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/(\\d+)$`);
 
 /**
  * @param {string|ReturnType<markup>} rawBody

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -20,7 +20,7 @@ import { setAttributes } from "@web/core/utils/xml";
 
 const urlRegexp =
     /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{1,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|[.]*[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
-const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/(\\d+)$`);
+export const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/(\\d+)$`);
 
 /**
  * @param {string|ReturnType<markup>} rawBody

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -43,6 +43,7 @@ import { edit, press, queryFirst } from "@odoo/hoot-dom";
 import { browser } from "@web/core/browser/browser";
 import { MailComposerFormController } from "@mail/chatter/web/mail_composer_form";
 import { useSubEnv } from "@odoo/owl";
+import { url } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -1941,4 +1942,31 @@ test("mentions can be correctly cut with ctrl+A and ctrl+X", async () => {
     cut(editor);
     await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
     await contains(editor.editable, { textContent: "" });
+});
+
+test.tags("html composer");
+test("Paste message link should be prettified", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "channel1" });
+    const messageId_1 = pyEnv["mail.message"].create({
+        body: "Message on partner",
+        res_id: channelId,
+        model: "discuss.channel",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    pasteText(editor, `${url(`/mail/message/${messageId_1} `)}`);
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('channel1')");
+    await press("Enter");
+    await contains(".o-mail-Message:text('channel1')");
+    pasteText(editor, `${url(`/mail/message/100`)}`);
+    await press("Enter");
+    await contains(`.o-mail-Message:text('${url(`/mail/message/100`)}')`);
 });

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -42,6 +42,7 @@ import { edit, press, queryFirst } from "@odoo/hoot-dom";
 import { browser } from "@web/core/browser/browser";
 import { MailComposerFormController } from "@mail/chatter/web/mail_composer_form";
 import { useSubEnv } from "@odoo/owl";
+import { url } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -1911,4 +1912,31 @@ test("mentions can be correctly cut with ctrl+A and ctrl+X", async () => {
     cut(editor);
     await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
     await contains(editor.editable, { textContent: "" });
+});
+
+test.tags("html composer");
+test("Paste message link should be prettified", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "channel1" });
+    const messageId_1 = pyEnv["mail.message"].create({
+        body: "Message on partner",
+        res_id: channelId,
+        model: "discuss.channel",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    pasteText(editor, `${url(`/mail/message/${messageId_1} `)}`);
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('channel1')");
+    await press("Enter");
+    await contains(".o-mail-Message:text('channel1')");
+    pasteText(editor, `${url(`/mail/message/100`)}`);
+    await press("Enter");
+    await contains(`.o-mail-Message:text('${url(`/mail/message/100`)}')`);
 });


### PR DESCRIPTION
Before this commit, the message mentions in the HTML composer were not properly validated and rendered.

This commit adds the implementation to validate message mentions and render them correctly in the mention plugin.

task-5489852

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
