### PR TITLE
[FIX] im_livechat: no 'start call' thread actions for livechat visitors

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_actions_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_actions_patch.js
@@ -12,7 +12,7 @@ patch(ThreadAction.prototype, {
         ];
         if (
             thread?.channel_type === "livechat" &&
-            !store.self_partner &&
+            store.self_partner?.main_user_id?.share !== false &&
             !visitorActions.includes(action.id)
         ) {
             return false;

--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -7,15 +7,17 @@ import {
     contains,
     inputFiles,
     insertText,
+    mockGetMedia,
     onRpcBefore,
     start,
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import { asyncStep, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
+import { asyncStep, serverState, waitForSteps, withUser } from "@web/../tests/web_test_helpers";
 
 import { deserializeDateTime } from "@web/core/l10n/dates";
+import { rpc } from "@web/core/network/rpc";
 import { getOrigin } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
@@ -44,6 +46,52 @@ test("Conversation name is operator livechat user name", async () => {
     await start({ authenticateAs: false });
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-ChatWindow-header", { text: "MitchellOp" });
+});
+
+test("Portal users should not be able to start a call", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    await loadDefaultEmbedConfig();
+    const joelUid = pyEnv["res.users"].create({
+        name: "Joel",
+        share: true,
+        login: "joel",
+        password: "joel",
+    });
+    const joelPid = pyEnv["res.partner"].create({
+        name: "Joel",
+        user_ids: [joelUid],
+    });
+    pyEnv["res.partner"].write(serverState.partnerId, { user_livechat_username: "MitchellOp" });
+    await start({ authenticateAs: { login: "joel", password: "joel" } });
+    await click(".o-livechat-LivechatButton");
+    await contains(".o-mail-ChatWindow-header:text('MitchellOp')");
+    await insertText(".o-mail-Composer-input", "Hello MitchellOp!");
+    await triggerHotkey("Enter");
+    await contains(".o-mail-Message[data-persistent]:contains('Hello MitchellOp!')");
+    await contains(".o-mail-ChatWindow-header .o-mail-ActionList-button", { count: 2 });
+    await contains(".o-mail-ChatWindow-header .o-mail-ActionList-button[title='Fold']");
+    await contains(".o-mail-ChatWindow-header .o-mail-ActionList-button[title*='Close']");
+    await contains(".o-discuss-Call", { count: 0 });
+    // simulate operator starts call
+    const [channelId] = pyEnv["discuss.channel"].search([
+        ["channel_type", "=", "livechat"],
+        [
+            "channel_member_ids",
+            "in",
+            pyEnv["discuss.channel.member"].search([["partner_id", "=", joelPid]]),
+        ],
+    ]);
+    await withUser(serverState.userId, () =>
+        rpc("/mail/rtc/channel/join_call", { channel_id: channelId }, { silent: true })
+    );
+    await contains(".o-discuss-Call button", { count: 2 });
+    await contains(".o-discuss-Call button[title='Join Video Call']");
+    await contains(".o-discuss-Call button[title='Join Call']");
+    // still same actions in header
+    await contains(".o-mail-ChatWindow-header .o-mail-ActionList-button", { count: 2 });
+    await contains(".o-mail-ChatWindow-header .o-mail-ActionList-button[title='Fold']");
+    await contains(".o-mail-ChatWindow-header .o-mail-ActionList-button[title*='Close']");
 });
 
 test("avatar url contains access token for non-internal users", async () => {


### PR DESCRIPTION
Before this commit, portal visitor could start a call in livechat.

This comes from bad condition for start call button, which was only checking the current user is a guest. Portal users are authenticated and don't have guest, so they were mistakenly elligible for "Start Call" button.

This commit restrict the button further to not show only for internal users in livechat conversations.