### PR TITLE
[FIX] account: update bank account priority on move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1039,17 +1039,14 @@ class AccountMove(models.Model):
     def _compute_partner_bank_id(self):
         def _bank_selection_key(bank):
             """Sorting priority:
-            0. Same currency as the move
-            1. No currency set
-            2. Different currency
+            0. Same currency as the move or no currency
+            1. Different currency
             Then: prefer banks allowing outgoing payments (trusted ones)
             """
-            if bank.currency_id == move.currency_id:
+            if bank.currency_id == move.currency_id or not bank.currency_id:
                 currency_priority = 0
-            elif not bank.currency_id:
-                currency_priority = 1
             else:
-                currency_priority = 2
+                currency_priority = 1
             return (currency_priority, not bank.allow_out_payment)
 
         for move in self:


### PR DESCRIPTION
In 656a26c309dae58e0f680421311a11344d72b1f5 , we prioritized bank accounts with a strict currency match over accounts with no currency. That's problematic for a multi-currency account, as leaving currency empty is normal; in that case, it's impossible to set it as the default.

Updated sorting priorities as the no currency account is at the same level of priority as the currency match.

task-5322123


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
