### PR TITLE
[FIX] mail: restrict manual modification of reply_to in templates

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -41,7 +41,7 @@
                             <field name="recipient_ids" widget="many2many_tags"
                                 domain="[('active', '=', True)]"/>
                             <field name="email_cc"/>
-                            <field name="reply_to"/>
+                            <field name="reply_to" readonly="1"/>
                             <field name="scheduled_date" placeholder="YYYY-MM-DD HH:MM:SS"/>
                         </group>
                         <notebook>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -66,7 +66,7 @@
                                             placeholder="Comma-separated ids of recipient partners"/>
                                     <field name="email_cc" invisible="use_default_to"
                                             placeholder="Comma-separated carbon copy recipients addresses"/>
-                                    <field name="reply_to"
+                                    <field name="reply_to" invisible="not reply_to"
                                             placeholder="Email address to which replies will be redirected when sending emails in mass"/>
                                     <field name="scheduled_date" string="Scheduled Send Date"/>
                                 </group>


### PR DESCRIPTION
Prior to this commit, the `reply_to` field on email templates (`mail.template`) was fully editable by users. This frequently led to misconfigurations where users would manually enter incorrect email addresses, bypassing the system's default catchall behavior.

This resulted in:
1. Lost communication history: Replies were sent to private emails instead of routing back to the document chatter.
2. Deliverability issues: Manual values often failed SPF/DMARC checks, causing emails to bounce or land in spam.

This commit addresses the issue by:
1. Modifying the `mail.template` form view to hide the `reply_to` field when it is not set (`invisible="not reply_to"`). This aligns the form behavior with the preview wizard and prevents users from accidentally overriding the system default on standard templates.
2. Setting the `reply_to` field to `readonly="1"` on the technical email message view to prevent manual tampering with emails already in the queue.

opw-4894020

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
