### PR TITLE
[FIX] mail: auto focus video participant and fix layout overflow in chat window

### DIFF
--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -36,6 +36,7 @@ declare module "models" {
         focusAvailableVideo: () => void;
         focusStack: RtcSession[];
         hadSelfSession: boolean;
+        isCallDisplayedInChatWindow: boolean;
         lastSessionIds: Set<number>;
         promoteFullscreen: typeof CALL_PROMOTE_FULLSCREEN[keyof CALL_PROMOTE_FULLSCREEN];
         rtc_session_ids: RtcSession[];

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -27,7 +27,6 @@
             height: 10%;
             min-height: #{"max(10%, 100px)"};
             &.o-hasVideo.o-selfInCall {
-                width: 100%;
                 height: calc(100vw * 9 / 16);
             }
         }

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -110,6 +110,16 @@ export class RtcSession extends Record {
         compute() {
             return this.is_screen_sharing_on || this.is_camera_on;
         },
+        /** @this {import("models").RtcSession} */
+        onUpdate() {
+            if (
+                this.isVideoStreaming &&
+                this.channel?.channel_type === "chat" &&
+                this.store.rtc.selfSession?.in(this.channel.rtc_session_ids)
+            ) {
+                this.channel.focusAvailableVideo();
+            }
+        },
     });
     shortStatus = fields.Attr(undefined, {
         compute() {

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -156,16 +156,26 @@ const ThreadPatch = {
             },
         });
     },
+    get isCallDisplayedInChatWindow() {
+        return this.chat_window?.isOpen && !this.store.meetingViewOpened;
+    },
     get showCallView() {
         return !this.store.rtc.state.isFullscreen && this.rtc_session_ids.length > 0;
     },
     focusAvailableVideo() {
-        if (this.isDisplayedInDiscussAppDesktop || !this.store.settings.useCallAutoFocus) {
+        if (
+            !this.store.settings.useCallAutoFocus ||
+            !(
+                this.store.env.services.ui.isSmall ||
+                this.store.rtc.state.isPipMode ||
+                this.isCallDisplayedInChatWindow
+            )
+        ) {
             return;
         }
-        const otherStreamingSession = this.rtc_session_ids.find((session) => {
-            session.notEq(this.store.rtc.selfSession) && session.hasVideo;
-        });
+        const otherStreamingSession = this.rtc_session_ids.find(
+            (session) => session.notEq(this.store.rtc.selfSession) && session.hasVideo
+        );
         if (!otherStreamingSession) {
             return;
         }

--- a/addons/mail/static/src/discuss/call/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/public_web/thread_model_patch.js
@@ -1,0 +1,13 @@
+import { Thread } from "@mail/core/common/thread_model";
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Thread} */
+const ThreadPatch = {
+    get isCallDisplayedInChatWindow() {
+        return (
+            super.isCallDisplayedInChatWindow &&
+            (this.store.env.services.ui.isSmall || !this.store.discuss.isActive)
+        );
+    },
+};
+patch(Thread.prototype, ThreadPatch);

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -8,6 +8,7 @@ import {
     makeMockRtcNetwork,
     openDiscuss,
     patchUiSize,
+    setupChatHub,
     SIZES,
     start,
     startServer,
@@ -1057,4 +1058,34 @@ test("discuss sidebar call participant shows appropriate status icon", async () 
     await contains(".o-mail-DiscussSidebarCallParticipants:contains('bob') .fa-microphone-slash");
     await bobRemote.updateInfo({ is_deaf: true });
     await contains(".o-mail-DiscussSidebarCallParticipants:contains('bob') .fa-deaf");
+});
+
+test("auto-focus participant video in one-to-one call in chat window", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
+    pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: serverState.partnerId,
+    });
+    const channelMemberId = pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: pyEnv["res.partner"].create({ name: "Batman" }),
+    });
+    setupChatHub({ opened: [channelId] });
+    const env = await start();
+    const network = await makeMockRtcNetwork({ env, channelId });
+    const mockedRemote = network.makeMockRemote(channelMemberId);
+    await click("[title='Join Call']");
+    await contains(".o-discuss-CallParticipantCard", { count: 2 });
+    await mockedRemote.updateConnectionState("connected");
+    await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
+    await contains(".o-discuss-CallParticipantCard[title='Batman'] video");
+    await contains(".o-discuss-CallParticipantCard");
+    await mockedRemote.updateUpload("camera", null);
+    await click(".o-discuss-CallParticipantCard[title='Batman']");
+    await click("[title='Fullscreen']");
+    await contains(".o-mail-Meeting");
+    await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
+    await contains(".o-discuss-CallParticipantCard[title='Batman'] video");
+    await contains(".o-discuss-CallParticipantCard", { count: 2 }); // card does not get focused in meeting view
 });


### PR DESCRIPTION
Before this PR:
- Auto focus on a participant’s video when joining a call did not trigger due 
to a typo in the find() callback, causing it to always return undefined.
- The video-focus-on-join feature was only conditioned on the call component 
not being shown in the Discuss desktop view. This does not handle the cases 
when call is in meeting view or PiP view
- The video-focus-on-join feature only ran at call join time. In one-one calls, 
when the other participant turned on their camera after the call started, 
their video was not focused even when auto-focus was enabled
- When any participant had video enabled, the call component could overflow 
the chat window, causing an unwanted horizontal scrollbar.

This PR:
- Fixes the find() callback typo so the active streaming session is correctly 
detected and auto-focused when joining a call.
- Updates the video-focus-on-join conditions to support all intended layouts: 
    1. mobile (small UI)
    2. chat window
    3. PiP window.
- Extends the video-focus-on-join feature: in one-one calls, when the other 
participant turns on their camera mid-call, their video is now automatically 
focused (when auto-focus is enabled and the above layout conditions are met).
- Fixes layout overflow by preventing the call component from exceeding the 
chat window width.

Before / After fix (overflow issue):
<img width="300" height="640" alt="image" src="https://github.com/user-attachments/assets/a291949f-5a82-4c0c-a3c3-d31078e2e62e" /> <img width="300" height="640" alt="image" src="https://github.com/user-attachments/assets/f8405be4-e200-416b-b582-ecc057a0f9a3" />


part of task-[5227387](https://www.odoo.com/odoo/project/1519/tasks/5227387)