### PR TITLE
[FIX] purchase_mrp: UoM category error on kit

### DIFF
--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -47,6 +47,16 @@ class PurchaseOrder(models.Model):
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
+    def _compute_kit_quantities_from_moves(self, moves, kit_bom):
+        self.ensure_one()
+        moves_to_consider = moves.filtered(lambda m: m.state == 'done' and not m.scrapped)
+        order_qty = self.product_uom._compute_quantity(self.product_uom_qty, kit_bom.product_uom_id)
+        filters = {
+            'incoming_moves': lambda m: m.location_id.usage == 'supplier' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+            'outgoing_moves': lambda m: m.location_id.usage != 'supplier' and m.to_refund,
+        }
+        return moves_to_consider._compute_kit_quantities(self.product_id, order_qty, kit_bom, filters)
+
     def _compute_qty_received(self):
         kit_lines = self.env['purchase.order.line']
         lines_stock = self.filtered(lambda l: l.qty_received_method == 'stock_moves' and l.move_ids and l.state != 'cancel')
@@ -60,13 +70,7 @@ class PurchaseOrderLine(models.Model):
         for line in lines_stock:
             kit_bom = kits_by_company[line.company_id].get(line.product_id)
             if kit_bom:
-                moves = line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
-                order_qty = line.product_uom._compute_quantity(line.product_uom_qty, kit_bom.product_uom_id)
-                filters = {
-                    'incoming_moves': lambda m: m.location_id.usage == 'supplier' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                    'outgoing_moves': lambda m: m.location_id.usage != 'supplier' and m.to_refund
-                }
-                line.qty_received = moves._compute_kit_quantities(line.product_id, order_qty, kit_bom, filters)
+                line.qty_received = line._compute_kit_quantities_from_moves(line.move_ids, kit_bom)
                 kit_lines += line
         super(PurchaseOrderLine, self - kit_lines)._compute_qty_received()
 

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.fields import Date, Datetime
 from odoo.tools import mute_logger
 from odoo.tests import Form, tagged
@@ -233,6 +234,63 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         self.assertEqual(svl.value, 50)  # USD
         self.assertEqual(input_aml.amount_currency, 100)  # EUR
         self.assertEqual(input_aml.balance, 50)  # USD
+
+    def test_multicurrency_kit_different_uom_categories(self):
+        """
+            Create a kit with an UoM belonging to a different category than its component UoM.
+            Purchase that kit in a different currency than the company currency and validate the receipt.
+            Check the generated account entries.
+        """
+        eur = self.env.ref('base.EUR')
+
+        uom_unit = self.env.ref('uom.product_uom_unit')
+        uom_meter = self.env.ref('uom.product_uom_meter')
+
+        kit, component = self.env['product.product'].create([
+            {
+                'name': 'Kit multi UoM',
+                'type': 'product',
+                'uom_id': uom_unit.id,
+                'uom_po_id': uom_unit.id,
+                'categ_id': self.avco_category.id,
+            },
+            {
+                'name': 'Component meter',
+                'type': 'product',
+                'uom_id': uom_meter.id,
+                'uom_po_id': uom_meter.id,
+                'categ_id': self.avco_category.id,
+            },
+        ])
+
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'product_uom_id': uom_unit.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [Command.create({
+                'product_id': component.id,
+                'product_qty': 1.0,
+                'product_uom_id': uom_meter.id,
+            })],
+        })
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.vendor01.id,
+            'currency_id': eur.id,
+            'order_line': [Command.create({
+                'product_id': kit.id,
+                'product_qty': 1.0,
+                'product_uom': kit.uom_po_id.id,
+                'price_unit': 100.0,
+            })],
+        })
+        po.button_confirm()
+
+        receipt = po.picking_ids
+        receipt.button_validate()
+
+        self.assertEqual(receipt.move_ids.state, 'done')
 
     def test_fifo_cost_adjust_mo_quantity(self):
         """ An MO using a FIFO cost method product as a component should not zero-out the std cost


### PR DESCRIPTION
Steps to reproduce
------------------

1. Enable Units of Measure and Automatic Valuation.
2. Create:
  Product KIT, stockable, UoM category Unit, UoM = Units.
  BoM for KIT with at least one component whose UoM is in a different
     category (e.g. m from Length).
3. Go to the product's category and set the Costing Method to Average
   Cost (AVCO) and the Inventory Valuation to Automated.
4. Create a PO for KIT in a currency different from the company currency.
5. Confirm the PO and validate the receipt.

Issue
-----

Validating the receipt raises:

> The unit of measure m defined on the order line doesn't belong to the
> same category as the unit of measure kit defined on the product…

If you keep the PO currency equal to the company currency, the same kit
and BoM work and the receipt posts correctly.

Cause of the issue
------------------

Validating the receipt will call the `_action_done` of stock.move's and generate the related accounting entries. During this call and the currency of the PO is different from the company currency the `_generate_valuation_lines_data` will call the `_get_currency_convert_date` method:
https://github.com/odoo/odoo/blob/751d54207c6214a25a5a1def57137e2f2f9106e3/addons/purchase_stock/models/stock_move.py#L134-L140
This call will in turn call the `_get_qty_received_without_self`:
https://github.com/odoo/odoo/blob/751d54207c6214a25a5a1def57137e2f2f9106e3/addons/purchase_stock/models/stock_move.py#L121-L122
which was not written to handle kit products since it assumes that the product of the PO is the same as the one of the related move:
https://github.com/odoo/odoo/blob/751d54207c6214a25a5a1def57137e2f2f9106e3/addons/purchase_stock/models/stock_move.py#L102-L108

Fix
---

The qty_received is relevant to the _get_currency_convert_date as the method compares the qty_invoiced with the qty_received to determine whether to use the Invoice Date (when qty_invoiced > qty_received) or the Receipt Date.

https://github.com/odoo/odoo/blob/888e086dc6c7823b07993e90f70e2849e988fa7a/addons/purchase_stock/models/stock_move.py#L122-L126

  For kits, `qty_received` must be calculated by aggregating component
  moves to accurately determine this status. Since the standard logic
  crashes due to UoM mismatch, the override in `purchase_mrp` is
  necessary to provide the correct quantity for this date selection.

opw-5030761