### PR TITLE
[IMP] account: remove confirm update taxes popup

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1001,7 +1001,6 @@
                                             string="Update Taxes and Accounts"
                                             help="Recompute all taxes and accounts based on this fiscal position"
                                             class="btn-link mb-1 px-0" icon="fa-refresh"
-                                            confirm="This will update all taxes and accounts based on the currently selected fiscal position."
                                             invisible="not show_update_fpos or state in ['cancel', 'posted']"/>
                                 </div>
 


### PR DESCRIPTION
This commit removes the confirmation popup when pressing "update taxes and accounts" in invoices after changing the partner.

task-5324619


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
