### PR TITLE
[FIX] hr_recruitment: correct alignment of job position email field

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -74,7 +74,7 @@
                             <main>
                                 <div class="d-flex flex-row align-content-center ms-2">
                                     <div class="col-3 d-flex flex-column align-self-center o_kanban_card_header">
-                                        <div class="d-flex flex-row">
+                                        <div class="d-flex flex-row justify-content-between">
                                             <div class="d-flex fw-bold fs-3 o_kanban_card_header_title">
                                                 <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
                                                 <field class="fs-3" name="name"/>


### PR DESCRIPTION
Steps to reproduce:
---------------------------
1. Install the Recruitment app with demo data.
2. In Settings, add an Email Alias for the company.
3. Open the Recruitment app.
4. Click the Configure button on the job position kanban card.
5. In the Job Position form view, add an email alias.
6. Use the breadcrumbs to navigate back to the job positions.

Observation:
---------------------------
The email field for the job position is misaligned in the kanban card.

Issue:
---------------------------
The `div` containing the email is missing a `justify-content-*` class https://github.com/odoo/odoo/blob/5ab45d45073463495e517aca9fd061415a73e893/addons/hr_recruitment/views/hr_job_views.xml#L77

Solution:
---------------------------
Add the missing `justify-content-between` class to align the email properly.


Before:
<img width="1909" height="749" alt="before" src="https://github.com/user-attachments/assets/51790c71-f30d-4402-ae24-a5ccfb30ff9a" />

After:
<img width="1914" height="697" alt="after" src="https://github.com/user-attachments/assets/711f83f6-208e-44c3-83e2-8b736c697a9d" />

opw-5246587