### PR TITLE
[FIX] project: ensure portal customers can access public projects

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -657,6 +657,9 @@ class ProjectProject(models.Model):
             if vals.pop('is_favorite', False):
                 vals['favorite_user_ids'] = [self.env.uid]
         projects = super().create(vals_list)
+        for project in projects:
+            if project.privacy_visibility == 'portal':
+                project.message_subscribe(partner_ids=[project.partner_id.id])
         return projects
 
     def write(self, vals):

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -477,3 +477,16 @@ class TestProjectFlow(TestProjectCommon, MailCase):
         self.assertFalse(task1.user_ids)
         self.assertEqual(self.user_projectuser + self.user_projectmanager, task_2.user_ids)
         self.assertEqual(self.user_projectuser, task_3.user_ids)
+
+    def test_customer_can_access_public_project(self):
+        """Test that a customer is automatically subscribed when the project is public."""
+        project = self.env['project.project'].create({
+            'name': 'Public Project',
+            'privacy_visibility': 'portal',
+            'partner_id': self.partner_1.id,
+        })
+
+        self.assertIn(
+            self.partner_1, project.message_partner_ids,
+            "Customer should be automatically subscribed to the project when visibility is set to 'public'."
+        )


### PR DESCRIPTION
Steps to Reproduce:
-

1. Create a project with a customer that is a portal user.
2. Set the project visibility to Public.
3. Log in as the portal user → the project is not visible on the portal.

Issue:
-

 - The portal customer cannot see the project on the portal, even though the project is public.

Cause:
-

- Portal access is controlled by the rule requiring: ('privacy_visibility', '=', 'portal') ('message_partner_ids', 'child_of', portal_user_partner)
- This means a portal user must be a follower of the project in order to see it.

Solution:
-

On project creation:
- If the project visibility is set to 'portal', the customer is automatically added to the follower list.
- This ensures the customer satisfies the record rule and can properly access the project and its tasks on the portal.

task-5075093
