### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: separate PDF fetching from provider sync

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/data/cron.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/cron.xml
@@ -39,4 +39,14 @@
         <field name="interval_type">hours</field>
         <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
     </record>
+
+    <record id="ir_cron_nilvera_get_sale_pdf" model="ir.cron">
+        <field name="name">Nilvera: retrieve sale PDFs</field>
+        <field name="model_id" ref="model_account_move"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_nilvera_get_sale_pdf()</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
+        <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
 </odoo>

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -21,6 +21,18 @@ class AccountMoveSend(models.AbstractModel):
         return res
 
     # -------------------------------------------------------------------------
+    # ATTACHMENTS
+    # -------------------------------------------------------------------------
+
+    def _get_invoice_extra_attachments(self, move):
+        # EXTENDS 'account'
+        # Add the Nilvera PDF to the mail attachments.
+        attachments = super()._get_invoice_extra_attachments(move)
+        if move.l10n_tr_nilvera_send_status == 'succeed' and move.message_main_attachment_id.id != move.invoice_pdf_report_id.id:
+            attachments += move.message_main_attachment_id
+        return attachments
+
+    # -------------------------------------------------------------------------
     # ALERTS
     # -------------------------------------------------------------------------
 

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -13,6 +13,12 @@
                     <field name="l10n_tr_nilvera_send_status" class="oe_inline"/>
                 </div>
             </xpath>
+            <xpath expr="//header/field[@name='state']" position="before">
+                <button name="l10n_tr_nilvera_get_pdf"
+                        string="Fetch Nilvera PDF"
+                        type="object"
+                        invisible="move_type != 'out_invoice' or l10n_tr_nilvera_send_status != 'succeed'"/>
+            </xpath>
         </field>
     </record>
 
@@ -32,6 +38,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_invoice_tree"/>
         <field name="arch" type="xml">
+            <button name="action_force_register_payment" position="after">
+                <button name="l10n_tr_nilvera_get_pdf" type="object" string="Fetch Nilvera PDF"/>
+            </button>
             <xpath expr="//field[@name='abnormal_date_warning']" position="after">
                 <field name="l10n_tr_nilvera_send_status"
                     string="Nilvera Status"


### PR DESCRIPTION
Commit 2e1b0f16d8732e9450caf9ac313312e7ad42a2b2 extended _l10n_tr_nilvera_get_documents with a flow for invoices created in Odoo (fetch Nilvera PDF + set provider reference). This mixed two distinct flows.

Rationale:
- The reference from Nilvera is not needed. We also have this data since we are the senders.
- _l10n_tr_nilvera_get_documents should only import documents (moves) originating from the provider.
- The added logic was never executed because the method skips moves that already exist in Odoo.

Changes:
- Revert the parts of _l10n_tr_nilvera_get_documents related to Odoo-created invoices.
- Add a dedicated cron to fetch Nilvera-generated PDFs for invoices created and sent from Odoo. To do this in stable without adding a new field, the cron targets moves where message_main_attachment_id points to the PDF created by Odoo. Once the PDF from Nilvera is fetched, it is set as the main attachment instead.
-  Add a button to the list and the form view for invoices to fetch the Nilvera PDF.
- Add that PDF in the email attachments.

task-5265045