### PR TITLE
[FIX] mail: show 'copy to clipboard' on message action of non-ai convo

### DIFF
--- a/addons/mail/static/tests/mail_shared_tests.js
+++ b/addons/mail/static/tests/mail_shared_tests.js
@@ -42,3 +42,30 @@ export async function mailCanAddMessageReactionMobile() {
     await contains(".o-mail-MessageReaction:contains('🤣')");
     await contains(".o-mail-MessageReaction:contains('😀')");
 }
+
+export async function mailCanCopyTextToClipboardMobile() {
+    mockTouch(true);
+    mockUserAgent("android");
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create([
+        {
+            body: "Hello world",
+            res_id: channelId,
+            message_type: "comment",
+            model: "discuss.channel",
+        },
+        {
+            body: "Hello Odoo",
+            res_id: channelId,
+            message_type: "comment",
+            model: "discuss.channel",
+        },
+    ]);
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message:contains('Hello world')");
+    await click(".o-mail-Message:contains('Hello world') [title='Expand']");
+    await contains(".o-dropdown-item:contains('Copy to Clipboard')");
+}

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -1,4 +1,7 @@
-import { mailCanAddMessageReactionMobile } from "@mail/../tests/mail_shared_tests";
+import {
+    mailCanAddMessageReactionMobile,
+    mailCanCopyTextToClipboardMobile,
+} from "@mail/../tests/mail_shared_tests";
 import {
     SIZES,
     click,
@@ -86,6 +89,8 @@ test("enter key should create a newline in composer", async () => {
 });
 
 test("can add message reaction (mobile)", mailCanAddMessageReactionMobile);
+
+test("can copy text to clipboard (mobile)", mailCanCopyTextToClipboardMobile);
 
 test("Can edit message comment in chatter (mobile)", async () => {
     mockTouch(true);


### PR DESCRIPTION
Before this commit, "Copy to Clipboard" was sometimes not visible in the message action list when message had some text content.

This happens because message actions can condition overridden by some other modules, and the way overrides of action condition work is to have boolean value taking precedence over the local condition of action.

This architecture is meant to provide exhaustive list of actions to allow, which is quite useful to control what livechat visitors can have.

However this architecture requires overrides to properly return `undefined` when the local condition should apply, which was not the case for an override by `ai` module. So when `ai` module is installed, the "copy to clipboard" feature as not available.

This commit fixes the issue by adapting the condition in `ai` module to return `undefined` on non-AI conversations, and add test coverage for both `@mail` discuss suite and all overrides of discuss in `@test_discuss_full_enterprise`.

opw-5240768

https://github.com/odoo/enterprise/pull/99794