### PR TITLE
[FIX] web_editor, html_editor: replace vimeo video

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -37,7 +37,7 @@ export class VideoSelector extends Component {
         errorMessages: Function,
         vimeoPreviewIds: { type: Array, optional: true },
         isForBgVideo: { type: Boolean, optional: true },
-        media: { type: Object, optional: true },
+        media: { validate: (n) => n.nodeType === Node.ELEMENT_NODE, optional: true },
         "*": true,
     };
     static defaultProps = {

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -39,7 +39,7 @@ export class VideoSelector extends Component {
         errorMessages: Function,
         vimeoPreviewIds: {type: Array, optional: true},
         isForBgVideo: {type: Boolean, optional: true},
-        media: {type: Object, optional: true},
+        media: {validate: (n) => n.nodeType === Node.ELEMENT_NODE, optional: true},
         "*": true,
     };
     static defaultProps = {


### PR DESCRIPTION
Steps to reproduce:
===================
1- Website app > Open any page in Edit mode.
2- Drag a Video block into the page.
3- Paste a Vimeo video URL in the dialog and save. 
4- Save the page, then re-open it in Edit mode.
-> traceback

Cause:
======
The Wysiwyg "openMediaDialog" passes the selected media DOM node as "media" to the MediaDialog.
The MediaDialog forwards that value as "media" prop to VideoSelector. VideoSelector declared "media" as "{ type: Object, optional: true }". Owl validates "type: Object" as a plain object, not as any "typeof object".
DOM elements such as HTMLImageElement do not pass this plain object check, so Owl raises an error.

Solution:
=========
Relax the "media" prop type in VideoSelector so DOM nodes are accepted. In web_editor VideoSelector, change the "media" prop to "{ optional: true }".
In html_editor VideoSelector, also keep "media" declared as "{ optional: true }".

opw-5239889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
