### PR TITLE
[FIX] mail: camera button warning in voice

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -91,7 +91,7 @@ registerCallAction("deafen", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
 export const cameraOnAction = {
-    badge: ({ owner, store }) => !owner.env.inCallMenu && store.rtc.cameraPermission !== "granted",
+    badge: ({ owner, store, thread }) => !owner.env.inCallMenu && thread?.default_display_mode === "video_full_screen" && store.rtc.cameraPermission !== "granted",
     badgeIcon: "fa fa-exclamation",
     condition: ({ thread }) => thread?.isSelfInCall,
     disabledCondition: ({ store }) => store.rtc?.isRemote,
@@ -107,12 +107,15 @@ export const cameraOnAction = {
     onSelected: ({ owner, store }) => store.rtc.toggleVideo("camera", { env: owner.env }),
     sequence: 10,
     sequenceGroup: 120,
-    tags: ({ action, store }) => {
+    tags: ({ action, store, thread }) => {
         const tags = [];
         if (action.isActive) {
             tags.push(ACTION_TAGS.SUCCESS);
         }
-        if (store.rtc.cameraPermission !== "granted") {
+        if (
+            thread?.default_display_mode === "video_full_screen" &&
+            store.rtc.cameraPermission !== "granted"
+        ) {
             tags.push(ACTION_TAGS.DANGER, ACTION_TAGS.WARNING_BADGE);
         }
         return tags;

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1120,7 +1120,11 @@ function _process_request_for_all(store, name, params, context = {}) {
         });
     }
     if (name === "/discuss/create_group") {
-        const channelId = DiscussChannel._create_group(params.partners_to, params.name);
+        const channelId = DiscussChannel._create_group(
+            params.partners_to,
+            params.default_display_mode,
+            params.name
+        );
         store.add(channelId).resolve_data_request({
             channel: mailDataHelpers.Store.one(channelId, makeKwArgs({ only_id: true })),
         });

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -579,11 +579,13 @@ export class DiscussChannel extends models.ServerModel {
 
     /**
      * @param {number[]} partners_to
+     * @param {string} [default_display_mode=undefined]
      * @param {string} name
      * */
-    _create_group(partners_to, name) {
-        const kwargs = getKwArgs(arguments, "partners_to", "name");
+    _create_group(partners_to, default_display_mode, name) {
+        const kwargs = getKwArgs(arguments, "partners_to", "default_display_mode", "name");
         partners_to = kwargs.partners_to || [];
+        default_display_mode = kwargs.default_display_mode;
         name = kwargs.name || "";
 
         /** @type {import("mock_models").DiscussChannel} */
@@ -597,6 +599,7 @@ export class DiscussChannel extends models.ServerModel {
             channel_member_ids: partners.map((partner) =>
                 Command.create({ partner_id: partner.id })
             ),
+            default_display_mode: default_display_mode,
             name,
         });
         this._broadcast(


### PR DESCRIPTION
Only channels that have cameraPermission of `prompt` should
show the red and warning. If the permission is `denied` or `granted`,
no badge should be shown.

task-5263066

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
