### PR TITLE
[FIX] hr: start date missing in test

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -679,8 +679,8 @@ class TestVersionCron(TransactionCase):
         change their version.
         """
         with freeze_time('2023-10-06'):
-            self.employee.create_version(
-                {'date_version': '2023-10-07', "distance_home_work": 40}
+            self.employee.version_id = self.employee.create_version(
+                {'date_version': '2023-10-07', "distance_home_work": 40, 'contract_date_start': '2022-10-07'}
             )
 
         # Saving current employee data to compare later on


### PR DESCRIPTION
The test_version_cron_update_no_fields from hr/tests/test_hr_employee.py didn't pass on runbot saas-18.4 due to the lack of explicitly defined start date of contract leading to an error when trying to substract False to a datetime object.

I explicitly added a contract_date_start on the hr.version creation and modified the assigning line as the create_version function returns the new version object but doesn't attribute it to the employee directly.

Runbot error: 233590

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
