### PR TITLE
[FIX] account_peppol: onboarding

### DIFF
--- a/addons/account_peppol/__init__.py
+++ b/addons/account_peppol/__init__.py
@@ -11,6 +11,14 @@ from odoo.tools.sql import column_exists, create_column
 def pre_init_hook(cr):
     env = api.Environment(cr, SUPERUSER_ID, {})
 
+    # We set the edi mode to `prod` by default to ease the onboarding.
+    # Currently the switching between edi modes is error-prone.
+    # The mode is not stored on the proxy user. So system parameter may have been
+    # different at the time the proxy user was created.
+    peppol_in_demo = bool(env['ir.module.module'].search_count([('name', '=', 'account_peppol'), ('demo', '=', True)], limit=1))
+    if not peppol_in_demo and not env['account_edi_proxy_client.user'].search_count([], limit=1):
+        env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', 'prod')
+
     ubl_bis3 = env.ref('account_edi_ubl_cii.ubl_bis3', raise_if_not_found=False)
     if ubl_bis3 and ubl_bis3.name == "Peppol BIS Billing 3.0":
         ubl_bis3.name = "BIS Billing 3.0 (XML)"


### PR DESCRIPTION
Curently the peppol edi mode is set to `demo` by default.

This happens because the system parameter determining the mode
(`account_edi_proxy_client.demo`) is initalised with `demo`.
This happens when installing module `account_edi_proxy_client` in a
post init hook:
https://github.com/odoo/odoo/blob/6f40f3a85d4c6edf43a427d8575c5c95c3005cd4/addons/account_edi_proxy_client/__init__.py#L6

After this commit we set the mode to `prod` when installing `account_peppol`
in the post init hook. Except if the DB is in demo mode or we have
proxy users already.

The modules `l10n_it_edi` and `account_peppol` are the only current modules depending
on `account_edi_proxy_client`.

opw-5337830