### PR TITLE
[REF] mail: refactor mailbox icon

### DIFF
--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -19,11 +19,6 @@
                 </t>
             </t>
             <div t-elif="props.thread.channel?.channel_type === 'group'" class="o-mail-ThreadIcon oi fa-fw oi-users" t-att-class="largeClass" title="Grouped Chat"/>
-            <t t-elif="props.thread.model === 'mail.box'">
-                <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="largeClass"/>
-                <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="largeClass"/>
-                <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att-class="largeClass"/>
-            </t>
         </div>
     </t>
 

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -7,6 +7,7 @@ import { Thread } from "@mail/core/common/thread";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { Composer } from "@mail/core/common/composer";
 import { ImStatus } from "@mail/core/common/im_status";
+import { MailboxIcon } from "@mail/core/public_web/mailbox_icon";
 
 import { _t } from "@web/core/l10n/translation";
 import { FileUploader } from "@web/views/fields/file_handler";
@@ -21,6 +22,7 @@ export class DiscussContent extends Component {
         Composer,
         FileUploader,
         ImStatus,
+        MailboxIcon,
     };
     static props = ["thread?"];
     static template = "mail.DiscussContent";

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -17,9 +17,8 @@
                     </FileUploader>
                     <ImStatus t-if="thread.correspondent and showImStatus" className="'o-mail-DiscussContent-headerImStatus position-absolute'" member="thread.correspondent"/>
                 </div>
-                <t t-else="">
-                    <ThreadIcon className="'align-self-center fs-3 my-2 opacity-75'" size="'large'" thread="thread"/>
-                </t>
+                <MailboxIcon t-elif="thread.model === 'mail.box'" mailbox="thread" size="'large'"/>
+                <ThreadIcon t-else="" className="'align-self-center fs-3 my-2 opacity-75'" size="'large'" thread="thread"/>
                 <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-1">
                     <div t-if="thread.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">
                         <span class="fw-bolder cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.parent_channel_id.displayName" t-on-click="() => this.thread.parent_channel_id.open({ focus: true })"/>

--- a/addons/mail/static/src/core/public_web/mailbox_icon.js
+++ b/addons/mail/static/src/core/public_web/mailbox_icon.js
@@ -1,0 +1,12 @@
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class MailboxIcon extends Component {
+    static template = "mail.MailboxIcon";
+    static props = ["mailbox", "size?"];
+
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+    }
+}

--- a/addons/mail/static/src/core/public_web/mailbox_icon.xml
+++ b/addons/mail/static/src/core/public_web/mailbox_icon.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.MailboxIcon">
+        <div class="o-mail-MailboxIcon d-flex justify-content-center flex-shrink-0 bg-inherit opacity-75" t-att-class="{
+            'o-ms-1_5 me-2 pt-1': !store.discuss.isSidebarCompact and props.size !== 'large',
+            'fs-3': props.size === 'large',
+        }">
+            <div class="fa fa-fw" t-att-class="{
+                'fa-lg': store.discuss.isSidebarCompact or props.size === 'large',
+                'fa-inbox': props.mailbox.id === 'inbox',
+                'fa-star-o': props.mailbox.id === 'starred',
+                'fa-history': props.mailbox.id === 'history',
+            }"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.js
+++ b/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.js
@@ -1,4 +1,5 @@
 import { ThreadIcon } from "@mail/core/common/thread_icon";
+import { MailboxIcon } from "@mail/core/public_web/mailbox_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_app/sidebar/sidebar";
 import { useHover } from "@mail/utils/common/hooks";
 
@@ -12,7 +13,7 @@ import { markEventHandled } from "@web/core/utils/misc";
 export class Mailbox extends Component {
     static template = "mail.Mailbox";
     static props = ["mailbox"];
-    static components = { Dropdown, ThreadIcon };
+    static components = { Dropdown, MailboxIcon, ThreadIcon };
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
@@ -36,7 +36,7 @@
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss.isSidebarCompact ? '' : 'o-ms-1_5 me-2 pt-1')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
+            <MailboxIcon mailbox="mailbox"/>
             <t t-if="!store.discuss.isSidebarCompact">
                 <div class="me-2 text-truncate small opacity-75 opacity-100-hover" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2473,3 +2473,9 @@ test("do not show control panel without breadcrumbs", async () => {
     await contains(".o-mail-Discuss");
     await contains(".o_control_panel .breadcrumb", { text: serverState.partnerName });
 });
+
+test("Display mailbox icon in header", async () => {
+    await start();
+    await openDiscuss("mail.box_starred");
+    await contains(".o-mail-DiscussContent-header .fa-star-o");
+});


### PR DESCRIPTION
Before this commit, mailbox icons were part of the ThreadIcon component.
This commit removes the logic from ThreadIcon and moves it directly inside the only place it's used: sidebar/mailboxes.xml.
It also removes the dependency of the thread in ThreadIcon, allowing further improvements.

