### PR TITLE
[FIX] mail: sort subchannels by last interest date

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -1,5 +1,6 @@
 import { Thread } from "@mail/core/common/thread_model";
 import { fields } from "@mail/model/misc";
+import { compareDatetime } from "@mail/utils/common/misc";
 import { rpc } from "@web/core/network/rpc";
 
 import { patch } from "@web/core/utils/patch";
@@ -33,7 +34,7 @@ const threadPatch = {
         });
         this.sub_channel_ids = fields.Many("Thread", {
             inverse: "parent_channel_id",
-            sort: (a, b) => b.id - a.id,
+            sort: (a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id,
         });
         this.displayInSidebar = fields.Attr(false, {
             compute() {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -84,6 +84,39 @@ test("toggling category button does not hide active sub thread", async () => {
     await contains(".o-mail-DiscussSidebar-item", { text: "Sub Channel" });
 });
 
+test("sub threads are sorted with last_interest_dt", async () => {
+    const pyEnv = await startServer();
+    const mainChannelId = pyEnv["discuss.channel"].create({ name: "Main Channel" });
+    const [subChannelId1] = pyEnv["discuss.channel"].create([
+        {
+            name: "Sub Channel_1",
+            parent_channel_id: mainChannelId,
+            last_interest_dt: "2021-01-02 12:00:00",
+        },
+        {
+            name: "Sub Channel_2",
+            parent_channel_id: mainChannelId,
+            last_interest_dt: "2021-01-01 12:00:00",
+        },
+        {
+            name: "Sub Channel_3",
+            parent_channel_id: mainChannelId,
+            last_interest_dt: "2021-01-03 12:00:00",
+        },
+    ]);
+    await start();
+    await openDiscuss(subChannelId1);
+    await contains(".o-mail-DiscussSidebarChannel-subChannel", { count: 3 });
+    await contains(".o-mail-DiscussSidebarChannel-subChannel", {
+        text: "Sub Channel_3",
+        before: [".o-mail-DiscussSidebarChannel-subChannel", { text: "Sub Channel_1" }],
+    });
+    await contains(".o-mail-DiscussSidebarChannel-subChannel", {
+        text: "Sub Channel_1",
+        before: [".o-mail-DiscussSidebarChannel-subChannel", { text: "Sub Channel_2" }],
+    });
+});
+
 test("Closing a category sends the updated user setting to the server.", async () => {
     onRpc("res.users.settings", "set_res_users_settings", ({ kwargs }) => {
         asyncStep("/web/dataset/call_kw/res.users.settings/set_res_users_settings");


### PR DESCRIPTION
Sub-channel search/list is currently ordered by id, but it would be more
natural to order them by last interest to be able to quickly see/find
those that are actually active and still relevant today at the top
of the list.

task-5265234


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
