### PR TITLE
 [FIX] mail: fix allowed companies when fetching mail data

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -108,5 +108,9 @@ class WebclientController(ThreadController):
             record_id, model = params.get("id"), params.get("model")
             if not record_id or model not in ("res.users", "res.partner"):
                 return
-            record = request.env[model].with_context(active_test=False).search([("id", "=", record_id)])
+            context = {
+                "active_test": False,
+                "allowed_company_ids": request.env.user._get_company_ids(),
+            }
+            record = request.env[model].with_context(**context).search([("id", "=", record_id)])
             store.add(record, record._get_store_avatar_card_fields(store.target))

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -355,13 +355,9 @@ export class Store extends BaseStore {
     }
 
     _fetchStoreDataRpc(fetchParams) {
-        const context = {
-            ...user.context,
-            allowed_company_ids: user.allowedCompanies.map((c) => c.id),
-        };
         return rpc(
             this.fetchReadonly ? "/mail/data" : "/mail/action",
-            { fetch_params: fetchParams, context },
+            { fetch_params: fetchParams, context: user.context },
             { silent: this.fetchSilent }
         );
     }

--- a/addons/test_discuss_full/static/tests/tours/avatar_card_tour.js
+++ b/addons/test_discuss_full/static/tests/tours/avatar_card_tour.js
@@ -31,6 +31,21 @@ registry.category("web_tour.tours").add("avatar_card_tour", {
             content: "Check that the employee's job title is displayed",
             trigger: ".o_avatar_card:contains(Test Job Title)",
         },
+        {
+            trigger: ".o-mail-ActivityMenu-counter:text('2')",
+        },
+        {
+            trigger: ".o_switch_company_menu button",
+            run: "click",
+        },
+        {
+            trigger: `[role=button][title='Switch to Company 2']`,
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            trigger: ".o-mail-ActivityMenu-counter:text('1')",
+        },
     ],
 });
 

--- a/addons/test_discuss_full/tests/test_avatar_card_tour.py
+++ b/addons/test_discuss_full/tests/test_avatar_card_tour.py
@@ -86,12 +86,35 @@ class TestAvatarCardTour(MailCommon, HttpCase):
                 "state": "validate",
             }
         )
+        cls.test_record = cls.env["hr.department"].create(
+            [
+                {"name": "Test", "company_id": cls.env.company.id},
+                {"name": "Test 2", "company_id": cls.env.company.id},
+                {"name": "Test 3", "company_id": cls.company_2.id},
+            ]
+        )
 
     def _setup_channel(self, user):
         self.user_employee_c2.partner_id.sudo().with_user(self.user_employee_c2).message_post(
             body="Test message in chatter",
             message_type="comment",
             subtype_xmlid="mail.mt_comment",
+        )
+        activity_type_todo = "mail.mail_activity_data_todo"
+        self.test_record[0].activity_schedule(
+            activity_type_todo,
+            summary="Test Activity for Company 2",
+            user_id=user.id,
+        )
+        self.test_record[1].activity_schedule(
+            activity_type_todo,
+            summary="Another Test Activity for Company 2",
+            user_id=user.id,
+        )
+        self.test_record[2].activity_schedule(
+            activity_type_todo,
+            summary="Test Activity for Company 3",
+            user_id=user.id,
         )
 
     @users("admin", "hr_user")


### PR DESCRIPTION
Before this commit, all mail data were retrieved with a context
containing all companies ids, which therefore was fetching more data
than expected. This behaviour was the desired one only for the
`avatar_card`.

With this commit, we revert the context to what was existing previously
and only apply the all companies context to the avatar card.

task-5322823

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
