### PR TITLE
[FIX] hr_skills: Fix bug in resume section when no versions exist

### DIFF
--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -156,6 +156,8 @@ class HrEmployee(models.Model):
             raise AccessError(self.env._("You cannot access the resume of this employee."))
         res = []
         employee_versions = self.env['hr.employee'].sudo().browse(res_id).version_ids
+        if not employee_versions:
+            return res
         interval_date_start = False
         for i in range(len(employee_versions) - 1):
             current_version = employee_versions[i]


### PR DESCRIPTION
Due to some issues with migration, some employee might not have a version, which would result in breaking the code of generating the resume lines. This commit adds an extra level of protection for those case.

Task-5336589


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
