### PR TITLE
[FIX] mail: max-width on message thread preview

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/message_patch.scss
+++ b/addons/mail/static/src/discuss/core/public_web/message_patch.scss
@@ -1,0 +1,3 @@
+.o-mail-Message .o-mail-SubChannelPreview {
+    max-width: $o-mail-LinkPreview-width;
+}

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
@@ -6,7 +6,7 @@
             <div class="d-flex flex-column w-100">
                 <div class="d-flex w-100">
                     <span class="o-fw-600 text-truncate small" t-esc="thread.displayName"/>
-                    <span class="flex-grow-1"/>
+                    <span class="flex-grow-1 pe-1"/>
                     <span t-if="message" class="text-muted smaller flex-shrink-0" t-esc="dateText(message)"/>
                 </div>
                 <div class="o-mail-SubChannelPreview-lastMessage text-start text-muted fw-normal smaller overflow-hidden ms-2">


### PR DESCRIPTION
Before this commit, thread preview below message in message list may took lots of width. This is a problem because the thread preview could be more visible than the message itself.

This commit fixes the issue by having a max-width on the thread preview from a message, similar max-width as a link preview.

Before
<img width="903" height="723" alt="Screenshot 2025-11-18 at 16 10 56" src="https://github.com/user-attachments/assets/1b493eb9-6fe9-4150-bc77-a524337286f7" />


After
<img width="902" height="738" alt="Screenshot 2025-11-18 at 16 21 32" src="https://github.com/user-attachments/assets/757c81df-3aec-4d96-a8ab-3bfccef13157" />

