### PR TITLE
[FIX] project_mrp_workorder_account: allow users to mark WO as done

### DIFF
--- a/addons/project_mrp_account/models/mrp_workorder.py
+++ b/addons/project_mrp_account/models/mrp_workorder.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import models, Command
 
 
 class MrpWorkorder(models.Model):
@@ -11,4 +11,4 @@ class MrpWorkorder(models.Model):
         project = self.production_id.project_id
         mo_analytic_line_vals = self.env['account.analytic.account']._perform_analytic_distribution(project._get_analytic_distribution(), value, hours, self.mo_analytic_account_line_ids, self)
         if mo_analytic_line_vals:
-            self.mo_analytic_account_line_ids += self.env['account.analytic.line'].sudo().create(mo_analytic_line_vals)
+            self.sudo().mo_analytic_account_line_ids = [Command.create(line_val) for line_val in mo_analytic_line_vals]


### PR DESCRIPTION
[FIX] project_mrp_workorder_account: allow WO completion

Steps to reproduce:
- Enable Analytic Accounting.
- Assign a project A to User A.
- Create user B with Manufacturing User + Timesheet User rights.
- Create a storable product “P1” with the following BoM:
    - Component: 1 unit of C1
    - Workorder: Operation of 60 minutes
    - Project: Project A
- As user B:
- Create a mo to produce one unit of “P1”
    - confirm the MO
    - start the workorder and try to mark it as done.

Issue:
An access error is raised when creating analytic lines:
"Sorry 'user B' doesn't have read access to account.analytic.line"

Explanation:
Since the project is assigned to Mitchell Admin and not to Marc Demo,
the access rule below applies:
https://github.com/odoo/odoo/blob/19.0/addons/hr_timesheet/security/hr_timesheet_security.xml#L50-L62

Because Marc Demo belongs to the "Timesheet User" group but not to
the "Accounting" group, he lacks the required access rights,
which triggers the analytic line read restriction.

opw-5262213