### PR TITLE
[IMP] orm: public Model.read_group method

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -366,7 +366,9 @@ class Base(models.AbstractModel):
             for records within the group.
 
         """
-        assert isinstance(groupby, (list, tuple)) and groupby
+        assert isinstance(groupby, (list, tuple))
+        if not groupby:
+            raise ValueError(self.env._("Need at least one item to groupby"))
 
         aggregates = list(aggregates)
         if '__count' not in aggregates:  # Used for computing length of sublevel groups

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -2,7 +2,7 @@ from odoo import Command, fields
 from odoo.tests import common, new_test_user, tagged
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('at_install', '-post_install')
 class TestPrivateReadGroup(common.TransactionCase):
 
     @classmethod
@@ -1521,3 +1521,56 @@ class TestPrivateReadGroup(common.TransactionCase):
                     RelatedBase._read_group([], [fname_chain], ['__count']),
                     [('bar_a', 1), (False, 4)],
                 )
+
+
+@tagged('at_install', '-post_install')
+class TestPublicReadGroup(common.TransactionCase):
+
+    def test_public_read_group(self):
+        User = self.env['test_read_group.user']
+        mario, luigi = User.create([{'name': 'Mario'}, {'name': 'Luigi'}])
+        tasks = self.env['test_read_group.task'].create([
+            {   # both users
+                'name': "Super Mario Bros.",
+                'user_ids': [Command.set((mario + luigi).ids)],
+            },
+            {   # mario only
+                'name': "Paper Mario",
+                'user_ids': [Command.set(mario.ids)],
+            },
+            {   # luigi only
+                'name': "Luigi's Mansion",
+                'user_ids': [Command.set(luigi.ids)],
+            },
+            {   # no user
+                'name': 'Donkey Kong',
+            },
+        ])
+        self.assertEqual(
+            tasks.read_group([], ['user_ids'], ['__count']),
+            [
+                (mario.id, 2),
+                (luigi.id, 2),
+                (False, 1),
+            ],
+        )
+
+        orders = self.env['test_read_group.order'].create([
+            {
+                'name': 'order 1',
+            },
+            {
+                'name': 'order 2',
+            },
+            {
+                'name': 'order 3',
+            },
+        ])
+        orders[1:].many2one_id = orders[0]
+        self.assertEqual(
+            orders.read_group([], ['many2one_id'], ['many2one_id:array_agg', 'name:min']),
+            [
+                (orders[0].id, orders[0].ids * 2, 'order 2'),
+                (False, [None], 'order 1'),
+            ],
+        )

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -2,7 +2,7 @@ from odoo import Command, fields
 from odoo.tests import common, new_test_user, tagged
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('at_install', '-post_install')
 class TestPrivateReadGroup(common.TransactionCase):
 
     @classmethod
@@ -1518,3 +1518,56 @@ class TestPrivateReadGroup(common.TransactionCase):
                     RelatedBase._read_group([], [fname_chain], ['__count']),
                     [('bar_a', 1), (False, 4)],
                 )
+
+
+@tagged('at_install', '-post_install')
+class TestPublicReadGroup(common.TransactionCase):
+
+    def test_public_read_group(self):
+        User = self.env['test_read_group.user']
+        mario, luigi = User.create([{'name': 'Mario'}, {'name': 'Luigi'}])
+        tasks = self.env['test_read_group.task'].create([
+            {   # both users
+                'name': "Super Mario Bros.",
+                'user_ids': [Command.set((mario + luigi).ids)],
+            },
+            {   # mario only
+                'name': "Paper Mario",
+                'user_ids': [Command.set(mario.ids)],
+            },
+            {   # luigi only
+                'name': "Luigi's Mansion",
+                'user_ids': [Command.set(luigi.ids)],
+            },
+            {   # no user
+                'name': 'Donkey Kong',
+            },
+        ])
+        self.assertEqual(
+            tasks.read_group([], ['user_ids'], ['__count']),
+            [
+                (mario.id, 2),
+                (luigi.id, 2),
+                (False, 1),
+            ],
+        )
+
+        orders = self.env['test_read_group.order'].create([
+            {
+                'name': 'order 1',
+            },
+            {
+                'name': 'order 2',
+            },
+            {
+                'name': 'order 3',
+            },
+        ])
+        orders[1:].many2one_id = orders[0]
+        self.assertEqual(
+            orders.read_group([], ['many2one_id'], ['many2one_id:array_agg', 'name:min']),
+            [
+                (orders[0].id, orders[0].ids * 2, 'order 2'),
+                (False, [None], 'order 1'),
+            ],
+        )

--- a/odoo/addons/test_web/tests/test_web_read_group.py
+++ b/odoo/addons/test_web/tests/test_web_read_group.py
@@ -143,6 +143,9 @@ class TestWebReadGroup(common.TransactionCase):
                 },
             )
 
+        with self.assertRaisesRegex(ValueError, "Need at least one item to groupby"):
+            Model.web_read_group(domain=[], groupby=[], aggregates=['__count'])
+
     @patch("odoo.addons.web.models.models.MAX_NUMBER_OPENED_GROUPS", 2)
     def test_auto_unfold_limit(self):
         Model = self.env["test_read_group.aggregate"]

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -36,7 +36,7 @@ import warnings
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping
 from inspect import getmembers
-from operator import itemgetter
+from operator import call, itemgetter
 
 import psycopg2.errors
 import psycopg2.extensions
@@ -1913,8 +1913,9 @@ class BaseModel(metaclass=MetaModel):
 
         return result
 
+    @typing.final
     @api.model
-    def _read_group(
+    def read_group(
         self,
         domain: DomainType,
         groupby: Sequence[str] = (),
@@ -1929,6 +1930,69 @@ class BaseModel(metaclass=MetaModel):
 
         :param domain: :ref:`A search domain <reference/orm/domains>`. Use an empty
                 list to match all records.
+        :param groupby: list of groupby descriptions by which the records will be grouped.
+                A groupby description is either a field (then it will be grouped by that field)
+                or a string `'field:granularity'`. Right now, the only supported granularities
+                are `'day'`, `'week'`, `'month'`, `'quarter'` or `'year'`, and they only make sense for
+                date/datetime fields.
+                Additionally integer date parts are also supported:
+                `'year_number'`, `'quarter_number'`, `'month_number'`, `'iso_week_number'`, `'day_of_year'`, `'day_of_month'`,
+                'day_of_week', 'hour_number', 'minute_number' and 'second_number'.
+        :param aggregates: list of aggregates specification.
+                Each element is `'field:agg'` (aggregate field with aggregation function `'agg'`).
+                The possible aggregation functions are the ones provided by
+                `PostgreSQL <https://www.postgresql.org/docs/current/static/functions-aggregate.html>`_,
+                `'count_distinct'` with the expected meaning and `'recordset'` to act like `'array_agg'`
+                (with ids deduplicated and without NULL values).
+        :param having: A domain where the valid "fields" are the aggregates.
+        :param offset: optional number of groups to skip
+        :param limit: optional max number of groups to return
+        :param order: optional ``order by`` specification, for
+                overriding the natural sort ordering of the groups,
+                see also :meth:`~.search`.
+        :return: list of tuples containing in the order the groups values and aggregates values (flatten):
+                `[(groupby_1_value, ... , aggregate_1_value_aggregate, ...), ...]`.
+
+        :raise AccessError: if user is not allowed to access requested information
+        """
+        groups = self._read_group(domain, groupby, aggregates, having=having, offset=offset, limit=limit, order=order)
+        if not groups:
+            return groups
+        # check the first line for data types, transform records into ids (id for groupby, ids for aggregates)
+        decoders = []
+        for i, value in enumerate(groups[0]):
+            if isinstance(value, BaseModel):
+                if i < len(groupby):
+                    decoders.append(lambda v: v.id)
+                else:
+                    decoders.append(lambda v: v.ids)
+            else:
+                decoders.append(None)
+        if any(decoders):
+            decoders = [d or (lambda x: x) for d in decoders]
+            groups = [
+                # much faster version of :
+                # tuple(dec(val) for dec, val in zip(decoders, group))
+                tuple(map(call, decoders, group))
+                for group in groups
+            ]
+        return groups
+
+    @api.model
+    def _read_group(
+        self,
+        domain: DomainType,
+        groupby: Sequence[str] = (),
+        aggregates: Sequence[str] = (),
+        having: DomainType = (),
+        offset: int = 0,
+        limit: int | None = None,
+        order: str | None = None,
+    ) -> list[tuple]:
+        """ Get fields aggregations specified by ``aggregates`` grouped by the given ``groupby``
+        fields where record are filtered by the ``domain``.
+
+        :param domain: :ref:`A search domain <reference/orm/domains>`.
         :param groupby: list of groupby descriptions by which the records will be grouped.
                 A groupby description is either a field (then it will be grouped by that field)
                 or a string `'field:granularity'`. Right now, the only supported granularities

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1891,6 +1891,72 @@ class BaseModel(metaclass=MetaModel):
 
         return result
 
+    @typing.final
+    @api.model
+    def read_group(
+        self,
+        domain: DomainType,
+        groupby: Sequence[str] = (),
+        aggregates: Sequence[str] = (),
+        having: DomainType = (),
+        offset: int = 0,
+        limit: int | None = None,
+        order: str | None = None,
+    ) -> list[tuple]:
+        """ Get fields aggregations specified by ``aggregates`` grouped by the given ``groupby``
+        fields where record are filtered by the ``domain``.
+
+        :param domain: :ref:`A search domain <reference/orm/domains>`. Use an empty
+                list to match all records.
+        :param groupby: list of groupby descriptions by which the records will be grouped.
+                A groupby description is either a field (then it will be grouped by that field)
+                or a string `'field:granularity'`. Right now, the only supported granularities
+                are `'day'`, `'week'`, `'month'`, `'quarter'` or `'year'`, and they only make sense for
+                date/datetime fields.
+                Additionally integer date parts are also supported:
+                `'year_number'`, `'quarter_number'`, `'month_number'`, `'iso_week_number'`, `'day_of_year'`, `'day_of_month'`,
+                'day_of_week', 'hour_number', 'minute_number' and 'second_number'.
+        :param aggregates: list of aggregates specification.
+                Each element is `'field:agg'` (aggregate field with aggregation function `'agg'`).
+                The possible aggregation functions are the ones provided by
+                `PostgreSQL <https://www.postgresql.org/docs/current/static/functions-aggregate.html>`_,
+                `'count_distinct'` with the expected meaning and `'recordset'` to act like `'array_agg'`
+                converted into a recordset.
+        :param having: A domain where the valid "fields" are the aggregates.
+        :param offset: optional number of groups to skip
+        :param limit: optional max number of groups to return
+        :param order: optional ``order by`` specification, for
+                overriding the natural sort ordering of the groups,
+                see also :meth:`~.search`.
+        :return: list of tuples containing in the order the groups values and aggregates values (flatten):
+                `[(groupby_1_value, ... , aggregate_1_value_aggregate, ...), ...]`.
+                If group is related field, the value of it will be a recordset (with a correct prefetch set).
+
+        :raise AccessError: if user is not allowed to access requested information
+        """
+        groups = self._read_group(domain, groupby, aggregates, having=having, offset=offset, limit=limit, order=order)
+        if not groups:
+            return groups
+        # check the first line for data types, transform records into ids (id for groupby, ids for aggregates)
+        decoders = []
+        for i, value in enumerate(groups[0]):
+            if isinstance(value, BaseModel):
+                if i < len(groupby):
+                    decoders.append(lambda v: v.id)
+                else:
+                    decoders.append(lambda v: v.ids)
+            else:
+                decoders.append(None)
+        if any(decoders):
+            groups = [
+                tuple(
+                    decoder(v) if decoder is not None else v
+                    for decoder, v in zip(decoders, group)
+                )
+                for group in groups
+            ]
+        return groups
+
     @api.model
     def _read_group(
         self,

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1933,8 +1933,6 @@ class BaseModel(metaclass=MetaModel):
 
         :raise AccessError: if user is not allowed to access requested information
         """
-        self.browse().check_access('read')
-
         query = self._search(domain)
         if query.is_empty():
             if not groupby:
@@ -1961,6 +1959,8 @@ class BaseModel(metaclass=MetaModel):
             query.order = self._read_group_orderby(query.table, order, groupby_terms)
             query.groupby = SQL(", ").join(groupby_terms.values())
             query.having = self._read_group_having(query.table, list(having))
+        elif not select_args:
+            raise ValueError(self.env._("Need groupby or aggregates."))
 
         # row_values: [(a1, b1, c1), (a2, b2, c2), ...]
         row_values = self.env.execute_query(query.select(*select_args))


### PR DESCRIPTION
Add a public method `Model.read_group` to be called from RPC.  It is essentially an adapter for method `_read_group`, which is intended for internal use only (because it returns recordsets).

The only alternative so far was method `web_read_group`, which provides this feature with much post-processing (formatting) that is not always desired.  For instance, date and datetime values are returned as labels and kinda obsfuscate their corresponding raw value.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
