### PR TITLE
[FIX] sale_project: compute sale_line_id on subtasks after parent creation

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -863,9 +863,9 @@ class ProjectTask(models.Model):
             if task.allow_milestones:
                 vals['milestone_id'] = milestone_mapping.get(vals['milestone_id'], vals['milestone_id'])
             if not default.get('child_ids') and task.child_ids:
-                default = {
-                    'parent_id': False,
-                }
+                whitelisted_fields = self._get_template_default_context_whitelist() if self.env.context.get('copy_from_template') else []
+                default = {key: value for key, value in default.items() if key in whitelisted_fields}
+                default['parent_id'] = False
                 current_task = task
                 if self.env.context.get('copy_from_template'):
                     current_task = current_task.with_context(active_test=True)

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1928,3 +1928,61 @@ class TestSaleProject(TestSaleProjectCommon):
         self.assertFalse(optional_product_line.project_id)
         optional_product_line.write({'product_uom_qty': 1})
         self.assertEqual(optional_product_line.project_id.sale_order_id, sale_order_with_option)
+
+    def test_subtask_inherits_sale_line_from_template(self):
+        """Test that subtasks created from project template inherit sale_line_id from parent task."""
+
+        project_template = self.env['project.project'].create({
+            'name': 'Project Template with Subtasks',
+        })
+        parent_task_template = self.env['project.task'].create({
+            'name': 'Parent Task Template',
+            'project_id': project_template.id,
+        })
+        self.env['project.task'].create([
+            {
+                'name': 'Subtask Template 1',
+                'parent_id': parent_task_template.id,
+                'project_id': project_template.id,
+            },
+            {
+                'name': 'Subtask Template 2',
+                'parent_id': parent_task_template.id,
+                'project_id': project_template.id,
+            }
+        ])
+
+        service_product = self.env['product.product'].create({
+            'name': 'Service with Project Template',
+            'standard_price': 20,
+            'list_price': 40,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'uom_id': self.uom_hour.id,
+            'service_tracking': 'task_in_project',
+            'project_id': False,
+            'project_template_id': project_template.id,
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        sale_order_line = self.env['sale.order.line'].create({
+            'order_id': sale_order.id,
+            'product_id': service_product.id,
+            'product_uom_qty': 1,
+        })
+        sale_order.action_confirm()
+
+        created_project = sale_order_line.project_id
+        self.assertTrue(created_project, "A new project should have been created")
+
+        created_tasks = created_project.task_ids
+        parent_task = created_tasks.filtered(lambda t: not t.parent_id)
+        subtasks = created_tasks.filtered(lambda t: t.parent_id)
+
+        self.assertEqual(len(subtasks), 2, "Should have exactly two subtasks from template")
+        self.assertEqual(parent_task.sale_line_id, sale_order_line, "Parent task should have sale_line_id set")
+
+        for subtask in subtasks:
+            self.assertEqual(subtask.sale_line_id, sale_order_line, "Subtask '%s' should inherit sale_line_id from parent task" % subtask.name)


### PR DESCRIPTION
When creating tasks from a project template via a Sales Order, the main
task is created with its sale_line_id set correctly, but subtasks from
the template do not inherit the sale_line_id from their parent.

Steps to reproduce:
1. Create a project template with a parent task and subtasks
2. Create a service product that uses this project template
3. Create and confirm a Sales Order with this product
4. Check the created tasks: main task has sale_line_id, subtasks don't
5. Log hours on a subtask: the timesheet's so_line remains empty

Root cause:
When copying a project template, the copy_data() method for subtasks
was resetting the default dict to only contain 'parent_id': False. This
meant that whitelisted fields like sale_line_id from the parent task
were not propagated to the subtasks during the copy operation.

Solution:
When copying from a template (copy_from_template context), preserve
whitelisted fields (including sale_line_id) in the default dict before
copying subtasks. This allows subtasks to naturally inherit sale_line_id
from their parent during creation, so the compute method works correctly.

opw-5185519