### PR TITLE
[FIX] l10n_es_edi_verifactu: field dependencies

### DIFF
--- a/addons/l10n_es_edi_verifactu/wizard/account_resequence.py
+++ b/addons/l10n_es_edi_verifactu/wizard/account_resequence.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountResequenceWizard(models.TransientModel):
@@ -7,9 +7,10 @@ class AccountResequenceWizard(models.TransientModel):
     # Technical field to display (or not) banner in wizard
     l10n_es_edi_verifactu_required_in_prod = fields.Boolean(compute='_compute_l10n_es_edi_verifactu_required_in_prod')
 
+    @api.depends('move_ids.country_code', 'move_ids.l10n_es_edi_verifactu_required', 'move_ids.company_id.l10n_es_edi_verifactu_test_environment')
     def _compute_l10n_es_edi_verifactu_required_in_prod(self):
         for wizard in self:
             wizard.l10n_es_edi_verifactu_required_in_prod = (
-                any(move.l10n_es_edi_verifactu_required for move in wizard.move_ids)
+                any(move.country_code == 'ES' and move.l10n_es_edi_verifactu_required for move in wizard.move_ids)
                 and any(not company.l10n_es_edi_verifactu_test_environment for company in wizard.move_ids.company_id)
             )


### PR DESCRIPTION
[FIX] l10n_es_edi_verifactu: field dependencies

Fixing the dependencies of the compute field
'l10n_es_edi_verifactu_required_in_prod', and add a check on the country_code of the move_ids.

runbot-234038
