### PR TITLE
[FIX] sale: set the correct module version

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -2,6 +2,7 @@
 
 {
     'name': 'Sales',
+    'version': '1.2',
     'category': 'Sales/Sales',
     'summary': 'Sales internal machinery',
     'description': """


### PR DESCRIPTION
The module version '1.2' was [removed](https://github.com/odoo/odoo/commit/717619571d1297d6b299b7c47b728841bcd81e69) from the manifest making the practical version '1.0'.
This fix sets the version back to avoid bumping it down.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
