### PR TITLE
[IMP] account: add force_overwrite parameter to _load_translations

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1295,7 +1295,7 @@ class AccountChartTemplate(models.AbstractModel):
                 or code_translations.get_python_translations(translation_module, generic_lang).get(record[fname])
             )
 
-    def _load_translations(self, langs=None, companies=None, template_data=None):
+    def _load_translations(self, langs=None, companies=None, template_data=None, overwrite=False, force_overwrite=False):
         """Load the translations of the chart template.
 
         :param langs: the lang code to load the translations for. If one of the codes is not present,
@@ -1348,4 +1348,4 @@ class AccountChartTemplate(models.AbstractModel):
                             translation_importer.model_translations[mname][field][xml_id][lang] = value_translated
                             break
 
-        translation_importer.save(overwrite=False)
+        translation_importer.save(overwrite=overwrite, force_overwrite=force_overwrite)


### PR DESCRIPTION
Currently, when loading chart template translations, existing translations
cannot be overwritten for records with noupdate=True flag, even when localization updates require translation corrections.

This limitation prevents proper localization maintenance, especially when:
- Chart template translations need to be updated to fix incorrect or outdated translations
- Localization modules need to ensure translations are synchronized with the latest chart template versions
- Manual translation corrections need to be applied during localization setup or updates

By adding the force_overwrite parameter, localization modules can now explicitly request to overwrite existing translations, including those protected by noupdate=True, enabling proper translation management for localization purposes.

The parameter defaults to False to maintain backward compatibility and preserve existing behavior when not explicitly requested.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
