### PR TITLE
[FIX] website: open anchor links in new tab if option is enabled

### DIFF
--- a/addons/website/static/src/interactions/anchor_slide.js
+++ b/addons/website/static/src/interactions/anchor_slide.js
@@ -46,30 +46,12 @@ export class AnchorSlide extends Interaction {
         hash = "#" + CSS.escape(hash.substring(1));
         const anchorEl = this.el.ownerDocument.querySelector(hash);
         const scrollValue = anchorEl?.dataset.anchor;
-        if (!anchorEl || !scrollValue) {
+        // No need to scroll when target is _blank as it should open a new tab
+        if (!anchorEl || !scrollValue || this.el.target === "_blank") {
             return;
         }
 
-        const offcanvasEl = this.el.closest(".offcanvas.o_navbar_mobile");
-        if (offcanvasEl && offcanvasEl.classList.contains("show")) {
-            // Special case for anchors in offcanvas in mobile: we can't just
-            // scrollTo() after preventDefault because preventDefault would
-            // prevent the offcanvas to be closed. The choice is then to close
-            // it ourselves manually and once it's fully closed, then start our
-            // own smooth scrolling.
-            ev.preventDefault();
-            Offcanvas.getInstance(offcanvasEl).hide();
-            this.addListener(
-                offcanvasEl,
-                "hidden.bs.offcanvas",
-                () => this.manageScroll(hash, anchorEl, scrollValue),
-                // the listener must be automatically removed when invoked
-                { once: true }
-            );
-        } else {
-            ev.preventDefault();
-            this.manageScroll(hash, anchorEl, scrollValue);
-        }
+        this.manageScroll(hash, anchorEl, scrollValue);
     }
 
     /**


### PR DESCRIPTION
Steps to Reproduce:
1. Create an anchor link for any dropped snippet.
2. Insert the link through the link popover.
3. Enable the "Open in New Window" option.
4. Click on Save.
5. Click on the link.

Issue:
Even though the "Open in New Window" option is enabled, the page scrolls in the same tab instead of opening in a new window and scrolling to the targeted view.

Reason:
When an anchor link has target="_blank", "ev.preventDefault()" was still being called, which prevented the browser from performing its default behavior of opening the link in a new tab.

Fix:
Removed "ev.preventDefault()" for such links, as the expected behavior is to open them in a new tab whenever target="_blank" is set. Additionally, the offcanvas mobile-specific logic has been removed, as it is no longer necessary now that "ev.preventDefault()" is no longer used.

task-5104027