### PR TITLE
[FIX] l10n_gcc_invoice: display line names in English and Arabic

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -146,6 +146,18 @@
                 <span name="th_subtotal_en" t-if="display_in_en" t-translation="off">Amount<br/></span>
             </xpath>
             <!-- End Arabic & English table headers -->
+            <!-- Arabic & English table body -->
+            <xpath expr="//td[@name='account_invoice_line_name']/span" position="replace">
+                <t t-if="line.product_id and display_in_lang_sec">
+                    <t t-set="english_name" t-value="line.with_context(lang='en_US').product_id.display_name"/>
+                    <t t-set="arabic_name" t-value="line.with_context(lang=o.env['res.lang']._get_code('ar_001')).product_id.display_name"/>
+
+                    <span t-out="arabic_name + '\n'" t-if="arabic_name not in line.name" t-options="{'widget': 'text'}" dir="rtl"/>
+                    <span t-out="english_name + '\n'" t-if="(english_name != arabic_name) and (english_name not in line.name)" t-options="{'widget': 'text'}"/>
+                </t>
+                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._get_data(code=lang).direction"/>
+            </xpath>
+            <!-- End Arabic & English table body -->
             <!-- Arabic & English payment terms -->
             <span id="payment_terms_note_id" position="before">
                 <span id="payment_terms_note_id_lang_sec"


### PR DESCRIPTION
### Issue:
In GCC invoices the product names are not in both languages.

### Steps to reproduce:
- Install "l10n_sa" and switch to a Saudi company
- Have a product with its name translated in both English and Arabic
- Create an invoice with this product, print it
- The product name is only displayed in the language of the partner

### Cause:
[This refactor](https://github.com/odoo/odoo/commit/1cddcab8b8626b34c437a51d320b0a3e4698dae7) removed the [part of the code responsible for displaying the product in both languages](https://github.com/odoo/odoo/blob/f9090fff6b3564c0d7ce2363a283b81ea10b3906/addons/l10n_gcc_invoice/views/report_invoice.xml#L286-L293). Now only `line.name` is displayed.

### Solution:
We use the same XML architecture as in 18.0.
As `line.name` is composed of several fields combined we need to check if the English and/or Arabic name is in `line.name` to display it or not.

We use a replace in the xpath to add `dir="rtl"` on `line.name`. This ensure that when the partner lang is Arabic then `line.name` is displayed right to left.

### Note:
`line.name` can contain other field like `description_sale` or `description_purchase` that will still be displayed in only one language.

opw-5219783