### PR TITLE
[FIX] hr_holidays_attendance: fix traceback on time off ledger

### DIFF
--- a/addons/hr_holidays_attendance/report/hr_leave_attendance_report.py
+++ b/addons/hr_holidays_attendance/report/hr_leave_attendance_report.py
@@ -73,12 +73,6 @@ class HrLeaveAttendanceReport(models.Model):
     def _timestamped(self, date):
         return fields.Datetime.context_timestamp(self, date).date()
 
-    @api.model
-    def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None) -> list[tuple]:
-        if order and any('date' in group for group in groupby):
-            order += ' desc'
-        return super()._read_group(domain, groupby, aggregates, having, offset, limit, order)
-
     def _select(self):
         return """
          SELECT row_number() OVER (ORDER BY gs.day DESC, emp.id) AS id,

--- a/addons/hr_holidays_attendance/views/hr_leave_attendance_report_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_attendance_report_views.xml
@@ -5,7 +5,7 @@
         <field name="name">hr.leave.attendance.report.list</field>
         <field name="model">hr.leave.attendance.report</field>
         <field name="arch" type="xml">
-            <list sample="1">
+            <list sample="1" default_order="date desc">
                 <field name="employee_id"/>
                 <field name="date"/>
                 <field name="schedule_id" optional="hide"/>


### PR DESCRIPTION
Version - 19.0

## Issue:
Sorting the Date column in the Time Off Ledger triggers a traceback when attempting to sort in ascending order.

## Steps to reproduce:
- Open the Attendances app
- Navigate to Time Off Ledger report
- Click on dates column for sorting --> you get a traceback

## Cause:
The code always appends `' desc'` to the order clause to enforce a default descending sort.
When the UI already provides a direction (e.g. `date:month ASC`), this results in an invalid combined order such as `date:month ASC desc`, raising: `ValueError: Invalid order 'date: month ASC desc' for _read_group().`

## Fix:
Add a check to avoid appending `' desc'` when the order string already contains `asc` or `desc`.

## Impact:
Sorting the Date column no longer crashes.
Users can now sort the report correctly in both ascending and descending order, with descending remaining the default.

task-5331052

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
