### PR TITLE
[FIX] html_builder: prevent error on searching many2one field

### DIFF
--- a/addons/html_builder/static/src/plugins/many2one_option.js
+++ b/addons/html_builder/static/src/plugins/many2one_option.js
@@ -15,7 +15,6 @@ export class Many2OneOption extends BaseOptionComponent {
             const contactOpts = JSON.parse(el.dataset.oeContactOptions || "{}");
             this.nullText = contactOpts.null_text;
             this.model = el.dataset.oeMany2oneModel;
-            this.domain = JSON.parse(el.dataset.oeMany2oneDomain || "[]");
             const searchResult = await this.orm.searchRead(
                 "ir.model",
                 [["model", "=", this.model]],

--- a/addons/html_builder/static/src/plugins/many2one_option.xml
+++ b/addons/html_builder/static/src/plugins/many2one_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.Many2OneOption">
     <BuilderRow label="label">
-        <BuilderMany2One action="'many2One'" model="model" fields="['name']" domain="domain" nullText="nullText" allowUnselect="false"/>
+        <BuilderMany2One action="'many2One'" model="model" fields="['name']" nullText="nullText" allowUnselect="false"/>
     </BuilderRow>
 </t>
 

--- a/addons/html_editor/models/ir_qweb_fields.py
+++ b/addons/html_editor/models/ir_qweb_fields.py
@@ -26,7 +26,6 @@ from werkzeug import urls
 from odoo import _, api, models, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import posix_to_ldml
-from odoo.tools.json import scriptsafe as json_safe
 from odoo.tools.misc import file_open, get_lang, babel_locale_parse
 
 REMOTE_CONNECTION_TIMEOUT = 2.5
@@ -241,7 +240,6 @@ class IrQwebFieldMany2one(models.AbstractModel):
 
     @api.model
     def attributes(self, record, field_name, options, values=None):
-        field = record._fields[field_name]
         attrs = super().attributes(record, field_name, options, values)
         if options.get('inherit_branding'):
             many2one = record[field_name]
@@ -252,7 +250,6 @@ class IrQwebFieldMany2one(models.AbstractModel):
                 attrs['data-oe-many2one-allowreset'] = 1
                 if not many2one:
                     attrs['data-oe-many2one-model'] = record._fields[field_name].comodel_name
-            attrs['data-oe-many2one-domain'] = json_safe.dumps(field._description_domain(self.env))
         return attrs
 
     @api.model


### PR DESCRIPTION
Currently, Editing the address or organizer on an event page currently triggers an error.

steps to reproduce:
1) Install `website_event` module
2) Login as admin and create one event click on `Go to Website` smart button. 
3) Switch to Editor mode> Click on `My Company` under Organizers
   (also works with Location).
4) on the right side bar click on `Contact drop-down`

Error:
`ValueError: Domain() invalid item in domain: ')'`

Root Cause:
after [this commit](https://github.com/odoo/odoo/pull/219810/commits/221127900bb6f72bf00715ff90727a87ef5d982c), the domain for many2one fields was fetched from the backend. In this case, the domain received looks like:
```
'(company_id and ['|', ('company_id', '=', False), ('company_id', 'parent_of',
[company_id])] or ['|', ('company_id', '=', False), ('company_id', 'parent_of', '')]) + ([])'
```
At [1], this domain is passed to `search`, and `Object.values` turns it into an array of single-character strings. Passing this array to `name_search` causes the error.

FIX:
Revert the changes from PR https://github.com/odoo/odoo/pull/219810. as the original purpose of that PR is still met without them.

[1]- https://github.com/odoo/odoo/blob/12ec5d2d9cd93fffb10bf10326cf3cde7707ea0c/addons/html_builder/static/src/core/building_blocks/select_many2x.js#L101-L112

sentry-6916986959
