### PR TITLE
[FIX] stock: make stock_action_field studio editable

### DIFF
--- a/addons/stock/static/src/fields/stock_action_field.js
+++ b/addons/stock/static/src/fields/stock_action_field.js
@@ -57,8 +57,13 @@ const stockActionField = {
     ...monetaryField,
     component: StockActionField,
     supportedOptions: [
-        ...floatField.supportedOptions,
-        ...monetaryField.supportedOptions,
+        Object.values(
+            Object.fromEntries(
+                [...floatField.supportedOptions, ...monetaryField.supportedOptions].map(
+                    (option) => [option.name, option]
+                )
+            )
+        ),
         {
             label: _t("Action Name"),
             name: "action_name",


### PR DESCRIPTION
### Steps to reproduce:

- Go to Inventory > Reporting > Stock
- Toggle studio and enable debug mode
- Click on the "On Hand" column
#### > UncaughtPromiseError > OwlError > Uncaught Promise:
> Got duplicate key in t-foreach: /list[1]/field[x]_hide_trailing_zeros

#### Note:

We enabled debug mode to raise template rendering issues but without debug mode the template of the left studio panel is simply not rendered.

### Cause of the issue:

The `qty_available` displayed in the `product.product` list view https://github.com/odoo/odoo/blob/12ec5d2d9cd93fffb10bf10326cf3cde7707ea0c/addons/stock/views/product_views.xml#L574-L575 is associated with a `stock_action_field` widget. However, since e4c51ad8a6da17339923875de7fa303544b717e1 this widget has become an hybrid entity able to support both the float and the monetary fields: https://github.com/odoo/odoo/blob/12ec5d2d9cd93fffb10bf10326cf3cde7707ea0c/addons/stock/static/src/fields/stock_action_field.js#L12-L22 The issue is due to the fact that the template of sudio component `TypeWidgetProperties` can not be rendered for our `qty_avaialble` field as it receives the `hide_trailing_zeros` boolean attribute twice in this `t-foreach`:
https://github.com/odoo/enterprise/blob/4ba22ee091938d382fb79ef386b4761e4e15479a/web_studio/static/src/client_action/view_editor/interactive_editor/properties/type_widget_properties/type_widget_properties.xml#L23-L25 
This happens because the `stock_action_field` adds it twice in its supportedOptions:
https://github.com/odoo/odoo/blob/12ec5d2d9cd93fffb10bf10326cf3cde7707ea0c/addons/stock/static/src/fields/stock_action_field.js#L55-L67 once because of the `floatField.supportedOptions`: https://github.com/odoo/odoo/blob/12ec5d2d9cd93fffb10bf10326cf3cde7707ea0c/addons/web/static/src/views/fields/float/float_field.js#L119-L124 and once because of the `monetaryField.supportedOptions`: https://github.com/odoo/odoo/blob/12ec5d2d9cd93fffb10bf10326cf3cde7707ea0c/addons/web/static/src/views/fields/monetary/monetary_field.js#L113-L118

opw-5188594

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
