### PR TITLE
[FIX] mail: protect against void date in msg

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3000,7 +3000,10 @@ class MailThread(models.AbstractModel):
                 [('res_id', '=', self.id), ('model', '=', self._name), ('message_type', '!=', 'user_notification')],
                 order='date desc, id desc',
                 limit=200,  # arbitrary, but sometimes loops / spam may creater a long history
-            ).sorted(lambda msg: (msg.message_type in ('comment', 'email'), msg.date, msg.id), reverse=True)
+            ).sorted(
+                lambda msg: (msg.message_type in ('comment', 'email'), msg.date or msg.create_date, msg.id),
+                reverse=True,
+            )
             current_ancestor = current_ancestor[:1]
         return current_ancestor.id
 

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -6,7 +6,6 @@ import itertools
 import socket
 
 from datetime import datetime
-
 from unittest.mock import DEFAULT
 from unittest.mock import patch
 
@@ -203,7 +202,10 @@ class MailGatewayCommon(MailCommon):
         })
 
         # Set a first message on public group to test update and hierarchy
-        cls.fake_email = cls._create_gateway_message(cls.test_record, '123456')
+        cls.fake_email = cls._create_gateway_message(
+            cls.test_record, '123456',
+            date=datetime(2025, 11, 19, 10, 30, 0),
+        )
 
     def _reinject(self, force_msg_id=False, debug_log=False):
         """ Tool to automatically 'inject' an outgoing mail into the gateway.
@@ -226,6 +228,7 @@ class MailGatewayCommon(MailCommon):
     def _create_gateway_message(cls, record, msg_id_prefix, **values):
         msg_values = {
             'author_id': cls.partner_1.id,
+            'date': cls.env.cr.now(),
             'email_from': cls.partner_1.email_formatted,
             'body': '<p>Generic body</p>',
             'message_id': f'<{msg_id_prefix}-openerp-{record.id}-{record._name}@{socket.gethostname()}>',
@@ -1407,78 +1410,104 @@ class TestMailgateway(MailGatewayCommon):
             'alias_model_id': self.env['ir.model']._get(self.test_record._name).id,
             'alias_contact': 'everyone',
         })
-        reply1 = self._create_gateway_message(
-            self.test_record, 'reply1', parent_id=self.fake_email.id,
-        )
-        reply2 = self._create_gateway_message(
-            self.test_record, 'reply2', parent_id=self.fake_email.id,
-            subtype_id=self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
-        )
-        reply1_1 = self._create_gateway_message(
-            self.test_record, 'reply1_1', parent_id=reply1.id,
-            subtype_id=self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
-        )
-        reply2_1 = self._create_gateway_message(
-            self.test_record, 'reply2_1', parent_id=reply2.id,
-        )
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            reply1 = self._create_gateway_message(
+                self.test_record, 'reply1', parent_id=self.fake_email.id,
+            )
+            reply2 = self._create_gateway_message(
+                self.test_record, 'reply2', parent_id=self.fake_email.id,
+                subtype_id=self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
+            )
+            reply1_1 = self._create_gateway_message(
+                self.test_record, 'reply1_1', parent_id=reply1.id,
+                subtype_id=self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
+            )
+            reply2_1 = self._create_gateway_message(
+                self.test_record, 'reply2_1', parent_id=reply2.id,
+            )
 
         # reply to reply1 using multiple references
-        self.format_and_process(
-            MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
-            subject='Reply to reply1',
-            extra=f'References: {reply1.message_id} {self.fake_email.message_id}'
-        )
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            self.format_and_process(
+                MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
+                subject='Reply to reply1',
+                extra=f'References: {reply1.message_id} {self.fake_email.message_id}',
+            )
         new_msg = self.test_record.message_ids[0]
         self.assertEqual(new_msg.parent_id, reply1, 'Newer parent found should be selected')
         self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_comment'), 'Mail: reply to a comment should be a comment')
 
-        self.format_and_process(
-            MAIL_TEMPLATE, self.email_from, f'test.gateway@{self.alias_domain}',
-            subject='Reply to reply1_1 (with noise)',
-            extra=f'References: {reply1_1.message_id} {reply1.message_id} {reply1.message_id}'
-        )
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            self.format_and_process(
+                MAIL_TEMPLATE, self.email_from, f'test.gateway@{self.alias_domain}',
+                subject='Reply to reply1_1 (with noise)',
+                extra=f'References: {reply1_1.message_id} {reply1.message_id} {reply1.message_id}',
+            )
         new_msg = self.test_record.message_ids[0]
         self.assertEqual(new_msg.parent_id, reply1_1, 'Newer parent found should be selected')
         self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_note'), 'Mail: reply to a note should be a note')
 
         # ordering should not impact
-        self.format_and_process(
-            MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
-            subject='Reply to reply1 (order issue)',
-            extra=f'References: {self.fake_email.message_id} {reply1.message_id}'
-        )
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            self.format_and_process(
+                MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
+                subject='Reply to reply1 (order issue)',
+                extra=f'References: {self.fake_email.message_id} {reply1.message_id}',
+            )
         new_msg = self.test_record.message_ids[0]
         self.assertEqual(new_msg.parent_id, reply1, 'Mail: flattening attach to original message')
         self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_comment'), 'Mail: reply to a comment should be a comment')
 
         # history with last one being a note
-        self.format_and_process(
-            MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
-            subject='Reply to reply1_1',
-            extra=f'References: {reply1_1.message_id} {self.fake_email.message_id}'
-        )
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            self.format_and_process(
+                MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
+                subject='Reply to reply1_1',
+                extra=f'References: {reply1_1.message_id} {self.fake_email.message_id}',
+            )
         new_msg = self.test_record.message_ids[0]
         self.assertEqual(new_msg.parent_id, reply1_1, 'Mail: flattening attach to original message')
         self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_note'), 'Mail: reply to a note should be a note')
 
         # messed up history (two child branches): gateway initial parent is newest one
-        self.format_and_process(
-            MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
-            subject='Reply to reply2_1 (with noise)',
-            date=datetime.now(),
-            extra=f'References: {reply1_1.message_id} {reply2_1.message_id}'
-        )
-        new_msg = self.test_record.message_ids[0]
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)), \
+             self.mock_mail_gateway(), self.mock_mail_app():
+            self.format_and_process(
+                MAIL_TEMPLATE, self.email_from, f'groups@{self.alias_domain}',
+                subject='Reply to reply2_1 (with noise)',
+                date=datetime(2025, 11, 20, 10, 30, 0),
+                extra=f'References: {reply1_1.message_id} {reply2_1.message_id}',
+            )
+        new_msg = self._new_msgs
+        self.assertEqual(new_msg, self.test_record.message_ids[0])
+        self.assertEqual(new_msg.date, datetime(2025, 11, 20, 10, 30, 0))
         self.assertEqual(new_msg.parent_id, reply2_1, 'Mail: flattening attach to original message')
         self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_comment'), 'Mail: parent should be a comment')
 
         # no references: new discussion thread started. Alias allows to post on
-        # a record without replying, aka without references, which means no parent_id
-        self.format_and_process(
-            MAIL_TEMPLATE, self.email_from, alias_update.alias_full_name,
-            subject='New thread',
-            extra='References:'
-        )
+        # a record without replying, aka without references, which means parent
+        # set to last email / discussion message
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            old_msg = self._create_gateway_message(
+                self.test_record, 'old_msg',
+                date=datetime(2024, 11, 20, 10, 30, 0),
+                parent_id=reply1.id,
+            )
+        self.assertEqual(old_msg.date, datetime(2024, 11, 20, 10, 30, 0))
+        with self.mock_datetime_and_now(datetime(2024, 11, 20, 10, 30, 0)):
+            old_disturbing_msg = self._create_gateway_message(
+                self.test_record, 'old_disturbinh_msg',
+                date=False,
+                parent_id=reply1.id,
+            )
+        self.assertFalse(old_disturbing_msg.date)
+
+        with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):
+            self.format_and_process(
+                MAIL_TEMPLATE, self.email_from, alias_update.alias_full_name,
+                subject='New thread',
+                extra='References:'
+            )
         last_msg = self.test_record.message_ids[0]
         self.assertEqual(last_msg.parent_id, new_msg, 'No free message, attached to last thread comment / email')
         self.assertEqual(last_msg.subtype_id, self.env.ref('mail.mt_comment'), 'Mail: parent should be a comment')


### PR DESCRIPTION
'date' field is not required on mail.message model which means it could hold a void value. It is generally set (either through email date, either because there is a default defined) but in some cases it is unset. We therefore have to be careful when sorting on it, as we may mix boolean and datetime values, which leads to a crash.

Task-5342539
