### PR TITLE
[IMP] base: faster assets bundle generation

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -882,7 +882,17 @@ class JavascriptAsset(WebAsset):
         return content
 
     def minify(self):
-        return self.with_header(rjsmin(self.content))
+        cache = self.bundle.env.cr.cache.setdefault('assets_js_transpiled', {})
+        cache_key = None
+        if self._filename and self.last_modified:
+            cache_key = (self._filename, self.last_modified)
+            content = cache.get(cache_key)
+            if content is not None:
+                return content
+        content = self.with_header(rjsmin(self.content))
+        if cache_key:
+            cache[cache_key] = content
+        return content
 
     def _fetch_content(self):
         try:

--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -176,7 +176,7 @@ class IrAsset(models.Model):
 
         # 2. Process all addons' manifests.
         for addon in addons:
-            for command in Manifest.for_addon(addon)['assets'].get(bundle, ()):
+            for command in Manifest.for_addon(addon)._Manifest__manifest_cached['assets'].get(bundle, ()):
                 directive, target, path_def = self._process_command(command)
                 self._process_path(bundle, directive, target, path_def, asset_paths, seen, addons, installed, bundle_start_index, **assets_params)
 


### PR DESCRIPTION
Part of #236221

This pr aims to speedup the generation and validation of assets bundle. 

1. Cache js minified files

Multiple bundle will use the same js file, this file will be transpiled and minified wich is slow.
The first commit uses a cache (during the transaction) to cache those result, leading to a significant increase in performance when generating multiple assets bundle.

2. Faster fill_assets_path
When trying to find all assets, for each bundle and each include bundle we will check the manifest for each addons. 
This check should be a simple lookup in a dict but it is actually a deep copy leading to reduced performances. 
This second commit proposes to bypass the deepcopy since this limited scope won't modify the manifest and just iterate over a structure

With those two changes the generation of js assets goes from 30-50 second to 10-20 second (approximation, looking at a few build only)