### PR TITLE
[FIX] web: user groups field: show privilege placeholder

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -140,10 +140,11 @@ export class SelectMenu extends Component {
 
         this.selectedChoice = this.getSelectedChoice(this.props);
         onWillUpdateProps((nextProps) => {
-            if (this.state.choices !== nextProps.choices) {
+            const choicesChanged = this.state.choices !== nextProps.choices;
+            if (choicesChanged) {
                 this.state.choices = nextProps.choices;
             }
-            if (this.props.value !== nextProps.value) {
+            if (choicesChanged || this.props.value !== nextProps.value) {
                 this.selectedChoice = this.getSelectedChoice(nextProps);
             }
         });

--- a/addons/web/static/src/views/fields/selection/selection_field.js
+++ b/addons/web/static/src/views/fields/selection/selection_field.js
@@ -46,7 +46,7 @@ export class SelectionField extends Component {
                 return [...this.specialData.data];
             case "selection":
                 return this.props.record.fields[this.props.name].selection.filter(
-                    (option) => option[0] !== false && option[1] !== ""
+                    (option) => option[1] !== ""
                 );
             default:
                 return [];

--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.js
@@ -70,9 +70,11 @@ class ResUserGroupIdsField extends Component {
                         helpLines.push(`- ${groups[gid].name}: ${groups[gid].comment}`);
                     }
                 }
+                const selection = privilege.group_ids.map((gId) => [gId, groups[gId].name]);
+                selection.unshift([false, privilege.placeholder || ""]);
                 this._fields[this.getFieldName(privilege)] = {
                     help: helpLines.join("\n"),
-                    selection: privilege.group_ids.map((gId) => [gId, groups[gId].name]),
+                    selection,
                     string: privilege.name,
                     type: "selection",
                 };
@@ -183,7 +185,7 @@ class ResUserGroupIdsField extends Component {
                         this.shadowedGroupIds.push(groupId);
                         groupId = false;
                     }
-                    this.values[this.getFieldName(privilege)] = groupId;
+                    this.values[fieldName] = groupId;
                 }
             }
             if (this.extraCategory) {


### PR DESCRIPTION
Before this commit, privilege's placeholders were ignored in the res_users_group_ids field widget. Those placeholders were supposed to be added in the selection and act as a "no group" value. This commit fixes the issue.

task~5275552

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
