### PR TITLE
[FIX] stock: prevent error when try to create new operation type

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -834,7 +834,8 @@ class Picking(models.Model):
                 else:
                     picking.state = 'done'
             else:
-                if picking.location_id.should_bypass_reservation() and all(m.procure_method == 'make_to_stock' for m in picking.move_ids):
+                if (picking.location_id and picking.location_id.should_bypass_reservation()) \
+                    and all(m.procure_method == 'make_to_stock' for m in picking.move_ids):
                     picking.state = 'assigned'
                 else:
                     relevant_move_state = self.env['stock.move'].browse(picking_move_lines[picking_id])._get_relevant_state_among_moves()


### PR DESCRIPTION
The system will crash with error when user try to create new operation type in recepit.

**Steps to produce:**
- Install `Inventory` module with demo data.
- `Inventory > Configuration > Settings > under Warehouse > Enable Storage Locations`.
- Inventory > Receipts > Open any receipt > remove value of `Operation Type` and then `Source Location`.
- Type test in `Operation Type` and click on `create` > click discard.

**Error:**
`ValueError: Expected singleton: stock.location()`

**Cause:**
- When we remove the `Operation Type` and the `Source Location` values from the picking, and then try to create a new operation type and then `discarding the wizard` triggers the `onchange`, which then raises the error from [1].

**Solution:**
- We can prevent this error by checking `picking.location` before doing `picking.location_id.should_bypass_reservation()`.

[1]https://github.com/odoo/odoo/blob/483ce91547b8045e8dfaa6ae8cac8573a01f54d0/addons/stock/models/stock_picking.py#L837

sentry-7041514835
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
