### PR TITLE
[FIX] pos_viva_wallet: serialization errors from concurrent requests

### DIFF
--- a/addons/pos_viva_wallet/controllers/main.py
+++ b/addons/pos_viva_wallet/controllers/main.py
@@ -23,8 +23,11 @@ class PosVivaWalletController(http.Controller):
             if request.httprequest.data:
                 data = request.get_json_data()
                 terminal_id = data.get('EventData', {}).get('TerminalId', '')
+                event_type = data.get('EventTypeId')
                 data_webhook = data.get('EventData', {})
-                if terminal_id:
+                if event_type != 1796:  # Transaction Payment Created
+                    _logger.warning('received a message with an unknown event type "%s". See https://developer.viva.com/webhooks-for-payments/#webhook-events.', event_type)
+                elif terminal_id:
                     payment_method_sudo = request.env['pos.payment.method'].sudo().search([('viva_wallet_terminal_id', '=', terminal_id)], limit=1)
                     payment_method_sudo._retrieve_session_id(data_webhook)
                 else:

--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -49,9 +49,9 @@ export class PaymentVivaWallet extends PaymentInterface {
     }
 
     _viva_wallet_handle_response(response, paymentLine) {
-        paymentLine.set_payment_status("waitingCard");
         if (response.error) {
             this._show_error(response.error);
+            return false;
         }
         return this.waitForPaymentConfirmation(paymentLine);
     }
@@ -120,13 +120,7 @@ export class PaymentVivaWallet extends PaymentInterface {
      * This method is called from pos_bus when the payment
      * confirmation from Viva Wallet is received via the webhook and confirmed in the retrieve_session_id.
      */
-    async handleVivaWalletStatusResponse(paymentLine) {
-        const notification = await this.env.services.orm.silent.call(
-            "pos.payment.method",
-            "get_latest_viva_wallet_status",
-            [[this.payment_method_id.id]]
-        );
-
+    handleVivaWalletStatusResponse(paymentLine, notification) {
         if (!notification) {
             this._handle_odoo_connection_failure(paymentLine);
             return;
@@ -191,9 +185,9 @@ export class PaymentVivaWallet extends PaymentInterface {
     }
 
     handleSuccessResponse(line, notification) {
-        line.transaction_id = notification.transactionId;
-        line.card_type = notification.applicationLabel;
-        line.cardholder_name = notification.FullName || "";
+        line.transaction_id = notification.transaction_id;
+        line.card_type = notification.card_type;
+        line.cardholder_name = notification.cardholder_name;
     }
 
     _show_error(msg, title) {

--- a/addons/pos_viva_wallet/static/src/overrides/pos_store.js
+++ b/addons/pos_viva_wallet/static/src/overrides/pos_store.js
@@ -16,7 +16,8 @@ patch(PosStore.prototype, {
                     paymentLine.get_payment_status() !== "retry"
                 ) {
                     paymentLine.payment_method_id.payment_terminal.handleVivaWalletStatusResponse(
-                        paymentLine
+                        paymentLine,
+                        payload
                     );
                 }
             }


### PR DESCRIPTION
When using many Viva terminals linked to the same DB, there could be many serialization errors due to concurrent writes to the DB. This is because the webhook controller writes to the
`viva_wallet_latest_response` field of the payment method. The webhook request would be automatically retried later, but this could result in duplicate notifications being sent to the POS, or notifications being handled too late.

This commit stops using the `viva_wallet_latest_response` field, instead sending the information directly via the websocket to the POS. Only the required information is sent to reduce the size of the message.

In addition, there are two other minor fixes:
- In the event that the initial payment request to Viva failed, the POS will no longer poll the payment status (this resulted in a Session ID not found error).
- The webhook controller will now check the event type it receives, and only process the 'Transaction Payment Created' events. This should prevent any unintended behaviour if other webhooks are set up in Viva.

opw-5226966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
