### PR TITLE
[REF] web: remove unused hasTouch in KanbanRecord

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 import { ColorList } from "@web/core/colorlist/colorlist";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
-import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
@@ -203,7 +202,6 @@ export class KanbanRecord extends Component {
             Object.assign(this.dataState.record, getFormattedRecord(record))
         );
         this.rootRef = useRef("root");
-        this.hasTouch = hasTouch();
 
         this.longTouchTimer = null;
         this.touchStartMs = 0;


### PR DESCRIPTION
This commit removes an unused variable that was set on the Kanban record. There is no need to check that the browser is used primarly with touch, because event listeners are set on the element from the XML unconditionally, and the template don't change.