### PR TITLE
[REV] account: hide sections and notes in journal items tab

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -183,16 +183,18 @@ class AccountMove(models.Model):
     line_ids = fields.One2many(
         'account.move.line',
         'move_id',
-        string='Account Move Line Items',
+        string='Journal Items',
         copy=True,
     )
 
-    journal_line_ids = fields.One2many(  # /!\ journal_line_ids is just a subset of line_ids.
+    # /!\ Deprecated! Kept in stable, but will be removed in master.
+    journal_line_ids = fields.One2many(
         comodel_name='account.move.line',
         inverse_name='move_id',
-        string='Journal Items',
+        string='Journal Items (DEPRECATED)',
         copy=False,
         domain=[('display_type', 'not in', ('line_section', 'line_note'))],
+        exportable=False,
     )
 
     # === Link to the partial that created this exchange move === #
@@ -3526,7 +3528,7 @@ class AccountMove(models.Model):
         return _('This entry has been reversed from %s', self._get_html_link()) if default.get('reversed_entry_id') else _('This entry has been duplicated from %s', self._get_html_link())
 
     def _sanitize_vals(self, vals):
-        if vals.get('invoice_line_ids') and vals.get('journal_line_ids'):
+        if vals.get('invoice_line_ids') and vals.get('line_ids'):
             # values can sometimes be in only one of the two fields, sometimes in
             # both fields, sometimes one field can be explicitely empty while the other
             # one is not, sometimes not...
@@ -3535,15 +3537,15 @@ class AccountMove(models.Model):
                 for command, line_id, *line_vals in vals['invoice_line_ids']
                 if command == Command.UPDATE
             }
-            for command, line_id, *line_vals in vals['journal_line_ids']:
+            for command, line_id, *line_vals in vals['line_ids']:
                 if command == Command.UPDATE and line_id in update_vals:
                     line_vals[0].update(update_vals.pop(line_id))
             for line_id, line_vals in update_vals.items():
-                vals['journal_line_ids'] += [Command.update(line_id, line_vals)]
+                vals['line_ids'] += [Command.update(line_id, line_vals)]
             for command, line_id, *line_vals in vals['invoice_line_ids']:
                 assert command not in (Command.SET, Command.CLEAR)
-                if [command, line_id, *line_vals] not in vals['journal_line_ids']:
-                    vals['journal_line_ids'] += [(command, line_id, *line_vals)]
+                if [command, line_id, *line_vals] not in vals['line_ids']:
+                    vals['line_ids'] += [(command, line_id, *line_vals)]
             del vals['invoice_line_ids']
         return vals
 

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -325,14 +325,14 @@ class TestAccountMove(AccountTestInvoicingCommon):
         move_form.date = fields.Date.from_string('2016-01-01')
 
         # New line that should get 400.0 as debit.
-        with move_form.journal_line_ids.new() as line_form:
+        with move_form.line_ids.new() as line_form:
             line_form.name = 'debit_line'
             line_form.account_id = self.company_data['default_account_revenue']
             line_form.currency_id = self.other_currency
             line_form.amount_currency = 1200.0
 
         # New line that should get 400.0 as credit.
-        with move_form.journal_line_ids.new() as line_form:
+        with move_form.line_ids.new() as line_form:
             line_form.name = 'credit_line'
             line_form.account_id = self.company_data['default_account_revenue']
             line_form.currency_id = self.other_currency
@@ -380,9 +380,9 @@ class TestAccountMove(AccountTestInvoicingCommon):
         )
         # You can change the balance manually without changing the currency amount
         with Form(move) as move_form:
-            with move_form.journal_line_ids.edit(0) as line_form:
+            with move_form.line_ids.edit(0) as line_form:
                 line_form.debit = 200
-            with move_form.journal_line_ids.edit(1) as line_form:
+            with move_form.line_ids.edit(1) as line_form:
                 line_form.credit = 200
 
         self.assertRecordValues(
@@ -433,7 +433,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='entry'))
 
         # Create a new account.move.line with debit amount.
-        with move_form.journal_line_ids.new() as debit_line:
+        with move_form.line_ids.new() as debit_line:
             debit_line.name = 'debit_line_1'
             debit_line.account_id = self.account
             debit_line.debit = 1000
@@ -441,7 +441,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             debit_line.tax_ids.add(self.included_percent_tax)
 
         # Create a third account.move.line with credit amount.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'credit_line_1'
             credit_line.account_id = self.account
             credit_line.credit = 1200
@@ -843,12 +843,12 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         # Create a new account.move.line with debit amount.
         income_account = self.company_data['default_account_revenue']
-        with move_form.journal_line_ids.new() as debit_line:
+        with move_form.line_ids.new() as debit_line:
             debit_line.name = 'debit'
             debit_line.account_id = income_account
             debit_line.debit = 120
 
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'credit'
             credit_line.account_id = income_account
             credit_line.credit = 100
@@ -874,12 +874,12 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         move_form = Form(self.env['account.move'])
 
-        with move_form.journal_line_ids.new() as debit_line_form:
+        with move_form.line_ids.new() as debit_line_form:
             debit_line_form.name = 'debit'
             debit_line_form.account_id = test_account
             debit_line_form.debit = 115
 
-        with move_form.journal_line_ids.new() as credit_line_form:
+        with move_form.line_ids.new() as credit_line_form:
             credit_line_form.name = 'credit'
             credit_line_form.account_id = test_account
             credit_line_form.credit = 100
@@ -902,12 +902,12 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         move_form = Form(self.env['account.move'])
 
-        with move_form.journal_line_ids.new() as credit_line_form:
+        with move_form.line_ids.new() as credit_line_form:
             credit_line_form.name = 'credit'
             credit_line_form.account_id = test_account
             credit_line_form.credit = 115
 
-        with move_form.journal_line_ids.new() as debit_line_form:
+        with move_form.line_ids.new() as debit_line_form:
             debit_line_form.name = 'debit'
             debit_line_form.account_id = test_account
             debit_line_form.debit = 100
@@ -1009,9 +1009,9 @@ class TestAccountMove(AccountTestInvoicingCommon):
         tax_line = move.line_ids.filtered('tax_repartition_line_id')
         self.assertEqual(tax_line.debit, 721.44)
         with Form(move) as move_form:
-            with move_form.journal_line_ids.edit(2) as line_form:
+            with move_form.line_ids.edit(2) as line_form:
                 line_form.debit = 721.43
-            move_form.journal_line_ids.remove(3)
+            move_form.line_ids.remove(3)
         move = move_form.save()
         tax_line = move.line_ids.filtered('tax_repartition_line_id')
         self.assertEqual(tax_line.debit, 721.43)

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2243,7 +2243,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
     def test_in_invoice_line_tax_line_delete(self):
         with self.assertRaisesRegex(ValidationError, "You cannot delete a tax line"):
             with Form(self.invoice) as invoice_form:
-                invoice_form.journal_line_ids.remove(2)
+                invoice_form.line_ids.remove(2)
 
     @freeze_time('2022-06-17')
     def test_fiduciary_mode_date_suggestion(self):
@@ -2809,7 +2809,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         payment_term_line = self.invoice.line_ids.filtered(lambda l: l.display_type == 'payment_term')
         index = self.invoice.line_ids.ids.index(payment_term_line.id)
         with Form(self.invoice) as move_form:
-            with move_form.journal_line_ids.edit(index) as line_form:
+            with move_form.line_ids.edit(index) as line_form:
                 line_form.name = 'XYZ'
         move_form.save()
         self.invoice.action_post()
@@ -2850,7 +2850,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
     def test_journal_item_on_payable_account(self):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
 
-        with move_form.journal_line_ids.new() as line_form:
+        with move_form.line_ids.new() as line_form:
             line_form.account_id = self.company_data['default_account_payable']
 
         with self.assertRaisesRegex(UserError, 'Any journal item on a payable account must have a due date and vice versa.'):

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -375,7 +375,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         move_form.ref = 'azerty'
 
         # Debit base tax line.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'debit_line_1'
             credit_line.account_id = self.company_data['default_account_revenue']
             credit_line.debit = 1000.0
@@ -384,7 +384,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
 
 
         # Balance the journal entry.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'balance'
             credit_line.account_id = self.company_data['default_account_revenue']
             credit_line.credit = 1100.0
@@ -403,7 +403,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         move_form.ref = 'azerty'
 
         # Debit base tax line.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'debit_line_1'
             credit_line.account_id = self.company_data['default_account_revenue']
             credit_line.credit = 1000.0
@@ -411,7 +411,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.tax_ids.add(sale_tax)
 
         # Balance the journal entry.
-        with move_form.journal_line_ids.new() as debit_line:
+        with move_form.line_ids.new() as debit_line:
             debit_line.name = 'balance'
             debit_line.account_id = self.company_data['default_account_revenue']
             debit_line.debit = 1100.0
@@ -461,7 +461,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         move_form.ref = 'azerty'
 
         # Debit base tax line.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'debit_line_1'
             credit_line.account_id = self.company_data['default_account_revenue']
             credit_line.debit = 1000.0
@@ -469,7 +469,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.tax_ids.add(purch_tax)
 
         # Balance the journal entry.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'balance'
             credit_line.account_id = self.company_data['default_account_revenue']
             credit_line.credit = 1100.0
@@ -488,7 +488,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         move_form.ref = 'azerty'
 
         # Debit base tax line.
-        with move_form.journal_line_ids.new() as credit_line:
+        with move_form.line_ids.new() as credit_line:
             credit_line.name = 'debit_line_1'
             credit_line.account_id = self.company_data['default_account_revenue']
             credit_line.credit = 1000.0
@@ -496,7 +496,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.tax_ids.add(purch_tax)
 
         # Balance the journal entry.
-        with move_form.journal_line_ids.new() as debit_line:
+        with move_form.line_ids.new() as debit_line:
             debit_line.name = 'balance'
             debit_line.account_id = self.company_data['default_account_revenue']
             debit_line.debit = 1100.0
@@ -569,7 +569,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             with Form(self.env['account.move'], view='account.view_move_form') as move_form:
                 for line_field in ('debit', 'credit'):
                     line_amount = tax_field == line_field and 1000 or 1150
-                    with move_form.journal_line_ids.new() as line_form:
+                    with move_form.line_ids.new() as line_form:
                         line_form.name = '%s_line' % line_field
                         line_form.account_id = self.company_data['default_account_revenue']
                         line_form.debit = line_field == 'debit' and line_amount or 0

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1336,7 +1336,7 @@
                                 </group>
                             </page>
                             <page id="aml_tab" string="Journal Items" groups="account.group_account_readonly" name="aml_tab">
-                                <field name="journal_line_ids"
+                                <field name="line_ids"
                                        mode="list,kanban"
                                        context="{
                                            'default_move_type': context.get('default_move_type'),
@@ -1348,10 +1348,11 @@
                                        }"
                                        invisible="payment_state == 'invoicing_legacy' and move_type != 'entry'"
                                        readonly="state != 'draft'">
-                                    <list editable="bottom" string="Journal Items" default_order="sequence, id">
+                                    <list editable="bottom" string="Journal Items" decoration-muted="display_type in ('line_section', 'line_note')" default_order="sequence, id">
                                         <!-- Displayed fields -->
                                         <field name="account_id"
-                                               required="1"
+                                               invisible="display_type in ('line_section', 'line_note')"
+                                               required="display_type not in ('line_section', 'line_note')"
                                                domain="[('company_ids', 'parent_of', company_id)]" />
                                         <field name="partner_id"
                                                optional="show"
@@ -1365,6 +1366,7 @@
                                                business_domain_compute="parent.move_type in ['out_invoice', 'out_refund', 'out_receipt'] and 'invoice' or parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] and 'bill' or 'general'"/>
                                         <field name="date_maturity"
                                                optional="hide"
+                                               invisible="display_type in ('line_section', 'line_note')"
                                                column_invisible="context.get('view_no_maturity')"/>
                                         <field name="amount_currency"
                                                groups="base.group_multi_currency"
@@ -1381,15 +1383,15 @@
                                                }"
                                                options="{'no_create': True}"
                                                force_save="1"
-                                               readonly="tax_line_id or (parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and account_type in ('asset_receivable', 'liability_payable'))"/>
+                                               readonly="display_type in ('line_section', 'line_note') or tax_line_id or (parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and account_type in ('asset_receivable', 'liability_payable'))"/>
                                         <field name="debit"
                                                sum="Total Debit"
                                                invisible="display_type in ('line_section', 'line_note')"
-                                               readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('product')"/>
+                                               readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"/>
                                         <field name="credit"
                                                sum="Total Credit"
                                                invisible="display_type in ('line_section', 'line_note')"
-                                               readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('product')"/>
+                                               readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"/>
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"
                                                string="Discount Date"

--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='journal_line_ids']//field[@name='account_id']" position="after">
+            <xpath expr="//field[@name='line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' column_invisible="True"/>
                 <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>
             </xpath>

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -64,7 +64,7 @@
             <xpath expr="//field[@name='invoice_line_ids']/list//field[@name='product_id']" position="after">
                 <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
             </xpath>
-            <xpath expr="//field[@name='journal_line_ids']/list//field[@name='name']" position="after">
+            <xpath expr="//field[@name='line_ids']/list//field[@name='name']" position="after">
                 <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
             </xpath>
             <xpath expr="//header" position="inside">

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -32,7 +32,7 @@
                 <field name="purchase_line_id" groups="purchase.group_purchase_user" column_invisible="True"/>
                 <field name="purchase_order_id" groups="purchase.group_purchase_user" column_invisible="parent.move_type != 'in_invoice'" optional="hide"/>
             </xpath>
-            <xpath expr="//field[@name='journal_line_ids']/list/field[@name='company_id']" position="after">
+            <xpath expr="//field[@name='line_ids']/list/field[@name='company_id']" position="after">
                 <field name="purchase_line_id" groups="purchase.group_purchase_user" column_invisible="True"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">

--- a/addons/stock_landed_costs/views/account_move_views.xml
+++ b/addons/stock_landed_costs/views/account_move_views.xml
@@ -27,7 +27,7 @@
                 <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type != 'in_invoice'" readonly="product_type != 'service'" optional="hide" groups="stock.group_stock_manager"/>
             </xpath>
 
-            <xpath expr="//field[@name='journal_line_ids']/list/field[@name='name']" position="after">
+            <xpath expr="//field[@name='line_ids']/list/field[@name='name']" position="after">
                 <field name="product_type" column_invisible="True" groups="stock.group_stock_manager"/>
                 <field name="is_landed_costs_line" column_invisible="True" groups="stock.group_stock_manager"/>
             </xpath>


### PR DESCRIPTION
This reverts commit 6ed1e43b3f7d53c6a45fe24a1c68f8386e6adf8e.

The commit is reverted because the `journal_line_ids` field is causing issues with onchange methods that rely on cached values. Specifically, the automatic computation of `debit`/`credit` when adding new lines to a journal entry was failing.

While `journal_line_ids` (as a subset of `line_ids`) works correctly when the data is stored in the database, its absence during an onchange computation
(which relies solely on cache) led to incorrect behavior.

In stable versions, `journal_line_ids` is:
* Kept but deprecated.
* Made non-exportable.

The field will be removed in `master`.

task-5241650

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
