### PR TITLE
[FIX] web: empty <t/> instead of undefined on rendering invisible roots

### DIFF
--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -251,7 +251,7 @@ export class ViewCompiler {
     compile(key, params = {}) {
         const root = this.templates[key].cloneNode(true);
         const child = this.compileNode(root, params);
-        const newRoot = createElement("t", [child]);
+        const newRoot = createElement("t", child ? [child] : []);
         newRoot.setAttribute("t-translation", "off");
         return newRoot;
     }

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -461,6 +461,19 @@ QUnit.module("Views", (hooks) => {
         }
     });
 
+    QUnit.test("button box rendering invisible", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><div name="button_box" invisible="1"><button id="btn1">MyButton</button></div></form>`,
+            resId: 2,
+        });
+        const panelActions = target.querySelector(".o_control_panel .o_control_panel_actions")
+        assert.strictEqual(panelActions.childElementCount, 0);
+        assert.strictEqual(panelActions.textContent, "");
+    });
+
     QUnit.test("form view gets size class on small and big screens", async (assert) => {
         let uiSize = SIZES.MD;
         const bus = new EventBus();


### PR DESCRIPTION
Currently if the root node of a template is invisible at compile time
the "new root" will contain the word "undefined" in plain text.

Instead if we skip rendering the root for whatever reason, the new root
should simply be an empty t node.

This lead to issues in full-size forms specifically as the controller
compiles the buttons separately. Meaning if the buttons div was evaluated
to be invisible for whatever reason you would get "undefined" where stats
buttons normally go.

task-5322823