### PR TITLE
[FIX] portal: fix multiple portal access grant and revoke

### DIFF
--- a/addons/portal/tests/test_portal_wizard.py
+++ b/addons/portal/tests/test_portal_wizard.py
@@ -172,3 +172,22 @@ class TestPortalWizard(MailCommon):
         portal_user.with_company(company_1).action_grant_access()
 
         self.assertEqual(portal_user.user_id.company_id, company_2, 'Must create the user in the same company as the partner.')
+
+    def test_portal_wizard_multiple_access_changes(self):
+        portal_wizard = self.env['portal.wizard'].with_context(active_ids=[self.partner.id]).create({})
+        self.assertEqual(len(portal_wizard.user_ids), 1)
+
+        portal_user = portal_wizard.user_ids[0]
+        self.assertFalse(portal_user.user_id)
+        self.assertFalse(portal_user.is_portal)
+
+        for _ in range(2):
+            portal_user.action_grant_access()
+            self.assertTrue(portal_user.user_id.active)
+            self.assertTrue(portal_user.is_portal)
+            self.assertTrue(self.partner.signup_type)
+
+            portal_user.action_revoke_access()
+            self.assertFalse(portal_user.user_id.active)
+            self.assertTrue(portal_user.is_portal)
+            self.assertFalse(self.partner.signup_type)

--- a/addons/portal/wizard/portal_wizard_views.xml
+++ b/addons/portal/wizard/portal_wizard_views.xml
@@ -43,14 +43,15 @@
                             <button name="action_refresh_modal" type="object" icon="fa-user-times text-danger"
                                 invisible="email_state != 'exist'" title="Email Address already taken by another user"/>
                             <field name="login_date"/>
+                            <field name="is_active" column_invisible="True"/>
                             <field name="is_portal" column_invisible="True"/>
                             <field name="is_internal" column_invisible="True"/>
                             <button string="Grant Access" name="action_grant_access" type="object" class="btn-secondary"
-                                invisible="is_portal or is_internal or email_state != 'ok'"/>
+                                invisible="(is_portal and is_active) or is_internal or email_state != 'ok'"/>
                             <button string="Revoke Access" name="action_revoke_access" type="object" class="btn-secondary"
-                                invisible="not is_portal or is_internal"/>
+                                invisible="not is_portal or not is_active or is_internal"/>
                             <button string="Re-Invite" name="action_invite_again" type="object" class="btn-secondary"
-                                invisible="not is_portal or is_internal or email_state != 'ok'"/>
+                                invisible="not is_portal or not is_active or is_internal or email_state != 'ok'"/>
                             <button string="Internal User" invisible="not is_internal"
                                 disabled="True" title="This partner is linked to an internal User and already has access to the Portal."/>
                         </list>


### PR DESCRIPTION
**Steps to reproduce:**
- Go to the Contact app
- Go to the record of a partner
- Go to the actions dropdown menu of the record
- Grant portal access
- Remove the access
- Grant the access again
- Second grant is blocked

**Issue:**
Active check is needed when granting access to a previous portal user which was archived.

**Fix:**
Only block when the user is an active portal user.

Also need to add `is_active` field to toggle the buttons in the xml as we can't directly access
`user_id.active` in the view.

related: https://github.com/odoo/odoo/commit/d49d91ffd463a68cb6ccc881aa14ac58bd2cf65b

opw-4760550
