### PR TITLE
[FIX] pos_online_payment: fix tb while capturing online payment with invoice

### DIFF
--- a/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
@@ -218,7 +218,7 @@ patch(OrderPaymentValidation.prototype, {
             (this.order.isPaidWithCash() || this.order.change) &&
             this.pos.config.iface_cashdrawer
         ) {
-            this.hardwareProxy.printer.openCashbox();
+            this.pos.hardwareProxy.openCashbox();
         }
 
         if (isInvoiceRequested) {
@@ -228,7 +228,7 @@ patch(OrderPaymentValidation.prototype, {
                     body: _t("The invoice could not be generated."),
                 });
             } else {
-                await this.invoiceService.downloadPdf(orderJSON[0].account_move);
+                await this.pos.env.services.account_move.downloadPdf(orderJSON[0].account_move);
             }
         }
 


### PR DESCRIPTION
steps to reproduce:
- Create an Online Payment payment method.
- Open POS, create an order, and validate it using the Online Payment method with Invoice enabled.

issue:
- A traceback error is displayed after validating the order.

fix:
- Fixed the `invoice PDF download` actions so it use the correct service.
- Also, corrected for the cashbox action.

task: 5269502
