### PR TITLE
[IMP] hr_version: remove date_start/end

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -51,6 +51,7 @@ class HrVersion(models.Model):
     active = fields.Boolean(default=True, tracking=True)
 
     date_version = fields.Date(string="Effective Date", required=True, default=fields.Date.today, tracking=True, groups="hr.group_hr_user")
+    next_version = fields.Many2one('hr.version', compute="_compute_next_version", store=True, groups="hr.group_hr_user")
     last_modified_uid = fields.Many2one('res.users', string='Last Modified by',
                                         default=lambda self: self.env.uid, required=True, groups="hr.group_hr_user")
     last_modified_date = fields.Datetime(string='Last Modified on', default=fields.Datetime.now, required=True,
@@ -384,6 +385,11 @@ class HrVersion(models.Model):
     def _compute_display_name(self):
         for version in self:
             version.display_name = version.name if not version.employee_id else format_date_abbr(version.env, version.date_version)
+
+    @api.depends('employee_id.version_ids.date_version')
+    def _compute_next_version(self):
+        for version in self:
+            version.next_version = version.employee_id.version_ids.filtered(lambda r: r.date_version > version.date_version).sorted("date_version")[:1]
 
     def _compute_is_current(self):
         today = fields.Date.today()

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -772,3 +772,46 @@ class TestHrVersion(TestHrCommon):
         self.assertEqual(HrEmployee_with_manager_user.search([('hr_responsible_id', '=', self.res_users_hr_manager.id), ('id', 'in', employees.ids)]), employee1)
         self.assertEqual(HrEmployee_with_manager_user.search([('version_id.hr_responsible_id', '=', self.res_users_hr_manager.id), ('id', 'in', employees.ids)]), employee1)
         self.assertEqual(HrEmployee_with_manager_user.search([('member_of_department', '=', True), ('id', 'in', employees.ids)]), employee1)
+
+    def test_hr_version_next_version1(self):
+        """
+        Test the added next_version field on hr.version useful for computations on versions.
+        """
+        employee = self.env['hr.employee'].create([
+            {
+                'name': 'Employee',
+                'date_version': '2025-01-01',
+            }
+        ])
+        version1 = employee.version_id
+
+        # Only one version
+        self.assertEqual(version1.next_version, self.env["hr.version"], "no next version exists")
+
+        # 2 versions :
+        # 1 -> 2
+        version2 = employee.create_version({'date_version': '2025-03-01'})
+        self.assertEqual(version1.next_version, version2,
+                         "the next version should be the version 2")
+        self.assertEqual(version2.next_version, self.env["hr.version"],
+                         "the last version should not have a next version")
+
+        # 1 new version in the middle of the 2 previous ones
+        # 1 -> 3 -> 2
+        version3 = employee.create_version({'date_version': '2025-02-01'})
+        self.assertEqual(version1.next_version, version3,
+                         "the next version should be the version 3")
+        self.assertEqual(version3.next_version, version2,
+                         "the next version should be the version 2")
+        self.assertEqual(version2.next_version, self.env["hr.version"],
+                         "the last version should not have a next version")
+
+        # the last version edited to be between the 2 others:
+        # 1 -> 2 -> 3
+        version2.update({'date_version': '2025-01-15'})
+        self.assertEqual(version1.next_version, version2,
+                         "the next version should be the version 2")
+        self.assertEqual(version2.next_version, version3,
+                         "the next version should be the version 3")
+        self.assertEqual(version3.next_version, self.env["hr.version"],
+                         "the last version should not have a next_version")


### PR DESCRIPTION
Problem
----------
`date_start` and `date_end` should be removed on `hr_version` and replaced by `date_version` or `contract_date_start/end` depending on the logic.

Purpose
----------
Add `next_version` on `hr_version`, to get the effective date range of a version and more (rather than filter and sort everytime versions_ids of the employee of a version).

Solution
----------
First commit to add the `next_version`. (It allows others to help optimizations and `date_start/end` removal on this base).
Multiple commits to changes sepcifics methods, and make the review easier.
Last commit to remove the `date_start` and `date_end` fields.

task-4866306