### PR TITLE
[FIX] event, website_event: allow outlook calendar to render HTML event descriptions

### DIFF
--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -13,11 +13,18 @@ class EventController(Controller):
 
     @route(['''/event/<model("event.event"):event>/ics'''], type='http', auth="public")
     def event_ics_file(self, event, **kwargs):
+        return self.create_event_ics_file(event, False)
+
+    @route(['''/event/<model("event.event"):event>/outlook_ics'''], type='http', auth="public")
+    def event_outlook_ics_file(self, event, **kwargs):
+        return self.create_event_ics_file(event, True)
+
+    def create_event_ics_file(self, event, is_outlook):
         lang = request.context.get('lang', request.env.user.lang)
         if request.env.user._is_public():
             lang = request.cookies.get('frontend_lang')
         event = event.with_context(lang=lang)
-        files = event._get_ics_file()
+        files = event._get_ics_file_outlook() if is_outlook else event._get_ics_file()
         if not event.id in files:
             return NotFound()
         content = files[event.id]

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -195,6 +195,7 @@ class WebsiteEventController(http.Controller):
             'range': range,
             'google_url': lazy(lambda: urls.get('google_url')),
             'iCal_url': lazy(lambda: urls.get('iCal_url')),
+            'iCal_url_outlook': lazy(lambda: urls.get('iCal_url_outlook')),
             'registration_error_code': post.get('registration_error_code'),
         }
 
@@ -401,7 +402,8 @@ class WebsiteEventController(http.Controller):
             'attendees': attendees_sudo,
             'event': event,
             'google_url': urls.get('google_url'),
-            'iCal_url': urls.get('iCal_url')
+            'iCal_url': urls.get('iCal_url'),
+            'iCal_url_outlook': urls.get('iCal_url_outlook'),
         }
 
     # ------------------------------------------------------------

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -483,7 +483,8 @@ class Event(models.Model):
         encoded_params = werkzeug.urls.url_encode(params)
         google_url = GOOGLE_CALENDAR_URL + encoded_params
         iCal_url = f'/event/{self.id:d}/ics?{encoded_params}'
-        return {'google_url': google_url, 'iCal_url': iCal_url}
+        iCal_url_outlook = f'/event/{self.id:d}/outlook_ics?{encoded_params}'
+        return {'google_url': google_url, 'iCal_url': iCal_url, 'iCal_url_outlook': iCal_url_outlook}
 
     def _default_website_meta(self):
         res = super(Event, self)._default_website_meta()

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -221,7 +221,7 @@
                 <a t-att-href="iCal_url" class="btn btn-light o_wevent_add_to_ical" title="Add to iCal">
                     <i role="img" class="fa fa-apple"/>
                 </a>
-                <a t-att-href="iCal_url" class="btn btn-light o_wevent_add_to_outlook" title="Add to Outlook">
+                <a t-att-href="iCal_url_outlook" class="btn btn-light o_wevent_add_to_outlook" title="Add to Outlook">
                     <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
                 </a>
                 <a t-att-href="google_url" class="btn btn-light o_wevent_add_to_google_calendar" title="Add to Google" target="_blank">


### PR DESCRIPTION
****Behavior:****
**Current:**
When exporting an event for Outlook Calendar, the file returned is the same as for ICalendar(.ics), however Outlook cannot handle the HTML description of the event when passed through the 'DESCRIPTION:' field which causes the event description to display raw HTML tags.

**Solution:**
Outlook can use the 'X-ALT-DESC:' field with 'text/html' parameter to handle HTML. A new route was created to generate the event's ics file with the correct parameters for Outlook.

****Steps to reproduce:****
- Go to an event from Website
- Select the Outlook icon under 'Add to calendar'
- Import the file to Outlook Calendar
- You'll notice HTML tags in the description of the event.

opw-5116354