### PR TITLE
[IMP] mail: make raise hand primary action and move autofocus speaker to setting

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -34,7 +34,7 @@ export class CallActionList extends Component {
                     (a) => !a.tags.includes(ACTION_TAGS.CALL_LAYOUT)
                 );
                 const sequenceGroup = filtered[0].sequenceGroup;
-                const maxQuickActions = sequenceGroup === 200 ? 1 : 4;
+                const maxQuickActions = sequenceGroup === 200 ? 2 : 4;
                 const quickActions = filtered.slice(0, maxQuickActions);
                 const moreActions = filtered.slice(maxQuickActions);
                 const newGroup = moreActions?.length

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -167,17 +167,6 @@ registerCallAction("share-screen", {
     sequenceGroup: 200,
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.SUCCESS : undefined),
 });
-registerCallAction("auto-focus", {
-    condition: ({ owner, channel, store }) =>
-        !owner.env.inCallMenu && channel?.eq(store.rtc?.channel),
-    name: ({ store }) =>
-        store.settings.useCallAutoFocus ? _t("Disable speaker autofocus") : _t("Autofocus speaker"),
-    isActive: ({ store }) => store.settings?.useCallAutoFocus,
-    icon: ({ action }) => (action.isActive ? "fa fa-eye" : "fa fa-eye-slash"),
-    onSelected: ({ store }) => (store.settings.useCallAutoFocus = !store.settings.useCallAutoFocus),
-    sequence: 50,
-    sequenceGroup: 200,
-});
 registerCallAction("fullscreen", {
     btnClass: ({ owner, channel }) =>
         attClassObjectToString({

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -97,6 +97,10 @@ export class CallSettings extends Component {
         this.store.settings.useBlur = ev.target.checked;
     }
 
+    onChangeCallAutoFocus() {
+        this.store.settings.useCallAutoFocus = !this.store.settings.useCallAutoFocus;
+    }
+
     onChangeShowOnlyVideo(ev) {
         const showOnlyVideo = ev.target.checked;
         this.store.settings.showOnlyVideo = Boolean(showOnlyVideo);

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -99,6 +99,13 @@
                     <t t-set="onchange" t-value="onChangeShowOnlyVideo"/>
                 </t>
             </div>
+            <div class="d-flex flex-column my-1">
+                <t t-call="discuss.CallSettings.textToggler">
+                    <t t-set="text">Auto-focus speaker</t>
+                    <t t-set="value" t-value="store.settings.useCallAutoFocus"/>
+                    <t t-set="onchange" t-value="onChangeCallAutoFocus"/>
+                </t>
+            </div>
             <div t-if="store.settings.hasCanvasFilterSupport" class="d-flex flex-column my-1 o-discuss-CallSettings-item">
                 <t t-call="discuss.CallSettings.textToggler">
                     <t t-set="text">Blur video background</t>

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -188,8 +188,9 @@ test("call auto focus is 'off", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Start Call']");
-    await click(".o-discuss-CallActionList [title='More']");
-    await contains(".o-dropdown-item:contains('Autofocus speaker')");
+    await click("button[aria-label='Video Settings']");
+    await click(".o-discuss-QuickVideoSettings button:has(:text('Advanced Settings'))");
+    await contains("input[title='Auto-focus speaker']:not(:checked)");
     // correct local storage values
     const useCallAutoFocusKey = makeRecordFieldLocalId(Settings.localId(), "useCallAutoFocus");
     expect(localStorage.getItem(useCallAutoFocusKey)).toBe(toRawValue(false));

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -61,12 +61,8 @@ test("basic rendering", async () => {
     await contains(".o-discuss-CallActionList button[aria-label='Turn camera on']");
     await contains("button[aria-label='Video Settings']");
     await contains(".o-discuss-CallActionList button[aria-label='Share Screen']");
-    await contains("[title='More']");
+    await contains("button[aria-label='Raise Hand']");
     await contains(".o-discuss-CallActionList button[aria-label='Disconnect']");
-    await click("[title='More']");
-    await contains(".o-dropdown-item", { count: 2 });
-    await contains(".o-dropdown-item:contains('Raise Hand')");
-    await contains(".o-dropdown-item:contains('Disable speaker autofocus')");
     await contains(".o-discuss-Call-layoutActions button", { count: 2 });
     await contains(".o-discuss-Call-layoutActions button[title='Picture in Picture']");
     await contains(".o-discuss-Call-layoutActions button[title='Fullscreen']");
@@ -217,11 +213,9 @@ test("can share screen", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Start Call']");
-    await click("[title='More']");
     await click("[title='Share Screen']");
     await contains("video");
     await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
-    await click("[title='More']");
     await click("[title='Stop Sharing Screen']");
     await contains("video", { count: 0 });
 });
@@ -299,7 +293,6 @@ test("Can share user camera and screen together", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Start Call']");
-    await click("[title='More']");
     await click("[title='Share Screen']");
     await click("[title='Turn camera on']");
     await contains("video", { count: 2 });
@@ -311,7 +304,6 @@ test("Click on inset card should replace the inset and active stream together", 
     await start();
     await openDiscuss(channelId);
     await click("[title='Start Call']");
-    await click("[title='More']");
     await click("[title='Share Screen']");
     await click("[title='Turn camera on']");
     await contains("video[type='screen']:not(.o-inset)");
@@ -472,12 +464,10 @@ test("Systray icon shows latest action", async () => {
     await contains(".o-discuss-CallMenu-buttonContent .fa-deaf");
     await click("[title='Turn camera on']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-video-camera");
-    await click("[title='More']");
     await click("[title='Share Screen']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-desktop");
     await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
-    await click("[title='More']");
-    await click(".o-dropdown-item:contains('Raise Hand')");
+    await click("[title='Raise Hand']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-hand-paper-o");
 });
 
@@ -488,7 +478,6 @@ test("Systray icon keeps track of earlier actions", async () => {
     await openDiscuss(channelId);
     await click("[title='Start Call']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-microphone");
-    await click("[title='More']");
     await click("[title='Share Screen']");
     // stack: ["share-screen"]
     await contains(".o-discuss-CallMenu-buttonContent .fa-desktop");
@@ -800,7 +789,6 @@ test("shows warning on infinite mirror effect (screen-sharing then fullscreen)",
     await start();
     await openDiscuss(channelId);
     await click("[title='Start Call']");
-    await click("[title='More']");
     await click("[title='Share Screen']");
     await contains("video");
     await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
@@ -905,11 +893,9 @@ test("dynamic focus switches to talking participant", async () => {
     await contains(".o-discuss-CallParticipantCard[title='Alice']");
     rtc.updateSessionInfo({ [aliceSessionId]: { isTalking: false } });
     await contains(".o-discuss-CallParticipantCard[title='Bob']");
-    await click("[title='More']");
-    await click(".o-dropdown-item:contains('Disable speaker autofocus')");
-    await contains(".o-dropdown-item", { count: 0 });
-    await click("[title='More']");
-    await contains(".o-dropdown-item:contains('Autofocus speaker')");
+    await click("button[aria-label='Video Settings']");
+    await click(".o-discuss-QuickVideoSettings button:has(:text('Advanced Settings'))");
+    await click("input[title='Auto-focus speaker']:checked");
 });
 
 test("should not show context menu on participant card when not in a call", async () => {

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -60,6 +60,7 @@ test("Renders the call settings", async () => {
     await contains("span", { text: "Voice detection sensitivity" });
     await contains("button", { text: "Test" });
     await contains("label", { text: "Show video participants only" });
+    await contains("label", { text: "Auto-focus speaker" });
     await contains("label", { text: "Blur video background" });
 });
 


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Reorder More action buttons

**Desired behavior after PR is merged:**
- Raise Hand is now displayed as a standalone primary action button.
- Auto-Focus Speaker has been relocated to `Voice & Video Settings`
since it is considered an advanced control.

Before:
<img width="300" height="119" alt="image" src="https://github.com/user-attachments/assets/d5ec013b-1df3-43d9-89cf-7d659877de32" />

After:
<img width="278" height="47" alt="image" src="https://github.com/user-attachments/assets/2fc67d5c-58df-42ce-9f44-14bf40efdcd6" />

<img width="571" height="610" alt="image" src="https://github.com/user-attachments/assets/6bae5c4c-bb7f-4f7b-bf80-14055599685b" /><br/>



task - [5380388](https://www.odoo.com/odoo/project/1519/tasks/5380388)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
