### PR TITLE
[FIX] portal_rating: default options for admin users

### DIFF
--- a/addons/portal_rating/static/src/js/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/js/portal_rating_composer.js
@@ -125,9 +125,15 @@ const RatingPopupComposer = publicWidget.Widget.extend({
         this._reloadRatingPopupComposer();
     },
 
+    /**
+     * Update the widget options using data received from the mail composer or popup rating composer
+     *
+     * @param {Object} data
+     * @private
+     */
     _update_options: function (data) {
         const message = data["mail.message"] && data["mail.message"][0];
-        const defaultOptions = {
+        const updatedOptions = {
             default_message:
                 data.default_message || (message && message.body.replace(/<[^>]+>/g, "")),
             default_message_id:
@@ -141,8 +147,9 @@ const RatingPopupComposer = publicWidget.Widget.extend({
             default_rating_value:
                 data.default_rating_value || this.rating_value || 4,
         };
-        Object.assign(data, defaultOptions);
-        this.options = Object.assign(this.options, data);
+        if (message?.author && message.author.id === this.options.partner_id) {
+            Object.assign(this.options, data, updatedOptions);
+        }
     },
 });
 

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -234,3 +234,82 @@ registry.category("web_tour.tours").add("course_review_modification", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("course_review_modification_by_admin", {
+    url: "/slides",
+    steps: () => [
+        {
+            trigger: "a:text(Basics of Gardening - Test)",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            trigger: "a[id=review-tab]:text(Reviews (1))",
+            run: "click",
+        },
+        {
+            trigger: ".o_rating_popup_composer span:text(Add Review)",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains(Non admin user review) .o_website_rating_static[title='3 stars on 5']",
+            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Expand']",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-moreMenu [title='Edit']",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer-input",
+            run: "edit Admin edited this review.",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message a:text(save)",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-body:contains(Admin edited this review.)",
+        },
+        // If it fails here, it means that the default values have changed after the admin edited someone else's review.
+        {
+            trigger: ".o_rating_popup_composer span:text(Add Review)",
+            run: "click",
+        },
+        {
+            trigger: "div.o_portal_chatter_composer textarea",
+            run: "edit New comment from admin",
+        },
+        {
+            trigger:
+                ".modal.modal_shown.show button.o_portal_chatter_composer_btn:text(Post review)",
+            run: "click",
+        },
+        {
+            trigger: "a[id=review-tab]:text(Reviews (2))",
+            run: "click",
+        },
+        {
+            trigger: ".o_rating_popup_composer span:text(Edit Review)",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-body:contains(Admin edited this review.)",
+            run: "hover && click #chatterRoot:shadow .o-mail-Message:contains(Admin edited this review.) [title='Expand']",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-moreMenu [title='Delete']",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow button:text(Confirm)",
+            run: "click",
+        },
+        {
+            trigger: "a[id=review-tab]:text(Reviews (1))",
+            run: "click",
+        },
+        // If it fails here, it means that the default values have changed after the admin deleted someone else's review.
+        {
+            trigger: ".o_rating_popup_composer span:text(Edit Review)",
+        },
+    ],
+});

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -250,6 +250,19 @@ class TestUi(TestUICommon):
         self.user_portal.karma = 20
         self.start_tour("/slides", "course_review_modification", login=self.user_portal.login)
 
+    def test_course_review_modification_by_admin(self):
+        self.channel.message_post(
+            body="Non admin user review",
+            message_type="comment",
+            rating_value="3",
+            subtype_xmlid="mail.mt_comment"
+        )
+        self.start_tour(
+            "/slides",
+            "course_review_modification_by_admin",
+            login=self.user_admin.login,
+        )
+
     def test_fullscreen_slide_text_highlights(self):
         self.env['slide.slide'].create({
             'name': 'Article test',


### PR DESCRIPTION
*: website_slides

The default values for the admin user should not be changed by editing or deleting others' messages in courses.

task-5326273

