### PR TITLE
[FIX] web: Hoot - remove error if no tests

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -1741,7 +1741,7 @@ export class Runner {
         this._populateState = false;
 
         if (!this.state.tests.length) {
-            throw new HootError(`no tests to run`, { level: "critical" });
+            logger.logGlobal(`no tests to run`);
         }
 
         // Reduce non-included suites & tests info to a miminum


### PR DESCRIPTION
This commit replaces the error thrown if there is no test found by a log.

runbot-234051