### PR TITLE
[IMP] lunch: change time format from 12-hour to 24-hour

### DIFF
--- a/addons/lunch/tests/common.py
+++ b/addons/lunch/tests/common.py
@@ -102,7 +102,6 @@ class TestsCommon(common.TransactionCase):
                 'name': 'New York UTC-5',
                 'mode': 'chat',
                 'notification_time': 10,
-                'notification_moment': 'am',
                 'tz': 'America/New_York',
                 'message': "",
             }).with_context(tz='America/New_York')
@@ -111,7 +110,6 @@ class TestsCommon(common.TransactionCase):
                 'name': 'Tokyo UTC+9',
                 'mode': 'chat',
                 'notification_time': 8,
-                'notification_moment': 'am',
                 'tz': 'Asia/Tokyo',
                 'message': "",
             }).with_context(tz='Asia/Tokyo')

--- a/addons/lunch/views/lunch_alert_views.xml
+++ b/addons/lunch/views/lunch_alert_views.xml
@@ -54,10 +54,7 @@
                             </div>
                             <div class="o_col">
                                 <widget name="week_days"/>
-                                <div class="o_row" invisible="mode != 'chat'">
-                                    <field name="notification_time" required="mode == 'chat'" widget="float_time"/>
-                                    <field name="notification_moment"/>
-                                </div>
+                                <field name="notification_time" invisible="mode != 'chat'" required="mode == 'chat'" widget="float_time"/>
                             </div>
                             <field name="tz" groups="base.group_no_one"/>
                         </group>
@@ -82,8 +79,7 @@
                             <field name="mode"/>
                             <span invisible="mode != 'chat'">
                                 to <field name="recipients"/>
-                                on <field name="notification_time"/>
-                                <field name="notification_moment"/>
+                                on <field name="notification_time" widget="float_time"/>
                             </span>
                         </div>
                         <field name="location_ids" widget="many2many_tags"/>

--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -56,8 +56,7 @@
                             <field name="delivery"/>
                             <field name="available_location_ids" widget="many2many_tags"/>
                             <field name="send_by" widget="radio"/>
-                            <label for="automatic_email_time" invisible="send_by != 'mail'"/>
-                            <div class="o_row" invisible="send_by != 'mail'"><field name="automatic_email_time" widget="float_time"/> <field name="moment"/></div>
+                            <field name="automatic_email_time" widget="float_time" invisible="send_by != 'mail'"/>
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
Before this commit, the lunch module automatic_email_time and notification_time
time field used a 12-hour format with AM/PM.

Changes:
 - Use a 24-hour time format instead of AM/PM for vendor notifications to ensure clarity and consistency.
 - Remove the unused time_to_float function.
 - Move the local float_to_time helper to lunch_alert, as it is no longer used in lunch_supplier and should be kept close to its remaining usage.

Impact:
Users now see time in 24-hour format without AM/PM.

task-5270259


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
