### PR TITLE
[IMP] hr_expense: Bill reference duplicate prevention

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1577,6 +1577,11 @@ class HrExpense(models.Model):
         return_vals = []
         for employee_sudo, expenses_sudo in self.sudo().grouped('employee_id').items():
             multiple_expenses_name = _("Expenses of %(employee)s", employee=employee_sudo.name)
+            if (len(expenses_sudo) > 1):
+                latest_date = expenses_sudo[0].date
+                for expense in expenses_sudo:
+                    latest_date = max(latest_date, expense.date)
+                multiple_expenses_name = _("Expenses of %(employee)s", employee=employee_sudo.name + " " + format_date(env=self.env, value=latest_date, date_format="medium"))
             move_ref = expenses_sudo.name if len(expenses_sudo) == 1 else multiple_expenses_name
             return_vals.append({
             **expenses_sudo._prepare_move_vals(),


### PR DESCRIPTION
Before :
If several expenses of one employee are posted simultaneously then the bill reference for one employee is always stay the same,  causing the bill duplicate warning to be triggered as it is based on the bill reference

After:
If several expenses of one employee are posted simultaneously then the most recent date is appended behind the bill reference.

Task : 5262550

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
