### PR TITLE
[REF] spreadsheet: centralize addEmptyGranularity in pivot_helper

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_helpers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_helpers.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { EvaluationError, helpers } from "@odoo/o-spreadsheet";
 
-const { isDateOrDatetimeField } = helpers;
+const { isDateOrDatetimeField, parseDimension } = helpers;
 
 /**
  * @typedef {import("@odoo/o-spreadsheet").Token} Token
@@ -90,4 +90,17 @@ export function parseGroupField(allFields, groupFieldString) {
 
 export function domainHasNoRecordAtThisPosition(domain) {
     return domain.some((node) => node.value === "NO_RECORD_AT_THIS_POSITION");
+}
+
+export function addEmptyGranularity(groupBys, fields) {
+    return groupBys.map((g) => {
+        const dimension = parseDimension(g);
+        if (isDateOrDatetimeField(fields[dimension.fieldName])) {
+            return {
+                granularity: "month",
+                ...dimension,
+            };
+        }
+        return dimension;
+    });
 }

--- a/addons/spreadsheet/static/tests/helpers/pivot.js
+++ b/addons/spreadsheet/static/tests/helpers/pivot.js
@@ -1,27 +1,14 @@
 import { PivotArchParser } from "@web/views/pivot/pivot_arch_parser";
 import { OdooPivot } from "@spreadsheet/pivot/odoo_pivot";
+import { addEmptyGranularity } from "@spreadsheet/pivot/pivot_helpers";
 import { getBasicPivotArch, getPyEnv } from "@spreadsheet/../tests/helpers/data";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
-import { helpers } from "@odoo/o-spreadsheet";
-const { parseDimension, isDateOrDatetimeField } = helpers;
 
 /**
  * @typedef {import("@spreadsheet").OdooSpreadsheetModel} OdooSpreadsheetModel
  * @typedef {import("@spreadsheet").Zone} Zone
  */
-
-function addEmptyGranularity(dimensions, fields) {
-    return dimensions.map((dimension) => {
-        if (dimension.fieldName !== "id" && isDateOrDatetimeField(fields[dimension.fieldName])) {
-            return {
-                granularity: "month",
-                ...dimension,
-            };
-        }
-        return dimension;
-    });
-}
 
 async function insertStaticPivot(model, pivotId, params) {
     const ds = model.getters.getPivot(pivotId);
@@ -85,14 +72,8 @@ export async function insertPivotInSpreadsheet(model, pivotId, params) {
             aggregator: pyEnv[resModel]._fields[measure]?.aggregator,
         })),
         model: resModel,
-        columns: addEmptyGranularity(
-            archInfo.colGroupBys.map(parseDimension),
-            pyEnv[resModel]._fields
-        ),
-        rows: addEmptyGranularity(
-            archInfo.rowGroupBys.map(parseDimension),
-            pyEnv[resModel]._fields
-        ),
+        columns: addEmptyGranularity(archInfo.colGroupBys, pyEnv[resModel]._fields),
+        rows: addEmptyGranularity(archInfo.rowGroupBys, pyEnv[resModel]._fields),
         name: "Partner Pivot",
         actionXmlId: params.actionXmlId,
     };


### PR DESCRIPTION
## Description

Current behavior before PR:
- The addEmptyGranularity function was duplicated across multiple places,
  leading to redundant code and harder maintenance.

Desired behavior after PR is merged:
- The addEmptyGranularity function is moved to pivot_helper so it can
  be reused from anywhere without redefining it in several places.

Task: [5253761](https://www.odoo.com/odoo/project/2328/tasks/5253761)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
