### PR TITLE
[FIX] im_livechat: do not allow visitor to start calls

### DIFF
--- a/addons/im_livechat/controllers/rtc.py
+++ b/addons/im_livechat/controllers/rtc.py
@@ -12,7 +12,7 @@ class LivechatRtcController(RtcController):
     @add_guest_to_context
     def channel_call_join(self, channel_id, check_rtc_session_ids=None, camera=False):
         # sudo: discuss.channel - visitor can check if there is an ongoing call
-        if request.env.user.is_public and request.env["discuss.channel"].sudo().search([
+        if not request.env.user._is_internal() and request.env["discuss.channel"].sudo().search([
             ("id", "=", channel_id),
             ("channel_type", "=", "livechat"),
             ("rtc_session_ids", "=", False),

--- a/addons/im_livechat/tests/test_call.py
+++ b/addons/im_livechat/tests/test_call.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import tagged, HttpCase, JsonRpcException
+from odoo.tests.common import new_test_user, tagged, HttpCase, JsonRpcException
 
 
 @tagged("post_install", "-at_install")
@@ -12,16 +12,28 @@ class TestCall(HttpCase):
         livechat_channel = self.env["im_livechat.channel"].create(
             {"name": "Test Livechat Channel", "user_ids": [operator.id]}
         )
-        data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {
-                "anonymous_name": "Visitor",
-                "channel_id": livechat_channel.id,
-                "persisted": True,
-            },
-        )
-        with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
-            self.make_jsonrpc_request(
-                "/mail/rtc/channel/join_call",
-                {"channel_id": data["channel_id"]},
+        for pseudo_user in [
+            new_test_user(self.env, "portal_user", groups="base.group_portal"),
+            self.env["mail.guest"].create({"name": "Guest"}),
+        ]:
+            user = pseudo_user if pseudo_user._name == "res.users" else self.env["res.users"]
+            guest = pseudo_user if pseudo_user._name == "mail.guest" else self.env["mail.guest"]
+            if user:
+                self.authenticate(user.login, user.login)
+            else:
+                self.authenticate(None, None)
+            if guest:
+                self.opener.cookies[guest._cookie_name] = guest._format_auth_cookie()
+            data = self.make_jsonrpc_request(
+                "/im_livechat/get_session",
+                {
+                    "anonymous_name": "Visitor",
+                    "channel_id": livechat_channel.id,
+                    "persisted": True,
+                },
             )
+            with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
+                self.make_jsonrpc_request(
+                    "/mail/rtc/channel/join_call",
+                    {"channel_id": data["channel_id"]},
+                )


### PR DESCRIPTION
In [1], we fixed an issue where the start call button would be visible to portal partners. We do not want visitors to initiate calls on live chats.

However, there also is a guard in the `rtc` controller which only checks that public users cannot start calls. The server code should also be adapted to properly ensure no live chat visitor can start a call.

[1]: https://github.com/odoo/odoo/pull/236272

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
