### PR TITLE
[FIX] web: remove unnecessary scrollbars in notebook

### DIFF
--- a/addons/web/static/src/core/notebook/notebook.scss
+++ b/addons/web/static/src/core/notebook/notebook.scss
@@ -9,6 +9,7 @@
     .o_notebook_headers {
         margin: 0 var(--Notebook-margin-x, 0);
         overflow-x: auto;
+        overflow-y: hidden;
 
         @include media-breakpoint-down(md) {
             &::-webkit-scrollbar {

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -527,6 +527,7 @@
 
                 > .o_field_html .note-editable {
                     min-height: 180px;
+                    overflow-y: hidden;
                     &:hover, &:focus {
                         border-color: transparent;
                     }


### PR DESCRIPTION
This commit removes extraneous scrollbars that could appear in notebook headers or in HTML fields inside notebooks, depending on the content and browser zoom level.

task-5283167
