### PR TITLE
[IMP] account: Use invoice_label for tax name in invoice tax computation

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -962,7 +962,7 @@ class AccountMoveLine(models.Model):
                 amount_currency = line.amount_currency
                 handle_price_include = False
                 quantity = 1
-            compute_all_currency = line.tax_ids.compute_all(
+            compute_all_currency = line.with_context(is_invoice=line.move_id.is_invoice(True)).tax_ids.compute_all(
                 amount_currency,
                 currency=line.currency_id,
                 quantity=quantity,

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -896,6 +896,7 @@ class AccountTax(models.Model):
         taxes_vals = []
         i = 0
         cumulated_tax_included_amount = 0
+        fname = 'invoice_label' if self._context.get('is_invoice', False) else 'name'
         for tax in taxes:
             price_include = self._context.get('force_price_include', tax.price_include)
 
@@ -968,7 +969,7 @@ class AccountTax(models.Model):
 
                 taxes_vals.append({
                     'id': tax.id,
-                    'name': partner and tax.with_context(lang=partner.lang).name or tax.name,
+                    'name': partner and tax.with_context(lang=partner.lang)[fname] or tax.name,
                     'amount': sign * line_amount,
                     'base': float_round(sign * tax_base_amount, precision_rounding=prec),
                     'sequence': tax.sequence,


### PR DESCRIPTION
When computing taxes for invoice lines, the system should use the `invoice_label` field instead of the default `name` field to display tax information. This allows invoices to show more appropriate tax labels that may differ from the internal tax name.

Technical details:
- Added `is_invoice` context when calling `tax_ids.compute_all()` in `account.move.line._compute_all_tax()` method
- Modified `account.tax.compute_all()` to check for `is_invoice` context and select appropriate field name (`invoice_label` for invoices, `name` for other documents)
- The selected field name is used when building the tax values dictionary
  returned by `compute_all()`

This change ensures that invoice tax lines display the correct label as defined in the tax's `invoice_label` field, which is particularly useful for localized tax reporting requirements where the invoice label may differ from the internal tax name.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
