### PR TITLE
[IMP] mail: discuss call improvements

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.js
+++ b/addons/mail/static/src/discuss/call/common/device_select.js
@@ -3,6 +3,7 @@ import { Component, onWillDestroy, onWillStart, useState } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
+import { isBrowserChrome } from "@web/core/browser/feature_detection";
 
 const deviceKind = new Set(["audioinput", "videoinput", "audiooutput"]);
 
@@ -23,6 +24,7 @@ export class DeviceSelect extends Component {
             userDevices: [],
         });
         this.abortController = new AbortController();
+        this.isBrowserChrome = isBrowserChrome();
         onWillStart(async () => {
             if (!browser.navigator.mediaDevices) {
                 // zxing-js: isMediaDevicesSuported or canEnumerateDevices is false.
@@ -61,6 +63,24 @@ export class DeviceSelect extends Component {
         }
     }
 
+    async showPermissionDialog(kind) {
+        if (kind === "videoinput") {
+            if (this.store.rtc.cameraPermission === "denied") {
+                this.store.rtc.showMediaUnavailableWarning({ camera: true });
+            } else {
+                this.store.rtc.showMediaPermissionDialog("camera");
+                return;
+            }
+        } else {
+            if (this.store.rtc.microphonePermission === "denied") {
+                this.store.rtc.showMediaUnavailableWarning({ microphone: true });
+            } else {
+                this.store.rtc.showMediaPermissionDialog("microphone");
+                return;
+            }
+        }
+    }
+
     isSelected(id) {
         switch (this.props.kind) {
             case "audioinput":
@@ -84,5 +104,12 @@ export class DeviceSelect extends Component {
                 this.store.settings.audioOutputDeviceId = ev.target.value;
                 return;
         }
+    }
+
+    isPermissionGranted(kind) {
+        if (kind === "videoinput") {
+            return this.store.rtc.cameraPermission === "granted";
+        }
+        return this.store.rtc.microphonePermission === "granted";
     }
 }

--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -2,8 +2,22 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallDeviceSelect">
-        <select name="inputDevice" class="form-select d-flex shadow-sm" t-on-change="onChangeSelectAudioInput">
-            <option value="">Browser default</option>
+        <select
+            t-if="!isPermissionGranted(props.kind)"
+            name="inputDevice"
+            class="form-select d-flex shadow-sm"
+            t-on-pointerdown.prevent="() => this.showPermissionDialog(props.kind)"
+            t-on-keydown.prevent="() => this.showPermissionDialog(props.kind)"
+        >
+            <option value="">Permission Needed</option>
+        </select>
+        <select
+            t-else=""
+            name="inputDevice"
+            class="form-select d-flex shadow-sm"
+            t-on-change="onChangeSelectAudioInput"
+        >
+            <option t-if="!isBrowserChrome" value="">Browser Default</option>
             <t t-foreach="state.userDevices" t-as="device" t-key="device_index">
                 <option t-if="device.kind === props.kind" t-att-selected="isSelected(device.deviceId)" t-att-value="device.deviceId">
                     <t t-esc="device.label || 'device ' + device_index"/>

--- a/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.QuickVideoSettings">
         <div class="o-discuss-QuickVideoSettings d-flex flex-column gap-1">
-            <label class="btn border-transparent d-flex flex-column align-items-baseline">
+            <label class="btn border-transparent d-flex flex-column align-items-baseline cursor-default">
                 <span class="flex-shrink-0 pe-2">
                     Camera
                 </span>
@@ -12,7 +12,7 @@
             </label>
             <div t-if="!isBrowserSafari()" class="btn border-transparent d-flex gap-2" t-on-click="() => store.settings.useBlur = !store.settings.useBlur">
                 <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer gap-2">
-                    <i class="fa fa-fw fa-photo"/><span class="text-truncate text-wrap">Blur background</span>
+                    <i class="fa fa-fw fa-photo"/><span class="text-truncate text-wrap">Blur Background</span>
                 </label>
                 <div class="flex-grow-1"/>
                 <div class="form-check form-switch">
@@ -20,7 +20,7 @@
                 </div>
             </div>
             <button class="btn border-transparent d-flex align-items-center gap-2" t-on-click="onClickVideoSettings">
-                <i class="fa fa-fw fa-gear"/><span>Video Settings</span>
+                <i class="fa fa-fw fa-gear"/><span>Advanced Settings</span>
             </button>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/call/common/quick_voice_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_voice_settings.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.QuickVoiceSettings">
         <div class="o-discuss-QuickVoiceSettings d-flex flex-column gap-1">
-            <label class="btn border-transparent d-flex flex-column align-items-baseline">
+            <label class="btn border-transparent d-flex flex-column align-items-baseline cursor-default">
                 <span class="flex-shrink-0 pe-2">
                     Microphone
                 </span>
@@ -20,7 +20,7 @@
                     <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.use_push_to_talk ? 'checked' : ''"/>
                 </div>
             </button>
-            <label class="btn border-transparent d-flex flex-column align-items-baseline">
+            <label class="btn border-transparent d-flex flex-column align-items-baseline cursor-default">
                 <span class="flex-shrink-0 pe-2">
                     Speakers
                 </span>

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -253,7 +253,10 @@ test("device input/output id", async () => {
     localStorage.setItem("mail_user_setting_audio_input_device_id", "audio_input_2_id");
     localStorage.setItem("mail_user_setting_audio_output_device_id", "audio_output_2_id");
     localStorage.setItem("mail_user_setting_camera_input_device_id", "video_input_2_id");
-    await start();
+    const env = await start();
+    const rtc = env.services["discuss.rtc"];
+    rtc.microphonePermission = "granted";
+    rtc.cameraPermission = "granted";
     await openDiscuss(channelId);
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -39,7 +39,8 @@ test("Renders the call settings", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchUiSize({ size: SIZES.SM });
-    await start();
+    const env = await start();
+    const rtc = env.services["discuss.rtc"];
     await openDiscuss(channelId);
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");
@@ -49,7 +50,10 @@ test("Renders the call settings", async () => {
     await contains("label[aria-label='Camera']");
     await contains("label[aria-label='Microphone']");
     await contains("label[aria-label='Speakers']");
+    await contains("option", { textContent: "Permission Needed", count: 3 });
+    rtc.microphonePermission = "granted";
     await contains("option[value=mockAudioDeviceId]");
+    rtc.cameraPermission = "granted";
     await contains("option[value=mockVideoDeviceId]");
     await contains("button", { text: "Voice Detection" });
     await contains("button", { text: "Push to Talk" });


### PR DESCRIPTION
This commit removes the 'Browser Default' placeholder for audio/video device 
selection on Chromium-based browsers, as they already return their own default 
device and the placeholder causes confusion.

The device-selection dropdown will now display 'Permission Needed' when 
permissions are not granted. Clicking the dropdown will trigger the permission 
dialog if the necessary permissions are not granted.

labels have also been improved for better clarity.

Part of Task-5227387

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
