### PR TITLE
[FIX] web: popover positioning improvements

### DIFF
--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -135,7 +135,15 @@ function computePosition(popper, target, { container, flip, margin, position, sh
     // Boxes
     const popBox = popper.getBoundingClientRect();
     const targetBox = target.getBoundingClientRect();
-    const contBox = container.getBoundingClientRect();
+    const contRect = container.getBoundingClientRect();
+    // Shrink the container a little bit (up to 20px) so that the popper avoids sticking to its edges
+    const getContainerMargin = (val) => Math.min(20, Math.max(0, Math.round((val - 40) / 2)));
+    const contBox = {
+        top: contRect.top + getContainerMargin(contRect.height),
+        left: contRect.left + getContainerMargin(contRect.width),
+        right: contRect.right - getContainerMargin(contRect.width),
+        bottom: contRect.bottom - getContainerMargin(contRect.height),
+    };
     const iframeBox = iframe?.getBoundingClientRect() ?? { top: 0, left: 0 };
 
     const containerIsHTMLNode = container === container.ownerDocument.firstElementChild;

--- a/addons/web/static/src/views/calendar/hooks/calendar_popover_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/calendar_popover_hook.js
@@ -6,7 +6,7 @@ import { useComponent, useExternalListener } from "@odoo/owl";
 export function useCalendarPopover(component) {
     const owner = useComponent();
     let popoverClass = "";
-    const popoverOptions = { position: "right", onClose: cleanup };
+    const popoverOptions = { onClose: cleanup };
     Object.defineProperty(popoverOptions, "popoverClass", { get: () => popoverClass });
     const popover = usePopover(component, popoverOptions);
     const dialog = useService("dialog");

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -455,6 +455,7 @@ test("arrow follows target and can get sucked", async () => {
         }
         .popover-target {
             background-color: bisque;
+            margin-left: 20px;
             width: 50px;
             height: 50px;
         }

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -674,8 +674,8 @@ test("popper as child of another", async () => {
     class Parent extends Component {
         static components = { Child };
         static template = /* xml */ xml`
-            <div id="container" t-ref="container" style="background-color: salmon; display: flex; align-items: center; justify-content: center; width: 450px; height: 450px; margin: 25px; overflow: auto">
-                <div id="target" t-ref="target" style="background-color: tomato; width: 200px; height: 600px"/>
+            <div id="container" t-ref="container" style="background-color: salmon; display: flex; align-items: center; justify-content: center; width: 450px; height: 350px; margin: 25px; overflow: auto">
+                <div id="target" t-ref="target" style="background-color: tomato; width: 200px; height: 500px"/>
                 <div id="popper" t-ref="popper"><Child/></div>
             </div>
         `;
@@ -790,8 +790,14 @@ function shrinkPopperTest(position, offset, onPositioned, popperStyle = {}) {
                     container: () => container.el,
                     onPositioned(el) {
                         expect.step("onPositioned");
+                        const contRect = container.el.getBoundingClientRect();
                         onPositioned({
-                            c: container.el.getBoundingClientRect(),
+                            c: {
+                                top: contRect.top + 20,
+                                left: contRect.left + 20,
+                                right: contRect.right - 20,
+                                bottom: contRect.bottom - 20,
+                            },
                             p: el.getBoundingClientRect(),
                             t: target.el.getBoundingClientRect(),
                         });
@@ -975,156 +981,138 @@ function getRepositionTest(from, to, containerStyleChanges) {
 }
 
 // -----------------------------------------------------------------------------
+test("reposition from top-start to top", getRepositionTest("top-start", "bottom-start", "top"));
 test(
-    "reposition from top-start to bottom-start",
-    getRepositionTest("top-start", "bottom-start", "top")
+    "reposition from top-start to top right",
+    getRepositionTest("top-start", "bottom-start", "top right")
 );
 test(
-    "reposition from top-start to bottom-end",
-    getRepositionTest("top-start", "bottom-end", "top right")
-);
-test(
-    "reposition from top-start to top-start",
+    "reposition from top-start to slimfit bottom",
     getRepositionTest("top-start", "top-start", "slimfit bottom")
 );
-test("reposition from top-start to top-end", getRepositionTest("top-start", "top-end", "right"));
+test("reposition from top-start to right", getRepositionTest("top-start", "top-start", "right"));
 // -----------------------------------------------------------------------------
+test("reposition from top-middle to top", getRepositionTest("top-middle", "bottom-middle", "top"));
 test(
-    "reposition from top-middle to bottom-middle",
-    getRepositionTest("top-middle", "bottom-middle", "top")
-);
-test(
-    "reposition from top-middle to top-middle",
+    "reposition from top-middle to slimfit bottom",
     getRepositionTest("top-middle", "top-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
+test("reposition from top-end to top left", getRepositionTest("top-end", "bottom-end", "top left"));
+test("reposition from top-end to top", getRepositionTest("top-end", "bottom-end", "top"));
+test("reposition from top-end to left", getRepositionTest("top-end", "top-end", "left"));
 test(
-    "reposition from top-end to bottom-start",
-    getRepositionTest("top-end", "bottom-start", "top left")
-);
-test("reposition from top-end to bottom-end", getRepositionTest("top-end", "bottom-end", "top"));
-test("reposition from top-end to top-start", getRepositionTest("top-end", "top-start", "left"));
-test(
-    "reposition from top-end to top-end",
+    "reposition from top-end to slimfit bottom",
     getRepositionTest("top-end", "top-end", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
+test("reposition from left-start to left", getRepositionTest("left-start", "right-start", "left"));
 test(
-    "reposition from left-start to right-start",
-    getRepositionTest("left-start", "right-start", "left")
+    "reposition from left-start to left bottom",
+    getRepositionTest("left-start", "right-start", "left bottom")
 );
 test(
-    "reposition from left-start to right-end",
-    getRepositionTest("left-start", "right-end", "left bottom")
-);
-test(
-    "reposition from left-start to left-start",
+    "reposition from left-start to slimfit top",
     getRepositionTest("left-start", "left-start", "slimfit top")
 );
 test(
-    "reposition from left-start to left-end",
-    getRepositionTest("left-start", "left-end", "bottom")
+    "reposition from left-start to bottom",
+    getRepositionTest("left-start", "left-start", "bottom")
 );
 // -----------------------------------------------------------------------------
 test(
-    "reposition from left-middle to right-middle",
+    "reposition from left-middle to left",
     getRepositionTest("left-middle", "right-middle", "left")
 );
 test(
-    "reposition from left-middle to left-middle",
+    "reposition from left-middle to slimfit bottom",
     getRepositionTest("left-middle", "left-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
 test(
-    "reposition from left-end to right-start",
-    getRepositionTest("left-end", "right-start", "left top")
+    "reposition from left-end to left top",
+    getRepositionTest("left-end", "right-end", "left top")
 );
-test("reposition from left-end to right-end", getRepositionTest("left-end", "right-end", "left"));
-test("reposition from left-end to left-start", getRepositionTest("left-end", "left-start", "top"));
+test("reposition from left-end to left", getRepositionTest("left-end", "right-end", "left"));
+test("reposition from left-end to top", getRepositionTest("left-end", "left-end", "top"));
 test(
-    "reposition from left-end to left-end",
+    "reposition from left-end to slimfit bottom",
     getRepositionTest("left-end", "left-end", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
 test(
-    "reposition from bottom-start to bottom-start",
+    "reposition from bottom-start to slimfit top",
     getRepositionTest("bottom-start", "bottom-start", "slimfit top")
 );
 test(
-    "reposition from bottom-start to bottom-end",
-    getRepositionTest("bottom-start", "bottom-end", "right")
+    "reposition from bottom-start to right",
+    getRepositionTest("bottom-start", "bottom-start", "right")
 );
 test(
-    "reposition from bottom-start to top-start",
+    "reposition from bottom-start to bottom",
     getRepositionTest("bottom-start", "top-start", "bottom")
 );
 test(
-    "reposition from bottom-start to top-end",
-    getRepositionTest("bottom-start", "top-end", "bottom right")
+    "reposition from bottom-start to bottom right",
+    getRepositionTest("bottom-start", "top-start", "bottom right")
 );
 // -----------------------------------------------------------------------------
 test(
-    "reposition from bottom-middle to bottom-middle",
+    "reposition from bottom-middle to slimfit top",
     getRepositionTest("bottom-middle", "bottom-middle", "slimfit top")
 );
 test(
-    "reposition from bottom-middle to top-middle",
+    "reposition from bottom-middle to bottom",
     getRepositionTest("bottom-middle", "top-middle", "bottom")
 );
 // -----------------------------------------------------------------------------
+test("reposition from bottom-end to left", getRepositionTest("bottom-end", "bottom-end", "left"));
 test(
-    "reposition from bottom-end to bottom-start",
-    getRepositionTest("bottom-end", "bottom-start", "left")
-);
-test(
-    "reposition from bottom-end to bottom-end",
+    "reposition from bottom-end to slimfit top",
     getRepositionTest("bottom-end", "bottom-end", "slimfit top")
 );
 test(
-    "reposition from bottom-end to top-start",
-    getRepositionTest("bottom-end", "top-start", "bottom left")
+    "reposition from bottom-end to bottom left",
+    getRepositionTest("bottom-end", "top-end", "bottom left")
 );
-test("reposition from bottom-end to top-end", getRepositionTest("bottom-end", "top-end", "bottom"));
+test("reposition from bottom-end to bottom", getRepositionTest("bottom-end", "top-end", "bottom"));
 // -----------------------------------------------------------------------------
 test(
-    "reposition from right-start to right-start",
+    "reposition from right-start to slimfit top",
     getRepositionTest("right-start", "right-start", "slimfit top")
 );
 test(
-    "reposition from right-start to right-end",
-    getRepositionTest("right-start", "right-end", "bottom")
+    "reposition from right-start to bottom",
+    getRepositionTest("right-start", "right-start", "bottom")
 );
 test(
-    "reposition from right-start to left-start",
+    "reposition from right-start to right",
     getRepositionTest("right-start", "left-start", "right")
 );
 test(
-    "reposition from right-start to left-end",
-    getRepositionTest("right-start", "left-end", "right bottom")
+    "reposition from right-start to right bottom",
+    getRepositionTest("right-start", "left-start", "right bottom")
 );
 // -----------------------------------------------------------------------------
 test(
-    "reposition from right-middle to right-middle",
+    "reposition from right-middle to slimfit bottom",
     getRepositionTest("right-middle", "right-middle", "slimfit bottom")
 );
 test(
-    "reposition from right-middle to left-middle",
+    "reposition from right-middle to right",
     getRepositionTest("right-middle", "left-middle", "right")
 );
 // -----------------------------------------------------------------------------
+test("reposition from right-end to top", getRepositionTest("right-end", "right-end", "top"));
 test(
-    "reposition from right-end to right-start",
-    getRepositionTest("right-end", "right-start", "top")
-);
-test(
-    "reposition from right-end to right-end",
+    "reposition from right-end to slimfit bottom",
     getRepositionTest("right-end", "right-end", "slimfit bottom")
 );
 test(
-    "reposition from right-end to left-start",
-    getRepositionTest("right-end", "left-start", "right top")
+    "reposition from right-end to right top",
+    getRepositionTest("right-end", "left-end", "right top")
 );
-test("reposition from right-end to left-end", getRepositionTest("right-end", "left-end", "right"));
+test("reposition from right-end to right", getRepositionTest("right-end", "left-end", "right"));
 
 function getFittingTest(position, styleAttribute) {
     return async () => {


### PR DESCRIPTION
This PR addresses two positioning issues:

- **Calendar**: Removed forced horizontal positioning. Popovers can now display below/above events, fixing layout issues with wide events.
- **Screen Edges**: Added a 20px buffer to the position calculation logic to prevent popovers from sticking to the edges of the screen/container.

task-4453491
