### PR TITLE
[IMP] point_of_sale: trigger product search on Enter key press

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -53,13 +53,17 @@ export class Navbar extends Component {
     }
 
     handleKeydown(event) {
-        const isEndCharacter = event.key?.match(/(Enter|Tab)/);
         const isSpecialKey =
             !["Control", "Alt"].includes(event.key) && (event.key?.length > 1 || event.metaKey);
 
         clearTimeout(this.timeout);
-        if (isEndCharacter) {
+        if (event.key === "Tab") {
             this.checkInput(event);
+        } else if (event.key === "Enter") {
+            this.checkInput(event);
+            if (event.target === this.inputRef?.el) {
+                this.pos.searchProductsFromDB();
+            }
         } else {
             if (!isSpecialKey) {
                 this.bufferedInput += event.key;

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -62,7 +62,7 @@
                         <p t-else="">There are no products in this category.</p>
                     </div>
                     <div t-if="searchWord" class="search-more-button d-flex justify-content-center m-2">
-                        <button class="btn btn-primary btn-lg lh-lg" t-on-click="onPressEnterKey">Search more</button>
+                        <button class="btn btn-primary btn-lg lh-lg" t-on-click="() => this.pos.searchProductsFromDB()">Search more</button>
                     </div>
                 </div>
                 <t t-if="ui.isSmall">


### PR DESCRIPTION
Before this commit:
- Pressing the Enter key while searching for products in the POS screen had no effect.
- Users were required to click the "Search More" button to perform a search.

After this commit:
- Pressing Enter now triggers the same product search action as the "Search More" button, improving usability and efficiency during product lookup.

task-4890054

Linked PR : https://github.com/odoo/enterprise/pull/100831
