### PR TITLE
[REF] mail: refactor hasMemberList

### DIFF
--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -26,5 +26,8 @@ const discussChannelPatch = {
     get chatChannelTypes() {
         return [...super.chatChannelTypes, "livechat"];
     },
+    get memberListTypes() {
+        return [...super.memberListTypes, "livechat"];
+    },
 };
 patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -18,9 +18,6 @@ patch(Thread.prototype, {
             this.channel.appAsLivechats?.defaultLivechatCategory
         );
     },
-    get hasMemberList() {
-        return this.channel?.channel_type === "livechat" || super.hasMemberList;
-    },
     get allowedToLeaveChannelTypes() {
         return [...super.allowedToLeaveChannelTypes, "livechat"];
     },

--- a/addons/im_livechat/static/src/embed/common/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/common/disabled_features.js
@@ -3,9 +3,6 @@ import { Thread } from "@mail/core/common/thread_model";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
-    get hasMemberList() {
-        return false;
-    },
     get hasAttachmentPanel() {
         return this.channel?.channel_type !== "livechat" && super.hasAttachmentPanel;
     },

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -66,6 +66,12 @@ export class DiscussChannel extends Record {
     }
     /** @type {"not_fetched"|"pending"|"fetched"} */
     fetchMembersState = "not_fetched";
+    get memberListTypes() {
+        return ["channel", "group"];
+    }
+    get hasMemberList() {
+        return this.memberListTypes.includes(this.channel_type);
+    }
     hasOtherMembersTyping = fields.Attr(false, {
         /** @this {import("models").Thread} */
         compute() {

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -266,9 +266,6 @@ const threadPatch = {
             this.isLoadingAttachments = false;
         }
     },
-    get hasMemberList() {
-        return ["channel", "group"].includes(this.channel?.channel_type);
-    },
     get hasSelfAsMember() {
         return Boolean(this.self_member_id);
     },


### PR DESCRIPTION
This commit refactors `hasMemberList`, it's moving to `discuss.channel` model and facilitates override by using a memberListTypes getter.

PR enterprise: https://github.com/odoo/enterprise/pull/99918