### PR TITLE
[FIX] core: check_access active_test

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4149,7 +4149,7 @@ class BaseModel(metaclass=MetaModel):
         if any(self._ids):
             Rule = self.env['ir.rule']
             domain = Rule._compute_domain(self._name, operation)
-            if domain and (forbidden := self - self.sudo().filtered_domain(domain)):
+            if domain and (forbidden := self - self.sudo().with_context(active_test=False).filtered_domain(domain)):
                 return forbidden, functools.partial(Rule._make_access_error, operation, forbidden)
 
         return None


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/219703, we ir.rule domain doesn't depend on active_test context key. But `_check_access` is still depending on active_test which is not consistent.

Fix it.
