### PR TITLE
[FIX] website_slides: rating cards background

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -62,6 +62,7 @@ $line-height-truncate: 1.5em;
         // transparent header/footer to be impacted and we also only want the
         // "box" of boxed layouts to be impacted (not the color behind the box).
         background-color: $o-wslides-color-bg;
+        --body-bg: #{$o-wslides-color-bg};
     }
 
     .o_wslides_home_nav {


### PR DESCRIPTION
PR #229272 sets the background color of the portal chatter to `body-bg`, aligning it correctly with the other parts of the chatter and website themes. However, `website_slides` module has a customized scss variable to change its main body background color which makes the background color for the rating cards (chatter top) being different in this module.
This change sets the `--body-bg` in this customized scss to the same variable used for the background color, aligning the background colors with each other.

Before:
<img width="1182" height="552" alt="image" src="https://github.com/user-attachments/assets/6aba4609-e99c-48de-8af7-a97029859fab" />


After:
<img width="1097" height="555" alt="image" src="https://github.com/user-attachments/assets/0d4ed53b-6d83-4eba-8499-0d38b10b4234" />


