### PR TITLE
[IMP] account: sending of invoices should happen in postcommit

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -163,7 +163,7 @@ class PaymentTransaction(models.Model):
                 if mail_template.exists():
                     send_context['mail_template'] = mail_template
 
-            tx.env['account.move.send']._generate_and_send_invoices(
+            tx.env['account.move.send']._generate_and_send_invoices_post_commit(
                 invoice_to_send,
                 **send_context,
             )


### PR DESCRIPTION
When the payment transactions trigger the creation of invoices and then the sending of those invoices by mail and through the EDI to the government, any concurrent update can make that entire process fail all at once.  This mainly happens when the user himself is paying through the portal as this will create the invoice from the payment.

When invoices are sent to the government however, we want to be sure that when sent, it gets updated in Odoo as well, so we are aware what is happening.

The problem we got is that invoice 1 is sent to the government (l10n_in_edi) as number 01 and then that transaction is totally rolled back that the invoice is not even there anymore, it risks that the government's numbers and your numbers do not correspond anymore.

So, we should avoid that that invoice can be sent when before there is a concurrent update (on payment transaction in this case) waiting for destroying it when committing.  So, the simple idea would be to only do the invoice sending through a post commit.  As we are locking the invoice itself for the sending to the government that should be enough to avoid the invoice sending for not being registered in Odoo.

We create one extra method in account and rename the called method in sale, because the methods for sending have a return value which is used in the wizard to directly inform the user.  We do not need those in the cron.

opw-5029676

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
