### PR TITLE
[IMP] website: add images to page layout option dropdown

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.scss
@@ -42,7 +42,7 @@
         }
     }
 
-    &:first-child:last-child {
+    &:first-child {
         .o-hb-select-toggle {
             --btn-padding-x: #{map-get($spacers , 2)};
         }

--- a/addons/html_builder/static/src/utils/utils.js
+++ b/addons/html_builder/static/src/utils/utils.js
@@ -13,26 +13,20 @@ export function getSnippetName(snippetEl) {
     if (snippetEl.dataset.name) {
         return snippetEl.dataset.name;
     }
-    if (snippetEl.matches("img")) {
-        return _t("Image");
-    }
-    if (snippetEl.matches(".fa")) {
-        return _t("Icon");
-    }
-    if (snippetEl.matches(".media_iframe_video")) {
-        return _t("Video");
-    }
-    if (snippetEl.parentNode?.matches(".row")) {
-        return _t("Column");
-    }
-    if (snippetEl.matches("#wrapwrap > main")) {
-        return _t("Page Options");
-    }
-    if (snippetEl.matches(".btn")) {
-        return _t("Button");
-    }
-    if (snippetEl.matches("[data-snippet=s_website_form]")) {
-        return _t("Form");
+    const snippetNameRules = [
+        { selector: "img", name: _t("Image") },
+        { selector: ".fa", name: _t("Icon") },
+        { selector: ".media_iframe_video", name: _t("Video") },
+        { selector: ".row > *", name: _t("Column") },
+        { selector: "#wrapwrap > main", name: _t("Page Options") },
+        { selector: ".btn", name: _t("Button") },
+        { selector: "[data-snippet=s_website_form]", name: _t("Form") },
+        { selector: "#wrapwrap", name: _t("Website") },
+    ];
+    for (const { selector, name } of snippetNameRules) {
+        if (snippetEl.matches(selector)) {
+            return name;
+        }
     }
     return _t("Block");
 }

--- a/addons/html_editor/static/src/utils/image.js
+++ b/addons/html_editor/static/src/utils/image.js
@@ -100,10 +100,12 @@ export function getImageSrc(el) {
     // The plugin transfer the `src` on a `span`, but parallax can be achieved via other means.
     // example: CSS variables without this DOM manipulation.
     // Decouple.
-    if (el.querySelector(".s_parallax_bg")) {
-        el = el.querySelector(".s_parallax_bg");
+    const parallaxEl = el.querySelector(":scope > .s_parallax_bg_wrap > .s_parallax_bg");
+    if (parallaxEl) {
+        el = parallaxEl;
     }
-    const url = backgroundImageCssToParts(el.style.backgroundImage).url;
+    const backgroundImage = el.style.backgroundImage || getComputedStyle(el).backgroundImage;
+    const url = backgroundImageCssToParts(backgroundImage).url;
     return url && getBgImageURLFromURL(url);
 }
 

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -29,23 +29,62 @@
         </BuilderRow>
         <BuilderRow label.translate="Page Layout">
             <BuilderSelect action="'customizeWebsiteVariable'" actionParam="'layout'">
-                <BuilderSelectItem actionValue="'full'" id="'layout_full_opt'">Full</BuilderSelectItem>
-                <BuilderSelectItem actionValue="'boxed'">Boxed</BuilderSelectItem>
-                <BuilderSelectItem actionValue="'framed'">Framed</BuilderSelectItem>
-                <BuilderSelectItem actionValue="'postcard'">Postcard</BuilderSelectItem>
+                <BuilderSelectItem actionValue="'full'" id="'layout_full_opt'" label.translate="Full">
+                    <Image attrs="{ style: 'margin-top: 10px !important;' }"
+                         src="'/website/static/src/img/snippets_options/page_layout_full.svg'"/>
+                    <span>Full</span>
+                </BuilderSelectItem>
+                <BuilderSelectItem actionValue="'boxed'" label.translate="Boxed">
+                    <Image attrs="{ style: 'margin-top: 10px !important;' }"
+                         src="'/website/static/src/img/snippets_options/page_layout_boxed.svg'"/>
+                    <span>Boxed</span>
+                </BuilderSelectItem>
+                <BuilderSelectItem actionValue="'framed'" label.translate="Framed">
+                    <Image attrs="{ style: 'margin-top: 10px !important;' }"
+                         src="'/website/static/src/img/snippets_options/page_layout_framed.svg'"/>
+                    <span>Framed</span>
+                </BuilderSelectItem>
+                <BuilderSelectItem actionValue="'postcard'" label.translate="Postcard">
+                    <Image attrs="{ style: 'margin-top: 10px !important;' }"
+                         src="'/website/static/src/img/snippets_options/page_layout_postcard.svg'"/>
+                    <span>Postcard</span>
+                </BuilderSelectItem>
             </BuilderSelect>
+            <BuilderButton
+                action="'toggleBodyBgImage'"
+                id="'body_bg_image_opt'"
+                title.translate="Image"
+                preview="false"
+                className="'ms-auto fa fa-fw fa-camera px-2'"
+            />
         </BuilderRow>
-        <BuilderRow label.translate="Background" level="1">
-            <BuilderColorPicker t-if="!this.isActiveItem('layout_full_opt')"
-                enabledTabs="['solid', 'custom']"
+        <BuilderRow label.translate="Background" level="1" t-if="!this.isActiveItem('layout_full_opt')">
+            <BuilderColorPicker enabledTabs="['solid', 'custom']"
                 action="'customizeWebsiteColor'"
                 actionParam="'body'"/>
-            <BuilderButtonGroup action="'customizeBodyBgType'">
-                <BuilderButton title.translate="Image" actionValue="'image'" className="'fa fa-fw fa-camera'"/>
-                <BuilderButton title.translate="Pattern" actionValue="'pattern'" className="'fa fa-fw fa-th'"/>
-                <BuilderButton title.translate="None" actionValue="'NONE'" className="'fa fa-fw fa-ban'"/>
-            </BuilderButtonGroup>
         </BuilderRow>
+        <BuilderRow label.translate="Image" level="1" t-if="this.isActiveItem('body_bg_image_opt')">
+            <BuilderButton action="'replaceBodyBgImage'" title.translate="Replace Image" preview="false" type="'global'">
+                Replace
+            </BuilderButton>
+            <BuilderButton action="'removeBodyBgImage'" preview="false" icon="'oi-close'" className="'btn-danger-color-hover'"/>
+            <ImageSize/>
+        </BuilderRow>
+        <BuilderRow label.translate="Position" level="1" t-if="this.isActiveItem('body_bg_image_opt')">
+            <BuilderSelect action="'customizeWebsiteVariable'" actionParam="'body-image-type'" preview="false">
+                <BuilderSelectItem actionValue="'image'">Cover</BuilderSelectItem>
+                <BuilderSelectItem actionValue="'pattern'" id="'body_bg_repeat_opt'">Repeat pattern</BuilderSelectItem>
+            </BuilderSelect>
+            <BuilderButton icon="'fa-crosshairs'" title.translate="Background Position" preview="false" action="'bodyBgPositionOverlay'"/>
+        </BuilderRow>
+        <BuilderContext t-if="isActiveItem('body_bg_repeat_opt')" action="'customizeWebsiteVariable'">
+            <BuilderRow label.translate="Width" level="2">
+                <BuilderNumberInput actionParam="'body-image-pattern-width'" placeholder.translate="auto" unit="'px'" min="1" default="null"/>
+            </BuilderRow>
+            <BuilderRow label.translate="Height" level="2">
+                <BuilderNumberInput actionParam="'body-image-pattern-height'" placeholder.translate="auto" unit="'px'" min="1" default="null"/>
+            </BuilderRow>
+        </BuilderContext>
     </BuilderContext>
 </t>
 

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -21,6 +21,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { CustomizeWebsiteVariableAction } from "../customize_website_plugin";
 import { EditHeadBodyDialog } from "@website/components/edit_head_body_dialog/edit_head_body_dialog";
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { ImageSize } from "@html_builder/plugins/image/image_size";
 
 /**
  * @typedef { Object } ThemeTabShared
@@ -69,12 +70,19 @@ export class ThemeTabPlugin extends Plugin {
         theme_options: [
             withSequence(
                 OPTION_POSITIONS.SETTINGS,
-                this.getThemeOptionBlock("website-settings", _t("Website"), [
-                    ThemeColorsOption,
-                    class ThemeWebsiteSettingsOption extends BaseOptionComponent {
-                        static template = "website.ThemeWebsiteSettingsOption";
-                    },
-                ])
+                this.getThemeOptionBlock(
+                    "website-settings",
+                    "",
+                    [
+                        ThemeColorsOption,
+                        class ThemeWebsiteSettingsOption extends BaseOptionComponent {
+                            static template = "website.ThemeWebsiteSettingsOption";
+                            static components = { ImageSize };
+                        },
+                    ],
+                    this.document.querySelector("#wrapwrap"),
+                    true
+                )
             ),
             withSequence(
                 OPTION_POSITIONS.PARAGRAPH,
@@ -227,11 +235,16 @@ export class ThemeTabPlugin extends Plugin {
         );
     }
 
-    getThemeOptionBlock(id, name, options) {
-        // TODO Have a specific kind of options container that takes the specific parameters like name, no element, no selector...
-        const el = this.document.createElement("div");
-        el.dataset.name = name;
-        this.document.body.appendChild(el); // Currently editingElement needs to be isConnected
+    getThemeOptionBlock(id, name, options, el = null, hasOverlayOptions = false) {
+        let divEl = null;
+        // TODO Have a specific kind of options container that takes the
+        // specific parameters like name, no element, no selector...
+        if (!el) {
+            divEl = this.document.createElement("div");
+            divEl.dataset.name = name;
+            this.document.body.appendChild(divEl); // Currently editingElement needs to be isConnected
+            el = divEl;
+        }
 
         const optionsArray = Array.isArray(options) ? options : [options];
         optionsArray.forEach((option) => {
@@ -241,7 +254,7 @@ export class ThemeTabPlugin extends Plugin {
         return {
             id: id,
             element: el,
-            hasOverlayOptions: false,
+            hasOverlayOptions,
             headerMiddleButton: false,
             isClonable: false,
             isRemovable: false,

--- a/addons/website/static/src/img/snippets_options/page_layout_boxed.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_boxed.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="87" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-341.08" y1="513.78" x2="-341.08" y2="511.93" gradientTransform="matrix(44, 0, 0, -17, 15050.29, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="12.04" y1="5.66" x2="73.26" y2="5.66" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="47.27" y="20.68" width="19.23" height="12.63" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="47.27" y="20.68" width="19.53" height="12.9" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-338.14" y1="514.3" x2="-338.27" y2="514.34" gradientTransform="matrix(32.81, 0, 0, -17.65, 11162.9, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="47.27" y="20.68" width="19.23" height="12.76" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-342.8" y1="519.42" x2="-343" y2="519.4" gradientTransform="matrix(61.88, 0, 0, -25.41, 21267.5, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g id="Boxed">
+    <g>
+      <rect x="12.04" y="11.33" width="61.21" height="31.31" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+      <g>
+        <g>
+          <rect id="path-2" x="18.42" y="22.03" width="22.11" height="1.88"/>
+          <rect id="path-2-2" data-name="path-2" x="18.42" y="22.03" width="22.11" height="1.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-3" data-name="path-2" x="18.42" y="25.8" width="19.24" height="0.88" fill="#fff"/>
+          <rect id="path-2-4" data-name="path-2" x="18.42" y="25.8" width="19.24" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-5" data-name="path-2" x="18.42" y="28.43" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-6" data-name="path-2" x="18.42" y="28.43" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-7" data-name="path-2" x="18.42" y="31.06" width="19.24" height="0.88" fill="#fff"/>
+          <rect id="path-2-8" data-name="path-2" x="18.42" y="31.06" width="19.24" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g id="Group">
+        <rect id="Rectangle" x="12.04" width="61.21" height="11.33" fill="url(#linear-gradient-2)"/>
+      </g>
+      <g id="Group-4" opacity="0.8">
+        <g id="Group-2" data-name="Group">
+          <path id="Rectangle-2" data-name="Rectangle" d="M61.57,4.92V6.41H29.4V4.92Z" fill="#fff"/>
+        </g>
+      </g>
+      <path id="Rectangle-3" data-name="Rectangle" d="M66,4.36h2.85A1.24,1.24,0,0,1,70,5.66h0A1.24,1.24,0,0,1,68.84,7H66a1.24,1.24,0,0,1-1.17-1.3h0A1.25,1.25,0,0,1,66,4.36Z" fill="#fff"/>
+      <path id="Rectangle-4" data-name="Rectangle" d="M16.27,4.36h8.87a1,1,0,0,1,1,1.1v.41a1,1,0,0,1-1,1.09H16.27a1,1,0,0,1-1-1.09V5.46A1,1,0,0,1,16.27,4.36Z" fill="#fff"/>
+      <g>
+        <rect x="46.9" y="20.28" width="19.99" height="13.42" fill="#fff"/>
+        <g>
+          <rect id="path-1-4" data-name="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#79d1f2"/>
+          <g mask="url(#mask)">
+            <ellipse cx="63.68" cy="23.91" rx="2.07" ry="2.11" fill="#f3ec60"/>
+          </g>
+          <g mask="url(#mask-2-2)">
+            <path d="M66.6,33.39c0-.21.51-3.63-.09-3.64h-.19c-4,0-7.44,1.5-8.51,3.56C57.58,33.74,66.6,33.57,66.6,33.39Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+          </g>
+          <g mask="url(#mask-3)">
+            <path d="M47.27,33.31c3.21,0,13.41.25,13.36,0-.71-3.24-5.77-5.76-13.36-6.18Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+          </g>
+        </g>
+        <path d="M66.88,20.28V33.7h-20V20.28Zm-.37.4H47.27V33.31H66.51Z" fill="#fff" fill-rule="evenodd"/>
+      </g>
+      <rect x="12.04" y="42.64" width="61.21" height="19.31" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+      <g>
+        <circle cx="54.66" cy="52.29" r="1.39" fill="#fff"/>
+        <circle cx="60" cy="52.29" r="1.39" fill="#fff"/>
+        <circle cx="65.49" cy="52.29" r="1.39" fill="#fff"/>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-9" data-name="path-2" x="35.84" y="49.22" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-10" data-name="path-2" x="35.84" y="49.22" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-11" data-name="path-2" x="35.84" y="51.85" width="9.41" height="0.88" fill="#fff"/>
+          <rect id="path-2-12" data-name="path-2" x="35.84" y="51.85" width="9.41" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-13" data-name="path-2" x="35.84" y="54.49" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-14" data-name="path-2" x="35.84" y="54.49" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-15" data-name="path-2" x="18.42" y="49.21" width="8.28" height="0.88" fill="#fff"/>
+          <rect id="path-2-16" data-name="path-2" x="18.42" y="49.21" width="8.28" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-17" data-name="path-2" x="18.42" y="51.84" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-18" data-name="path-2" x="18.42" y="51.84" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-19" data-name="path-2" x="18.42" y="54.47" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-20" data-name="path-2" x="18.42" y="54.47" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+    </g>
+  </g>
+  <rect x="0" y="0" width="85.26" height="61.95" fill="none" stroke="#767684" stroke-width="2"/>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_framed.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_framed.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="87" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-437.08" y1="513.44" x2="-437.08" y2="511.93" gradientTransform="matrix(44, 0, 0, -17, 19274.28, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="12.05" y1="11.33" x2="73.27" y2="11.33" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="48.25" y="24.13" width="17.31" height="11.37" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="48.25" y="24.13" width="17.57" height="11.61" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-433.41" y1="514.17" x2="-433.53" y2="514.2" gradientTransform="matrix(32.81, 0, 0, -17.65, 14287.87, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="48.25" y="24.13" width="17.31" height="11.48" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-439.44" y1="519.33" x2="-439.62" y2="519.3" gradientTransform="matrix(61.88, 0, 0, -25.41, 27247.69, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g id="Framed">
+    <g>
+      <rect x="12.05" y="16.99" width="61.21" height="25.65" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+      <g>
+        <g>
+          <rect id="path-2" x="19.53" y="25.35" width="19.9" height="1.7"/>
+          <rect id="path-2-2" data-name="path-2" x="19.53" y="25.35" width="19.9" height="1.7" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-3" data-name="path-2" x="19.53" y="28.74" width="17.31" height="0.79" fill="#fff"/>
+          <rect id="path-2-4" data-name="path-2" x="19.53" y="28.74" width="17.31" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-5" data-name="path-2" x="19.53" y="31.11" width="14.74" height="0.79" fill="#fff"/>
+          <rect id="path-2-6" data-name="path-2" x="19.53" y="31.11" width="14.74" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-7" data-name="path-2" x="19.53" y="33.48" width="17.31" height="0.79" fill="#fff"/>
+          <rect id="path-2-8" data-name="path-2" x="19.53" y="33.48" width="17.31" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g id="Group">
+        <rect id="Rectangle" x="12.05" y="5.66" width="61.21" height="11.33" fill="url(#linear-gradient-2)"/>
+      </g>
+      <g id="Group-4" opacity="0.8">
+        <g id="Group-2" data-name="Group">
+          <path id="Rectangle-2" data-name="Rectangle" d="M61.58,10.58v1.5H29.42v-1.5Z" fill="#fff"/>
+        </g>
+      </g>
+      <path id="Rectangle-3" data-name="Rectangle" d="M66,10h2.85A1.24,1.24,0,0,1,70,11.33h0a1.24,1.24,0,0,1-1.17,1.3H66a1.24,1.24,0,0,1-1.16-1.3h0A1.24,1.24,0,0,1,66,10Z" fill="#fff"/>
+      <path id="Rectangle-4" data-name="Rectangle" d="M16.29,10h8.86a1,1,0,0,1,1,1.09v.41a1,1,0,0,1-1,1.1H16.29a1,1,0,0,1-1-1.1v-.41A1,1,0,0,1,16.29,10Z" fill="#fff"/>
+      <g>
+        <rect x="47.91" y="23.78" width="17.99" height="12.08" fill="#fff"/>
+        <g>
+          <rect id="path-1-4" data-name="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#79d1f2"/>
+          <g mask="url(#mask)">
+            <ellipse cx="63.01" cy="27.04" rx="1.87" ry="1.9" fill="#f3ec60"/>
+          </g>
+          <g mask="url(#mask-2-2)">
+            <path d="M65.64,35.57c0-.19.46-3.26-.08-3.27h-.17c-3.63,0-6.7,1.35-7.66,3.2C57.52,35.89,65.64,35.74,65.64,35.57Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+          </g>
+          <g mask="url(#mask-3)">
+            <path d="M48.25,35.5c2.88,0,12.07.23,12,0-.64-2.91-5.2-5.18-12-5.56Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+          </g>
+        </g>
+        <path d="M65.9,23.78V35.85h-18V23.78Zm-.34.35H48.25V35.5H65.56Z" fill="#fff" fill-rule="evenodd"/>
+      </g>
+      <rect x="12.05" y="42.64" width="61.22" height="13.65" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+      <g>
+        <circle cx="53.41" cy="49.46" r="1.25" fill="#fff"/>
+        <circle cx="58.21" cy="49.46" r="1.25" fill="#fff"/>
+        <circle cx="63.16" cy="49.46" r="1.25" fill="#fff"/>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-9" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-10" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-11" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff"/>
+          <rect id="path-2-12" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-13" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-14" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-15" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff"/>
+          <rect id="path-2-16" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-17" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-18" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-19" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-20" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+    </g>
+  </g>
+  <rect x="0" y="0" width="85.26" height="61.95" fill="none" stroke="#767684" stroke-width="2"/>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_full.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_full.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="87" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-247.54" y1="513.78" x2="-247.54" y2="511.93" gradientTransform="matrix(44, 0, 0, -17, 10934.29, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="0" y1="5.67" x2="85.27" y2="5.67" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="49.01" y="19.22" width="23.75" height="15.61" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="49.01" y="19.22" width="24.11" height="15.95" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-245.13" y1="514.22" x2="-245.29" y2="514.27" gradientTransform="matrix(32.81, 0, 0, -17.65, 8117.83, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="49.01" y="19.22" width="23.75" height="15.77" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-248.56" y1="519.39" x2="-248.81" y2="519.36" gradientTransform="matrix(61.88, 0, 0, -25.41, 15440.22, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g id="Full">
+    <g>
+      <rect y="11.34" width="85.26" height="31.36" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+      <g>
+        <g>
+          <rect id="path-2" x="12.05" y="22.06" width="22.81" height="1.89"/>
+          <rect id="path-2-2" data-name="path-2" x="12.05" y="22.06" width="22.81" height="1.89" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-3" data-name="path-2" x="12.05" y="25.84" width="19.84" height="0.88" fill="#fff"/>
+          <rect id="path-2-4" data-name="path-2" x="12.05" y="25.84" width="19.84" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-5" data-name="path-2" x="12.05" y="28.47" width="16.9" height="0.88" fill="#fff"/>
+          <rect id="path-2-6" data-name="path-2" x="12.05" y="28.47" width="16.9" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-7" data-name="path-2" x="12.05" y="31.11" width="19.84" height="0.88" fill="#fff"/>
+          <rect id="path-2-8" data-name="path-2" x="12.05" y="31.11" width="19.84" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g id="Group">
+        <rect id="Rectangle" width="85.27" height="11.34" fill="url(#linear-gradient-2)"/>
+      </g>
+      <g id="Group-4" opacity="0.8">
+        <g id="Group-2" data-name="Group">
+          <path id="Rectangle-2" data-name="Rectangle" d="M69,5.24V7H24.2V5.24Z" fill="#fff"/>
+        </g>
+      </g>
+      <path id="Rectangle-3" data-name="Rectangle" d="M75.13,3.87h4a1.83,1.83,0,0,1,1.62,2h0a1.83,1.83,0,0,1-1.62,2h-4a1.83,1.83,0,0,1-1.62-2h0A1.83,1.83,0,0,1,75.13,3.87Z" fill="#fff"/>
+      <path id="Rectangle-4" data-name="Rectangle" d="M6,3.87H18.29a1.54,1.54,0,0,1,1.37,1.67v.63a1.54,1.54,0,0,1-1.37,1.67H6A1.54,1.54,0,0,1,4.6,6.17V5.54A1.54,1.54,0,0,1,6,3.87Z" fill="#fff"/>
+      <g>
+        <rect x="48.54" y="18.74" width="24.68" height="16.59" fill="#fff"/>
+        <g>
+          <rect id="path-1-4" data-name="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#79d1f2"/>
+          <g mask="url(#mask)">
+            <ellipse cx="69.26" cy="23.22" rx="2.56" ry="2.61" fill="#f3ec60"/>
+          </g>
+          <g mask="url(#mask-2-2)">
+            <path d="M72.86,34.94c0-.26.64-4.48-.11-4.49h-.23c-5,0-9.18,1.85-10.51,4.39C61.73,35.38,72.86,35.16,72.86,34.94Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+          </g>
+          <g mask="url(#mask-3)">
+            <path d="M49,34.84c4,.07,16.55.32,16.48,0-.87-4-7.12-7.11-16.48-7.64Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+          </g>
+        </g>
+        <path d="M73.22,18.74V35.33H48.54V18.74Zm-.47.48H49V34.84H72.75Z" fill="#fff" fill-rule="evenodd"/>
+      </g>
+      <rect y="42.7" width="85.27" height="19.25" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+      <g>
+        <circle cx="58.83" cy="52.37" r="1.55" fill="#fff"/>
+        <circle cx="65.02" cy="52.37" r="1.55" fill="#fff"/>
+        <circle cx="71.2" cy="52.37" r="1.55" fill="#fff"/>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-9" data-name="path-2" x="33.24" y="49.28" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-10" data-name="path-2" x="33.24" y="49.28" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-11" data-name="path-2" x="33.24" y="51.92" width="13.95" height="0.88" fill="#fff"/>
+          <rect id="path-2-12" data-name="path-2" x="33.24" y="51.92" width="13.95" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-13" data-name="path-2" x="33.24" y="54.55" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-14" data-name="path-2" x="33.24" y="54.55" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-15" data-name="path-2" x="11.94" y="49.28" width="12.26" height="0.88" fill="#fff"/>
+          <rect id="path-2-16" data-name="path-2" x="11.94" y="49.28" width="12.26" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-17" data-name="path-2" x="11.94" y="51.92" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-18" data-name="path-2" x="11.94" y="51.92" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-19" data-name="path-2" x="11.94" y="54.55" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-20" data-name="path-2" x="11.94" y="54.55" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_postcard.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_postcard.svg
@@ -1,0 +1,114 @@
+<svg id="Postcard" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="87" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-535.26" y1="513.44" x2="-535.26" y2="512.27" gradientTransform="matrix(44, 0, 0, -17, 23594.27, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="12.05" y1="5.66" x2="73.27" y2="5.66" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="46.82" y="21.3" width="17.31" height="11.37" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="46.82" y="21.3" width="17.57" height="11.61" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-530.86" y1="514.33" x2="-530.97" y2="514.36" gradientTransform="matrix(32.81, 0, 0, -17.65, 17483.86, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="46.82" y="21.3" width="17.31" height="11.48" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-538.3" y1="519.44" x2="-538.48" y2="519.41" gradientTransform="matrix(61.88, 0, 0, -25.41, 33363.79, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="12.05" y="16.99" width="61.21" height="19.99" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+    <g>
+      <g>
+        <rect id="path-2" x="20.85" y="22.52" width="18.92" height="1.7"/>
+        <rect id="path-2-2" data-name="path-2" x="20.85" y="22.52" width="18.92" height="1.7" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-3" data-name="path-2" x="20.85" y="25.91" width="16.46" height="0.79" fill="#fff"/>
+        <rect id="path-2-4" data-name="path-2" x="20.85" y="25.91" width="16.46" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-5" data-name="path-2" x="20.85" y="28.28" width="14.02" height="0.79" fill="#fff"/>
+        <rect id="path-2-6" data-name="path-2" x="20.85" y="28.28" width="14.02" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-7" data-name="path-2" x="20.85" y="30.65" width="16.46" height="0.79" fill="#fff"/>
+        <rect id="path-2-8" data-name="path-2" x="20.85" y="30.65" width="16.46" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+    </g>
+    <g id="Group">
+      <rect id="Rectangle" x="12.05" width="61.21" height="11.33" fill="url(#linear-gradient-2)"/>
+    </g>
+    <g id="Group-4" opacity="0.8">
+      <g id="Group-2" data-name="Group">
+        <path id="Rectangle-2" data-name="Rectangle" d="M61.58,4.92V6.41H29.42V4.92Z" fill="#fff"/>
+      </g>
+    </g>
+    <path id="Rectangle-3" data-name="Rectangle" d="M66,4.36h2.85A1.25,1.25,0,0,1,70,5.66h0A1.24,1.24,0,0,1,68.85,7H66a1.24,1.24,0,0,1-1.16-1.3h0A1.24,1.24,0,0,1,66,4.36Z" fill="#fff"/>
+    <path id="Rectangle-4" data-name="Rectangle" d="M16.29,4.36h8.86a1,1,0,0,1,1,1.1v.41a1,1,0,0,1-1,1.09H16.29a1,1,0,0,1-1-1.09V5.46A1,1,0,0,1,16.29,4.36Z" fill="#fff"/>
+    <g>
+      <rect x="46.48" y="20.95" width="17.99" height="12.08" fill="#fff"/>
+      <g>
+        <rect id="path-1-4" data-name="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#79d1f2"/>
+        <g mask="url(#mask)">
+          <ellipse cx="61.59" cy="24.21" rx="1.87" ry="1.9" fill="#f3ec60"/>
+        </g>
+        <g mask="url(#mask-2-2)">
+          <path d="M64.21,32.74c0-.19.47-3.26-.08-3.27H64c-3.63,0-6.69,1.35-7.66,3.2C56.1,33.06,64.21,32.91,64.21,32.74Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+        </g>
+        <g mask="url(#mask-3)">
+          <path d="M46.82,32.67c2.89,0,12.07.23,12,0-.64-2.91-5.19-5.18-12-5.56Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+        </g>
+      </g>
+      <path d="M64.47,21V33h-18V21Zm-.34.35H46.82V32.67H64.13Z" fill="#fff" fill-rule="evenodd"/>
+    </g>
+    <rect x="12.04" y="42.64" width="61.21" height="13.65" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+    <g>
+      <circle cx="53.41" cy="49.46" r="1.25" fill="#fff"/>
+      <circle cx="58.21" cy="49.46" r="1.25" fill="#fff"/>
+      <circle cx="63.16" cy="49.46" r="1.25" fill="#fff"/>
+    </g>
+    <g>
+      <g opacity="0.6">
+        <rect id="path-2-9" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-10" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-11" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff"/>
+        <rect id="path-2-12" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-13" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-14" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+    </g>
+    <g>
+      <g opacity="0.6">
+        <rect id="path-2-15" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff"/>
+        <rect id="path-2-16" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-17" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-18" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-19" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-20" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+    </g>
+  </g>
+  <rect x="0" y="0" width="85.26" height="61.95" fill="none" stroke="#767684" stroke-width="2"/>
+</svg>

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -111,7 +111,8 @@ export function changeOption(
 ) {
     const noPalette = allowPalette
         ? ""
-        : !document.querySelector(".o_popover .o_font_color_selector") && ".o_customize_tab";
+        : !document.querySelector(".o_popover .o_font_color_selector") &&
+          ".o-tab-content > [role='tabpanel']";
     const option_block = `${noPalette} [data-container-title='${blockName}']`;
     return {
         trigger: `${option_block} ${actionId}, ${option_block} [data-action-id="${actionId}"]`,

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2109,6 +2109,9 @@ $o-base-website-values-palette: (
 
     'body-image': null,
     'body-image-type': 'image', // 'image' or 'pattern'
+    'body-image-pattern-width': null,
+    'body-image-pattern-height': null,
+    'body-image-background-position': null,
 
     'layout': 'full', // 'full' / 'boxed'
     'color-palettes-name': null, // Default to the individual variables for each color palette type

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -186,15 +186,29 @@ $-seen-urls: ();
 
 @mixin body-image-bg-style() {
     background-image: url("#{str-slice(o-website-value('body-image'), 1)}");
-    background-position: center;
     background-attachment: fixed;
     @if o-website-value('body-image-type') == 'pattern' {
-        background-size: auto;
+        $pattern-width: o-website-value('body-image-pattern-width');
+        $pattern-height: o-website-value('body-image-pattern-height');
+        $pattern-size: auto;
+
+        @if $pattern-width and $pattern-height {
+            $pattern-size: $pattern-width $pattern-height;
+        } @else if $pattern-width {
+            $pattern-size: $pattern-width;
+        } @else if $pattern-height {
+            $pattern-size: auto $pattern-height;
+        }
+
+        background-size: $pattern-size;
         background-repeat: repeat;
     } @else {
         background-size: cover;
         background-repeat: no-repeat;
     }
+
+    background-position: o-website-value('body-image-background-position') or center;
+
 };
 
 // Manage custom offcanvas such as the one used for mobile mega menu nav

--- a/addons/website/static/tests/builder/website_builder/customize_website.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website.test.js
@@ -14,7 +14,7 @@ import {
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
 import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
-import { CustomizeBodyBgTypeAction } from "@website/builder/plugins/customize_website_plugin";
+import { ReplaceBgImageAction } from "@html_builder/plugins/background_option/background_image_option_plugin";
 import { renderToString } from "@web/core/utils/render";
 
 defineWebsiteModels();
@@ -431,19 +431,12 @@ test("theme background image is properly set", async () => {
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA" +
         "A".repeat(1000);
 
-    // Using historyImageSrc to avoid mocking the gallery dialog
-    patchWithCleanup(CustomizeBodyBgTypeAction.prototype, {
-        async load(editingElement) {
-            editingElement.historyImageSrc = { src: base64Image };
-            super.load(editingElement);
-        },
-        apply(params) {
-            params.loadResult = {
-                imageSrc: base64Image,
-                oldImageSrc: "",
-                oldValue: "'image'",
-            };
-            super.apply(params);
+    // To avoid mocking the media dialog
+    patchWithCleanup(ReplaceBgImageAction.prototype, {
+        async load() {
+            const img = document.createElement("img");
+            img.src = base64Image;
+            return img;
         },
     });
 
@@ -470,12 +463,8 @@ test("theme background image is properly set", async () => {
 
     await contains("[data-name='theme']").click();
     await animationFrame();
-    expect(
-        ".o_theme_tab button[data-action-id='customizeBodyBgType'][data-action-value='image']"
-    ).toHaveCount(1);
-    await contains(
-        ".o_theme_tab button[data-action-id='customizeBodyBgType'][data-action-value='image']"
-    ).click();
+    expect(".o_theme_tab button[data-action-id='toggleBodyBgImage']").toHaveCount(1);
+    await contains(".o_theme_tab button[data-action-id='toggleBodyBgImage']").click();
     await animationFrame();
     await expect.verifySteps(["scss_customization", "bundle_reload"]);
 });

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -1,5 +1,6 @@
 import { areCssValuesEqual } from "@html_builder/utils/utils_css";
 import {
+    changeOptionInPopover,
     clickOnEditAndWaitEditMode,
     clickOnSave,
     goToTheme,
@@ -138,17 +139,88 @@ registerWebsitePreviewTour(
         },
         ...clickOnEditAndWaitEditMode(),
         ...goToTheme(),
+        ...changeOptionInPopover("Website", "Page Layout", "Boxed"),
         {
-            trigger: "div[data-label='Background'] button[data-action-value='NONE'].active",
+            content: "Wait for the background color picker",
+            trigger: "[data-label='Background'] button.o_we_color_preview",
         },
         {
-            content: "Click on the Background Image selection",
-            trigger: "div[data-label='Background'] button[data-action-value='image']:not(.active)",
+            content: "Add a body background image",
+            trigger:
+                "div[data-label='Page Layout'] button[data-action-id='toggleBodyBgImage']:not(.active)",
             run: "click",
         },
         {
-            content: "The media dialog should open",
-            trigger: ".o_select_media_dialog",
+            content: "Pick the test image",
+            trigger: ".o_select_media_dialog .o_button_area[aria-label='bg_test.png']",
+            run: "click",
+        },
+        {
+            content: "Wait for image options to be visible",
+            trigger:
+                ".o_theme_tab button[data-action-id='replaceBodyBgImage'], .o_theme_tab button[data-action-id='removeBodyBgImage']",
+        },
+        ...changeOptionInPopover("Website", "Position", "Repeat pattern"),
+        {
+            content: "Set pattern width",
+            trigger: ".o_theme_tab [data-action-param='body-image-pattern-width'] > input",
+            run: "edit 123 && click body",
+        },
+        {
+            content: "Ensure pattern width applied",
+            trigger: ":iframe #wrapwrap",
+            async run({ anchor, waitUntil }) {
+                let size = "";
+                try {
+                    await waitUntil(
+                        () => {
+                            size = getComputedStyle(anchor).backgroundSize;
+                            return size.includes("123px");
+                        },
+                        {
+                            timeout: 8000,
+                        }
+                    );
+                } catch {
+                    throw new Error(`Expected background-size width to be 123px, got ${size}`);
+                }
+            },
+        },
+        {
+            content: "Set pattern height",
+            trigger: ".o_theme_tab [data-action-param='body-image-pattern-height'] > input",
+            run: "edit 77 && click body",
+        },
+        {
+            content: "Ensure pattern size applied",
+            trigger: ":iframe #wrapwrap",
+            async run({ anchor, waitUntil }) {
+                let size = "";
+                try {
+                    await waitUntil(
+                        () => {
+                            size = getComputedStyle(anchor).backgroundSize;
+                            return size.includes("123px") && size.includes("77px");
+                        },
+                        {
+                            timeout: 8000,
+                        }
+                    );
+                } catch {
+                    throw new Error(
+                        `Expected background-size to include 123px and 77px, got ${size}`
+                    );
+                }
+            },
+        },
+        {
+            content: "Remove the body background image",
+            trigger: ".o_theme_tab button[data-action-id='removeBodyBgImage']",
+            run: "click",
+        },
+        {
+            content: "Image controls should be hidden",
+            trigger: ".o_theme_tab :not(:has(button[data-action-id='replaceBodyBgImage'])",
         },
     ]
 );

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -395,6 +395,13 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_1', login='admin')
 
     def test_08_website_style_custo(self):
+        self.env['ir.attachment'].create({
+            'public': True,
+            'type': 'url',
+            'url': '/web/image/123/bg_test.png',
+            'name': 'bg_test.png',
+            'mimetype': 'image/png',
+        })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')
 
     def test_09_website_edit_link_popover(self):


### PR DESCRIPTION
**Expand page layout background options**

Steps to reproduce:

- Go to Website > Edit.
- Open the Theme tab and the Page Layout dropdown.

Before this commit the layout picker showed only text, the background
controls were laid out differently from snippet options, and there was
no way to set pattern size or the background position.

After this commit the layout dropdown shows thumbnails, the theme tab
mirrors snippet background options, and adds pattern sizing and
background position controls.

task-2359250
