### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: “Refresh status” no longer fetches docs

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
@@ -30,10 +30,6 @@ class AccountJournal(models.Model):
         self.env['account.move']._cron_nilvera_get_new_einvoice_purchase_documents()
 
     def button_refresh_out_einvoices_status(self):
-        """ Extends account to get the status from Nilvera for all processing invoices in
-        all journals and fetches E-Invoice, & E-Archive invoices from nilvera
-        """
+        # EXTENDS 'account'
         super().button_refresh_out_einvoices_status()
         self.env['account.move']._cron_nilvera_get_invoice_status()
-        self.env['account.move']._cron_nilvera_get_new_einvoice_sale_documents()
-        self.env['account.move']._cron_nilvera_get_new_earchive_sale_documents()


### PR DESCRIPTION
The “Refresh e-Invoices status” button previously also triggered the crons that fetch eArchive and eInvoice sales documents, mixing status updates with document synchronization.

This change scopes the button to status updates only. Fetching eArchive/eInvoice sales documents remains handled by their scheduled crons.

task-5344128
