### PR TITLE
[FIX] account: fix cash basis tax calculation for full payments

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -515,6 +515,7 @@ class AccountPartialReconcile(models.Model):
         for move_values in tax_cash_basis_values_per_move.values():
             move = move_values['move']
             pending_cash_basis_lines = []
+            amount_residual_per_tax_line = {line.id: line.amount_residual_currency for line_type, line in move_values['to_process_lines'] if line_type == 'tax'}
 
             for partial_values in move_values['partials']:
                 partial = partial_values['partial']
@@ -554,8 +555,13 @@ class AccountPartialReconcile(models.Model):
                             move_values['is_fully_paid']
                             or line.currency_id.compare_amounts(abs(line.amount_residual_currency), abs(amount_currency)) < 0
                         )
+                        and partial_values == move_values['partials'][-1]
                     ):
-                        amount_currency = line.amount_residual_currency
+                        # If the move is supposed to be fully paid, and we're on the last partial for it,
+                        # put the remaining amount to avoid rounding issues
+                        amount_currency = amount_residual_per_tax_line[line.id]
+                    if caba_treatment == 'tax':
+                        amount_residual_per_tax_line[line.id] -= amount_currency
                     balance = partial_values['payment_rate'] and amount_currency / partial_values['payment_rate'] or 0.0
 
                     # ==========================================================================

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -5934,3 +5934,126 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         # Check that there is two exchanges for the two partials
         self.assertEqual(len(partials.mapped('exchange_move_id')), 2)
+
+    def test_reconcile_cash_basis_payment_term_full_amount(self):
+        """ Test cash basis accounting with a payment term with multiple installments but paying full amount.
+        When creating a payment for the full amount instead of the first installment,
+        the cash basis entries should have proportional tax amounts.
+        """
+        self.env.company.tax_exigibility = True
+
+        # Create payment term: 30% now, balance 60 days
+        payment_term = self.env['account.payment.term'].create({
+            'name': '30% now, balance 60 days',
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50.0,
+                    'nb_days': 0,
+                }),
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50.0,
+                    'nb_days': 60,
+                }),
+            ],
+        })
+
+        # Create invoice with cash basis tax and payment term
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2016-01-01',
+            'date': '2016-01-01',
+            'invoice_payment_term_id': payment_term.id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 99.99,
+                'tax_ids': [Command.set(self.cash_basis_tax_a_third_amount.ids)],
+            })],
+        })
+        invoice.action_post()
+
+        # Pay full amount instead of just the first 30%
+        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+                'payment_date': '2016-01-01',
+                'amount': 133.32,  # Full amount instead of 30%
+            })._create_payments()
+
+        tax_cash_basis_moves = self._get_caba_moves(invoice)
+        tax_lines = tax_cash_basis_moves.line_ids.filtered(
+            lambda l: l.account_id == self.tax_account_1 and l.credit > 0
+        ).sorted('id')
+        self.assertRecordValues(tax_lines, [
+            {'credit': 16.67, 'name': 'tax_1'},
+            {'credit': 16.66, 'name': 'tax_1'},
+        ])
+
+    def test_reconcile_cash_basis_payment_term_full_amount_two_invoices(self):
+        """ Test cash basis accounting with a payment term with multiple installments but paying full amount on 2
+        invoices at the same time
+        """
+        self.env.company.tax_exigibility = True
+
+        # Create payment term: 30% now, balance 60 days
+        payment_term = self.env['account.payment.term'].create({
+            'name': '30% now, balance 60 days',
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50.0,
+                    'nb_days': 0,
+                }),
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50.0,
+                    'nb_days': 60,
+                }),
+            ],
+        })
+
+        # Create invoice with cash basis tax and payment term
+        invoices = self.env['account.move'].create([
+            {
+                'move_type': 'out_invoice',
+                'partner_id': self.partner_a.id,
+                'invoice_date': '2016-01-01',
+                'date': '2016-01-01',
+                'invoice_payment_term_id': payment_term.id,
+                'invoice_line_ids': [Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 99.99,
+                    'tax_ids': [Command.set(self.cash_basis_tax_a_third_amount.ids)],
+                })],
+            },
+            {
+                'move_type': 'out_invoice',
+                'partner_id': self.partner_a.id,
+                'invoice_date': '2016-01-01',
+                'date': '2016-01-01',
+                'invoice_payment_term_id': payment_term.id,
+                'invoice_line_ids': [Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 99.99,
+                    'tax_ids': [Command.set(self.cash_basis_tax_a_third_amount.ids)],
+                })],
+            },
+        ])
+        invoices.action_post()
+
+        # Pay full amount instead of just the first 30%
+        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoices.ids).create({
+                'payment_date': '2016-01-01',
+                'amount': 266.64,  # Full amount of both invoices
+            })._create_payments()
+
+        tax_cash_basis_moves = self._get_caba_moves(invoices)
+        tax_lines = tax_cash_basis_moves.line_ids.filtered(
+            lambda l: l.account_id == self.tax_account_1 and l.credit > 0
+        ).sorted('id')
+        self.assertRecordValues(tax_lines, [
+            {'credit': 16.67, 'name': 'tax_1'},
+            {'credit': 16.66, 'name': 'tax_1'},
+            {'credit': 16.67, 'name': 'tax_1'},
+            {'credit': 16.66, 'name': 'tax_1'},
+        ])


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the `Accounting` module.
2. Enable cash basis taxes in
   `Accounting → Configuration → Settings → Taxes → Cash Basis`.
3. Create a tax, set `Tax Exigibility` to `Based on Payment`, and assign a
   `Cash Basis Transition Account`.
4. Create an invoice with the cash basis tax and a payment term such as
   `30% now, balance in 60 days`.
5. Record a full payment on the invoice instead of just the first installment.
6. Review the generated cash basis journal entries.

**Observed behavior:**
* Cash basis entries are created for the full tax amount, not proportionally.
* Paying the full invoice with payment terms causes duplicated tax entries.

This came from the fact that we didn't consider a move would be fully paid by
several lines at the same time, like with installments.

We now only put the leftover amount when the move is fully paid and we're on
the last partial.


Also fix the fact that paying 2 invoices at the same time in full does not benefit from the batches

opw-5061136




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
