### PR TITLE
[FIX] spreadsheet_edition: security errors when copying

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -28,7 +28,7 @@ class SpreadsheetDashboard(models.Model):
         string='Is Favorite',
         help='Indicates whether the dashboard is favorited by the current user'
     )
-    main_data_model_ids = fields.Many2many('ir.model')
+    main_data_model_ids = fields.Many2many('ir.model', copy=False)
 
     @api.depends_context('uid')
     @api.depends('favorite_user_ids')

--- a/addons/test_spreadsheet/__manifest__.py
+++ b/addons/test_spreadsheet/__manifest__.py
@@ -15,5 +15,5 @@
     'depends': ['spreadsheet'],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
-    'data': ['security/ir.model.access.csv'],
+    'data': ['security/spreadsheet_test_security.xml', 'security/ir.model.access.csv'],
 }

--- a/addons/test_spreadsheet/security/ir.model.access.csv
+++ b/addons/test_spreadsheet/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_spreadsheet_test_all,access.spreadsheet.test.all,model_spreadsheet_test,base.group_user,1,1,1,1
+access_spreadsheet_test_all,access.spreadsheet.test.all,model_spreadsheet_test,test_spreadsheet.group_spreadsheet_test,1,1,1,1
+access_spreadsheet_test_admin,access.spreadsheet.test.admin,model_spreadsheet_test,base.group_system,1,1,1,1

--- a/addons/test_spreadsheet/security/spreadsheet_test_security.xml
+++ b/addons/test_spreadsheet/security/spreadsheet_test_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="group_spreadsheet_test" model="res.groups">
+            <field name="name">group_spreadsheet_test</field>
+            <field name="sequence">20</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
In order to be able to copy a spreadsheet or a dashboard on which the user has access to, without requiring a bunch of extra security rights, this fix removes the need to
- when copying a dashboard, the copy of the field 'main_data_model_ids' that is only used on standard dashboards, would require the read right on ir_model for no good reasons
- when copying any spreadsheety document (spreadsheet, dashboard, etc.) the remove the field spreadsheet_revision_ids from the data sent by the client, so the field security won't be triggered on an empty field

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
