### PR TITLE
[FIX] website_event: add consistent HTML tag specification

### DIFF
--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -83,9 +83,10 @@ function websiteEditEventTourSteps() {
         ...clickOnEditAndWaitEditMode(),
         {
             content: "edit the short description of the event",
-            trigger: ":iframe .opt_events_list_columns small",
+            trigger: ":iframe .opt_events_list_columns",
             run: function () {
-                this.anchor.innerHTML = "new short description";
+                const descriptionEl = this.anchor.querySelector("[itemprop='description']");
+                descriptionEl.textContent = "new short description";
             }
         },
         ...clickOnSave(),


### PR DESCRIPTION
The tour test testUI.test_website_event_tour was failling because the HTML tag specify to edit the event description was not precise enough and led to wrong modification.

I specified the itemprop property of the specific tag to edit in order to erase the previous ambiguity. 
The proposed fix is inspired by the saas-18.4 version of the code.

Runbot error: 226574

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
