### PR TITLE
[FIX] mail: can drag-drop in composer with discuss call in PiP

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -183,7 +183,7 @@ export class Composer extends Component {
                 },
                 () =>
                     this.props.allowUpload &&
-                    (!this.store.meetingViewOpened || this.env.inMeetingView)
+                    (!this.store.rtc.state.isFullscreen || this.env.inMeetingView)
             );
         }
         useChildSubEnv({ inComposer: true });

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Meeting">
-        <div t-if="store.rtc.channel" class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}">
+        <div t-if="store.rtc.channel" class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'o-fullscreen': store.rtc.state.isFullscreen, 'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}">
             <div class="d-flex flex-grow-1 h-100 o-min-height-0 gap-1 position-relative">
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
                     <Call hasOverlay="false" isPip="props.isPip"/>


### PR DESCRIPTION
Before this commit, when in a discuss call with Picture-in-Picture, drag-drop of files in composer was not working on odoo tab.

Steps to reproduce:
- start a call from discuss app
- open call view in picture-in-picture
- drag a file and drop in the main tab of conversation with call => no dropzone visual and cannot drop file to composer

This happens because condition for dropzone was on meeting view being open, which assumes this comes from fullscreen mode but the meeting view can also be shown in picture-in-picture mode.

This commit fixes the issue by disabling composer outside of meeting view when explicitly in fullscreen mode. That way picture-in-picture mode is not mistakenly preventing the dropzone on odoo tab.