### PR TITLE
[IMP] hr_attendance: improve linkage between employees and overtime rulesets

### DIFF
--- a/addons/hr/views/hr_version_views.xml
+++ b/addons/hr/views/hr_version_views.xml
@@ -28,6 +28,31 @@
         </field>
     </record>
 
+    <record id="hr_version_list_view_enhanced" model="ir.ui.view">
+        <field name="name">hr.version.list.view.enhanced</field>
+        <field name="model">hr.version</field>
+        <field name="arch" type="xml">
+            <list string="Records" default_order='employee_id ASC' create="0" delete="0">
+                <field name="employee_id" optional="show" widget="many2one_avatar_employee"/>
+                <field name="date_version" readonly="False" string="Effective Date"/>
+                <field name="contract_date_start" string="Contract Period" widget="daterange" options="{'end_date_field': 'contract_date_end'}" optional="hide"/>
+                <field name="currency_id" column_invisible="1"/>
+                <field name="wage" widget="monetary" optional="hide"/>
+                <field name="contract_type_id" optional="hide"/>
+                <field name="structure_type_id" optional="hide"/>
+                <field name="job_id" optional="show"/>
+                <field name="department_id" optional="show"/>
+                <field name="hr_responsible_id" optional="hide"/>
+                <field name="resource_calendar_id" optional="hide"/>
+                <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
+                <field name="create_uid" optional="hide"/>
+                <field name="create_date" optional="hide"/>
+                <field name="last_modified_uid" optional="hide" readonly="1"/>
+                <field name="last_modified_date" optional="hide" readonly="1"/>
+            </list>
+        </field>
+    </record>
+
     <record id="hr_version_graph_view" model="ir.ui.view">
         <field name="name">hr.version.graph</field>
         <field name="model">hr.version</field>
@@ -102,6 +127,29 @@
                 <separator />
                 <filter string="Working Schedule" name="group_by_resource_calendar_id" domain="[]" context="{'group_by': 'resource_calendar_id'}"/>
                 <filter string="Salary Structure Type" name="group_by_structure_type_id" domain="[]" context="{'group_by': 'structure_type_id'}"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="hr_version_search_view_enhanced" model="ir.ui.view">
+        <field name="name">hr.version.search.view.enhanced</field>
+        <field name="model">hr.version</field>
+        <field name="arch" type="xml">
+            <search string="Employees">
+                <field name="employee_id" string="Employee" filter_domain="['|', ('employee_id.work_email', 'ilike', self), ('employee_id.name', 'ilike', self)]"/>
+                <field name="department_id"/>
+                <field name="job_id"/>
+                <field name="resource_calendar_id"/>
+                <field name="company_id"/>
+                <separator/>
+                <filter name="employee_id.newly_hired" string="Newly Hired" domain="[('employee_id.newly_hired', '=', True)]"/>
+                <filter name="departure_reason_id" string="Departure" domain="[('departure_reason_id', '!=', False)]" />
+                <separator/>
+                <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                <group>
+                    <filter name="group_department" string="Department" domain="[]" context="{'group_by': 'department_id'}"/>
+                    <filter name="group_job" string="Job Position" domain="[]" context="{'group_by': 'job_id'}"/>
+                </group>
             </search>
         </field>
     </record>

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -29,6 +29,7 @@ actions(Check in/Check out) performed by them.
         'views/res_config_settings_views.xml',
         'views/hr_attendance_kiosk_templates.xml',
         'views/hr_attendance_overtime_rule_views.xml',
+        'views/hr_version_views.xml',
     ],
     'demo': [
         'data/hr_attendance_demo.xml'

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -112,6 +112,23 @@
                             <h1><field name="name" placeholder="e.g. Legal Rules"/></h1>
                         </div>
                     </header>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="action_show_versions"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-id-card-o"
+                            invisible="not id"
+                            >
+                            <field name="versions_count" widget="statinfo" string="Employees" invisible="not versions_count"/>
+                            <div class="o_field_widget o_stat_info" invisible="versions_count">
+                                <div class="o_field_widget o_stat_info ms-1">
+                                    <span class="o_stat_value">Add</span>
+                                    <span class="o_stat_text">Employees</span>
+                                </div>
+                            </div>
+                        </button>
+                    </div>
                     <group>
                         <group>
                             <field name="rate_combination_mode"/>

--- a/addons/hr_attendance/views/hr_version_views.xml
+++ b/addons/hr_attendance/views/hr_version_views.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="hr_version_list_view_enhanced_hr_attendance_base" model="ir.ui.view">
+        <field name="name">hr.version.list.view.enhanced.hr.attendance.base</field>
+        <field name="model">hr.version</field>
+        <field name="inherit_id" ref="hr.hr_version_list_view_enhanced"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="date_version" position="replace"/>
+            <field name="resource_calendar_id" position="replace"/>
+            <field name="job_id" position="after">
+                <field name="resource_calendar_id" optional="show"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="hr_version_list_view_enhanced_hr_attendance_add" model="ir.ui.view">
+        <field name="name">hr.version.list.view.enhanced.hr.attendance.add</field>
+        <field name="model">hr.version</field>
+        <field name="inherit_id" ref="hr_version_list_view_enhanced_hr_attendance_base"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <header>
+                    <button display="always" name="action_assign_ruleset" type="object" string="Add" class="btn-primary"/>
+                </header>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_version_list_view_enhanced_hr_attendance" model="ir.ui.view">
+        <field name="name">hr.version.list.view.enhanced.hr.attendance</field>
+        <field name="model">hr.version</field>
+        <field name="inherit_id" ref="hr_version_list_view_enhanced_hr_attendance_base"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <header>
+                    <button display="always" name="action_open_version_selector" type="object" string="Add Employees" class="btn-primary"/>
+                    <button name="action_unassign_ruleset" type="object" string="Remove" class="btn-secondary"/>
+                </header>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_version_search_view_enhanced_hr_attendance" model="ir.ui.view">
+        <field name="name">hr.version.search.view.enhanced.hr.attendance</field>
+        <field name="model">hr.version</field>
+        <field name="inherit_id" ref="hr.hr_version_search_view_enhanced"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//search/group/filter[@name='group_department']" position="before">
+                <filter name="group_resource_calendar" string="Working Hours" domain="[]" context="{'group_by': 'resource_calendar_id'}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_version_list_view" model="ir.actions.act_window">
+        <field name="name">Employees</field>
+        <field name="res_model">hr.version</field>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="hr_attendance.hr_version_list_view_enhanced_hr_attendance"/>
+        <field name="search_view_id" ref="hr_attendance.hr_version_search_view_enhanced_hr_attendance"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Records.
+            </p><p>
+                There are no employees assigned to this overtime ruleset.
+            </p>
+        </field>
+    </record>
+    
+    <record id="hr_version_list_view_add" model="ir.actions.act_window">
+        <field name="name">Employees</field>
+        <field name="res_model">hr.version</field>
+        <field name="view_mode">list</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="hr_attendance.hr_version_list_view_enhanced_hr_attendance_add"/>
+        <field name="search_view_id" ref="hr_attendance.hr_version_search_view_enhanced_hr_attendance"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Records.
+            </p><p>
+                There are no employees without an overtime ruleset.
+            </p>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Currently there is no view for showing all the employees (or hr versions) that are linked to a specific overtime ruleset. This commit adds a smart button to show that list, allow the removal of the ruleset from selected employees, and allow the assignment of the ruleset to employees in bulk.

Task-5189039
