### PR TITLE
[FIX] html_builder: edit theme with google 700 size only font

### DIFF
--- a/addons/html_builder/static/src/plugins/font/font_plugin.js
+++ b/addons/html_builder/static/src/plugins/font/font_plugin.js
@@ -86,7 +86,7 @@ export class BuilderFontPlugin extends Plugin {
         for (const font of googleFonts) {
             const fontURL = `https://fonts.googleapis.com/css?family=${encodeURIComponent(
                 font
-            ).replace(/%20/g, "+")}`;
+            ).replace(/%20/g, "+")}:300,300i,400,400i,700,700i`;
             fontsToLoad.push(fontURL);
         }
         for (const font of googleLocalFonts) {


### PR DESCRIPTION
Steps to reproduce:
===================
1. Edit the website theme and set an external font, e.g., UnifrakturCook.
2. Save, exit, then reopen the editor and go to the Theme tab. → Traceback occurs.

Cause:
======
Some Google Fonts (e.g., UnifrakturCook) only provide a single weight (700).
When fetching the font, html_builder does not request a specific weight, so Google Fonts attempts to return the default set, including 300. Since that weight does not exist for these fonts, Google Fonts responds with an error, leading to the traceback.

This issue is same to the one fixed here:
https://github.com/odoo/odoo/commit/f843c591c0377e0dab1a1f0cfaca36c1981c8880

but the fix was not ported during  refactoring.

opw-5259891
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
