### PR TITLE
[FIX] iot_drivers: retry on wrong bb response

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_driver_base.py
@@ -114,8 +114,9 @@ class SerialDriver(Driver):
                 self._connection = connection
 
         with self._device_lock:
-            super().action(data)
+            res = super().action(data)
             time.sleep(self._protocol.commandDelay)
+            return res
 
     def run(self):
         """Continuously gets new measures from the device."""


### PR DESCRIPTION
Following documentation, max timeout should be 1.5s and we should retry 3 times on every bb NACK/invalid data.
