### PR TITLE
[FIX] hr_recruitment: ensure active test in job activities query

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -116,6 +116,7 @@ class Job(models.Model):
               AND act.date_deadline <= %(today)s::date AND app.active
               AND app.job_id IN %(job_ids)s
               AND sta.hired_stage IS NOT TRUE
+              AND act.active
             GROUP BY app.job_id, act_state
         """, {
             'today': fields.Date.context_today(self),


### PR DESCRIPTION
**Steps to reproduce:**
- Create an activity type with `keep_done` enabled
- Go to Recruitment
- Open a job position
- Select an application
- Create an activity with the new activity type
- Ensure its date is in the past
- Go to the dashboard, you will see the overdue activity
- Go to the record and mark the activity as done
- Go back to the dashboard, the activity count is not updated

**Issue:**
Before https://github.com/odoo/odoo/commit/d290f3f3f23e activities were not kept by default in the database when marked as done. But it was still possible to enable this in the activity type using `keep_done`. The current behavior is to always keep the activity and archive it on done.

In both cases the `_compute_activities` raw query should not take archived activities into account.

**Fix:**
Added the activity active check to the raw query.

opw-5108204
