### PR TITLE
[FIX] project: hide unfollow button in the portal when the task is not saved

### DIFF
--- a/addons/project/static/src/project_sharing/chatter/portal_chatter_patch.xml
+++ b/addons/project/static/src/project_sharing/chatter/portal_chatter_patch.xml
@@ -4,7 +4,7 @@
     <t t-inherit="portal.Chatter" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Chatter-top')]" position="before">
             <div class="d-flex justify-content-end">
-                <button t-if="props.displayFollowButton" class="btn btn-link w-auto" t-on-click="toggleIsFollower">
+                <button t-if="props.displayFollowButton and props.threadId" class="btn btn-link w-auto" t-on-click="toggleIsFollower">
                     <t t-if="state.isFollower">
                         Unfollow
                     </t>


### PR DESCRIPTION
Currently, an error occurs when a portal user opens a shared project and clicks 
the `Unfollow` button in the chatter of a `new(unsaved)` task.

**Steps to produce:**

- Install the `project` module.
- Open the project app and create a new project with at least one task.
- From the project’s `dropdown menu(⋮)`, select `Share Project`.
- Add a `collaborator: Joel Willis`, with `Edit access mode`, copy the `public link`, and click `Share Project`.
- Open the shared link in an incognito window and sign in as a `portal user`.
- Open the project folder > open any task > click `New` > click `Unfollow` button.

**Error**:
`ValueError: Expected singleton: project.task()`

**Root cause:**
The Unfollow button at [1], is displayed even when the task record is 
not yet saved (`props.threadId` is `undefined`). At [2], the method is 
called on an empty recordset, causing an `error`.

**Fix:**
This commit prevents the error by ensuring the `Unfollow` button is hidden 
when the record is `unsaved`.

[1]: https://github.com/odoo/odoo/blob/be138ef2ff1b3a83f77fe300f789d754ed3383fd/addons/project/static/src/project_sharing/chatter/portal_chatter_patch.xml#L7-L14

[2]: https://github.com/odoo/odoo/blob/be138ef2ff1b3a83f77fe300f789d754ed3383fd/addons/project/models/project_task.py#L2022

No task ID