### PR TITLE
[FIX] website_slides: prevent traceback when saving edited description

### DIFF
--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -372,7 +372,7 @@
             <h3 class="o_line_clamp card-title h6" t-field="channel.name"/>
             <span t-if="not channel.is_published" class="badge text-bg-danger">Unpublished</span>
             <div class="card-text d-flex flex-column flex-grow-1 mt-1">
-                <small class="o_line_clamp" t-field="channel.description_short"/>
+                <div class="o_line_clamp small" t-field="channel.description_short"/>
                 <div t-if="channel_frontend_tags" class="small o_wslides_desc_truncate_2_badges">
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">


### PR DESCRIPTION
Steps to reproduce:
---------------------------
1. Install the `website_slides` module.
2. Navigate to the Courses page on the website.
3. Open the Website Editor.
4. Modify the short description of any course.
5. Click the Save button.

Observation:
---------------------------
A traceback is raised:
```
File '/data/build/odoo/addons/website/models/ir_ui_view.py', line 514, in save_embedded_field
          Model = self.env[el.get('data-oe-model')]
```

Issue:
---------------------------
In the template
https://github.com/odoo/odoo/blob/9333df06e15134df92efed765cf95db38c0dfede/addons/website_slides/views/website_slides_templates_homepage.xml#L375 the short description is rendered inside a `<small>` tag. When parsed by `lxml`, the `<small>` tag is converted to a self-closing element and the text becomes wrapped in a new `<p>` inside an additional `<div>`.
```
b'<div><small class='o_line_clamp' data-oe-xpath='/t[1]/a[1]/div[2]/div[1]/small[1]'
data-oe-model='slide.channel' data-oe-id='1' data-oe-field='description_short'
data-oe-type='html' data-oe-expression='channel.description_short'
data-oe-sanitize='allow_form' spellcheck='false'/><p>Learn the basics of gardening! th new</p></div>'
```
This wrapper `<div>` does not contain the required `data-oe-model` attribute, causing `save_embedded_field` to fail.

Solution:
---------------------------
Replace the `<small>` tag with a `<div>` tag, adding the `small` class to preserve styling. This prevents lxml from producing a self-closing tag and ensures the attributes remain on the correct element.

opw-5273079