### PR TITLE
[FIX] point_of_sale: prevent unfocused input when popup is open

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
@@ -61,11 +61,12 @@ class NumberBuffer extends EventBus {
         super();
         this.setup(...arguments);
     }
-    setup({ sound, localization }) {
+    setup({ sound, localization, popup }) {
         this.isReset = false;
         this.bufferHolderStack = [];
         this.sound = sound;
         this.defaultDecimalPoint = localization.decimalPoint;
+        this.popup = popup;
         window.addEventListener("keyup", this._onKeyboardInput.bind(this));
     }
     /**
@@ -161,6 +162,10 @@ class NumberBuffer extends EventBus {
             : 0;
     }
     _onKeyboardInput(event) {
+        const popups = this.popup ? Object.values(this.popup.popups) : [];
+        if (popups.length && !popups.some((popup) => popup.component.name === "NumberPopup")) {
+            return;
+        }
         return (
             this._currentBufferHolder &&
             this._bufferEvents(this._onInput((event) => event.key))(event)
@@ -319,7 +324,7 @@ class NumberBuffer extends EventBus {
 export const numberBufferService = {
     dependencies: NumberBuffer.serviceDependencies,
     start(env, deps) {
-        return new NumberBuffer(deps);
+        return new NumberBuffer({ ...deps, popup: env.services.popup });
     },
 };
 

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/PosLoyaltyTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/helpers/SelectionPopupTourMethods";
@@ -581,5 +582,40 @@ registry.category("web_tour.tours").add("test_points_update_after_global_discoun
             PosLoyalty.pointsTotalIs(192),
             PosLoyalty.orderTotalIs("92"),
             PosLoyalty.finalizeOrder("Bank", "92"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_number_buffer_popup", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+
+            ProductScreen.clickHomeCategory(),
+
+            ProductScreen.addOrderline("Whiteboard Pen", "2"),
+            ProductScreen.selectedOrderlineHas("Whiteboard Pen", "2.0", "6.40"),
+            ProductScreen.totalAmountIs("3.52"),
+            {
+                content: "click Enter Code button",
+                trigger: '.control-buttons .control-button span:contains("Enter Code")',
+            },
+            {
+                content: "Click modal header",
+                trigger: ".popup.popup-textinput .modal-header",
+                run: "click",
+            },
+            {
+                content: "Simulate keyboard input",
+                trigger: "body",
+                run() {
+                    const ev = new KeyboardEvent("keyup", { key: "3"});
+                    window.dispatchEvent(ev);
+                },
+            },
+            Chrome.confirmPopup(),
+            ProductScreen.selectedOrderlineHas("Whiteboard Pen", "2.0"),
+            ProductScreen.totalAmountIs("3.52"),
+            Chrome.endTour(),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2741,3 +2741,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="pos_user",
         )
         self.assertEqual(loyalty_card.points, 192)
+
+    def test_number_buffer_popup(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_number_buffer_popup', login="pos_user")


### PR DESCRIPTION
When the "Enter Code" text popup is open in POS, typing outside the input field still affected the active orderline quantity because the number buffer globally captured key events. This change blocks number buffer handling only when the top popup is the text input popup.

Steps to reproduce:
-------------------
* Open a POS session.
* Add a product (quantity one).
* Click “Enter Code”.
* Click outside the popup input, then type a code.
> Observation:
Quantities on the selected product increase even though a popup modal is open.

Why the fix:
------------
The number_buffer was listening to global keyup events and only ignored events targeting INPUT/TEXTAREA. With a modal open, keystrokes outside inputs still modified quantities. We now:
Ignore number buffer events only when the top popup is TextInputPopup (so virtual numpad popups still work). Make popup usage optional (inject via env.services?.popup) to avoid breaking cases that don’t start the popup service.

opw-5144792
