### PR TITLE
[FIX] iot_box_builder: ghostscript deprecation warning

### DIFF
--- a/setup/iot_box_builder/configuration/requirements.txt
+++ b/setup/iot_box_builder/configuration/requirements.txt
@@ -3,7 +3,7 @@ gatt; sys_platform == "linux" and "rpi" in platform_release
 
 # The following requirements are needed only on Windows Virtual IoT:
 aiortc; sys_platform == "win32"
-ghostscript==0.7; sys_platform == "win32"
+ghostscript==0.8.1; sys_platform == "win32"
 decorator; sys_platform == "win32"
 
 # The following requirements are needed on every platforms, but are installed


### PR DESCRIPTION
The PIP package `ghostscript` released a new version 0.8.1 that stops using the deprecated `distutils` library. We update to this version so that we don't get the `DeprecationWarning` in the IoT logs on Windows.

task-4576234

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
