### PR TITLE
[FIX] web: color slider getting reset

### DIFF
--- a/addons/web/static/src/core/colorpicker/colorpicker.js
+++ b/addons/web/static/src/core/colorpicker/colorpicker.js
@@ -3,6 +3,7 @@ import {
     convertHslToRgb,
     convertRgbaToCSSColor,
     convertRgbToHsl,
+    normalizeCSSColor,
 } from "@web/core/utils/colors";
 import { uniqueId } from "@web/core/utils/functions";
 import { clamp } from "@web/core/utils/numbers";
@@ -94,7 +95,9 @@ export class Colorpicker extends Component {
             const newSelectedColor = newProps.selectedColor
                 ? newProps.selectedColor
                 : newProps.defaultColor;
-            this.setSelectedColor(newSelectedColor);
+            if (normalizeCSSColor(newSelectedColor) !== this.colorComponents.cssColor) {
+                this.setSelectedColor(newSelectedColor);
+            }
         });
     }
 

--- a/addons/web/static/tests/core/colorpicker.test.js
+++ b/addons/web/static/tests/core/colorpicker.test.js
@@ -1,0 +1,41 @@
+import { test, expect, animationFrame } from "@odoo/hoot";
+import { queryOne, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
+import { Component, useState, xml } from "@odoo/owl";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { Colorpicker } from "@web/core/colorpicker/colorpicker";
+
+test("should preserve color slider when picking max lightness color", async () => {
+    class TestColorPicker extends Component {
+        static template = xml`
+            <div style="width: 222px">
+                <Colorpicker selectedColor="state.color" onColorPreview.bind="onColorChange" onColorSelect.bind="onColorChange"/>
+            </div>`;
+        static components = { Colorpicker };
+        static props = ["*"];
+        setup() {
+            this.state = useState({
+                color: "#FFFF00",
+            });
+        }
+        onColorChange({ cssColor }) {
+            this.state.color = cssColor;
+        }
+    }
+    await mountWithCleanup(TestColorPicker);
+    const colorPickerArea = queryOne(".o_color_pick_area");
+    const colorPickerRect = colorPickerArea.getBoundingClientRect();
+
+    const clientX = colorPickerRect.left + colorPickerRect.width / 2;
+    const clientY = colorPickerRect.top; // Lightness 100%
+    manuallyDispatchProgrammaticEvent(colorPickerArea, "mousedown", {
+        clientX,
+        clientY,
+    });
+    manuallyDispatchProgrammaticEvent(colorPickerArea, "mouseup", {
+        clientX,
+        clientY,
+    });
+
+    await animationFrame();
+    expect(colorPickerArea).toHaveStyle({ backgroundColor: "rgb(255, 255, 0)" });
+});

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -4224,9 +4224,10 @@ class SnippetsMenu extends Component {
             this.lastElement = false;
         });
 
-        if (!$target.closest('we-button, we-toggler, we-select, .o_we_color_preview').length) {
+        if (!$target.closest('we-button, we-toggler, we-select, .o_we_color_preview').length && !this._isColorpickerClick) {
             this._closeWidgets();
         }
+        delete this._isColorpickerClick;
         if (!$target.closest('body > *').length || $target.is('#iframe_target')) {
             return;
         }
@@ -4538,6 +4539,9 @@ class SnippetsMenu extends Component {
             clearTimeout(enableTimeoutID);
             reenable();
         });
+        if (ev.target.closest(".o_colorpicker_widget")) {
+            this._isColorpickerClick = true;
+        }
     }
     /**
      * @private

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2176,7 +2176,9 @@ export class Wysiwyg extends Component {
         return backgroundGradient || $(targetElement).css(colorType === "text" ? 'color' : 'backgroundColor');
     }
     onColorpaletteDropdownHide(ev) {
-        return !(ev.clickEvent && ev.clickEvent.__isColorpickerClick);
+        const shouldHide = !(ev.clickEvent && this._isColorpickerClick);
+        delete this._isColorpickerClick;
+        return shouldHide;
     }
     onColorpaletteDropdownShow(colorType) {
         const selectedColor = this._getSelectedColor($, colorType);
@@ -3049,6 +3051,9 @@ export class Wysiwyg extends Component {
                 this._pendingBlur = false;
             }
             this._shouldDelayBlur = false;
+        }
+        if (e.target.closest(".o_colorpicker_widget")) {
+            this._isColorpickerClick = true;
         }
     }
     _onBlur() {


### PR DESCRIPTION
**Current behavior before PR:**

In editor's custom gradient picker, if `#FFFFFF` is picked from the very top of picker area, the color slider is reset to color `red`. This happens because when moving picker pointer to the top of area, `selectedColor` prop is updated to `#FFFFFF`, which calls `onWillUpdateProps` callback. As result, `convertRgbToHsl` sets hue value 0 for `#FFFFFF`, setting color slider to red.

**Desired behavior after PR is merged:**

This commit ensures that in `onWillUpdateProps` callback, `setSelectedColor` should not get called if `newSelectedColor` is the same as `this.colorComponents.cssColor` to prevent updating UI twice while picking the color.

task-5170041




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
