### PR TITLE
[IMP] point_of_sale: wip

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -86,6 +86,7 @@
             ('remove', 'point_of_sale/static/src/backend/views/pivot/*'),
             ('remove', 'point_of_sale/static/src/backend/views/graph/*'),
             'point_of_sale/static/src/backend/test_epos/*',
+            'point_of_sale/static/src/backend/local_printer_selector/*',
         ],
         'web.assets_backend_lazy': [
             'point_of_sale/static/src/backend/views/pivot/*',

--- a/addons/point_of_sale/models/pos_printer.py
+++ b/addons/point_of_sale/models/pos_printer.py
@@ -37,7 +37,8 @@ class PosPrinter(models.Model):
         default='epson_epos',
         selection=[
             ('epson_epos', 'IP address'),
-        ]
+            ('local', 'Local Printer'),
+        ],
     )
     use_type = fields.Selection(selection=[
         ('preparation', "Preparation"),
@@ -53,6 +54,7 @@ class PosPrinter(models.Model):
         ),
     )
     use_lna = fields.Boolean(string="Use Local Network Access")
+    local_printer_data = fields.Json(string='Local Printer Data', help="Stores local printer identification and metadata (vendor_id, product_id, name, etc.)")
 
     def copy_data(self, default=None):
         default = dict(default or {}, pos_config_ids=[(5, 0, 0)], epson_printer_ip="0.0.0.0")
@@ -68,7 +70,7 @@ class PosPrinter(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['id', 'name', 'product_categories_ids', 'printer_type', 'use_type', 'use_lna', 'epson_printer_ip']
+        return ['id', 'name', 'product_categories_ids', 'printer_type', 'use_type', 'use_lna', 'epson_printer_ip', 'local_printer_data']
 
     @api.constrains('epson_printer_ip')
     def _constrains_epson_printer_ip(self):

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -42,7 +42,7 @@ export class Navbar extends Component {
         this.dialog = useService("dialog");
         this.notification = useService("notification");
         this.dialog = useService("dialog");
-        this.isDisplayStandalone = isDisplayStandalone();
+        this.isDisplayStandalone = isDisplayStandalone() || Boolean(window.OdooNativeApp);
         this.isBarcodeScannerSupported = isBarcodeScannerSupported;
         this.timeout = null;
         this.bufferedInput = "";

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -45,6 +45,7 @@ import { logPosMessage } from "../utils/pretty_console_log";
 import { initLNA } from "../utils/init_lna";
 import { uuid } from "@web/core/utils/strings";
 import { GeneratePrinterData } from "../utils/generate_printer_data";
+import { OdooLocalPrinter } from "@point_of_sale/app/utils/printer/local_printer";
 
 const { DateTime } = luxon;
 export const CONSOLE_COLOR = "#F5B427";
@@ -1275,6 +1276,8 @@ export class PosStore extends WithLazyGetterTrap {
     createPrinter(config) {
         if (config.printer_type === "epson_epos") {
             return new EpsonPrinter({ printer: config });
+        } else if (config.printer_type === "local") {
+            return new OdooLocalPrinter({ printer: config });
         }
     }
     async _loadFonts() {

--- a/addons/point_of_sale/static/src/app/utils/printer/local_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/local_printer.js
@@ -1,0 +1,80 @@
+import { _t } from "@web/core/l10n/translation";
+import { BasePrinter } from "@point_of_sale/app/utils/printer/base_printer";
+
+const ERROR_MESSAGES = {
+    PRINTER_NOT_FOUND: {
+        title: _t("Printer Not Found"),
+        body: _t("No printer is available. Please check printer connection and try again."),
+    },
+    CONNECTION_FAILED: {
+        title: _t("Connection Failed"),
+        body: _t("Failed to connect to printer service."),
+    },
+    PRINT_FAILED: {
+        title: _t("Printing Failed"),
+        body: _t("Failed to print. Please check printer connection and try again."),
+    },
+};
+
+export class OdooLocalPrinter extends BasePrinter {
+    async setup({ printer }) {
+        super.setup(...arguments);
+        this.odooNativeApp = window.OdooNativeApp;
+        this.printer = printer.local_printer_data || {};
+    }
+
+    async openCashbox() {
+        await this._execute("cash_drawer");
+    }
+
+    async sendPrintingJob(image) {
+        return this._execute("print_receipt", { image });
+    }
+
+    async _execute(action, data = {}) {
+        try {
+            const response = await this.odooNativeApp.action({
+                action,
+                device: JSON.parse(JSON.stringify(this.printer)),
+                data,
+            });
+
+            if (response.status === true) {
+                return {
+                    result: true,
+                    message: response.message || _t("Print job sent successfully"),
+                    canRetry: false,
+                };
+            } else {
+                return this._getErrorResult(response.error_code, "PRINT_FAILED");
+            }
+        } catch {
+            return this._getErrorResult("CONNECTION_FAILED");
+        }
+    }
+
+    _getErrorResult(errorCode, defaultCode = "CONNECTION_FAILED") {
+        const message = ERROR_MESSAGES[errorCode] || ERROR_MESSAGES[defaultCode];
+        return {
+            result: false,
+            errorCode,
+            canRetry: true,
+            message: {
+                title: message.title,
+                body: message.body,
+            },
+        };
+    }
+
+    getActionError() {
+        const actionError = super.getResultsError();
+        actionError.message.body += _t(
+            "Please check that the printer is turned on and connected, then try again."
+        );
+        return actionError;
+    }
+
+    getResultsError(printResult) {
+        return printResult || this._getErrorResult("CONNECTION_FAILED");
+    }
+}

--- a/addons/point_of_sale/static/src/backend/local_printer_selector/local_printer_selector.js
+++ b/addons/point_of_sale/static/src/backend/local_printer_selector/local_printer_selector.js
@@ -1,0 +1,71 @@
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { capitalize } from "@web/core/utils/strings";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+
+export class LocalPrinterSelector extends Component {
+    static template = "point_of_sale.LocalPrinterSelector";
+    static components = { AutoComplete };
+    static props = {
+        ...standardWidgetProps,
+    };
+
+    setup() {
+        this.odooNativeApp = window.OdooNativeApp || null;
+        this.state = useState({ printers: [], value: "" });
+        onWillStart(async () => {
+            await this._loadPrinters();
+            this.state.value = this.value || "";
+        });
+    }
+
+    async _loadPrinters() {
+        const { status, devices = [] } = this.odooNativeApp
+            ? await this.odooNativeApp.devices({ device_type: "printer" })
+            : {};
+        this.state.printers = status ? devices : [];
+    }
+
+    get value() {
+        return this.props.record.data.local_printer_data?.display_name || "";
+    }
+
+    get sources() {
+        return [
+            {
+                optionSlot: "printer_option",
+                options: () =>
+                    this.state.printers.map((printer) => ({
+                        label: printer.display_name,
+                        data: {
+                            device_type: capitalize(printer.device_type),
+                            communication_protocol: capitalize(printer.communication_protocol),
+                        },
+                        onSelect: () => this.onSelect(printer),
+                    })),
+            },
+        ];
+    }
+
+    onSelect(printer) {
+        this.state.value = printer.display_name;
+        this.props.record.update({
+            local_printer_data: printer,
+        });
+    }
+
+    onInput({ inputValue }) {
+        this.state.value = inputValue;
+    }
+
+    onBlur() {
+        if (!this.state.printers.some((p) => p.display_name === this.state.value)) {
+            this.state.value = this.value;
+        }
+    }
+}
+
+registry.category("fields").add("local_printer_selector", {
+    component: LocalPrinterSelector,
+});

--- a/addons/point_of_sale/static/src/backend/local_printer_selector/local_printer_selector.xml
+++ b/addons/point_of_sale/static/src/backend/local_printer_selector/local_printer_selector.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="point_of_sale.LocalPrinterSelector">
+        <AutoComplete
+            id="'local_printer_autocomplete'"
+            value="state.value"
+            sources="sources"
+            placeholder.translate="Select a device"
+            dropdown="true"
+            autoSelect="true"
+            onInput.bind="onInput"
+            onBlur.bind="onBlur"
+        >
+            <t t-set-slot="printer_option" t-slot-scope="props">
+                    <span t-esc="props.label"/>
+                    <span class="ms-4 text-muted" t-esc="props.data.device_type"/>
+                    <span class="ms-4 text-muted" t-esc="props.data.communication_protocol"/>
+            </t>
+        </AutoComplete>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
+++ b/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
@@ -50,7 +50,7 @@ export class TestEPos extends Component {
             const response = await this.orm.read(
                 "pos.printer",
                 [printer_id],
-                ["epson_printer_ip", "name", "printer_type"]
+                ["epson_printer_ip", "name", "printer_type", "local_printer_data"]
             );
             return response[0];
         } else {
@@ -60,6 +60,7 @@ export class TestEPos extends Component {
                 name: data.name,
                 epson_printer_ip: data.epson_printer_ip,
                 printer_type: data.printer_type,
+                local_printer_data: data.local_printer_data,
             };
         }
     }
@@ -140,6 +141,29 @@ export class TestEPos extends Component {
                     )}`,
                     { type: "danger" }
                 );
+            }
+        } else if (printer.printer_type === "local") {
+            if (!window.OdooNativeApp) {
+                this.notification.add(_t("Local printer is only available in the desktop app."), {
+                    type: "warning",
+                });
+                return;
+            }
+
+            try {
+                const response = await window.action({
+                    action: "print_status_receipt",
+                    device: JSON.parse(JSON.stringify(printer.local_printer_data)),
+                });
+
+                if (!response?.status) {
+                    this.notification.add(
+                        _t("Failed to print a test receipt on the local printer."),
+                        { type: "danger" }
+                    );
+                }
+            } catch {
+                this.notification.add(_t("Cannot reach the local printer."), { type: "danger" });
             }
         }
     }

--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -15,8 +15,10 @@
                     <group>
                         <group>
                             <field name="use_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
+                            <field name="printer_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
+                            <field name="local_printer_data" widget="local_printer_selector" invisible="printer_type != 'local'" required="printer_type == 'local'"/>
                             <field name="epson_printer_ip" invisible="printer_type != 'epson_epos'" placeholder="10.100.50.87" required="printer_type == 'epson_epos'"/>
-                            <field name="use_lna"/>
+                            <field name="use_lna" invisible="printer_type == 'local'"/>
                             <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags" required="use_type == 'preparation'"/>
                         </group>
                     </group>


### PR DESCRIPTION
Expand POS printing capabilities so that the client can detect and use
a local USB printer (via `window.printer`) without requiring any network
printer or IoT Box setup. This allows users to rely solely on a directly
connected USB printer for receipt printing.
- Extend PosStore to instantiate a new `LocalPrinter` when
`window.printer.printReceipt` is available.
- Introduce LocalPrinter class to handle: printer setup, vendor/product ID
retrieval, sending jobs to the local printer with
fallback on failure.

Task:5368831