### PR TITLE
[FIX] im_livechat: error when accessing chats linked to help status

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -68,7 +68,6 @@ class ImLivechatChannelMemberHistory(models.Model):
             ("none", "No Help"),
         ],
         compute="_compute_help_status",
-        search="_search_help_status",
         store=True,
     )
     response_time_hour = fields.Float("Response Time", aggregator="avg")


### PR DESCRIPTION
The `help_status` field of the channel member history model is used to quickly find sessions where help was requested/provided. However, the field exposes a `_search` method that doesn't exists which lead in a crash when clicking on the agent report bars when grouping by `help_status`. This field is stored so we don't need the search.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
