### PR TITLE
[IMP] web: improve missing record display

### DIFF
--- a/addons/web/static/src/core/record_selectors/multi_record_selector.js
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.js
@@ -40,20 +40,17 @@ export class MultiRecordSelector extends Component {
     async computeDerivedParams(props = this.props) {
         const displayNames = await this.getDisplayNames(props);
         this.tags = this.getTags(props, displayNames);
+        /**
+         * Placeholder should be empty if there is at least one tag. We cannot use
+         * the default behavior of the input placeholder because even if there is
+         * a tag, the input is still empty.
+         */
+        this.placeholder = this.tags.length ? "" : this.props.placeholder;
     }
 
     async getDisplayNames(props) {
         const ids = this.getIds(props);
         return this.nameService.loadDisplayNames(props.resModel, ids);
-    }
-
-    /**
-     * Placeholder should be empty if there is at least one tag. We cannot use
-     * the default behavior of the input placeholder because even if there is
-     * a tag, the input is still empty.
-     */
-    get placeholder() {
-        return this.getTags(this.props, {}).length ? "" : this.props.placeholder;
     }
 
     getIds(props = this.props) {
@@ -62,13 +59,12 @@ export class MultiRecordSelector extends Component {
 
     getTags(props, displayNames) {
         return props.resIds.map((id, index) => {
-            const text =
-                typeof displayNames[id] === "string"
-                    ? displayNames[id]
-                    : _t("Inaccessible/missing record ID: %s", id);
+            const text = typeof displayNames[id] === "string" ? displayNames[id] : String(id);
             return {
                 id,
                 text,
+                tooltip:
+                    typeof displayNames[id] === "string" ? text : _t("Missing record (ID: %s)", id),
                 onDelete: () => {
                     this.deleteTag(index);
                 },

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.xml
@@ -8,7 +8,7 @@
                     <AvatarTag imageUrl="tag.img" onDelete="tag.onDelete" text="tag.text"/>
                 </t>
                 <t t-else="">
-                    <BadgeTag onDelete="tag.onDelete" text="tag.text"/>
+                    <BadgeTag onDelete="tag.onDelete" text="tag.text" color="tag.color" tooltip="tag.tooltip"/>
                 </t>
             </t>
             <RecordAutocomplete

--- a/addons/web/static/src/core/tree_editor/tree_processor.js
+++ b/addons/web/static/src/core/tree_editor/tree_processor.js
@@ -29,7 +29,7 @@ function formatValue(val, disambiguate, fieldDef, displayNames) {
         if (typeof displayNames[val] === "string") {
             val = displayNames[val];
         } else {
-            return _t("Inaccessible/missing record ID: %s", val);
+            return _t("Missing record");
         }
     }
     if (fieldDef?.type === "selection") {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -1511,7 +1511,7 @@ test("many2one field (readonly)", async () => {
         },
         {
             domain: `[("product_id", "=", 2)]`,
-            text: "Product = Inaccessible/missing record ID: 2",
+            text: "Product = Missing record",
         },
         {
             domain: `[("product_id", "!=", 37)]`,
@@ -1535,11 +1535,11 @@ test("many2one field (readonly)", async () => {
         },
         {
             domain: `[("product_id", "in", [1, 37])]`,
-            text: "Product = Inaccessible/missing record ID: 1 or xphone",
+            text: "Product = Missing record or xphone",
         },
         {
             domain: `[("product_id", "in", [1, uid, 37])]`,
-            text: 'Product = Inaccessible/missing record ID: 1 or uid or "xphone"',
+            text: 'Product = Missing record or uid or "xphone"',
         },
         {
             domain: `[("product_id", "in", ["abc"])]`,
@@ -1551,7 +1551,7 @@ test("many2one field (readonly)", async () => {
         },
         {
             domain: `[("product_id", "in", 2)]`,
-            text: "Product = Inaccessible/missing record ID: 2",
+            text: "Product = Missing record",
         },
     ];
     const parent = await makeDomainSelector({ readonly: true });
@@ -1879,6 +1879,25 @@ test("many2many field: operator set/not set (edit)", async () => {
     expect(getCurrentOperator()).toBe(label("set"));
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([`[("product_ids", "!=", False)]`]);
+});
+
+test("many2many field: operation includes a missing record", async () => {
+    addProductIds();
+    await makeDomainSelector({
+        domain: `[("product_ids", "in", [1,41])]`,
+        isDebugMode: true,
+    });
+    expect(getCurrentOperator()).toBe(label("in", "many2many"));
+    expect(getCurrentValue()).toBe("1 xpad", {
+        message: "missing record tags only show the id of the record",
+    });
+    expect(".o_multi_record_selector .o_tag:first").toHaveClass("o_tag_color_1", {
+        message: "missing record tags are displayed in red",
+    });
+    expect(".o_multi_record_selector .o_tag:first").toHaveAttribute(
+        "data-tooltip",
+        "Missing record (ID: 1)"
+    );
 });
 
 test("Include archived button basic use", async () => {

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -867,7 +867,7 @@ test("display names in facets", async () => {
 
     expect(getFacetTexts()).toEqual([
         "Bar = John",
-        "Bar = David or Inaccessible/missing record ID: 5555",
+        "Bar = David or Missing record",
         `Bar ${label("set")}`,
         "Id = 2",
     ]);


### PR DESCRIPTION
This commit improves how missing records inside a domain are displayed. Instead of showing `Inaccessible/missing record ID: *id of the record*` when a record is missing, the UI now behaves as follows:

- Search facets & readonly domain selector: shown as `Missing record`
- Editable domain selector: shown as a red tag with the raw id and a tooltip showing `Missing record (ID: *id of the record*)`

This results in a cleaner display while still providing the necessary technical details when editing domains.

task-4281034