### PR TITLE
[FIX] l10n_sa_edi: Amount shows  negative in Bill print

### DIFF
--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -28,12 +28,12 @@
                     </tr>
                     <tr>
                         <td><p class="m-0" t-esc="sar_rate" t-options='{"widget": "float", "precision": 5}'/></td>
-                        <td><p class="m-0" t-esc="o.amount_untaxed_signed"
+                        <td><p class="m-0" t-esc="o.amount_untaxed"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
                         <td><p class="m-0"
                             t-esc="o.currency_id._convert(o.amount_tax, o.company_id.currency_id, o.company_id, curr_date)"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
-                        <td><p class="m-0" t-esc="o.amount_total_signed"
+                        <td><p class="m-0" t-esc="o.amount_total"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
                     </tr>
                 </table>


### PR DESCRIPTION
**Steps to reproduce:**
- Create a vendor bill with currency not matching the currency of an SA company
- Print the bill in the SA EDI specific format (is not shown on preview) or export as PDF

**Issue:**
Amounts displayed in the currency conversion section of the bill incorrectly show negative values for subtotal and total.

**Solution:**
The view affecting the bill in question referred to `o.amount_untaxed_signed` and `o.amount_total_signed` where either unsigned `o.amount_untaxed` and `o.amount_total` or `abs(o.amount_[...]_signed)` should be used instead, as in other localizations.

opw-5253213


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
