### PR TITLE
[FIX] l10n_nl: correct traduction of tax description translation

### DIFF
--- a/addons/l10n_nl/data/template/account.tax-nl.csv
+++ b/addons/l10n_nl/data/template/account.tax-nl.csv
@@ -3,7 +3,7 @@
 "","","","","","","","","","","tax","invoice","","","","",""
 "","","","","","","","","","","base","refund","-1e (omzet)","","","",""
 "","","","","","","","","","","tax","refund","","","","",""
-"btw_9","10","9% ST","Sales/turnover low 9%","9% VAT","9.0","percent","sale","tax_group_9","","base","invoice","+1b (omzet)","","","BTW te vorderen laag (inkopen) 9%","9% BTW","Niedrige Mehrwertsteuerforderungen (Käufe) 9%","9% MwSt"
+"btw_9","10","9% ST","Sales/turnover low 9%","9% VAT","9.0","percent","sale","tax_group_9","","base","invoice","+1b (omzet)","","","Verkopen/omzet laag 9%","9% BTW","Niedrige Mehrwertsteuerforderungen (Käufe) 9%","9% MwSt"
 "","","","","","","","","","","tax","invoice","+1b (BTW)","vat_payable_l","","",""
 "","","","","","","","","","","base","refund","-1b (omzet)","","","",""
 "","","","","","","","","","","tax","refund","-1b (BTW)","vat_payable_l","","",""


### PR DESCRIPTION
The traduction of te description of the 9% ST tax was wrong and was TVA to get back on a sale tax

task-5217323
