### PR TITLE
[FIX] account: do not copy `invoice_origin` on 'account.move'

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -550,6 +550,7 @@ class AccountMove(models.Model):
         string='Origin',
         readonly=True,
         tracking=True,
+        copy=False,
         help="The document(s) that generated the invoice.",
     )
     invoice_incoterm_id = fields.Many2one(


### PR DESCRIPTION
Currently we copy the `invoice_origin` field on moves (when copying / duplicating moves).
I.e. when copying a move that was created from a SO we end up with the `invoice_origin` filled on the copied move (but the
 SO is not linked and does not really have anything to do with the
 move anymore)

This can i.e. lead to issues in EDIs (`l10n_es_edi_verifactu` like in the ticket) that send the `invoice_origin` as part of the data about the move.

Reproduce
1. Create a sales order (SO).
2. Create an invoice from the SO (and confirm). You can see that the SO is linked at the top (smart button).
3. Copy the invoice (and confirm). You can see that the SO is not linked.
4. Go to the invoices list view and make the "Source Document" visible.
5. Both the invoices have the same SO as their "Source Document".

opw-5115495