### PR TITLE
[FIX] account: recipient bank in vendor bills

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1063,8 +1063,9 @@ class AccountMove(models.Model):
                     or move.bank_partner_id.property_inbound_payment_method_line_id
                 )
             ) and payment_method.journal_id:
-                move.partner_bank_id = payment_method.journal_id.bank_account_id
-                continue
+                if move.is_inbound():
+                    move.partner_bank_id = payment_method.journal_id.bank_account_id
+                    continue
 
             move.partner_bank_id = move.bank_partner_id.bank_ids.filtered(
                 lambda bank: not bank.company_id or bank.company_id == move.company_id


### PR DESCRIPTION
Issue:
When a payment method is set for a vendor and creating a bill for this vendor, the recipient bank was set to the bank account linked to the payment method in 'My company', instead of the vendor bank account.

Cause:
The rewriting of the '_compute_partner_bank_id' function in the account.move model in V19.

Step to reproduce:
0. Use a Belgian Company inside runbot;
1. Make sure SEPA credit transfer is configured;
2. Add an IBAN account on a contact. In the 'sales & purchase' tab, add the payment method "SEPA credit transfer". 
That way, when a bill is created for that contact, the "payment method" will already be filled in on the bill (other info tab).
3. Create a bill for that contact: you will see in the 'Recipient bank' field of the bill that the database's company bank account is added, instead of the bank account of the contact.

opw-5262223

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
