### PR TITLE
Remove pytz

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -668,7 +668,7 @@ class AccountPartialReconcile(models.Model):
             if counterpart_line.reconciled:
                 continue
 
-            reconciliation_plan.append((counterpart_line + lines))
+            reconciliation_plan.append(counterpart_line + lines)
 
         # passing add_caba_vals in the context to make sure that any exchange diff that would be created for
         # this cash basis move would set the field draft_caba_move_vals accordingly on the partial

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import pytz
+from datetime import UTC
 
 from odoo import models, fields, tools, _
 from odoo.tools import is_html_empty
@@ -20,7 +19,6 @@ class MailActivity(models.Model):
             date_deadline = self[0].date_deadline  # updated, hence all same value
             # also protect against loops in case of ill-managed timezones
             events = self.calendar_event_id.with_context(mail_activity_meeting_update=True)
-            user_tz = self.env.context.get('tz') or 'UTC'
             for event in events:
                 # allday: just apply diff between dates
                 if event.allday and event.start_date != date_deadline:
@@ -28,7 +26,7 @@ class MailActivity(models.Model):
                 # otherwise: we have to check if day did change, based on TZ
                 elif not event.allday:
                     # old start in user timezone
-                    old_deadline_dt = pytz.utc.localize(event.start).astimezone(pytz.timezone(user_tz))
+                    old_deadline_dt = event.start.replace(tzinfo=UTC).astimezone(self.env.tz)
                     date_diff = date_deadline - old_deadline_dt.date()
                     event.start = event.start + date_diff
 

--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models, modules, _
 from odoo.exceptions import AccessError
-
-from pytz import timezone, UTC
 
 
 class ResUsers(models.Model):
@@ -119,15 +118,15 @@ class ResUsers(models.Model):
         #   |           |
         #   |           | <--- `stop_dt_utc` = `stop_dt` if user lives in an area of West longitude (positive shift compared to UTC, America for example)
         #   |           |
-        start_dt_utc = start_dt = datetime.datetime.now(UTC)
-        stop_dt_utc = UTC.localize(datetime.datetime.combine(start_dt_utc.date(), datetime.time.max))
+        start_dt_utc = start_dt = datetime.datetime.now(datetime.UTC)
+        stop_dt_utc = datetime.datetime.combine(start_dt_utc.date(), datetime.time.max.replace(tzinfo=datetime.UTC))
 
         tz = self.env.user.tz
         if tz:
-            user_tz = timezone(tz)
+            user_tz = ZoneInfo(tz)
             start_dt = start_dt_utc.astimezone(user_tz)
-            stop_dt = user_tz.localize(datetime.datetime.combine(start_dt.date(), datetime.time.max))
-            stop_dt_utc = stop_dt.astimezone(UTC)
+            stop_dt = datetime.datetime.combine(start_dt.date(), datetime.time.max.replace(tzinfo=user_tz, fold=1))
+            stop_dt_utc = stop_dt.astimezone(datetime.UTC)
 
         start_date = start_dt.date()
 

--- a/addons/calendar/tests/test_mail_activity_mixin.py
+++ b/addons/calendar/tests/test_mail_activity_mixin.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, time
-from dateutil.relativedelta import relativedelta
+from datetime import datetime, time, UTC
+from zoneinfo import ZoneInfo
 
-import pytz
+from dateutil.relativedelta import relativedelta
 
 from odoo import tests
 from odoo.tests import tagged
@@ -56,8 +56,8 @@ class TestMailActivityMixin(MailCommon):
             test_record = self.env['res.partner'].browse(self.test_record.id)
             self.assertEqual(test_record.activity_ids, self.env['mail.activity'])
 
-            now_utc = datetime.now(pytz.UTC)
-            now_user = now_utc.astimezone(pytz.timezone(self.env.user.tz or 'UTC'))
+            now_utc = datetime.now(UTC)
+            now_user = now_utc.astimezone(ZoneInfo(self.env.user.tz or 'UTC'))
             today_user = now_user.date()
 
             date1 = today_user + relativedelta(days=1)

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import pytz
+from datetime import datetime, date, UTC
+from zoneinfo import ZoneInfo
 
-from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 from werkzeug.urls import url_encode
@@ -377,10 +377,10 @@ class DigestDigest(models.Model):
         return date.today() + delta
 
     def _compute_timeframes(self, company):
-        start_datetime = datetime.utcnow()
+        start_datetime = datetime.now(UTC)
         tz_name = company.resource_calendar_id.tz
         if tz_name:
-            start_datetime = pytz.timezone(tz_name).localize(start_datetime)
+            start_datetime = start_datetime.replace(tzinfo=ZoneInfo(tz_name))
         return [
             (_('Last 24 hours'), (
                 (start_datetime + relativedelta(days=-1), start_datetime),

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -1,7 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 import os
-import pytz
+from datetime import UTC
+from zoneinfo import ZoneInfo
 
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.fields import Domain
@@ -447,8 +448,8 @@ class EventRegistration(models.Model):
 
         is_date_closed_today = False
         if self.date_closed:
-            event_tz = pytz.timezone(self.event_id.date_tz)
-            now = fields.Datetime.now(pytz.UTC).astimezone(event_tz)
+            event_tz = ZoneInfo(self.event_id.date_tz)
+            now = fields.Datetime.now().replace(tzinfo=UTC).astimezone(event_tz)
             closed_date = self.date_closed.astimezone(event_tz)
             is_date_closed_today = now.date() == closed_date.date()
 

--- a/addons/event/models/event_slot.py
+++ b/addons/event/models/event_slot.py
@@ -1,5 +1,5 @@
-import pytz
-from datetime import datetime
+from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -70,11 +70,11 @@ class EventSlot(models.Model):
     @api.depends("date", "date_tz", "start_hour", "end_hour")
     def _compute_datetimes(self):
         for slot in self:
-            event_tz = pytz.timezone(slot.date_tz)
+            event_tz = ZoneInfo(slot.date_tz)
             start = datetime.combine(slot.date, float_to_time(slot.start_hour))
             end = datetime.combine(slot.date, float_to_time(slot.end_hour))
-            slot.start_datetime = event_tz.localize(start).astimezone(pytz.UTC).replace(tzinfo=None)
-            slot.end_datetime = event_tz.localize(end).astimezone(pytz.UTC).replace(tzinfo=None)
+            slot.start_datetime = start.replace(tzinfo=event_tz).astimezone(UTC).replace(tzinfo=None)
+            slot.end_datetime = end.replace(tzinfo=event_tz).astimezone(UTC).replace(tzinfo=None)
 
     @api.depends("seats_available")
     @api.depends_context('name_with_seats_availability')

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import datetime
+from uuid import uuid4
 
-import pytz
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
-from uuid import uuid4
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError
@@ -179,8 +179,8 @@ class CalendarEvent(models.Model):
             values['follow_recurrence'] = google_event.is_recurrence_follower()
         if google_event.start.get('dateTime'):
             # starting from python3.7, use the new [datetime, date].fromisoformat method
-            start = parse(google_event.start.get('dateTime')).astimezone(pytz.utc).replace(tzinfo=None)
-            stop = parse(google_event.end.get('dateTime')).astimezone(pytz.utc).replace(tzinfo=None)
+            start = parse(google_event.start.get('dateTime')).astimezone(datetime.UTC).replace(tzinfo=None)
+            stop = parse(google_event.end.get('dateTime')).astimezone(datetime.UTC).replace(tzinfo=None)
             values['allday'] = False
         else:
             start = parse(google_event.start.get('date'))
@@ -307,8 +307,8 @@ class CalendarEvent(models.Model):
         else:
             # For timed events, 'date' must be set to None to indicate that it's not an all-day event.
             # Otherwise, if both 'date' and 'dateTime' are set, Google may not recognize it as a timed event
-            start['dateTime'] = pytz.utc.localize(self.start).isoformat()
-            end['dateTime'] = pytz.utc.localize(self.stop).isoformat()
+            start['dateTime'] = self.start.replace(tzinfo=datetime.UTC).isoformat()
+            end['dateTime'] = self.stop.replace(tzinfo=datetime.UTC).isoformat()
         reminders = [{
             'method': "email" if alarm.alarm_type == "email" else "popup",
             'minutes': alarm.duration_minutes

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -1,12 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import datetime
 import logging
 from contextlib import contextmanager
 from functools import wraps
-from requests import HTTPError
-import pytz
+
 from dateutil.parser import parse
 from markupsafe import Markup
+from requests import HTTPError
 
 from odoo import api, fields, models, _
 from odoo.fields import Domain
@@ -203,7 +203,7 @@ class GoogleCalendarSync(models.AbstractModel):
             # Use the record's write_date to apply Google updates only if they are newer than Odoo's write_date.
             odoo_record_write_date = write_dates.get(odoo_record.id, odoo_record.write_date)
             # Migration from 13.4 does not fill write_date. Therefore, we force the update from Google.
-            if not odoo_record_write_date or updated >= pytz.utc.localize(odoo_record_write_date):
+            if not odoo_record_write_date or updated >= odoo_record_write_date.replace(tzinfo=datetime.UTC):
                 vals = dict(self._odoo_values(gevent, default_reminders), need_sync=False)
                 odoo_record.with_context(dont_notify=True)._write_from_google(gevent, vals)
                 synced_records |= odoo_record

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1,16 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import pytz
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, UTC
+from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
+
 from odoo.tests.common import tagged, new_test_user
 from odoo.exceptions import ValidationError
 from odoo.addons.google_calendar.models.res_users import ResUsers
 from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle, patch_api
 from odoo.addons.google_calendar.utils.google_calendar import GoogleEvent, GoogleCalendarService
 from odoo import Command, tools
-from unittest.mock import patch
 
 
 @patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
@@ -112,7 +112,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
 
     @property
     def now(self):
-        return pytz.utc.localize(datetime.now()).isoformat()
+        return datetime.now().replace(tzinfo=UTC).isoformat()
 
     def sync(self, events):
         events.clear_type_ambiguity(self.env)
@@ -943,8 +943,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         google_events = GoogleEvent(values)
         self.env['calendar.recurrence']._sync_google2odoo(google_events)
         no_duplicate_gevent = google_events.filter(lambda e: e.id == "9lxiofipomymx2yr1yt0hpep99")
-        dt_start = datetime.fromisoformat(no_duplicate_gevent.start["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=0)
-        dt_end = datetime.fromisoformat(no_duplicate_gevent.end["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=23)
+        dt_start = datetime.fromisoformat(no_duplicate_gevent.start["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=0)
+        dt_end = datetime.fromisoformat(no_duplicate_gevent.end["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=23)
         no_duplicate_event = self.env["calendar.event"].search(
             [
                 ("name", "=", no_duplicate_gevent.summary),
@@ -1249,12 +1249,12 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             }, ],
             'reminders': {'overrides': [{"method": "email", "minutes": 10}], 'useDefault': False},
             'start': {
-                'dateTime': pytz.utc.localize(start).isoformat(),
+                'dateTime': start.replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/Brussels',
                 'date': None
             },
             'end': {
-                'dateTime': pytz.utc.localize(end).isoformat(),
+                'dateTime': end.replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/Brussels',
                 'date': None
             },
@@ -1268,7 +1268,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         # No further notifications should be created.
         values = {
             'id': google_id,
-            'updated': pytz.utc.localize(updated).isoformat(),
+            'updated': updated.replace(tzinfo=UTC).isoformat(),
             'description': 'New Super description',
             'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
             'summary': 'Pricing was not good, now it is correct',
@@ -1280,12 +1280,12 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             }, ],
             'reminders': {'overrides': [{"method": "email", "minutes": 10}], 'useDefault': False},
             'start': {
-                'dateTime': pytz.utc.localize(start).isoformat(),
+                'dateTime': start.replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/Brussels',
                 'date': None,
             },
             'end': {
-                'dateTime': pytz.utc.localize(end).isoformat(),
+                'dateTime': end.replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/Brussels',
                 'date': None,
             },
@@ -1326,12 +1326,12 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
                 'responseStatus': 'needsAction'
             }],
             'start': {
-                'dateTime': pytz.utc.localize(start).isoformat(),
+                'dateTime': start.replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/Brussels'
             },
             'reminders': {'overrides': [{"method": "email", "minutes": 30}], 'useDefault': False},
             'end': {
-                'dateTime': pytz.utc.localize(end).isoformat(),
+                'dateTime': end.replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/Brussels'
             },
         }
@@ -1920,8 +1920,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         google_event = GoogleEvent(google_value)
         self.env['calendar.recurrence']._sync_google2odoo(google_event)
         # Get the time slot of the day
-        day_start = datetime.fromisoformat(google_event.start["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=0)
-        day_end = datetime.fromisoformat(google_event.end["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=23)
+        day_start = datetime.fromisoformat(google_event.start["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=0)
+        day_end = datetime.fromisoformat(google_event.end["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=23)
         # Get created events
         day_events = self.env["calendar.event"].search(
             [
@@ -1994,8 +1994,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         # specific_event: 59orfkiunbn2vlp6c2tndq6ui0_20230526T070000Z
 
         # Range to check
-        day_start = datetime.fromisoformat(specific_event.start["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=0)
-        day_end = datetime.fromisoformat(specific_event.end["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=23)
+        day_start = datetime.fromisoformat(specific_event.start["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=0)
+        day_end = datetime.fromisoformat(specific_event.end["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=23)
 
         # Synchronize recurrent events
         self.env['calendar.recurrence']._sync_google2odoo(recurrent_events)
@@ -2099,8 +2099,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         recurrent_events = google_events.filter(lambda e: e.is_recurrence())
         specific_event = google_events - recurrent_events
         # Range to check
-        day_start = datetime.fromisoformat(specific_event.start["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=0)
-        day_end = datetime.fromisoformat(specific_event.end["dateTime"]).astimezone(pytz.utc).replace(tzinfo=None).replace(hour=23)
+        day_start = datetime.fromisoformat(specific_event.start["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=0)
+        day_end = datetime.fromisoformat(specific_event.end["dateTime"]).astimezone(UTC).replace(tzinfo=None).replace(hour=23)
 
         # Synchronize recurrent events
         self.env['calendar.recurrence']._sync_google2odoo(recurrent_events)

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import timedelta
-from pytz import timezone, UTC
+from datetime import timedelta, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models, tools
 from odoo.tools import format_time
@@ -101,7 +101,7 @@ class HrEmployeePublic(models.Model):
             tz = employee.tz
             # sudo: res.users - can access presence of accessible user
             if last_presence := employee.user_id.sudo().presence_ids.last_presence:
-                last_activity_datetime = last_presence.replace(tzinfo=UTC).astimezone(timezone(tz)).replace(tzinfo=None)
+                last_activity_datetime = last_presence.replace(tzinfo=UTC).astimezone(ZoneInfo(tz)).replace(tzinfo=None)
                 employee.last_activity = last_activity_datetime.date()
                 if employee.last_activity == fields.Date.today():
                     employee.last_activity_time = format_time(self.env, last_presence, time_format='short')

--- a/addons/hr/models/resource.py
+++ b/addons/hr/models/resource.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 from datetime import datetime
-from pytz import timezone
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models
 from odoo.tools.intervals import Intervals
@@ -77,14 +77,14 @@ class ResourceResource(models.Model):
     def _get_contracts_valid_periods(self, start, end):
         res = defaultdict(lambda: defaultdict(Intervals))
         timezones = {resource.tz for resource in self}
-        date_start = min(start.astimezone(timezone(tz)).date() for tz in timezones)
-        date_end = max(end.astimezone(timezone(tz)).date() for tz in timezones)
+        date_start = min(start.astimezone(ZoneInfo(tz)).date() for tz in timezones)
+        date_end = max(end.astimezone(ZoneInfo(tz)).date() for tz in timezones)
         contracts = self.employee_id._get_versions_with_contract_overlap_with_period(date_start, date_end)
         for contract in contracts:
-            tz = timezone(contract.employee_id.tz)
+            tz = ZoneInfo(contract.employee_id.tz)
             res[contract.employee_id.resource_id.id][contract.resource_calendar_id] |= Intervals([(
-                tz.localize(datetime.combine(contract.contract_date_start, datetime.min.time())) if contract.contract_date_start > start.astimezone(tz).date() else start,
-                tz.localize(datetime.combine(contract.contract_date_end, datetime.max.time())) if contract.contract_date_end and contract.contract_date_end < end.astimezone(tz).date() else end,
+                datetime.combine(contract.contract_date_start, datetime.min.time(), tzinfo=tz) if contract.contract_date_start > start.astimezone(tz).date() else start,
+                datetime.combine(contract.contract_date_end, datetime.max.time(), tzinfo=tz) if contract.contract_date_end and contract.contract_date_end < end.astimezone(tz).date() else end,
                 self.env['resource.calendar.attendance']
             )])
         return res

--- a/addons/hr/models/resource_calendar_leaves.py
+++ b/addons/hr/models/resource_calendar_leaves.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
-from pytz import timezone, utc
+from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import models
 
@@ -12,7 +12,7 @@ class ResourceCalendarLeaves(models.Model):
     def _compute_calendar_id(self):
         def date2datetime(date, tz):
             dt = datetime.fromordinal(date.toordinal())
-            return tz.localize(dt).astimezone(utc).replace(tzinfo=None)
+            return dt.replace(tzinfo=tz).astimezone(UTC).replace(tzinfo=None)
 
         leaves_by_contract = self.grouped(lambda leave: leave.resource_id.employee_id.version_id)
         # set aside leaves without version_id for super
@@ -21,7 +21,7 @@ class ResourceCalendarLeaves(models.Model):
             self.env['resource.calendar.leaves'],
         )
         for contract, leaves in leaves_by_contract.items():
-            tz = timezone(contract.resource_calendar_id.tz or 'UTC')
+            tz = ZoneInfo(contract.resource_calendar_id.tz or 'UTC')
             start_dt = date2datetime(contract.date_start, tz)
             end_dt = date2datetime(contract.date_end, tz) if contract.date_end else datetime.max
             # only modify leaves that fall under the active contract

--- a/addons/hr/tests/test_attendances.py
+++ b/addons/hr/tests/test_attendances.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from pytz import timezone
-
 from datetime import datetime, date
+from zoneinfo import ZoneInfo
 
 from odoo.tests import tagged
 
@@ -63,7 +62,7 @@ class TestAttendances(TestHrCommon):
         cls.employee.resource_calendar_id = contract_now.resource_calendar_id
 
     def test_incoming_overlapping_contract(self):
-        tz = timezone("Europe/Brussels")
+        tz = ZoneInfo("Europe/Brussels")
         check_in_tz = datetime.combine(datetime(2024, 6, 1), datetime.min.time()).astimezone(tz)
         check_out_tz = datetime.combine(datetime(2024, 6, 30), datetime.max.time()).astimezone(tz)
         intervals = self.employee._employee_attendance_intervals(check_in_tz, check_out_tz, lunch=False)

--- a/addons/hr/tests/test_flexible_resource_calendar.py
+++ b/addons/hr/tests/test_flexible_resource_calendar.py
@@ -1,10 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import pytz
-from datetime import datetime, date
+from datetime import datetime, date, UTC
 
 from odoo.tests.common import tagged, TransactionCase
-
-UTC = pytz.timezone('UTC')
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytz
-from datetime import datetime
+from datetime import datetime, UTC
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from odoo import fields
 from odoo.tests import Form, new_test_user
@@ -84,8 +84,8 @@ class TestHrAttendance(TransactionCase):
         """ Test day start is correctly computed according to the employee's timezone """
 
         def tz_datetime(year, month, day, hour, minute):
-            tz = pytz.timezone('Europe/Brussels')
-            return tz.localize(datetime(year, month, day, hour, minute)).astimezone(pytz.utc).replace(tzinfo=None)
+            tz = ZoneInfo('Europe/Brussels')
+            return datetime(year, month, day, hour, minute).replace(tzinfo=tz).astimezone(UTC).replace(tzinfo=None)
 
         employee = self.env['hr.employee'].create({'name': 'Cunégonde', 'tz': 'Europe/Brussels'})
         self.env['hr.attendance'].create({
@@ -99,7 +99,7 @@ class TestHrAttendance(TransactionCase):
         })
 
         # now = 2019/3/2 14:00 in the employee's timezone
-        with patch.object(fields.Datetime, 'now', lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(pytz.utc).replace(tzinfo=None)):
+        with patch.object(fields.Datetime, 'now', lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(UTC).replace(tzinfo=None)):
             self.assertEqual(employee.hours_today, 5, "It should have counted 5 hours")
 
     def test_remove_check_in_value_from_attendance(self):

--- a/addons/hr_calendar/models/calendar_event.py
+++ b/addons/hr_calendar/models/calendar_event.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import UTC
+
 from dateutil.relativedelta import relativedelta
-from pytz import UTC
 
 from odoo import api, models
-
 from odoo.tools.intervals import Intervals
 from odoo.tools.date_utils import localized, sum_intervals
 

--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from pytz import UTC, timezone
-from datetime import datetime
 from collections import defaultdict
+from datetime import datetime, UTC
 from functools import reduce
+from zoneinfo import ZoneInfo
 
 from odoo import api, models
 from odoo.fields import Domain
@@ -53,7 +53,7 @@ class ResPartner(models.Model):
 
         # Compute all work intervals per calendar
         for calendar, resources in resources_by_calendar.items():
-            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=resources, tz=timezone(calendar.tz))
+            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=resources, tz=ZoneInfo(calendar.tz))
             del work_intervals[False]
             # Merge all employees intervals to avoid to compute it multiples times
             if merge:
@@ -100,8 +100,8 @@ class ResPartner(models.Model):
         # This is the format expected by the fullcalendar library to do the overlay
         return [{
             "daysOfWeek": [(interval[0].weekday() + 1) % 7],
-            "startTime":  interval[0].astimezone(timezone(self.env.user.tz or 'UTC')).strftime("%H:%M"),
-            "endTime": interval[1].astimezone(timezone(self.env.user.tz or 'UTC')).strftime("%H:%M"),
+            "startTime":  interval[0].astimezone(ZoneInfo(self.env.user.tz or 'UTC')).strftime("%H:%M"),
+            "endTime": interval[1].astimezone(ZoneInfo(self.env.user.tz or 'UTC')).strftime("%H:%M"),
         } for interval in working_intervals] if working_intervals else [{
             # 7 is used a dummy value to gray the full week
             # Returning an empty list would leave the week uncolored

--- a/addons/hr_calendar/tests/test_event_interval.py
+++ b/addons/hr_calendar/tests/test_event_interval.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
+
 from odoo.tests import tagged
-from datetime import datetime
-from pytz import timezone
 from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon
 
 
@@ -32,13 +33,13 @@ class TestEventInterval(TestHrCalendarCommon):
         self.assertEqual(result.get(event)._items, [])
         self.assertEqual(result.get(allday_event)._items, [
             (
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 8, 0, 0)),
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 12, 0, 0)),
+                datetime(2024, 7, 12, 8, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
+                datetime(2024, 7, 12, 12, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
                 self.env['resource.calendar']
             ),
             (
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 13, 0, 0)),
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 16, 0, 0)),
+                datetime(2024, 7, 12, 13, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
+                datetime(2024, 7, 12, 16, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
                 self.env['resource.calendar']
             )
         ])
@@ -55,13 +56,13 @@ class TestEventInterval(TestHrCalendarCommon):
         result = event._get_events_interval()
         self.assertEqual(result.get(event)._items, [
             (
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 8, 0, 0)),
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 12, 0, 0)),
+                datetime(2024, 7, 12, 8, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
+                datetime(2024, 7, 12, 12, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
                 self.env['resource.calendar']
             ),
             (
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 13, 0, 0)),
-                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 16, 0, 0)),
+                datetime(2024, 7, 12, 13, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
+                datetime(2024, 7, 12, 16, 0, 0).replace(tzinfo=ZoneInfo('Europe/Brussels')),
                 self.env['resource.calendar']
             )
         ])
@@ -117,8 +118,8 @@ class TestEventInterval(TestHrCalendarCommon):
         result = event._get_events_interval()
         self.assertEqual(result.get(event)._items, [
             (
-                timezone('UTC').localize(datetime(2024, 7, 12, 8, 30, 0)),
-                timezone('UTC').localize(datetime(2024, 7, 12, 9, 30, 0)),
+                datetime(2024, 7, 12, 8, 30, 0).replace(tzinfo=UTC),
+                datetime(2024, 7, 12, 9, 30, 0).replace(tzinfo=UTC),
                 self.env['resource.calendar']
             )
         ])

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -4,10 +4,9 @@
 
 import logging
 import operator as py_operator
-import pytz
-
 from collections import defaultdict
-from datetime import date, datetime, time
+from datetime import date, datetime, time, UTC
+
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
@@ -598,8 +597,8 @@ class HrLeaveType(models.Model):
                 if closest_expiration_date:
                     closest_allocation_expire = format_date(self.env, closest_expiration_date)
                     calendar = employee.resource_calendar_id
-                    start_datetime = datetime.combine(target_date, time.min).replace(tzinfo=pytz.UTC)
-                    end_datetime = datetime.combine(closest_expiration_date, time.max).replace(tzinfo=pytz.UTC)
+                    start_datetime = datetime.combine(target_date, time.min, tzinfo=UTC)
+                    end_datetime = datetime.combine(closest_expiration_date, time.max, tzinfo=UTC)
                     closest_allocation_dict = {}
                     if not calendar:
                         closest_allocation_dict['hours'] = float_round((end_datetime - start_datetime).total_seconds() / 3600, precision_rounding=0.001)

--- a/addons/hr_holidays/tests/test_flexible_resource_calendar.py
+++ b/addons/hr_holidays/tests/test_flexible_resource_calendar.py
@@ -1,10 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import pytz
-from datetime import datetime, date
+from datetime import datetime, date, UTC
 
 from odoo.tests.common import tagged, TransactionCase
-
-UTC = pytz.timezone('UTC')
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1,10 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, date, timedelta
 import time
+from datetime import datetime, date, timedelta
+
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
-from pytz import timezone
 
 from odoo import fields, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -606,7 +606,6 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
     def _test_leave_with_tz(self, tz, local_date_from, local_date_to, number_of_days):
         self.user_employee.tz = tz
-        tz = timezone(tz)
 
         # We use new instead of create to avoid the leaves generated for the
         # different timezones clashing with each other.

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta
-
-from pytz import UTC, timezone
+from datetime import datetime, timedelta, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models
 from odoo.exceptions import AccessError, UserError
@@ -73,9 +72,9 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
         self.ensure_one()
         employees = self._get_employees_from_allocation_mode()
 
-        tz = timezone(self.company_id.resource_calendar_id.tz or self.env.user.tz or 'UTC')
-        date_from_tz = tz.localize(datetime.combine(self.date_from, datetime.min.time())).astimezone(UTC).replace(tzinfo=None)
-        date_to_tz = tz.localize(datetime.combine(self.date_to, datetime.max.time())).astimezone(UTC).replace(tzinfo=None)
+        tz = ZoneInfo(self.company_id.resource_calendar_id.tz or self.env.user.tz or 'UTC')
+        date_from_tz = datetime.combine(self.date_from, datetime.min.time(), tzinfo=tz).astimezone(UTC).replace(tzinfo=None)
+        date_to_tz = datetime.combine(self.date_to, datetime.max.time(), tzinfo=tz).astimezone(UTC).replace(tzinfo=None)
 
         conflicting_leaves = self.env['hr.leave'].with_context(
             tracking_disable=True,

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -1,11 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
 from collections import defaultdict
 from datetime import datetime, time
 from statistics import mode
-import re
-
-import pytz
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError, AccessError, ValidationError

--- a/addons/hr_work_entry/tests/test_work_entry.py
+++ b/addons/hr_work_entry/tests/test_work_entry.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date, datetime
+from datetime import date, datetime, UTC
+from zoneinfo import ZoneInfo
+
 from dateutil.relativedelta import relativedelta
-import pytz
 
 from odoo.tests.common import tagged
 from odoo.addons.hr_work_entry.tests.common import TestWorkEntryBase
@@ -15,7 +16,7 @@ class TestWorkEntry(TestWorkEntryBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.tz = pytz.timezone(cls.richard_emp.tz)
+        cls.tz = ZoneInfo(cls.richard_emp.tz)
         cls.start = datetime(2015, 11, 1, 1, 0, 0)
         cls.end = datetime(2015, 11, 30, 23, 59, 59)
         cls.resource_calendar_id = cls.env['resource.calendar'].create({'name': 'My Calendar'})
@@ -38,7 +39,7 @@ class TestWorkEntry(TestWorkEntryBase):
 
     def test_work_entry(self):
         self.richard_emp.generate_work_entries(self.start, self.end)
-        attendance_nb = len(self.resource_calendar_id._attendance_intervals_batch(self.start.replace(tzinfo=pytz.utc), self.end.replace(tzinfo=pytz.utc))[False])
+        attendance_nb = len(self.resource_calendar_id._attendance_intervals_batch(self.start.replace(tzinfo=UTC), self.end.replace(tzinfo=UTC))[False])
         work_entry_nb = self.env['hr.work.entry'].search_count([
             ('employee_id', '=', self.richard_emp.id),
             ('date', '>=', self.start),
@@ -99,8 +100,8 @@ class TestWorkEntry(TestWorkEntryBase):
             'wage': 1000,
         })
         self.env['resource.calendar.leaves'].create({
-            'date_from': pytz.timezone('Asia/Hong_Kong').localize(datetime(2023, 8, 2, 0, 0, 0)).astimezone(pytz.utc).replace(tzinfo=None),
-            'date_to': pytz.timezone('Asia/Hong_Kong').localize(datetime(2023, 8, 2, 23, 59, 59)).astimezone(pytz.utc).replace(tzinfo=None),
+            'date_from': datetime(2023, 8, 2, 0, 0, 0).replace(tzinfo=ZoneInfo('Asia/Hong_Kong')).astimezone(UTC).replace(tzinfo=None),
+            'date_to': datetime(2023, 8, 2, 23, 59, 59).replace(tzinfo=ZoneInfo('Asia/Hong_Kong')).astimezone(UTC).replace(tzinfo=None),
             'calendar_id': hk_resource_calendar_id.id,
             'work_entry_type_id': self.work_entry_type_leave.id,
         })

--- a/addons/hr_work_entry_holidays/models/hr_version.py
+++ b/addons/hr_work_entry_holidays/models/hr_version.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import pytz
+import datetime
 
 from odoo import api, models
 from odoo.fields import Domain
@@ -35,8 +34,8 @@ class HrVersion(models.Model):
             if work_entry_types and work_entry_types[:1].code in bypassing_codes:
                 return work_entry_types[:1]
 
-        interval_start = interval[0].astimezone(pytz.utc).replace(tzinfo=None)
-        interval_stop = interval[1].astimezone(pytz.utc).replace(tzinfo=None)
+        interval_start = interval[0].astimezone(datetime.UTC).replace(tzinfo=None)
+        interval_stop = interval[1].astimezone(datetime.UTC).replace(tzinfo=None)
         including_rcleaves = [l[2] for l in leaves if l[2] and interval_start >= l[2].date_from and interval_stop <= l[2].date_to]
         including_global_rcleaves = [l for l in including_rcleaves if not l.holiday_id]
         including_holiday_rcleaves = [l for l in including_rcleaves if l.holiday_id]

--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, date
+from zoneinfo import ZoneInfo
+
 from dateutil.relativedelta import relativedelta
-import pytz
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import tagged
@@ -17,7 +18,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
     @classmethod
     def setUpClass(cls):
         super(TestWorkeEntryHolidaysWorkEntry, cls).setUpClass()
-        cls.tz = pytz.timezone(cls.richard_emp.tz)
+        cls.tz = ZoneInfo(cls.richard_emp.tz)
         cls.start = datetime(2015, 11, 1, 1, 0, 0)
         cls.end = datetime(2015, 11, 30, 23, 59, 59)
         cls.resource_calendar_id = cls.env['resource.calendar'].create({'name': 'Zboub'})

--- a/addons/html_editor/models/ir_qweb_fields.py
+++ b/addons/html_editor/models/ir_qweb_fields.py
@@ -13,10 +13,10 @@ import json
 import logging
 import os
 import re
-from datetime import datetime
+from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
 
 import babel
-import pytz
 import requests
 from lxml import etree, html
 from PIL import Image as I
@@ -265,10 +265,7 @@ class IrQwebFieldDatetime(models.AbstractModel):
         tz_name = element.attrib.get('data-oe-original-tz') or self.env.context.get('tz') or self.env.user.tz
         if tz_name:
             try:
-                user_tz = pytz.timezone(tz_name)
-                utc = pytz.utc
-
-                dt = user_tz.localize(dt).astimezone(utc)
+                dt = dt.replace(tzinfo=ZoneInfo(tz_name)).astimezone(UTC)
             except Exception:  # noqa: BLE001
                 logger.warning(
                     "Failed to convert the value for a field of the model"

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import Markup
-from werkzeug.exceptions import NotFound
 from urllib.parse import urlsplit
-from pytz import timezone
+from zoneinfo import ZoneInfo
+
+from werkzeug.exceptions import NotFound
 
 from odoo import http, _
 from odoo.http import content_disposition, request
@@ -212,7 +212,7 @@ class LivechatController(http.Controller):
         if not channel:
             raise NotFound()
         user, guest = request.env["res.users"]._get_current_persona()
-        tz = timezone(user.tz or guest.timezone or "UTC")
+        tz = ZoneInfo(user.tz or guest.timezone or "UTC")
         pdf, _type = (
             request.env["ir.actions.report"]
             .sudo()

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -1,14 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+from zoneinfo import ZoneInfo
+
+from markupsafe import Markup
+
 from odoo import api, fields, models, _, tools
 from odoo.addons.base.models.ir_qweb_fields import nl2br
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tools import email_normalize, email_split, html2plaintext, plaintext2html
 from odoo.tools.mimetypes import get_extension
-
-import json
-from markupsafe import Markup
-from pytz import timezone
 
 
 def is_livechat_channel(channel):
@@ -560,7 +561,7 @@ class DiscussChannel(models.Model):
         render_context = {
             "company": company,
             "channel": self,
-            "tz": timezone(tz),
+            "tz": ZoneInfo(tz),
         }
         mail_body = self.env['ir.qweb']._render('im_livechat.livechat_email_template', render_context, minimal_qcontext=True)
         mail_body = self.env['mail.render.mixin']._replace_local_links(mail_body)

--- a/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py
+++ b/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
+import datetime
 import hashlib
 import json
-
-import pytz
 
 from asn1crypto import cms, core, x509, algos, tsp
 
@@ -129,7 +128,7 @@ class L10n_Eg_EdiThumbDrive(models.Model):
             cms.CMSAttribute({
                 'type': cms.CMSAttributeType('signing_time'),
                 'values': (
-                cms.Time({'utc_time': core.UTCTime(signing_time.replace(tzinfo=pytz.UTC))}),)
+                cms.Time({'utc_time': core.UTCTime(signing_time.replace(tzinfo=datetime.UTC))}),)
             }),
         ])
 

--- a/addons/l10n_eg_edi_eta/tests/common.py
+++ b/addons/l10n_eg_edi_eta/tests/common.py
@@ -1,8 +1,6 @@
-from datetime import datetime
-from pytz import timezone
+from datetime import datetime, UTC
 
 from odoo.fields import Command
-from odoo.tests import tagged
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
 
 
@@ -14,7 +12,7 @@ class TestEGEdiCommon(AccountEdiTestCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.frozen_today = datetime(year=2022, month=3, day=15, hour=0, minute=0, second=0, tzinfo=timezone('utc'))
+        cls.frozen_today = datetime(year=2022, month=3, day=15, hour=0, minute=0, second=0, tzinfo=UTC)
 
         cls.currency_aed_id = cls.setup_other_currency('AED', rates=[('2022-03-14', 0.198117095128)])
 

--- a/addons/l10n_es_edi_sii/tests/common.py
+++ b/addons/l10n_es_edi_sii/tests/common.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import base64
-from pytz import timezone
-from datetime import datetime
+from datetime import datetime, UTC
 
 from odoo.tools import misc
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
@@ -19,7 +18,7 @@ class TestEsEdiCommon(AccountEdiTestCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.frozen_today = datetime(year=2019, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone('utc'))
+        cls.frozen_today = datetime(year=2019, month=1, day=1, hour=0, minute=0, second=0, tzinfo=UTC)
 
         # Allow to see the full result of AssertionError.
         cls.maxDiff = None

--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -1,13 +1,13 @@
+import base64
 import gzip
 import json
 import re
-import base64
 from datetime import datetime
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 import requests
 from lxml import etree
-from pytz import timezone
 from requests.exceptions import RequestException
 
 from odoo import _, api, fields, models, release
@@ -349,7 +349,7 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             **self._get_header_values(),
             **self._get_sender_values(),
             **(self._get_recipient_values(values['partner'], values["is_simplified"]) if values['partner'] and not self.is_cancel or not values['is_sale'] else {}),
-            'datetime_now': datetime.now(tz=timezone('Europe/Madrid')),
+            'datetime_now': datetime.now(tz=ZoneInfo('Europe/Madrid')),
             'format_date': lambda d: datetime.strftime(d, '%d-%m-%Y'),
             'format_time': lambda d: datetime.strftime(d, '%H:%M:%S'),
             'format_float': format_float,

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -2,11 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
-import requests
-
-from pytz import timezone
-from datetime import date, datetime
+from datetime import date, datetime, UTC
 from unittest.mock import Mock
+
+import requests
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
@@ -22,7 +21,7 @@ class TestEsEdiTbaiCommon(TestAccountMoveSendCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.frozen_today = datetime(year=2025, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone('utc'))
+        cls.frozen_today = datetime(year=2025, month=1, day=1, hour=0, minute=0, second=0, tzinfo=UTC)
 
         # Allow to see the full result of AssertionError.
         cls.maxDiff = None

--- a/addons/l10n_es_edi_verifactu/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu/models/verifactu_document.py
@@ -1,13 +1,13 @@
-from datetime import datetime, timedelta
-from psycopg2 import OperationalError
-from pytz import timezone
-from werkzeug.urls import url_quote_plus, url_encode
-
 import hashlib
+import json
 import logging
 import math
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
 import requests.exceptions
-import json
+from psycopg2 import OperationalError
+from werkzeug.urls import url_quote_plus, url_encode
 
 from odoo import _, api, fields, models
 from odoo.addons.certificate.tools import CertificateAdapter
@@ -545,7 +545,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
             'previous_record_identifier': previous_record_identifier,
         }
 
-        generation_time_string = fields.Datetime.now(timezone('Europe/Madrid')).astimezone(timezone('Europe/Madrid')).isoformat()
+        generation_time_string = fields.Datetime.now(ZoneInfo('Europe/Madrid')).astimezone(ZoneInfo('Europe/Madrid')).isoformat()
 
         record_type_vals = {
             'IDVersion': VERIFACTU_VERSION,

--- a/addons/l10n_fr_pos_cert/models/res_company.py
+++ b/addons/l10n_fr_pos_cert/models/res_company.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime, UTC
+
 from odoo import models, api, fields, _
 from odoo.exceptions import UserError
-from datetime import datetime
 from odoo.fields import Datetime, Date
 from odoo.tools.misc import format_date
-import pytz
 
 
 def ctx_tz(record, field):
@@ -15,7 +15,7 @@ def ctx_tz(record, field):
     if ctx.get('lang'):
         res_lang = record.env['res.lang']._get_data(code=ctx['lang'])
     if res_lang:
-        timestamp = pytz.utc.localize(timestamp, is_dst=False)
+        timestamp = timestamp.replace(tzinfo=UTC)
         tz = record.env.tz
         return datetime.strftime(timestamp.astimezone(tz), res_lang.date_format + ' ' + res_lang.time_format)
     return Datetime.context_timestamp(record, timestamp)

--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
+
 import requests
-import pytz
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -1,6 +1,3 @@
-import pytz
-from stdnum.in_ import pan, gstin
-
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import RedirectWarning
 

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -652,7 +652,7 @@ class AccountMove(models.Model):
         if self.company_currency_id != self.currency_id:
             json_payload["ValDtls"].update({
                 "TotInvValFc": in_round(
-                    (tax_details.get("base_amount_currency") + tax_details.get("tax_amount_currency")))
+                    tax_details.get("base_amount_currency") + tax_details.get("tax_amount_currency"))
             })
         if seller_buyer['seller_details'] != seller_buyer['dispatch_details']:
             json_payload['DispDtls'] = self._get_l10n_in_edi_partner_details(

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -1,9 +1,8 @@
-import pytz
+import datetime
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
 from odoo.exceptions import AccessError, ValidationError
-from stdnum.in_ import pan, gstin
 
 
 class ResCompany(models.Model):
@@ -70,9 +69,9 @@ class ResCompany(models.Model):
             }
         # validity data-time in Indian standard time(UTC+05:30) convert IST to UTC
         if data := response.get('data'):
-            tz = pytz.timezone("Asia/Kolkata")
-            local_time = tz.localize(fields.Datetime.to_datetime(data["TokenExpiry"]))
-            utc_time = local_time.astimezone(pytz.utc)
+            tz = ZoneInfo("Asia/Kolkata")
+            local_time = fields.Datetime.to_datetime(data["TokenExpiry"]).replace(tzinfo=tz)
+            utc_time = local_time.astimezone(datetime.UTC)
             self_sudo.write({
                 'l10n_in_edi_token_validity': fields.Datetime.to_string(utc_time),
                 'l10n_in_edi_token': data['AuthToken'],

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -3,7 +3,6 @@
 import base64
 import json
 import logging
-import pytz
 import re
 
 from datetime import datetime

--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta, time
-import pytz
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
@@ -149,7 +149,7 @@ class HrLeave(models.Model):
                 for offset in range((leave.request_date_to - leave.request_date_from).days + 1)
             }
 
-        tz = pytz.timezone(self.env.context.get("tz") or self.env.user.tz or "UTC")
+        tz = ZoneInfo(self.env.context.get("tz") or self.env.user.tz or "UTC")
         public_holidays_dates_by_company = {
             company_id: {
                 (datetime.date(holiday.date_from.astimezone(tz)) + timedelta(days=offset)): holiday

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import re
+from datetime import datetime, UTC
 
-from datetime import datetime
-from pytz import UTC
 from lxml import etree
 
 from odoo import api, models

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -1,12 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
-
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from freezegun import freeze_time
 from lxml import etree
-from pytz import timezone
-from odoo import Command
 
+from odoo import Command
 from odoo.exceptions import ValidationError, UserError
 from odoo.tests import tagged
 from odoo.tools import misc
@@ -75,7 +75,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/simplified/credit.xml',
             expected_xpath=self.credit_note_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2023, 3, 10, 14, 59, 38, tzinfo=timezone('Etc/GMT-3'))
+            freeze_time_at=datetime(2023, 3, 10, 14, 59, 38, tzinfo=ZoneInfo('Etc/GMT-3'))
         )
 
     def testCreditNoteStandard(self):
@@ -103,7 +103,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/standard/credit.xml',
             expected_xpath=self.credit_note_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2022, 9, 5, 9, 39, 15, tzinfo=timezone('Etc/GMT-3')),
+            freeze_time_at=datetime(2022, 9, 5, 9, 39, 15, tzinfo=ZoneInfo('Etc/GMT-3')),
             additional_xpath=additional_xpath
         )
 
@@ -127,7 +127,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/simplified/debit.xml',
             expected_xpath=self.debit_note_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2023, 3, 10, 15, 1, 46, tzinfo=timezone('Etc/GMT-3'))
+            freeze_time_at=datetime(2023, 3, 10, 15, 1, 46, tzinfo=ZoneInfo('Etc/GMT-3'))
         )
 
     def testDebitNoteStandard(self):
@@ -155,7 +155,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/standard/debit.xml',
             expected_xpath=self.debit_note_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2022, 9, 5, 9, 45, 27, tzinfo=timezone('Etc/GMT-3')),
+            freeze_time_at=datetime(2022, 9, 5, 9, 45, 27, tzinfo=ZoneInfo('Etc/GMT-3')),
             additional_xpath=additional_xpath
         )
 
@@ -179,7 +179,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/simplified/invoice.xml',
             expected_xpath=self.invoice_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2023, 3, 10, 14, 56, 55, tzinfo=timezone('Etc/GMT-3'))
+            freeze_time_at=datetime(2023, 3, 10, 14, 56, 55, tzinfo=ZoneInfo('Etc/GMT-3'))
         )
 
     def testInvoiceStandard(self):
@@ -201,7 +201,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/standard/invoice.xml',
             expected_xpath=self.invoice_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
+            freeze_time_at=datetime(2022, 9, 5, 8, 20, 2, tzinfo=ZoneInfo('Etc/GMT-3'))
         )
 
     def testInvoiceWithDownpayment(self):
@@ -210,7 +210,7 @@ class TestEdiZatca(TestSaEdiCommon):
             self.skipTest("Sale module is not installed")
         self.env.user.group_ids += self.env.ref('sales_team.group_sale_salesman')
 
-        freeze = datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
+        freeze = datetime(2022, 9, 5, 8, 20, 2, tzinfo=ZoneInfo('Etc/GMT-3'))
 
         # Helper to test generated files
         saudi_pricelist = self.env['product.pricelist'].create({
@@ -325,7 +325,7 @@ class TestEdiZatca(TestSaEdiCommon):
             test_file_path='l10n_sa_edi/tests/compliance/standard/invoice.xml',
             expected_xpath=self.invoice_applied_xpath,
             move_data=move_data,
-            freeze_time_at=datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
+            freeze_time_at=datetime(2022, 9, 5, 8, 20, 2, tzinfo=ZoneInfo('Etc/GMT-3'))
         )
 
     def testCompanyOnSimplifiedInvoiceQR(self):

--- a/addons/l10n_tw_edi_ecpay/utils.py
+++ b/addons/l10n_tw_edi_ecpay/utils.py
@@ -3,8 +3,9 @@
 import base64
 import datetime
 import json
-import pytz
 import urllib.parse
+from zoneinfo import ZoneInfo
+
 import requests
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -17,8 +18,8 @@ TIMEOUT = 20
 
 def transfer_time(time_before):
     ecpay_time = datetime.datetime.strptime(time_before, "%Y-%m-%d %H:%M:%S")
-    ecpay_time = pytz.timezone('Asia/Taipei').localize(ecpay_time)
-    return ecpay_time.astimezone(pytz.UTC).strftime("%Y-%m-%d %H:%M:%S")
+    ecpay_time = ecpay_time.replace(tzinfo=ZoneInfo('Asia/Taipei'))
+    return ecpay_time.astimezone(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def encrypt(data, cipher):

--- a/addons/lunch/tests/test_supplier.py
+++ b/addons/lunch/tests/test_supplier.py
@@ -1,10 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import pytz
-
 from datetime import datetime, time, timedelta
-from freezegun import freeze_time
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.tests import tagged, common
@@ -73,7 +73,7 @@ env['lunch.supplier'].browse([{self.supplier_kothai.id}])._send_auto_email()""")
                 self.assertEqual(
                     list(Supplier._search_available_today('in', [True])),
                     ['&', '|', ('recurrency_end_date', '=', False),
-                        ('recurrency_end_date', '>', value.astimezone(pytz.timezone(self.env.user.tz)).date()),
+                        ('recurrency_end_date', '>', value.astimezone(ZoneInfo(self.env.user.tz)).date()),
                         (dayname, 'in', [True])],
                 )
 

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import pytz
 import uuid
 from datetime import datetime, timedelta
 
@@ -9,6 +8,7 @@ from odoo import _, api, fields, models
 from odoo.http import request
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
+from odoo.tools.date_utils import all_timezones
 from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
 
@@ -82,7 +82,7 @@ class MailGuest(models.Model):
 
     def _get_timezone_from_request(self, request):
         timezone = request.cookies.get('tz')
-        return timezone if timezone in pytz.all_timezones else False
+        return timezone if timezone in all_timezones else False
 
     def _update_name(self, name):
         self.ensure_one()

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from ast import literal_eval
 import logging
-import pytz
-
+from ast import literal_eval
 from collections import defaultdict, Counter
 from datetime import date, datetime, timedelta
+
 from dateutil.relativedelta import MO, relativedelta
 
 from odoo import api, fields, models, _

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -1,10 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections.abc import Iterable
-from datetime import datetime
-
 import logging
-import pytz
+from collections.abc import Iterable
+from datetime import datetime, UTC
 
 from odoo import api, fields, models
 from odoo.fields import Domain
@@ -191,7 +189,7 @@ class MailActivityMixin(models.AbstractModel):
             )::INT AS activity_state
             """,
             activity_t.date_deadline,
-            fields.Datetime.now().astimezone(pytz.utc),
+            fields.Datetime.now().astimezone(UTC),
             activity_t.user_tz,
         ))
 

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -108,7 +108,7 @@ class MailLinkPreview(models.Model):
 
     def _is_domain_thottled(self, url):
         domain = urlparse(url).netloc
-        date_interval = fields.Datetime.to_string((datetime.now() - relativedelta(seconds=10)))
+        date_interval = fields.Datetime.to_string(datetime.now() - relativedelta(seconds=10))
         call_counter = self.env["mail.link.preview"].search_count(
             [("source_url", "ilike", domain), ("create_date", ">", date_interval)]
         )

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -5,13 +5,12 @@ import ast
 import datetime
 import json
 import logging
-import psycopg2
-import pytz
 import re
 import smtplib
 from collections import defaultdict
-
 from datetime import timedelta
+
+import psycopg2
 from dateutil.parser import parse
 
 from odoo import _, api, fields, models, modules, SUPERUSER_ID, tools
@@ -313,10 +312,10 @@ class MailMail(models.Model):
         if parsed_datetime:
             parsed_datetime = parsed_datetime.replace(microsecond=0)
             if not parsed_datetime.tzinfo:
-                parsed_datetime = pytz.utc.localize(parsed_datetime)
+                parsed_datetime = parsed_datetime.replace(tzinfo=datetime.UTC)
             else:
                 try:
-                    parsed_datetime = parsed_datetime.astimezone(pytz.utc)
+                    parsed_datetime = parsed_datetime.astimezone(datetime.UTC)
                 except Exception:
                     pass
         return parsed_datetime

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -12,9 +12,7 @@ import hmac
 import json
 import lxml
 import logging
-import pytz
 import time
-
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from email import message_from_string
@@ -1872,9 +1870,9 @@ class MailThread(models.AbstractModel):
                     # naive datetime, so we arbitrarily decide to make it
                     # UTC, there's no better choice. Should not happen,
                     # as RFC2822 requires timezone offset in Date headers.
-                    stored_date = parsed_date.replace(tzinfo=pytz.utc)
+                    stored_date = parsed_date.replace(tzinfo=datetime.UTC)
                 else:
-                    stored_date = parsed_date.astimezone(tz=pytz.utc)
+                    stored_date = parsed_date.astimezone(tz=datetime.UTC)
             except Exception:
                 _logger.info('Failed to parse Date header %r in incoming mail '
                              'with message-id %r, assuming current date/time.',

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -1,6 +1,6 @@
 import base64
-import pytz
-from datetime import date, datetime
+from datetime import date, datetime, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import _, api, exceptions, fields, models, modules
 
@@ -438,5 +438,5 @@ class CardCampaign(models.Model):
                     isinstance(result[el], (date, datetime))
                     and (tz := record._mail_get_timezone())
                 ):
-                    result[el] = pytz.utc.localize(result[el]).astimezone(pytz.timezone(tz)).replace(tzinfo=None)
+                    result[el] = result[el].replace(tzinfo=UTC).astimezone(ZoneInfo(tz)).replace(tzinfo=None)
         return result

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import pytz
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
+
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
@@ -314,8 +315,8 @@ class CalendarEvent(models.Model):
         }
 
         commands_attendee, commands_partner = self._odoo_attendee_commands_m(microsoft_event)
-        timeZone_start = pytz.timezone(microsoft_event.start.get('timeZone'))
-        timeZone_stop = pytz.timezone(microsoft_event.end.get('timeZone'))
+        timeZone_start = ZoneInfo(microsoft_event.start.get('timeZone'))
+        timeZone_stop = ZoneInfo(microsoft_event.end.get('timeZone'))
         start = parse(microsoft_event.start.get('dateTime')).astimezone(timeZone_start).replace(tzinfo=None)
         if microsoft_event.isAllDay:
             stop = parse(microsoft_event.end.get('dateTime')).astimezone(timeZone_stop).replace(tzinfo=None) - relativedelta(days=1)
@@ -370,8 +371,8 @@ class CalendarEvent(models.Model):
 
     @api.model
     def _microsoft_to_odoo_recurrence_values(self, microsoft_event, default_values=None):
-        timeZone_start = pytz.timezone(microsoft_event.start.get('timeZone'))
-        timeZone_stop = pytz.timezone(microsoft_event.end.get('timeZone'))
+        timeZone_start = ZoneInfo(microsoft_event.start.get('timeZone'))
+        timeZone_stop = ZoneInfo(microsoft_event.end.get('timeZone'))
         start = parse(microsoft_event.start.get('dateTime')).astimezone(timeZone_start).replace(tzinfo=None)
         if microsoft_event.isAllDay:
             stop = parse(microsoft_event.end.get('dateTime')).astimezone(timeZone_stop).replace(tzinfo=None) - relativedelta(days=1)
@@ -519,8 +520,8 @@ class CalendarEvent(models.Model):
                 start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'Europe/London'}
                 end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'Europe/London'}
             else:
-                start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'Europe/London'}
-                end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'Europe/London'}
+                start = {'dateTime': self.start.replace(tzinfo=UTC).isoformat(), 'timeZone': 'Europe/London'}
+                end = {'dateTime': self.stop.replace(tzinfo=UTC).isoformat(), 'timeZone': 'Europe/London'}
 
             values['start'] = start
             values['end'] = end
@@ -657,8 +658,8 @@ class CalendarEvent(models.Model):
             start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'Europe/London'}
             end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'Europe/London'}
         else:
-            start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'Europe/London'}
-            end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'Europe/London'}
+            start = {'dateTime': self.start.replace(tzinfo=UTC).isoformat(), 'timeZone': 'Europe/London'}
+            end = {'dateTime': self.stop.replace(tzinfo=UTC).isoformat(), 'timeZone': 'Europe/London'}
 
         values['start'] = start
         values['end'] = end

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -1,11 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import datetime
 import logging
 from contextlib import contextmanager
 from functools import wraps
-import pytz
-from dateutil.parser import parse
 from datetime import timedelta
+
+from dateutil.parser import parse
 
 from odoo import api, fields, models
 from odoo.fields import Domain
@@ -320,7 +320,7 @@ class MicrosoftCalendarSync(models.AbstractModel):
                 odoo_event = self.browse(mevent.odoo_id(self.env)).exists()
 
             if odoo_event:
-                odoo_event_updated_time = pytz.utc.localize(odoo_event.write_date)
+                odoo_event_updated_time = odoo_event.write_date.replace(tzinfo=datetime.UTC)
                 ms_event_updated_time = parse(mevent.lastModifiedDateTime)
 
                 # If the update comes from an old event/recurrence, check if time diff between updates is reasonable.

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -1,16 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import pytz
-from datetime import datetime, timedelta
-from markupsafe import Markup
-from unittest.mock import patch, MagicMock
 from contextlib import contextmanager
+from datetime import datetime, timedelta, UTC
+from unittest.mock import patch, MagicMock
+
 from freezegun import freeze_time
+from markupsafe import Markup
 
 from odoo import fields
-
 from odoo.tests.common import HttpCase
-
 from odoo.addons.microsoft_calendar.models.microsoft_sync import MicrosoftCalendarSync
 
 def mock_get_token(user):
@@ -118,11 +116,11 @@ class TestCommon(HttpCase):
                 'contentType': "text",
             },
             "start": {
-                'dateTime': pytz.utc.localize(self.simple_event_values["start"]).isoformat(),
+                'dateTime': self.simple_event_values["start"].replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/London'
             },
             "end": {
-                'dateTime': pytz.utc.localize(self.simple_event_values["stop"]).isoformat(),
+                'dateTime': self.simple_event_values["stop"].replace(tzinfo=UTC).isoformat(),
                 'timeZone': 'Europe/London'
             },
             "isAllDay": False,

--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
+from datetime import datetime, UTC
+
 from dateutil.relativedelta import relativedelta
-from pytz import UTC
 
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.tests import tagged

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -1,10 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from datetime import datetime, timedelta
-from dateutil.parser import parse
 import logging
-import pytz
+from datetime import datetime, timedelta, UTC
 from unittest.mock import patch, ANY
+
+from dateutil.parser import parse
 from freezegun import freeze_time
 
 from odoo import Command
@@ -166,11 +165,11 @@ class TestUpdateEvents(TestCommon):
                 'seriesMasterId': 'REC123',
                 'type': 'exception',
                 'start': {
-                    'dateTime': pytz.utc.localize(new_date).isoformat(),
+                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'end': {
-                    'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
+                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'isAllDay': False
@@ -246,7 +245,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_name_of_one_and_future_events_of_recurrence_from_odoo(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, _mock_delete
     ):
         """
         Update a Odoo event name and future events from a recurrence from the organizer calendar.
@@ -286,7 +285,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_start_of_one_and_future_events_of_recurrence_from_odoo(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, mock_delete
     ):
         """
         Update a Odoo event start date and future events from a recurrence from the organizer calendar.
@@ -346,11 +345,11 @@ class TestUpdateEvents(TestCommon):
                 'seriesMasterId': 'REC123',
                 'type': 'exception',
                 'start': {
-                    'dateTime': pytz.utc.localize(new_date).isoformat(),
+                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'end': {
-                    'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
+                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'isAllDay': False
@@ -363,7 +362,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_start_of_one_and_future_events_of_recurrence_from_odoo_with_overlap(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, mock_delete
     ):
         """
         Update a Odoo event start date and future events from a recurrence from the organizer calendar,
@@ -419,11 +418,11 @@ class TestUpdateEvents(TestCommon):
                 'seriesMasterId': 'REC123',
                 'type': 'exception',
                 'start': {
-                    'dateTime': pytz.utc.localize(new_date).isoformat(),
+                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'end': {
-                    'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
+                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'isAllDay': False
@@ -436,7 +435,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_one_and_future_events_of_recurrence_from_odoo_attendee_calendar(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, mock_delete
     ):
         """
         Update a Odoo event name and future events from a recurrence from the attendee calendar.
@@ -487,11 +486,11 @@ class TestUpdateEvents(TestCommon):
                 'seriesMasterId': 'REC123',
                 'type': 'exception',
                 'start': {
-                    'dateTime': pytz.utc.localize(new_date).isoformat(),
+                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'end': {
-                    'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
+                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'isAllDay': False
@@ -506,7 +505,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_name_of_all_events_of_recurrence_from_odoo(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, _mock_delete
     ):
         """
         Update all events name from a recurrence from the organizer calendar.
@@ -541,7 +540,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_start_of_all_events_of_recurrence_from_odoo(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, mock_delete
     ):
         """
         Update all events start date from a recurrence from the organizer calendar.
@@ -580,11 +579,11 @@ class TestUpdateEvents(TestCommon):
                 'seriesMasterId': 'REC123',
                 'type': 'exception',
                 'start': {
-                    'dateTime': pytz.utc.localize(new_date).isoformat(),
+                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'end': {
-                    'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
+                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'isAllDay': False
@@ -605,7 +604,7 @@ class TestUpdateEvents(TestCommon):
     @patch.object(MicrosoftCalendarService, 'insert')
     @patch.object(MicrosoftCalendarService, 'patch')
     def test_update_all_events_of_recurrence_from_odoo_attendee_calendar(
-        self, mock_patch, mock_insert, mock_delete
+        self, mock_patch, _mock_insert, mock_delete
     ):
         """
         Update all events start date from a recurrence from the attendee calendar.
@@ -644,11 +643,11 @@ class TestUpdateEvents(TestCommon):
                 'seriesMasterId': 'REC123',
                 'type': 'exception',
                 'start': {
-                    'dateTime': pytz.utc.localize(new_date).isoformat(),
+                    'dateTime': new_date.replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'end': {
-                    'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
+                    'dateTime': (new_date + timedelta(hours=1)).replace(tzinfo=UTC).isoformat(),
                     'timeZone': 'Europe/London'
                 },
                 'isAllDay': False
@@ -1411,7 +1410,7 @@ class TestUpdateEvents(TestCommon):
 
     @freeze_time('2021-09-22')
     @patch.object(MicrosoftCalendarService, 'patch')
-    def test_restart_sync_with_synced_recurrence(self, mock_patch):
+    def test_restart_sync_with_synced_recurrence(self, _mock_patch):
         """ Ensure that sync restart is not blocked when there are recurrence outliers in Odoo database. """
         # Stop synchronization, set recurrent events as outliers and restart sync with Outlook.
         self.organizer_user.stop_microsoft_synchronization()

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
+from datetime import timedelta, datetime
+from functools import partial
+from random import randint
+from zoneinfo import ZoneInfo
 
 from babel.dates import format_date
 from collections import defaultdict
 from dateutil import relativedelta
-from datetime import timedelta, datetime
-from functools import partial
-from pytz import timezone
-from random import randint
 
 from odoo import api, exceptions, fields, models, _
 from odoo.exceptions import UserError, ValidationError
@@ -353,11 +353,11 @@ class MrpWorkcenter(models.Model):
         resource = self.resource_id
         revert = to_timezone(start_datetime.tzinfo)
         start_datetime = localized(start_datetime)
-        get_available_intervals = partial(self.resource_calendar_id._work_intervals_batch, resources=resource, tz=timezone(self.resource_calendar_id.tz))
+        get_available_intervals = partial(self.resource_calendar_id._work_intervals_batch, resources=resource, tz=ZoneInfo(self.resource_calendar_id.tz))
         workorder_intervals_leaves_domain = [('time_type', '=', 'other')]
         if leaves_to_ignore:
             workorder_intervals_leaves_domain.append(('id', 'not in', leaves_to_ignore.ids))
-        get_workorder_intervals = partial(self.resource_calendar_id._leave_intervals_batch, domain=workorder_intervals_leaves_domain, resources=resource, tz=timezone(self.resource_calendar_id.tz))
+        get_workorder_intervals = partial(self.resource_calendar_id._leave_intervals_batch, domain=workorder_intervals_leaves_domain, resources=resource, tz=ZoneInfo(self.resource_calendar_id.tz))
         extra_leaves_slots_intervals = Intervals([(localized(start), localized(stop), self.env['resource.calendar.attendance']) for start, stop in extra_leaves_slots])
 
         remaining = duration = max(duration, 1 / 60)

--- a/addons/mrp/tests/test_oee.py
+++ b/addons/mrp/tests/test_oee.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, time, UTC
+from zoneinfo import ZoneInfo
+
 from freezegun import freeze_time
-from pytz import timezone, utc
 
 from odoo import fields
 from odoo.addons.mrp.tests.common import TestMrpCommon
@@ -45,11 +46,11 @@ class TestOee(TestMrpCommon):
         if day.weekday() in (5, 6):
             day -= timedelta(days=2)
 
-        tz = timezone(self.workcenter_1.resource_calendar_id.tz)
+        tz = ZoneInfo(self.workcenter_1.resource_calendar_id.tz)
 
         def time_to_string_utc_datetime(time):
             return fields.Datetime.to_string(
-                tz.localize(datetime.combine(day, time)).astimezone(utc)
+                datetime.combine(day, time, tzinfo=tz).astimezone(UTC)
             )
 
         start_time = time_to_string_utc_datetime(time(10, 43, 22))

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
 from datetime import datetime
 from uuid import uuid4
-import pytz
-from collections import defaultdict
 
 from odoo import api, fields, models, _, Command, tools, SUPERUSER_ID
 from odoo.http import request
@@ -390,7 +389,6 @@ class PosConfig(models.Model):
     def get_statistics_for_session(self, session):
         self.ensure_one()
         currency = self.currency_id
-        timezone = pytz.timezone(self.env.context.get('tz') or self.env.user.tz or 'UTC')
         statistics = {
             'cash': {
                 'raw_opening_cash': session.cash_register_balance_start,
@@ -398,7 +396,7 @@ class PosConfig(models.Model):
             },
             'date': {
                 'is_started': bool(session.start_at),
-                'start_date': session.start_at.astimezone(timezone).strftime('%b %d') if session.start_at else False,
+                'start_date': session.start_at.astimezone(self.env.tz).strftime('%b %d') if session.start_at else False,
             },
             'orders': {
                 'paid': False,

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
 import logging
 import json
-from datetime import datetime
-from markupsafe import Markup
+from datetime import datetime, UTC
 from itertools import groupby
 from collections import defaultdict
 from uuid import uuid4
@@ -10,13 +10,12 @@ from random import randrange
 from pprint import pformat
 
 import psycopg2
-import pytz
+from markupsafe import Markup
 
 from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare, formatLang
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Command, Domain
-import base64
 
 
 _logger = logging.getLogger(__name__)
@@ -1687,8 +1686,8 @@ class PosOrderLine(models.Model):
             # because shipping_date is date and date_planned is datetime
             from_zone = self.env.tz
             shipping_date = fields.Datetime.to_datetime(self.order_id.shipping_date)
-            shipping_date = from_zone.localize(shipping_date)
-            date_deadline = shipping_date.astimezone(pytz.UTC).replace(tzinfo=None)
+            shipping_date = shipping_date.replace(tzinfo=from_zone)
+            date_deadline = shipping_date.astimezone(UTC).replace(tzinfo=None)
         else:
             date_deadline = self.order_id.date_order
 

--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import timedelta
-
-import pytz
+import datetime
 
 from odoo import api, fields, models, _
 from odoo.fields import Domain
@@ -19,24 +17,24 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
         else:
             # start by default today 00:00:00
             user_tz = self.env.tz
-            today = user_tz.localize(fields.Datetime.from_string(fields.Date.context_today(self)))
-            date_start = today.astimezone(pytz.timezone('UTC')).replace(tzinfo=None)
+            today = fields.Datetime.from_string(fields.Date.context_today(self)).replace(tzinfo=user_tz)
+            date_start = today.astimezone(datetime.UTC).replace(tzinfo=None)
 
         if date_stop:
             date_stop = fields.Datetime.from_string(date_stop)
             # avoid a date_stop smaller than date_start
-            if (date_stop < date_start):
-                date_stop = date_start + timedelta(days=1, seconds=-1)
+            if date_stop < date_start:
+                date_stop = date_start + datetime.timedelta(days=1, seconds=-1)
         else:
             # stop by default today 23:59:59
-            date_stop = date_start + timedelta(days=1, seconds=-1)
+            date_stop = date_start + datetime.timedelta(days=1, seconds=-1)
 
         return date_start, date_stop
 
     def _get_domain(self, date_start=False, date_stop=False, config_ids=False, session_ids=False):
         domain = Domain('state', 'in', ['paid', 'done'])
 
-        if (session_ids):
+        if session_ids:
             domain &= Domain('session_id', 'in', session_ids)
         else:
             date_start, date_stop = self._get_date_start_and_date_stop(date_start, date_stop)

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
             load=False
         )
 
-        combo_products = self.browse((p['id'] for p in products if p["type"] == "combo"))
+        combo_products = self.browse(p['id'] for p in products if p["type"] == "combo")
         combo_products_choice = self.search_read(
             [("id", 'in', combo_products.combo_ids.combo_item_ids.product_id.product_tmpl_id.ids), ("id", "not in", [p['id'] for p in products])],
             fields,

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
-from pytz import UTC
 from collections import defaultdict
-from datetime import timedelta, datetime, time
+from datetime import timedelta, datetime, time, UTC
+
 from lxml import html
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
@@ -2100,8 +2100,8 @@ class ProjectTask(models.Model):
     def get_unusual_days(self, date_from, date_to=None):
         calendar = self.env.company.resource_calendar_id
         return calendar._get_unusual_days(
-            datetime.combine(fields.Date.from_string(date_from), time.min).replace(tzinfo=UTC),
-            datetime.combine(fields.Date.from_string(date_to), time.max).replace(tzinfo=UTC)
+            datetime.combine(fields.Date.from_string(date_from), time.min, tzinfo=UTC),
+            datetime.combine(fields.Date.from_string(date_to), time.max, tzinfo=UTC)
         )
 
     def action_redirect_to_project_task_form(self):

--- a/addons/project_timesheet_holidays/models/hr_leave.py
+++ b/addons/project_timesheet_holidays/models/hr_leave.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from zoneinfo import ZoneInfo
 
 from odoo import fields, models, _
-
-import pytz
 
 
 class HrLeave(models.Model):
@@ -38,7 +37,7 @@ class HrLeave(models.Model):
             if not calendar or not calendar.tz:
                 continue
 
-            calendar_timezone = pytz.timezone(calendar.tz)
+            calendar_timezone = ZoneInfo(calendar.tz)
 
             if calendar.flexible_hours and (leave.request_unit_hours or leave.request_unit_half or leave.date_from.date() == leave.date_to.date()):
                 leave_date = leave.date_from.astimezone(calendar_timezone).date()

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1,11 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
-
+from ast import literal_eval
 from collections import defaultdict
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from dateutil.relativedelta import relativedelta
-from pytz import timezone
-from ast import literal_eval
 from markupsafe import escape, Markup
 from werkzeug.urls import url_encode
 
@@ -1245,7 +1245,7 @@ class PurchaseOrder(models.Model):
         """ Returns the timezone of the order's user or the company's partner
         or UTC if none of them are set. """
         self.ensure_one()
-        return timezone(self.user_id.tz or self.company_id.partner_id.tz or 'UTC')
+        return ZoneInfo(self.user_id.tz or self.company_id.partner_id.tz or 'UTC')
 
     def _update_date_planned_for_lines(self, updated_dates):
         # create or update the activity

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
-from datetime import datetime, time
+from datetime import datetime, time, UTC
 
 from dateutil.relativedelta import relativedelta
-from pytz import UTC
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -654,7 +653,7 @@ class PurchaseOrderLine(models.Model):
         """Return a datetime which is the noon of the input date(time) according
         to order user's time zone, convert to UTC time.
         """
-        return self.order_id.get_order_timezone().localize(datetime.combine(date, time(12))).astimezone(UTC).replace(tzinfo=None)
+        return datetime.combine(date, time(12), tzinfo=self.order_id.get_order_timezone()).astimezone(UTC).replace(tzinfo=None)
 
     @api.model
     def _date_in_the_past(self):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -1,10 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import timedelta
+from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
 from psycopg2.errors import IntegrityError
-from pytz import timezone
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
@@ -156,7 +155,7 @@ class TestPurchase(AccountTestInvoicingCommon):
 
         # check date_planned is correctly set
         self.assertEqual(po.date_planned, date_planned)
-        po_tz = timezone(po.user_id.tz)
+        po_tz = ZoneInfo(po.user_id.tz)
         localized_date_planned = po.date_planned.astimezone(po_tz)
         self.assertEqual(localized_date_planned, po.get_localized_date_planned())
         # Ensure that the function get_localized_date_planned can accept a date in string format

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from pytz import utc
+from datetime import UTC
 
 from odoo import api, fields, models
 from odoo.tools.date_utils import localized
@@ -196,9 +196,9 @@ class ResourceMixin(models.AbstractModel):
 
         # naive datetimes are made explicit in UTC
         if not from_datetime.tzinfo:
-            from_datetime = from_datetime.replace(tzinfo=utc)
+            from_datetime = from_datetime.replace(tzinfo=UTC)
         if not to_datetime.tzinfo:
-            to_datetime = to_datetime.replace(tzinfo=utc)
+            to_datetime = to_datetime.replace(tzinfo=UTC)
         compute_leaves = self.env.context.get('compute_leaves', True)
 
         for calendar, records in records_by_calendar.items():
@@ -228,9 +228,9 @@ class ResourceMixin(models.AbstractModel):
 
         # naive datetimes are made explicit in UTC
         if not from_datetime.tzinfo:
-            from_datetime = from_datetime.replace(tzinfo=utc)
+            from_datetime = from_datetime.replace(tzinfo=UTC)
         if not to_datetime.tzinfo:
-            to_datetime = to_datetime.replace(tzinfo=utc)
+            to_datetime = to_datetime.replace(tzinfo=UTC)
 
         attendances = calendar._attendance_intervals_batch(from_datetime, to_datetime, resource)[resource.id]
         leaves = calendar._leave_intervals_batch(from_datetime, to_datetime, resource, domain)[resource.id]

--- a/addons/resource/tests/test_flexible_resource_calendar.py
+++ b/addons/resource/tests/test_flexible_resource_calendar.py
@@ -1,10 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import pytz
-from datetime import datetime, date
+from datetime import datetime, date, UTC
 
 from odoo.tests.common import tagged, TransactionCase
-
-UTC = pytz.timezone('UTC')
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/addons/resource/tests/test_resource_calendar.py
+++ b/addons/resource/tests/test_resource_calendar.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import pytz
-from datetime import datetime
+from datetime import datetime, UTC
 
 from odoo.tests.common import tagged, TransactionCase
 
@@ -28,7 +27,6 @@ class TestResourceCalendar(TransactionCase):
             'hour_from': 14,   # 18:00 UTC
             'hour_to': 17,     # 21:00 UTC
         })
-        UTC = pytz.timezone('UTC')
         start_dt = datetime(2025, 6, 4, 18, 0, 0).astimezone(UTC)
         end_dt = datetime(2025, 6, 4, 21, 0, 0).astimezone(UTC)
         result_per_resource_id = calendar._attendance_intervals_batch(
@@ -54,7 +52,6 @@ class TestResourceCalendar(TransactionCase):
             'full_time_required_hours': 7.0,
             'flexible_hours': True,
         })
-        UTC = pytz.timezone('UTC')
         start_dt = datetime(2025, 6, 4, 0, 0, 0).astimezone(UTC)
         end_dt = datetime(2025, 6, 4, 12, 0, 0).astimezone(UTC)
         result_per_resource_id = calendar._attendance_intervals_batch(

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -4,8 +4,7 @@ import itertools
 import random
 from collections import defaultdict
 from functools import partial
-
-from pytz import timezone
+from zoneinfo import ZoneInfo
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -700,7 +699,7 @@ class SaleOrder(models.Model):
         if confirmed_txs_dates:
             # If order is getting confirmed, use the earliest finalized transaction's create date
             tx_date = min(confirmed_txs_dates)
-            return tx_date.astimezone(timezone(order_tz)).date()
+            return tx_date.astimezone(ZoneInfo(order_tz)).date()
         return fields.Date.context_today(self.with_context(tz=order_tz))
 
     def _get_applicable_program_points(self, domain=None):

--- a/addons/sale_loyalty/tests/test_program_rules.py
+++ b/addons/sale_loyalty/tests/test_program_rules.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, timedelta
+from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
-from pytz import timezone
 
 from odoo.exceptions import ValidationError
 from odoo.fields import Command, Datetime
@@ -424,7 +424,7 @@ class TestProgramRules(TestSaleCouponCommon, PaymentCommon):
                 "Promo should not be applied if only valid in the customer's time zone",
             )
 
-        with freeze_time(timezone(self.env.company.partner_id.tz).localize(midnight)):
+        with freeze_time(midnight.replace(tzinfo=ZoneInfo(self.env.company.partner_id.tz))):
             # Try apply reward at London midnight (expired)
             self._auto_rewards(order, self.immediate_promotion_program)
             self.assertFalse(
@@ -433,7 +433,7 @@ class TestProgramRules(TestSaleCouponCommon, PaymentCommon):
             )
 
         self.partner.tz = 'Europe/Brussels'
-        with freeze_time(timezone(self.partner.tz).localize(midnight)):
+        with freeze_time(midnight.replace(tzinfo=ZoneInfo(self.partner.tz))):
             # Apply reward at Brussels midnight (still valid in company's time zone)
             self._auto_rewards(order, self.immediate_promotion_program)
             self.assertTrue(

--- a/addons/spreadsheet/utils/formatting.py
+++ b/addons/spreadsheet/utils/formatting.py
@@ -1,7 +1,6 @@
 import re
 from datetime import datetime, timedelta
-
-import pytz
+from zoneinfo import ZoneInfo
 
 strftime_to_spreadsheet_time_format_table = {
     "%H": "hh",
@@ -63,7 +62,7 @@ SECONDS_PER_DAY = 24 * 60 * 60
 
 
 def datetime_to_spreadsheet_date_number(dt, tz_name):
-    context_tz = pytz.timezone(tz_name)
+    context_tz = ZoneInfo(tz_name)
     localized_datetime = dt.astimezone(context_tz)
     offset = localized_datetime.utcoffset() / timedelta(seconds=1)
     timestamp = dt.timestamp() + offset

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from pytz import timezone, UTC
 from collections import defaultdict
-from datetime import datetime, time
+from datetime import datetime, time, UTC
+from zoneinfo import ZoneInfo
+
 from dateutil import relativedelta
 from psycopg2 import OperationalError
 
@@ -796,7 +797,7 @@ class StockWarehouseOrderpoint(models.Model):
         return True
 
     def _get_orderpoint_procurement_date(self):
-        return timezone(self.company_id.partner_id.tz or 'UTC').localize(datetime.combine(self.lead_horizon_date, time(12))).astimezone(UTC).replace(tzinfo=None)
+        return datetime.combine(self.lead_horizon_date, time(12), tzinfo=ZoneInfo(self.company_id.partner_id.tz or 'UTC')).astimezone(UTC).replace(tzinfo=None)
 
     def _get_orderpoint_products(self):
         return self.env['product.product'].search([('is_storable', '=', True), ('stock_move_ids', '!=', False)])

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1,10 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import math
-import pytz
 from ast import literal_eval
-from datetime import date, timedelta
+from datetime import date, timedelta, UTC
 from collections import defaultdict
 
 from odoo import _, api, fields, models
@@ -1804,16 +1802,16 @@ class StockPicking(models.Model):
         date_category = ""
 
         if datetime:
-            datetime = datetime.astimezone(pytz.UTC)
+            datetime = datetime.astimezone(UTC)
             if datetime < start_yesterday:
                 date_category = "before"
-            elif datetime >= start_yesterday and datetime < start_today:
+            elif start_yesterday <= datetime < start_today:
                 date_category = "yesterday"
-            elif datetime >= start_today and datetime < start_day_1:
+            elif start_today <= datetime < start_day_1:
                 date_category = "today"
-            elif datetime >= start_day_1 and datetime < start_day_2:
+            elif start_day_1 <= datetime < start_day_2:
                 date_category = "day_1"
-            elif datetime >= start_day_2 and datetime < start_day_3:
+            elif start_day_2 <= datetime < start_day_3:
                 date_category = "day_2"
             else:
                 date_category = "after"
@@ -1847,7 +1845,7 @@ class StockPicking(models.Model):
             self.env.user, fields.Datetime.now()
         ).replace(hour=0, minute=0, second=0, microsecond=0)
 
-        start_today = start_today.astimezone(pytz.UTC).replace(tzinfo=None)
+        start_today = start_today.astimezone(UTC).replace(tzinfo=None)
 
         start_yesterday = start_today + timedelta(days=-1)
         start_day_1 = start_today + timedelta(days=1)

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date, datetime, timedelta
-from dateutil.relativedelta import relativedelta
-from psycopg2 import IntegrityError
+from datetime import date, datetime, timedelta, UTC
 from unittest.mock import patch
 from unittest.mock import DEFAULT
+from zoneinfo import ZoneInfo
 
-import pytz
+from dateutil.relativedelta import relativedelta
+from psycopg2 import IntegrityError
 
 from odoo import fields, exceptions, tests
 from odoo.addons.mail.tests.common import mail_new_test_user
@@ -607,8 +607,8 @@ class TestActivityViewHelpers(TestActivityCommon):
             test_record, test_record_2 = self.env['mail.test.activity'].browse(
                 (self.test_record + self.test_record_2).ids
             )
-            now_utc = datetime.now(pytz.UTC)
-            now_user = now_utc.astimezone(pytz.timezone(self.env.user.tz or 'UTC'))
+            now_utc = datetime.now(UTC)
+            now_user = now_utc.astimezone(ZoneInfo(self.env.user.tz or 'UTC'))
             today_user = now_user.date()
 
             for days, user_id in ((-1, self.user_employee_2), (0, self.user_employee), (1, self.user_admin)):

--- a/addons/test_mail/tests/test_mail_activity_mixin.py
+++ b/addons/test_mail/tests/test_mail_activity_mixin.py
@@ -1,10 +1,10 @@
-from datetime import date, datetime, timedelta, timezone
+import random
+from datetime import date, datetime, timedelta, timezone, UTC
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
-from unittest.mock import patch
-
-import pytz
-import random
 
 from odoo import fields, tests
 from odoo.addons.mail.models.mail_activity import MailActivity
@@ -43,8 +43,8 @@ class TestActivityMixin(TestActivityCommon):
             self.assertEqual(len(self.test_record.message_ids), 1)
             self.assertEqual(self.test_record.env.user, self.user_employee)
 
-            now_utc = datetime.now(pytz.UTC)
-            now_user = now_utc.astimezone(pytz.timezone(self.env.user.tz or 'UTC'))
+            now_utc = datetime.now(UTC)
+            now_user = now_utc.astimezone(ZoneInfo(self.env.user.tz or 'UTC'))
             today_user = now_user.date()
 
             # Test various scheduling of activities

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -1,17 +1,17 @@
 
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import pytz
 import re
 import smtplib
-from email import message_from_string
-
 from datetime import datetime, timedelta
+from email import message_from_string
+from socket import gaierror, timeout
+from unittest.mock import call, patch, PropertyMock
+from zoneinfo import ZoneInfo
+
 from freezegun import freeze_time
 from markupsafe import Markup
 from OpenSSL.SSL import Error as SSLError
-from socket import gaierror, timeout
-from unittest.mock import call, patch, PropertyMock
 
 from odoo import api, Command, fields, SUPERUSER_ID
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
@@ -336,7 +336,7 @@ class TestMailMail(MailCommon):
             # falsy values
             False, '', 'This is not a date format',
             # datetimes (UTC/GMT +10 hours for Australia/Brisbane)
-            now, pytz.timezone('Australia/Brisbane').localize(now),
+            now, now.replace(tzinfo=ZoneInfo('Australia/Brisbane')),
             # string
             fields.Datetime.to_string(now - timedelta(days=1)),
             fields.Datetime.to_string(now + timedelta(days=1)),
@@ -348,7 +348,7 @@ class TestMailMail(MailCommon):
         ]
         expected_datetimes = [
             False, False, False,
-            now, now - pytz.timezone('Australia/Brisbane').utcoffset(now),
+            now, now - ZoneInfo('Australia/Brisbane').utcoffset(now),
             now - timedelta(days=1), now + timedelta(days=1), now + timedelta(days=1),
             now + timedelta(hours=-1),
             now + timedelta(hours=1),

--- a/addons/test_resource/tests/common.py
+++ b/addons/test_resource/tests/common.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import datetime
-
-from pytz import timezone, utc
+from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
@@ -12,14 +11,14 @@ class TestResourceCommon(TransactionCase):
     def datetime_tz(cls, year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=None):
         """ Return a `datetime` object with a given timezone (if given). """
         dt = datetime(year, month, day, hour, minute, second, microsecond)
-        return timezone(tzinfo).localize(dt) if tzinfo else dt
+        return dt.replace(tzinfo=ZoneInfo(tzinfo)) if tzinfo else dt
 
     @classmethod
     def datetime_str(cls, year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=None):
         """ Return a fields.Datetime value with the given timezone. """
         dt = datetime(year, month, day, hour, minute, second, microsecond)
         if tzinfo:
-            dt = timezone(tzinfo).localize(dt).astimezone(utc)
+            dt = dt.replace(tzinfo=ZoneInfo(tzinfo)).astimezone(UTC)
         return fields.Datetime.to_string(dt)
 
     @classmethod
@@ -33,7 +32,7 @@ class TestResourceCommon(TransactionCase):
                         0,
                         0,
                         {
-                            "name": "%s_%d" % (name, index),
+                            "name": f"{name}_{index:d}",
                             "hour_from": att[0],
                             "hour_to": att[1],
                             "dayofweek": str(att[2]),
@@ -57,7 +56,7 @@ class TestResourceCommon(TransactionCase):
                         0,
                         0,
                         {
-                            "name": "%s_%d" % (name, index),
+                            "name": f"{name}_{index:d}",
                             "hour_from": att[0],
                             "hour_to": att[1],
                             "dayofweek": str(att[2]),

--- a/addons/test_resource/tests/test_calendar.py
+++ b/addons/test_resource/tests/test_calendar.py
@@ -1,6 +1,5 @@
-from datetime import date, datetime
-
-from pytz import timezone
+from datetime import date, datetime, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import fields
 
@@ -352,15 +351,15 @@ class TestCalendar(TestResourceCommon):
         self.env.user.tz = "America/Los_Angeles"
         self.calendar_jean.tz = "America/Los_Angeles"
         attendances = self.calendar_jean._attendance_intervals_batch(
-            datetime.combine(date(2023, 1, 1), datetime.min.time(), tzinfo=timezone("UTC")),
-            datetime.combine(date(2023, 1, 31), datetime.max.time(), tzinfo=timezone("UTC")))
+            datetime.combine(date(2023, 1, 1), datetime.min.time(), tzinfo=UTC),
+            datetime.combine(date(2023, 1, 31), datetime.max.time(), tzinfo=UTC))
         last_attendance = list(attendances[False])[-1]
         self.assertEqual(last_attendance[0].replace(tzinfo=None), datetime(2023, 1, 31, 8))
         self.assertEqual(last_attendance[1].replace(tzinfo=None), datetime(2023, 1, 31, 15, 59, 59, 999999))
 
         attendances = self.calendar_jean._attendance_intervals_batch(
-            datetime.combine(date(2023, 1, 1), datetime.min.time(), tzinfo=timezone("America/Los_Angeles")),
-            datetime.combine(date(2023, 1, 31), datetime.max.time(), tzinfo=timezone("America/Los_Angeles")))
+            datetime.combine(date(2023, 1, 1), datetime.min.time(), tzinfo=ZoneInfo("America/Los_Angeles")),
+            datetime.combine(date(2023, 1, 31), datetime.max.time(), tzinfo=ZoneInfo("America/Los_Angeles")))
         last_attendance = list(attendances[False])[-1]
         self.assertEqual(last_attendance[0].replace(tzinfo=None), datetime(2023, 1, 31, 8))
         self.assertEqual(last_attendance[1].replace(tzinfo=None), datetime(2023, 1, 31, 16))

--- a/addons/test_resource/tests/test_performance.py
+++ b/addons/test_resource/tests/test_performance.py
@@ -3,9 +3,8 @@
 
 import logging
 import time
-import pytz
+from datetime import datetime, UTC
 
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo.tests import tagged, TransactionCase, warmup
@@ -31,8 +30,8 @@ class TestResourcePerformance(TransactionCase):
         ])
         with self.assertQueryCount(__system__=1):
             # Generate attendances for a whole year
-            start = pytz.utc.localize(datetime.now() + relativedelta(month=1, day=1))
-            stop = pytz.utc.localize(datetime.now() + relativedelta(month=12, day=31))
+            start = datetime.now(UTC) + relativedelta(month=1, day=1)
+            stop = datetime.now(UTC) + relativedelta(month=12, day=31)
             start_time = time.time()
             calendar._attendance_intervals_batch(start, stop, resources=resources.resource_id)
             _logger.info('Attendance Intervals Batch (100): --- %s seconds ---', time.time() - start_time)

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -1,8 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
-
-from pytz import utc
+from datetime import datetime, UTC
 
 from odoo.tools.date_utils import sum_intervals
 from odoo.tools.intervals import Intervals
@@ -17,12 +15,12 @@ class TestResource(TestResourceCommon):
 
     def test_calendars_validity_within_period(self):
         calendars = self.jean.resource_id._get_calendars_validity_within_period(
-            utc.localize(datetime(2021, 7, 1, 8, 0, 0)),
-            utc.localize(datetime(2021, 7, 30, 17, 0, 0)),
+            datetime(2021, 7, 1, 8, 0, 0).replace(tzinfo=UTC),
+            datetime(2021, 7, 30, 17, 0, 0).replace(tzinfo=UTC),
         )
         interval = Intervals([(
-            utc.localize(datetime(2021, 7, 1, 8, 0, 0)),
-            utc.localize(datetime(2021, 7, 30, 17, 0, 0)),
+            datetime(2021, 7, 1, 8, 0, 0).replace(tzinfo=UTC),
+            datetime(2021, 7, 30, 17, 0, 0).replace(tzinfo=UTC),
             self.env['resource.calendar.attendance'],
         )])
 
@@ -35,8 +33,8 @@ class TestResource(TestResourceCommon):
         self.assertFalse(interval - jean_entry[jean_calendar], "Calendar validity should cover all interval")
 
         calendars = self.env['resource.resource']._get_calendars_validity_within_period(
-            utc.localize(datetime(2021, 7, 1, 8, 0, 0)),
-            utc.localize(datetime(2021, 7, 30, 17, 0, 0)),
+            datetime(2021, 7, 1, 8, 0, 0).replace(tzinfo=UTC),
+            datetime(2021, 7, 30, 17, 0, 0).replace(tzinfo=UTC),
         )
         self.assertEqual(1, len(calendars), "The dict returned by calendars validity should only have 1 entry")
         self.assertEqual(1, len(calendars[False]), "False (default) should only have one calendar")
@@ -54,24 +52,24 @@ class TestResource(TestResourceCommon):
             'resource_calendar_id': calendars[i % calendars_len].id,
         } for i in range(0, 50)])
 
-        start = utc.localize(datetime(2021, 7, 7, 12, 0, 0))
-        end = utc.localize(datetime(2021, 7, 16, 23, 59, 59))
+        start = datetime(2021, 7, 7, 12, 0, 0).replace(tzinfo=UTC)
+        end = datetime(2021, 7, 16, 23, 59, 59).replace(tzinfo=UTC)
         with self.assertQueryCount(13):
             work_intervals, _ = self.resources_test.resource_id._get_valid_work_intervals(start, end)
 
         self.assertEqual(len(work_intervals), 50)
 
     def test_get_valid_work_intervals(self):
-        start = utc.localize(datetime(2021, 7, 7, 12, 0, 0))
-        end = utc.localize(datetime(2021, 7, 16, 23, 59, 59))
+        start = datetime(2021, 7, 7, 12, 0, 0).replace(tzinfo=UTC)
+        end = datetime(2021, 7, 16, 23, 59, 59).replace(tzinfo=UTC)
         work_intervals, _ = self.jean.resource_id._get_valid_work_intervals(start, end)
         sum_work_intervals = sum_intervals(work_intervals[self.jean.resource_id.id])
         self.assertEqual(58, sum_work_intervals, "Sum of the work intervals for the resource jean should be 40h+18h = 58h")
 
     def test_get_valid_work_intervals_calendars_only(self):
         calendars = [self.calendar_jean, self.calendar_john, self.calendar_jules, self.calendar_patel]
-        start = utc.localize(datetime(2021, 7, 7, 12, 0, 0))
-        end = utc.localize(datetime(2021, 7, 16, 23, 59, 59))
+        start = datetime(2021, 7, 7, 12, 0, 0).replace(tzinfo=UTC)
+        end = datetime(2021, 7, 16, 23, 59, 59).replace(tzinfo=UTC)
         _, calendars_intervals = self.env['resource.resource']._get_valid_work_intervals(start, end, calendars)
         sum_work_intervals_jean = sum_intervals(calendars_intervals[self.calendar_jean.id])
         self.assertEqual(58, sum_work_intervals_jean, "Sum of the work intervals for the calendar of jean should be 40h+18h = 58h")

--- a/addons/test_resource/tests/test_timezones.py
+++ b/addons/test_resource/tests/test_timezones.py
@@ -1,7 +1,6 @@
-from datetime import date, datetime
+from datetime import date, datetime, UTC
 
 from freezegun import freeze_time
-from pytz import utc
 
 from odoo.tests import tagged
 
@@ -217,9 +216,9 @@ class TestTimezones(TestResourceCommon):
         })
         intervals = resource._get_unavailable_intervals(datetime(2022, 9, 21), datetime(2022, 9, 22))
         self.assertEqual(next(iter(intervals.values())), [
-            (datetime(2022, 9, 21, 0, 0, tzinfo=utc), datetime(2022, 9, 21, 6, 0, tzinfo=utc)),
-            (datetime(2022, 9, 21, 10, 0, tzinfo=utc), datetime(2022, 9, 21, 11, 0, tzinfo=utc)),
-            (datetime(2022, 9, 21, 15, 0, tzinfo=utc), datetime(2022, 9, 22, 0, 0, tzinfo=utc)),
+            (datetime(2022, 9, 21, 0, 0, tzinfo=UTC), datetime(2022, 9, 21, 6, 0, tzinfo=UTC)),
+            (datetime(2022, 9, 21, 10, 0, tzinfo=UTC), datetime(2022, 9, 21, 11, 0, tzinfo=UTC)),
+            (datetime(2022, 9, 21, 15, 0, tzinfo=UTC), datetime(2022, 9, 22, 0, 0, tzinfo=UTC)),
         ])
 
     def test_flexible_resource_leave_interval(self):
@@ -247,8 +246,8 @@ class TestTimezones(TestResourceCommon):
             'date_to': '2025-03-07 17:00:00',
         })
 
-        start_dt = datetime(2025, 3, 7, 8, 0, 0, tzinfo=utc)
-        end_dt = datetime(2025, 3, 7, 16, 00, 00, 00, tzinfo=utc)
+        start_dt = datetime(2025, 3, 7, 8, 0, 0, tzinfo=UTC)
+        end_dt = datetime(2025, 3, 7, 16, 00, 00, 00, tzinfo=UTC)
 
         intervals = flexible_calendar._leave_intervals_batch(start_dt, end_dt, [flex_resource])
         intervals_list = list(intervals[flex_resource.id])

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -164,7 +164,7 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
             ('website_id', 'in', (website_1 + website_2).ids),
         ])
         assert (
-            set((view_website_1 + view_website_2)).issubset(theme_child_view.copy_ids)
+            set(view_website_1 + view_website_2).issubset(theme_child_view.copy_ids)
             and view_website_1.website_id == website_1
             and view_website_2.website_id == website_2
         ), "Theme View should have been copied to the website."

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -86,7 +86,7 @@ class GroupsTreeNode:
 
         if self.data:
             return aggregate_func(data)
-        return aggregate_func((child.aggregated_values.get(field_name) for child in self.children.values()))
+        return aggregate_func(child.aggregated_values.get(field_name) for child in self.children.values())
 
     def _get_avg_aggregate(self, field_name, data):
         aggregate_func = OPERATOR_MAPPING.get('sum')

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -2,11 +2,11 @@
 import contextlib
 import functools
 import logging
-from lxml import etree
 import unittest
+from zoneinfo import ZoneInfoNotFoundError, ZoneInfo
 
-import pytz
 import werkzeug
+from lxml import etree
 
 import odoo
 from odoo import api, models, tools
@@ -235,9 +235,9 @@ class IrHttp(models.AbstractModel):
     def _frontend_pre_dispatch(cls):
         super()._frontend_pre_dispatch()
 
-        if not request.env.context.get('tz'):
-            with contextlib.suppress(pytz.UnknownTimeZoneError):
-                request.update_context(tz=pytz.timezone(request.geoip.location.time_zone).zone)
+        if not request.env.context.get('tz') and (tz := request.geoip.location.time_zone):
+            with contextlib.suppress(ZoneInfoNotFoundError):
+                request.update_context(tz=ZoneInfo(tz).key)
 
         website = request.env['website'].get_current_website()
         user = request.env.user

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -1,15 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta
-
 import hashlib
-import pytz
+from datetime import datetime, timedelta
 
 from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
 from odoo.fields import Domain
 from odoo.tools import _, SQL
+from odoo.tools.date_utils import all_timezones
 from odoo.tools.misc import _format_time_ago
 from odoo.http import request
 
@@ -387,7 +386,7 @@ class WebsiteVisitor(models.Model):
 
     def _get_visitor_timezone(self):
         tz = request.cookies.get('tz') if request else None
-        if tz in pytz.all_timezones:
+        if tz in all_timezones:
             return tz
         elif not self.env.user._is_public():
             return self.env.user.tz

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-import pytz
-import babel.dates
 from collections import defaultdict
+from zoneinfo import ZoneInfo
+
+import babel.dates
+import werkzeug
 
 from odoo import http, tools, models
 from odoo.addons.website.controllers.main import QueryURL
@@ -37,7 +38,7 @@ class WebsiteBlog(http.Controller):
             dom, groupby=['published_date:month'])
 
         locale = get_lang(request.env).code
-        tzinfo = pytz.timezone(request.env.context.get('tz', 'utc') or 'utc')
+        tzinfo = ZoneInfo(request.env.context.get('tz') or 'UTC')
         fmt = tools.DEFAULT_SERVER_DATETIME_FORMAT
 
         res = defaultdict(list)

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta
-from pytz import timezone, utc
+from datetime import datetime, timedelta, UTC
+from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models
 from odoo.tools import is_html_empty
@@ -131,16 +131,16 @@ class EventSponsor(models.Model):
             elif sponsor.hour_from is False or sponsor.hour_to is False:
                 sponsor.is_in_opening_hours = True
             else:
-                event_tz = timezone(sponsor.event_id.date_tz)
+                event_tz = ZoneInfo(sponsor.event_id.date_tz)
                 # localize now, begin and end datetimes in event tz
                 dt_begin = sponsor.event_id.date_begin.astimezone(event_tz)
                 dt_end = sponsor.event_id.date_end.astimezone(event_tz)
-                now_utc = utc.localize(fields.Datetime.now().replace(microsecond=0))
+                now_utc = fields.Datetime.now().replace(microsecond=0, tzinfo=UTC)
                 now_tz = now_utc.astimezone(event_tz)
 
                 # compute opening hours
-                opening_from_tz = event_tz.localize(datetime.combine(now_tz.date(), float_to_time(sponsor.hour_from)))
-                opening_to_tz = event_tz.localize(datetime.combine(now_tz.date(), float_to_time(sponsor.hour_to)))
+                opening_from_tz = datetime.combine(now_tz.date(), float_to_time(sponsor.hour_from), tzinfo=event_tz)
+                opening_to_tz = datetime.combine(now_tz.date(), float_to_time(sponsor.hour_to), tzinfo=event_tz)
                 if sponsor.hour_to == 0:
                     # when closing 'at midnight', we consider it's at midnight the next day
                     opening_to_tz = opening_to_tz + timedelta(days=1)

--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -3,6 +3,7 @@
 import base64
 import gzip
 import uuid
+from datetime import UTC
 
 from dateutil.relativedelta import relativedelta
 from werkzeug.urls import url_encode, url_parse
@@ -329,8 +330,10 @@ class ProductFeed(models.Model):
             start_date = combination_info['discount_start_date']
             end_date = combination_info['discount_end_date']
             if start_date and end_date:
-                price_info['sale_price_effective_date'] = '/'.join(
-                    map(utils.gmc_format_date, (start_date, end_date)),
+                price_info['sale_price_effective_date'] = (
+                    start_date.replace(tzinfo=UTC).isoformat(timespec='minutes')
+                    + '/' +
+                    end_date.replace(tzinfo=UTC).isoformat(timespec='minutes')
                 )
 
         # Note: Google only supports a restricted set of unit and computes the comparison prices

--- a/addons/website_sale/utils.py
+++ b/addons/website_sale/utils.py
@@ -1,10 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from pytz import UTC
-
-
 def gmc_format_price(price, currency):
     return f'{currency.round(price)} {currency.name}'
-
-def gmc_format_date(dt):
-    return UTC.localize(dt).isoformat(timespec='minutes')

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1,17 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import UTC
+from zoneinfo import ZoneInfo
 
 import babel
 import base64
 import contextlib
 import json
 import logging
-import pytz
 import re
 from collections import defaultdict
 from functools import reduce
 from operator import getitem
-
-from pytz import timezone
 
 from odoo import api, fields, models, tools
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
@@ -129,7 +128,7 @@ class IrActionsActions(models.Model):
             'time': tools.safe_eval.time,
             'datetime': tools.safe_eval.datetime,
             'dateutil': tools.safe_eval.dateutil,
-            'timezone': timezone,
+            'timezone': ZoneInfo,
             'float_compare': float_compare,
             'b64encode': base64.b64encode,
             'b64decode': base64.b64decode,
@@ -492,9 +491,9 @@ class IrActionsServerHistory(models.Model):
         self.display_name = False
         for history in self.filtered('create_date'):
             locale = get_lang(self.env).code
-            tzinfo = pytz.timezone(self.env.user.tz)
+            tzinfo = ZoneInfo(self.env.user.tz)
             datetime = history.create_date.replace(microsecond=0)
-            datetime = pytz.utc.localize(datetime, is_dst=False)
+            datetime = datetime.replace(tzinfo=UTC)
             datetime = datetime.astimezone(tzinfo) if tzinfo else datetime
             date_label = babel.dates.format_datetime(
                 datetime,

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
 import functools
 import itertools
+import json
+from datetime import UTC
 from typing import NamedTuple
-
-import pytz
 
 from odoo import api, Command, fields, models
 from odoo.tools import OrderedSet
@@ -396,9 +395,9 @@ class IrFieldsConverter(models.AbstractModel):
             )
 
         input_tz = self._input_tz()# Apply input tz to the parsed naive datetime
-        dt = input_tz.localize(parsed_value, is_dst=False)
+        dt = parsed_value.replace(tzinfo=input_tz, fold=1)
         # And convert to UTC before reformatting for writing
-        return fields.Datetime.to_string(dt.astimezone(pytz.UTC)), []
+        return fields.Datetime.to_string(dt.astimezone(UTC)), []
 
     @api.model
     def _get_boolean_translations(self, src):
@@ -570,7 +569,7 @@ class IrFieldsConverter(models.AbstractModel):
         skip_record = False
         if self.env.context.get('import_file'):
             import_set_empty_fields = self.env.context.get('import_set_empty_fields') or []
-            field_path = "/".join((self.env.context.get('parent_fields_hierarchy', []) + [field.name]))
+            field_path = "/".join(self.env.context.get('parent_fields_hierarchy', []) + [field.name])
             set_empty = field_path in import_set_empty_fields
             skip_record = field_path in self.env.context.get('import_skip_records', [])
         if id is None and not set_empty and not skip_record:

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import datetime, timedelta
 import logging
-import pytz
+from datetime import datetime, timedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError

--- a/odoo/addons/base/tests/test_date_utils.py
+++ b/odoo/addons/base/tests/test_date_utils.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import date, datetime, time, timedelta, timezone
 from functools import partial
+from zoneinfo import ZoneInfo
 
-import pytz
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
@@ -293,12 +293,12 @@ class TestDateRangeFunction(BaseCase):
 
     def test_date_range_with_timezone_aware_datetimes_other_than_utc(self):
         """ Check date_range with timezone-aware datetimes other than UTC."""
-        timezone = pytz.timezone('Europe/Brussels')
+        timezone = ZoneInfo('Europe/Brussels')
 
         start = datetime(1985, 1, 1)
         end = datetime(1986, 1, 1)
-        start = timezone.localize(start)
-        end = timezone.localize(end)
+        start = start.replace(tzinfo=timezone)
+        end = end.replace(tzinfo=timezone)
 
         expected = [datetime(1985, 1, 1, 0, 0),
                     datetime(1985, 2, 1, 0, 0),
@@ -314,31 +314,31 @@ class TestDateRangeFunction(BaseCase):
                     datetime(1985, 12, 1, 0, 0),
                     datetime(1986, 1, 1, 0, 0)]
 
-        expected = [timezone.localize(e) for e in expected]
+        expected = [e.replace(tzinfo=timezone) for e in expected]
 
         dates = list(date_range(start, end))
         self.assertEqual(expected, dates)
 
     def test_date_range_with_mismatching_zones(self):
         """ Check date_range with mismatching zone should raise an exception."""
-        start_timezone = pytz.timezone('Europe/Brussels')
-        end_timezone = pytz.timezone('America/Recife')
+        start_timezone = ZoneInfo('Europe/Brussels')
+        end_timezone = ZoneInfo('America/Recife')
 
         start = datetime(1985, 1, 1)
         end = datetime(1986, 1, 1)
-        start = start_timezone.localize(start)
-        end = end_timezone.localize(end)
+        start = start.replace(tzinfo=start_timezone)
+        end = end.replace(tzinfo=end_timezone)
 
         with self.assertRaises(ValueError):
             list(date_range(start, end))
 
     def test_date_range_with_inconsistent_datetimes(self):
         """ Check date_range with a timezone-aware datetime and a naive one."""
-        context_timezone = pytz.timezone('Europe/Brussels')
+        context_timezone = ZoneInfo('Europe/Brussels')
 
         start = datetime(1985, 1, 1)
         end = datetime(1986, 1, 1)
-        end = context_timezone.localize(end)
+        end = end.replace(tzinfo=context_timezone)
 
         with self.assertRaises(ValueError):
             list(date_range(start, end))

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -3,8 +3,7 @@
 import base64
 import datetime
 import os.path
-
-import pytz
+from zoneinfo import ZoneInfo
 
 from odoo.tests.common import tagged, BaseCase, TransactionCase
 from odoo.tools import config, misc, urls
@@ -112,7 +111,7 @@ class TestFormatLangDate(TransactionCase):
 
         # -- test `time`
         time_part = datetime.time(16, 30, 22)
-        time_part_tz = datetime.time(16, 30, 22, tzinfo=pytz.timezone('America/New_York'))  # 4:30 PM timezoned
+        time_part_tz = datetime.time(16, 30, 22, tzinfo=ZoneInfo('America/New_York'))  # 4:30 PM timezoned
 
         self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part, time_format='HH:mm:ss'), '16:30:22')
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part, time_format="ah:m:ss"), '\u4e0b\u53484:30:22')
@@ -122,7 +121,7 @@ class TestFormatLangDate(TransactionCase):
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part, time_format='ah:mm'), '\u4e0b\u53484:30')
 
         # Check timezoned time part
-        self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part_tz, time_format='HH:mm:ss Z'), '16:30:22 -0504')
+        self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part_tz, time_format='HH:mm:ss Z'), '16:30:22 -0500')
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part_tz, time_format='zzzz ah:mm:ss'), '\u5317\u7f8e\u4e1c\u90e8\u6807\u51c6\u65f6\u95f4\u0020\u4e0b\u53484:30:22')
 
         #Check timezone conversion in format_time
@@ -142,7 +141,7 @@ class TestFormatLangDate(TransactionCase):
         self.assertEqual(misc.format_date(self.env, date_datetime), '01/01/2017')
 
         # Force London timezone
-        date_datetime = date_datetime.replace(tzinfo=pytz.UTC)
+        date_datetime = date_datetime.replace(tzinfo=datetime.UTC)
         self.assertEqual(misc.format_date(self.env, date_datetime), '12/31/2016', "User's tz must be ignored when tz is specifed in datetime object")
 
 

--- a/odoo/addons/base/tests/test_tz.py
+++ b/odoo/addons/base/tests/test_tz.py
@@ -1,10 +1,11 @@
 import datetime
 import logging
-import pytz
 from unittest.mock import patch
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from odoo.tests.common import tagged, TransactionCase
-from odoo._monkeypatches.pytz import _tz_mapping
+from odoo._monkeypatches.zoneinfo import _tz_mapping
+from odoo.tools.date_utils import all_timezones
 
 _logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class TestTZ(TransactionCase):
         d = datetime.datetime(1969, 7, 16)
         # See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
         def assertTZEqual(tz1, tz2):
-            self.assertEqual(tz1.localize(d).strftime('%z'), tz2.localize(d).strftime('%z'))
+            self.assertEqual(d.replace(tzinfo=tz1).strftime('%z'), d.replace(tzinfo=tz2).strftime('%z'))
 
             # in some version of tzdata the timezones are not symlink, as an example in 2023c-0ubuntu0.20.04.1
             # this as a side effect to have sligh difference in timezones seconds, breaking the following assertions
@@ -33,26 +34,26 @@ class TestTZ(TransactionCase):
                 if source == 'Pacific/Enderbury':  # this one was wrong in some version of tzdata
                     continue
                 try:
-                    target_tz = pytz.timezone(target)
-                except pytz.UnknownTimeZoneError:
+                    target_tz = ZoneInfo(target)
+                except ZoneInfoNotFoundError:
                     _logger.info("Skipping test for %s -> %s, target does not exist", source, target)
                     continue
-                assertTZEqual(pytz.timezone(source), target_tz)
+                assertTZEqual(ZoneInfo(source), target_tz)
 
     def test_dont_adapt_available_tz(self):
         with patch.dict(_tz_mapping, {
             'DeprecatedUtc': 'UTC',
             'America/New_York': 'UTC',
         }):
-            self.assertNotIn('DeprecatedUtc', pytz.all_timezones_set, 'DeprecatedUtc is not available')
-            self.assertEqual(pytz.timezone('DeprecatedUtc'), pytz.timezone('UTC'), 'DeprecatedUtc does not exist and should have been replaced with UTC')
-            self.assertIn('America/New_York', pytz.all_timezones_set, 'America/New_York is available')
-            self.assertNotEqual(pytz.timezone('America/New_York'), pytz.timezone('UTC'), 'America/New_York exists and should not have been replaced with UTC')
+            self.assertNotIn('DeprecatedUtc', all_timezones, 'DeprecatedUtc is not available')
+            self.assertEqual(ZoneInfo('DeprecatedUtc'), ZoneInfo("UTC"), 'DeprecatedUtc does not exist and should have been replaced with UTC')
+            self.assertIn('America/New_York', all_timezones, 'America/New_York is available')
+            self.assertNotEqual(ZoneInfo('America/New_York'), ZoneInfo("UTC"), 'America/New_York exists and should not have been replaced with UTC')
 
     def test_cannot_set_deprecated_timezone(self):
         # this should be ok
         self.env.user.tz = "America/New_York"
-        if "US/Eastern" not in pytz.all_timezones:
+        if "US/Eastern" not in all_timezones:
             with self.assertRaises(ValueError):
                 self.env.user.tz = "US/Eastern"
 
@@ -62,7 +63,6 @@ class TestTZ(TransactionCase):
         self.env.cr.execute("""UPDATE res_partner set tz='US/Eastern' WHERE id=%s""", (partner.id,))
         partner.invalidate_recordset()
         self.assertEqual(partner.tz, 'US/Eastern')  # tz was update despite selection not existing, but data was not migrated
-        # comparing with 'America/New_York' see tools/_monkeypatches_pytz.py for mapping
-        expected_offset = datetime.datetime.now(pytz.timezone('America/New_York')).strftime('%z')
+        expected_offset = datetime.datetime.now(ZoneInfo('America/New_York')).strftime('%z')
         # offest will be -0400 in summer, -0500 in winter
-        self.assertEqual(partner.tz_offset, expected_offset, "We don't expect pytz.timezone to fail if the timezone diseapeared when chaging os version")
+        self.assertEqual(partner.tz_offset, expected_offset)

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -7,8 +7,8 @@ import os
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 from urllib.parse import urlencode
+from zoneinfo import ZoneInfo
 
-import pytz
 from freezegun import freeze_time
 
 import odoo
@@ -201,8 +201,8 @@ class TestHttpSession(TestHttpBase):
             datetime.datetime.now(),
             datetime.date.today(),
             datetime.time(1, 33, 7),
-            pytz.timezone('UTC'),
-            pytz.timezone('Europe/Brussels'),
+            datetime.UTC,
+            ZoneInfo('Europe/Brussels'),
             str,
             int,
             float,

--- a/odoo/addons/test_web/tests/test_read_group_formatted.py
+++ b/odoo/addons/test_web/tests/test_read_group_formatted.py
@@ -1,5 +1,5 @@
-from datetime import datetime, time
-from pytz import UTC, timezone
+from datetime import datetime, time, UTC
+from zoneinfo import ZoneInfo
 
 import babel
 
@@ -742,9 +742,9 @@ class TestFormattedReadGroup(common.TransactionCase):
         def set_context(lang):
             '''Add `lang` & `tz` to context, and add localized `datetime` values.'''
             tz = tz_by_lang[lang]
-            tzinfo = timezone(tz)
+            tzinfo = ZoneInfo(tz)
             for record in records:
-                local_dt = tzinfo.localize(datetime.combine(record.date, time.min))
+                local_dt = datetime.combine(record.date, time.min, tzinfo=tzinfo)
                 record.datetime = local_dt.astimezone(UTC).replace(tzinfo=None)
             return Model.with_context(lang=lang, tz=tz)
 

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 
 import functools
 import logging
-import pytz
 import typing
-import warnings
 from collections import defaultdict, deque
 from collections.abc import Mapping
 from contextlib import contextmanager
+from datetime import UTC
 from pprint import pformat
 from weakref import ref as weakref
+from zoneinfo import ZoneInfo
 
 from odoo.exceptions import AccessError, UserError, CacheMiss
 from odoo.sql_db import BaseCursor
@@ -302,10 +302,10 @@ class Environment(Mapping[str, "BaseModel"]):
         timezone = self.context.get('tz') or self.user.tz
         if timezone:
             try:
-                return pytz.timezone(timezone)
+                return ZoneInfo(timezone)
             except Exception:  # noqa: BLE001
                 _logger.debug("Invalid timezone %r", timezone, exc_info=True)
-        return pytz.utc
+        return UTC
 
     @functools.cached_property
     def lang(self) -> str | None:

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -259,10 +259,10 @@ class Many2one(_Relational):
             self.bypass_search_access = True
         elif self.delegate:
             comodel_name = self.comodel_name or 'comodel_name'
-            raise TypeError((
+            raise TypeError(
                 f"The delegate field {self} must be declared in the model class e.g.\n"
                 f"_inherits = {{{comodel_name!r}: {name!r}}}"
-            ))
+            )
 
     def setup_nonrelated(self, model):
         super().setup_nonrelated(model)

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -7,14 +7,12 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
-
 from contextlib import closing
 from datetime import datetime
 from xml.etree import ElementTree as ET
 
 import psycopg2
 from psycopg2.extensions import quote_ident
-from pytz import country_timezones
 
 import odoo.api
 import odoo.modules.neutralize

--- a/odoo/tools/_vendor/send_file.py
+++ b/odoo/tools/_vendor/send_file.py
@@ -26,6 +26,10 @@ from werkzeug.urls import url_quote
 from werkzeug.wrappers import Response
 from werkzeug.wsgi import wrap_file
 
+if t.TYPE_CHECKING:
+    from wsgiref.types import WSGIEnvironment
+
+
 _logger = logging.getLogger(__name__)
 
 

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -33,11 +33,11 @@ from functools import reduce, wraps
 from itertools import islice, groupby as itergroupby
 from operator import itemgetter
 from types import MappingProxyType
+from zoneinfo import ZoneInfo
 
 import babel
 import babel.dates
 import markupsafe
-import pytz
 from lxml import etree, objectify
 
 from odoo.loglevels import exception_to_unicode
@@ -1408,9 +1408,9 @@ def format_datetime(
         timestamp = value
 
     tz_name = tz or env.user.tz or 'UTC'
-    utc_datetime = pytz.utc.localize(timestamp, is_dst=False)
+    utc_datetime = timestamp.replace(tzinfo=datetime.UTC)
     try:
-        context_tz = pytz.timezone(tz_name)
+        context_tz = ZoneInfo(tz_name)
         localized_datetime = utc_datetime.astimezone(context_tz)
     except Exception:
         localized_datetime = utc_datetime
@@ -1461,9 +1461,9 @@ def format_time(
             value = Datetime.from_string(value)
         assert isinstance(value, datetime.datetime)
         tz_name = tz or env.user.tz or 'UTC'
-        utc_datetime = pytz.utc.localize(value, is_dst=False)
+        utc_datetime = value.replace(tzinfo=datetime.UTC)
         try:
-            context_tz = pytz.timezone(tz_name)
+            context_tz = ZoneInfo(tz_name)
             localized_time = utc_datetime.astimezone(context_tz).timetz()
         except Exception:
             localized_time = utc_datetime.timetz()

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -20,6 +20,7 @@ import logging
 import sys
 import types
 import typing
+import zoneinfo
 from opcode import opmap, opname
 from types import CodeType
 
@@ -472,9 +473,6 @@ import dateutil
 mods = ['parser', 'relativedelta', 'rrule', 'tz']
 for mod in mods:
     __import__('dateutil.%s' % mod)
-# make sure to patch pytz before exposing
-from odoo._monkeypatches.pytz import patch_module as patch_pytz  # noqa: E402, F401
-patch_pytz()
 
 datetime = wrap_module(__import__('datetime'), ['date', 'datetime', 'time', 'timedelta', 'timezone', 'tzinfo', 'MAXYEAR', 'MINYEAR'])
 dateutil = wrap_module(dateutil, {
@@ -485,7 +483,4 @@ dateutil = wrap_module(dateutil, {
 })
 json = wrap_module(__import__('json'), ['loads', 'dumps'])
 time = wrap_module(__import__('time'), ['time', 'strptime', 'strftime', 'sleep'])
-pytz = wrap_module(__import__('pytz'), [
-    'utc', 'UTC', 'timezone',
-])
-dateutil.tz.gettz = pytz.timezone
+dateutil.tz.gettz = zoneinfo.ZoneInfo

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,13 +39,13 @@ python-dateutil==2.8.2 ; python_version >= '3.11'
 python-magic==0.4.27; sys_platform != 'win32' and python_version >= '3.12'  # (noble)
 python-ldap==3.4.4 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 python-stdnum==1.19 ; python_version >= '3.11'
-pytz  # no version pinning to avoid OS perturbations
 pyusb==1.2.1
 qrcode==7.4.2 ; python_version >= '3.11'
 reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
 requests==2.31.0 ; python_version >= '3.11' # (Noble)
 rjsmin==1.2.0 ; python_version >= '3.11'
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
+tzdata; sys_platform == 'win32'  # no version pinning to keep it updated, assume *nix have tzdata (it's a dep of python on debian, fedora, and arch)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
 vobject==0.9.6.1
 Werkzeug==3.0.1 ; python_version >= '3.12'  # (Noble) Avoid deprecation warnings

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'pyserial',
         'python-dateutil',
         'python-stdnum',
-        'pytz',
         'pyusb >= 1.0.0b1',
         'qrcode',
         'reportlab',  # windows binary pypi.python.org/pypi/reportlab

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -54,7 +54,6 @@ RUN apt-get update -qq &&  \
         python3-serial \
         python3-setuptools \
         python3-stdnum \
-        python3-tz \
         python3-usb \
         python3-vobject \
         python3-werkzeug \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -44,7 +44,6 @@ RUN dnf install \
         python3-pyldap \
         python3-pyOpenSSL \
         python3-pyserial \
-        python3-pytz \
         python3-pyusb \
         python3-qrcode \
         python3-reportlab \

--- a/setup/requirements-check.py
+++ b/setup/requirements-check.py
@@ -60,7 +60,6 @@ Version = Tuple[int, ...]
 
 # shared beween debian and ubuntu
 SPECIAL = {
-    'pytz': 'tz',
     'libsass': 'libsass-python',
 }
 SUPPORTED_FORMATS = ('txt', 'ansi', 'svg', 'html', 'json')


### PR DESCRIPTION
https://pypi.org/project/pytz/

> Projects using Python 3.9 or later should be using the support now included as part of the standard library, and third party packages work with it such as tzdata. pytz offers no advantages beyond backwards compatibility with code written for earlier versions of Python.

Dependencies aside, `ZoneInfo` does not suffer from the `localize` trap: by default pytz eagerly hands out the oldest version of a given zone, and can't adapt it correctly based on the datetime being zoned so setting tzinfo (via ctor or `datetime.replace`) is broken, which is why pytz requires using `pytz.localize`.

`ZoneInfo` and `datetime` can work together to avoid that issue.

`is_dst` versus `fold`
----------------------

One of the complexities of the migration is that pytz and the standard library use different methods / concepts around timezone offset transitions (mostly standard/dst or winter/summer times, but this also applies for timezone shifts). Specifically, pytz has an `is_dst` flag which specifies whether one should apply the DST time or the STD time during the transition period (either dates falling in the gap for std -> dst or duplicated ("folded") dates during std -> dst). The standard library has a `fold` attribute which specifies whether the selected time should be the one before (0) or after (1) the transition.

The issue is that `fold == is_dst` during the transition from std to dst, but `fold == not is_dst` during the transition from dst to std. The latter is the one which usually causes issues (dates falling during the gap are equally wrong on both offsets after all) so migrating `is_dst=False` to `fold=1` could make some sense...

![is_dst](https://pytz-deprecation-shim.readthedocs.io/en/latest/_images/fold_pytz.svg)
![fold](https://pytz-deprecation-shim.readthedocs.io/en/latest/_images/fold_495.svg)

Hilariously in most occurrences in Odoo this was completely useless: `is_dst` is not sticky, it *only* applies to the `localize` call, and since UTC is a fixed offset timezone `pytz.utc.localize(..., is_dst=...)` never does anything. These flags are only relevant when setting a timezone which can have offset transitions.

However there is the case of `calendar` which is strongly wedded to pytz-style semantics (this is part of its tests). For that case I elected to essentially replicate pytz semantics, by folding both ways, checking if the date is during a transition, and taking the date with the smallest utcoffset (which corresponds to standard time, which corresponds to `is_dst=False`). The relevant team can revisit this if they decide to change their recurrence semantics.

Implicit / default `is_dst`
---------------------------

*However* there is a trap here: `is_dst=False` is the default value, so any `localize` call which is not useless (not from UTC) should be configured to `fold=1`. So in theory every `localize` call where `is_dst` is not specified *and* the timezone is not utc should be migrated to `.replace(tzinfo=..., fold=1)`. That is at least under the assumption that the DST behaviour was picked specifically.

As that seems unlikely, only the locations which had `is_dst` specified and were specifically tested were converted. But that means there may be needs to patch up some of the replaces in case we do in fact want instants *following* folds rather than preceding.

Assertions
----------

One thing pytz has which has gone missing in the stdlib is assertions, specifically:

- `pytz.<TZ>.localize` will raise an exception if the datetime is   already zoned, `datetime.replace` doesn't give a fuck
- `is_dst=None` will raise an exception if the datetime being created is in a gap (when the offset increases) or a fold (when the offset decreases), `fold` offers no such ability