### PR TITLE
[FIX] l10n_it: Fix VAT due/deductible amounts

### DIFF
--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -148,14 +148,14 @@
                             <record id="tax_monthly_report_line_vp6_vp6a_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit - VP5.credit</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="formula">VP4.debit + VP5.credit</field>
+                                <field name="subformula">if_below(EUR(0))</field>
                                 <field name="blank_if_zero" eval="True"/>
                             </record>
                             <record id="tax_monthly_report_line_vp6_vp6b_credit" model="account.report.expression">
                                 <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">-(VP4.debit - VP5.credit)</field>
+                                <field name="formula">VP4.debit + VP5.credit</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                                 <field name="blank_if_zero" eval="True"/>
                             </record>


### PR DESCRIPTION
The VP6 - VAT due/deductible line of the Italian Monthly VAT Report, introduced in https://github.com/odoo/odoo/commit/51a72ab42d118d6fb0eb3e3545a09e10019b9140, was using an incorrect `formula`.
For instance, €200 due and €100 deductible resulted in €300 instead of the expected €100.
This commit fixes the computation.

Ticket [link](https://www.odoo.com/odoo/project.task/5178831)
opw-5178831

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
