### PR TITLE
[FIX] account: prevent traceback when opening account.code.mapping via menu

### DIFF
--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -1,4 +1,5 @@
-from odoo import fields, models, api
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
 from odoo.tools import Query
 
 COMPANY_OFFSET = 10000
@@ -52,7 +53,10 @@ class AccountCodeMapping(models.Model):
                     for account_id in account_ids
                     for company in self.env.user.with_context(active_test=True).company_ids.sorted(lambda c: (c.sequence, c.name))
                 ]).filtered_domain(remaining_domain)._as_query()
-        raise NotImplementedError
+        raise UserError(_(
+            "Account Code Mapping cannot be accessed directly. "
+            "It is designed to be used only through the Chart of Accounts."
+        ))
 
     def _compute_account_id(self):
         for record in self:


### PR DESCRIPTION
**Steps to reproduce:**
* Install **Accounting** and ensure Studio is available.
* Using **Studio**, create a new menu item pointing to the model *account.code.mapping*.
* Save the menu and click it to open the corresponding view.

**Observed behavior:**
* Opening the Studio-created menu triggers a full traceback.

**Cause:**
* The model *account.code.mapping* overrides `_search()` and raises `NotImplementedError` when no `account_ids` can be extracted from the domain, which is the case when opening the view without filters.
* The missing `_search` logic for empty domains was never implemented, and the resulting exception propagates to the UI as a traceback.

**Fix:**
* Replace the `NotImplementedError` with a user-friendly `UserError` explaining that the view cannot be opened without specifying relevant filters, preventing the traceback and improving clarity.

opw-5183909
