### PR TITLE
[FIX] stock: use more moves for orderpoint daily demand

### DIFF
--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -881,6 +881,23 @@ class TestProcRule(TransactionCase):
         self.assertListEqual(graph_data['x_axis_vals'], ['', 'In 4 day(s)', 'In 8 day(s)', 'In 12 day(s)'])
         self.assertListEqual([curve_line_val['y'] for curve_line_val in graph_data['curve_line_vals']], [40, 20, 40, 20, 40, 20])
 
+        late_out_move = self.env['stock.move'].create({
+            'product_id': self.product.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 15.0,
+            'location_id': warehouse.lot_stock_id.id,
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'date': datetime.today() - timedelta(days=5),
+        })
+        late_out_move._action_confirm()
+        info._compute_json_replenishment_graph()
+        graph_data = loads(info.json_replenishment_graph)
+        self.assertEqual(graph_data['daily_demand'], 8.57)
+        self.assertEqual(graph_data['average_stock'], 30.0)
+        self.assertEqual(graph_data['ordering_period'], 2.0)
+        self.assertListEqual(graph_data['x_axis_vals'], ['', 'In 2 day(s)', 'In 4 day(s)', 'In 6 day(s)'])
+        self.assertListEqual([curve_line_val['y'] for curve_line_val in graph_data['curve_line_vals']], [40, 20, 40, 20, 40, 20])
+
 
 class TestProcRuleLoad(TransactionCase):
     def setUp(cls):

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -158,7 +158,7 @@ class StockReplenishmentInfo(models.TransientModel):
                 [('product_id', '=', replenishment_report.product_id.id)],
                 [('date', '>=', date_from)],
                 [('date', '<=', datetime.combine(date_to, time.max))],
-                [('state', '=', 'done')],
+                [('state', 'in', ['assigned', 'confirmed', 'partially_available', 'done'])],
                 [('company_id', '=', replenishment_report.orderpoint_id.company_id.id)],
             ])
             quantity_out = self.env['stock.move']._read_group(


### PR DESCRIPTION
In the replenishment info wizard, the daily demand based on previous periods of time only takes 'done' moves into account. This is different from the purchase catalog which also takes 'assigned', 'confirmed' and 'partially_available' moves.

This PR adds those 3 states in the domain when searching for moves.

task 5219526

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
