### PR TITLE
[FIX] event: remove encapsulating notification layout for badge email

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -281,7 +281,6 @@ class EventRegistration(models.Model):
             default_res_ids=self.ids,
             default_template_id=template.id if template else False,
             default_composition_mode='comment',
-            default_email_layout_xmlid="mail.mail_notification_light",
         )
         return {
             'name': _('Compose Email'),


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Event module
- Go to an open event
- Register for the event
- Go to the Attendees of the event
- On the attendee record, click `Send by Email`
- The received email shows twice the header and footer

**Issue:**
Encapsulating notification layout was applied with `default_email_layout_xmlid` 
but the main template used is `event_registration_mail_template_badge` which
already has its own header and footer.

**Fix:**
Removed the `default_email_layout_xmlid`

opw-5032767
