### PR TITLE
[FIX] account_edi_ubl_cii: xml import error customization id

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -81,7 +81,7 @@ class AccountMove(models.Model):
                 return self.env['account.edi.xml.ubl_20']
             if ubl_version.text in ('2.1', '2.2', '2.3'):
                 return self.env['account.edi.xml.ubl_21']
-        if customization_id is not None:
+        if customization_id is not None and customization_id.text:
             if 'xrechnung' in customization_id.text:
                 return self.env['account.edi.xml.ubl_de']
             if customization_id.text == 'urn:cen.eu:en16931:2017#compliant#urn:fdc:nen.nl:nlcius:v1.0':


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: xml import error customization id

This error happens when the user tries to import an xml invoice in accounting > customer > invoice and the CustomizationID tag is empty. The cause of this is the CustomizationID tag that exists in the file, but it's empty.
This tag is mandatory in a ubl file, so we cannot process the file if it's empty.

opw-5238398
