### PR TITLE
[FIX] purchase: add price unit by uom in PO comparison view

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -829,7 +829,7 @@
                 <field name="partner_id" string="Vendor"/>
                 <field name="company_id" optional="show" groups="base.group_multi_company"/>
                 <field name="product_uom_qty" string="Quantity"/>
-                <field name="price_unit" widget="monetary"/>
+                <field name="price_unit_product_uom" widget="monetary" string="Unit Price"/>
                 <field name="price_subtotal" widget="monetary" string="Total Untaxed"/>
                 <field name="state" optional="hide"/>
             </list>


### PR DESCRIPTION
**Problem:**
    In the Purchase Comparison view the unit price is
    expressed in the uom of the purchase order line
    so two purchase order lines with different uom will
    be compared without the client knowing it.
    
**Steps to reproduce:**
- create a new product
- set a unit cost of 1
- in the sales tab, in the packagings add
pack of 6
- Create and confirm a PO for 6 unit of this
product
- create and confirm a PO for 1 pack of 6 of
this product
- on the second PO click on the 'price comparison'
smart button

**Current behavior:**
The unit price average on the group by line
is 3.5.
If you click on the line you'll see that the
price unit for the second purchase order line
is expressed in the uom of the purchase order
line (so here it is 6$ per pack of 6).
So the average does not realy make sense.

**Cause of the issue:**
On the purchase order lines price_unit
is expressed in the UoM of the line and not the
uom of the product

**fix:**
We replace the unit price column by a column
with a unit price expressed in the uom of
the product.
The trade off is that, because the new field
is not stored, we don't have an average in
the group by line anymore.

opw-5220196
