### PR TITLE
[FIX] l10n_dk_nemhandel: Unregister IAP side will block user db

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_edi_proxy_user.py
+++ b/addons/l10n_dk_nemhandel/models/account_edi_proxy_user.py
@@ -185,7 +185,7 @@ class AccountEdiProxyClientUser(models.Model):
                 )
             except UserError as e:
                 _logger.error(
-                    'Error while receiving the document from Nemhandel Proxy: %s', e.message,
+                    'Error while receiving the document from Nemhandel Proxy: %s', ', '.join(e.args),
                 )
                 continue
 
@@ -341,7 +341,7 @@ class AccountEdiProxyClientUser(models.Model):
             try:
                 self._call_nemhandel_proxy(endpoint='/api/nemhandel/1/cancel_nemhandel_registration')
             except UserError as e:
-                if e.message != "The user doesn't exist on the proxy":
+                if e.args and e.args[0] != "The user doesn't exist on the proxy":
                     raise
 
         self.company_id.l10n_dk_nemhandel_proxy_state = 'not_registered'


### PR DESCRIPTION
If you unregister a Nemhandel user, it won't ever be picked up by the user db. 
And trying to unregister by hand will give a traceback. 
This is due to mismatch between Exception types.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
