### PR TITLE
[FIX] {stock_,}account, sale_project: analytic distribution cogs expense line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1068,7 +1068,7 @@ class AccountMoveLine(models.Model):
     def _compute_analytic_distribution(self):
         cache = {}
         for line in self:
-            if line.display_type == 'product' or not line.move_id.is_invoice(include_receipts=True):
+            if line.display_type in ('product', 'cogs') or not line.move_id.is_invoice(include_receipts=True):
                 related_distribution = line._related_analytic_distribution()
                 root_plans = self.env['account.analytic.account'].browse(
                     list({int(account_id) for ids in related_distribution for account_id in ids.split(',') if account_id.strip()})
@@ -3515,6 +3515,11 @@ class AccountMoveLine(models.Model):
         """
         self.ensure_one()
         return self.move_id.state == 'posted'
+
+    def _force_analytic_distribution(self):
+        """ Helper used to know if we need to force the value of analytic distribution or leave it to the compute method """
+        self.ensure_one()
+        return False
 
     # -------------------------------------------------------------------------
     # PUBLIC ACTIONS

--- a/addons/sale_project/models/account_move_line.py
+++ b/addons/sale_project/models/account_move_line.py
@@ -73,3 +73,9 @@ class AccountMoveLine(models.Model):
         mapping_from_invoice = super()._sale_determine_order()
         mapping_from_invoice.update(self._get_so_mapping_from_project())
         return mapping_from_invoice
+
+    def _force_analytic_distribution(self):
+        self.ensure_one()
+        if self.env['sale.order'].search_count([('name', '=', self.move_id.invoice_origin), ('project_id', '!=', False)]):
+            return True
+        return super()._force_analytic_distribution()

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -146,13 +146,14 @@ class AccountMove(models.Model):
                     'price_unit': price_unit,
                     'amount_currency': -amount_currency,
                     'account_id': debit_interim_account.id,
+                    'analytic_distribution': False,
                     'display_type': 'cogs',
                     'tax_ids': [],
                     'cogs_origin_id': line.id,
                 })
 
                 # Add expense account line.
-                lines_vals_list.append({
+                expense_line_vals = {
                     'name': line.name[:64] if line.name else '',
                     'move_id': move.id,
                     'partner_id': move.commercial_partner_id.id,
@@ -162,11 +163,13 @@ class AccountMove(models.Model):
                     'price_unit': -price_unit,
                     'amount_currency': amount_currency,
                     'account_id': credit_expense_account.id,
-                    'analytic_distribution': line.analytic_distribution,
                     'display_type': 'cogs',
                     'tax_ids': [],
                     'cogs_origin_id': line.id,
-                })
+                }
+                if line._force_analytic_distribution():
+                    expense_line_vals['analytic_distribution'] = line.analytic_distribution
+                lines_vals_list.append(expense_line_vals)
         return lines_vals_list
 
     def _get_anglo_saxon_price_ctx(self):


### PR DESCRIPTION
Steps:

- Activate automatic accounting
- Create a product P:
  • Storable, track inventory
  • Set a cost
  • Product category FIFO, automated valuation
- Activate analytic accounting
- Create a distribution model for that applies to expense account
- Create an invoice for product P, set an analytic (different from the
  one set on the model above)
- Confirm
-> On the cogs expense line, the analytic account is the one from the
   product line, it should be the one set on distribution model

Cause:

The analytic distribution is forced to the same value as the product
line at the creation of cogs lines.

Fix:

Adding a helper to know if we need to force the value of analytic
distribution or leave it to the compute method.
This is especially needed for invoices that are originated by a sale order linked
to a project, since we calculate profitability items regarding the
project's distribution.

Note:

This is an issue that has been addressed several times in differents
way, the reason of this fix is that we think that user should rely on
distribution models: if they want a distribution to be applied on the
cogs line, they should create a distribution model that meet their
needs.

opw-5193666
