### PR TITLE
[FIX] l10n_eg_edi_eta: fix JSONDecodeError catching

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -8,7 +8,6 @@ import requests
 from werkzeug.urls import url_quote
 from base64 import b64encode
 from odoo.addons.account.tools import LegacyHTTPAdapter
-from json.decoder import JSONDecodeError
 
 from odoo import api, models, _
 from odoo.tools.float_utils import json_float_round
@@ -57,7 +56,7 @@ class AccountEdiFormat(models.Model):
         if not request_response.ok:
             try:
                 response_data = request_response.json()
-            except JSONDecodeError as ex:
+            except requests.exceptions.JSONDecodeError as ex:
                 return {
                     'error': str(ex),
                     'blocking_level': 'error'


### PR DESCRIPTION
Before this commit:
Steps
1) When clients try to download e-invoice for ETA
2) If ETA rejects the request, Odoo fails to parse to JSON 
3) a JSONDecodeError exception is raised
4) Odoo doesn't catch it and a traceback is raised

=> A JSONDecodeError is raised but actually it's not json.decoder.JSONDecodeError, it's actually requests.exceptions.JSONDecodeError as mentioned here https://requests.readthedocs.io/en/latest/api/#requests.JSONDecodeError

After this commit:
If the request is rejected and Odoo failed to parse the response to JSON the exception is catched properly.

opw-5241411
opw-5272195
