### PR TITLE
[IMP] mail: restricts removing attachments in discuss channels

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -202,7 +202,13 @@ class ChannelController(http.Controller):
             domain.append(["id", "<", before])
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
         attachments = request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
-        store = Store().add(attachments, "_store_attachment_fields")
+        store = Store().add(
+            attachments,
+            lambda res: (
+                res.from_method("_store_attachment_fields"),
+                res.from_method("_store_permissions_fields"),
+            ),
+        )
         return {"store_data": store.get_result(), "count": len(attachments)}
 
     @http.route("/discuss/channel/join", methods=["POST"], type="jsonrpc", auth="public")

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -1,6 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from functools import partial
+
 from odoo import models, fields
+from odoo.tools import OrderedSet
 from odoo.addons.mail.tools.discuss import Store
 
 
@@ -8,6 +11,52 @@ class IrAttachment(models.Model):
     _inherit = "ir.attachment"
 
     voice_ids = fields.One2many("discuss.voice.metadata", "attachment_id")
+
+    def _check_access(self, operation):
+        """Check access for attachments in Discuss channels.
+
+        An attachment can be deleted by:
+        - the author of the message related to the attachment.
+        - admins/owners of the channel.
+        - system admins.
+
+        This method acts as a strict filter on `super()`, only removing access.
+        """
+        res = super()._check_access(operation)
+
+        if operation not in ("write", "unlink"):
+            return res
+        if self.env.is_system():
+            return res
+
+        remaining = self
+        error_func = None
+        forbidden_ids = OrderedSet()
+        if res:
+            forbidden, error_func = res
+            remaining -= forbidden
+            forbidden_ids.update(forbidden._ids)
+
+        channel_attachments_sudo = remaining.sudo().filtered(lambda a: a.res_model == "discuss.channel")
+        if not channel_attachments_sudo:
+            return res
+
+        channels = self.env["discuss.channel"].browse(channel_attachments_sudo.mapped("res_id"))
+        channel_by_id = {c.id: c for c in channels}
+        for attachment in channel_attachments_sudo:
+            if any(message.author_id == self.env.user.partner_id for message in attachment.message_ids):
+                continue
+            if channel_by_id[attachment.res_id].self_member_id.sudo().channel_role in ("admin", "owner"):
+                continue
+            forbidden_ids.add(attachment.id)
+
+        if forbidden_ids:
+            forbidden = self.browse(forbidden_ids)
+            if error_func is None:
+                error_func = partial(forbidden._make_access_error, operation)
+            return forbidden, error_func
+
+        return res
 
     def _bus_channel(self):
         self.ensure_one()
@@ -23,6 +72,16 @@ class IrAttachment(models.Model):
         # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible
         # attachments is fine
         res.many("voice_ids", [], sudo=True)
+
+    def _store_permissions_fields(self, res: Store.FieldList):
+        if self.env.user._is_internal():
+            res.many("message_ids", ["author_id"])
+        else:
+            res.attr(
+                "ownership_token",
+                lambda a: a._get_ownership_token(),
+                predicate=lambda a: any(m.is_current_user_or_guest_author for m in a.message_ids)
+            )
 
     def _post_add_create(self, **kwargs):
         super()._post_add_create(**kwargs)

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -11,6 +11,7 @@ from odoo.addons.mail.tools.discuss import Store
 class IrAttachment(models.Model):
     _inherit = 'ir.attachment'
 
+    message_ids = fields.Many2many("mail.message", "message_attachment_rel", "attachment_id", "message_id", copy=False)
     thumbnail = fields.Image()
     has_thumbnail = fields.Boolean(compute="_compute_has_thumbnail")
 

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -28,7 +28,7 @@ export class Attachment extends FileModelMixin(Record) {
     res_name;
     /** @type {string} */
     thumbnail_access_token;
-    message = fields.One("mail.message", { inverse: "attachment_ids" });
+    message_ids = fields.Many("mail.message", { inverse: "attachment_ids" });
     /** @type {string} */
     ownership_token;
     create_date = fields.Datetime();
@@ -67,8 +67,8 @@ export class Attachment extends FileModelMixin(Record) {
     }
 
     get isDeletable() {
-        if (this.message && this.store.self_user?.share !== false) {
-            return this.message.editable;
+        if (this.store.self_user?.share !== false) {
+            return this.ownership_token;
         }
         return true;
     }

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -36,7 +36,7 @@ export class Message extends Record {
         }
     }
 
-    attachment_ids = fields.Many("ir.attachment", { inverse: "message" });
+    attachment_ids = fields.Many("ir.attachment", { inverse: "message_ids" });
     author_id = fields.One("res.partner");
     author_guest_id = fields.One("mail.guest");
     get author() {

--- a/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
@@ -5,8 +5,14 @@ import { patch } from "@web/core/utils/patch";
 /** @type {import("models").Attachment} */
 const attachmentPatch = {
     get isDeletable() {
-        if (this.message && this.thread?.channel) {
-            return this.message.editable;
+        if (
+            this.thread?.channel &&
+            this.store.self_user?.share === false &&
+            !this.store.self_user.is_admin &&
+            !this.message_ids.some((m) => m.isSelfAuthored) &&
+            !["admin", "owner"].includes(this.thread?.self_member_id?.channel_role)
+        ) {
+            return false;
         }
         return super.isDeletable;
     },

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -17,6 +17,7 @@ from . import test_discuss_res_role
 from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
 from . import test_guest
+from . import test_ir_attachment
 from . import test_message_controller
 from . import test_guest_feature
 from . import test_toggle_upload

--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -30,14 +30,9 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
         whether or not limited `ownership_token` is sent"""
         channel = self.env["discuss.channel"].create({"name": "public channel"})
         self._execute_subtests_delete(self.all_users, token=True, allowed=True, thread=channel)
+        self._execute_subtests_delete(self.user_admin, token=False, allowed=True, thread=channel)
         self._execute_subtests_delete(
-            (self.user_admin, self.user_employee),
-            token=False,
-            allowed=True,
-            thread=channel,
-        )
-        self._execute_subtests_delete(
-            (self.guest, self.user_portal, self.user_public),
+            (self.guest, self.user_employee, self.user_portal, self.user_public),
             token=False,
             allowed=False,
             thread=channel,

--- a/addons/mail/tests/discuss/test_ir_attachment.py
+++ b/addons/mail/tests/discuss/test_ir_attachment.py
@@ -1,0 +1,46 @@
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.exceptions import AccessError
+
+
+class TestDiscussAttachment(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.channel = cls.env["discuss.channel"]._create_channel(name="Channel", group_id=None)
+        cls.channel._add_members(users=cls.user_admin | cls.user_employee)
+
+    def _create_attachment(self, author):
+        attachment = self.env["ir.attachment"].create({
+            "name": "Attachment",
+            "res_model": "discuss.channel",
+            "res_id": self.channel.id
+        })
+        self.env["mail.message"].create({
+            "model": "discuss.channel",
+            "res_id": self.channel.id,
+            "author_id": author.partner_id.id,
+            "attachment_ids": attachment.ids,
+        })
+        return attachment
+
+    def _execute_subtest_delete(self, user, author, allowed, channel_role=None):
+        with self.subTest(user=user.name, author=author.name, channel_role=channel_role):
+            attachment = self._create_attachment(author)
+            if channel_role:
+                self.channel.channel_member_ids.filtered(
+                    lambda m: m.partner_id == user.partner_id
+                ).channel_role = channel_role
+            if allowed:
+                attachment.with_user(user).unlink()
+                self.assertFalse(attachment.exists())
+            else:
+                with self.assertRaises(AccessError):
+                    attachment.with_user(user).unlink()
+
+    def test_delete_attachment(self):
+        self._execute_subtest_delete(self.user_employee, author=self.user_employee, allowed=True)
+        self._execute_subtest_delete(self.user_employee, author=self.user_admin, allowed=False)
+        self._execute_subtest_delete(self.user_employee, author=self.user_admin, allowed=True, channel_role="admin")
+        self._execute_subtest_delete(self.user_employee, author=self.user_admin, allowed=True, channel_role="owner")
+        self._execute_subtest_delete(self.user_admin, author=self.user_employee, allowed=True)

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -12,6 +12,7 @@ import uuid
 import warnings
 from collections import defaultdict
 from collections.abc import Collection
+from functools import partial
 
 import psycopg2
 import werkzeug
@@ -555,16 +556,7 @@ class IrAttachment(models.Model):
             forbidden = self.browse(forbidden_ids)
             forbidden.invalidate_recordset(SECURITY_FIELDS)  # avoid cache pollution
             if error_func is None:
-                def error_func():
-                    return AccessError(self.env._(
-                        "Sorry, you are not allowed to access this document. "
-                        "Please contact your system administrator.\n\n"
-                        "(Operation: %(operation)s)\n\n"
-                        "Records: %(records)s, User: %(user)s",
-                        operation=operation,
-                        records=forbidden[:6],
-                        user=self.env.uid,
-                    ))
+                error_func = partial(forbidden._make_access_error, operation)
             return forbidden, error_func
         return None
 
@@ -596,6 +588,17 @@ class IrAttachment(models.Model):
             res_ids.difference_update(records._ids)
             for res_id in res_ids:
                 yield res_model, res_id
+
+    def _make_access_error(self, operation: str) -> AccessError:
+        return AccessError(self.env._(
+            "Sorry, you are not allowed to access this document. "
+            "Please contact your system administrator.\n\n"
+            "(Operation: %(operation)s)\n\n"
+            "Records: %(records)s, User: %(user)s",
+            operation=operation,
+            records=self.ids[:6],
+            user=self.env.uid,
+        ))
 
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):


### PR DESCRIPTION
With this commit attachments in discuss channels will be removable by:
- The author of the message related to the attachment
- The channel admins
- The channel owners
- The system admins

task-5343276