### PR TITLE
[FIX] website: edit branding after translation

### DIFF
--- a/addons/website/static/src/builder/plugins/remove_translation_branding_plugin.js
+++ b/addons/website/static/src/builder/plugins/remove_translation_branding_plugin.js
@@ -1,0 +1,21 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+export class RemoveTranslationBrandingPlugin extends Plugin {
+    static id = "removeTranslationBrandingPlugin";
+
+    setup() {
+        // Cleaning translation branding nodes that could have been saved
+        // by error between with code between d4d428ff1d (29th October 2025) and
+        // f09dc4d9d3 (19th November 2025)
+        this.editable
+            .querySelectorAll("span[data-oe-model][data-oe-translation-source-sha]")
+            .forEach((brandingElement) => {
+                brandingElement.replaceWith(...brandingElement.childNodes);
+            });
+    }
+}
+
+registry
+    .category("website-plugins")
+    .add(RemoveTranslationBrandingPlugin.id, RemoveTranslationBrandingPlugin);

--- a/addons/website/static/tests/builder/setup_html_builder.test.js
+++ b/addons/website/static/tests/builder/setup_html_builder.test.js
@@ -56,3 +56,17 @@ test("Admin navbar is hidden in edit mode", async () => {
     await waitFor(":iframe section");
     expect(".o_main_navbar").not.toBeVisible();
 });
+
+test("saved translation branding is removed in edit mode", async () => {
+    // This situation should not happen with up-to-date code, but translation
+    // branding nodes could have been saved with code between d4d428ff1d (29th
+    // October 2025) and f09dc4d9d3 (19th November 2025)
+    await setupWebsiteBuilder(`
+        <h1 class="title">
+            <span data-oe-model="ir.ui.view" data-oe-id="526"
+                  data-oe-field="arch_db" data-oe-translation-state="to_translate"
+                  data-oe-translation-source-sha="123">Hello</span>
+        </h1>
+    `);
+    expect(":iframe h1.title").toHaveInnerHTML("Hello");
+});


### PR DESCRIPTION
Scenario:

- run Odoo with source code between [1] (29th october 2025) and [2]
  (19th november 2025)

- translate a string in an embedded field with a BR added outside the
  translation contenteditable (eg. select completely a LI element and
  replace the content by something else)

- save

- edit the content in source language, save (with or without any change)

Result: traceback error containing:

>  File "addons/html_editor/models/ir_ui_view.py", line 66, in save_embedded_field
>    model = 'ir.qweb.field.' + el.get('data-oe-type')
>            ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
> TypeError: can only concatenate str (not "NoneType") to str

Cause:

Commit [1] removed o_editable on nodes that should not be editable, but
that caused those nodes to no longer have data-oe-readonly attribute.

When replacing the whole content translation node, the original content
is first removed, after which DeletePlugin.fillShrunkBlocks adds a BR
after the translation node.

This caused the ancestor [data-oe-model] to be set as o_dirty, event if
it was not editable or [contenteditable].

On save, the ancestor with .o_dirty[data-oe-model] was saved while
containing translation branding SPAN, which when editing the page in
source language, would cause an error on save.

Fix:

Up to 19.0, when the website editor is started in non-translation mode:
remove the translation branding SPAN.

[1] d4d428ff1d5be46135973aa806f206a1076bfcf7
[2] f09dc4d9d35e1e3707c9483fc6004cf162a3f4ca

opw-5234578