### PR TITLE
[FIX] account_edi_ubl_cii: import duplicate bank accounts

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -382,7 +382,7 @@ class AccountEdiCommon(models.AbstractModel):
 
         # clear the context, because creation of partner when importing should not depend on the context default values
         ResPartnerBank = self.env['res.partner.bank'].with_env(self.env(context=clean_context(self.env.context)))
-        bank_details = list(map(sanitize_account_number, bank_details))
+        bank_details = list(set(map(sanitize_account_number, bank_details)))
 
         if invoice.move_type in ('out_refund', 'in_invoice'):
             partner = invoice.partner_id

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -597,3 +597,14 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         self.env['account.edi.common']._import_retrieve_and_fill_partner_bank_details(invoice, [acc_number])
         self.assertEqual(invoice.partner_bank_id, partner_bank, "Partner bank must be the same")
         self.assertTrue(partner_bank.active, "Partner bank must be the activated")
+
+    def test_bank_details_import_duplicate(self):
+        acc_number = '1234567890'
+        invoice = self.env['account.move'].create({
+            'partner_id': self.partner_a.id,
+            'move_type': 'in_invoice',
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})],
+        })
+        # Importing should not try to create multiple partner bank records with the same account number.
+        # It would cause a traceback due to a unique constraint on the (sanitized) account number, partner pair.
+        self.env['account.edi.common']._import_retrieve_and_fill_partner_bank_details(invoice, [acc_number, acc_number])


### PR DESCRIPTION
Currently `_import_retrieve_and_fill_partner_bank_details` may try to to create multiple res partner bank with the same account. This can i.e. happen in case there are multiple `cac:PaymenMeans` nodes in the XML.

After this commit we filter out duplicate bank accounts numbers.

opw-5149621