### PR TITLE
[FIX] website: Vimeo videos loop and hide controls

### DIFF
--- a/addons/website/static/src/js/content/generate_video_iframe.js
+++ b/addons/website/static/src/js/content/generate_video_iframe.js
@@ -12,32 +12,6 @@ const SUPPORTED_DOMAINS = [
 ];
 
 /**
- * Escapes a string to HTML interpolation.
- * Remark: this function is already available in the codebase (see:
- * `web/.../core/utils/strings.js`), but we need to reimplement it
- * here for non-lazy code.
- *
- * @param {String} str The string to escape.
- * @returns {String}
- */
-export function escape(str) {
-    if (!str) {
-        return "";
-    }
-    for (const [unescaped, escaped] of [
-        ["&", "&amp;"],
-        ["<", "&lt;"],
-        [">", "&gt;"],
-        ["'", "&#x27;"],
-        ['"', "&quot;"],
-        ["`", "&#x60;"],
-    ]) {
-        str = str.replaceAll(unescaped, escaped);
-    }
-    return str;
-}
-
-/**
  * Builds a video iframe for a saved `src` and appends it to the DOM.
  *
  * @param {HTMLElement} parentEl The iframe container.
@@ -57,7 +31,7 @@ export function generateVideoIframe(parentEl) {
 
     // Rebuild the iframe. Depending on version / compatibility / instance, the
     // src is saved in the 'data-src' attribute or the 'data-oe-expression' one.
-    const src = escape(parentEl.dataset.oeExpression || parentEl.dataset.src);
+    const src = parentEl.dataset.oeExpression || parentEl.dataset.src;
     // Validate the src to only accept supported domains we can trust
     const m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);
     if (!m) {


### PR DESCRIPTION
When setting options like "Loop" or "Hide Player Controls" on an
embedded Vimeo video, these settings were not applied on the final
page after saving.

Steps to reproduce:
===================
- Go to the Website editor.
- Drag and drop a "Media List" or similar snippet.
- Double-click the video placeholder to open the media dialog.
- In the "Video" tab, paste a Vimeo URL.
- Enable "Loop" and/or "Hide Player Controls".
- Save the page.
-> Observe that the video does not loop and the controls are still
  visible.

Cause:
======
When rebuilding the iframe, `generateVideoIframe` was processing the
video's `src` URL through using `escape()` function. This function
is designed to prevent XSS by converting characters like
`&` into their HTML entity equivalent, `&amp;`.

However, Vimeo video URLs use the `&` character to separate query
parameters (e.g., `?loop=1&controls=0`). The `escape()` function
was converting this URL to `?loop=1&amp;controls=0`. but `setAttribute`
already handles URL values safely. so Vimeo player will receive url
containing &amp;amp;.
This broke the URL's structure. The Vimeo player received a malformed
URL, could not parse the parameters correctly, and therefore ignored
the options for looping and controls.

escape was used before cause  The original code was adding the iframe
using `.html(...)`
see commit: https://github.com/odoo-dev/odoo/commit/8749410b1033ddec1207ce1db42d1889a0d2ea33

side note 1: before saving the vimeo video works because we render it
without the double escaping of & (as will be the case for saved video
if this PR is applied)

side note 2: the issue of double escaping also apply to youtube, but it
seems to be ok with superfluous & in URL while in vimeo:

https://player.vimeo.com/video/1138854841?autoplay=1&amp;muted=1&amp;autopause=0&amp;controls=0&amp;loop=1
has the video that doesn't loop, is not muted (so doesn't auto play in
an iframe on most browser) and show controls
https://player.vimeo.com/video/1138854841?autoplay=1&muted=1&autopause=0&controls=0&loop=1:
all option works

Solution:
=========
The unnecessary `escape()` call has been removed.
since the video should be only added using media dialog and the
`setAttribute(...)` will escape it by default

opw-5225261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
