### PR TITLE
[FIX] calendar: prevent scrollbar in create new event modal

### DIFF
--- a/addons/calendar/static/src/scss/calendar_event_views.scss
+++ b/addons/calendar/static/src/scss/calendar_event_views.scss
@@ -15,7 +15,7 @@
  **********************************************************/
 
 .modal-dialog:has(.o_calendar_event_form_quick_create) {
-    --modal-width: 450px;
+    --modal-width: 490px;
 }
 
 .o_calendar_event_form_quick_create {


### PR DESCRIPTION
**Current behavior before PR:**

- The new event modal was reduced in width, causing the placeholder to have insufficient space. When focusing the editable area, this resulted in an unnecessary scrollbar.

**Desired behavior after PR is merged:**

- The width of the event creation modal has been increased, preventing the scrollbar from appearing when the cursor is inside the editable area.

task-5207448
