### PR TITLE
[FIX] l10n_es_edi_facturae: incorrect XML on credit notes

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -157,7 +157,7 @@
                     <EndDate t-out="invoice['Corrective']['TaxPeriod']['EndDate']"/>
                 </TaxPeriod>
                 <CorrectionMethod>01</CorrectionMethod>
-                <CorrectionMethodDescription>Rectificación modelo íntegro.</CorrectionMethodDescription>
+                <CorrectionMethodDescription>Rectificación íntegra</CorrectionMethodDescription>
             </Corrective>
         </template>
 

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -40,6 +40,32 @@ COUNTRY_CODE_MAP = {
     "AX": "ALA", "AZ": "AZE", "IE": "IRL", "ID": "IDN", "UA": "UKR", "QA": "QAT", "MZ": "MOZ"
 }
 REVERSED_COUNTRY_CODE = {v: k for k, v in COUNTRY_CODE_MAP.items()}
+#  The reason type should be exactly the fields given below.
+#  We cannot rely on the translated Selection since a single character difference would render the XML incorrect.
+SPANISH_CREDIT_REASON_TYPE = {
+    '01': 'Número de la factura',
+    '02': 'Serie de la factura',
+    '03': 'Fecha expedición',
+    '04': 'Nombre y apellidos/Razón Social-Emisor',
+    '05': 'Nombre y apellidos/Razón Social-Receptor',
+    '06': 'Identificación fiscal Emisor/obligado',
+    '07': 'Identificación fiscal Receptor',
+    '08': 'Domicilio Emisor/Obligado',
+    '09': 'Domicilio Receptor',
+    '10': 'Detalle Operación',
+    '11': 'Porcentaje impositivo a aplicar',
+    '12': 'Cuota tributaria a aplicar',
+    '13': 'Fecha/Periodo a aplicar',
+    '14': 'Clase de factura',
+    '15': 'Literales legales',
+    '16': 'Base imponible',
+    '80': 'Cálculo de cuotas repercutidas',
+    '81': 'Cálculo de cuotas retenidas',
+    '82': 'Base imponible modificada por devolución de envases / embalajes',
+    '83': 'Base imponible modificada por descuentos y bonificaciones',
+    '84': 'Base imponible modificada por resolución firme, judicial o administrativa',
+    '85': 'Base imponible modificada cuotas repercutidas no satisfechas. Auto de declaración de concurso',
+}
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
@@ -147,8 +173,7 @@ class AccountMove(models.Model):
             tax_period = refunded_invoice._l10n_es_edi_facturae_get_tax_period()
 
             reason_code = self.l10n_es_edi_facturae_reason_code or '10'
-            reason_description = [label for code, label in self._fields['l10n_es_edi_facturae_reason_code'].selection
-                                  if code == reason_code][0]
+            reason_description = SPANISH_CREDIT_REASON_TYPE[reason_code]
             return {
                 'refunded_invoice_record': refunded_invoice,
                 'ReasonCode': reason_code,

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -65,13 +65,13 @@
         <Corrective>
           <InvoiceNumber>INV/2023/00001</InvoiceNumber>
           <ReasonCode>10</ReasonCode>
-          <ReasonDescription>Item line</ReasonDescription>
+          <ReasonDescription>Detalle Operación</ReasonDescription>
           <TaxPeriod>
             <StartDate>2023-01-01</StartDate>
             <EndDate>2023-01-31</EndDate>
           </TaxPeriod>
           <CorrectionMethod>01</CorrectionMethod>
-          <CorrectionMethodDescription>Rectificación modelo íntegro.</CorrectionMethodDescription>
+          <CorrectionMethodDescription>Rectificación íntegra</CorrectionMethodDescription>
         </Corrective>
       </InvoiceHeader>
       <InvoiceIssueData>

--- a/addons/l10n_es_edi_facturae/wizard/account_move_reversal.py
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_reversal.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, _
 
 
 class AccountMoveReversal(models.TransientModel):
@@ -15,3 +15,10 @@ class AccountMoveReversal(models.TransientModel):
         res = super(AccountMoveReversal, self).reverse_moves(is_modify)
         self.new_move_ids.l10n_es_edi_facturae_reason_code = self.l10n_es_edi_facturae_reason_code
         return res
+
+    def _get_ref_string(self, move):
+        if move._l10n_es_edi_facturae_get_default_enable():
+            field = self.env['account.move']._fields['l10n_es_edi_facturae_reason_code']
+            reason_descr = dict(field._description_selection(self.env)).get(self.l10n_es_edi_facturae_reason_code)
+            return _('Reversal of: %(move_name)s - %(reason)s', move_name=move.name, reason=reason_descr)
+        return super()._get_ref_string(move)

--- a/addons/l10n_es_edi_facturae/wizard/account_move_reversal_view.xml
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_reversal_view.xml
@@ -22,7 +22,7 @@
                 <field name="reason" position="replace">
                     <field name="country_code" invisible="1"/>
                     <field name="l10n_es_edi_facturae_reason_code" string="Reason" invisible="country_code != 'ES'"/>
-                    <field name="reason" string="Reason" invisible="move_type == 'entry' and country_code == 'ES'"/>
+                    <field name="reason" string="Reason" invisible="country_code == 'ES'"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
In cases of credit notes, the xml would not be validated by the FACe. This was caused by the field 'ReasonDescription', which can only be one of the proposed field.

We used to provide it in English when the available reasons are only in Spanish.

Also fixed CorrectionMethodDescription.

See https://www.facturae.gob.es/formato/Paginas/version-3-2.aspx for more documentation.

ticket-5184181

Took the opportunity to improve the reversal wizard : 
In the reversal wizard, two fields 'Reason' would be displayed.

Only kept the mandatory one and used it in place of the non-mandatory one.