### PR TITLE
[FIX] spreadsheet: use translation context

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/odoo_module.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/odoo_module.js
@@ -5,9 +5,10 @@ odoo.define(
     ["@web/core/l10n/translation", "@spreadsheet/o_spreadsheet/o_spreadsheet"],
     function (require) {
         "use strict";
-        const { _t, translationLoaded, translatedTerms } = require("@web/core/l10n/translation");
+        const { appTranslateFn, translationLoaded, translatedTerms } = require("@web/core/l10n/translation");
         const spreadsheet = require("@spreadsheet/o_spreadsheet/o_spreadsheet");
         window.o_spreadsheet = spreadsheet;
+        const _t = (str, ...args) => appTranslateFn(str, "spreadsheet", ...args);
         spreadsheet.setTranslationMethod(_t, () => translatedTerms[translationLoaded]);
         return spreadsheet;
     }


### PR DESCRIPTION
When we give the translation function to the o-spreadsheet library, we give `_t` which doesn't have the translation context which means all translations fallback on the general translated terms instead of using the spreadsheet specific terms.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
