### PR TITLE
[IMP] account: allow multi-line formulas

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -592,8 +592,8 @@ class AccountReportExpression(models.Model):
         ],
         required=True
     )
-    formula = fields.Char(string="Formula", required=True)
-    subformula = fields.Char(string="Subformula")
+    formula = fields.Text(string="Formula", required=True)
+    subformula = fields.Text(string="Subformula")
     date_scope = fields.Selection(
         string="Date Scope",
         selection=[
@@ -652,7 +652,8 @@ class AccountReportExpression(models.Model):
                 raise_formula_error(expression)
 
         for expression in expressions_by_engine.get('account_codes', []):
-            for token in ACCOUNT_CODES_ENGINE_SPLIT_REGEX.split(expression.formula.replace(' ', '')):
+            cleaned_formula = re.sub(r'\s+', '', expression.formula)
+            for token in ACCOUNT_CODES_ENGINE_SPLIT_REGEX.split(cleaned_formula):
                 if token:  # e.g. if the first character of the formula is "-", the first token is ''
                     token_match = ACCOUNT_CODES_ENGINE_TERM_REGEX.match(token)
                     prefix = token_match['prefix']
@@ -660,7 +661,7 @@ class AccountReportExpression(models.Model):
                         raise_formula_error(expression)
 
         for expression in expressions_by_engine.get('aggregation', []):
-            if not AGGREGATION_ENGINE_FORMULA_REGEX.fullmatch(expression.formula):
+            if not AGGREGATION_ENGINE_FORMULA_REGEX.fullmatch(expression.formula.strip()):
                 raise_formula_error(expression)
 
 
@@ -684,10 +685,6 @@ class AccountReportExpression(models.Model):
     def _get_auditable_engines(self):
         return {'tax_tags', 'domain', 'account_codes', 'external', 'aggregation'}
 
-    def _strip_formula(self, vals):
-        if 'formula' in vals and isinstance(vals['formula'], str):
-            vals['formula'] = re.sub(r'\s+', ' ', vals['formula'].strip())
-
     def _create_tax_tags(self, tag_name, country):
         existing_tag = self.env['account.account.tag']._get_tax_tags(tag_name, country.id)
         if not existing_tag:
@@ -698,13 +695,11 @@ class AccountReportExpression(models.Model):
     def create(self, vals_list):
         # Overridden so that we create the corresponding account.account.tag objects when instantiating an expression
         # with engine 'tax_tags'.
-        for vals in vals_list:
-            self._strip_formula(vals)
 
         result = super().create(vals_list)
 
         for expression in result:
-            tag_name = expression.formula if expression.engine == 'tax_tags' else None
+            tag_name = re.sub(r'\s+', ' ', expression.formula.strip()) if expression.engine == 'tax_tags' else None
             if tag_name:
                 country = expression.report_line_id.report_id.country_id
                 self._create_tax_tags(tag_name, country)
@@ -713,8 +708,6 @@ class AccountReportExpression(models.Model):
 
     def write(self, vals):
 
-        self._strip_formula(vals)
-
         tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
 
         if vals.get('engine') == 'tax_tags':
@@ -722,6 +715,7 @@ class AccountReportExpression(models.Model):
             tags_create_vals = []
             for expression_with_new_engine in self - tax_tags_expressions:
                 tag_name = vals.get('formula') or expression_with_new_engine.formula
+                tag_name = re.sub(r'\s+', ' ', tag_name.strip())
                 country = expression_with_new_engine.report_line_id.report_id.country_id
                 if not self.env['account.account.tag']._get_tax_tags(tag_name, country.id):
                     tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(


### PR DESCRIPTION
Formula expression in reports do not allow multi-line formulas, For long formulas this could be unpleasent for user experience This change allow the user to input multi-line formulas and subformulas and also show them as multiline in the views.
task: 5208320

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
