### PR TITLE
[IMP] l10n_sk: Added tax groups accounts

### DIFF
--- a/addons/l10n_sk/data/template/account.tax.group-sk.csv
+++ b/addons/l10n_sk/data/template/account.tax.group-sk.csv
@@ -1,4 +1,4 @@
-"id","name","country_id","name@sk"
-"tax_group_vat_23","VAT 23%","base.sk","DPH 23%"
-"tax_group_vat_19","VAT 19%","base.sk","DPH 19%"
-"tax_group_vat_0","VAT 0%","base.sk","DPH 0%"
+"id","name","country_id","tax_payable_account_id","tax_receivable_account_id","name@sk"
+"tax_group_vat_23","VAT 23%","base.sk","chart_sk_343220","chart_sk_343120","DPH 23%"
+"tax_group_vat_19","VAT 19%","base.sk","chart_sk_343220","chart_sk_343120","DPH 19%"
+"tax_group_vat_0","VAT 0%","base.sk","chart_sk_343220","chart_sk_343120","DPH 0%"


### PR DESCRIPTION
This commit adds tax_payable_account_id and tax_receivable_account_id to all tax groups in Slovak tempalte.

opw-5264511





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
