### PR TITLE
[FIX] account: self-billing, suppliers name in the sequence

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4235,10 +4235,9 @@ class AccountMove(models.Model):
             starting_sequence = "%s/%s/%s" % (self.journal_id.code, year_part, '0000' if is_staggered_year else '00000')
         else:
             if self.journal_id.is_self_billing:
-                partner_identifier = str(self.partner_id.commercial_partner_id.id) if self.partner_id else _('[Partner id]')
-                starting_sequence = "%s%s/%s/%02d/0000" % (
-                    self.journal_id.code,
-                    partner_identifier.zfill(5),
+                partner_identifier = str(self.partner_id.commercial_partner_id.name) if self.partner_id else _('[Partner id]')
+                starting_sequence = "%s/%s/%02d/0000" % (
+                    partner_identifier,
                     year_part,
                     move_date.month,
                 )


### PR DESCRIPTION
Issue:
For self-billing in PEPPOL, the name of the supplier is supposed to show as a legal requirement on te vendor bill, but it was not the case.

Cause:
It was the id of the partner that was shown.

Steps to reproduce:
1. Activate Peppol (BE company), demo is fine.
2. Create a purchase journal for self billing, and enable self-billing in advanced settings of peppol.
3. Link the created purchase journal to self billing.
4. Create a vendor bill with the self billing journal and confirm. Notice that the name of the vendor is not shown in the name of the bill.

opw-5212805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
