### PR TITLE
[FIX] stock: reserve on quants at quantity increase

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
         },
         {
             trigger: ".modal .modal-body .o_field_widget[name=quantity] input",
-            run: 'edit 27',
+            run: 'edit 25',
         },
         {
             content: "Click Save",
@@ -58,7 +58,7 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             run: "click",
         },
         {
-            trigger: ".o_data_row > td:contains('43')",
+            trigger: ".o_data_row:has([name=product_uom_qty]:contains(5.00)) > td:contains(25)",
             run: "click",
         },
         {

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2247,39 +2247,82 @@ Please change the quantity done or the rounding precision of your unit of measur
             return []
 
     def _set_quantity_done_prepare_vals(self, qty):
+        def _move_qty(qty):
+            return self.product_id.uom_id._compute_quantity(qty, self.product_uom, round=False)
+
+        self.ensure_one()
         res = []
+        qty = self.product_uom._compute_quantity(qty, self.product_id.uom_id, round=False)
+        total_qty = qty
+        consumed_quant = set()
         for ml in self.move_line_ids:
             ml_qty = ml.quantity
+            if float_compare(ml_qty, 0, precision_rounding=ml.product_uom_id.rounding) < 0:
+                continue
+
+            if ml.product_uom_id != self.product_id.uom_id:
+                ml_qty = ml.product_uom_id._compute_quantity(ml_qty, self.product_id.uom_id, round=False)
+
             if float_is_zero(qty, precision_rounding=self.product_uom.rounding):
-                res.append((2, ml.id))
+                res.append(Command.delete(ml.id))
                 continue
-            if float_compare(ml_qty, 0, precision_rounding=ml.product_uom_id.rounding) <= 0:
-                continue
-            # Convert move line qty into move uom
-            if ml.product_uom_id != self.product_uom:
-                ml_qty = ml.product_uom_id._compute_quantity(ml_qty, self.product_uom, round=False)
 
+            if float_compare(ml_qty, qty, precision_rounding=ml.product_id.uom_id.rounding) > 0:
+                if ml.product_uom_id != self.product_id.uom_id:
+                    qty = ml.product_id.uom_id._compute_quantity(qty, ml.product_uom_id, round=False)
+                res.append(Command.update(ml.id, {'quantity': qty}))
+                qty = 0
+                continue
+
+            if ml.result_package_id:
+                qty -= ml_qty
+                continue
+            # remove what already on the line
             taken_qty = min(qty, ml_qty)
-            # Convert taken qty into move line uom
-            if ml.product_uom_id != self.product_uom:
-                taken_qty = self.product_uom._compute_quantity(taken_qty, ml.product_uom_id, round=False)
-
-            # Assign qty_done and explicitly round to make sure there is no inconsistency between
-            # ml.qty_done and qty.
-            taken_qty = float_round(taken_qty, precision_rounding=ml.product_uom_id.rounding)
-            res.append((1, ml.id, {'quantity': taken_qty}))
-            if ml.product_uom_id != self.product_uom:
-                taken_qty = ml.product_uom_id._compute_quantity(taken_qty, self.product_uom, round=False)
             qty -= taken_qty
+            if float_compare(_move_qty(qty), 0, precision_rounding=self.product_uom.rounding) <= 0:
+                continue
 
-        if float_compare(qty, 0.0, precision_rounding=self.product_uom.rounding) > 0:
+            # find a quant similar to the move line on which we can reserve
+            ml_quants = self.env['stock.quant']._get_reserve_quantity(self.product_id,
+                                                                      ml.location_id,
+                                                                      qty,
+                                                                      lot_id=ml.lot_id,
+                                                                      package_id=ml.package_id,
+                                                                      owner_id=ml.owner_id,
+                                                                      strict=True)
+            avail_qty = sum(q[1] for q in ml_quants)
+            # the quant did not add the quantity reserved on this specific move line
+            consumed_quant |= {q[0].id for q in ml_quants}
+            if float_compare(avail_qty, qty, precision_rounding=self.product_uom.rounding) <= 0:
+                qty -= avail_qty  # decrease the target quantity for the next move lines
+                avail_qty += ml_qty  # add the actual move line quantity as we will update it and not `+=` it
+                if ml.product_uom_id != self.product_id.uom_id:
+                    avail_qty = ml.product_id.uom_id._compute_quantity(avail_qty, ml.product_uom_id, round=False)
+                res.append(Command.update(ml.id, {'quantity': avail_qty}))
+
+        # First reserve on quants
+        if float_compare(_move_qty(qty), 0, precision_rounding=self.product_uom.rounding) > 0:
+            quants = self.env['stock.quant']._get_reserve_quantity(self.product_id, self.location_id, total_qty)
+            for quant, avail_qty in quants:
+                if quant.id in consumed_quant:
+                    continue
+                # compare the stock move quantity with the product free quantity
+                taken_qty = min(qty, avail_qty)
+                qty -= taken_qty
+                res.append(Command.create(self._prepare_move_line_vals(quantity=taken_qty, reserved_quant=quant)))
+                if float_compare(_move_qty(qty), 0, precision_rounding=self.product_uom.rounding) <= 0:
+                    break
+
+        # If quant is not enough, create a(some) move lines from the move itself
+        if float_compare(_move_qty(qty), 0, precision_rounding=self.product_uom.rounding) > 0:
             if self.product_id.tracking != 'serial':
+                qty = _move_qty(qty)
                 vals = self._prepare_move_line_vals(quantity=0)
                 vals['quantity'] = qty
                 res.append((0, 0, vals))
             else:
-                uom_qty = self.product_uom._compute_quantity(qty, self.product_id.uom_id)
-                for i in range(0, int(uom_qty)):
+                for _i in range(0, int(qty)):
                     vals = self._prepare_move_line_vals(quantity=0)
                     vals['quantity'] = 1
                     vals['product_uom_id'] = self.product_id.uom_id.id

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2220,6 +2220,48 @@ class StockMove(TransactionCase):
         move_partial._action_assign()
         self.assertEqual(move_partial.state, 'assigned')
 
+    def test_availability_10(self):
+        """ test the reservation is taken into account when updating the quantity on a move."""
+        # make some stock
+        shelf_1, shelf_2 = self.stock_location.child_ids
+        lot1, lot2, lot3 = self.env['stock.lot'].create([{
+            'name': 'lot%s' % str(i),
+            'product_id': self.product_lot.id,
+        } for i in range(1, 4)])
+        pack = self.env['stock.quant.package'].create({'name': 'pack'})
+        self.env['stock.quant']._update_available_quantity(self.product_lot, shelf_1, 3, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(self.product_lot, shelf_2, 3, lot_id=lot2)
+        self.env['stock.quant']._update_available_quantity(self.product_lot, shelf_1, 1, lot_id=lot3)
+        self.env['stock.quant']._update_available_quantity(self.product_lot, shelf_2, 3, lot_id=lot2, package_id=pack)
+
+        move = self.env['stock.move'].create({
+            'name': 'test_availability_10',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product_lot.id,
+            'product_uom': self.product_lot.uom_id.id,
+            'product_uom_qty': 1.0,
+        })
+
+        move._action_confirm()
+        move._action_assign()
+        self.assertRecordValues(move.move_line_ids, [
+            {'quantity': 1.0, 'location_id': shelf_1.id, 'lot_id': lot1.id, 'package_id': False},
+        ])
+
+        move.quantity = 8.0
+        self.assertRecordValues(move.move_line_ids, [
+            {'quantity': 3.0, 'location_id': shelf_1.id, 'lot_id': lot1.id, 'package_id': False},
+            {'quantity': 3.0, 'location_id': shelf_2.id, 'lot_id': lot2.id, 'package_id': False},
+            {'quantity': 1.0, 'location_id': shelf_1.id, 'lot_id': lot3.id, 'package_id': False},
+            {'quantity': 1.0, 'location_id': shelf_2.id, 'lot_id': lot2.id, 'package_id': pack.id},
+        ])
+
+        move.quantity = 3.0
+        self.assertRecordValues(move.move_line_ids, [
+            {'quantity': 3.0, 'location_id': shelf_1.id, 'lot_id': lot1.id, 'package_id': False},
+        ])
+
     def test_past_quantity(self):
         """Test the quantity is correct when looking in the past."""
         # make some stock

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
         },
         {
             trigger:
-                ".modal:contains(open: stock move) .o_list_footer .o_list_number > span:contains(7)",
+                ".modal:contains(open: stock move) .o_list_footer .o_list_number > span:contains('7')",
         },
         {
             content: "Click Save",
@@ -76,7 +76,7 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
         },
         {
             content: "Click in cell to start edition",
-            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains(47)",
+            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains(27)",
             run: "click",
         },
         {


### PR DESCRIPTION
Increasing the quantity of a stock move will create a move line with the same data as the stock move (location and product), no lot, nor package.

This commit make the increase of quantity mimic the reservation process by getting first the available quants. The move line are then created accordingly.

Backport of odoo/odoo#230344
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
