### PR TITLE
[REF] mail: call settings with localStorage=true

### DIFF
--- a/addons/im_livechat/static/tests/upgrade_19_1.test.js
+++ b/addons/im_livechat/static/tests/upgrade_19_1.test.js
@@ -5,16 +5,12 @@ import { makeRecordFieldLocalId } from "@mail/model/misc";
 import { toRawValue } from "@mail/utils/common/local_storage";
 import { contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
 
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineLivechatModels();
-
-beforeEach(() => {
-    serverState.serverVersion = [99, 9]; // high version so following upgrades keep good working of feature
-});
 
 test("category 'Livechat' is folded", async () => {
     const pyEnv = await startServer();

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -56,7 +56,7 @@ export class Settings extends Record {
     // Video settings
     backgroundBlurAmount = fields.Attr(10, { localStorage: true });
     edgeBlurAmount = fields.Attr(10, { localStorage: true });
-    showOnlyVideo = false;
+    showOnlyVideo = fields.Attr(false, { localStorage: true });
     useBlur = fields.Attr(false, { localStorage: true });
     blurPerformanceWarning = fields.Attr(false, {
         compute() {
@@ -297,8 +297,6 @@ export class Settings extends Record {
         this.voiceActivationThreshold = voiceActivationThresholdString
             ? parseFloat(voiceActivationThresholdString)
             : this.voiceActivationThreshold;
-        this.showOnlyVideo =
-            browser.localStorage.getItem("mail_user_setting_show_only_video") === "true";
     }
     /**
      * @private

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -54,8 +54,8 @@ export class Settings extends Record {
     push_to_talk_key;
 
     // Video settings
-    backgroundBlurAmount = 10;
-    edgeBlurAmount = 10;
+    backgroundBlurAmount = fields.Attr(10, { localStorage: true });
+    edgeBlurAmount = fields.Attr(10, { localStorage: true });
     showOnlyVideo = false;
     useBlur = fields.Attr(false, { localStorage: true });
     blurPerformanceWarning = fields.Attr(false, {
@@ -299,12 +299,6 @@ export class Settings extends Record {
             : this.voiceActivationThreshold;
         this.showOnlyVideo =
             browser.localStorage.getItem("mail_user_setting_show_only_video") === "true";
-        const backgroundBlurAmount = browser.localStorage.getItem(
-            "mail_user_setting_background_blur_amount"
-        );
-        this.backgroundBlurAmount = backgroundBlurAmount ? parseInt(backgroundBlurAmount) : 10;
-        const edgeBlurAmount = browser.localStorage.getItem("mail_user_setting_edge_blur_amount");
-        this.edgeBlurAmount = edgeBlurAmount ? parseInt(edgeBlurAmount) : 10;
     }
     /**
      * @private

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -35,9 +35,14 @@ export class Settings extends Record {
 
     // Voice settings
     // DeviceId of the audio input selected by the user
-    audioInputDeviceId = "";
-    audioOutputDeviceId = "";
-    cameraInputDeviceId = "";
+    audioInputDeviceId = fields.Attr("", { localStorage: true });
+    audioOutputDeviceId = fields.Attr("", { localStorage: true });
+    cameraInputDeviceId = fields.Attr("", {
+        localStorage: true,
+        onUpdate() {
+            this.cameraFacingMode = undefined;
+        },
+    });
     use_push_to_talk = false;
     voice_active_duration = 200;
     volumes = fields.Many("Volume");
@@ -176,34 +181,6 @@ export class Settings extends Record {
     }
 
     /**
-     * @param {String} audioInputDeviceId
-     */
-    async setAudioInputDevice(audioInputDeviceId) {
-        this.audioInputDeviceId = audioInputDeviceId;
-        browser.localStorage.setItem("mail_user_setting_audio_input_device_id", audioInputDeviceId);
-    }
-    /**
-     * @param {String} audioOutputDeviceId
-     */
-    async setAudioOutputDevice(audioOutputDeviceId) {
-        this.audioOutputDeviceId = audioOutputDeviceId;
-        browser.localStorage.setItem(
-            "mail_user_setting_audio_output_device_id",
-            audioOutputDeviceId
-        );
-    }
-    /**
-     * @param {String} cameraInputDeviceId
-     */
-    async setCameraInputDevice(cameraInputDeviceId) {
-        this.cameraFacingMode = undefined;
-        this.cameraInputDeviceId = cameraInputDeviceId;
-        browser.localStorage.setItem(
-            "mail_user_setting_camera_input_device_id",
-            cameraInputDeviceId
-        );
-    }
-    /**
      * @param {string} value
      */
     setDelayValue(value) {
@@ -320,15 +297,6 @@ export class Settings extends Record {
         this.voiceActivationThreshold = voiceActivationThresholdString
             ? parseFloat(voiceActivationThresholdString)
             : this.voiceActivationThreshold;
-        this.audioInputDeviceId = browser.localStorage.getItem(
-            "mail_user_setting_audio_input_device_id"
-        );
-        this.audioOutputDeviceId = browser.localStorage.getItem(
-            "mail_user_setting_audio_output_device_id"
-        );
-        this.cameraInputDeviceId = browser.localStorage.getItem(
-            "mail_user_setting_camera_input_device_id"
-        );
         this.showOnlyVideo =
             browser.localStorage.getItem("mail_user_setting_show_only_video") === "true";
         const backgroundBlurAmount = browser.localStorage.getItem(

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -2,7 +2,6 @@ import { hasHardwareAcceleration } from "@mail/utils/common/misc";
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 import { fields, Record } from "@mail/model/export";
-import { debounce } from "@web/core/utils/timing";
 import { rpc } from "@web/core/network/rpc";
 
 export class Settings extends Record {
@@ -10,15 +9,8 @@ export class Settings extends Record {
 
     setup() {
         super.setup();
-        this.saveVoiceThresholdDebounce = debounce(() => {
-            browser.localStorage.setItem(
-                "mail_user_setting_voice_threshold",
-                this.voiceActivationThreshold.toString()
-            );
-        }, 2000);
         this.hasCanvasFilterSupport =
             typeof document.createElement("canvas").getContext("2d").filter !== "undefined";
-        this._loadLocalSettings();
     }
 
     // Notification settings
@@ -48,7 +40,7 @@ export class Settings extends Record {
     volumes = fields.Many("Volume");
     volumeSettingsTimeouts = new Map();
     // Normalized [0, 1] volume at which the voice activation system must consider the user as "talking".
-    voiceActivationThreshold = 0.05;
+    voiceActivationThreshold = fields.Attr(0.05, { localStorage: true });
     // true if listening to keyboard input to register the push to talk key.
     isRegisteringKey = false;
     push_to_talk_key;
@@ -223,13 +215,6 @@ export class Settings extends Record {
             )
         );
     }
-    /**
-     * @param {float} voiceActivationThreshold
-     */
-    setThresholdValue(voiceActivationThreshold) {
-        this.voiceActivationThreshold = voiceActivationThreshold;
-        this.saveVoiceThresholdDebounce();
-    }
 
     // methods
 
@@ -286,17 +271,6 @@ export class Settings extends Record {
     setPushToTalk(value) {
         this.use_push_to_talk = value;
         this._saveSettings();
-    }
-    /**
-     * @private
-     */
-    _loadLocalSettings() {
-        const voiceActivationThresholdString = browser.localStorage.getItem(
-            "mail_user_setting_voice_threshold"
-        );
-        this.voiceActivationThreshold = voiceActivationThresholdString
-            ? parseFloat(voiceActivationThresholdString)
-            : this.voiceActivationThreshold;
     }
     /**
      * @private

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -43,3 +43,13 @@ upgrade_19_1.add("mail_user_setting_camera_input_device_id", ({ value }) => ({
     key: "Settings,undefined:cameraInputDeviceId",
     value,
 }));
+
+upgrade_19_1.add("mail_user_setting_background_blur_amount", ({ value }) => ({
+    key: "Settings,undefined:backgroundBlurAmount",
+    value: parseInt(value),
+}));
+
+upgrade_19_1.add("mail_user_setting_edge_blur_amount", ({ value }) => ({
+    key: "Settings,undefined:edgeBlurAmount",
+    value: parseInt(value),
+}));

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -53,3 +53,8 @@ upgrade_19_1.add("mail_user_setting_edge_blur_amount", ({ value }) => ({
     key: "Settings,undefined:edgeBlurAmount",
     value: parseInt(value),
 }));
+
+upgrade_19_1.add("mail_user_setting_show_only_video", {
+    key: "Settings,undefined:showOnlyVideo",
+    value: true,
+});

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -28,3 +28,18 @@ upgrade_19_1.add("mail_user_setting_use_blur", {
     key: "Settings,undefined:useBlur",
     value: true,
 });
+
+upgrade_19_1.add("mail_user_setting_audio_input_device_id", ({ value }) => ({
+    key: "Settings,undefined:audioInputDeviceId",
+    value,
+}));
+
+upgrade_19_1.add("mail_user_setting_audio_output_device_id", ({ value }) => ({
+    key: "Settings,undefined:audioOutputDeviceId",
+    value,
+}));
+
+upgrade_19_1.add("mail_user_setting_camera_input_device_id", ({ value }) => ({
+    key: "Settings,undefined:cameraInputDeviceId",
+    value,
+}));

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -58,3 +58,8 @@ upgrade_19_1.add("mail_user_setting_show_only_video", {
     key: "Settings,undefined:showOnlyVideo",
     value: true,
 });
+
+upgrade_19_1.add("mail_user_setting_voice_threshold", ({ value }) => ({
+    key: "Settings,undefined:voiceActivationThreshold",
+    value: parseFloat(value),
+}));

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -2,7 +2,6 @@ import { Component, onWillStart, useExternalListener, useState, xml } from "@odo
 
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
-import { debounce } from "@web/core/utils/timing";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
 import { useMicrophoneVolume } from "@mail/utils/common/hooks";
@@ -28,18 +27,6 @@ export class CallSettings extends Component {
             userDevices: [],
         });
         this.pttExtService = useService("discuss.ptt_extension");
-        this.saveBackgroundBlurAmount = debounce(() => {
-            browser.localStorage.setItem(
-                "mail_user_setting_background_blur_amount",
-                this.store.settings.backgroundBlurAmount.toString()
-            );
-        }, 2000);
-        this.saveEdgeBlurAmount = debounce(() => {
-            browser.localStorage.setItem(
-                "mail_user_setting_edge_blur_amount",
-                this.store.settings.edgeBlurAmount.toString()
-            );
-        }, 2000);
         useExternalListener(browser, "keydown", this._onKeyDown, { capture: true });
         useExternalListener(browser, "keyup", this._onKeyUp, { capture: true });
         onWillStart(async () => {
@@ -138,12 +125,10 @@ export class CallSettings extends Component {
 
     onChangeBackgroundBlurAmount(ev) {
         this.store.settings.backgroundBlurAmount = Number(ev.target.value);
-        this.saveBackgroundBlurAmount();
     }
 
     onChangeEdgeBlurAmount(ev) {
         this.store.settings.edgeBlurAmount = Number(ev.target.value);
-        this.saveEdgeBlurAmount();
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -108,11 +108,7 @@ export class CallSettings extends Component {
 
     onChangeShowOnlyVideo(ev) {
         const showOnlyVideo = ev.target.checked;
-        this.store.settings.showOnlyVideo = showOnlyVideo;
-        browser.localStorage.setItem(
-            "mail_user_setting_show_only_video",
-            this.store.settings.showOnlyVideo
-        );
+        this.store.settings.showOnlyVideo = Boolean(showOnlyVideo);
         const activeRtcSessions = this.store.allActiveRtcSessions;
         if (showOnlyVideo && activeRtcSessions) {
             activeRtcSessions

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -100,7 +100,7 @@ export class CallSettings extends Component {
     }
 
     onChangeSelectAudioInput(ev) {
-        this.store.settings.setAudioInputDevice(ev.target.value);
+        this.store.settings.audioInputDeviceId = ev.target.value;
     }
 
     onClickDownloadLogs() {

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -45,7 +45,7 @@
                             </div>
                         </button>
                         <label class="w-100 d-flex ms-2" title="Voice detection sensitivity" aria-label="Voice detection sensitivity">
-                            <input class="o-Discuss-CallSettings-thresholdInput form-range rounded" t-attf-style="--volume: {{microphoneVolume.value * 100}}%;" type="range" min="0.001" max="1" step="0.001" t-model="store.settings.voiceActivationThreshold" t-on-input="store.settings.saveVoiceThresholdDebounce"/>
+                            <input class="o-Discuss-CallSettings-thresholdInput form-range rounded" t-attf-style="--volume: {{microphoneVolume.value * 100}}%;" type="range" min="0.001" max="1" step="0.001" t-model="store.settings.voiceActivationThreshold"/>
                         </label>
                     </div>
                 </t>

--- a/addons/mail/static/src/discuss/call/common/device_select.js
+++ b/addons/mail/static/src/discuss/call/common/device_select.js
@@ -75,13 +75,13 @@ export class DeviceSelect extends Component {
     onChangeSelectAudioInput(ev) {
         switch (this.props.kind) {
             case "audioinput":
-                this.store.settings.setAudioInputDevice(ev.target.value);
+                this.store.settings.audioInputDeviceId = ev.target.value;
                 return;
             case "videoinput":
-                this.store.settings.setCameraInputDevice(ev.target.value);
+                this.store.settings.cameraInputDeviceId = ev.target.value;
                 return;
             case "audiooutput":
-                this.store.settings.setAudioOutputDevice(ev.target.value);
+                this.store.settings.audioOutputDeviceId = ev.target.value;
                 return;
         }
     }

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -42,6 +42,8 @@ test("use blur is 'on'", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     localStorage.setItem("mail_user_setting_use_blur", "true");
+    localStorage.setItem("mail_user_setting_background_blur_amount", "2"); // range from 0-20, to percentage. 2 => 10%
+    localStorage.setItem("mail_user_setting_edge_blur_amount", "6"); // range from 0-20, to percentage. 6 => 30%
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
@@ -53,9 +55,24 @@ test("use blur is 'on'", async () => {
     await contains(
         ".o-discuss-CallSettings-item:has(label:contains('Blur video background')) input:checked"
     );
+    await contains(
+        "label[title='Background blur intensity'] .o-discuss-DiscussCallSettings-width-text-percentage:text('10%')"
+    );
+    await contains(
+        "label[title='Edge blur intensity'] .o-discuss-DiscussCallSettings-width-text-percentage:text('30%')"
+    );
     const useBlurKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
     expect(localStorage.getItem(useBlurKey)).toBe(toRawValue(true));
+    const backgroundBlurAmountKey = makeRecordFieldLocalId(
+        Settings.localId(),
+        "backgroundBlurAmount"
+    );
+    expect(localStorage.getItem(backgroundBlurAmountKey)).toBe(toRawValue(2));
+    const edgeBlurAmountKey = makeRecordFieldLocalId(Settings.localId(), "edgeBlurAmount");
+    expect(localStorage.getItem(edgeBlurAmountKey)).toBe(toRawValue(6));
     expect(localStorage.getItem("mail_user_setting_use_blur")).toBe(null);
+    expect(localStorage.getItem("mail_user_setting_background_blur_amount")).toBe(null);
+    expect(localStorage.getItem("mail_user_setting_edge_blur_amount")).toBe(null);
 });
 
 test("member default open is 'off'", async () => {
@@ -144,7 +161,7 @@ test("call auto focus is 'off", async () => {
     expect(localStorage.getItem("mail_user_setting_disable_call_auto_focus")).toBe(null);
 });
 
-test("Renders the call settings", async () => {
+test("device input/output id", async () => {
     patchWithCleanup(browser.navigator.mediaDevices, {
         enumerateDevices: () =>
             Promise.resolve([

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -93,6 +93,27 @@ test("show only video 'on'", async () => {
     expect(localStorage.getItem("mail_user_setting_show_only_video")).toBe(null);
 });
 
+test("voice activation threshold", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    localStorage.setItem("mail_user_setting_voice_threshold", "0.3");
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
+    await click("[title='Open Actions Menu']");
+    await click(".o-dropdown-item", { text: "Call Settings" });
+    await contains(".o-discuss-CallSettings");
+    await contains(".o-Discuss-CallSettings-thresholdInput:value(0.3)");
+    const voiceActivationThresholdKey = makeRecordFieldLocalId(
+        Settings.localId(),
+        "voiceActivationThreshold"
+    );
+    expect(localStorage.getItem(voiceActivationThresholdKey)).toBe(toRawValue(0.3));
+    expect(localStorage.getItem("mail_user_setting_voice_threshold")).toBe(null);
+});
+
 test("member default open is 'off'", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -75,6 +75,24 @@ test("use blur is 'on'", async () => {
     expect(localStorage.getItem("mail_user_setting_edge_blur_amount")).toBe(null);
 });
 
+test("show only video 'on'", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    localStorage.setItem("mail_user_setting_show_only_video", "true");
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
+    await click("[title='Open Actions Menu']");
+    await click(".o-dropdown-item", { text: "Call Settings" });
+    await contains(".o-discuss-CallSettings");
+    await contains("input[title='Show video participants only']:checked");
+    const showOnlyVideoKey = makeRecordFieldLocalId(Settings.localId(), "showOnlyVideo");
+    expect(localStorage.getItem(showOnlyVideoKey)).toBe(toRawValue(true));
+    expect(localStorage.getItem("mail_user_setting_show_only_video")).toBe(null);
+});
+
 test("member default open is 'off'", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import {
     click,
     contains,
@@ -15,15 +15,11 @@ import { toRawValue } from "@mail/utils/common/local_storage";
 import { Settings } from "@mail/core/common/settings_model";
 import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
 import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
-import { getService, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
+import { getService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 
 describe.current.tags("desktop");
 defineMailModels();
-
-beforeEach(() => {
-    serverState.serverVersion = [99, 9]; // high version so following upgrades keep good working of feature
-});
 
 test("message sound is 'off'", async () => {
     localStorage.setItem("mail.user_setting.message_sound", "false");

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -13,7 +13,7 @@ import { parseRawValue, toRawValue } from "@mail/utils/common/local_storage";
 import { Settings } from "@mail/core/common/settings_model";
 import { makeRecordFieldLocalId } from "@mail/model/misc";
 import { describe, test, expect } from "@odoo/hoot";
-import { patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
 
@@ -91,7 +91,6 @@ test("activate blur", async () => {
 });
 
 test("local storage for call settings", async () => {
-    serverState.serverVersion = [99, 9]; // HOOT uses 1.0 version by default
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     const backgroundBlurAmountKey = makeRecordFieldLocalId(

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -94,14 +94,25 @@ test("activate blur", async () => {
 test("local storage for call settings", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
-    localStorage.setItem("mail_user_setting_background_blur_amount", "3");
-    localStorage.setItem("mail_user_setting_edge_blur_amount", "5");
+    const backgroundBlurAmountKey = makeRecordFieldLocalId(
+        Settings.localId(),
+        "backgroundBlurAmount"
+    );
+    localStorage.setItem(backgroundBlurAmountKey, toRawValue(3));
+    const edgeBlurAmountKey = makeRecordFieldLocalId(Settings.localId(), "edgeBlurAmount");
+    localStorage.setItem(edgeBlurAmountKey, toRawValue(5));
     localStorage.setItem("mail_user_setting_show_only_video", "true");
     const useBlurLocalStorageKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
     localStorage.setItem(useBlurLocalStorageKey, toRawValue(true));
     patchWithCleanup(localStorage, {
         setItem(key, value) {
-            if (key.startsWith("mail_user_setting")) {
+            if (
+                key.startsWith("mail_user_setting") ||
+                [
+                    "Settings,undefined:backgroundBlurAmount",
+                    "Settings,undefined:edgeBlurAmount",
+                ].includes(key)
+            ) {
                 expect.step(`${key}: ${value}`);
             }
             return super.setItem(key, value);

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -101,7 +101,8 @@ test("local storage for call settings", async () => {
     localStorage.setItem(backgroundBlurAmountKey, toRawValue(3));
     const edgeBlurAmountKey = makeRecordFieldLocalId(Settings.localId(), "edgeBlurAmount");
     localStorage.setItem(edgeBlurAmountKey, toRawValue(5));
-    localStorage.setItem("mail_user_setting_show_only_video", "true");
+    const showOnlyVideoKey = makeRecordFieldLocalId(Settings.localId(), "showOnlyVideo");
+    localStorage.setItem(showOnlyVideoKey, toRawValue(true));
     const useBlurLocalStorageKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
     localStorage.setItem(useBlurLocalStorageKey, toRawValue(true));
     patchWithCleanup(localStorage, {
@@ -111,6 +112,7 @@ test("local storage for call settings", async () => {
                 [
                     "Settings,undefined:backgroundBlurAmount",
                     "Settings,undefined:edgeBlurAmount",
+                    "Settings,undefined:showOnlyVideo",
                 ].includes(key)
             ) {
                 expect.step(`${key}: ${value}`);
@@ -133,7 +135,7 @@ test("local storage for call settings", async () => {
 
     // testing save to local storage
     await click("input[title='Show video participants only']");
-    await expect.waitForSteps(["mail_user_setting_show_only_video: false"]);
+    await expect.waitForSteps(["Settings,undefined:showOnlyVideo: false"]);
     await click("input[title='Blur video background']");
     expect(localStorage.getItem(useBlurLocalStorageKey)).toBe(null);
     await editInput(document.body, ".o-Discuss-CallSettings-thresholdInput", 0.3);

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -319,6 +319,9 @@ export async function start(options) {
             after(() => this.clear());
         },
     });
+    if (!options?.serverVersion) {
+        serverState.serverVersion = [99, 9]; // so local storage entries upgrade to latest version. HOOT sets 1.0 otherwise, ignoring all upgrades...
+    }
     if (!MockServer.current) {
         await startServer();
     }


### PR DESCRIPTION
This converts fields for call settings with new `{ localStorage: true }` on record fields, which reduces LOCs in actual code.

Part of Task-5003012

https://github.com/odoo/enterprise/pull/100062