### PR TITLE
[FIX] web_editor: open a popover for inline document download

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -24,6 +24,7 @@ const LinkPopoverWidget = Widget.extend({
         this.$target = $(target);
         this.container = this.options.container || this.target.ownerDocument.body;
         this.href = this.$target.attr('href'); // for template
+        this.isDocument = !!$(target).attr("data-mimetype");
         this._dp = new DropPrevious();
     },
     /**

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -173,14 +173,14 @@
                 <a href="#" class="mx-1 o_we_copy_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Copy Link">
                     <i class="fa fa-clone"/>
                 </a>
-                <a href="#" class="mx-1 o_we_edit_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Edit Link">
+                <a href="#" t-att-hidden="widget.isDocument ? true : undefined" class="mx-1 o_we_edit_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Edit Link">
                     <i class="fa fa-edit"/>
                 </a>
-                <a href="#" class="ms-1 o_we_remove_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Remove Link">
+                <a href="#" t-att-hidden="widget.isDocument ? true : undefined" class="ms-1 o_we_remove_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="Remove Link">
                     <i class="fa fa-chain-broken"/>
                 </a>
             </div>
-            <a href="#" target="_blank" class="o_we_full_url mt-1 text-muted d-none" t-esc="widget.href" title="Open in a new tab"/>
+            <a href="#" t-att-hidden="widget.isDocument ? true : undefined" target="_blank" class="o_we_full_url mt-1 text-muted d-none" t-esc="widget.href" title="Open in a new tab"/>
         </div>
     </div>
     <we-customizeblock-option t-name="wysiwyg.widgets.linkTools">


### PR DESCRIPTION
Before this commit: the document uploaded by /image cannot be downloaded
on clicking.

After this commit: we open a popover for document without the editing
buttons. The user may download the document by clicking the link. Also
the toolbar is hidden for attachments.

task-3648796



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
