### PR TITLE
[FIX] stock_account: compute avg price using only move with same product

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -56,6 +56,14 @@ class StockMove(models.Model):
     def _get_all_related_sm(self, product):
         return super()._get_all_related_sm(product) | self.filtered(lambda m: m.sale_line_id.product_id == product)
 
+    def write(self, vals):
+        res = super().write(vals)
+        if 'product_id' in vals:
+            for move in self:
+                if move.sale_line_id and move.product_id != move.sale_line_id.product_id:
+                    move.sale_line_id = False
+        return res
+
 
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"


### PR DESCRIPTION
When duplicating a delivery linked to a sale order and changing the product on the duplicated picking, validating the return could lead to an error when validating the original picking of the initial product.

The issue occurred because the average price computation was mixing stock moves of different products when consuming valuation layers, leading to a UoM singleton error.

Steps to reproduce:
- Create storable products P1 and P2:
  - Category: AVCO
  - P1 UoM: Unit
  - P2 UoM: Dozen
- Create a sale order with 1 unit of P1
- Confirm the SO
- Open the generated picking
- Duplicate it → a new picking is created and still linked to the same SO
- Change the product on the duplicated picking to P2
- Confirm and validate it
- Create a return on this picking and validate it
- Go back to the original picking of P1 and try to validate it

Problem:
A UserError is raised due to mixed products in the average price computation, resulting in a “Expected singleton: uom.uom(...)”

This fix ensures that average price is computed only using stock moves belonging to the same product.

opw-5027089
