### PR TITLE
[IMP] core: generate lossless h265 screencasts

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2050,7 +2050,7 @@ class Screencaster:
                 '-y', '-loglevel', 'warning',
                 '-f', 'concat', '-safe', '0', '-i', concat_script_path,
                 '-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2',
-                '-pix_fmt', 'yuv420p', '-g', '0',
+                '-c:v', 'libx265', '-x265-params', 'lossless=1',
                 outfile,
             ], preexec_fn=_preexec, check=True)
         except subprocess.CalledProcessError:


### PR DESCRIPTION
- `-g 0` turns out to significantly increases file size without increasing quality (apparently it makes every frame an i-frame)
- lossless video seems useful for comparing different runs, and while it *is* costly it's pretty reasonable for screencasting (5~6 times the size of a normal output, but a third the size of current outputs)
- "lossless h264" (per ffmpeg) does not seem to actually be lossless
- lossless av1 does work (and is slightly smaller than h265), but the libsvtav1 shipped by ubuntu does not support it, and libaom is *extremely* slow, so that might be something to revisit in a few years

Testing on the main flow tour (desktop),

- the current setting generates a 40MB file
- removing `-g 0` generates a 2.6MB file, quality seems about the same
- h264 pseudo-lossless yields a 9.4MB file
- h265 lossless is 16.9MB
- av1 (libsvtav1) is 2.5MB
- av1 lossless (libaom) is 13.2MB
