### PR TITLE
[IMP] website: introduce layout option for kickoff snippet

### DIFF
--- a/addons/website/static/tests/builder/options/layout_option.test.js
+++ b/addons/website/static/tests/builder/options/layout_option.test.js
@@ -67,3 +67,16 @@ test("Adding columns does not introduce extra offset (offset class removed on cl
     await contains("[data-action-id='changeColumnCount'][data-action-value='5']").click();
     expect(":iframe .s_text_block .container > .row > .offset-lg-1").toHaveCount(1);
 });
+
+test("Changing the number of columns (base case)", async () => {
+    await setupWebsiteBuilderWithSnippet("s_kickoff");
+    expect(":iframe .s_kickoff > .container").toHaveClass("s_allow_columns");
+    expect(":iframe .s_kickoff .row > .col-lg-6").toHaveCount(0);
+    await contains(":iframe .s_kickoff").click();
+    await contains("[data-label='Layout'] .dropdown").click();
+    await contains("[data-action-id='changeColumnCount'][data-action-value='2']").click();
+    expect(":iframe .s_kickoff .row > .col-lg-6").toHaveCount(2);
+    await contains("[data-label='Layout'] .dropdown").click();
+    await contains("[data-action-id='changeColumnCount'][data-action-value='3']").click();
+    expect(":iframe .s_kickoff .row > .col-lg-4").toHaveCount(3);
+});

--- a/addons/website/views/snippets/s_kickoff.xml
+++ b/addons/website/views/snippets/s_kickoff.xml
@@ -8,7 +8,7 @@
         </span>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="o_we_shape o_html_builder_Connections_06" style="background-image: url('/html_editor/shape/html_builder/Connections/06.svg?c5=o-color-4');"/>
-        <div class="container">
+        <div class="container s_allow_columns">
             <p class="lead">Your Journey Starts Here,</p>
             <h1 class="display-1">Let's kick<br/>things off !</h1>
         </div>


### PR DESCRIPTION
 This PR adds the missing layout option for the s_kickoff snippet. It upgrades legacy containers for consistency and enables proper use of column layouts and related controls within the website builder.

 task-5319760