### PR TITLE
[FIX] point_of_sale: ensure POS digest link displays uninvoiced orders

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -272,7 +272,7 @@
         <field name="name">Orders</field>
         <field name="res_model">pos.order</field>
         <field name="view_mode">graph,list,form,kanban,pivot</field>
-        <field name="domain">[('state', 'not in', ['draft', 'cancel']), ('account_move', '!=', False)]</field>
+        <field name="domain">[('state', 'not in', ['draft', 'cancel']), ('account_move', '=', False)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No data yet!


### PR DESCRIPTION
The POS digest email shows metrics based on *uninvoiced* POS orders, but the “Open Report” link in the digest opens a report filtered to *invoiced* orders only. As a result, when all POS orders are uninvoiced, the link leads to an empty view.

### Steps to reproduce

1. Ensure that all existing POS orders are **uninvoiced**.
2. Enable Developer Mode, then navigate to **Settings → Technical → Email → Digest Email**.
3. Open any digest and click **"Send Now"** to generate a new digest email.
4. Open the generated digest and click the **POS report** link.

This results in a blank page.

### Cause

There is a mismatch between:

* the digest computation (showing only uninvoiced orders), and
* the report view called by the digest link (showing only invoiced orders).

### Fix
Ensure the POS report shows unvoiced orders.

opw-5087701
