### PR TITLE
[FIX] sale_*: fix no docs in confirmed quotation

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -28,7 +28,6 @@ class IrActionsReport(models.Model):
 
         for order in orders:
             if (
-                order.state == 'sale'
                 or order.id not in result
                 or 'stream' not in result[order.id]
             ):


### PR DESCRIPTION
This reverts https://github.com/odoo/odoo/pull/179842

There is no reason to disable printing the documents inside the quotation for a confirmed SO if the users wishes to do that, because if the user wants to print the quotation without the additional documents, there is already a way for them to do that just as easily by selecting the "Quotation/Order" option to print instead of the "PDF Quote".

opw-5242743