### PR TITLE
[FIX] mail: avoid reverting the warning activity filter

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -116,8 +116,6 @@ class MailActivityMixin(models.AbstractModel):
             record.activity_user_id = record.activity_ids[0].user_id if record.activity_ids else False
 
     def _search_activity_exception_decoration(self, operator, operand):
-        if Domain.is_negative_operator(operator):
-            return NotImplemented
         return [('activity_ids.activity_type_id.decoration_type', operator, operand)]
 
     @api.depends('activity_ids.state')

--- a/addons/test_mail/tests/test_mail_activity_mixin.py
+++ b/addons/test_mail/tests/test_mail_activity_mixin.py
@@ -397,6 +397,19 @@ class TestActivityMixin(TestActivityCommon):
         })
         self.assertEqual(MailTestActivity.search([('activity_user_id', '!=', True)]), self.test_record_2)
 
+    def test_mail_activity_mixin_search_exception_decoration(self):
+        """Test the search on "activity_exception_decoration".
+
+        Domain ('activity_exception_decoration', '!=', False) should only return
+        records that have at least one warning/danger activity.
+        """
+        record_warning, record_normal, _ = self.test_record, self.test_record_2, self.env['mail.test.activity'].create({'name': 'No activities'})
+        record_warning.activity_schedule('mail.mail_activity_data_warning', user_id=self.env.user.id)
+        record_normal.activity_schedule('test_mail.mail_act_test_todo', user_id=self.env.user.id)
+
+        records = self.env['mail.test.activity'].search([('activity_exception_decoration', '!=', False)])
+        self.assertEqual(records, record_warning)
+
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.tests')
     def test_mail_activity_mixin_search_state_basic(self):
         """Test the search method on the "activity_state".


### PR DESCRIPTION
Steps To Reproduce
------------------

1- To purchase orders
2- Create random purchase orders (with activity and without and with warning) 
3- Select the Warning Filter

Issue
-----

1- Only POs with no activities show on the list.
2- The behavior in versions previous to 18.3 works perfectly fine, showing only POs with warnings.

Cause
-----

The issue is caused by this commit: 92301a5b300dec1ddfca44dc35318b83d67c56fa.
The search logic for the activity_exception_decoration field was changed to refuse negative operators (`!=`):

https://github.com/odoo/odoo/blob/92301a5b300dec1ddfca44dc35318b83d67c56fa/addons/mail/models/mail_activity_mixin.py#L118-L121

This forces the ORM to invert the filter:
https://github.com/odoo/odoo/blob/9a8350cb476af73d6bf4eea75344963eac1c7831/odoo/orm/domains.py#L873-L880

For this case, this transforms the intended query: 
`Exists(activity_exception_decoration != False)`  ("Has Warning")
Into the inverted query:
`NOT Exists(activity_exception_decoration == False)` ("Does NOT have a Normal activity")

This incorrectly hides records that have both warning and normal activities, and incorrectly shows records with no activities at all.

opw-5177277

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
