### PR TITLE
[IMP] point_of_sale,sale_stock{_product_expiry},stock_account: extend invoiced lot values

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -55,7 +55,7 @@ class AccountMove(models.Model):
                             'uom_name': line.product_uom_id.name,
                             'lot_name': lot.lot_name,
                             'pos_lot_id': lot.id,
-                        })
+                        } | self._extract_extra_invoiced_lot_values(lot))
 
         return lot_values
 

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -87,7 +87,7 @@ class AccountMove(models.Model):
                 'lot_name': lot.name,
                 # The lot id is needed by localizations to inherit the method and add custom fields on the invoice's report.
                 'lot_id': lot.id,
-            })
+            } | self._extract_extra_invoiced_lot_values(lot))
 
         return res
 

--- a/addons/sale_stock_product_expiry/models/__init__.py
+++ b/addons/sale_stock_product_expiry/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move
 from . import sale_order_line

--- a/addons/sale_stock_product_expiry/models/account_move.py
+++ b/addons/sale_stock_product_expiry/models/account_move.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _extract_extra_invoiced_lot_values(self, lot):
+        extra_values = super()._extract_extra_invoiced_lot_values(lot)
+        extra_values['lot_expiration_date'] = lot.expiration_date
+        return extra_values

--- a/addons/sale_stock_product_expiry/tests/__init__.py
+++ b/addons/sale_stock_product_expiry/tests/__init__.py
@@ -1,1 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_account_move
 from . import test_perishable_qty_at_date

--- a/addons/sale_stock_product_expiry/tests/test_account_move.py
+++ b/addons/sale_stock_product_expiry/tests/test_account_move.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import Command, fields
+from odoo.addons.sale_stock.tests.common import TestSaleStockCommon
+
+
+class TestInvoicedLotValues(TestSaleStockCommon):
+    def test_lot_expiration(self):
+        """ Checks if lot expiration date is included in `_get_invoiced_lot_values()` """
+        expiration_date = fields.Datetime.today() + relativedelta(days=3)
+        lot = self.env['stock.lot'].create({
+            'name': 'lot_product_a_0001',
+            'product_id': self.product_a.id,
+            'expiration_date': fields.Datetime.to_string(expiration_date),
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1,
+                })
+            ]
+        })
+        # Set lots, validate records, generate invoices (required for `_get_invoiced_lot_values()`)
+        sale_order.action_confirm()
+        sale_order.picking_ids.move_line_ids.lot_id = lot
+        sale_order.picking_ids.button_validate()
+        sale_order._create_invoices()
+        invoice = sale_order.invoice_ids
+        invoice.action_post()
+        lot_values = invoice._get_invoiced_lot_values()
+
+        self.assertEqual(len(lot_values), 1)
+        self.assertEqual(lot_values[0]['lot_expiration_date'], expiration_date)

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -168,3 +168,12 @@ class AccountMove(models.Model):
 
     def _get_invoiced_lot_values(self):
         return []
+
+    def _extract_extra_invoiced_lot_values(self, lot):
+        lot.ensure_one()
+        # Compute lot properties
+        lot_properties = lot.product_id.lot_properties_definition
+        # Store the value of each property
+        for prop in lot_properties:
+            prop['value'] = lot.lot_properties.get(prop['name'])
+        return {'lot_properties': lot_properties}


### PR DESCRIPTION
It's common in pharmaceutical industry to provide expiration dates of lots on customer invoices. Because of that, the lot expiration date is now added to `_get_invoiced_lot_values()`, together with lot properties.

Task: 4985878
Related: https://github.com/odoo/enterprise/pull/103649

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
