### PR TITLE
[IMP] account,l10n_de: allow adding attachment in log notes with audit

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -395,7 +395,9 @@ class AccountDocumentImportMixin(models.AbstractModel):
         self.ensure_one()
         attachments_to_attach = attachments.filtered(self._should_attach_to_record)
         if attachments_to_attach:
-            attachments_to_attach.write({
+            # No need to write to attachments that have the same res_model and res_id
+            attachments_to_write = attachments_to_attach.filtered(lambda a: a.res_model != self._name or a.res_id != self.id)
+            attachments_to_write.write({
                 'res_model': self._name,
                 'res_id': self.id,
             })

--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -1,7 +1,11 @@
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+import logging
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon, AccountTestInvoicingHttpCommon
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests import tagged, new_test_user
+
+_logger = logging.getLogger(__name__)
 
 
 @tagged('post_install', '-at_install')
@@ -151,3 +155,101 @@ class TestAuditTrail(AccountTestInvoicingCommon):
             'customer_rank': 1,
         })
         partner.unlink()
+
+
+@tagged('post_install', '-at_install')
+class TestAuditTrailAttachment(AccountTestInvoicingHttpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.restrictive_audit_trail = True
+        cls.document_installed = 'documents_account' in cls.env['ir.module.module']._installed()
+        if cls.document_installed:
+            cls.env.user.company_id.documents_account_settings = True
+            folder_test = cls.env['documents.document'].create({
+                'name': 'folder_test',
+                'type': 'folder',
+            })
+            cls.env['documents.account.folder.setting'].sudo().create({
+                'folder_id': folder_test.id,
+                'journal_id': cls.company_data['default_journal_sale'].id,
+            })
+
+    def _send_and_print(self, invoice):
+        return self.env['account.move.send'].with_context(
+            force_report_rendering=True,
+        )._generate_and_send_invoices(invoice)
+
+    def test_audit_trail_attachment(self):
+        invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'name': 'product',
+                'quantity': 1,
+                'price_unit': 100,
+            })],
+        }])
+        invoice.action_post()
+        self.assertFalse(invoice.message_main_attachment_id)
+
+        # Print the invoice for the first time
+        first_attachment = self._send_and_print(invoice)
+        self.assertTrue(first_attachment)
+
+        # Remove the attachment, it should only archive it instead of deleting it
+        first_attachment.unlink()
+        self.assertTrue(first_attachment.exists())
+        # But we cannot entirely remove it
+        with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
+            first_attachment.unlink()
+
+        # Print a second time the invoice, it generates a new attachment
+        invoice.invalidate_recordset()
+        second_attachment = self._send_and_print(invoice)
+        self.assertNotEqual(first_attachment, second_attachment)
+
+        # Make sure we can browse all the attachments in the UI (as it changes the main attachment)
+        first_attachment.register_as_main_attachment()
+        self.assertEqual(invoice.message_main_attachment_id, first_attachment)
+        second_attachment.register_as_main_attachment()
+        self.assertEqual(invoice.message_main_attachment_id, second_attachment)
+
+        if self.document_installed:
+            # Make sure we can change the version history of the document
+            document = self.env['documents.document'].search([
+                ('res_model', '=', 'account.move'),
+                ('res_id', '=', invoice.id),
+                ('name', '=ilike', '%.pdf'),
+            ])
+            self.assertTrue(document)
+            document.attachment_id = first_attachment
+            document.attachment_id = second_attachment
+        else:
+            _logger.runbot("Documents module is not installed, skipping part of the test")
+
+    def test_audit_trail_write_attachment(self):
+        invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'name': 'product',
+                'quantity': 1,
+                'price_unit': 100,
+            })],
+        }])
+        invoice.action_post()
+        self.assertFalse(invoice.message_main_attachment_id)
+
+        # Print the invoice for the first time
+        self._send_and_print(invoice)
+        attachment = invoice.message_main_attachment_id
+
+        with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
+            attachment.write({
+                'res_id': self.env.user.id,
+                'res_model': self.env.user._name,
+            })
+
+        with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
+            attachment.datas = b'new data'

--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -253,3 +253,12 @@ class TestAuditTrailAttachment(AccountTestInvoicingHttpCommon):
 
         with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
             attachment.datas = b'new data'
+
+        # Adding an attachment to the log notes should be allowed
+        another_attachment = self.env['ir.attachment'].create({
+            'name': 'doc.pdf',
+            'res_model': 'mail.compose.message',
+            # Ensures a bytes-like object with guessed mimetype = 'application/pdf' (checked in _except_audit_trail())
+            'datas': attachment.datas,
+        })
+        invoice.message_post(message_type='comment', attachment_ids=another_attachment.ids)

--- a/addons/l10n_de/tests/test_audit_trail.py
+++ b/addons/l10n_de/tests/test_audit_trail.py
@@ -1,11 +1,6 @@
-import logging
-
-from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon, AccountTestInvoicingHttpCommon
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
-
-_logger = logging.getLogger(__name__)
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -14,22 +9,6 @@ class TestAuditTrailDE(AccountTestInvoicingHttpCommon):
     @AccountTestInvoicingCommon.setup_chart_template('de_skr03')
     def setUpClass(cls):
         super().setUpClass()
-        cls.document_installed = 'documents_account' in cls.env['ir.module.module']._installed()
-        if cls.document_installed:
-            cls.env.user.company_id.documents_account_settings = True
-            folder_test = cls.env['documents.document'].create({
-                'name': 'folder_test',
-                'type': 'folder',
-            })
-            cls.env['documents.account.folder.setting'].sudo().create({
-                'folder_id': folder_test.id,
-                'journal_id': cls.company_data['default_journal_sale'].id,
-            })
-
-    def _send_and_print(self, invoice):
-        return self.env['account.move.send'].with_context(
-            force_report_rendering=True,
-        )._generate_and_send_invoices(invoice)
 
     def test_audit_trail_setting(self):
         self.assertEqual(self.env.company.country_id.code, 'DE')
@@ -37,77 +16,3 @@ class TestAuditTrailDE(AccountTestInvoicingHttpCommon):
         self.assertTrue(self.env.company.restrictive_audit_trail)
         with self.assertRaisesRegex(UserError, "Can't disable restricted audit trail: forced by localization."):
             self.env.company.restrictive_audit_trail = False
-
-    def test_audit_trail_de(self):
-        invoice = self.env['account.move'].create([{
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_line_ids': [Command.create({
-                'name': 'product',
-                'quantity': 1,
-                'price_unit': 100,
-            })],
-        }])
-        invoice.action_post()
-        self.assertFalse(invoice.message_main_attachment_id)
-
-        # Print the invoice for the first time
-        first_attachment = self._send_and_print(invoice)
-        self.assertTrue(first_attachment)
-
-        # Remove the attachment, it should only archive it instead of deleting it
-        first_attachment.unlink()
-        self.assertTrue(first_attachment.exists())
-        # But we cannot entirely remove it
-        with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
-            first_attachment.unlink()
-
-        # Print a second time the invoice, it generates a new attachment
-        invoice.invalidate_recordset()
-        second_attachment = self._send_and_print(invoice)
-        self.assertNotEqual(first_attachment, second_attachment)
-
-        # Make sure we can browse all the attachments in the UI (as it changes the main attachment)
-        first_attachment.register_as_main_attachment()
-        self.assertEqual(invoice.message_main_attachment_id, first_attachment)
-        second_attachment.register_as_main_attachment()
-        self.assertEqual(invoice.message_main_attachment_id, second_attachment)
-
-        if self.document_installed:
-            # Make sure we can change the version history of the document
-            document = self.env['documents.document'].search([
-                ('res_model', '=', 'account.move'),
-                ('res_id', '=', invoice.id),
-                ('name', '=ilike', '%.pdf'),
-            ])
-            self.assertTrue(document)
-            document.attachment_id = first_attachment
-            document.attachment_id = second_attachment
-        else:
-            _logger.runbot("Documents module is not installed, skipping part of the test")
-
-    def test_audit_trail_write(self):
-        invoice = self.env['account.move'].create([{
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_line_ids': [Command.create({
-                'name': 'product',
-                'quantity': 1,
-                'price_unit': 100,
-            })],
-        }])
-        invoice.action_post()
-        self.assertFalse(invoice.message_main_attachment_id)
-
-        # Print the invoice for the first time
-        self._send_and_print(invoice)
-        attachment = invoice.message_main_attachment_id
-
-        with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
-            attachment.write({
-                'res_id': self.env.user.id,
-                'res_model': self.env.user._name,
-            })
-
-        with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail."):
-            attachment.datas = b'new data'


### PR DESCRIPTION
To replicate:
1. In Settings, enable Restrictive Audit Trail
2. Create and post an invoice
3. Click on "Log note" and add a PDF attachment to the note
4. Click "Log"
5. Error ("You cannot remove parts of a restricted audit trail.") is raised.

With restrictive audit trail enabled, attachments cannot be deleted and writing to the attachment is restricted. However, when adding an attachment via the log notes, this writes to the attachment, setting the res_model to account.move and raising the error when _except_audit_trail() performs the check for a second time. This second write is triggered in `fix_attachments_on_record()`, introduced in odoo#189979.

This commit fixes that by also comparing the old values of the attachment and the new values to be written. If any of them are different, we proceed as before. Attachments cannot be deleted or changed. But if all values are the same, we do not perform the check, so an attachment can still be added.

In this commit we also move the attachment audit trail tests from l10n_de to account. In odoo#203229, the attachment audit trail checks were moved from to account, but the tests remained in the localization. An additional case covering the attachments in log notes was also added to the tests.

opw-5107912


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
