### PR TITLE
[FIX] sale_mrp: keep cogs price unit in product uom

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -30,6 +30,7 @@ class AccountMoveLine(models.Model):
 
                 moves = so_line.move_ids
                 average_price_unit = 0
+                # Components quantities for 1 'unit' in the product's base uom
                 components_qty = so_line._get_bom_component_qty(bom)
                 storable_components = self.env['product.product'].search([('id', 'in', list(components_qty.keys())), ('is_storable', '=', True)])
                 for product in storable_components:
@@ -38,5 +39,4 @@ class AccountMoveLine(models.Model):
                     product = product.with_company(self.company_id)
                     average_price_unit += factor * prod_moves._get_price_unit()
                 price_unit = average_price_unit / bom.product_qty or price_unit
-                price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -49,6 +49,7 @@ class TestSaleMRPAngloSaxonValuation(TestSaleCommon, ValuationReconciliationTest
         self.component_bb = self._create_product(name='Component BB', is_storable=False, standard_price=5.00)
         self.kit_a = self._create_product(name='Kit A', is_storable=True, standard_price=0.00)
         self.kit_b = self._create_product(name='Kit B', is_storable=False, standard_price=0.00)
+        pack_2 = self.env['uom.uom'].create({'name': 'Pack of 2', 'relative_factor': 2, 'relative_uom_id': self.kit_a.uom_id.id})
 
         self.kit_a.write({
             'property_account_expense_id': self.company_data['default_account_expense'].id,
@@ -87,7 +88,8 @@ class TestSaleMRPAngloSaxonValuation(TestSaleCommon, ValuationReconciliationTest
                 (0, 0, {
                     'name': self.kit_a.name,
                     'product_id': self.kit_a.id,
-                    'product_uom_qty': 1.0,
+                    'product_uom_qty': 0.5,
+                    'product_uom_id': pack_2.id,
                     'price_unit': 1,
                     'tax_ids': False,
                 })],

--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -49,6 +49,8 @@ class AccountMoveLine(models.Model):
         return -price_unit if self.move_id.move_type == 'in_refund' else price_unit
 
     def _get_cogs_value(self):
+        """ Get the COGS price unit in the product's default unit of measure.
+        """
         self.ensure_one()
 
         if not self.product_id:


### PR DESCRIPTION
Steps to reproduce:
- Make a kit in uom A
- Sell that kit in uom B

Issue:
The cogs price_unit will be computed in the SO line's uom rather than based on the kit's default uom.

Harmonize the code so it's clear that `_get_cogs_value()` is always expected to give the unit price in the product's base uom, not in the uom of the account move line.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
