### PR TITLE
[FIX] mail: fix cropped badge

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -44,7 +44,7 @@ $o-discuss-talkingColor: lighten($success, 10%);
     }
 
     & .o-innerBadge {
-        min-width: 2.7ch; // same as .badge, without using .badge to keep semantics of a single .badge
+        min-width: $o-badge-min-width; // same as .badge, without using .badge to keep semantics of a single .badge
     }
 }
 


### PR DESCRIPTION
In community, the badges in the sidebar looked cropped. 
By replacing the fixed `min-width` value with the corresponding variable, the badges' shape is fixed. 

| Before | After |
| ------------- | ------------- |
| <img width="296" height="901" alt="Screenshot 2025-11-20 at 16 50 23" src="https://github.com/user-attachments/assets/5dba05a2-5a0e-4563-a555-de72e607abf6" /> | <img width="296" height="901" alt="Screenshot 2025-11-20 at 16 50 08" src="https://github.com/user-attachments/assets/28c49c5a-57e9-49cb-ba9d-c65e2f8976a0" /> |

task-5223774




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
