### PR TITLE
[FIX] l10n_ar: line colspan xpath

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -139,12 +139,13 @@
         <t t-set="section_subtotal" t-value="line.get_section_subtotal()" position="attributes">
             <attribute name="t-value">line.get_section_subtotal() + l10n_ar_values['price_subtotal']</attribute>
         </t>
-        <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not line.tax_ids else 0)" position="attributes">
+        <xpath expr="//t/tr/t[@t-set='line_colspan']" position="attributes">
             <attribute name="t-value">3 + (1 if display_discount else 0) + (1 if not line.tax_ids and not o._l10n_ar_include_vat() else 0)</attribute>
-        </t>
-        <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not grouped_line.get('taxes') else 0)" position="attributes">
+        </xpath>
+
+        <xpath expr="//t/t/t[@t-else='']/t[@t-set='line_colspan']" position="attributes">
             <attribute name="t-value">3 + (1 if display_discount else 0) + (1 if display_taxes and not grouped_line.get('taxes') and o._l10n_ar_include_vat() else 0)</attribute>
-        </t>
+        </xpath>
         <!-- label amount for subtotal column on b2b and b2c -->
         <xpath expr="//th[@name='th_subtotal']/span" position="replace">
             <span>Amount</span>


### PR DESCRIPTION
The xpath of the line colspan was not precise enough. Since a change needs to be
 done in account_intrastat (check enterprise pr), those xpath conflicted.

opw-5185296

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
