### PR TITLE
[FIX] web, *: adapt and hide useless elements in print mode

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -17,7 +17,7 @@
                         <td>
                             <a title="assign to invoice"
                                role="button"
-                               class="oe_form_field btn btn-secondary outstanding_credit_assign"
+                               class="oe_form_field btn btn-secondary outstanding_credit_assign d-print-none"
                                t-att-data-id="line.id"
                                style="margin-right: 0px; padding-left: 5px; padding-right: 5px;"
                                href="#"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -807,7 +807,7 @@
                                 </templates>
                             </kanban>
                         </field>
-                        <div class="float-end d-flex gap-1 mb-2"
+                        <div class="float-end d-flex d-print-none gap-1 mb-2"
                              name="so_button_below_order_lines">
                             <button
                                 string="Discount"

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1088,6 +1088,10 @@
     .oe_button_box, .o_form_statusbar {
         display: none !important;
     }
+
+    .o_form_view .o_form_sheet {
+        --formView-sheet-border-width: 0;
+    }
 }
 
 .o_form_view.o_xxl_form_view {

--- a/addons/web/static/src/views/form/form_label.xml
+++ b/addons/web/static/src/views/form/form_label.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.FormLabel">
         <label class="o_form_label" t-att-for="props.id" t-att-class="className" >
-            <t t-esc="props.string"/><sup class="text-info p-1" t-if="hasTooltip" t-att="{'data-tooltip-template': 'web.FieldTooltip', 'data-tooltip-info': tooltipInfo, 'data-tooltip-touch-tap-to-show': 'true'}">?</sup>
+            <t t-esc="props.string"/><sup class="d-print-none text-info p-1" t-if="hasTooltip" t-att="{'data-tooltip-template': 'web.FieldTooltip', 'data-tooltip-info': tooltipInfo, 'data-tooltip-touch-tap-to-show': 'true'}">?</sup>
         </label>
     </t>
 

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -108,7 +108,7 @@
                 </t>
             </t>
             <t t-else="">
-                <div t-if="props.addLabel" class="o_kanban_record o-kanban-button-new btn btn-link py-4" accesskey="shift+c" t-on-click.stop.prevent="() => props.onAdd()">
+                <div t-if="props.addLabel" class="o_kanban_record o-kanban-button-new btn btn-link d-print-none py-4" accesskey="shift+c" t-on-click.stop.prevent="() => props.onAdd()">
                     <t t-out="props.addLabel" />
                 </div>
                 <!-- kanban ghost cards are used to properly space last elements. -->

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -96,7 +96,7 @@
                         <td t-att-colspan="getGroupNameCellColSpan()">
                             <button
                                 t-if="props.list.isGrouped and canCreateGroup and !state.showGroupInput"
-                                class="btn btn-link o_list_group_add"
+                                class="btn btn-link o_list_group_add d-print-none"
                                 t-on-click.stop.prevent="() => this.state.showGroupInput = true"
                             >
                                 Add a <t t-out="this.props.list.groupByField.string"/>
@@ -140,7 +140,7 @@
             <t t-foreach="list.records" t-as="record" t-key="record.id">
                 <t t-call="{{ constructor.recordRowTemplate }}"/>
             </t>
-            <tr t-if="displayRowCreates">
+            <tr t-if="displayRowCreates" class="d-print-none">
                 <td t-if="withHandleColumn"/>
                 <td t-att-colspan="withHandleColumn ? nbCols - 1 : nbCols"
                     class="o_field_x2many_list_row_add"


### PR DESCRIPTION
*: account, sale

This change adjusts layouts for print mode and removes interface parts that do not belong on printed documents.

Form View:
- Removed border on the sheet
- Removed actions line at end of list the list view (`o_field_x2many_list_row_add`)
- Removed "?" tooltip indicator
- Made list view full width in print mode

Kanban View:
- Removed "new" button (`.o-kanban-button-new`)

Specific:
- Accounting form view: removed "Add" outstanding credit buttons (`.outstanding_credit_assign`)
- Sale form view: removed `.so_button_below_order_lines`

ENT: https://github.com/odoo/enterprise/pull/100068
task-5265277

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
