### PR TITLE
[FIX] sale: Ensure sale order preview shows correct down payment percentage

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -134,7 +134,7 @@
                 <t t-call="portal.portal_record_sidebar" id="sale_order_portal_sidebar">
                     <t t-set="classes" t-value="'col-lg-4 col-xxl-3 d-print-none'"/>
                     <t t-set="title">
-                        <t t-if="sale_order.state in 'draft,sent' and sale_order.prepayment_percent != 1.0">
+                        <t t-if="sale_order._has_to_be_paid() and sale_order.prepayment_percent != 1.0">
                             <h4>Down payment</h4>
                             <h2>
                                 <t


### PR DESCRIPTION
****Behavior:****
**Current:**
When setting the online payment percentage to something else than 100% and then turning off the setting. The preview of sale orders still show a down payment with the percentage set previously. This is caused because there is no check on wheter the setting is activated or not in the template.

****Steps to reproduce:****
- In Settings->Sales: activate Online Payment.
- Set it to somethings else than 100% then save.
- Turn the setting off then save.
- Create a Sale Order.
- There will be a down payment of 0€ with the percentage you set in parentheses.

opw-5254575