### PR TITLE
[FIX] event: ensure company access on event email templates

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -33,7 +33,7 @@
                     </span>
                 </td><td valign="middle" align="right">
                     <a t-attf-href="/event/{{ object.event_id.id }}/my_tickets?badge_mode=1&amp;registration_ids={{ registration_ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(registration_ids) }}"
-                        target="_blank" t-attf-style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.user_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
+                        target="_blank" t-attf-style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
                         Download Badges
                     </a>
                     <t t-if="not object.company_id.uses_default_logo">
@@ -56,7 +56,7 @@
                         Hello <t t-out="object.name or default_name"/>,<br/><br/>
                         Please find attached your badge for
                         <t t-if="event_website_url">
-                            <a t-att-href="event_website_url" t-attf-style="font-weight:bold;color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;"
+                            <a t-att-href="event_website_url" t-attf-style="font-weight:bold;color:{{object.event_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;"
                                 t-out="object.event_id.name or ''">OpenWood Collection Online Reveal</a>
                         </t>
                         <t t-else="">
@@ -191,7 +191,7 @@
                             <ul>
                                 <li><t t-out="event_organizer.name or ''">YourCompany</t></li>
                                 <t t-if="event_organizer.email">
-                                    <li>Mail: <a t-attf-href="mailto:{{ event_organizer.email }}" t-attf-style="text-decoration:none;color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};" t-out="event_organizer.email">info@yourcompany.com</a></li>
+                                    <li>Mail: <a t-attf-href="mailto:{{ event_organizer.email }}" t-attf-style="text-decoration:none;color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};" t-out="event_organizer.email">info@yourcompany.com</a></li>
                                 </t>
                                 <t t-if="event_organizer.phone">
                                     <li>Phone: <t t-out="event_organizer.phone">+1 650-123-4567</t></li>
@@ -250,10 +250,10 @@
     <t t-if="object.company_id">
         <table width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;">
         <tr><td style="text-align: center; font-size: 14px;">
-            Sent by <a target="_blank" t-attf-href="{{ object.company_id.website }}" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};" t-out="object.company_id.name or ''">YourCompany</a>
+            Sent by <a target="_blank" t-attf-href="{{ object.company_id.website }}" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};" t-out="object.company_id.name or ''">YourCompany</a>
             <t t-if="is_online">
                 <br />
-                Discover <a href="/event" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};">all our events</a>.
+                Discover <a href="/event" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};">all our events</a>.
             </t>
         </td></tr>
         </table>
@@ -298,7 +298,7 @@
                     </span>
                     <div style="margin-bottom: 5px;margin-top: 18px;">
                         <a t-if="object.event_id.address_id" t-attf-href="/event/{{ object.event_id.id }}/my_tickets?registration_ids={{ object.ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(object.ids) }}&amp;responsive_html=1"
-                            target="_blank" t-attf-style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.user_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
+                            target="_blank" t-attf-style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
                             View Tickets
                         </a>
                         <a t-else="event_website_url" t-att-href="event_website_url"
@@ -333,7 +333,7 @@
                         Hello <t t-out="object.name or default_name"/>,<br/><br/>
                         We are happy to confirm your registration to the event
                         <t t-if="event_website_url">
-                            <a t-att-href="event_website_url" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;font-weight:bold;"
+                            <a t-att-href="event_website_url" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;font-weight:bold;"
                                 t-out="object.event_id.name or ''">OpenWood Collection Online Reveal</a>
                         </t>
                         <t t-else="">
@@ -479,7 +479,7 @@
                             <ul>
                                 <li><t t-out="event_organizer.name or ''">YourCompany</t></li>
                                 <t t-if="event_organizer.email">
-                                    <li>Mail: <a t-attf-href="mailto:{{ event_organizer.email }}" t-attf-style="text-decoration:none; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};" t-out="event_organizer.email or ''">info@yourcompany.com</a></li>
+                                    <li>Mail: <a t-attf-href="mailto:{{ event_organizer.email }}" t-attf-style="text-decoration:none; color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};" t-out="event_organizer.email or ''">info@yourcompany.com</a></li>
                                 </t>
                                 <t t-if="event_organizer.phone">
                                     <li>Phone: <t t-out="event_organizer.phone">+1 650-123-4567</t></li>
@@ -538,10 +538,10 @@
     <t t-if="object.company_id">
         <table width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;">
         <tr><td style="text-align: center; font-size: 14px;">
-            Sent by <a target="_blank" t-attf-href="{{ object.company_id.website }}" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};" t-out="object.company_id.name or ''">YourCompany</a>
+            Sent by <a target="_blank" t-attf-href="{{ object.company_id.website }}" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};" t-out="object.company_id.name or ''">YourCompany</a>
             <t t-if="is_online">
                 <br />
-                Discover <a href="/event" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};">all our events</a>.
+                Discover <a href="/event" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};">all our events</a>.
             </t>
         </td></tr>
         </table>
@@ -583,7 +583,7 @@
                     <span style="font-size: 20px; font-weight: bold;" t-out="object.name or default_name"/>
                     <div style="margin-bottom: 5px;margin-top: 18px;">
                         <a t-if="object.event_id.address_id" t-attf-href="/event/{{ object.event_id.id }}/my_tickets?registration_ids={{ object.ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(object.ids) }}&amp;responsive_html=1"
-                            target="_blank" style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.user_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
+                            target="_blank" style="padding: 8px 12px; font-size: 12px; color: {{object.event_id.company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none !important; font-weight: 400; background-color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
                             View Tickets
                         </a>
                         <a t-else="event_website_url" t-att-href="event_website_url"
@@ -618,7 +618,7 @@
                         Hello <t t-out="object.name or default_name"/>,<br/><br/>
                         We are excited to remind you that the event
                         <t t-if="event_website_url">
-                            <a t-att-href="event_website_url" t-attf-style="font-weight:bold;color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;"
+                            <a t-att-href="event_website_url" t-attf-style="font-weight:bold;color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;"
                                 t-out="object.event_id.name or ''">OpenWood Collection Online Reveal</a>
                         </t>
                         <t t-else="">
@@ -754,7 +754,7 @@
                             <ul>
                                 <li t-out="event_organizer.name or ''">YourCompany</li>
                                 <t t-if="event_organizer.email">
-                                    <li>Mail: <a t-attf-href="mailto:{{ event_organizer.email }}" t-attf-style="text-decoration:none; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};" t-out="event_organizer.email or ''"></a></li>
+                                    <li>Mail: <a t-attf-href="mailto:{{ event_organizer.email }}" t-attf-style="text-decoration:none; color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};" t-out="event_organizer.email or ''"></a></li>
                                 </t>
                                 <t t-if="event_organizer.phone">
                                     <li>Phone: <t t-out="event_organizer.phone or ''"></t></li>
@@ -804,10 +804,10 @@
 <tr><td align="center" style="min-width: 590px;">
     <table t-if="object.company_id" width="590" border="0" cellpadding="0" cellspacing="0" style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;">
       <tr><td style="text-align: center; font-size: 14px;">
-        Sent by <a target="_blank" t-attf-href="{{ object.company_id.website }}" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};" t-out="object.company_id.name or ''">YourCompany</a>
+        Sent by <a target="_blank" t-attf-href="{{ object.company_id.website }}" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};" t-out="object.company_id.name or ''">YourCompany</a>
         <t t-if="'website_url' in object.event_id and object.event_id.website_url">
             <br />
-            Discover <a href="/event" t-attf-style="color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}};">all our events</a>.
+            Discover <a href="/event" t-attf-style="color: {{object.event_id.company_id.email_secondary_color or '#875A7B'}};">all our events</a>.
         </t>
       </td></tr>
     </table>


### PR DESCRIPTION
Steps to reproduce:

1. Create a multi-company environment with at least two companies.
2. Create a new user with Company 1 as default and access to Company 2. (+ Admin rights for events.)
3. Connect to the user and switch to Company 2.
4. Go to Events > Any event on this company with at least 1 attendee.
5. Go to the attendee form and in the chatte go to send message and expand.
6. Finally, try to select an email template from the 3 dots.

This issue was introduced by commit aff20f8, which added logic to style email buttons using company-specific colors.

The bug occurs because the template incorrectly retrieves the company of the current user sending the email instead of the company linked to the event registration (object.company_id). This leads to two problems in a multi-company environment:

1. The button colors will always be based on the user's default company, leading to incorrect styling.

2. It can provoke an access rights error when trying to read the email colors of a company that is not the one we've currently selected.

To fix this, we should ensure that the email templates for events use the company associated with the event registration (object.company_id) when styling the email buttons. This way, the correct company context is used, ensuring proper access rights and more accurate button styling.

opw-5256010


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
