### PR TITLE
[FIX] stock_picking_batch: make the trigger wait the correct value

### DIFF
--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -37,16 +37,25 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
         },
         {
             trigger: ".modal:contains(detailed operations) .o_list_number[name=quantity] input",
-            run: "edit 2 && press Tab",
+            run: "edit 2",
         },
         {
             trigger:
-                ".modal:contains(detailed operations) .o_list_footer .o_list_number > span:contains('7')",
+                ".modal:contains(detailed operations) .o_list_footer .o_list_number",
+            run: "click"
+        },
+        {
+            trigger:
+                ".modal:contains(detailed operations) .o_list_footer .o_list_number > span:contains('2')",
         },
         {
             content: "Click Save",
             trigger: ".modal:contains(detailed operations) .o_form_button_save",
             run: "click",
+        },
+        {
+            content: "Click in cell to start edition",
+            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains('Product A')",
         },
         {
             content: "Click in cell to start edition",


### PR DESCRIPTION
The commit a4f4d8c7d8e37 made this test fail undeterministicall. This commit enforce the triggers to be sure each step is correctly executed.

Runbot : 234227

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
