### PR TITLE
[FIX] base: use context's lang for the group hierarchy

### DIFF
--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -307,7 +307,7 @@ class ResGroups(models.Model):
         self.view_group_hierarchy = self._get_view_group_hierarchy()
 
     @api.model
-    @tools.ormcache(cache='groups')
+    @tools.ormcache('self.env.lang', cache='groups')
     def _get_view_group_hierarchy(self):
         return {
             'groups': {

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -257,7 +257,7 @@ class ResUsers(models.Model):
     def _default_view_group_hierarchy(self):
         return self.env['res.groups']._get_view_group_hierarchy()
 
-    view_group_hierarchy = fields.Json(string='Technical field for user group setting', store=False, default=_default_view_group_hierarchy)
+    view_group_hierarchy = fields.Json(string='Technical field for user group setting', store=False, copy=False, default=_default_view_group_hierarchy)
     role = fields.Selection([('group_user', 'Member'), ('group_system', 'Administrator')], compute='_compute_role', readonly=False, string="Role")
 
     _login_key = models.Constraint("UNIQUE (login)",

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -441,6 +441,28 @@ class TestUsers2(UsersCommonCase):
             with self.assertRaises(ValidationError, msg="The user cannot be at the same time in groups: ['Membre', 'Portal', 'Foo / Small user group']"):
                 user_form.save()
 
+    def test_view_group_hierarchy(self):
+        """Test that the group hierarchy shows up in the correct language of the user."""
+        self.env['res.lang']._activate_lang('fr_FR')
+        group_system = self.env.ref('base.group_system')
+        group_system.with_context(lang='fr_FR').name = 'Administrateur'
+
+        view_group_hierarchy_en = self.env['res.groups']._get_view_group_hierarchy()
+        view_group_hierarchy_fr = self.env['res.groups'].with_context(lang='fr_FR')._get_view_group_hierarchy()
+        self.assertNotEqual(view_group_hierarchy_en['groups'][group_system.id]['name'], 'Administrateur')
+        self.assertEqual(view_group_hierarchy_fr['groups'][group_system.id]['name'], 'Administrateur')
+
+        # Should work the other way around too
+        self.env.registry.clear_cache('groups')
+        view_group_hierarchy_fr = self.env['res.groups'].with_context(lang='fr_FR')._get_view_group_hierarchy()
+        view_group_hierarchy_en = self.env['res.groups']._get_view_group_hierarchy()
+        self.assertNotEqual(view_group_hierarchy_en['groups'][group_system.id]['name'], 'Administrateur')
+        self.assertEqual(view_group_hierarchy_fr['groups'][group_system.id]['name'], 'Administrateur')
+
+        with patch('odoo.addons.base.models.res_groups.ResGroups._get_view_group_hierarchy') as mock:
+            self.user_portal_1.copy_data()
+            self.assertFalse(mock.called)
+
     @users('portal_1')
     @mute_logger('odoo.addons.base.models.ir_model')
     def test_self_writeable_fields(self):

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -57,7 +57,7 @@ _REGISTRY_CACHES = {
     'routing': 1024,  # 2 entries per website
     'routing.rewrites': 8192,  # url_rewrite entries
     'templates.cached_values': 2048, # arbitrary
-    'groups': 1,  # contains all res.groups
+    'groups': 64,  # contains all res.groups
 }
 
 # cache invalidation dependencies, as follows:


### PR DESCRIPTION
## Before this commit:
When opening the user's form view, the group hierarchy is loaded using the context's language, and cached. However, switching language or creating a new user (which copies the portal template user) could result in the group hierarchy being displayed in the wrong language. This occurs because the cache does not account for the language changes.

## After this commit:
Make the cache language-dependent to ensure group names and translated fields are always displayed in the user's current language. Also remove the unnecessary copy of the `view_group_hierarchy` field.
