### PR TITLE
[FIX] l10n_latam_check: fix unbalanced entry

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -146,12 +146,11 @@ class AccountPayment(models.Model):
             # One line per check
             checks_total = sum(payment.l10n_latam_new_check_ids.mapped('amount'))
             liquidity_balance_total = 0.0
-            liquidity_balance = 0.0
             for check in payment.l10n_latam_new_check_ids:
                 liquidity_amount_currency = -check.amount
 
                 if check == payment.l10n_latam_new_check_ids[-1]:
-                    liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance - liquidity_balance)
+                    liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance - liquidity_balance_total)
                 else:
                     liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance * check.amount / checks_total)
                     liquidity_balance_total += liquidity_balance


### PR DESCRIPTION
Setup:
- Install l10n_latam_check
- Set an outstanding payment account on the outgoing payment method
"Own Checks" in the "Bank" journal.
- Activate a foreign currency

Steps to reproduce:
- Go to "Accounting/Vendors/Payments"
- Create new payment with a foreign currency, with the journal "Bank"
and "Own Checks" as payment method
- Create 3 "Checks" lines (whatever dates or amounts)
- Post
-> Invalid Operation: The entry is not balanced.

Issue:
- There appears to be a typo in `_l10n_latam_check_split_move`, where
`liquidity_balance` is used instead of `liquidity_balance_total`

opw-5151228
