### PR TITLE
[FIX] portal: incorrect due date calculation

### DIFF
--- a/addons/portal/static/src/js/portal_sidebar.js
+++ b/addons/portal/static/src/js/portal_sidebar.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import publicWidget from "@web/legacy/js/public/public_widget";
-import { deserializeDateTime } from "@web/core/l10n/dates";
+import { deserializeDate } from "@web/core/l10n/dates";
 
 const { DateTime } = luxon;
 
@@ -28,7 +28,7 @@ var PortalSidebar = publicWidget.Widget.extend({
     _setDelayLabel: function () {
         var $sidebarTimeago = this.$el.find('.o_portal_sidebar_timeago').toArray();
         $sidebarTimeago.forEach((el) => {
-            var dateTime = deserializeDateTime($(el).attr('datetime')).startOf('day'),
+            var dateTime = deserializeDate($(el).attr('datetime')).startOf('day'),
                 today = DateTime.now().startOf('day'),
                 diff = dateTime.diff(today).as("days"),
                 displayStr;


### PR DESCRIPTION
This commit fixes the incorrect due date calculation of invoices. If user timezone is set to any UTC-* timezone, then the due date is calculated as the previous day to the actual due date. This is because the function `deserializeDateTime` was used, which considers the input date as UTC timezone and converts it to system timezone.

For example, if the due date is "2025-11-20 00:00:00" and the system timezone is UTC-3, then the calculated due date is "2025-11-19 21:00:00".  So when getting the difference from today's date (assuming today is "2025-11-20"), the difference is 1 day (which is not the expected value).

This commit replaces the call of `deserializeDateTime` with `deserializeDate`, which removes the system timezone conversion.

opw-5160764

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
