### PR TITLE
[FIX] hr_expense: fix tax amount in expense import

### DIFF
--- a/addons/hr_expense/tests/__init__.py
+++ b/addons/hr_expense/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_expenses_mail_import
 from . import test_expenses_states
 from . import test_ui
 from . import test_expenses_tour
+from . import test_expenses_import

--- a/addons/hr_expense/tests/test_expenses_import.py
+++ b/addons/hr_expense/tests/test_expenses_import.py
@@ -1,0 +1,54 @@
+import csv
+import io
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestExpenseImport(TransactionCase):
+
+    def test_import_expense_with_no_price_unit(self):
+        """ Test importing expenses from a CSV file using base_import """
+
+        output = io.StringIO()
+        writer = csv.writer(output, quoting=1)
+        writer.writerow(['__export__.hr_expense_22_431eb43b', 'Mitchell Admin', 'Test Expense', '2025-10-23', 'Meals', 'Employee (to reimburse)', '', '', '160.00', 'account.1_purchase_tax_template', ''])
+
+        import_wizard = self.env['base_import.import'].create({
+            'res_model': 'hr.expense',
+            'file': output.getvalue().encode(),
+            'file_name': 'test_expenses.csv',
+            'file_type': 'text/csv',
+        })
+
+        options = {
+            'separator': ',',
+            'quoting': '"',
+            'date_format': '',
+            'headers': False,
+        }
+
+        # This maps the CSV column index to field technical name
+        fields = ['id', 'employee_id', 'name', 'date', 'product_id', 'payment_mode', 'activity_ids', 'analytic_distribution', 'total_amount_currency', 'tax_ids/id', '']
+        columns = []
+
+        with mute_logger('odoo.addons.base_import.models.base_import'):
+            result = import_wizard.execute_import(
+                fields=fields,
+                columns=columns,
+                options=options
+            )
+
+        # Check that there were no error messages in the result
+        self.assertFalse(result.get('messages'), "Import failed with messages: %s" % result.get('messages'))
+
+        # Fetch the created expense
+        expense = self.env['hr.expense'].search([('name', '=', 'Test Expense')], limit=1)
+        self.assertTrue(expense, "Expense record should be created")
+
+        self.assertEqual(expense.total_amount, 160.0, "Total amount should match the imported value")
+
+        # Tax is 15% (included in total amount)
+        # Tax amount should 160 - (160/1.15) = 20.87
+        self.assertAlmostEqual(expense.tax_amount, 20.87, places=2, msg="Tax amount should be calculated from the total (included)")


### PR DESCRIPTION
This commit adds expense import test when using total_amount_currency with price_unit missing.

opw-5211041

---

**Workaround:** Use `total_amount_currency` instead of `total_amount`. Original bug complaint described below.

**Version:** Odoo 18.0, 18.4, and 19.0. The feature works as expected in Odoo 17.

**Steps:**

1. On an Odoo 18 or 19 database, ensure an Expense Category (e.g., "Meals") is configured with a tax (e.g., 12% VAT, Price Included).
2. Prepare an import file (XLSX/CSV) with columns for Total (tax-included amount) and Category.
3. Go to Expenses > My Expenses > Actions > Import records.
4. Upload the file. Map the Total column to the "Total" field and the Category column to the "Category" field.
5. Complete the import and open the newly created expense.
6. Result: The Total is correct, the Category is correct, and the 12% tax is listed, but the **`Tax Amount`** field shows 0.00.
7. Expected Result (from Odoo 17): The system should auto-calculate and populate the Tax Amount based on the Total and the tax rate from the Category.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
