### PR TITLE
[IMP] iot_drivers: type objects shared between threads

### DIFF
--- a/addons/iot_drivers/__init__.py
+++ b/addons/iot_drivers/__init__.py
@@ -14,7 +14,7 @@ from . import tools
 from . import websocket_client
 from . import iot_handlers
 
-for interface_thread in main.interfaces.values():
+for interface_thread in interface.interfaces.values():
     interface_thread().start()
 
 _get = requests.get

--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -5,7 +5,8 @@ import requests
 from threading import Thread
 import time
 
-from odoo.addons.iot_drivers.main import iot_devices, manager
+from odoo.addons.iot_drivers.main import manager
+from odoo.addons.iot_drivers.driver import iot_devices
 from odoo.addons.iot_drivers.tools import helpers, system, upgrade, wifi
 from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST, IOT_IDENTIFIER
 

--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from odoo import http
 from odoo.addons.iot_drivers.tools import certificate, helpers, route, system, upgrade, wifi
 from odoo.addons.iot_drivers.tools.system import IS_RPI, IOT_IDENTIFIER, IOT_SYSTEM, ODOO_START_TIME, SYSTEM_START_TIME
-from odoo.addons.iot_drivers.main import iot_devices, unsupported_devices
+from odoo.addons.iot_drivers.driver import iot_devices
+from odoo.addons.iot_drivers.interface import unsupported_devices
 from odoo.addons.iot_drivers.connection_manager import connection_manager
 from odoo.tools.misc import file_path
 from odoo.addons.iot_drivers.server_logger import server_logger

--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import inspect
 import logging
 from threading import Thread, Event
 
-from odoo.addons.iot_drivers.main import drivers, iot_devices
 from odoo.addons.iot_drivers.event_manager import event_manager
 from odoo.addons.iot_drivers.tools.helpers import toggleable
 from odoo.tools.lru import LRU
@@ -87,3 +87,7 @@ class Driver(Thread):
     def disconnect(self):
         self._stopped.set()
         del iot_devices[self.device_identifier]
+
+
+drivers: list[type[Driver]] = []
+iot_devices: dict[str, Driver] = {}

--- a/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
@@ -11,7 +11,7 @@ import werkzeug
 from odoo import http
 from odoo.addons.iot_drivers.browser import Browser, BrowserState
 from odoo.addons.iot_drivers.driver import Driver
-from odoo.addons.iot_drivers.main import iot_devices
+from odoo.addons.iot_drivers.driver import iot_devices
 from odoo.addons.iot_drivers.tools import helpers, route, system
 from odoo.addons.iot_drivers.tools.helpers import Orientation
 from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER

--- a/addons/iot_drivers/iot_handlers/drivers/keyboard_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/keyboard_driver_L.py
@@ -16,9 +16,8 @@ from usb import util
 
 from odoo import http
 from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
-from odoo.addons.iot_drivers.driver import Driver
+from odoo.addons.iot_drivers.driver import Driver, iot_devices
 from odoo.addons.iot_drivers.event_manager import event_manager
-from odoo.addons.iot_drivers.main import iot_devices
 from odoo.addons.iot_drivers.tools import helpers, route, system
 
 _logger = logging.getLogger(__name__)

--- a/addons/iot_drivers/iot_handlers/drivers/l10n_ke_edi_serial_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/l10n_ke_edi_serial_driver.py
@@ -9,7 +9,7 @@ from functools import reduce
 
 from odoo import http
 from odoo.addons.iot_drivers.iot_handlers.drivers.serial_driver_base import SerialDriver, SerialProtocol, serial_connection
-from odoo.addons.iot_drivers.main import iot_devices
+from odoo.addons.iot_drivers.driver import iot_devices
 from odoo.addons.iot_drivers.tools import route
 
 _logger = logging.getLogger(__name__)

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -14,7 +14,7 @@ from odoo.addons.iot_drivers.connection_manager import connection_manager
 from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import PrinterDriverBase
 from odoo.addons.iot_drivers.iot_handlers.interfaces.printer_interface_L import conn, cups_lock
-from odoo.addons.iot_drivers.main import iot_devices
+from odoo.addons.iot_drivers.driver import iot_devices
 from odoo.addons.iot_drivers.tools import helpers, route, system, wifi
 from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -9,8 +9,7 @@ from PIL import Image, ImageOps
 import re
 import time
 
-from odoo.addons.iot_drivers.driver import Driver
-from odoo.addons.iot_drivers.main import iot_devices
+from odoo.addons.iot_drivers.driver import Driver, iot_devices
 from odoo.addons.iot_drivers.event_manager import event_manager
 
 _logger = logging.getLogger(__name__)

--- a/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
@@ -17,7 +17,7 @@ import subprocess
 import time
 
 from odoo.addons.iot_drivers.interface import Interface
-from odoo.addons.iot_drivers.main import iot_devices
+from odoo.addons.iot_drivers.driver import iot_devices
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -8,6 +8,8 @@ import subprocess
 from threading import Thread
 import time
 
+from odoo.addons.iot_drivers.driver import iot_devices
+from odoo.addons.iot_drivers.interface import unsupported_devices
 from odoo.addons.iot_drivers.tools import certificate, helpers, system, upgrade, wifi
 from odoo.addons.iot_drivers.websocket_client import WebsocketClient
 
@@ -16,11 +18,6 @@ if system.IS_RPI:
     DBusGMainLoop(set_as_default=True)  # Must be started from main thread
 
 _logger = logging.getLogger(__name__)
-
-drivers = []
-interfaces = {}
-iot_devices = {}
-unsupported_devices = {}
 
 
 class Manager(Thread):


### PR DESCRIPTION
To ease development, we typed `drivers`, `iot_devices`, and `interfaces` objects.
    
This commit also makes `Interface` inherit from ABC in order to make it clearer that it's abstract.
    
see odoo/enterprise#100080