### PR TITLE
[REF] mail, project: remove `_thread_to_store` function

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -250,14 +250,14 @@ class ThreadController(http.Controller):
     def mail_thread_unsubscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_unsubscribe(partner_ids)
-        return Store().add(
-            thread, [], as_thread=True, request_list=["followers", "suggestedRecipients"]
-        ).get_result()
+        store = Store()
+        fields = thread._get_store_thread_fields(store.target, ["followers", "suggestedRecipients"])
+        return store.add(thread, fields, as_thread=True).get_result()
 
     @http.route("/mail/thread/subscribe", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_subscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_subscribe(partner_ids)
-        return Store().add(
-            thread, [], as_thread=True, request_list=["followers", "suggestedRecipients"]
-        ).get_result()
+        store = Store()
+        fields = thread._get_store_thread_fields(store.target, ["followers", "suggestedRecipients"])
+        return store.add(thread, fields, as_thread=True).get_result()

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -63,13 +63,11 @@ class WebclientController(ThreadController):
                 **params.get("access_params", {}),
             )
             if not thread:
-                store.add(
-                    request.env[params["thread_model"]].browse(params["thread_id"]),
-                    {"hasReadAccess": False, "hasWriteAccess": False},
-                    as_thread=True,
-                )
+                thread = request.env[params["thread_model"]].browse(params["thread_id"])
+                fields = {"hasReadAccess": False, "hasWriteAccess": False}
             else:
-                store.add(thread, request_list=params["request_list"], as_thread=True)
+                fields = thread._get_store_thread_fields(store.target, params["request_list"])
+            store.add(thread, fields, as_thread=True)
 
     @classmethod
     def _process_request_for_logged_in_user(self, store: Store, name, params):

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -49,11 +49,8 @@ class MailThreadMainAttachment(models.AbstractModel):
                     key=lambda r: (r.mimetype.endswith('pdf'), r.mimetype.startswith('image'))
                 ).id
 
-    def _thread_to_store(self, store: Store, fields, *, request_list=None):
-        super()._thread_to_store(store, fields, request_list=request_list)
-        if request_list and "attachments" in request_list:
-            store.add(
-                self,
-                Store.One("message_main_attachment_id", []),
-                as_thread=True,
-            )
+    def _get_store_thread_fields(self, target: Store.Target, request_list):
+        res = super()._get_store_thread_fields(target, request_list)
+        if "attachments" in request_list:
+            res.append("message_main_attachment_id")
+        return res

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -110,18 +110,11 @@ class Store:
                     else []
                 )
         fields = Store._format_fields(fields) + Store._format_fields(extra_fields)
-        if as_thread:
-            if hasattr(records, "_thread_to_store"):
-                records._thread_to_store(self, fields, **kwargs)
-            else:
-                assert not kwargs
-                self.add_records_fields(records, fields, as_thread=True)
+        if not as_thread and hasattr(records, "_to_store"):
+            records._to_store(self, fields, **kwargs)
         else:
-            if hasattr(records, "_to_store"):
-                records._to_store(self, fields, **kwargs)
-            else:
-                assert not kwargs
-                self.add_records_fields(records, fields)
+            assert not kwargs
+            self.add_records_fields(records, fields, as_thread=as_thread)
         return self
 
     def add_global_values(self, **values):

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1269,14 +1269,11 @@ class ProjectProject(models.Model):
         for partner, tasks in dict_tasks_per_partner.items():
             tasks.message_subscribe(dict_partner_ids_to_subscribe_per_partner[partner])
 
-    def _thread_to_store(self, store: Store, fields, *, request_list=None):
-        super()._thread_to_store(store, fields, request_list=request_list)
-        if request_list and "followers" in request_list:
-            store.add(
-                self,
-                {"collaborator_ids": Store.Many(self.collaborator_ids.partner_id, [])},
-                as_thread=True,
-            )
+    def _get_store_thread_fields(self, target: Store.Target, request_list):
+        res = super()._get_store_thread_fields(target, request_list)
+        if "followers" in request_list:
+            res.append(Store.Many("collaborator_ids", [], value=lambda p: p.collaborator_ids.partner_id))
+        return res
 
     @api.depends('task_count', 'open_task_count')
     def _compute_task_completion_percentage(self):


### PR DESCRIPTION
The `_thread_to_store` function was the original way to add data to store for a thread, but since then the `Store` class was added and it provides a better API, and `_thread_to_store` was only kept for legacy reasons.

`_thread_to_store` is unnecessarily magically called inside `Store` implementation, but it could just be explicit instead.

`_thread_to_store` should be converted to be a method that returns a list of fields.

`store.add` callers that expected  `_thread_to_store` to be called by giving an empty field list and `as_thread=True` should simply pass as fields the result of the new function.

task-5347566

https://github.com/odoo/enterprise/pull/100087