### PR TITLE
[FIX] account: Issue with invoice printing

### DIFF
--- a/addons/account/data/service_cron.xml
+++ b/addons/account/data/service_cron.xml
@@ -14,7 +14,7 @@
         <field name="name">Send invoices automatically</field>
         <field name="model_id" ref="model_account_move"/>
         <field name="state">code</field>
-        <field name="code">model._cron_account_move_send(job_count=20)</field>
+        <field name="code">model._cron_account_move_send()</field>
         <field name="user_id" ref="base.user_root"/>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>


### PR DESCRIPTION
Repro steps:
1. Create a customer whose language is Arabic
2. Create 16 or more invoices for that customer
3. Send these invoices together all at once

Issue:
PDFs generated for the invoices are strange, some have missing logo in the header, while others have the header repeated multiple times on the page.

Root cause:
wkhtmltopdf does not have enough time to render all these PDFs at once, so it fails to render them properly leading to these half-rendered PDFs.

Solution:
This commit solves this issue by reducing the number of invoices that the cron processes at once from 20 to only 10 (the default of the function _cron_account_move_send). This would ensure that wkhtmltopdf has enough time to process and render a batch of invoices at once.

opw-4997495





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
