### PR TITLE
[IMP] mass_mailing, *: template previews & mailing targets

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -38,6 +38,7 @@ class HrEmployee(models.Model):
     _order = 'name'
     _inherit = ['mail.thread.main.attachment', 'mail.activity.mixin', 'resource.mixin', 'avatar.mixin']
     _mail_post_access = 'read'
+    _mailing_enabled = True
     _primary_email = 'work_email'
     _inherits = {'hr.version': 'version_id'}
 

--- a/addons/marketing_card/views/mailing_mailing_views.xml
+++ b/addons/marketing_card/views/mailing_mailing_views.xml
@@ -15,7 +15,7 @@
                     confirm-title="Confirm Cards Update" confirm-label="Update Cards">Update <field name="card_requires_sync_count"/> Cards</button>
                 </header>
             </xpath>
-            <xpath expr="//header//button[@name='action_set_favorite']" position="attributes">
+            <xpath expr="//field[@name='favorite']" position="attributes">
                 <attribute name="invisible" separator=" or " add="card_campaign_id"/>
             </xpath>
             <xpath expr="//field[@name='mailing_model_id']" position="attributes">

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -83,11 +83,8 @@
             ('remove', 'web/static/fonts/fonts.scss'),
             'mass_mailing/static/src/builder/**/*',
         ],
-        'mass_mailing.assets_iframe_style': [
-            # minimal style assets required to view the mail content
-            # convert_inline ONLY uses this and inline styles.
-
-            # useful scss from /web web.assets_frontend
+        'mass_mailing.assets_iframe_helpers': [
+            # minimal assets for mass_mailing isolated iframes from web.
             ('include', 'web._assets_helpers'),
             'web/static/src/scss/bootstrap_overridden.scss',
             ('include', 'web._assets_frontend_helpers'),
@@ -95,6 +92,21 @@
             'web/static/lib/bootstrap/scss/_variables.scss',
             'web/static/lib/bootstrap/scss/_maps.scss',
             ('include', 'web._assets_bootstrap_frontend'),
+            ('include', 'web.icons_fonts'),
+            'web/static/src/scss/animation.scss',
+            'web/static/src/scss/mimetypes.scss',
+            'web/static/src/scss/ui.scss',
+        ],
+        'mass_mailing.assets_iframe_theme_selector': [
+            # minimal assets for theme selector iframe
+            ('include', 'mass_mailing.assets_iframe_helpers'),
+            'mass_mailing/static/src/themes/iframe_assets/**/*',
+        ],
+        'mass_mailing.assets_iframe_style': [
+            # minimal style assets required to view the mail content
+            # convert_inline ONLY uses this and inline styles.
+
+            ('include', 'mass_mailing.assets_iframe_helpers'),
 
             # useful scss from /html_editor web.assets_frontend
             # TODO EGGMAIL: could improve load time by splitting scss from JS files
@@ -108,11 +120,6 @@
             ('after', 'web/static/lib/bootstrap/scss/_maps.scss', 'mass_mailing/static/src/scss/mass_mailing.ui.scss'),
 
             'html_editor/static/src/scss/bootstrap_overridden.scss',
-
-            ('include', 'web.icons_fonts'),
-            'web/static/src/scss/animation.scss',
-            'web/static/src/scss/mimetypes.scss',
-            'web/static/src/scss/ui.scss',
 
             ('include', 'mass_mailing.assets_mail_themes'),
             'mass_mailing/static/src/scss/mass_mailing_mail.scss',
@@ -140,7 +147,8 @@
         'web.assets_backend': [
             'mass_mailing/static/src/editor/**/*',
             'mass_mailing/static/src/fields/**/*',
-            'mass_mailing/static/src/themes/**/*',
+            'mass_mailing/static/src/themes/*',
+            'mass_mailing/static/src/themes/theme_selector/**/*',
             'mass_mailing/static/src/iframe/**/*',
             'mass_mailing/static/src/scss/mailing_filter_widget.scss',
             'mass_mailing/static/src/scss/mass_mailing.scss',

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -797,9 +797,10 @@ class MailingMailing(models.Model):
         """Display the mailing contact import-by-paste wizard for this mailing's contact lists"""
         self.ensure_one()
         action = self.env['ir.actions.actions']._for_xml_id('mass_mailing.mailing_contact_import_action')
+        action['context'] = {'no_redirect': True}
         if self.contact_list_ids:
-            action['context'] = {
-                'default_mailing_list_ids': self.contact_list_ids[0].ids,
+            action['context'] |= {
+                'default_mailing_list_ids': self.contact_list_ids.ids,
                 'default_subscription_ids': [(0, 0, {'list_id': self.contact_list_ids[0].id})],
             }
         action['domain'] = [('list_ids', 'in', self.contact_list_ids.ids)]

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -793,10 +793,10 @@ class MailingMailing(models.Model):
             ),
         return action
 
-    def action_view_mailing_contacts(self):
-        """Show the mailing contacts who are in a mailing list selected for this mailing."""
+    def action_import_mailing_contacts(self):
+        """Display the mailing contact import-by-paste wizard for this mailing's contact lists"""
         self.ensure_one()
-        action = self.env['ir.actions.actions']._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
+        action = self.env['ir.actions.actions']._for_xml_id('mass_mailing.mailing_contact_import_action')
         if self.contact_list_ids:
             action['context'] = {
                 'default_mailing_list_ids': self.contact_list_ids[0].ids,

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -580,42 +580,6 @@ class MailingMailing(models.Model):
     # ACTIONS
     # ------------------------------------------------------
 
-    def action_set_favorite(self):
-        """Add the current mailing in the favorites list."""
-        self.favorite = True
-
-        return {
-            'type': 'ir.actions.client',
-            'tag': 'display_notification',
-            'params': {
-                'message': _(
-                    'Design added to the %s Templates!',
-                    ', '.join(self.mapped('mailing_model_id.name')),
-                ),
-                'next': {'type': 'ir.actions.act_window_close'},
-                'sticky': False,
-                'type': 'info',
-            }
-        }
-
-    def action_remove_favorite(self):
-        """Remove the current mailing from the favorites list."""
-        self.favorite = False
-
-        return {
-            'type': 'ir.actions.client',
-            'tag': 'display_notification',
-            'params': {
-                'message': _(
-                    'Design removed from the %s Templates!',
-                    ', '.join(self.mapped('mailing_model_id.name')),
-                ),
-                'next': {'type': 'ir.actions.act_window_close'},
-                'sticky': False,
-                'type': 'info',
-            }
-        }
-
     def action_duplicate(self):
         self.ensure_one()
         if mass_mailing_copy := self.copy():

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.fields import Domain
@@ -172,9 +174,22 @@ class MailingContact(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.mailing_contact_to_list_action")
         action['view_mode'] = 'form'
         action['target'] = 'new'
-        action['context'] = ctx
+        action['context'] = ctx | json.loads(action['context'])
 
         return action
+
+    def action_open_base_import(self):
+        """Open the base import wizard to import mailing list contacts with a xlsx file."""
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'import',
+            'name': _('Import Mailing Contacts'),
+            'params': {
+                'context': self.env.context,
+                'active_model': 'mailing.contact',
+            },
+        }
 
     @api.model
     def get_import_templates(self):

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -18,12 +18,9 @@ class MailingList(models.Model):
     # As this model has their own data merge, avoid to enable the generic data_merge on that model.
     _disable_data_merge = True
 
-    def _get_default_color(self):
-        return randint(1, 11)
-
     name = fields.Char(string='Mailing List', required=True)
     active = fields.Boolean(default=True)
-    color = fields.Integer(string='Color', default=_get_default_color)
+    color = fields.Integer(string='Color', default=0)
     contact_count = fields.Integer(compute="_compute_mailing_list_statistics", string='Number of Contacts')
     contact_count_email = fields.Integer(compute="_compute_mailing_list_statistics", string="Number of Emails")
     contact_count_opt_out = fields.Integer(compute="_compute_mailing_list_statistics", string="Number of Opted-out")

--- a/addons/mass_mailing/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing/report/mailing_trace_report_views.xml
@@ -85,7 +85,7 @@
 
         <!-- Actions and Menuitems -->
        <record id="mailing_trace_report_action_mail" model="ir.actions.act_window">
-           <field name="name">Mass Mailing Analysis</field>
+           <field name="name">Mailing Analysis</field>
            <field name="res_model">mailing.trace.report</field>
            <field name="domain">[('mailing_type', '=', 'mail')]</field>
            <field name="view_mode">graph,pivot,list</field>

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.xml
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.xml
@@ -6,7 +6,7 @@
             <button t-if="props.toggleCodeView" t-on-click="props.toggleCodeView"
                 class="o-hb-btn btn d-flex align-items-center o_codeview_btn" title="Code View" accesskey="d"><i class="fa fa-code"/></button>
             <button t-on-click="props.toggleFullScreen"
-                class="o-hb-btn btn d-flex align-items-center" title="Fullscreen" accesskey="f">
+                class="o-hb-btn btn btn-primary d-flex align-items-center" title="Fullscreen" accesskey="f">
                 <span t-attf-class="fa fa-expand"/>
             </button>
         </t>

--- a/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
@@ -8,8 +8,8 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 export const OPTION_POSITIONS = {
     BODY: 10,
     SETTINGS: 20,
-    HEADINGS: 30,
-    PARAGRAPH: 40,
+    PARAGRAPH: 30,
+    HEADINGS: 40,
     BUTTON: 50,
     LINK: 60,
     SEPARATORS: 70,

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
@@ -33,14 +33,14 @@
             </BuilderButton>
         </BuilderButtonGroup>
     </BuilderRow>
-    <BuilderRow label.translate="Mailing Background" extraLabelClass="'pe-2'">
+    <BuilderRow label.translate="Background Color" extraLabelClass="'pe-2'">
         <BuilderColorPicker noTransparency="true"
             enabledTabs="['solid', 'custom']"
             styleAction="'background-color'"
             applyTo="'.o_layout'"
         />
     </BuilderRow>
-    <BuilderRow label.translate="Content Background" extraLabelClass="'pe-2'">
+    <BuilderRow label.translate="Mailing Color" extraLabelClass="'pe-2'">
         <BuilderColorPicker noTransparency="true"
             enabledTabs="['solid', 'custom']"
             action="'mass_mailing.CustomizeMailingVariable'"

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -4,7 +4,7 @@ import { LocalOverlayContainer } from "@html_editor/local_overlay_container";
 import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
 import { normalizeHTML, parseHTML } from "@html_editor/utils/html";
 import { MassMailingIframe } from "@mass_mailing/iframe/mass_mailing_iframe";
-import { ThemeSelector } from "@mass_mailing/themes/theme_selector/theme_selector";
+import { ThemeSelectorIframe } from "@mass_mailing/themes/theme_selector/theme_selector_iframe";
 import { getCSSRules, toInline } from "@mail/views/web/fields/html_mail_field/convert_inline";
 import { onWillUpdateProps, status, toRaw, useEffect, useRef } from "@odoo/owl";
 import { loadBundle } from "@web/core/assets";
@@ -21,7 +21,7 @@ export class MassMailingHtmlField extends HtmlField {
         ...HtmlField.components,
         LocalOverlayContainer,
         MassMailingIframe,
-        ThemeSelector,
+        ThemeSelectorIframe,
     };
     static props = {
         ...HtmlField.props,

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.xml
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.xml
@@ -1,7 +1,7 @@
 <templates>
     <t t-name="mass_mailing.HtmlField">
         <t t-if="state.showThemeSelector">
-            <ThemeSelector config="this.getThemeSelectorConfig()"/>
+            <ThemeSelectorIframe config="this.getThemeSelectorConfig()"/>
         </t>
         <t t-if="state.showCodeView">
             <div class="d-flex">

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -134,7 +134,6 @@ export class MassMailingIframe extends Component {
         };
         const sidebarResize = () => {
             const sidebar = this.sidebarRef.el;
-            const iframe = this.iframeRef.el;
             if (!sidebar) {
                 return;
             }
@@ -170,7 +169,12 @@ export class MassMailingIframe extends Component {
                     : `${stickyHeight}px`;
                 const maxHeight = this.state.isMobile
                     ? 1000
-                    : iframe.getBoundingClientRect().height;
+                    : Math.max(
+                          // height to fill remaining viewport space on an unscrolled page
+                          window.innerHeight - sidebar.parentElement.getBoundingClientRect().y - 5,
+                          // height of the parent element
+                          sidebar.parentElement.clientHeight
+                      );
                 const offsetHeight =
                     window.innerHeight -
                     stickyHeight -

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -2,6 +2,7 @@ import {
     Component,
     onMounted,
     onWillDestroy,
+    onWillUnmount,
     onWillUpdateProps,
     status,
     useComponent,
@@ -223,6 +224,11 @@ export class MassMailingIframe extends Component {
             },
             () => [this.state.isMobile]
         );
+        onWillUnmount(() => {
+            if (this.htmlResizeObserver) {
+                this.htmlResizeObserver.disconnect();
+            }
+        });
     }
 
     get isBrowserSafari() {
@@ -235,7 +241,7 @@ export class MassMailingIframe extends Component {
         if (status(this) === "destroyed") {
             return;
         }
-        const htmlResizeObserver = new ResizeObserver(this.throttledResize);
+        this.htmlResizeObserver = new ResizeObserver(this.throttledResize);
         this.iframeRef.el.contentDocument.body.classList.add("o_in_iframe");
         if (this.props.withBuilder) {
             this.iframeRef.el.contentDocument.body.classList.add("o_mass_mailing_with_builder");
@@ -243,7 +249,7 @@ export class MassMailingIframe extends Component {
             this.iframeRef.el.contentDocument.body.classList.add("bg-white");
         }
         this.iframeRef.el.contentDocument.body.appendChild(this.renderBodyContent());
-        htmlResizeObserver.observe(
+        this.htmlResizeObserver.observe(
             this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR)
         );
         if (this.props.readonly) {

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -16,7 +16,7 @@
                     </div>
                 </div>
                 <div t-if="!props.readonly and props.withBuilder and !props.showThemeSelector and !props.showCodeView">
-                    <div class="position-sticky o_mass_mailing-builder_sidebar border-start border-dark o_builder_sidebar_open"
+                    <div class="position-sticky o_mass_mailing-builder_sidebar o_builder_sidebar_open"
                         t-att-class="{ 'd-none': this.env.isSmall }" t-ref="sidebarRef">
                         <LazyComponent t-if="state.ready" Component="'mass_mailing.MassMailingBuilder'"
                             props="() => ({

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -52,6 +52,19 @@ html:has(.o_layout, .o_basic_theme) {
     }
 }
 
+:host(.o_mail_favorite_preview) {
+    .o_layout.o_basic_theme {
+        padding: 16px;
+    }
+    .o_layout .o_mail_wrapper {
+        max-width: unset;
+    }
+    .container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
 html:has(.o_layout) {
     .editor_enable .o_mail_wrapper_td.oe_empty:empty {
         &:not(:focus) {

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -40,6 +40,10 @@ html:has(.o_layout, .o_basic_theme) {
         .o_mass_mailing_value ~ .o_loading_screen {
             display: none !important;
         }
+
+        .o_layout.o_basic_theme {
+            padding: 16px;
+        }
     }
 
     .container {

--- a/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
+++ b/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
@@ -11,6 +11,7 @@ import {
     Many2OneField,
 } from "@web/views/fields/many2one/many2one_field";
 import { Component, useState, useEffect } from "@odoo/owl";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 export class MailingFilterDropdown extends Dropdown {
     setup() {
@@ -42,10 +43,12 @@ export class FieldMany2OneMailingFilter extends Component {
         ...Many2OneField.props,
         domain_field: { type: String, optional: true },
         model_field: { type: String, optional: true },
+        noLabel: { type: Boolean, optional: true },
     };
     static defaultProps = {
         domain_field: "mailing_domain",
         model_field: "mailing_model_id",
+        noLabel: false,
     };
 
     setup() {
@@ -204,10 +207,11 @@ registry.category("fields").add("mailing_filter", {
             availableTypes: ["char"]
         },
     ],
-    extractProps({ options }) {
+    extractProps({ attrs, options }) {
         const props = extractM2OFieldProps(...arguments);
         props.domain_field = options.domain_field;
         props.model_field = options.model_field;
+        props.noLabel = exprToBoolean(attrs.nolabel);
         return props;
     },
 });

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -41,13 +41,13 @@
         run: 'click',
     }, {
         isActive: ["enterprise"],
-        trigger: 'div[name="body_arch"] .o_mailing_template_preview_wrapper [data-name="newsletter"]',
+        trigger: 'div[name="body_arch"] :iframe .o_mailing_template_preview_wrapper [data-name="newsletter"]',
         content: markup(_t('Choose this <b>theme</b>.')),
         tooltipPosition: 'left',
         run: 'click',
     }, {
         isActive: ["community"],
-        trigger: 'div[name="body_arch"] .o_mailing_template_preview_wrapper [data-name="default"]',
+        trigger: 'div[name="body_arch"] :iframe .o_mailing_template_preview_wrapper [data-name="default"]',
         content: markup(_t('Choose this <b>theme</b>.')),
         tooltipPosition: 'right',
         run: 'click',

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -64,7 +64,7 @@
         tooltipPosition: 'top',
         run: 'click',
     }, {
-        trigger: 'button[name="action_set_favorite"]',
+        trigger: 'div.o_favorite',
         content: _t('Click on this button to add this mailing to your templates.'),
         tooltipPosition: 'bottom',
         run: 'click',

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -11,6 +11,18 @@
     .o_notebook .o_notebook_headers .nav-link[name="mail_debug"] {
         display: none;
     }
+
+    .o_notebook .o_notebook_content .o_field_mass_mailing_html {
+        margin: 0 var(--Notebook-margin-x, 0);
+    }
+
+    .o_notebook > .tab-content > .tab-pane {
+        &:has(.o_field_mass_mailing_html) {
+            padding-top: 0;
+            padding-bottom: 0;
+            margin-bottom: calc(var(--formView-sheet-padding-y, 16px) * -1);
+        }
+    }
 }
 
 @include media-breakpoint-up(lg) {

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -23,6 +23,10 @@
             margin-bottom: calc(var(--formView-sheet-padding-y, 16px) * -1);
         }
     }
+
+    .o_field_boolean_favorite i {
+        font-size: inherit;
+    }
 }
 
 @include media-breakpoint-up(lg) {

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -52,12 +52,6 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
     // Align the model / domain container with subject field in large devices
     // and provide better tap area to the filter
     @include media-breakpoint-up(md) {
-        div[name="mailing_model_id_container"] {
-            width: 96%;
-        }
-        .o_mailing_filter_width {
-            max-width: 25%;
-        }
         .o_readonly_modifier.o_mailing_filter_readonly_width ,
         &.o_form_readonly .o_mailing_filter_readonly_width {
             max-width: 100%;

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -23,7 +23,3 @@ body.editor_enable.o_basic_theme.o_in_iframe {
 .oe_structure {
     width: 100%;
 }
-
-:root {
-    font-size: 14px;
-}

--- a/addons/mass_mailing/static/src/themes/iframe_assets/theme_selector.scss
+++ b/addons/mass_mailing/static/src/themes/iframe_assets/theme_selector.scss
@@ -13,7 +13,7 @@
     margin: 0;
 
     h5 {
-        font-size: 1rem !important;
+        font-size: 14px;
         color: #ffffff;
     }
 
@@ -57,7 +57,6 @@
         float: left;
         clear: none;
         width: 100%;
-        max-width: 20%;
         transition: all 0.3s ease 0s;
 
         &:first-child {
@@ -115,27 +114,51 @@
             }
         }
     }
+    .o_mail_templates_grid {
+        display: grid;
+        grid-template-columns: repeat(5, 20%);
+        grid-auto-rows: 1fr;
+    }
 
     .o_mail_template_preview {
         color: #ffffff;
         cursor: pointer;
         padding: 10px 1.5rem;
-        width: 20%;
-        div i.o_mail_template_remove_favorite {
-            display: none;
+        img {
+            width: 100%;
+            height: 100%;
         }
-        div:hover i.o_mail_template_remove_favorite {
-            display: inline-block;
+        i.fa-star {
+            color: $o-main-favorite-color;
+        }
+        .o_mail_template_remove_favorite i {
+            display:  none;
+        }
+        &:hover .o_mail_template_remove_favorite i {            
+            display: block;
             &:hover {
                 color: red;
             }
         }
-        img {
-            width: 20px;
-            height: 20px;
-        }
-        i.fa-star {
-            color: $o-main-favorite-color;
+    }
+
+    .o_mail_favorite_preview_wrapper {
+        display: inline-block;
+        width: 100%;
+        position: relative;
+        flex-grow: 1;
+        background-color: #e8ebee;
+        overflow: hidden;
+
+        .o_mail_favorite_preview {
+            position: absolute;
+            transform-origin: top left;
+            overflow: hidden;
+            white-space: wrap;
+            color: black;
+            height: 1000%;
+            transform: scale(0.2);
+            width: calc(500% + 5px);
         }
     }
 }
@@ -145,8 +168,13 @@
     // can not be done with "o_xxs_form_view" because those
     // elements are inside an iframe (HTML field).
     .o_mail_theme_selector {
-        .dropdown-item {
-            max-width: 50%!important;
+        .o_mail_templates_grid {
+            grid-template-columns: repeat(2, 50%) !important;
+        }
+
+        .o_mail_favorite_preview_wrapper .o_mail_favorite_preview {
+            transform: scale(0.5);
+            width: calc(200% + 5px);
         }
     }
 }

--- a/addons/mass_mailing/static/src/themes/theme_selector/favorite_preview.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/favorite_preview.js
@@ -1,0 +1,36 @@
+import { Component, onMounted, onWillStart, useRef } from "@odoo/owl";
+import { localization } from "@web/core/l10n/localization";
+import { renderToFragment } from "@web/core/utils/render";
+
+export class FavoritePreview extends Component {
+    static template = "mass_mailing.FavoritePreview";
+    static props = {
+        template: Object,
+        styleSheetsPromise: Promise,
+    };
+
+    setup() {
+        this.isRTL = localization.direction === "rtl";
+        this.shadowRootRef = useRef("shadowRoot");
+        this.styleSheets = [];
+        onWillStart(async () => {
+            this.styleSheets = await this.props.styleSheetsPromise;
+        });
+        onMounted(() => {
+            this.setupShadowRoot();
+        });
+    }
+
+    setupShadowRoot() {
+        const root = this.shadowRootRef.el.attachShadow({ mode: "open" });
+        root.adoptedStyleSheets = [...root.adoptedStyleSheets, ...this.styleSheets];
+        root.replaceChildren(this.renderBodyContent());
+    }
+
+    renderBodyContent() {
+        return renderToFragment("mass_mailing.FavoritePreviewBody", {
+            ...this.props.template,
+            isRTL: this.isRTL,
+        });
+    }
+}

--- a/addons/mass_mailing/static/src/themes/theme_selector/favorite_preview.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/favorite_preview.xml
@@ -1,0 +1,16 @@
+<templates>
+    <t t-name="mass_mailing.FavoritePreview">
+        <div class="o_mail_favorite_preview_wrapper mb-2">
+            <div t-ref="shadowRoot" class="o_mail_favorite_preview" inert="inert"/>
+        </div>
+    </t>
+
+    <t t-name="mass_mailing.FavoritePreviewBody">
+        <div class="o_favorite_template_preview">
+            <div class="o_mass_mailing_value o_readonly"
+                t-att-class="{'o_rtl': isRTL}">
+                <t t-out="bodyArch"/>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.js
@@ -1,51 +1,92 @@
-import { Component, onWillStart, useState } from "@odoo/owl";
+import {
+    Component,
+    onMounted,
+    onWillStart,
+    onWillUnmount,
+    status,
+    useRef,
+    useState,
+} from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { FavoritePreview } from "./favorite_preview";
+import { useThrottleForAnimation } from "@web/core/utils/timing";
+import { effect } from "@web/core/utils/reactive";
+import { KeepLast } from "@web/core/utils/concurrency";
 
 export class ThemeSelector extends Component {
     static template = "mass_mailing.ThemeSelector";
     static props = {
         config: { type: Object },
+        styleSheetsPromise: Promise,
+        themesPromise: Promise,
+        // Reactive wrapper for favoriteThemes promise: { promise }
+        favoriteThemes: Object,
+        iframeRef: Object,
+    };
+    static components = {
+        FavoritePreview,
     };
 
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
         this.themeService = useService("mass_mailing.themes");
+        this.themeSelectorWrapperRef = useRef("themeSelectorWrapper");
         this.config = this.props.config;
-        this.themes = this.themeService.getThemes();
-        this.favoriteTemplates = useState([]);
+        this.commonThemes = this.themeService.getCommonThemes();
+        this.simpleThemes = this.themeService.getSimpleThemes();
+        this.state = useState({
+            loading: false,
+            favoriteTemplates: [],
+        });
         onWillStart(async () => {
-            const themeServicePromise = this.themeService.load();
-            const favoritePromise = this.orm.call("mailing.mailing", "action_fetch_favorites", [
-                this.favoriteDomain,
-            ]);
-            const [favoriteTemplates] = await Promise.all([favoritePromise, themeServicePromise]);
-            Object.assign(
-                this.favoriteTemplates,
-                favoriteTemplates.map((favorite) => ({
-                    html: favorite.body_arch,
-                    id: favorite.id,
-                    modelId: favorite.mailing_model_id[0],
-                    modelName: favorite.mailing_model_id[1],
-                    name: `template_${favorite.id}`,
-                    nowrap: true,
-                    subject: favorite.subject,
-                    userId: favorite.user_id[0],
-                    userName: favorite.user_id[1],
-                }))
+            const { themesPromise, favoriteThemes } = this.props;
+            const [favoriteTemplates] = await Promise.all([favoriteThemes.promise, themesPromise]);
+            Object.assign(this.state, { favoriteTemplates });
+        });
+        let favoriteThemesPromise = this.props.favoriteThemes.promise;
+        const keepLastFavoriteThemes = new KeepLast();
+        effect(
+            async (favoriteThemes) => {
+                if (status(this) === "destroyed") {
+                    return;
+                }
+                if (favoriteThemesPromise !== favoriteThemes.promise) {
+                    favoriteThemesPromise = favoriteThemes.promise;
+                    this.state.loading = true;
+                    const favoriteTemplates = await keepLastFavoriteThemes.add(
+                        favoriteThemesPromise
+                    );
+                    Object.assign(this.state, { favoriteTemplates });
+                    this.state.loading = false;
+                }
+            },
+            [this.props.favoriteThemes]
+        );
+        this.throttledResize = useThrottleForAnimation(() => {
+            if (status(this) === "destroyed") {
+                return;
+            }
+            const iframe = this.props.iframeRef.el;
+            iframe.style.width = "";
+            const height = Math.trunc(
+                this.themeSelectorWrapperRef.el.getBoundingClientRect().height
             );
+            iframe.style.height = height + "px";
+        });
+        onMounted(() => {
+            this.htmlResizeObserver = new ResizeObserver(this.throttledResize);
+            this.htmlResizeObserver.observe(this.themeSelectorWrapperRef.el);
+        });
+        onWillUnmount(() => {
+            this.htmlResizeObserver.disconnect();
         });
     }
 
-    get favoriteDomain() {
-        return this.props.config.filterTemplates
-            ? [["mailing_model_id", "=", this.props.config.mailingModelId]]
-            : [];
-    }
-
-    async onRemoveFavorite(index) {
-        const favorite = this.favoriteTemplates[index];
-        if (!favorite) {
+    async onRemoveFavorite(ev, index) {
+        ev.stopPropagation();
+        const favorite = this.state.favoriteTemplates[index];
+        if (this.state.loading || !favorite) {
             return;
         }
         const notificationAction = await this.orm.call(
@@ -53,15 +94,21 @@ export class ThemeSelector extends Component {
             "action_remove_favorite",
             [favorite.id]
         );
-        this.favoriteTemplates.splice(index, 1);
+        this.state.favoriteTemplates.splice(index, 1);
         this.action.doAction(notificationAction);
     }
 
     onSelectFavorite(html) {
+        if (this.state.loading) {
+            return;
+        }
         this.props.config.setThemeHTML(html);
     }
 
     onSelectTheme(themeOptions) {
+        if (this.state.loading) {
+            return;
+        }
         this.props.config.setThemeHTML(themeOptions.html);
     }
 }

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.js
@@ -12,6 +12,7 @@ import { FavoritePreview } from "./favorite_preview";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { effect } from "@web/core/utils/reactive";
 import { KeepLast } from "@web/core/utils/concurrency";
+import { _t } from "@web/core/l10n/translation";
 
 export class ThemeSelector extends Component {
     static template = "mass_mailing.ThemeSelector";
@@ -89,13 +90,18 @@ export class ThemeSelector extends Component {
         if (this.state.loading || !favorite) {
             return;
         }
-        const notificationAction = await this.orm.call(
-            "mailing.mailing",
-            "action_remove_favorite",
-            [favorite.id]
-        );
+        await this.orm.write("mailing.mailing", [favorite.id], { favorite: false });
         this.state.favoriteTemplates.splice(index, 1);
-        this.action.doAction(notificationAction);
+        this.action.doAction({
+            type: "ir.actions.client",
+            tag: "display_notification",
+            params: {
+                message: _t("Design removed from the templates!"),
+                next: { type: "ir.actions.act_window_close" },
+                sticky: false,
+                type: "info",
+            },
+        });
     }
 
     onSelectFavorite(html) {

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.scss
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.scss
@@ -11,8 +11,6 @@
     overflow: auto;
     background-color: $o-we-sidebar-bg;
     margin: 0;
-    // TODO EGGMAIL identify why -5px
-    margin-bottom: calc(var(--formView-sheet-padding-y) * -1 - 5px);
 
     h5 {
         font-size: 1rem !important;

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
@@ -1,22 +1,36 @@
 <templates id="template">
     <div t-name="mass_mailing.ThemeSelector" class="o_mail_theme_selector">
-        <div class="o_mailing_template_preview_wrapper d-inline-block w-100">
-            <div t-foreach="favoriteTemplates" t-as="template" t-key="template_index"
-                class="o_mail_template_preview d-inline-block dropdown-item"
-                t-if="template.modelId === this.props.config.mailingModelId"
-                t-on-click="() => this.onSelectFavorite(template.html)">
-                <div class="d-inline-flex flex-row align-items-center border px-2 py-2 w-100">
-                    <i class="fa fa-star me-2"/>
-                    <span class="text-truncate" t-out="template.subject"/>
-                    <div class="ms-auto">
-                        <i class="o_mail_template_remove_favorite fa fa-trash ps-2 me-1" t-att-data-id="template.id" title="Remove from Templates"
-                            t-on-click="() => this.onRemoveFavorite(template_index)"/>
-                        <img t-if="template.userId" t-attf-src="/web/image/res.users/#{template.userId}/avatar_128" t-att-title="template.userName"/>
+        <div t-ref="themeSelectorWrapper" class="o_mailing_template_preview_wrapper d-inline-block w-100">
+            <div class="o_mail_templates_grid w-100">
+                <div t-foreach="simpleThemes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
+                    t-on-click="() => this.onSelectTheme(theme)" t-att-data-name="theme.name">
+                    <div class="o_thumb small mb-2" t-attf-style="background-image: url(#{theme.imgPath}_small.png)"/>
+                    <div class="o_thumb large mb-2" t-attf-style="background-image: url(#{theme.imgPath}_large.png)"/>
+                    <h5 class="text-capitalize text-truncate" t-out="theme.title"/>
+                </div>
+                <div t-foreach="state.favoriteTemplates" t-as="template" t-key="template_index"
+                    class="cursor-pointer dropdown-item px-4 o_mail_template_preview d-flex flex-column justify-content-between" role="menuitem"
+                    t-on-click="() => this.onSelectFavorite(template.bodyArch)">
+                    <!-- Template HTML preview -->
+                        <div t-if="template.imagePreviewSrc" class="s_dialog_preview s_dialog_preview_image">
+                            <img t-att-src="template.imagePreviewSrc"/>
+                        </div>
+                        <t t-else="">
+                            <div class="d-flex flex-grow-1">
+                                <FavoritePreview template="template" styleSheetsPromise="this.props.styleSheetsPromise"/>
+                            </div>
+                        </t>
+                    <div class="d-flex flex-row align-items-center mb-2 w-100">
+                        <i class="fa fa-star me-2"/>
+                        <h5 class="text-truncate mb-0" t-out="template.subject"/>
+                        <div class="lh-1 ms-auto o_mail_template_remove_favorite" 
+                            aria-label="Remove from Templates" aria-role="button"
+                            t-on-click="(ev) => this.onRemoveFavorite(ev, template_index)" title="Remove from Templates">
+                            <i class="fa fa-trash ps-2 me-1" t-att-data-id="template.id"/>
+                        </div> 
                     </div>
                 </div>
-            </div>
-            <div class="d-inline-block w-100">
-                <div t-foreach="themes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
+                <div t-foreach="commonThemes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
                     t-on-click="() => this.onSelectTheme(theme)" t-att-data-name="theme.name">
                     <div class="o_thumb small mb-2" t-attf-style="background-image: url(#{theme.imgPath}_small.png)"/>
                     <div class="o_thumb large mb-2" t-attf-style="background-image: url(#{theme.imgPath}_large.png)"/>

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.js
@@ -1,0 +1,189 @@
+import { ThemeSelector } from "./theme_selector";
+import { assets, AssetsLoadingError, getBundle, loadBundle } from "@web/core/assets";
+import {
+    Component,
+    markup,
+    onMounted,
+    onWillUnmount,
+    onWillUpdateProps,
+    reactive,
+    status,
+    useRef,
+    useState,
+} from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { renderToFragment } from "@web/core/utils/render";
+import { localization } from "@web/core/l10n/localization";
+import { browser } from "@web/core/browser/browser";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
+
+const CSSSheetsCache = new Map();
+
+export class ThemeSelectorIframe extends Component {
+    static template = "mass_mailing.ThemeSelectorIframe";
+    static props = {
+        config: Object,
+    };
+
+    setup() {
+        this.themeService = useService("mass_mailing.themes");
+        this.orm = useService("orm");
+        this.state = useState({
+            show: false,
+        });
+        this.themeSelectorProps = {
+            favoriteThemes: reactive({
+                promise: undefined,
+            }),
+        };
+        this.iframeRef = useRef("iframe");
+        onMounted(() => {
+            if (this.iframeRef.el.contentDocument.readyState === "complete") {
+                this.setupIframe();
+            } else {
+                // Browsers like Firefox only make iframe document available after dispatching "load"
+                this.iframeRef.el.addEventListener("load", () => this.setupIframe(), {
+                    once: true,
+                });
+            }
+        });
+        onWillUnmount(() => {
+            if (this.themeSelectorRoot) {
+                this.themeSelectorRoot.destroy();
+            }
+        });
+        onWillUpdateProps((newProps) => {
+            if (newProps.config.mailingModelId !== this.props.config.mailingModelId) {
+                this.themeSelectorProps.favoriteThemes.promise = this.fetchFavoriteThemes(newProps);
+            }
+        });
+    }
+
+    get isBrowserSafari() {
+        return isBrowserSafari();
+    }
+
+    getFavoriteDomain(props) {
+        return props.config.filterTemplates
+            ? [["mailing_model_id", "=", props.config.mailingModelId]]
+            : [];
+    }
+
+    getThemeSelectorProps() {
+        Object.assign(this.themeSelectorProps, {
+            config: this.props.config,
+            styleSheetsPromise: this.getStyleSheets(),
+            themesPromise: this.themeService.load(),
+            iframeRef: this.iframeRef,
+        });
+        this.themeSelectorProps.favoriteThemes.promise = this.fetchFavoriteThemes(this.props);
+        return this.themeSelectorProps;
+    }
+
+    async fetchFavoriteThemes(props) {
+        const favoriteTemplates = await this.orm.call("mailing.mailing", "action_fetch_favorites", [
+            this.getFavoriteDomain(props),
+        ]);
+        return favoriteTemplates.map((favorite) => ({
+            bodyArch: markup(favorite.body_arch),
+            id: favorite.id,
+            modelId: favorite.mailing_model_id[0],
+            modelName: favorite.mailing_model_id[1],
+            name: `template_${favorite.id}`,
+            nowrap: true,
+            subject: favorite.subject,
+            userId: favorite.user_id[0],
+            userName: favorite.user_id[1],
+        }));
+    }
+
+    renderHeadContent() {
+        return renderToFragment("mass_mailing.IframeHead", this);
+    }
+
+    async setupIframe() {
+        this.iframeRef.el.contentDocument.head.appendChild(this.renderHeadContent());
+        this.iframeRef.el.contentDocument.body.style.setProperty(
+            "direction",
+            localization.direction
+        );
+        this.themeSelectorRoot = this.__owl__.app.createRoot(ThemeSelector, {
+            props: this.getThemeSelectorProps(),
+        });
+        await Promise.all([
+            loadBundle("mass_mailing.assets_iframe_theme_selector", {
+                targetDoc: this.iframeRef.el.contentDocument,
+                css: true,
+                js: false,
+            }),
+            this.themeSelectorRoot.mount(this.iframeRef.el.contentDocument.body),
+        ]);
+        browser.requestAnimationFrame(() => {
+            if (status(this) !== "destroyed") {
+                this.state.show = true;
+            }
+        });
+    }
+
+    /**
+     * Get common stylesheets used for every favorite mail template
+     *
+     * @returns {Promise<Array<CSSStyleSheet>>}
+     */
+    async getStyleSheets() {
+        const { cssLibs } = await getBundle("mass_mailing.assets_iframe_style");
+        const loadCSSPromises = [];
+        if (cssLibs) {
+            loadCSSPromises.push(...cssLibs.map((url) => this.loadCSSSheets(url)));
+        }
+        const cssTexts = await Promise.all(loadCSSPromises);
+        const sheetPromises = [];
+        for (const cssText of cssTexts) {
+            const sheet = new this.iframeRef.el.contentDocument.defaultView.CSSStyleSheet();
+            sheetPromises.push(sheet.replace(cssText).then(() => sheet));
+        }
+        return Promise.all(sheetPromises);
+    }
+
+    /**
+     * Custom load which does not add the CSSStyleSheet in the current document
+     */
+    loadCSSSheets(url, retryCount = 0) {
+        if (CSSSheetsCache.has(url)) {
+            return CSSSheetsCache.get(url);
+        }
+        const promise = new Promise((resolve, reject) =>
+            fetch(url)
+                .then((response) => {
+                    if (!response.ok) {
+                        reject(
+                            new AssetsLoadingError(`The loading of ${url} failed`, {
+                                cause: response.status,
+                            })
+                        );
+                    }
+                    return response.text();
+                })
+                .then(resolve)
+                .catch(async (error) => {
+                    CSSSheetsCache.delete(url);
+                    if (retryCount < assets.retries.count) {
+                        const delay = assets.retries.delay + assets.retries.extraDelay * retryCount;
+                        await new Promise((res) => setTimeout(res, delay));
+                        this.loadCSSSheets(url, retryCount + 1)
+                            .then(resolve)
+                            .catch((reason) => {
+                                CSSSheetsCache.delete(url);
+                                reject(reason);
+                            });
+                    } else {
+                        reject(
+                            new AssetsLoadingError(`The loading of ${url} failed`, { cause: error })
+                        );
+                    }
+                })
+        );
+        CSSSheetsCache.set(url, promise);
+        return promise;
+    }
+}

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.scss
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.scss
@@ -1,0 +1,3 @@
+.o_mass_mailing_theme_selector_iframe_container {
+    min-height: 500px;
+}

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.xml
@@ -1,0 +1,14 @@
+<templates>
+<t t-name="mass_mailing.ThemeSelectorIframe">
+    <div class="o_mass_mailing_theme_selector_iframe_wrapper">
+        <div class="d-flex w-100 h-100">
+            <div class="flex-grow-1 o_mass_mailing_theme_selector_iframe_container">
+                <iframe t-ref="iframe" t-att-hidden="!state.show ? '' : false"
+                    t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"
+                    scrolling="no"/>
+            </div>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/mass_mailing/static/src/themes/theme_service.js
+++ b/addons/mass_mailing/static/src/themes/theme_service.js
@@ -25,7 +25,10 @@ export class ThemeModel extends Reactive {
         super();
         this.orm = services.orm;
         this.loadedAssets = new Set();
-        this.loadedThemes = new Map();
+        // Shared themes written by Odoo
+        this.commonThemes = new Map();
+        // Blank slate themes (text-only or empty)
+        this.simpleThemes = new Map();
         this.loadingPromise = new Deferred();
     }
 
@@ -61,7 +64,11 @@ export class ThemeModel extends Reactive {
             }
             // Wrap the Theme `html` with a technical layout.
             themeOptions.html = renderToMarkup("mass_mailing.ThemeLayout", themeOptions);
-            this.loadedThemes.set(themeOptions.name, themeOptions);
+            if (["basic", "empty"].includes(themeOptions.name)) {
+                this.simpleThemes.set(themeOptions.name, themeOptions);
+            } else {
+                this.commonThemes.set(themeOptions.name, themeOptions);
+            }
         }
     }
 
@@ -79,8 +86,13 @@ export class ThemeModel extends Reactive {
         return themeClass && getNameFromClass(themeClass);
     }
 
-    getThemes() {
-        return this.loadedThemes;
+    getCommonThemes() {
+        return this.commonThemes;
+    }
+
+    // The simple themes (basic, empty) are separated as they are displayed separately
+    getSimpleThemes() {
+        return this.simpleThemes;
     }
 
     async load(asset = "mass_mailing.email_designer_themes") {

--- a/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
@@ -12,7 +12,7 @@
                             <MailingFilterDropdown>
                                 <button class="btn py-0">
                                     <span class="o_mass_mailing_add_filter">
-                                        <span t-attf-class="o_mass_mailing_no_filter {{ this.props.record.data.mailing_filter_count ? 'd-none' : '' }}">Save as Favorite Filter</span>
+                                        <span t-attf-class="o_mass_mailing_no_filter {{ this.props.record.data.mailing_filter_count || this.props.noLabel ? 'd-none' : '' }}">Save as Favorite Filter</span>
                                         <i class="fa fa-floppy-o px-1 py-1"/>
                                     </span>
                                 </button>

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -227,7 +227,8 @@ describe("field HTML", () => {
         expect(queryOne(".o_mass_mailing_iframe_wrapper iframe")).toHaveClass("d-none");
         await click(
             waitFor(
-                ".o_mailing_template_preview_wrapper div[role='menuitem']:contains(Start From Scratch)"
+                ":iframe .o_mailing_template_preview_wrapper div[role='menuitem']:contains(Start From Scratch)",
+                { timeout: 1000 }
             )
         );
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
@@ -286,7 +287,7 @@ describe("field HTML", () => {
         });
         await contains(".o_data_cell").click();
         await waitFor(".o_dialog");
-        await contains(".o_dialog [data-name='event']").click();
+        await contains(".o_dialog :iframe [data-name='event']", { timeout: 1000 }).click();
         await waitFor(".o_dialog .o_mass_mailing-builder_sidebar", { timeout: 1000 });
         await contains(".o_dialog :iframe p", { timeout: 1000 }).click();
         await waitFor(
@@ -305,7 +306,7 @@ describe("field HTML", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        await click(waitFor(".o_mailing_template_preview_wrapper [data-name='default']"));
+        await click(waitFor(":iframe .o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass(
             "o_default_theme"
@@ -383,7 +384,7 @@ describe("field HTML: with loaded assets", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        await click(waitFor(".o_mailing_template_preview_wrapper [data-name='default']"));
+        await click(waitFor(":iframe .o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         const { bundleControls } = await htmlField.ensureIframeLoaded();
 

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -38,7 +38,7 @@ registry.category('web_tour.tours').add('mailing_campaign', {
         },
         {
             content: 'Pick the basic theme',
-            trigger: ".o_mailing_template_preview_wrapper [data-name='basic']",
+            trigger: ":iframe .o_mailing_template_preview_wrapper [data-name='basic']",
             run: "click",
         },
         {

--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -17,7 +17,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
     run: "click",
 }, {
     content: 'choose the theme "empty" to edit the mailing with snippets',
-    trigger: '[name="body_arch"] .o_mailing_template_preview_wrapper [data-name="empty"]',
+    trigger: '[name="body_arch"] :iframe .o_mailing_template_preview_wrapper [data-name="empty"]',
     run: "click",
 }, {
     content: 'wait for the editor to be rendered',

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -33,15 +33,15 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             run: "click",
         },
         {
-            trigger: ".o_mailing_template_preview_wrapper",
+            trigger: ":iframe .o_mailing_template_preview_wrapper",
         },
         {
             content: "Pick the basic theme",
-            trigger: '.o_mailing_template_preview_wrapper [data-name="basic"]',
+            trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="basic"]',
             run: "click",
         },
         {
-            trigger: "html:not(:has(.o_mailing_template_preview_wrapper))",
+            trigger: ":iframe html:not(:has(.o_mailing_template_preview_wrapper))",
         },
         {
             content: "Make sure the snippets menu is hidden",
@@ -54,7 +54,7 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             run: "click",
         },
         {
-            trigger: ".o_mailing_template_preview_wrapper",
+            trigger: ":iframe .o_mailing_template_preview_wrapper",
         },
         {
             content: "Fill in Subject",
@@ -73,7 +73,7 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         },
         {
             content: "Pick the newsletter theme",
-            trigger: '.o_mailing_template_preview_wrapper [data-name="newsletter"]',
+            trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="newsletter"]',
             run: "click",
         },
         {

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
@@ -26,7 +26,7 @@ registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
             content: 'Select item from dropdown',
             run: 'click',
         }, {
-            trigger: 'div[name="body_arch"] .o_mailing_template_preview_wrapper [data-name="default"]',
+            trigger: 'div[name="body_arch"] :iframe .o_mailing_template_preview_wrapper [data-name="default"]',
             content: markup('Choose this <b>theme</b>.'),
             run: 'click',
         }, {

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
@@ -21,11 +21,11 @@ registry.category("web_tour.tours").add('mass_mailing_dynamic_placeholder_tour',
             run: "edit Test Dynamic Placeholder",
         },
         {
-            trigger: ".o_mailing_template_preview_wrapper",
+            trigger: ":iframe .o_mailing_template_preview_wrapper",
         },
         {
             content: "Pick the basic theme",
-            trigger: '.o_mailing_template_preview_wrapper [data-name="basic"]',
+            trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="basic"]',
             run: "click",
         },
          {

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_tabs', {
     },
     {
         content: "Click on the 'Start From Scratch' template.",
-        trigger: '.o_mailing_template_preview_wrapper [data-name="empty"]',
+        trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="empty"]',
         run: "click",
     },
     {

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
     },
     {
         content: "Wait for the theme selector to load.",
-        trigger: '.o_mailing_template_preview_wrapper',
+        trigger: ':iframe .o_mailing_template_preview_wrapper',
         run: "click",
     },
     {
@@ -31,11 +31,11 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
     },
     {
         content: "Make sure the empty template is an option on non-mobile devices.",
-        trigger: '.o_mailing_template_preview_wrapper [data-name="empty"]',
+        trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="empty"]',
     },
     {
         content: "Click on the default 'welcome' template.",
-        trigger: '.o_mailing_template_preview_wrapper [data-name="default"]',
+        trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="default"]',
         run: "click",
     },
     { // necessary to wait for the cursor to be placed in the first p

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar_mobile.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar_mobile.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar_mobile', 
     {
         isActive: ["mobile"],
         content: "Check templates available in theme selector",
-        trigger: '.o_mailing_template_preview_wrapper',
+        trigger: ':iframe .o_mailing_template_preview_wrapper',
         run: function () {
             if (this.anchor.querySelector("#empty")) {
                 console.error('The empty template should not be visible on mobile.');
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar_mobile', 
     {
         isActive: ["mobile"],
         content: "Click on the 'Start From Scratch' template.",
-        trigger: '.o_mailing_template_preview_wrapper [data-name="default"]',
+        trigger: ':iframe .o_mailing_template_preview_wrapper [data-name="default"]',
         run: "click",
     },
     {

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -79,21 +79,6 @@ class TestMailingContactToList(MassMailCommon):
         subaction = action["params"]["next"]
         self.assertEqual(subaction["type"], "ir.actions.act_window_close")
 
-        # set mailing list, add contacts and redirect to mailing view
-        mailing2 = self.env['mailing.list'].create({
-            'name': 'Contacts Sublimator',
-        })
-
-        wizard_form.mailing_list_id = mailing2
-        wizard = wizard_form.save()
-        action = wizard.action_add_contacts_and_send_mailing()
-        self.assertEqual(contacts.list_ids, mailing + mailing2)
-        self.assertEqual(action["type"], "ir.actions.client")
-        self.assertTrue(action.get("params", {}).get("next"), "Should return a notification with a next action")
-        subaction = action["params"]["next"]
-        self.assertEqual(subaction["type"], "ir.actions.act_window")
-        self.assertEqual(subaction["context"]["default_contact_list_ids"], [mailing2.id])
-
 
 @tagged('mailing_list')
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -46,8 +46,9 @@
         <field name="arch" type="xml">
             <list string="Mailing List Contacts" sample="1" multi_edit="1">
                 <header>
-                    <button name="action_import" string="Import" type="object" display="always"
+                    <button name="action_import" string="Paste" type="object" display="always"
                         context="{'from_mailing_list_ids': context.get('active_ids') if context.get('active_model') == 'mailing.list' else False}"/>
+                    <button name="action_open_base_import" string="Upload" type="object" display="always"/>
                     <button name="action_add_to_mailing_list" string="Add to List" type="object"/>
                 </header>
                 <field name="create_date" string="Create Date" optional="show"/>

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -41,7 +41,7 @@
             <form string="Contact List">
                 <header>
                     <button name="action_open_import" string="Import Contacts"
-                        type="object" class="btn btn-secondary"/>
+                        type="object" class="btn btn-primary"/>
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -129,8 +129,8 @@
         <field name="model">mailing.list</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile o_kanban_mailing_list" sample="1"
-                    on_create="mass_mailing.action_mailing_list_quick_create"
-                    highlight_color="color">
+                    on_create="mass_mailing.action_mailing_list_quick_create" highlight_color="color"
+                    action="action_view_contacts" type="object">
                 <field name="active"/>
                 <templates>
                     <t t-name="menu" t-if="!selection_mode">

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -108,8 +108,8 @@
                         <field name="color" widget="color_picker"/>
                     </group>
                 </group>
-                 <footer>
-                    <button string="Create Mailing List" class="btn-primary" special="save" data-hotkey="q"/>
+                <footer>
+                    <button string="Create Mailing List" name="action_view_contacts" type="object" class="btn-primary" special="save" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
@@ -122,6 +122,7 @@
         <field name="view_mode">form</field>
         <field name="view_id" ref="mailing_list_view_form_simplified"/>
         <field name="target">new</field>
+        <field name="context">{'dialog_size' : 'large'}</field>
     </record>
 
     <record id="mailing_list_view_kanban" model="ir.ui.view">

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -40,8 +40,6 @@
         <field name="arch" type="xml">
             <form string="Contact List">
                 <header>
-                    <button name="action_send_mailing" string="Send Mailing"
-                        type="object" class="btn btn-primary"/>
                     <button name="action_open_import" string="Import Contacts"
                         type="object" class="btn btn-secondary"/>
                 </header>
@@ -76,8 +74,9 @@
                         </h1>
                     </div>
                     <group>
+                        <field name="active" invisible="1"/>
                         <group>
-                            <field name="is_public"/>
+                            <field name="is_public" widget="boolean_toggle"/>
                         </group>
                         <group>
                             <field name="color" widget="color_picker"/>
@@ -109,7 +108,7 @@
                     </group>
                 </group>
                 <footer>
-                    <button string="Create Mailing List" name="action_view_contacts" type="object" class="btn-primary" special="save" data-hotkey="q"/>
+                    <button string="Create Mailing List" name="action_view_contacts" type="object" class="btn-primary" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
@@ -203,11 +202,25 @@
                                     <span class="text-muted">Blacklist</span>
                                 </a>
                             </div>
-                            <div class="order-3 order-lg-4 py-0 my-auto me-lg-4 d-none d-md-block">
+                            <div class="order-3 order-lg-4 col-5 col-lg-2 py-0 pe-3 my-auto d-none d-md-flex flex-wrap justify-content-end gap-1">
                                 <button name="action_open_import" string="Import Contacts"
                                     type="object" class="btn btn-primary text-nowrap">
                                     Import Contacts
                                 </button>
+                            </div>
+                        </div>
+                    </t>
+                    <t t-name="menu" t-if="!selection_mode">
+                        <div class="d-flex flex-column">
+                            <a role="menuitem" class="dropdown-item oe_kanban_action" type="open" href="#">Edit</a>
+                            <hr class="my-1"/>
+                            <a role="menuitem" class="dropdown-item oe_kanban_action" name="action_send_mailing" type="object">New Mailing</a>
+                            <hr class="my-1"/>
+                            <a role="menuitem" class="dropdown-item oe_kanban_action" name="action_archive" href="#" type="object">Archive</a>
+                            <a role="menuitem" class="dropdown-item oe_kanban_action" name="unlink" type="object" href="#">Delete</a>
+                            <hr class="my-1 mb-2"/>
+                            <div t-if="widget.editable" role="menuitem" aria-haspopup="true">
+                                <field name="color" widget="kanban_color_picker"/>
                             </div>
                         </div>
                     </t>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -267,6 +267,7 @@
                                             'inline_field': 'body_html',
                                             'dynamic_placeholder': true,
                                             'dynamic_placeholder_model_reference_field': 'mailing_model_real',
+                                            'filterTemplates': true,
                                         }" readonly="state in ('sending', 'done')"/>
                                     <field name="is_body_empty" invisible="1"/>
                                 </div>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -73,16 +73,7 @@
                             data-hotkey="d" invisible="state != 'done'"/>
                         <button name="action_test" type="object" class="btn-secondary" string="Test" data-hotkey="k"/>
                         <button name="action_cancel" type="object" invisible="state != 'in_queue'" class="btn-secondary" string="Cancel" data-hotkey="x"/>
-                        <button type="object"
-                            name="action_set_favorite"
-                            class="btn-secondary"
-                            invisible="favorite"
-                            string="Add to Templates"/>
-                        <button type="object"
-                            name="action_remove_favorite"
-                            class="btn-secondary"
-                            invisible="not favorite"
-                            string="Remove from Templates"/>
+                        <button name="action_retry_failed" type="object" invisible="state != 'done' or failed == 0" class="oe_highlight" string="Retry" data-hotkey="y"/>
                         <field name="state" readonly="1" widget="statusbar" statusbar_visible="draft,in_queue,sending,done"/>
                     </header>
                     <div class="alert alert-info o_mass_mailing_alert_message" role="alert"
@@ -211,13 +202,17 @@
                             </button>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                        <div class="position-relative">
+                            <field name="favorite" class="fs-2 position-absolute" style="right: 0; top:0; line-height:0;"
+                                widget="boolean_favorite" nolabel="1" invisible="is_body_empty"/>
+                        </div>
                         <group class="o_mass_mailing_mailing_group">
                             <field name="active" invisible="1"/>
                             <field name="create_uid" invisible="1"/>
                             <field name="mailing_type" widget="radio" options="{'horizontal': true}"
                                 invisible="1"
                                 readonly="state != 'draft'" force_save="1"/>
-                            <field class="text-break" name="subject"
+                            <field class="text-break w-75" name="subject"
                                 options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
                                 readonly="state in ('sending', 'done')"
                                 widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -226,7 +226,7 @@
                                 <div class="row">
                                     <div class="col-md-auto">
                                         <field name="mailing_model_id" options="{'no_open': True, 'no_create': True}"
-                                            readonly="state in ('sending', 'done')"/>
+                                            readonly="state in ('sending', 'done')" placeholder="Select a Target"/>
                                     </div>
                                     <div invisible="not mailing_on_mailing_list" class="o_mass_mailing_contact_list_ids col-md-auto pt-1">
                                         <label for="contact_list_ids" string="Mailing Lists:" class="oe_edit_only pe-3"/>
@@ -237,11 +237,16 @@
                                                 readonly="state in ('sending', 'done')" options="{'color_field': 'color'}"/>
                                             <button icon="fa-user-plus" type="object" class="btn btn-secondary py-0 px-1 ms-1"
                                                 invisible="not contact_list_ids or not contact_list_ids or state in ('sending', 'done')"
-                                                name="action_view_mailing_contacts" title="Add Mailing Contacts"/>
+                                                name="action_import_mailing_contacts" title="Import Mailing Contacts"/>
                                         </div>
                                     </div>
-                                    <div invisible="mailing_on_mailing_list" class="col-md-auto o_mailing_filter_width">
-                                        <field name="mailing_filter_id" placeholder="Reload a favorite filter"
+                                    <div class="col-md-auto flex-grow-1 pt-1" invisible="mailing_on_mailing_list or not mailing_model_id">
+                                        <field name="mailing_domain" widget="domain"
+                                            options="{'model': 'mailing_model_real', 'foldable': True}"
+                                            readonly="state in ('sending', 'done')"/>
+                                    </div>
+                                    <div invisible="mailing_on_mailing_list" class="col-md-auto o_mailing_filter_width flex-shrink-1" title="Save as favorite">
+                                        <field name="mailing_filter_id" placeholder="Reload a favorite filter" nolabel="1"
                                                class="o_mailing_filter_readonly_width" widget="mailing_filter"
                                                options="{'no_create': 1, 'no_open': 1, 'domain_field': 'mailing_domain', 'model_field': 'mailing_model_id'}"
                                                readonly="state in ('sending', 'done')"/>
@@ -252,10 +257,6 @@
                                 <field name="mailing_model_name" invisible="1"/>
                                 <field name="mailing_on_mailing_list" invisible="1"/>
                                 <field name="mailing_model_real" invisible="1"/>
-                                <field name="mailing_domain" widget="domain"
-                                    options="{'model': 'mailing_model_real', 'foldable': true}"
-                                    invisible="mailing_on_mailing_list"
-                                    readonly="state in ('sending', 'done')"/>
                             </div>
                         </group>
                         <notebook>

--- a/addons/mass_mailing/views/mailing_menus.xml
+++ b/addons/mass_mailing/views/mailing_menus.xml
@@ -43,7 +43,7 @@
               id="menu_mass_mailing_report"
               sequence="90"
               parent="mass_mailing_menu_root"/>
-    <menuitem name="Mass Mailing Analysis"
+    <menuitem name="Mailing Analysis"
               id="mailing_menu_report_mailing"
               sequence="1"
               parent="menu_mass_mailing_report"

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -3,19 +3,19 @@
 
 <template id="email_designer_themes" groups="base.group_user">
     <t t-set="company_id" t-value="res_company"/>
-    <div data-name="basic"
-            title="Plain Text"
-            data-nowrap="1"
-            data-img="/mass_mailing/static/src/img/theme_imgs/basic_thumb"
-            data-images-info='{"logo": {"format": "png"}}'>
-        <t t-call="mass_mailing.theme_basic_template"/>
-    </div>
     <div data-name="empty"
             title="Start From Scratch"
             data-img="/mass_mailing/static/src/img/theme_imgs/empty_thumb"
             data-images-info='{"logo": {"format": "png"}}'
             data-hide-from-mobile="true">
         <t t-call="mass_mailing.theme_empty_template"/>
+    </div>
+    <div data-name="basic"
+            title="Plain Text"
+            data-nowrap="1"
+            data-img="/mass_mailing/static/src/img/theme_imgs/basic_thumb"
+            data-images-info='{"logo": {"format": "png"}}'>
+        <t t-call="mass_mailing.theme_basic_template"/>
     </div>
     <div data-name="default"
             title="Welcome Message"

--- a/addons/mass_mailing/views/themes_templates.xml
+++ b/addons/mass_mailing/views/themes_templates.xml
@@ -7,7 +7,9 @@
             <p><br/></p>
             <p>
                 <br/>
-                <a href="/unsubscribe_from_list">Unsubscribe</a>
+                <span style="font-size: 12px;">
+                    <a href="/unsubscribe_from_list">Unsubscribe</a>
+                </span>
             </p>
         </div>
     </template>

--- a/addons/mass_mailing/wizard/mailing_contact_import.py
+++ b/addons/mass_mailing/wizard/mailing_contact_import.py
@@ -91,12 +91,25 @@ class MailingContactImport(models.TransientModel):
 
         if ignored := len(contacts) - len(unique_contacts):
             message = _(
-                "Contacts successfully imported. Number of contacts imported: %(imported_count)s. Number of duplicates ignored: %(duplicate_count)s",
+                "%(imported_count)s contacts have been imported. %(duplicate_count)s contacts are duplicates and have been ignored.",
                 imported_count=len(unique_contacts),
                 duplicate_count=ignored,
             )
         else:
-            message = _("Contacts successfully imported. Number of contacts imported: %(imported_count)s", imported_count=len(unique_contacts))
+            message = _("%(imported_count)s contacts have been imported.", imported_count=len(unique_contacts))
+
+        if self.env.context.get('no_redirect'):
+            next_action = {'type': 'ir.actions.act_window_close'}
+        else:
+            next_action = {
+                'context': self.env.context,
+                'domain': [('id', 'in', new_contacts.ids)],
+                'name': _('New contacts imported'),
+                'res_model': 'mailing.contact',
+                'type': 'ir.actions.act_window',
+                'view_mode': 'list',
+                'views': [[False, 'list'], [False, 'form']],
+            }
 
         return {
             'type': 'ir.actions.client',
@@ -105,15 +118,7 @@ class MailingContactImport(models.TransientModel):
                 'message': message,
                 'type': 'success',
                 'sticky': False,
-                'next': {
-                    'context': self.env.context,
-                    'domain': [('id', 'in', new_contacts.ids)],
-                    'name': _('New contacts imported'),
-                    'res_model': 'mailing.contact',
-                    'type': 'ir.actions.act_window',
-                    'view_mode': 'list',
-                    'views': [[False, 'list'], [False, 'form']],
-                },
+                'next': next_action,
             }
         }
 

--- a/addons/mass_mailing/wizard/mailing_contact_import.py
+++ b/addons/mass_mailing/wizard/mailing_contact_import.py
@@ -118,15 +118,4 @@ class MailingContactImport(models.TransientModel):
         }
 
     def action_open_base_import(self):
-        """Open the base import wizard to import mailing list contacts with a xlsx file."""
-        self.ensure_one()
-
-        return {
-            'type': 'ir.actions.client',
-            'tag': 'import',
-            'name': _('Import Mailing Contacts'),
-            'params': {
-                'context': self.env.context,
-                'active_model': 'mailing.contact',
-            }
-        }
+        return self.env['mailing.contact'].action_open_base_import()

--- a/addons/mass_mailing/wizard/mailing_contact_import_views.xml
+++ b/addons/mass_mailing/wizard/mailing_contact_import_views.xml
@@ -8,7 +8,7 @@
                 <group>
                     <field name="mailing_list_ids" string="Import contacts in"
                         widget="many2many_tags" placeholder="Select mailing lists"
-                        options="{'no_create': True}"/>
+                        options="{'no_create': True, 'color_field': 'color'}"/>
                 </group>
                 <p>
                     Write or paste email addresses in the field below.

--- a/addons/mass_mailing/wizard/mailing_contact_to_list.py
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list.py
@@ -15,19 +15,6 @@ class MailingContactToList(models.TransientModel):
         """ Simply add contacts to the mailing list and close wizard. """
         return self._add_contacts_to_mailing_list({'type': 'ir.actions.act_window_close'})
 
-    def action_add_contacts_and_send_mailing(self):
-        """ Add contacts to the mailing list and redirect to a new mailing on
-        this list. """
-        self.ensure_one()
-
-        action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.mailing_mailing_action_mail")
-        action['views'] = [[False, "form"]]
-        action['target'] = 'current'
-        action['context'] = {
-            'default_contact_list_ids': [self.mailing_list_id.id]
-        }
-        return self._add_contacts_to_mailing_list(action)
-
     def _add_contacts_to_mailing_list(self, action):
         self.ensure_one()
 

--- a/addons/mass_mailing/wizard/mailing_contact_to_list.py
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list.py
@@ -27,15 +27,17 @@ class MailingContactToList(models.TransientModel):
                 }) for contact in contacts_to_add
             ]
         })
+        already_on_list_count = len(self.contact_ids) - len(contacts_to_add)
+        message = _("%(added_contacts_count)s Mailing Contacts have been added.", added_contacts_count=len(contacts_to_add))
+        if already_on_list_count:
+            message += _("\n\n%(already_on_list_count)s Mailing Contacts were already on this list.", already_on_list_count=already_on_list_count)
 
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
                 'type': 'info',
-                'message': _("%s Mailing Contacts have been added. ",
-                             len(contacts_to_add)
-                            ),
+                'message': message,
                 'sticky': False,
                 'next': action,
             }

--- a/addons/mass_mailing/wizard/mailing_contact_to_list_views.xml
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list_views.xml
@@ -7,22 +7,22 @@
             <field name="arch" type="xml">
                 <form string="Send a Sample Mail">
                     <group>
-                        <field name="mailing_list_id" options="{'no_create_edit': True, 'no_open': True}"/>
+                        <field name="mailing_list_id" options="{'no_create_edit': True, 'no_open': True}" placeholder="Select a list..."/>
                         <field name="contact_ids" invisible="1"/>
                     </group>
                     <footer>
-                        <button string="Add" name="action_add_contacts" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Add and Send Mailing" name="action_add_contacts_and_send_mailing" type="object" class="btn-primary" data-hotkey="w"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button string="Add to List" name="action_add_contacts" type="object" class="btn-primary" data-hotkey="q"/>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                     </footer>
                 </form>
             </field>
     </record>
 
     <record id="mailing_contact_to_list_action" model="ir.actions.act_window">
-        <field name="name">Add Selected Contacts to a Mailing List</field>
+        <field name="name">Add Contacts to a Mailing List</field>
         <field name="res_model">mailing.contact.to.list</field>
         <field name="view_mode">form</field>
+        <field name="context">{"dialog_size": "medium"}</field>
         <field name="target">new</field>
     </record>
 

--- a/addons/mass_mailing_sms/views/mailing_list_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_list_views.xml
@@ -18,17 +18,8 @@
                     </span>
                 </a>
             </xpath>
-        </field>
-    </record>
-
-    <record id="mailing_list_view_form" model="ir.ui.view">
-        <field name="name">mailing.list.view.form.inherit.sms</field>
-        <field name="model">mailing.list</field>
-        <field name="inherit_id" ref="mass_mailing.mailing_list_view_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_send_mailing']" position="after">
-                <button name="action_send_mailing_sms" string="Send SMS"
-                        type="object" class="btn btn-primary"/>
+            <xpath expr="//a[@name='action_send_mailing']" position="after">
+                <a role="menuitem" type="object" name="action_send_mailing_sms" class="dropdown-item oe_kanban_action">New SMS</a>
             </xpath>
         </field>
     </record>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -117,11 +117,8 @@
             <xpath expr="//field[@name='subject']" position="after">
                 <field class="text-break" name="sms_subject" string="Title" placeholder="e.g. Black Friday SMS coupon" invisible="mailing_type != 'sms'" readonly="state in ('sending', 'done')" required="mailing_type == 'sms'"/>
             </xpath>
-            <xpath expr="//button[@name='action_set_favorite']" position="attributes">
+            <xpath expr="//field[@name='favorite']" position="attributes">
                 <attribute name="invisible" separator=" or " add="mailing_type != 'mail'"/>
-            </xpath>
-            <xpath expr="//button[@name='action_remove_favorite']" position="attributes">
-                <attribute name="invisible">mailing_type != 'mail' or not favorite</attribute>
             </xpath>
             <xpath expr="//field[@name='preview']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail'</attribute>

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -25,6 +25,7 @@ class PurchaseOrder(models.Model):
     _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
     _mail_post_access = 'read'
+    _mailing_enabled = True
 
     @api.depends('order_line.price_subtotal', 'company_id', 'currency_id')
     def _amount_all(self):


### PR DESCRIPTION
Also modified: hr, marketing_card, mass_mailing_sms, purchase

This work bundles UX improvements in the main mass_mailing
flows (design and usability).

Excerpt, see each commit for further details:

---

Previously, favorite mailing templates were only identifiable through
their name and the name of their assignee. However, this made
finding a template harder than it should have been.

This PR introduces previews for mailing templates by embedding
the template's content inside the theme selector and scaling it down
to fit.

---

Tweak the selection of the recipients of a given mailing:

When sending a mailing to a mailing list, the user could add more
recipients to the list before sending the email. They used to open the
mailing list's list view. Now, the option directly displays the import
wizard (mailing.mailing_contact_import_action), cutting down on a step.

Employee and Purchase Order models are added to the list
of valid mailing targets.

---

Previously, mailing lists were created in a full window. From a user
flow standpoint this is cumbersome, as the mailing list form view
only has three fields, and plenty of control panel and header buttons
that are irrelevant to a list that doesn't exist yet.

This work makes it so creating a mailing list is done in a separate
dialog, with only the relevant fields and element displayed.
Upon list creation, that dialog takes the user to the (still empty)
contact list for that mailing list.

---

Slightly ease a few mailing list contact import flows.

- On clicking a mailing list in Kanban view, the user is
directly taken to the contact list.
- Inversely, completing the import-by-paste wizard opened from
the mailing form no longer redirects to the contact list.
- A few notifications that may be sent during these flows
are clarified.


task-4931230