### PR TITLE
[FIX] web_hierarchy: hierarchy view search panel clipping

### DIFF
--- a/addons/web_hierarchy/static/src/hierarchy_renderer.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="web_hierarchy.HierarchyRenderer">
-        <div class="o_hierarchy_renderer w-100 d-flex justify-content-center" t-ref="renderer">
+        <div class="o_hierarchy_renderer o_renderer w-100 d-flex justify-content-center" t-ref="renderer">
             <div class="o_hierarchy_container d-flex flex-column w-100 w-lg-75 h-100 p-2">
                 <t t-foreach="rows" t-as="row" t-key="row_index">
                     <t t-set="previousRow" t-value="!row_first ? rows[row_index - 1] : null"/>


### PR DESCRIPTION
Issue:
- The search panel was getting clipped when navigating deep into the hierarchy.
- `.o_content` enforced `height: 100%` and `overflow: hidden`, preventing the hierarchy from expanding and blocking vertical scroll.
- The JS test "drag node to scroll" queried `.o_content`, which is no longer the actual scrollable container in the hierarchy view, causing intermittent test failures.

Fix:
- Allow `.o_content` to grow and remove overflow restrictions only in the hierarchy view.
- Enable vertical scrolling on `.o_hierarchy_view.o_action` to support large hierarchies.
- Update the test to query `.o_hierarchy_view.o_action` so it targets the correct scrollable element.

Impact:
- Restores proper scrolling behavior.
- Prevents search panel truncation and preserves full UI usability.
- Stabilizes the hierarchy drag-scroll test without impacting other views.

Task: 5326054

