### PR TITLE
[FIX] html_editor: avoid applying color to empty text nodes

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -12,8 +12,9 @@ import {
     isEmptyBlock,
     isRedundantElement,
     isTextNode,
+    isVisibleTextNode,
     isWhitespace,
-    isZwnbsp,
+    isZWS,
 } from "@html_editor/utils/dom_info";
 import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { isColorGradient, rgbaToHex } from "@web/core/utils/colors";
@@ -329,7 +330,8 @@ export class ColorPlugin extends Plugin {
                         font = [];
                     }
                 } else if (
-                    (node.nodeType === Node.TEXT_NODE && !isZwnbsp(node)) ||
+                    (node.nodeType === Node.TEXT_NODE &&
+                        (isVisibleTextNode(node) || isZWS(node))) ||
                     (node.nodeName === "BR" && isEmptyBlock(node.parentNode)) ||
                     (node.nodeType === Node.ELEMENT_NODE &&
                         ["inline", "inline-block"].includes(getComputedStyle(node).display) &&

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -585,6 +585,20 @@ test("should keep font element on top of underline/strike (2)", async () => {
     });
 });
 
+test("should not apply color on an invisible text node", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[a</p>
+            <p>c]</p>
+        `,
+        stepFunction: setColor("rgb(255, 0, 0)", "color"),
+        contentAfter: `
+            <p><font style="color: rgb(255, 0, 0);">[a</font></p>
+            <p><font style="color: rgb(255, 0, 0);">c]</font></p>
+        `,
+    });
+});
+
 describe("colorElement", () => {
     test("should apply o_cc1 class to the element when a color wasn't defined", async () => {
         await testEditor({


### PR DESCRIPTION
**Current behavior before PR:**

- When multiple lines were selected within a block, any empty text nodes between them would also receive a font wrapper when applying a color.
- As a result, it appeared as though an extra line was being inserted when the color was applied.

**Desired behavior after PR is merged:**

- Empty text nodes that are not visible and are not zero-width space or line-break nodes are now filtered out before the font tag is created.
- This prevents font wrappers from being created around those nodes.

task-5344051




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
