### PR TITLE
[IMP] website: pause carousel autoplay when lightbox is opened

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/gallery.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery.js
@@ -15,6 +15,9 @@ export class Gallery extends Interaction {
         this.originalSources = [...this.el.querySelectorAll("img")].map((img) =>
             img.getAttribute("src")
         );
+        this.carouselEl = this.el.querySelector(".carousel");
+        this.carouselInstance =
+            this.carouselEl && window.Carousel.getOrCreateInstance(this.carouselEl);
     }
 
     /**
@@ -27,6 +30,13 @@ export class Gallery extends Interaction {
         const clickedEl = ev.currentTarget;
         if (clickedEl.matches("a > img")) {
             return;
+        }
+
+        // Pause carousel autoplay while the lightbox is active
+        if (this.carouselEl) {
+            this.carouselRideValue = this.carouselInstance._config.ride;
+            this.carouselInstance.pause();
+            this.carouselInstance._config.ride = false;
         }
 
         let imageEls = this.el.querySelectorAll("img");
@@ -64,6 +74,15 @@ export class Gallery extends Interaction {
         })[0];
         this.insert(this.modalEl, document.body);
         new Modal(this.modalEl, { keyboard: true }).show();
+
+        // Restore carousel autoplay when closing the lightbox modal
+        if (this.carouselEl) {
+            this.addListener(this.modalEl, "hidden.bs.modal", () => {
+                // Restore the carousel's original auto-cycling state
+                this.carouselInstance._config.ride = this.carouselRideValue;
+                this.carouselInstance._maybeEnableCycle();
+            });
+        }
     }
 }
 

--- a/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
@@ -1,54 +1,58 @@
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
-import { animationFrame, click, queryOne } from "@odoo/hoot-dom";
+import { animationFrame, click, leave, press, queryOne } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
 
 import { onceAllImagesLoaded } from "@website/utils/images";
 
-setupInteractionWhiteList("website.gallery_slider");
+setupInteractionWhiteList(["website.gallery_slider", "website.gallery", "website.base_lightbox"]);
 
 describe.current.tags("interaction_dev");
 
 const SLIDE_DURATION = 1000;
 
 // TODO Obtain rendering from `website.s_images_gallery` template ?
-const defaultGallery = `
-    <div id="wrapwrap">
-        <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-vcss="002" data-columns="3">
-            <div class="o_container_small overflow-hidden">
-                <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="false" data-bs-interval="0">
-                    <div class="carousel-inner">
-                        <div class="carousel-item active">
-                            <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
+function getDefaultGallery(bsRide = false, bsInterval = 0, showPopup = false) {
+    return `
+        <div id="wrapwrap">
+            <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default ${
+                showPopup ? " o_image_popup" : ""
+            }" data-vcss="002" data-columns="3">
+                <div class="o_container_small overflow-hidden">
+                    <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="${bsRide}" data-bs-interval="${bsInterval}">
+                        <div class="carousel-inner">
+                            <div class="carousel-item active">
+                                <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
+                            </div>
+                            <div class="carousel-item">
+                                <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
+                            </div>
+                            <div class="carousel-item">
+                                <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
+                            </div>
                         </div>
-                        <div class="carousel-item">
-                            <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
+                        <div class="o_carousel_controllers">
+                            <button class="carousel-control-prev o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="prev" aria-label="Previous" title="Previous">
+                                <span class="carousel-control-prev-icon" aria-hidden="true"/>
+                                <span class="visually-hidden">Previous</span>
+                            </button>
+                            <div class="carousel-indicators">
+                                <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active" aria-label="Carousel indicator"/>
+                                <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                                <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator"/>
+                            </div>
+                            <button class="carousel-control-next o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
+                                <span class="carousel-control-next-icon" aria-hidden="true"/>
+                                <span class="visually-hidden">Next</span>
+                            </button>
                         </div>
-                        <div class="carousel-item">
-                            <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
-                        </div>
-                    </div>
-                    <div class="o_carousel_controllers">
-                        <button class="carousel-control-prev o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="prev" aria-label="Previous" title="Previous">
-                            <span class="carousel-control-prev-icon" aria-hidden="true"/>
-                            <span class="visually-hidden">Previous</span>
-                        </button>
-                        <div class="carousel-indicators">
-                            <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active" aria-label="Carousel indicator"/>
-                            <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator"/>
-                            <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator"/>
-                        </div>
-                        <button class="carousel-control-next o_not_editable" contenteditable="false" data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
-                            <span class="carousel-control-next-icon" aria-hidden="true"/>
-                            <span class="visually-hidden">Next</span>
-                        </button>
                     </div>
                 </div>
-            </div>
-        </section>
-    </div>
-`;
+            </section>
+        </div>
+    `;
+}
 
 // TODO Obtain rendering from `website.gallery.s_image_gallery_mirror.lightbox` template ?
 const defaultLightbox = `
@@ -151,7 +155,7 @@ test("gallery_slider does nothing if there is no o_slideshow s_image_gallery", a
 });
 
 test("gallery_slider interaction on image gallery", async () => {
-    const { core } = await startInteractions(defaultGallery);
+    const { core } = await startInteractions(getDefaultGallery());
     expect(core.interactions).toHaveLength(1);
     await animationFrame();
     await onceAllImagesLoaded(getFixture());
@@ -210,4 +214,27 @@ test("gallery_slider interaction on old lightbox", async () => {
     const img3El = queryOne(".carousel-item.active img");
     expect(imgEl).not.toBe(img3El);
     expect(img2El).not.toBe(img3El);
+});
+
+test("carousel autoplay pauses while lightbox is open and resumes after closing", async () => {
+    const { core } = await startInteractions(getDefaultGallery("carousel", 500, true));
+    expect(core.interactions).toHaveLength(2);
+    expect(".carousel .carousel-item:nth-child(1)").toHaveClass("active");
+    expect(".carousel .carousel-item:nth-child(2)").not.toHaveClass("active");
+    expect(".carousel .carousel-item:nth-child(3)").not.toHaveClass("active");
+    await click(".carousel .carousel-item.active img");
+    await animationFrame();
+    expect(".o_image_lightbox").not.toBe(null);
+    // Trigger a mouseleave event to simulate the carousel's autoplay behavior
+    await leave(".carousel .carousel-item.active img");
+    await advanceTime(1000);
+    expect(".carousel .carousel-item:nth-child(1)").toHaveClass("active");
+    expect(".carousel .carousel-item:nth-child(2)").not.toHaveClass("active");
+    expect(".carousel .carousel-item:nth-child(3)").not.toHaveClass("active");
+    await press("Escape");
+    await animationFrame();
+    await advanceTime(1000);
+    expect(".carousel .carousel-item:nth-child(1)").not.toHaveClass("active");
+    expect(".carousel .carousel-item:nth-child(2)").toHaveClass("active");
+    expect(".carousel .carousel-item:nth-child(3)").not.toHaveClass("active");
 });


### PR DESCRIPTION
When opening the lightbox from an image inside an autoplaying carousel,
the carousel continued cycling in the background, causing unexpected
slide changes while the modal was active.

With this commit, the `s_image_gallery` carousel is paused when the
lightbox is opened, and its autoplay state is restored on modal close 
preserving the intended behavior.

task-[5241060](https://www.odoo.com/odoo/project/974/tasks/5241060)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
