### PR TITLE
[IMP] l10n_tw_edi_ecpay: add buyer creation logic before issuing B2B invoices.

### DIFF
--- a/addons/l10n_tw_edi_ecpay/__manifest__.py
+++ b/addons/l10n_tw_edi_ecpay/__manifest__.py
@@ -13,7 +13,7 @@
     """,
     "website": "https://www.odoo.com",
     "license": "LGPL-3",
-    "depends": ["l10n_tw"],
+    "depends": ["l10n_tw", "base_vat"],
     "data": [
         "security/ir.model.access.csv",
         "views/res_config_setting_view.xml",


### PR DESCRIPTION
This commit aims to address an edge case where the buyer identifier might not exist on ECPay before issuing a B2B invoice.

A call to "Add" a customer is made.

RtnCode 1 indicates successful creation, 6160052 - indicates buyer already exists, others are failure.

Additionally, add "base_vat" as dependency to enable client-sided validation for VAT before sending to ECPay.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
