### PR TITLE
[ADD] l10n_tr_nilvera_einvoice_extended: import invoice/bill from UBL TR 1.2

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
@@ -1,9 +1,15 @@
 from collections import defaultdict
+
 from lxml import etree
 
-from odoo import api, models
+from odoo import Command, _, api, models
 from odoo.tools import float_compare, frozendict
-from odoo.addons.l10n_tr_nilvera_einvoice_extended.tools.clean_node_dict import clean_node_dict
+from odoo.tools.misc import clean_context
+
+from odoo.addons.base.models.res_bank import sanitize_account_number
+from odoo.addons.l10n_tr_nilvera_einvoice_extended.tools.clean_node_dict import (
+    clean_node_dict,
+)
 from odoo.addons.l10n_tr_nilvera_einvoice_extended.tools.ubl_tr_invoice import TrInvoice
 
 
@@ -508,3 +514,521 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             if element.text == 'NO_ID':
                 element.text = ''
         return etree.tostring(xml_root, xml_declaration=True, encoding='UTF-8'), errors
+
+    # UBL TR 1.2 Decoder
+    # ========================
+
+    @api.model
+    def _get_profile_id(self, tree):
+        """Extracts ProfileID from the XML tree.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :return: str, ProfileID value.
+        """
+        return tree.findtext('.//cbc:ProfileID', namespaces=tree.nsmap)
+
+    @api.model
+    def _get_partner_node_name(self, tree):
+        """Maps ProfileID to partner node name (e.g., IHRACAT → BuyerCustomer).
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :return: str, partner node name.
+        """
+        profile_id = self._get_profile_id(tree)
+        profile_id_tree_node_map = defaultdict(lambda: 'AccountingCustomer', {
+            'IHRACAT': 'BuyerCustomer',
+        })
+        return profile_id_tree_node_map[profile_id]
+
+    @api.model
+    def _get_invoice_type_code(self, tree):
+        """Extracts the InvoiceTypeCode from the XML tree.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :return: str, InvoiceTypeCode value.
+        """
+        return tree.findtext('.//cbc:InvoiceTypeCode', namespaces=tree.nsmap)
+
+    def _extract_postal_address_from_xml(self, tree, node_name):
+        """Extracts postal address details (e.g., country, city, street) from XML for the given xml tree.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param node_name: str, i.e 'AccountingSupplier', 'AccountingCustomer', 'BuyerCustomer'.
+        :return: dict with postal address details.
+        """
+        nsmap = tree.nsmap
+        postal_address_cac = f'.//cac:{node_name}Party//cac:PostalAddress'
+
+        return {
+            'country_code': self._find_value(f'{postal_address_cac}/cac:Country/cbc:IdentificationCode', tree, nsmap),
+            'country_name': self._find_value(f'{postal_address_cac}/cac:Country/cbc:Name', tree, nsmap),
+            'street': self._find_value(f'{postal_address_cac}/cbc:StreetName', tree, nsmap),
+            'city': self._find_value(f'{postal_address_cac}/cbc:CitySubdivisionName', tree, nsmap),
+            'zip': self._find_value(f'{postal_address_cac}/cbc:PostalZone', tree, nsmap),
+            'state_name': self._find_value(f'{postal_address_cac}/cbc:CityName', tree, nsmap),
+        }
+
+    @api.model
+    def _extract_partner_vals_from_xml(self, tree, node_name):
+        """
+        Extracts partner values (name, VAT, address, etc.) for a given role.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param node_name: str, i.e 'AccountingSupplier', 'AccountingCustomer', 'BuyerCustomer'.
+        :return: dict with partner values.
+        """
+        nsmap = tree.nsmap
+        partner_vals = self._import_retrieve_partner_vals(tree, node_name)
+
+        partner_vals.update({
+            'vat': (
+                    self._find_value(
+                        f'.//cac:{node_name}Party//cac:PartyLegalEntity//cbc:CompanyID[string-length(text()) > 5]',
+                        tree, nsmap)
+                    or self._find_value(
+                f'.//cac:{node_name}Party//cac:PartyIdentification//cbc:ID[@schemeID="VKN"][string-length(text()) > 5]',
+                tree, nsmap)
+            ),
+            'phone': self._find_value(f'.//cac:{node_name}Party//cac:Contact//cbc:Telephone', tree, nsmap),
+            'email': self._find_value(f'.//cac:{node_name}Party//cac:Contact//cbc:ElectronicMail', tree, nsmap),
+            'name': (
+                    self._find_value(f'.//cac:{node_name}Party//cac:PartyName//cbc:Name', tree, nsmap)
+                    or self._find_value(f'.//cac:{node_name}Party//cbc:RegistrationName', tree, nsmap)
+            ),
+            'postal_address': self._extract_postal_address_from_xml(tree, node_name),
+        })
+        return partner_vals
+
+    @api.model
+    def _ensure_partner_address(self, partner, postal_address):
+        """
+        Checks and sets missing address details for the partner (e.g., country, state, city).
+        :param partner: res.partner record.
+        :param postal_address: dict with postal address details.
+        return: None
+        """
+        if partner and not partner.country_id and not partner.street and not partner.street2 and not partner.city and not partner.zip and not partner.state_id:
+            country_domain = []
+            if country_code := postal_address.get('country_code'):
+                country_domain.append(('code', '=', country_code))
+            elif country_name := postal_address.get('country_name'):
+                country_domain.append(('name', '=', country_name))
+            country = self.env['res.country'].search(country_domain) if country_domain else \
+                self.env[
+                    'res.country']
+            state_name = postal_address.get('state_name')
+            state = self.env['res.country.state'].search(
+                [('country_id', '=', country.id), ('name', '=', state_name)],
+                limit=1,
+            ) if state_name and country else self.env['res.country.state']
+
+            partner.write({
+                'country_id': country.id,
+                'street': postal_address.get('street'),
+                'street2': postal_address.get('additional_street'),
+                'city': postal_address.get('city'),
+                'zip': postal_address.get('zip'),
+                'state_id': state.id,
+            })
+
+    @api.model
+    def _create_partner(self, name, phone, email, vat, logs):
+        """
+        Creates a new partner with the given name, phone, email, and VAT details. If creation fails, returns False.
+        :param name: str, partner name.
+        :param phone: str, partner phone.
+        :param email: str, partner email.
+        :param vat: str, partner VAT number.
+        :param logs: list, to append log messages.
+        :return: res.partner record or False if creation failed.
+        """
+        if not name or not vat:
+            logs.append(_("Could not create a partner due to name or vat missing"))
+            return False
+
+        partner_vals = {'name': name, 'email': email, 'phone': phone, 'vat': vat}
+        partner = self.env['res.partner'].create(partner_vals)
+        logs.append(_("Could not retrieve a partner corresponding to '%s'. A new partner was created.", name))
+        return partner
+
+    @api.model
+    def _resolve_invoice_partner(self, tree, company_id, invoice_values, logs):
+        """
+        Retrieve or create the partner from the XML tree and set it to the invoice values.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param company_id: int, the company ID for context.
+        :param invoice_values: dict, to set the 'partner_id' if found or created.
+        :param logs: list, to append log messages.
+        :return: res.partner record.
+        """
+        partner_node_name = self._get_partner_node_name(tree)
+        partner_vals = self._extract_partner_vals_from_xml(tree, partner_node_name)
+
+        if not partner_vals.get('vat'):
+            logs.append(_("The partner VAT is missing; cannot retrieve or create the partner."))
+            return self.env['res.partner']
+
+        """ Retrieve the partner, if no matching partner is found, create it (only if he has a vat and a name) """
+        partner = self.env['res.partner'] \
+            .with_company(company_id) \
+            ._retrieve_partner(domain=[('vat', '=', partner_vals.get('vat'))])
+
+        if partner:
+            self._ensure_partner_address(partner, partner_vals.get('postal_address', {}))
+        else:
+            logs.append(_("No partner found with VAT %s. A new partner is created.", partner_vals.get('vat')))
+            # Create and verify partner
+            partner = self._create_partner(
+                partner_vals.get('name'),
+                partner_vals.get('phone'),
+                partner_vals.get('email'),
+                partner_vals.get('vat'),
+                logs,
+            )
+            self._ensure_partner_address(partner, partner_vals.get('postal_address', {}))
+            if partner:
+                partner.l10n_tr_check_nilvera_customer()
+
+        if partner:
+            invoice_values['partner_id'] = partner.id
+        return partner
+
+    @api.model
+    def _resolve_bank_account(self, tree, partner, invoice_values, logs):
+        """
+        Extract bank account details from the XML tree and set them to the invoice values.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param partner: res.partner record.
+        :param invoice_values: dict, to set 'partner_bank_id' if found or created
+        :param logs: list, to append log messages.
+        """
+        ns = tree.nsmap
+        payment_means = tree.find('.//cac:PaymentMeans', namespaces=ns)
+        if payment_means is None:
+            logs.append(_("No bank details were found in the document."))
+            return
+
+        bank_account_vals = []
+        for acc in payment_means.findall('.//cac:PayeeFinancialAccount', namespaces=ns):
+            bank_account_vals.append({
+                'account_id': sanitize_account_number(
+                    self._find_value('./cbc:ID', acc, ns),
+                ),
+                'currency_code': self._find_value('./cbc:CurrencyCode', acc, ns),
+            })
+
+        if not bank_account_vals:
+            logs.append(_("No bank details were found in the document."))
+            return
+
+        account_numbers = [val['account_id'] for val in bank_account_vals if val['account_id']]
+        existing_accounts = (self.env['res.partner.bank'].with_context(active_test=False)
+                             .search([('acc_number', 'in', account_numbers), ('partner_id', '=', partner.id)]))
+
+        if existing_accounts:
+            invoice_values['partner_bank_id'] = existing_accounts[0].id
+
+            if not existing_accounts[0].active:
+                existing_accounts[0].active = True
+                logs.append(_("An existing bank account %s has been reactivated", existing_accounts[0].acc_number))
+            return
+
+        ResPartnerBank = self.env['res.partner.bank'].with_env(self.env(context=clean_context(self.env.context)))
+        bank_account = ResPartnerBank.create({
+            'partner_id': partner.id,
+            'acc_number': bank_account_vals[0]['account_id'],
+            'currency_id': self.env['res.currency'].search([
+                ('name', '=', bank_account_vals[0]['currency_code']),
+            ], limit=1).id,
+        })
+        logs.append(_("A new bank account %s has been created.", bank_account.acc_number))
+        invoice_values['partner_bank_id'] = bank_account.id
+
+    @api.model
+    def _resolve_delivery_details(self, tree, invoice_values):
+        """
+        Extract delivery details from the XML tree and set them to the invoice values.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param invoice_values: dict, to set delivery details.
+        """
+        delivery_tree = tree.find(".//cac:InvoiceLine/cac:Delivery", tree.nsmap)
+        if delivery_tree is None:
+            return
+
+        delivery_terms_id = delivery_tree.findtext("cac:DeliveryTerms/cbc:ID", namespaces=tree.nsmap)
+        transport_mode_code = delivery_tree.findtext(
+            "cac:Shipment/cac:ShipmentStage/cbc:TransportModeCode", namespaces=tree.nsmap,
+        )
+
+        invoice_values['l10n_tr_shipping_type'] = transport_mode_code
+        invoice_values['invoice_incoterm_id'] = self.env['account.incoterms'].search(
+            [('code', '=', delivery_terms_id)], limit=1,
+        ).id
+
+    @api.model
+    def _resolve_export_exemption(self, tree, invoice_values, logs):
+        """
+        Sets export exemption details (e.g., exemption code, reason) for IHRACAT invoices.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param invoice_values: dict, to set exemption details.
+        :param logs: list, to append log messages.
+        """
+        invoice_type_code = self._get_invoice_type_code(tree)
+        if invoice_type_code not in ['ISTISNA', 'IHRACKAYITLI']:
+            return
+        tax_category_node = tree.find('./cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory', tree.nsmap)
+        if tax_category_node is not None:
+            tax_exemption_reason_code = tax_category_node.findtext('cbc:TaxExemptionReasonCode', namespaces=tree.nsmap)
+            tax_exemption_id = self.env['l10n_tr_nilvera_einvoice_extended.account.tax.code'].search([
+                ('code', '=', tax_exemption_reason_code),
+            ], limit=1)
+
+            if tax_exemption_id:
+                invoice_values['l10n_tr_exemption_code_id'] = tax_exemption_id.id
+            else:
+                logs.append(_("Could not find exemption code with reason '%s'"))
+
+    @api.model
+    def _resolve_basic_fields(self, tree, invoice_values, logs):
+        """
+        Set basic invoice fields from the XML tree.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param invoice_values: dict, to set basic invoice fields.
+        :param logs: list, to append log messages.
+        :return: None
+        """
+
+        profile_id = self._get_profile_id(tree)
+        # under profile_id on xml there is a ID, we will map it to bill reference/reference for bill and invoice
+        if profile_id == 'IHRACAT':
+            invoice_values['l10n_tr_is_export_invoice'] = True
+        elif profile_id in ['TEMELFATURA', 'KAMU']:
+            # EARSIVFATURA is ignored as it's not in the l10n_tr_gib_invoice_scenario field
+            invoice_values['l10n_tr_gib_invoice_scenario'] = profile_id
+
+        invoice_values['l10n_tr_gib_invoice_type'] = tree.findtext('.//cbc:InvoiceTypeCode', namespaces=tree.nsmap)
+        invoice_values['currency_id'], currency_logs = self._import_currency(tree, './/{*}DocumentCurrencyCode')
+        logs.extend(currency_logs)
+
+        invoice_values['invoice_date'] = tree.findtext('.//cbc:IssueDate', namespaces=tree.nsmap)
+        invoice_values['invoice_date_due'] = self._find_value('.//cac:PaymentMeans/cbc:PaymentDueDate', tree,
+                                                              tree.nsmap)
+        invoice_values['ref'] = (
+                self._find_value('./cac:OrderReference/cbc:ID', tree)
+                or self._find_value('./cbc:ID', tree)
+        )
+        invoice_values['narration'] = self._import_description(tree, xpaths=['./{*}Note', './{*}PaymentTerms/{*}Note'])
+
+    @api.model
+    def _get_product_id_by_default_code_or_ctsp(self, vals):
+        """
+        Retrieves product records based on their default codes.
+        :param vals: list of str, product default codes.
+        :return: dict mapping default_code to product.product record.
+        """
+        default_codes = [val[0] for val in vals if val[0]]
+        ctsp_numbers = [val[1] for val in vals if val[1]]
+        data_list = self.env['product.product']._read_group(
+            domain=[
+                '|',
+                ('default_code', 'in', default_codes),
+                ('l10n_tr_ctsp_number', 'in', ctsp_numbers),
+            ],
+            aggregates=['id:recordset'],
+            groupby=['default_code', 'l10n_tr_ctsp_number'],
+        )
+        result = {
+            'default_codes': {},
+            'ctsp_numbers': {},
+        }
+        for default_code, ctsp_number, records in data_list:
+            if default_code and default_code not in result['default_codes']:
+                result['default_codes'][default_code] = records
+            if ctsp_number and ctsp_number not in result['ctsp_numbers']:
+                result['ctsp_numbers'][ctsp_number] = records
+        return result
+
+    @api.model
+    def _get_tax_id_by_percentage(self, amount, move_type):
+        """
+        Retrieves the tax ID based on the percentage amount and account move type.
+        :param amount: float, tax percentage amount.
+        :param move_type: str, 'sale' or 'purchase'.
+        :return: int, tax ID.
+        """
+        return self.env['account.tax'].search([
+            ('country_id.code', '=', 'TR'),
+            ('amount', '=', amount),
+            ('amount_type', '=', 'percent'),
+            ('type_tax_use', '=', move_type),
+        ], limit=1, order='sequence').id
+
+    @api.model
+    def _get_tax_id_by_reason_code(self, withholding_code, move_type):
+        """
+        Retrieves the tax ID based on the withholding reason code and account move type.
+        :param withholding_code: str, withholding reason code.
+        :param move_type: str, 'sale' or 'purchase'.
+        :return: int, tax ID.
+        """
+        # There must be only one tax for each withholding code in Nilvera
+        # But based on model structure there can be multiple parent tax for each withholding code
+        return self.env['account.tax'].search([
+            ('children_tax_ids.l10n_tr_tax_withholding_code_id.code', '=', withholding_code),
+            ('country_id.code', '=', 'TR'),
+            ('type_tax_use', '=', move_type),
+        ], order='sequence', limit=1).id
+
+    @api.model
+    def _get_tax_id_by_tax_details(self, tax_details_list, profile_id, invoice_type, move_type):
+        """
+        Retrieves tax IDs for a list of tax details based on profile ID, invoice type, and account move type.
+        :param tax_details_list: list of dicts, each containing tax details.
+        :param profile_id: str, ProfileID from the XML.
+        :param invoice_type: str, InvoiceTypeCode from the XML.
+        :param move_type: str, 'sale' or 'purchase'.
+        :return: list of lists, each inner list contains tax IDs for the corresponding tax details
+        """
+        result = []
+        for tax_details in tax_details_list:
+            if profile_id == 'IHRACAT':
+                # this is a tax-exempt export
+                tax_id = self._get_tax_id_by_percentage(0, move_type=move_type)
+            elif invoice_type == 'TEVKIFAT':
+                tax_id = self._get_tax_id_by_reason_code(tax_details['withholding_reason_code'],
+                                                         move_type=move_type)
+            else:
+                tax_id = self._get_tax_id_by_percentage(tax_details['tax_percentage'], move_type=move_type)
+            result.append([tax_id] if tax_id else [])
+        return result
+
+    @api.model
+    def _extract_tax_details(self, line_tree, nsmap):
+        """
+        Extracts tax details (withholding reason code and tax percentage) from a line XML tree.
+        :param line_tree: lxml.etree.Element, the line XML tree.
+        :param nsmap: dict, namespace mapping for XML parsing.
+        :return: dict with tax details.
+        """
+        tax_percentage = self._find_value('.//cac:TaxTotal//cac:TaxSubtotal//cbc:Percent', line_tree, nsmap)
+        return {
+            'withholding_reason_code': self._find_value(
+                './/cac:WithholdingTaxTotal//cac:TaxSubtotal//cac:TaxCategory//cbc:TaxTypeCode', line_tree, nsmap),
+            'tax_percentage': float(tax_percentage) if tax_percentage else 0.0,
+        }
+
+    @api.model
+    def _parse_line_discount(self, line_tree, nsmap):
+        """
+        Extracts line discount percentage from a line XML tree.
+        :param line_tree: lxml.etree.Element, the line XML tree.
+        :param nsmap: dict, namespace mapping for XML parsing.
+        :return: float, discount percentage.
+        """
+        discount_percentage = self._find_value('.//cac:AllowanceCharge/cbc:MultiplierFactorNumeric', line_tree, nsmap)
+        return float(discount_percentage) * 100 if discount_percentage else 0.0
+
+    @api.model
+    def _resolve_invoice_lines(self, tree, invoice_values, move_type, logs):
+        """
+        Extracts and sets invoice line details from the XML tree into invoice values.
+        :param tree: lxml.etree.Element, the root of the XML tree.
+        :param invoice_values: dict, to set 'invoice_line_ids'.
+        :param move_type: str, 'sale' or 'purchase'.
+        :param logs: list, to append log messages.
+        :return: None
+        """
+        nsmap = tree.nsmap
+        profile_id = self._get_profile_id(tree)
+        invoice_type = self._get_invoice_type_code(tree)
+        lines_nodes = tree.findall('.//cac:InvoiceLine', namespaces=nsmap)
+        if not lines_nodes:
+            logs.append(_("No invoice lines were found in the document."))
+            return
+
+        # pre process data
+        line_data = []
+        for line_tree in lines_nodes:
+            line_data.append({
+                'default_code': self._find_value('.//cac:Item/cac:SellersItemIdentification/cbc:ID', line_tree, nsmap),
+                'ctsp_number': self._find_value('.//cbc:RequiredCustomsID', line_tree, nsmap),
+                'line_name': self._find_value('.//cac:Item/cbc:Description', line_tree, nsmap),
+                'price_unit': self._find_value('.//cac:Price/cbc:PriceAmount', line_tree, nsmap),
+                'discount_percentage': self._parse_line_discount(line_tree, nsmap),
+                'qty': self._find_value('.//cbc:InvoicedQuantity', line_tree, nsmap),
+                'tax_details': self._extract_tax_details(line_tree, nsmap),
+            })
+        product_ids_by_dc_ctsp = self._get_product_id_by_default_code_or_ctsp(
+            [(line['default_code'], line['ctsp_number']) for line in line_data if
+             line['default_code'] or line['ctsp_number']],
+        )
+
+        tax_id_by_tax_details = self._get_tax_id_by_tax_details(
+            [(line['tax_details']) for line in line_data if line['tax_details']],
+            profile_id,
+            invoice_type,
+            move_type,
+        )
+
+        # set line vals
+        invoice_values['invoice_line_ids'] = []
+        for i, data in enumerate(line_data):
+            product_id = product_ids_by_dc_ctsp['ctsp_numbers'].get(data['ctsp_number'], False) or \
+                         product_ids_by_dc_ctsp['default_codes'].get(data['default_code'], False)
+
+            line_val = {
+                'product_id': product_id.id if product_id else False,
+                'price_unit': float(data['price_unit'] or 0),
+                'quantity': float(data['qty'] or 0),
+                'tax_ids': tax_id_by_tax_details[i] if tax_id_by_tax_details[i] else False,
+                'discount': data['discount_percentage'],
+            }
+            if not product_id:
+                line_val['name'] = data['line_name']
+
+            invoice_values['invoice_line_ids'].append(Command.create(line_val))
+
+    def _import_fill_invoice(self, invoice, tree, qty_factor):
+        # EXTENDS account_edi_ubl_cii
+        # Adding custom decoder for Nilvera's TR1.2 UBL format
+
+        if tree.findtext('.//cbc:CustomizationID', namespaces=tree.nsmap) != 'TR1.2':
+            return super()._import_fill_invoice(invoice, tree, qty_factor)
+
+        if qty_factor == -1:
+            # TODO: Support credit note for UBL TR1.2
+            return [_("Invoice/Bill return creation from XML is not supported for TR1.2 UBL format yet.")]
+
+        logs = []
+        invoice_values = {}
+
+        # ==== Nilvera UUID ====
+        if uuid_node := tree.findtext('./{*}UUID'):
+            invoice_values['l10n_tr_nilvera_uuid'] = uuid_node
+
+        # ==== Process partner ====
+        partner_id = self._resolve_invoice_partner(
+            tree,
+            invoice.company_id,
+            invoice_values,
+            logs,
+        )
+
+        # ==== Process Bank details ====
+        bank_recipient = self.env.company.partner_id if invoice.is_inbound() else partner_id
+        self._resolve_bank_account(tree, bank_recipient, invoice_values, logs)
+
+        # ==== Delivery Details ====
+        self._resolve_delivery_details(tree, invoice_values)
+
+        # ==== Exemption Details ====
+        self._resolve_export_exemption(tree, invoice_values, logs)
+
+        # ==== Basic invoice fields ====
+        self._resolve_basic_fields(tree, invoice_values, logs)
+
+        # ==== Lines =====
+        move_type = 'sale' if invoice.is_inbound() else 'purchase'
+        self._resolve_invoice_lines(tree, invoice_values, move_type, logs)
+
+        invoice.write(invoice_values)
+
+        if not invoice.currency_id.active:
+            invoice.currency_id.active = True
+            logs.append(_("The currency %s has been reactivated.", invoice.currency_id.name))
+        return logs

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_xml_ubl_tr
+from . import test_ubl_tr_xml_decode

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/ihracat_sale.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/ihracat_sale.xml
@@ -1,0 +1,206 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice
+  xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+  xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+  xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>IHRACAT</cbc:ProfileID>
+  <cbc:ID>EIN2025000000001</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>ISTISNA</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:Note>YALNIZ : YÜZELLISEKIZ TRY KIRK KURUS</cbc:Note>
+  <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+  <cbc:LineCountNumeric>3</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/2025/1</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>ELEKTRONIK</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    <cbc:DocumentTypeCode>SEND_TYPE</cbc:DocumentTypeCode>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">1460415308</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Gümrük ve Ticaret Bakanlığı Gümrükler Genel Müdürlüğü- Bilgi İşlem Dairesi Başkanlığı</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CitySubdivisionName>Ulus</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cac:Country>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:Name>Ulus</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="PARTYTYPE">EXPORT</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>earchive_partner</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>earchive_partner</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+      <cac:Person>
+        <cbc:FirstName>earchive_partner</cbc:FirstName>
+        <cbc:FamilyName>___ignore___</cbc:FamilyName>
+      </cac:Person>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>TR0123456789</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:AllowanceCharge>
+    <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+    <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+    <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+  </cac:AllowanceCharge>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:TaxExemptionReasonCode>301</cbc:TaxExemptionReasonCode>
+        <cbc:TaxExemptionReason>Kısmi İstisna Diğerleri</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="TRY">158.40</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="TRY">18.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="TRY">158.40</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cac:Delivery>
+      <cac:DeliveryAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:DeliveryAddress>
+      <cac:DeliveryTerms>
+        <cbc:ID schemeID="INCOTERMS">DAF</cbc:ID>
+      </cac:DeliveryTerms>
+      <cac:Shipment>
+        <cbc:ID></cbc:ID>
+        <cac:GoodsItem>
+            <cbc:RequiredCustomsID>_CTSP_1234</cbc:RequiredCustomsID>
+        </cac:GoodsItem>
+        <cac:ShipmentStage>
+          <cbc:TransportModeCode>1</cbc:TransportModeCode>
+        </cac:ShipmentStage>
+      </cac:Shipment>
+    </cac:Delivery>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>product_ref</cbc:ID>
+      </cac:SellersItemIdentification>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/test_ubl_tr_xml_decode.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/test_ubl_tr_xml_decode.py
@@ -1,0 +1,401 @@
+import copy
+from unittest.mock import patch
+
+from lxml import etree
+
+from odoo import api
+from odoo.tests import tagged
+from odoo.tools import file_open
+
+from odoo.addons.l10n_tr_nilvera_einvoice.tests.test_xml_ubl_tr_common import (
+    TestUBLTRCommon,
+)
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLTRXMLDecode(TestUBLTRCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.account_edi_xml_ubl_tr = cls.env['account.edi.xml.ubl.tr']
+
+        # Preload all XMLs
+        cls.xml_templates = {
+            'satis': 'l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_sale_einvoice.xml',
+            'ihracat': 'l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/ihracat_sale.xml',
+            'tevkifat': 'l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_withholding_einvoice.xml',
+            'ihrackayitli': 'l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml',
+            'istisna': 'l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_tax_exempt_einvoice.xml',
+            'usd_currency': 'l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_earchive_multicurrency.xml',
+        }
+
+        cls.invoice_basic_sale_einvoice_tree = cls._load_xml_tree(cls.xml_templates['satis'])
+        # lxml does not accept None as prefix for default namespace in xpath queries.
+        cls.ns = {k or "ns": v for k, v in cls.invoice_basic_sale_einvoice_tree.nsmap.items()}
+
+        # ==== Partner ====
+        cls.partner_tr_customer = cls.env['res.partner'].create({
+            'name': 'TR Customer',
+            'country_id': cls.env.ref('base.tr').id,
+            'vat': '1729171602',
+        })
+
+        # ==== Bank Account ====
+        cls.partner_tr_bank_account = cls.env['res.partner.bank'].create({
+            'partner_id': cls.partner_tr_customer.id,
+            'acc_number': 'TEST IBAN 1234',
+            'currency_id': cls.env.ref('base.TRY').id,
+        })
+
+        # ==== Products ====
+        cls.product_with_ctsp = cls.env['product.product'].create({
+            'name': 'CTSP Product',
+            'type': 'consu',
+            'l10n_tr_ctsp_number': "_CTSP_TEST",
+        })
+
+        cls.product_with_default_code = cls.env['product.product'].create({
+            'name': 'Default Code Product',
+            'type': 'consu',
+            'default_code': "_DEF_CODE_5678",
+        })
+
+    # =====================================================================
+    # Helper: Load XML once
+    # =====================================================================
+    @classmethod
+    def _load_xml_tree(cls, path):
+        with file_open(path, 'rb') as xml_file:
+            return etree.fromstring(xml_file.read())
+
+    # =====================================================================
+    # Helper: Return cloned tree w/ nodes removed
+    # =====================================================================
+    @staticmethod
+    def _xml_remove_nodes(tree, xpath):
+        new_tree = copy.deepcopy(tree)
+        for node in new_tree.xpath(xpath, namespaces=TestUBLTRXMLDecode.ns):
+            parent = node.getparent()
+            if parent is not None:
+                parent.remove(node)
+        return new_tree
+
+    @staticmethod
+    def _update_xpath_text(tree, xpath, new_value):
+        new_tree = copy.deepcopy(tree)
+        for node in new_tree.xpath(xpath, namespaces=TestUBLTRXMLDecode.ns):
+            node.text = new_value
+        return new_tree
+
+    # =====================================================================
+    # Helper: Create invoice template
+    # =====================================================================
+    @api.model
+    def _create_invoice(self, move_type='out_invoice'):
+        return self.env['account.move'].create({
+            'move_type': move_type,
+        })
+
+    # =====================================================================
+    # BASIC PROVIDED TESTS
+    # =====================================================================
+
+    def test_l10n_tr_nilvera_uuid_field_is_set(self):
+        invoice = self._create_invoice()
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree, './/cbc:UUID', 'UUID_TEST_VALUE')
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertEqual(
+            invoice.l10n_tr_nilvera_uuid,
+            'UUID_TEST_VALUE',
+            'The UUID field was not set correctly from the XML.',
+        )
+
+    def test_node_name_mapping_is_correct(self):
+        tree = copy.deepcopy(self.invoice_basic_sale_einvoice_tree)
+        profile_id_node = tree.find('.//cbc:ProfileID', namespaces=self.ns)
+
+        # IHRACAT → BuyerCustomer
+        profile_id_node.text = 'IHRACAT'
+        node_name = self.account_edi_xml_ubl_tr._get_partner_node_name(tree)
+        self.assertEqual(node_name, 'BuyerCustomer', 'IHRACAT profile should map to BuyerCustomer node.')
+
+        # Other → AccountingCustomer
+        profile_id_node.text = 'random'
+        node_name = self.account_edi_xml_ubl_tr._get_partner_node_name(tree)
+        self.assertEqual(node_name, 'AccountingCustomer', 'Other profiles should map to AccountingCustomer node.')
+
+        profile_id_node.text = ''
+        node_name = self.account_edi_xml_ubl_tr._get_partner_node_name(tree)
+        self.assertEqual(node_name, 'AccountingCustomer', 'Empty profile should map to AccountingCustomer node.')
+
+    def test_partner_not_set_if_vkn_missing(self):
+        tree = self._xml_remove_nodes(self.invoice_basic_sale_einvoice_tree,
+                                      './/cac:PartyLegalEntity//cbc:CompanyID')
+        tree = self._xml_remove_nodes(tree, './/cac:PartyIdentification//cbc:ID[@schemeID="VKN"]')
+
+        partner_id = self.account_edi_xml_ubl_tr._resolve_invoice_partner(
+            tree, self.partner_tr_customer.company_id, {}, [])
+
+        self.assertFalse(partner_id, 'No partner should be set when VAT/VKN is missing.')
+
+    def test_fetch_existing_partner_by_vkn(self):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PartyLegalEntity//cbc:CompanyID', self.partner_tr_customer.vat)
+
+        partner_id = self.account_edi_xml_ubl_tr._resolve_invoice_partner(
+            tree, self.partner_tr_customer.company_id, {}, [])
+
+        self.assertEqual(partner_id.id, self.partner_tr_customer.id, 'Should fetch existing partner by VAT/VKN.')
+
+    @patch('odoo.addons.l10n_tr_nilvera.models.res_partner.ResPartner.l10n_tr_check_nilvera_customer')
+    @patch('odoo.addons.base_vat.models.res_partner.ResPartner._inverse_vat', new=lambda self: None)
+    def test_create_new_partner_and_verify_when_not_existing_vkn(self, l10n_tr_check_nilvera_customer_mocked):
+        new_vat = '0123456789000'
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PartyLegalEntity//cbc:CompanyID', new_vat)
+
+        non_existing_partner = self.env['res.partner'].search([('vat', '=', new_vat)])
+        self.assertFalse(non_existing_partner, 'Partner with new VAT should not exist before test.')
+
+        partner_id = self.account_edi_xml_ubl_tr._resolve_invoice_partner(
+            tree, self.partner_tr_customer.company_id, {}, [])
+
+        new_created_partner = self.env['res.partner'].search([('vat', '=', new_vat)])
+
+        self.assertEqual(partner_id.id, new_created_partner.id,
+                         'Should create and set new partner based on VAT/VKN.')
+
+        l10n_tr_check_nilvera_customer_mocked.assert_called_once()
+
+    def test_import_works_without_invoice_lines(self):
+        tree = self._xml_remove_nodes(self.invoice_basic_sale_einvoice_tree, './/cac:InvoiceLine')
+        invoice = self._create_invoice()
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.invoice_line_ids)
+        # Any other fields is set correctly, meaning the invoice is created without lines
+        self.assertTrue(invoice.partner_id)
+
+    def test_no_bank_account_when_payment_means_missing(self):
+        tree = self._xml_remove_nodes(self.invoice_basic_sale_einvoice_tree, './/cac:PaymentMeans')
+        partner = self.env.company.partner_id
+        vals = {}
+        self.account_edi_xml_ubl_tr._resolve_bank_account(tree, partner, vals, [])
+        self.assertNotIn('partner_bank_id', vals, 'No bank account should be set if PaymentMeans is missing.')
+
+    def test_existing_bank_account_detected_by_acc_number(self):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PaymentMeans//cac:PayeeFinancialAccount//cbc:ID',
+                                       self.partner_tr_bank_account.acc_number)
+        partner = self.partner_tr_customer
+        vals = {}
+        self.account_edi_xml_ubl_tr._resolve_bank_account(tree, partner, vals, [])
+
+        self.assertEqual(vals.get('partner_bank_id'), self.partner_tr_bank_account.id,
+                         'Should fetch existing bank account based on account no.')
+
+    def test_new_bank_account_created_if_not_existing(self):
+        new_iban = 'NEW-IBAN-5678'
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PaymentMeans//cac:PayeeFinancialAccount//cbc:ID',
+                                       new_iban)
+
+        non_existing_bank_account = self.env['res.partner.bank'].search([
+            ('partner_id', '=', self.partner_tr_customer.id),
+            ('acc_number', '=', new_iban),
+        ])
+        self.assertFalse(non_existing_bank_account, 'Bank account with new IBAN should not exist before test.')
+
+        partner = self.partner_tr_customer
+        vals = {}
+        self.account_edi_xml_ubl_tr._resolve_bank_account(tree, partner, vals, [])
+
+        new_created_bank_account = self.env['res.partner.bank'].search([
+            ('partner_id', '=', self.partner_tr_customer.id),
+            ('acc_number', '=', new_iban),
+        ])
+
+        self.assertEqual(vals.get('partner_bank_id'), new_created_bank_account.id,
+                         'Should create and set new bank account based on IBAN.')
+        self.assertEqual(new_created_bank_account.partner_id.id, self.partner_tr_customer.id,
+                         'New bank account should be linked to the correct partner.')
+
+    def test_product_resolution_by_ctsp_number(self):
+        ihracat_tree = self._load_xml_tree(self.xml_templates['ihracat'])
+        tree = self._update_xpath_text(ihracat_tree,
+                                       './/cac:InvoiceLine//cac:Delivery//cac:Shipment//cbc:RequiredCustomsID',
+                                       self.product_with_ctsp.l10n_tr_ctsp_number)
+
+        vals = {}
+        self.account_edi_xml_ubl_tr._resolve_invoice_lines(tree, vals, 'sale', [])
+
+        self.assertIn('invoice_line_ids', vals, 'invoice_line_ids should be in vals after resolving invoice lines.')
+        first_line = vals['invoice_line_ids'][0][2]
+        self.assertEqual(first_line.get('product_id'), self.product_with_ctsp.id,
+                         'Product should be resolved by CTSP number.')
+
+    def test_product_resolution_by_default_code(self):
+        ihracat_tree = self._load_xml_tree(self.xml_templates['ihracat'])
+        tree = self._update_xpath_text(ihracat_tree,
+                                       './/cac:InvoiceLine//cac:Item//cac:SellersItemIdentification//cbc:ID',
+                                       self.product_with_default_code.default_code)
+
+        vals = {}
+        self.account_edi_xml_ubl_tr._resolve_invoice_lines(tree, vals, 'sale', [])
+
+        self.assertIn('invoice_line_ids', vals, 'invoice_line_ids should be in vals after resolving invoice lines.')
+        first_line = vals['invoice_line_ids'][0][2]
+        self.assertEqual(first_line.get('product_id'), self.product_with_default_code.id,
+                         'Product should be resolved by default code.')
+
+    def test_product_resolution_fallback_to_name(self):
+        ihracat_tree = self._load_xml_tree(self.xml_templates['ihracat'])
+        tree = self._update_xpath_text(ihracat_tree,
+                                       './/cac:InvoiceLine//cac:Item//cbc:Description',
+                                       'Fallback Product Name')
+
+        vals = {}
+        self.account_edi_xml_ubl_tr._resolve_invoice_lines(tree, vals, 'sale', [])
+
+        self.assertIn('invoice_line_ids', vals, 'invoice_line_ids should be in vals after resolving invoice lines.')
+        first_line = vals['invoice_line_ids'][0][2]
+        self.assertFalse(first_line.get('product_id'),
+                         'Product should not be resolved by CTSP or default code, fallback to name used.')
+        self.assertEqual(first_line.get('name'), 'Fallback Product Name',
+                         'Product name should be set from the XML description.')
+
+    def test_multi_currency_is_set_from_xml(self):
+        tree = self._load_xml_tree(self.xml_templates['usd_currency'])
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+        self.assertEqual(invoice.currency_id.name, 'USD', 'Invoice currency should be set to USD from XML.')
+
+    def test_innactive_invoice_currency_is_set_active(self):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree, './/cbc:DocumentCurrencyCode', 'BDT')
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+        self.assertTrue(invoice.currency_id.active, 'Inactive currency should be set active when used in invoice.')
+
+    # =====================================================================
+    # Invoice Scenarios
+    # =====================================================================
+
+    # SATIS(Sale)
+    # =====================================================================
+    def test_import_satis(self):
+        invoice = self._create_invoice()
+        tree = copy.deepcopy(self.invoice_basic_sale_einvoice_tree)
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'satis should not be marked as export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'SATIS', 'Invoice type should be SATIS.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        first_line = invoice.invoice_line_ids[0]
+
+        # tax should not be zero
+        self.assertTrue(first_line.tax_ids, 'There should be taxes on the line.')
+        self.assertNotEqual(first_line.tax_ids.amount, 0.0, 'temelfatura_satis should have non-zero tax.')
+
+        # Discount field is set
+        # Not mandatory, but xml has it. So, check if it's set.
+        self.assertGreaterEqual(first_line.discount, 1, 'Discount field should be set on the line.')
+
+    # TEVKIFAT (WITHHOLDING)
+    # =====================================================================
+    def test_import_tevkifat(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['tevkifat'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'Should not be an export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'TEVKIFAT', 'Invoice type should be TEVKIFAT.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        first_line = invoice.invoice_line_ids[0]
+
+        self.assertTrue(first_line.tax_ids)
+        self.assertTrue(first_line.tax_ids.children_tax_ids, 'There should be child taxes for withholding.')
+
+        withholding_taxes = first_line.tax_ids.children_tax_ids.filtered('l10n_tr_tax_withholding_code_id')
+        self.assertTrue(withholding_taxes, 'tevkifat should be a tax with withholding reason')
+
+    # IHRACKAYITLI (Registered for Export)
+    # =====================================================================
+    def test_import_ihrackayitli(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['ihrackayitli'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'Should not be an export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'IHRACKAYITLI', 'Invoice type should be IHRACKAYITLI.')
+        self.assertTrue(invoice.l10n_tr_exemption_code_id, 'ihrackayitli should have an exemption code set.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        first_line = invoice.invoice_line_ids[0]
+
+        self.assertTrue(first_line.tax_ids)
+
+    # ISTISNA (Tax Exempt)
+    # =====================================================================
+    def test_import_istisna(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['istisna'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'Should not be an export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'ISTISNA', 'Invoice type should be ISTISNA.')
+        self.assertTrue(invoice.l10n_tr_exemption_code_id, 'istisna should have an exemption code set.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        first_line = invoice.invoice_line_ids[0]
+
+        self.assertTrue(first_line.tax_ids)
+
+    # IHRACAT (EXPORT)
+    # =====================================================================
+    def test_import_ihracat_export_invoice(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['ihracat'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertTrue(invoice.l10n_tr_is_export_invoice, 'ihracat should be marked as export invoice.')
+        self.assertTrue(invoice.l10n_tr_exemption_code_id, 'ihracat should have an exemption code set.')
+        self.assertTrue(invoice.l10n_tr_shipping_type, 'ihracat should have a shipping type set.')
+        self.assertTrue(invoice.invoice_incoterm_id, 'Incoterm should be set for export invoice.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        for line in invoice.invoice_line_ids:
+            if line.tax_ids:
+                self.assertEqual(line.tax_ids.amount, 0.0, 'Export invoice lines should have 0% tax.')
+
+    def test_credit_note_not_supported_logs_error(self):
+        invoice = self._create_invoice()
+        tree = copy.deepcopy(self.invoice_basic_sale_einvoice_tree)
+
+        logs = self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, qty_factor=-1)
+
+        self.assertTrue(any(
+            'invoice/bill return creation from xml is not supported for tr1.2 ubl format yet.' in log.lower() for log in
+            logs))
+
+    # =====================================================================
+    # FALLBACK → IF CustomizationID != TR1.2
+    # =====================================================================
+
+    @patch('odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20.AccountEdiXmlUbl_20._import_fill_invoice')
+    def test_fallback_to_super_when_not_ubl_tr(self, _import_fill_invoice_mocked):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree, './/cbc:CustomizationID',
+                                       'OTHER-VERSION')
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+        _import_fill_invoice_mocked.assert_called_once()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
Nilvera uses a customized UBL format (UBL TR 1.2) that differs from the standard UBL 2.1 structure.
Odoo's existing decoder only supports UBL 2.1, meaning any UBL TR 1.2 XML fetched, results in an empty or incomplete invoice, as the fields cannot be extracted.

## Current behavior before PR:

- Importing a TR 1.2 invoice (CustomizationID="TR1.2") results in an empty invoice most of the time, because the system attempts to parse it using the UBL 2.1 decoder.

## Desired behavior after PR is merged:

- A dedicated TR 1.2 decoder is introduced to fully support Turkish e-invoice imports for Nilvera.

- The decoder extracts all invoice content based on Customization-ID 1.2(UBL TR):

  - Partner details + fallback partner creation

  - Postal address and country/state resolution

  - Bank account

  - Delivery and export exemption fields

  - Product lookup via default code or CTSP number

  - Line taxes, discounts, and pricing

- Supported scenarios are explicitly limited to:

  - ProfileID: TEMELFATURA, IHRACAT, KAMU

  - InvoiceTypeCode: SATIS, TEVKIFAT, ISTISNA, IHRACKAYITLI

  - Both sale and purchase imports

- The decoder falls back to the base UBL importer when CustomizationID is not TR1.2.

- Comprehensive test cases are added to validate successful imports and edge scenarios.

task-5079559

---------
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)