### PR TITLE
[FIX] packaging: update dockerfile and remove useless sleeps

### DIFF
--- a/setup/package.dfsrc
+++ b/setup/package.dfsrc
@@ -1,7 +1,9 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM debian:bookworm
+FROM ubuntu:noble
 MAINTAINER Odoo S.A. <info@odoo.com>
+
+RUN userdel -r ubuntu
 
 RUN apt-get update && \
 	apt-get install -y locales && \

--- a/setup/package.py
+++ b/setup/package.py
@@ -59,7 +59,6 @@ def run_cmd(cmd, chdir=None, timeout=None):
 
 
 def _rpc_count_modules(addr='http://127.0.0.1', port=8069, dbname='mycompany'):
-    time.sleep(5)
     uid = xmlrpclib.ServerProxy('%s:%s/xmlrpc/2/common' % (addr, port)).authenticate(
         dbname, 'admin', 'admin', {}
     )
@@ -67,7 +66,6 @@ def _rpc_count_modules(addr='http://127.0.0.1', port=8069, dbname='mycompany'):
         dbname, uid, 'admin', 'ir.module.module', 'search', [('state', '=', 'installed')]
     )
     if len(modules) > 1:
-        time.sleep(1)
         toinstallmodules = xmlrpclib.ServerProxy('%s:%s/xmlrpc/2/object' % (addr, port)).execute(
             dbname, uid, 'admin', 'ir.module.module', 'search', [('state', '=', 'to install')]
         )
@@ -255,13 +253,13 @@ class Docker():
         logging.info('Starting to test Odoo install test')
         start_time = time.time()
         while self.is_running() and (time.time() - start_time) < INSTALL_TIMEOUT:
-            time.sleep(5)
+            time.sleep(5)  # give some time for odoo to install and start
             if os.path.exists(os.path.join(args.build_dir, 'odoo.pid')):
                 try:
                     _rpc_count_modules(port=self.exposed_port)
+                    return
                 finally:
                     self.stop()
-                return
         if self.is_running():
             self.stop()
             raise OdooTestTimeoutError('Odoo pid file never appeared after %s sec' % INSTALL_TIMEOUT)


### PR DESCRIPTION
The Dockerfile used for source package is still using the Bookworm distribution as base image. In order to be consistent with the Odoo supported distribution, let's update to Ubuntu Noble.

This commit also removes useless `sleeps` that were hiding a real bug.

It should help declutter #228456

