### PR TITLE
[FIX] payment_stripe, website_sale: use fiscal position in express checkout

### DIFF
--- a/addons/payment_stripe/static/src/js/express_checkout_form.js
+++ b/addons/payment_stripe/static/src/js/express_checkout_form.js
@@ -179,6 +179,9 @@ paymentExpressCheckoutForm.include({
                         },
                     },
                 );
+                this.paymentContext['minorAmount'] = await this.rpc(
+                    this.paymentContext['shippingAddressUpdateRoute'] + '/compute_taxes',
+                );
                 if (availableCarriers.length === 0) {
                     ev.updateWith({status: 'invalid_shipping_address'});
                 } else {

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1780,6 +1780,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return values
 
+    @http.route(
+        _express_checkout_shipping_route + '/compute_taxes', type='json', auth='public',
+        website=True, sitemap=False,
+    )
+    def express_checkout_shipping_address_compute_taxes(self):
+        order_sudo = request.website.sale_get_order()
+        order_sudo._recompute_taxes()
+
+        return payment_utils.to_minor_currency_units(order_sudo.amount_total, order_sudo.currency_id)
+
     def _get_shop_payment_errors(self, order):
         """ Check that there is no error that should block the payment.
 


### PR DESCRIPTION
## Issue:
When a fiscal position should apply based on the address provided during Express Checkout, it was not applied automatically
The correct fiscal position only appeared after reloading the checkout page
This issue affects public users using the eCommerce with Stripe Express Checkout

## Cause:
The fiscal position was correctly determined during the `availableCarriers` computation, but it was not propagated to the payment request itself
As a result, prices and taxes were only updated after a full page reload

## Steps to reproduce:
- Configure Stripe with Express Checkout (e.g., Google Pay)
- Create a fiscal position with automatic detection (Country = US, Tax mapping: 15% → 0%)
- Create a product using the 15% tax
- Go to the website shop and add the product to the cart
- Use Express Checkout with a US address
- Observe that the fiscal position is not applied unless the page is reloaded

opw-5018238