### PR TITLE
[FIX] account: ensure invoice PDF download returns correct document

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6508,6 +6508,9 @@ class AccountMove(models.Model):
         This is necessary to avoid the re-generation of the PDF through the action_report.
         Indeed, once a legal PDF is generated, it should be used and not re-generated.
         """
+        report = self.env['ir.actions.report'].search([('report_name', '=', 'account.report_invoice_with_payments'), ('binding_model_id', '!=', False)], limit=1)
+        if report:
+            return []
         return [{
             'key': 'download_pdf',
             'description': _('PDF'),

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -3,7 +3,7 @@
     <data>
         <!-- QWeb Reports -->
         <record id="account_invoices" model="ir.actions.report">
-            <field name="name">Invoice PDF</field>
+            <field name="name">PDF</field>
             <field name="model">account.move</field>
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice_with_payments</field>
@@ -11,7 +11,8 @@
             <field name="is_invoice_report">True</field>
             <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="attachment"/>
-            <field name="binding_model_id" eval="False"/>  <!-- removes the action from the Print menu (forced False value for update) -->
+            <field name="binding_model_id" ref="model_account_move"/>
+            <field name="binding_type">report</field>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice')),
  (4, ref('account.group_account_readonly'))]"/>
         </record>


### PR DESCRIPTION
## Issue:
In 18.0, downloading an invoice via the Download option returns a proforma PDF
instead of the proper invoice
The PDF (without payment) works as expected

## Cause:
The standard report is hidden and therefore not listed in the Print options
An equivalent report is added  in the Download options by `get_extra_print_items()`
But this action relies on `_get_invoice_legal_documents()`
which only returns the invoice if it was already generated using `Send`

The `Print` button works correctly because it uses the proper report directly

## Steps to reproduce:
- Open an Invoice
- Use the gear to Download > PDF
- The file is a proforma

opw-5111272