### PR TITLE
[FIX] account, account_peppol: prevent invalid XML characters from blocking Peppol sending

### DIFF
--- a/addons/account/tools/dict_to_xml.py
+++ b/addons/account/tools/dict_to_xml.py
@@ -1,4 +1,5 @@
 from lxml import etree
+from odoo.tools.xml_utils import remove_control_characters
 
 
 def dict_to_xml(node, *, nsmap={}, template=None, render_empty_nodes=False, tag=None, path=None):
@@ -66,7 +67,7 @@ def dict_to_xml(node, *, nsmap={}, template=None, render_empty_nodes=False, tag=
     # Add text content if present
     text = node.get('_text')
     if text is not None and text is not False:
-        element.text = str(text)
+        element.text = remove_control_characters(str(text).encode()).decode()
 
     # Add child nodes
     for child_tag, child in node.items():


### PR DESCRIPTION
## Issue:
When a character that's not compatible with XML is in an invoice, and you send it to Peppol, a traceback was raised: `ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters`

## Cause:
`dict_to_xml` converts each invoice field into XML, but certain control characters (e.g., `\x02`) are not allowed in XML according to the specification: https://www.w3.org/TR/xml/#charsets
If such a character appears in the data (e.g., imported through a product CSV), the XML generation crashes

## Steps to produce:
- Install `account_peppol` and `l10n_be` (to get the BE Company CoA)
- Import a product containing a control character:
`echo -e "name,default_code\nTest\x02Product,ABC123" > products.csv`
- Create an invoice for the BE company using the product `Test\x02Product`
- Send it via Send > by Peppol
- A traceback is raised

opw-5114648