### PR TITLE
[FIX] mail: mockUserAgent usage

### DIFF
--- a/addons/mail/static/tests/translation/translation.test.js
+++ b/addons/mail/static/tests/translation/translation.test.js
@@ -134,7 +134,7 @@ test("Toggle message translation on mobile", async () => {
     onRpcBefore("/mail/message/translate", () => {
         return { body: "To bad weather, good face.", lang_name: "Spanish", error: null };
     });
-    mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
+    mockUserAgent("android");
     await start();
     await openFormView("res.partner", partnerId);
     await click("button[title='Expand']");


### PR DESCRIPTION
The `mockUserAgent()` is meant to be used with a "platform" ("mac",
"windows", "android"...) as parameter and not a whole user agent string.

In specific cases, a custom string can be used instead, but only to be
added to the user agent string.

This commit adapts its usage(s) accordingly.