### PR TITLE
[IMP] web: datetime_field: make range optional even when the field is…

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -133,8 +133,8 @@
                         <group>
                             <field name="start_date" widget="daterange" options="{'end_date_field': 'stop_date'}" invisible="not allday" required="allday" readonly="not user_can_edit"/>
                             <field name="start" widget="daterange" options="{'end_date_field': 'stop'}" invisible="allday" required="not allday" readonly="not user_can_edit"/>
-                            <field name="stop_date" invisible="1"/>
-                            <field name="stop" invisible="1" />
+                            <field name="stop_date" required="allday" invisible="1"/>
+                            <field name="stop" required="not allday" invisible="1" />
                             <field name="unavailable_partner_ids" invisible="1" /> <!-- this field will be used in many2many_attendees widget -->
                             <label for="duration" class="fw-bold text-900 opacity-100"/>
                             <div class="d-flex gap-2">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -375,7 +375,7 @@
                                     readonly="state != 'confirm'"
                                     required="not date_from or not date_to"
                                     options="{'end_date_field': 'request_date_to', 'always_range': '1'}"/>
-                                <field name="request_date_to" invisible="1"/> <!-- For Form view test-->
+                                <field name="request_date_to" required="not date_from or not date_to" invisible="1"/> <!-- For Form view test-->
                                 <div>
                                     ( <field name="duration_display" readonly="1" class="w-auto"/> )
                                 </div>

--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
@@ -23,7 +23,7 @@
                         options="{'end_date_field': 'date_end_invoice_timesheet', 'always_range': 'true'}"
                         title="Only timesheets not yet invoiced (and validated, if applicable) from this period will be invoiced. If the period is not indicated, all timesheets not yet invoiced (and validated, if applicable) will be invoiced without distinction."
                     />
-                    <field name="date_end_invoice_timesheet" invisible="1" />
+                    <field name="date_end_invoice_timesheet" required="date_start_invoice_timesheet or date_end_invoice_timesheet" invisible="1" />
                 </group>
             </group>
         </field>

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -65,6 +65,13 @@ export function addFieldDependencies(activeFields, fields, fieldDependencies = [
         if (!("readonly" in field)) {
             field.readonly = true;
         }
+        if (!("required" in field)) {
+            if (field.name in activeFields) {
+                field.required = activeFields[field.name].required; // field already in the view
+            } else if (field.name in fields) {
+                field.required = fields[field.name].required; // check in field definition (model)
+            }
+        }
         if (field.name in activeFields) {
             patchActiveFields(activeFields[field.name], makeActiveField(field));
         } else {
@@ -281,7 +288,9 @@ export function extractFieldsFromArchInfo({ fieldNodes, widgetNodes }, fields) {
         } else {
             activeFields[fieldName] = activeField;
         }
+    }
 
+    for (const fieldNode of Object.values(fieldNodes)) {
         if (fieldNode.field) {
             let fieldDependencies = fieldNode.field.fieldDependencies;
             if (typeof fieldDependencies === "function") {

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -114,7 +114,9 @@ export class DateTimeField extends Component {
                 type: this.field.type,
                 range: this.isRange(value),
                 showRangeToggler:
-                    this.relatedField && !this.props.required && !this.props.alwaysRange,
+                    this.relatedField &&
+                    !this.isRequired(this.relatedField) &&
+                    !this.props.alwaysRange,
                 onToggleRange,
             };
             if (this.props.maxDate) {
@@ -303,8 +305,19 @@ export class DateTimeField extends Component {
         }
         return (
             this.props.alwaysRange ||
-            this.props.required ||
+            this.isRequired(this.relatedField) ||
             ensureArray(value).filter(Boolean).length === 2
+        );
+    }
+
+    /**
+     * @param {string} fieldName
+     * @returns {boolean}
+     */
+    isRequired(fieldName) {
+        return evaluateBooleanExpr(
+            this.props.record.activeFields[fieldName].required,
+            this.props.record.evalContextWithVirtualIds
         );
     }
 
@@ -451,8 +464,7 @@ export const dateField = {
             deps.push({
                 name: options[START_DATE_FIELD_OPTION],
                 type,
-                readonly: false,
-                ...attrs,
+                readonly: attrs.readonly || false,
             });
             if (options[END_DATE_FIELD_OPTION]) {
                 console.warn(
@@ -463,8 +475,7 @@ export const dateField = {
             deps.push({
                 name: options[END_DATE_FIELD_OPTION],
                 type,
-                readonly: false,
-                ...attrs,
+                readonly: attrs.readonly || false,
             });
         }
         return deps;

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -7,7 +7,7 @@
             <t t-if="props.readonly">
                 <span t-if="!isEmpty(startDateField)" class="text-truncate" t-esc="getFormattedValue(0)" t-att-data-tooltip="getFormattedValue(0, true)"/>
             </t>
-            <t t-elif="props.required or props.alwaysRange or !isEmpty(startDateField) or startDateField === props.name">
+            <t t-elif="isRange(values) or isRequired(startDateField) or !isEmpty(startDateField) or startDateField === props.name">
                 <t t-if="picker.activeInput !== startDateField and values[0]">
                     <button 
                         t-ref="start-date" 
@@ -46,7 +46,7 @@
                 <t t-if="props.readonly">
                     <span class="text-truncate" t-esc="getFormattedValue(1)" t-att-data-tooltip="getFormattedValue(1, true)"/>
                 </t>
-                <t t-elif="props.required or props.alwaysRange or !isEmpty(endDateField) or (isEmpty(startDateField) and endDateField === props.name)">
+                <t t-elif="isRange(values) or isRequired(endDateField) or !isEmpty(endDateField) or (isEmpty(startDateField) and endDateField === props.name)">
                     <t t-if="picker.activeInput !== endDateField and values[1]">
                         <button 
                             t-ref="end-date" 


### PR DESCRIPTION
… required

Before this commit, the range was automatically enforced when the main field was required (either in the view or on the field itself). As a result, the button to switch to a date range was hidden and both start and end dates became mandatory.

With this change, the range option remains available and optional. The range will only be required when the related field is required.

task-5186221

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
