### PR TITLE
[FIX] iot_drivers: send last message ID on subscribe

### DIFF
--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -46,7 +46,7 @@ class WebsocketClient(Thread):
             'event_name': 'subscribe',
             'data': {
                 'channels': [],
-                'last': 0,
+                'last': self.last_message_id,
                 'iot_token': helpers.get_token(),
             }
         }))
@@ -55,6 +55,7 @@ class WebsocketClient(Thread):
         """Synchronously handle messages received by the websocket."""
         for message in json.loads(messages):
             _logger.debug("websocket received a message: %s", pprint.pformat(message))
+            self.last_message_id = message["id"]
             payload = message['message']['payload']
             message_type = message['message']['type']
 
@@ -86,6 +87,7 @@ class WebsocketClient(Thread):
         self.websocket_url = urllib.parse.urlunsplit((scheme, url_parsed.netloc, 'websocket', '', ''))
         self.db_name = system.get_conf('db_name') or ''
         self.session_id = ''
+        self.last_message_id = 0
         super().__init__()
 
     def run(self):


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/100121

Before this commit, there was a chance that if the websocket was disconnected, the IoT box could miss a message sent to it.

After this commit, we keep track of the last message ID we received and send this along with the subscribe message, this way the server will send us any messages we missed during the downtime.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
