### PR TITLE
[FIX] l10n_sa_edi: invoice template css exchange rate

### DIFF
--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -6,7 +6,7 @@
 
             <!--    Add Currency Exchange rate if different currency than SAR    -->
             <xpath expr="//div[@name='exchange_rate']/.." position="attributes">
-                <attribute name="class" t-if="o.company_id.country_id.code == 'SA'">d-none</attribute>
+                <attribute name="t-att-class">'d-none' if o.company_id.country_id.code == 'SA' else 'row clearfix ms-auto text-nowrap border-top border-bottom p-2'</attribute>
             </xpath>
             <xpath expr="//div[hasclass('clearfix')]" position="after">
                 <table t-if="o.company_id.country_id.code == 'SA' and o.currency_id != o.company_id.currency_id"


### PR DESCRIPTION
Steps to reproduce:
- install l10n_ae
- switch to AE company
- create an invoice with a currency != AED and print -> exchange rate shows
- install l10n_sa_edi
- print the invoice with the AE company

-> in 17.0, the exchange rate is missing
-> in 18.0, the template is broken

The same fix can be applied for both 17.0 and 18.0. The main issue is that l10n_gcc_invoice is a template for 5 different countries, and all of them inherit it without primary=True, which results in many conflicts if several of these countries are installed on the database. Here, we only try to solve the most apparent issue, which is the broken template for the exchange rates. Note that in 19, a major PR has been fixing this inheriting issue: https://github.com/odoo/odoo/commit/1cddcab8b8626b34c437a51d320b0a3e4698dae7

opw-5215971

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
