### PR TITLE
[FIX] web: Prevent loading previous page when currently on first page

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -224,7 +224,7 @@ export class StaticList extends DataPoint {
             await this._applyCommands([[x2ManyCommands.DELETE, record.resId || record._virtualId]]);
             // All records of last page are deleted => reload the new last page
             if (this.count === this.offset) {
-                await this._load({ offset: this.offset - this.limit });
+                await this._load({ offset: Math.max(this.offset - this.limit, 0) });
             }
             await this._onUpdate();
         });

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -955,6 +955,40 @@ test("delete all records in last page (in field o2m inline list view)", async ()
     expect(".o_x2m_control_panel .o_pager").toHaveText("1-2 / 3");
 });
 
+test("delete all records then repopulate", async () => {
+    Partner._records[0].turtles = [1];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="turtles">
+                    <list editable="bottom" default_order="turtle_int">
+                        <field name="turtle_int" widget="handle"/>
+                        <field name="turtle_foo"/>
+                    </list>
+                </field>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_data_row").toHaveCount(1);
+    await contains(".o_list_record_remove").click();
+    expect(".o_data_row").toHaveCount(0);
+    await contains(".o_field_x2many_list_row_add a").click();
+    await contains(".o_field_one2many .o_list_renderer tbody input").edit("value 1", {
+        confirm: "blur",
+    });
+    expect(".o_data_row").toHaveCount(1);
+    await contains(".o_field_x2many_list_row_add a").click();
+    await contains(".o_field_one2many .o_list_renderer tbody input").edit("value 2", {
+        confirm: "blur",
+    });
+    expect(".o_data_row").toHaveCount(2);
+    await contains("tbody tr:eq(1) .o_handle_cell").dragAndDrop("tbody tr");
+    expect(".o_data_row").toHaveCount(2);
+    expect(queryAllTexts(".o_data_cell.o_list_char")).toEqual(["value 2", "value 1"]);
+});
+
 test.tags("desktop");
 test("nested x2manys with inline form, but not list", async () => {
     Turtle._views = { list: `<list><field name="turtle_foo"/></list>` };


### PR DESCRIPTION
****Behavior:****
**Current:**
When adding an element to any reorderable empty list, then deleting it, then adding two new ones, and lastly trying to reorder them. They will disappear until you reload the list.

This is occurring since list can be presented in multiple pages, the length of which is defined by the variable limit and the current page is represented by offset (multiple of limit) and when the last element of a page is deleted, we load the previous page (deduce limit from offset), the issue is that there isnt any checks that we are not currently on the first page of the list, and thus we change offset to a negative number (0-limit) which results in an empty list when trying to load the ids of the records (which happens when we reorder the list, and not when adding new elements which explains why they only disappear at that moment)

**Steps to reproduce:**
(example with sale orders but works with any manually sortable list)
- Create a Sale Order
- Add any product
- Delete it
- Add any two combination of product or sections
- Swap the order of both
- You'll see the elements disappear, when reloading the page they should come back.

opw-5191103