### PR TITLE
[FIX] pos_self_order: improve preparation ticket layout for self-orders

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -511,6 +511,9 @@ export class SelfOrder extends Reactive {
                     },
                     preset_name: order.preset_id?.name || "",
                     preset_time: order.presetDateTime,
+                    config_name: this.config.name,
+                    table_number: this.currentTable?.table_number,
+                    floating_order_name: order.floating_order_name,
                 };
                 const receipt = renderToElement("pos_self_order.OrderChangeReceipt", {
                     changes: printingChanges,

--- a/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
@@ -2,24 +2,30 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="pos_self_order.OrderChangeReceipt">
-        <div class="pos-receipt">
-            <div class="pos-receipt-title" t-if="changes.preset_name">
-                    <t t-esc="changes.preset_name"/> <t t-if="changes.preset_time">(<t t-esc="changes.preset_time"/>)</t>
-            </div>
-            <div class="pos-receipt-order-data"><t t-esc="changes.name"/></div>
-            <t t-if="changes.tracker || changes.trackingNumber">
-                <br />
-                <div class="pos-receipt-title">
-                    <t t-esc="changes.trackingNumber"/>
-                    <t t-if="changes.tracker">
-                        / Tracker number: <t t-esc="changes.tracker"/>
-                    </t>
+        <div class="pos-receipt m-0 p-0 pt-5">
+            <div class="receipt-header text-center">
+                <div class="pos-receipt-title" t-if="changes.preset_name">
+                    <t t-esc="changes.preset_name"/>
+                    <br/>
+                    <t t-if="changes.preset_time">(<t t-esc="changes.preset_time"/>)</t>
                 </div>
-            </t>
-            <br />
+                <div style="font-size: 78%;">
+                    <t t-out="changes.config_name + ' : ' + changes.time.hours + ':' + changes.time.minutes"/>
+                    <br/>
+                </div>
+                <span class="my-4" style="font-size: 150%;">
+                    <strong t-if="changes.table_number">Self-Order T <t t-esc="changes.table_number"/></strong>
+                    <strong t-elif="changes.tracker">Kiosk T <t t-esc="changes.tracker"/></strong>
+                    <strong t-else=""> Order <t t-if="changes.floating_order_name" t-esc="changes.floating_order_name"/></strong>
+                    <strong t-if="changes.trackingNumber" class="fw-light my-3">
+                        # <t t-esc="changes.trackingNumber"/>
+                    </strong>
+                </span>
+                <div class="pos-receipt-order-data" t-esc="changes.name"/>
+            </div>
+            <hr style="border: none; border-top: 4px dashed black;"/>
             <div class="pos-receipt-title">
                 NEW
-                <t t-esc='changes.time.hours'/>:<t t-esc='changes.time.minutes'/>
             </div>
             <br />
             <t t-foreach="changes.new" t-as="change" t-key="change_index">


### PR DESCRIPTION
Before this commit:
===================
- Some details were missing from the preparation tickets, such as the table number and configuration name.
- The order reference and time were not displayed in the correct positions.

After this commit:
==================
- Added the configuration name and table number to the receipt.
- Corrected the placement of the order reference and time.


Task: 5268966

| Before this PR | After this PR |
|--------|--------|
| <img width="511" height="431" alt="before" src="https://github.com/user-attachments/assets/ac5b2c45-5210-4a4e-86c7-953e2ab89eb1" /> |<img width="514" height="448" alt="after" src="https://github.com/user-attachments/assets/f1feb317-d5fe-469a-ab70-cf1dd793dce5" />|
