### PR TITLE
[REF] {,stock_}account: Remove journal_line_ids field

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -191,16 +191,6 @@ class AccountMove(models.Model):
         copy=True,
     )
 
-    # /!\ Deprecated! Kept in stable, but will be removed in master.
-    journal_line_ids = fields.One2many(
-        comodel_name='account.move.line',
-        inverse_name='move_id',
-        string='Journal Items (DEPRECATED)',
-        copy=False,
-        domain=[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))],
-        exportable=False,
-    )
-
     # === Link to the partial that created this exchange move === #
     exchange_diff_partial_ids = fields.One2many(
         comodel_name='account.partial.reconcile',
@@ -3821,7 +3811,7 @@ class AccountMove(models.Model):
         self._check_user_access([vals])
 
         unmodifiable_fields = [
-            'line_ids', 'invoice_line_ids', 'journal_line_ids',
+            'line_ids', 'invoice_line_ids',
             'date', 'invoice_date',
             'partner_id', 'fiscal_position_id',
             'invoice_payment_term_id',

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2900,7 +2900,7 @@ class TestStockValuation(TestStockValuationCommon):
         invoice = self._create_invoice(self.product_avco_auto, quantity=10, price_unit=100, product_uom=self.env.ref('uom.product_uom_pack_6'))
         self.assertEqual(self.product_avco_auto.standard_price, 10)
         self.assertRecordValues(
-            invoice.journal_line_ids,
+            invoice.line_ids,
             [
                 {'account_id': self.category_avco_auto.property_account_income_categ_id.id, 'credit': 1000.0, 'debit': 0.0},
                 {'account_id': self.account_receivable.id, 'credit': 0.0, 'debit': 1000.0},


### PR DESCRIPTION
As a followup to https://github.com/odoo/odoo/commit/f54dd97883152aca9c9d5de87fbb6e2d3399676f, we are now removing the `journal_line_ids` field from the `account.move` table.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
