### PR TITLE
[FIX] utm: restrict records creation to non public users

### DIFF
--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -92,7 +92,7 @@ class UtmMixin(models.AbstractModel):
         if cleaned_name:
             record = Model.with_context(active_test=False).search([('name', '=ilike', cleaned_name)], limit=1)
 
-        if not record:
+        if not record and not self.env.user._is_public():
             # No record found, create a new one
             record_values = {'name': cleaned_name}
             if 'is_auto_campaign' in record._fields:


### PR DESCRIPTION
**Steps to reproduce:**
- Install Link Tracker app
- Go to Link Tracker > UTMs
- Check UTM existing records (campaign, source, medium)
- None exist with the name "test"
- Go as a visitor on the event website
- Open a register event link on the website (e.g. `/event/live-music-festival-4/register`)
- Add UTM to the URL to simulate a marketing flow (e.g. `?utm_source=test&utm_medium=test&utm_campaign=test`)
- Register to the event
- Open the event on backend side
- Check attendees and find the new one
- Check the marketing section in debug mode
- New records were created and added for the UTM values

**Issue:**
No access rights are checked when making the registration and updating the utm values. When not found they are added to existing ones during the `default_get` with `_find_or_create_record`.

`return request.env['event.registration'].sudo().create(registrations_to_create)`

This means that public users (visitors of the website) can create unwanted utm records when registering via expired/malformed/altered links.

**Fix:**
Restrict the issue to non public users for now. Might need to apply access rules and avoid the sudo.

opw-4948208