### PR TITLE
[FIX] hr_work_entry: Fix archive and add active employees filter in work entries

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -15,6 +15,7 @@
         <field name="res_model">hr.work.entry</field>
         <field name="path">work-entries</field>
         <field name="view_mode">list,form,pivot</field>
+        <field name="context">{'search_default_active_employees': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No data to display
@@ -192,7 +193,8 @@
                 <filter name="group_work_entry_type" string="Type" context="{'group_by': 'work_entry_type_id'}"/>
                 <filter name="group_start_date" string="Date" context="{'group_by': 'date'}"/>
                 <separator/>
-                <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+                <filter name="active_employees" string="Active" domain="[('employee_id.active', '=', True)]"/>
+                <filter name="archived" string="Archived" domain="[('employee_id.active', '=', False)]"/>
             </search>
         </field>
     </record>


### PR DESCRIPTION
Before this commit:
The archive filter in work entries display canceled work entries. There is no way to display work entries for active employees only. After this commit:
The archive filter will display work entries of archived employees. The default search filter will be displaying the work entries of active employees only.

task-5349302

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
