### PR TITLE
[FIX] account_edi_ubl_cii, l10n_fr_facturx_chorus_pro: banner to install module

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, _
+from odoo import _, api, models
 from odoo.tools.misc import str2bool
 from odoo.addons.account.tools import dict_to_xml
 from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import FloatFmt, UBL_NAMESPACES
 
 from stdnum.no import mva
+
+CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
 
 
 class AccountEdiXmlUBLBIS3(models.AbstractModel):
@@ -26,6 +28,10 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     Thus, EHF 3 and Bis 3 are actually the same format. The specific rules for NO defined in Bis 3 are added in Bis 3.
     """
+
+    @api.model
+    def _is_customer_behind_chorus_pro(self, customer):
+        return customer.peppol_eas and customer.peppol_endpoint and f"{customer.peppol_eas}:{customer.peppol_endpoint}" == CHORUS_PRO_PEPPOL_ID
 
     # -------------------------------------------------------------------------
     # EXPORT

--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -45,6 +45,19 @@ class AccountMoveSend(models.AbstractModel):
                     'action_text': _("View Partner(s)"),
                     'action': not_configured_partners._get_records_action(name=_("Check Partner(s)"))
                 }
+
+            if any(
+                    self.env['account.edi.xml.ubl_bis3']._is_customer_behind_chorus_pro(partner)
+                    for partner in peppol_format_moves.partner_id.commercial_partner_id
+                ):
+                chorus_pro = self.env['ir.module.module'].sudo().search([('name', '=', 'l10n_fr_facturx_chorus_pro')], limit=1)
+                if chorus_pro and chorus_pro.state != 'installed':
+                    alerts['account_edi_ubl_cii_chorus_pro_install'] = {
+                        'message': _("Please install the french Chorus pro module to have all the specific rules."),
+                        'level': 'info',
+                        'action': chorus_pro._get_records_action(),
+                        'action_text': _("Install Chorus Pro"),
+                    }
         return alerts
 
     # -------------------------------------------------------------------------

--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -1,6 +1,4 @@
-from odoo import api, models, _
-
-CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
+from odoo import _, models
 
 
 class AccountEdiXmlUBLBIS3(models.AbstractModel):
@@ -10,10 +8,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
     See Pagero documentation: https://www.pagero.com/onboarding/aife/aife-en#requirements
     Chorus Pro documentation: https://communaute.chorus-pro.gouv.fr/wp-content/uploads/2017/07/Specifications_Externes_Annexe_EDI_V4.22.pdf
     """
-
-    @api.model
-    def _is_customer_behind_chorus_pro(self, customer):
-        return customer.peppol_eas and customer.peppol_endpoint and f"{customer.peppol_eas}:{customer.peppol_endpoint}" == CHORUS_PRO_PEPPOL_ID
 
     def _export_invoice_vals(self, invoice):
         """

--- a/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
@@ -3,7 +3,7 @@ from lxml import etree
 from odoo import Command
 from odoo.tests import tagged
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.addons.l10n_fr_facturx_chorus_pro.models.account_edi_xml_ubl_bis3 import CHORUS_PRO_PEPPOL_ID
+from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_bis3 import CHORUS_PRO_PEPPOL_ID
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')


### PR DESCRIPTION
This commit will add an alert when the customer use Chorus pro but don't have the module installed, and so don't have all the additional checks

<img width="982" height="242" alt="image" src="https://github.com/user-attachments/assets/fc35d4ee-9a8b-41b8-8ee3-cbc32b266379" />

task-5223874




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
