### PR TITLE
[FIX] web: datetime_field: make range optional even when the field is…

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -133,8 +133,8 @@
                         <group>
                             <field name="start_date" widget="daterange" options="{'end_date_field': 'stop_date'}" invisible="not allday" required="allday" readonly="not user_can_edit"/>
                             <field name="start" widget="daterange" options="{'end_date_field': 'stop'}" invisible="allday" required="not allday" readonly="not user_can_edit"/>
-                            <field name="stop_date" invisible="1"/>
-                            <field name="stop" invisible="1" />
+                            <field name="stop_date" required="allday" invisible="1"/>
+                            <field name="stop" required="not allday" invisible="1" />
                             <field name="unavailable_partner_ids" invisible="1" /> <!-- this field will be used in many2many_attendees widget -->
                             <label for="duration" class="fw-bold text-900 opacity-100"/>
                             <div class="d-flex gap-2">

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -66,6 +66,13 @@ export function addFieldDependencies(activeFields, fields, fieldDependencies = [
         if (!("readonly" in field)) {
             field.readonly = true;
         }
+        if (!("required" in field)) {
+            if (field.name in activeFields) {
+                field.required = activeFields[field.name].required; // field already in the view
+            } else if (field.name in fields) {
+                field.required = fields[field.name].required; // check in field definition (model)
+            }
+        }
         if (field.name in activeFields) {
             patchActiveFields(activeFields[field.name], makeActiveField(field));
         } else {

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -113,7 +113,12 @@ export class DateTimeField extends Component {
                 type: this.field.type,
                 range: this.isRange(value),
                 showRangeToggler:
-                    this.relatedField && !this.props.required && !this.props.alwaysRange,
+                    this.relatedField &&
+                    !evaluateBooleanExpr(
+                        this.props.record.activeFields[this.relatedField].required,
+                        this.props.record.evalContextWithVirtualIds
+                    ) &&
+                    !this.props.alwaysRange,
                 onToggleRange,
             };
             if (this.props.maxDate) {
@@ -287,7 +292,10 @@ export class DateTimeField extends Component {
         }
         return (
             this.props.alwaysRange ||
-            this.props.required ||
+            evaluateBooleanExpr(
+                this.props.record.activeFields[this.relatedField].required,
+                this.props.record.evalContextWithVirtualIds
+            ) ||
             ensureArray(value).filter(Boolean).length === 2
         );
     }
@@ -435,8 +443,7 @@ export const dateField = {
             deps.push({
                 name: options[START_DATE_FIELD_OPTION],
                 type,
-                readonly: false,
-                ...attrs,
+                readonly: attrs.readonly || false,
             });
             if (options[END_DATE_FIELD_OPTION]) {
                 console.warn(
@@ -447,8 +454,7 @@ export const dateField = {
             deps.push({
                 name: options[END_DATE_FIELD_OPTION],
                 type,
-                readonly: false,
-                ...attrs,
+                readonly: attrs.readonly || false,
             });
         }
         return deps;

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -7,7 +7,7 @@
             <t t-if="props.readonly">
                 <span t-if="!isEmpty(startDateField)" class="text-truncate" t-esc="getFormattedValue(0)" t-att-data-tooltip="getFormattedValue(0, true)"/>
             </t>
-            <t t-elif="props.required or props.alwaysRange or !isEmpty(startDateField) or startDateField === props.name">
+            <t t-elif="props.record.fields[startDateField].required or props.alwaysRange or !isEmpty(startDateField) or startDateField === props.name">
                 <t t-if="picker.activeInput !== startDateField and values[0]">
                     <button 
                         t-ref="start-date" 
@@ -45,7 +45,7 @@
                 <t t-if="props.readonly">
                     <span class="text-truncate" t-esc="getFormattedValue(1)" t-att-data-tooltip="getFormattedValue(1, true)"/>
                 </t>
-                <t t-elif="props.required or props.alwaysRange or !isEmpty(endDateField) or (isEmpty(startDateField) and endDateField === props.name)">
+                <t t-elif="props.record.fields[endDateField].required or props.alwaysRange or !isEmpty(endDateField) or (isEmpty(startDateField) and endDateField === props.name)">
                     <t t-if="picker.activeInput !== endDateField and values[1]">
                         <button 
                             t-ref="end-date" 

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -687,8 +687,9 @@ test("related end date, both start date and end date empty", async () => {
     expect(".o_toggle_range").toHaveCount(0);
 });
 
-test("required: related end date, both start date and end date empty", async () => {
+test("required: related end date not required, both start date and end date empty", async () => {
     Partner._records[0].datetime = false;
+    Partner._fields.datetime_end.required = false;
 
     await mountView({
         type: "form",
@@ -701,44 +702,56 @@ test("required: related end date, both start date and end date empty", async () 
         resId: 1,
     });
 
-    expect(".o_field_daterange input").toHaveCount(1);
-    expect(".o_field_daterange input:eq(0)").toHaveAttribute("data-field", "datetime");
-    expect(".o_field_daterange input:eq(0)").toHaveValue("");
-    expect(".o_toggle_range").toHaveCount(0);
-    await contains(".o_field_boolean input").click();
-    expect(".o_field_daterange input").toHaveCount(2);
-    expect(".o_field_daterange input:eq(0)").toHaveAttribute("data-field", "datetime");
-    expect(".o_field_daterange input:eq(0)").toHaveValue("");
-    expect(".o_field_daterange input:eq(1)").toHaveAttribute("data-field", "datetime_end");
-    expect(".o_field_daterange input:eq(1)").toHaveValue("");
-    expect(".o_toggle_range").toHaveCount(0);
-    await contains(".o_field_daterange input:eq(0)").edit("06/06/2023 12:00:00");
-    expect(".o_field_daterange input").toHaveCount(2);
-    expect(".o_field_daterange input:eq(0)").toHaveAttribute("data-field", "datetime");
-    expect(".o_field_daterange input:eq(0)").toHaveValue("06/06/2023 12:00:00");
-    expect(".o_field_daterange input:eq(1)").toHaveAttribute("data-field", "datetime_end");
-    expect(".o_field_daterange input:eq(1)").toHaveValue("");
-    expect(".o_toggle_range").toHaveCount(0);
-    await contains(".o_field_daterange input:eq(1)").edit("07/07/2023 13:00:00");
-    expect(".o_field_daterange input").toHaveCount(0);
-    expect(".o_field_daterange button").toHaveCount(2);
-    expect(".o_field_daterange button:eq(0)").toHaveAttribute("data-field", "datetime");
-    expect(".o_field_daterange button:eq(0)").toHaveValue("06/06/2023 12:00:00");
-    expect(".o_field_daterange button:eq(1)").toHaveAttribute("data-field", "datetime_end");
-    expect(".o_field_daterange button:eq(1)").toHaveValue("07/07/2023 13:00:00");
-    expect(".o_toggle_range").toHaveCount(0);
-    await contains(".o_field_daterange button[data-field=datetime]").click();
-    await contains(".o_field_daterange input[data-field=datetime]").clear();
-    expect(".o_field_daterange input").toHaveCount(1);
-    expect(".o_field_daterange input").toHaveAttribute("data-field", "datetime");
-    expect(".o_field_daterange input").toHaveValue("");
-    expect(".o_field_daterange button").toHaveAttribute("data-field", "datetime_end");
-    expect(".o_field_daterange button").toHaveValue("07/07/2023 13:00:00");
-    expect(".o_toggle_range").toHaveCount(0);
+    expect(".o_field_daterange [data-field]").toHaveCount(1, {
+        message: "Only one field displayed because related field is optional",
+    });
+    // Open the picker
+    await contains(".o_field_daterange input[data-field=datetime]").click();
+    await animationFrame();
+    expect(".o_toggle_range").toHaveCount(1, { message: "range is optional" });
 
-    // Open the picker, this checks that props validation for the picker isn't
-    // broken by required being present
-    await contains(".o_field_daterange input:eq(0)").click();
+    await contains(".o_field_boolean input").click();
+    expect(".o_field_daterange [data-field]").toHaveCount(1, {
+        message:
+            "Only one field displayed because `datetime` is required but related field should stay optional",
+    });
+    // Open the picker
+    await contains(".o_field_daterange input[data-field=datetime]").click();
+    await animationFrame();
+    expect(".o_toggle_range").toHaveCount(1, { message: "range is still optional" });
+});
+
+test("required: related end date required, both start date and end date empty", async () => {
+    Partner._records[0].datetime = false;
+    Partner._fields.datetime_end.required = true;
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="bool_field"/>
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}" required="bool_field"/>
+            </form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_daterange [data-field]").toHaveCount(2, {
+        message: "Two fields are displayed because related field is required",
+    });
+    // Open the picker
+    await contains(".o_field_daterange input[data-field=datetime]").click();
+    await animationFrame();
+    expect(".o_toggle_range").toHaveCount(0, { message: "range is mandatory" });
+
+    await contains(".o_field_boolean input").click();
+    expect(".o_field_daterange [data-field]").toHaveCount(2, {
+        message: "Two fields are displayed because `datetime` and related field are required",
+    });
+    // Open the picker
+    await contains(".o_field_daterange input[data-field=datetime]").click();
+    await animationFrame();
+    expect(".o_toggle_range").toHaveCount(0, { message: "range is mandatory" });
 });
 
 test("related start date, both start date and end date empty", async () => {


### PR DESCRIPTION
… required

Before this commit, the range was automatically enforced when the main field was required (either in the view or on the field itself). As a result, the button to switch to a date range was hidden and both start and end dates became mandatory.

With this change, the range option remains available and optional. The range will only be required when the related field is required.

task-5186221

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
