### PR TITLE
[FIX] barcodes_gs1_nomenclature: fix GS1 barcode date error message formatting

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -55,7 +55,7 @@ class BarcodeNomenclature(models.Model):
                 date = datetime.datetime.strptime(str(year) + gs1_date[2:], '%Y%m%d')
             except ValueError as e:
                 raise ValidationError(_(
-                    "A GS1 barcode nomenclature pattern was matched. However, the barcode failed to be converted to a valid date: '%(error_message)'",
+                    "A GS1 barcode nomenclature pattern was matched. However, the barcode failed to be converted to a valid date: '%(error_message)s'",
                     error_message=e
                 ))
         return date.date()

--- a/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
@@ -26,6 +26,12 @@ class TestBarcodeGS1Nomenclature(TransactionCase):
         self.assertEqual(date.month, 2)
         self.assertEqual(date.year, 2020)
 
+        # GS1 barcode with invalid date
+        date_gs1 = "410551"
+        # The value should fail the GS1 date conversion logic and must raise a ValidationError.
+        with self.assertRaises(ValidationError):
+            barcode_nomenclature.gs1_date_to_date(date_gs1)
+
     def test_gs1_extanded_barcode_1(self):
         barcode_nomenclature = self.env['barcode.nomenclature'].browse(self.ref('barcodes_gs1_nomenclature.default_gs1_nomenclature'))
         # (01)94019097685457(10)33650100138(3102)002004(15)131018


### PR DESCRIPTION
**Steps to reproduce:**
1. Install Inventory.
2. Open Inventory → Configuration
3. Barcode Nomenclature and select the default GS1 Nomenclature.
4. Open Barcode → scan the code:154105510000000244.

**Observation:**
- Scanning a GS1 barcode with an invalid date crashes Odoo and raises a traceback.

**Cause:**
- The translated ValidationError message uses the wrong interpolation syntax:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py#L58
and therefore fails during rendering.

- Correct syntax should be:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/account/models/account_move.py#L5647

**Fix:**
- Fix faulty interpolation placeholder in  ValidationError message to use `%(error_message)s` instead of `'%(error_message)'`, preventing the traceback and allowing the error message to display correctly.

**opw-5253564**