### PR TITLE
[IMP] hr_skills: hide certification tab when we don't have any certification types

### DIFF
--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -21,6 +21,7 @@ class HrEmployee(models.Model):
         compute='_compute_current_employee_skill_ids', readonly=False)
     skill_ids = fields.Many2many('hr.skill', compute='_compute_skill_ids', store=True, groups="hr.group_hr_user")
     certification_ids = fields.One2many('hr.employee.skill', compute='_compute_certification_ids', readonly=False)
+    display_certification_page = fields.Boolean(compute="_compute_display_certification_page")
 
     @api.depends('employee_skill_ids')
     def _compute_current_employee_skill_ids(self):
@@ -37,6 +38,9 @@ class HrEmployee(models.Model):
     def _compute_certification_ids(self):
         for employee in self:
             employee.certification_ids = employee.employee_skill_ids.filtered('is_certification')
+
+    def _compute_display_certification_page(self):
+        self.display_certification_page = bool(self.env['hr.skill.type'].search_count([('is_certification', '=', True)], limit=1))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_skills/models/hr_employee_public.py
+++ b/addons/hr_skills/models/hr_employee_public.py
@@ -11,3 +11,4 @@ class HrEmployeePublic(models.Model):
         domain=[('skill_type_id.active', '=', True)])
     current_employee_skill_ids = fields.One2many('hr.employee.skill', related='employee_id.current_employee_skill_ids')
     certification_ids = fields.One2many('hr.employee.skill', related='employee_id.certification_ids')
+    display_certification_page = fields.Boolean(related="employee_id.display_certification_page")

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -139,7 +139,7 @@
                 </field>
             </div>
             <page name="resume" position="after">
-                <page name="certification" string="Certifications">
+                <page name="certification" string="Certifications" invisible="not display_certification_page">
                     <field name="certification_ids" mode="list" widget="one2many" nolabel="1" context="{'form_view_ref': 'hr_skills.employee_skill_view_inherit_certificate_form', 'dialog_size': 'large', 'default_employee_id': id, 'certificate_skill': True}">
                         <list
                             decoration-muted="valid_to and valid_to &lt; context_today().strftime('%Y-%m-%d')">


### PR DESCRIPTION
### Steps to Reproduce
1. Disable "Certification" on all Skill Types.
2. Open an Employee form and click "Add a line" in the Certifications tab.
3. The modal is blank, and saving triggers a "Missing required fields" error.

### Reason
The form needs a list of Certification Types to work. When that list is empty, the form is broken, but the tab was still shown to the user.

### Solution
Hide the "Certifications" tab entirely if no enabled certification types exist in the database.

Task: 5349249