### PR TITLE
[FIX] html_builder, html_editor: clean invalid characters in monetary fields

### DIFF
--- a/addons/html_builder/static/src/plugins/monetary_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/monetary_field_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { registry } from "@web/core/registry";
 
 const monetarySel = "[data-oe-field][data-oe-type=monetary]";
@@ -10,6 +11,12 @@ export class MonetaryFieldPlugin extends Plugin {
     resources = {
         content_editable_selectors: `${monetarySel} .oe_currency_value`,
         content_not_editable_selectors: monetarySel,
+
+        /** Handlers */
+        beforeinput_handlers: this.onBeforeInput.bind(this),
+
+        /** Processors */
+        clipboard_paste_text_processors: this.processUnsupportedHtmlForPaste.bind(this),
     };
 
     setup() {
@@ -37,6 +44,40 @@ export class MonetaryFieldPlugin extends Plugin {
                         .some((node) => amountEl.contains(node))
             )
         );
+    }
+
+    /**
+     * INPUT VALIDATION FOR MONETARY FIELDS
+     * Allowed characters:
+     *  - digits: 0-9
+     *  - "." and ","
+     *
+     * Why allow "." and "," any number of times?
+     * Because each locale uses them differently:
+     *  - US:     "." = decimal, "," = grouping separator
+     *  - Europe: "," = decimal, "." = grouping separator
+     *
+     * Note: Any invalid numeric pattern (wrong decimal/grouping usage) is
+     * validated later on the server when the value is parsed.
+     */
+    onBeforeInput(ev) {
+        const monetaryField = closestElement(ev.target, `${monetarySel} .oe_currency_value`);
+        if (!monetaryField || !ev.data) {
+            return;
+        }
+
+        const isValidInput = /\d/.test(ev.data) || ev.data === "." || ev.data === ",";
+        if (!isValidInput) {
+            ev.preventDefault();
+        }
+    }
+
+    processUnsupportedHtmlForPaste(selection, text) {
+        const monetaryField = closestElement(
+            selection.anchorNode,
+            `${monetarySel} .oe_currency_value`
+        );
+        return monetaryField ? text.replace(/[^\d.,]/g, "") : text;
     }
 }
 

--- a/addons/html_builder/static/tests/monetary_field.test.js
+++ b/addons/html_builder/static/tests/monetary_field.test.js
@@ -1,6 +1,8 @@
 import { setupHTMLBuilder } from "@html_builder/../tests/helpers";
-import { expect, test, describe } from "@odoo/hoot";
-import { click, queryOne } from "@odoo/hoot-dom";
+import { expect, test, describe, animationFrame } from "@odoo/hoot";
+import { click, manuallyDispatchProgrammaticEvent, queryOne } from "@odoo/hoot-dom";
+import { pasteText } from "@html_editor/../tests/_helpers/user_actions";
+import { nodeSize } from "@html_editor/utils/position";
 
 describe.current.tags("desktop");
 
@@ -27,4 +29,69 @@ test("clicking on the monetary field should select the amount", async () => {
             queryOne(":iframe span.oe_currency_value")
         )
     ).toBe(true, { message: "value of monetary field is selected" });
+});
+
+test("should restrict the monetary field to digits, dot, and comma only", async () => {
+    const { getEditor } = await setupHTMLBuilder(
+        `<span data-oe-model="product.template" data-oe-id="9" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price">
+            $<span class="span-in-currency"/>&nbsp;<span class="oe_currency_value">5,000</span>
+        </span>`
+    );
+
+    const editor = getEditor();
+    const monetaryField = queryOne(":iframe span.span-in-currency span.oe_currency_value");
+
+    // Cursor at end of monetary field.
+    editor.shared.selection.focusEditable();
+    editor.shared.selection.setSelection({
+        anchorNode: monetaryField,
+        anchorOffset: nodeSize(monetaryField),
+    });
+    await animationFrame();
+
+    const testCharacters = [",", "1", "2", "3", ",", "4", "5", "6", ".", "7", "a", "$"];
+
+    for (const char of testCharacters) {
+        // Dispatch a beforeinput event to validate the character.
+        const [beforeinputEvent] = await manuallyDispatchProgrammaticEvent.silent(
+            monetaryField,
+            "beforeinput",
+            {
+                inputType: "insertText",
+                data: char,
+            }
+        );
+
+        // If the character is blocked, skip insertion.
+        if (!beforeinputEvent.defaultPrevented) {
+            editor.document.execCommand("insertText", false, char);
+        }
+    }
+
+    expect(monetaryField.textContent).toBe("5,000,123,456.7");
+});
+
+test("should keep only digits, dot, and comma when pasting into a monetary field", async () => {
+    const { getEditor } = await setupHTMLBuilder(
+        `<span data-oe-model="product.template" data-oe-id="9" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price">
+            $<span class="span-in-currency"/>&nbsp;<span class="oe_currency_value">750.00</span>
+        </span>`
+    );
+
+    const editor = getEditor();
+    const monetaryField = queryOne(":iframe span.span-in-currency span.oe_currency_value");
+
+    // Select the entire monetary field.
+    await click(monetaryField);
+    await animationFrame();
+    expect(editor.shared.selection.areNodeContentsFullySelected(monetaryField)).toBe(true);
+
+    pasteText(editor, "1.234.56 extra text 7.891");
+    expect(monetaryField).toHaveText("1.234.567.891");
+
+    editor.shared.selection.setCursorEnd(monetaryField);
+    await animationFrame();
+
+    pasteText(editor, "Text: ,25");
+    expect(monetaryField).toHaveText("1.234.567.891,25");
 });

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -206,7 +206,10 @@ export class ClipboardPlugin extends Plugin {
      */
     handlePasteUnsupportedHtml(selection, clipboardData) {
         if (!isHtmlContentSupported(selection)) {
-            const text = clipboardData.getData("text/plain");
+            let text = clipboardData.getData("text/plain");
+            for (const processor of this.getResource("clipboard_paste_text_processors")) {
+                text = processor(selection, text);
+            }
             this.dependencies.dom.insert(text);
             return true;
         }


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Monetary fields accepted arbitrary characters such as letters, symbols, or other invalid characters. This allowed unwanted content to appear in editor DOM and could later cause server-side parsing issues when saving.

### Desired behavior after PR is merged:

- Input & paste behavior for `.oe_currency_value` now accepts only digits, dot (`.`), and comma (`,`), which are characters used across locales for numeric and monetary entry. This ensures monetaryfields always contain valid numeric values.

task-5155918

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
