### PR TITLE
[FIX] odoo: handle non-PDF attachments with embedded PDFs in pdf_first_page route

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -270,6 +270,14 @@ class IrAttachment(models.Model):
             else:
                 attach.raw = attach.db_datas
 
+    def _get_pdf_raw(self):
+        self.ensure_one()
+        if self.type != 'binary':
+            return False
+        if self.mimetype != 'application/pdf':
+            return False
+        return self.raw
+
     def _inverse_raw(self):
         self._set_attachment_data(lambda a: a.raw or b'')
 

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -222,10 +222,11 @@ def to_pdf_stream(attachment) -> io.BytesIO | None:
     if not attachment.raw:
         _logger.warning("%s has no raw data.", attachment)
         return None
+
+    if attachment_raw := attachment._get_pdf_raw():
+        return io.BytesIO(attachment_raw)
     stream = io.BytesIO(attachment.raw)
-    if attachment.mimetype.startswith('application/pdf'):
-        return stream
-    elif attachment.mimetype.startswith('image'):
+    if attachment.mimetype.startswith('image'):
         output_stream = io.BytesIO()
         Image.open(stream).convert("RGB").save(output_stream, format="pdf")
         return output_stream


### PR DESCRIPTION
The pdf_first_page route failed when called on non-PDF attachments that contain an embedded PDF
(e.g. XML invoices generated via Peppol).

This fix makes the route correctly extract and process the embedded PDF, allowing proper thumbnail
generation in those cases.

task-5246989

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
