### PR TITLE
[FIX] hr_timesheet: remove confusing measure from task analysis report

### DIFF
--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -13,7 +13,7 @@
                     <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="overtime" widget="timesheet_uom"/>
-                    <field name="total_hours_spent" widget="timesheet_uom"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" invisible="1"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours_percentage" invisible="1"/>
                 </xpath>
@@ -29,7 +29,7 @@
                     <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom"/>
                     <field name="subtask_effective_hours" widget="timesheet_uom"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" type="measure"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" type="measure" invisible="1"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                     <field name="overtime" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours_percentage" invisible="1"/>


### PR DESCRIPTION
Steps to Reproduce
---
Go to Project -> Reporting -> Task Analysis and switch to pivot view or graph view.

Issue
---
The "Hours by Tasks (including subtask)" measure duplicates due to the complicated hours counted on main task

Current Behaviour
---
Total time for a project is summed twice due to the inclusion of subtask hours in both parent and child tasks.

Expected Behaviour
---
Remove the measure Hours by Tasks ( including subtask) from both pivot and graph
views.

Fix
---
Removed the "Hours by Tasks (including subtask)" measure from the Task Analysis report to avoid confusion.

This change applies only to version 18.0.

Related:https://github.com/odoo/odoo/pull/184934

task-5144487