### PR TITLE
[IMP] point_of_sale: hide "to invoice" status in order list

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -302,7 +302,7 @@
                 <field name="user_id" widget="many2one_avatar_user" readonly="account_move or state == 'done'"/>
                 <field name="amount_total" sum="Amount total" widget="monetary" decoration-bf="1"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state not in ('draft','cancel')"/>
-                <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to_invoice'"/>
+                <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" invisible="invoice_status == 'to_invoice'"/>
                 <field name="is_edited" readonly="1" optional="hide"/>
             </list>
         </field>


### PR DESCRIPTION
In this commit:
- Hide the invoice status badge when the status is "to invoice" in order list.
- Prevent confusion by ensuring users don’t assume an invoice needs to be generated.

Task-5347495
