### PR TITLE
[FIX] html_editor: arrow keys on table picker should not navigate cells

### DIFF
--- a/addons/html_editor/static/src/main/table/table_picker.js
+++ b/addons/html_editor/static/src/main/table/table_picker.js
@@ -16,50 +16,56 @@ export class TablePicker extends Component {
             cols: 3,
             rows: 3,
         });
-        useExternalListener(this.props.editable.ownerDocument, "keydown", (ev) => {
-            const key = ev.key;
-            const isRTL = this.props.direction === "rtl";
-            switch (key) {
-                case "Enter":
-                    ev.preventDefault();
-                    this.insertTable();
-                    break;
-                case "ArrowUp":
-                    ev.preventDefault();
-                    if (this.state.rows > 1) {
-                        this.state.rows -= 1;
-                    }
-                    break;
-                case "ArrowDown":
-                    this.state.rows += 1;
-                    ev.preventDefault();
-                    break;
-                case "ArrowLeft":
-                    ev.preventDefault();
-                    if (isRTL) {
-                        this.state.cols += 1;
-                    } else {
-                        if (this.state.cols > 1) {
-                            this.state.cols -= 1;
+        useExternalListener(
+            this.props.editable.ownerDocument,
+            "keydown",
+            (ev) => {
+                ev.stopPropagation();
+                const key = ev.key;
+                const isRTL = this.props.direction === "rtl";
+                switch (key) {
+                    case "Enter":
+                        ev.preventDefault();
+                        this.insertTable();
+                        break;
+                    case "ArrowUp":
+                        ev.preventDefault();
+                        if (this.state.rows > 1) {
+                            this.state.rows -= 1;
                         }
-                    }
-                    break;
-                case "ArrowRight":
-                    ev.preventDefault();
-                    if (isRTL) {
-                        if (this.state.cols > 1) {
-                            this.state.cols -= 1;
+                        break;
+                    case "ArrowDown":
+                        this.state.rows += 1;
+                        ev.preventDefault();
+                        break;
+                    case "ArrowLeft":
+                        ev.preventDefault();
+                        if (isRTL) {
+                            this.state.cols += 1;
+                        } else {
+                            if (this.state.cols > 1) {
+                                this.state.cols -= 1;
+                            }
                         }
-                    } else {
-                        this.state.cols += 1;
-                    }
-                    break;
-                default:
-                    ev.stopImmediatePropagation();
-                    this.props.overlay.close();
-                    break;
-            }
-        });
+                        break;
+                    case "ArrowRight":
+                        ev.preventDefault();
+                        if (isRTL) {
+                            if (this.state.cols > 1) {
+                                this.state.cols -= 1;
+                            }
+                        } else {
+                            this.state.cols += 1;
+                        }
+                        break;
+                    default:
+                        ev.stopImmediatePropagation();
+                        this.props.overlay.close();
+                        break;
+                }
+            },
+            { capture: true }
+        );
     }
 
     updateSize(cols, rows) {

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -281,3 +281,72 @@ test("should close the table picker when any key except arrow keys pressed", asy
     await animationFrame();
     await expectElementCount(".o-we-tablepicker", 0);
 });
+
+test.tags("desktop");
+test("should not navigate table cells when table picker is open", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td><p>[]<br></p></td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    // open powerbox
+    await insertText(editor, "/");
+    await waitFor(".o-we-powerbox");
+
+    // filter to get table command in first position
+    await insertText(editor, "table");
+    await animationFrame();
+
+    // press enter to open tablepicker
+    await press("Enter");
+    await waitFor(".o-we-tablepicker");
+
+    // navigate to 1x3
+    press("ArrowUp");
+    await animationFrame();
+    press("ArrowUp");
+    await animationFrame();
+    press("Enter");
+    await animationFrame();
+    expectContentToBe(
+        el,
+        `
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <table class="table table-bordered o_table">
+                                <tbody>
+                                    <tr>
+                                        <td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                                        <td><p><br></p></td>
+                                        <td><p><br></p></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            <p><br></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `
+    );
+});


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

When the table picker was open inside a table, pressing the up/down arrow keys incorrectly moved the selection to the cell above or below.

Desired behavior after PR is merged:

While the table picker is open, arrow up/down no longer navigate between table cells.

task-5349547

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
