### PR TITLE
[FIX] base: prevent error when saving field with invalid domain

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -651,7 +651,12 @@ class IrModelFields(models.Model):
     @api.constrains('domain')
     def _check_domain(self):
         for field in self:
-            safe_eval(field.domain or '[]')
+            try:
+                safe_eval(field.domain or '[]')
+            except ValueError as e:
+                raise ValidationError(
+                    _("An error occurred while evaluating the domain:\n%(error)s", error=e)
+                ) from e
 
     @api.constrains('name')
     def _check_name(self):

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -429,6 +429,21 @@ class TestIrModel(TransactionCase):
         self.assertEqual(monetary_field.currency_field, "x_good_currency",
                          "The currency field in monetary should have x_good_currency as name")
 
+    def test_invalid_field_domain(self):
+        """Ensure assigning an invalid domain raises ValidationError."""
+        field_ripeness_id = self.env['ir.model.fields']._get('x_bananas', 'x_ripeness_id')
+
+        valid_domain = "[('x_name', '=', 'Green')]"
+        invalid_domain = "[('x_name', '=', Green)]"  # Green without quotes
+
+        field_ripeness_id.domain = valid_domain
+
+        with self.assertRaises(ValidationError) as error:
+            field_ripeness_id.domain = invalid_domain
+
+        self.assertIn('An error occurred while evaluating the domain', str(error.exception))
+        self.assertEqual(field_ripeness_id.domain, valid_domain)
+
 @tagged('-at_install', 'post_install')
 class TestIrModelEdition(TransactionCase):
     def test_new_ir_model_fields_related(self):


### PR DESCRIPTION
Currently an error is generated when the user tries to create or write fields
 with wrong domain.

Steps to produce an error
- Install sale_management and create a new field with the below detail
    - Model: `Sales order`
    - Field Type: `one2many`
    - Related Model: `sale.order`
    - Relation Field `partner_id`
    - Domain: `[('sale_order_id', 'in', sale_order_ids)]`
- Click on save

This error occurs because we have a constraint in the domain, and it is triggered
 when the user modifies the domain at code line [1]. Inside this constraint, we use
 `safe_eval` to evaluate the domain. During this evaluation, an error is raised because
 the user entered an incorrect domain.

This commit fixes the above issue by wrapping `safe_eval` inside a `try–except` 
block and raising a `ValidationError` with an appropriate message when an error occurs during domain evaluation.

[1]- https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/odoo/addons/base/models/ir_model.py#L651-L654

sentry-6964956583

