### PR TITLE
[IMP] l10n_*: introduce utility file for shared l10n_in functions

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -2,15 +2,12 @@ import logging
 import re
 
 from contextlib import contextmanager
-from markupsafe import Markup
 
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError, RedirectWarning, UserError
-from odoo.tools.float_utils import json_float_round
 from odoo.tools.image import image_data_uri
 from odoo.tools import SQL
 from odoo.tools.date_utils import get_month
-from odoo.addons.l10n_in.models.iap_account import IAP_SERVICE_NAME
 
 EDI_CANCEL_REASON = {
     # Same for both e-way bill and IRN
@@ -634,49 +631,6 @@ class AccountMove(models.Model):
             "buyer_details": self.partner_id,
             "ship_to_details": self.partner_shipping_id or self.partner_id
         }
-
-    @api.model
-    def _l10n_in_extract_digits(self, string):
-        if not string:
-            return ""
-        matches = re.findall(r"\d+", string)
-        return "".join(matches)
-
-    @api.model
-    def _l10n_in_is_service_hsn(self, hsn_code):
-        return self._l10n_in_extract_digits(hsn_code).startswith('99')
-
-    @api.model
-    def _l10n_in_round_value(self, amount, precision_digits=2):
-        """
-            This method is call for rounding.
-            If anything is wrong with rounding then we quick fix in method
-        """
-        return json_float_round(amount, precision_digits)
-
-    @api.model
-    def _get_l10n_in_tax_details_by_line_code(self, tax_details):
-        l10n_in_tax_details = {}
-        for tax_detail in tax_details.values():
-            if tax_detail["tax"].l10n_in_reverse_charge:
-                l10n_in_tax_details.setdefault("is_reverse_charge", True)
-            line_code = tax_detail["line_code"]
-            l10n_in_tax_details.setdefault("%s_rate" % (line_code), tax_detail["tax"].amount)
-            l10n_in_tax_details.setdefault("%s_amount" % (line_code), 0.00)
-            l10n_in_tax_details.setdefault("%s_amount_currency" % (line_code), 0.00)
-            l10n_in_tax_details["%s_amount" % (line_code)] += tax_detail["tax_amount"]
-            l10n_in_tax_details["%s_amount_currency" % (line_code)] += tax_detail["tax_amount_currency"]
-        return l10n_in_tax_details
-
-    @api.model
-    def _l10n_in_edi_get_iap_buy_credits_message(self):
-        url = self.env['iap.account'].get_credits_url(service_name=IAP_SERVICE_NAME)
-        return Markup("""<p><b>%s</b></p><p>%s <a href="%s">%s</a></p>""") % (
-            _("You have insufficient credits to send this document!"),
-            _("Please buy more credits and retry: "),
-            url,
-            _("Buy Credits")
-        )
 
     def _get_sync_stack(self, container):
         stack, update_containers = super()._get_sync_stack(container)

--- a/addons/l10n_in/models/account_move_line.py
+++ b/addons/l10n_in/models/account_move_line.py
@@ -2,6 +2,7 @@ import re
 from datetime import date
 
 from odoo import _, api, fields, models
+from odoo.addons.l10n_in import utils
 
 
 class AccountMoveLine(models.Model):
@@ -70,7 +71,7 @@ class AccountMoveLine(models.Model):
 
     def _l10n_in_check_invalid_hsn_code(self):
         self.ensure_one()
-        hsn_code = self.env['account.move']._l10n_in_extract_digits(self.l10n_in_hsn_code)
+        hsn_code = utils.l10n_in_extract_digits(self.l10n_in_hsn_code)
         if not hsn_code:
             return _("HSN code is not set in product line %(name)s", name=self.name)
         elif not re.match(r'^\d{4}$|^\d{6}$|^\d{8}$', hsn_code):

--- a/addons/l10n_in/models/iap_account.py
+++ b/addons/l10n_in/models/iap_account.py
@@ -1,3 +1,5 @@
+from markupsafe import Markup
+
 from odoo import api, models
 from odoo.addons.iap import jsonrpc
 
@@ -28,3 +30,14 @@ class IapAccount(models.Model):
         endpoint = IrConfigParam.get_str(config_parameter) or default_endpoint
         url = "%s%s" % (endpoint, url_path)
         return jsonrpc(url, params=params, timeout=timeout)
+
+    @api.model
+    def _l10n_in_edi_get_iap_buy_credits_message(self):
+        _ = self.env._
+        url = self.get_credits_url(service_name=IAP_SERVICE_NAME)
+        return Markup("""<p><b>%s</b></p><p>%s <a href="%s">%s</a></p>""") % (
+            _("You have insufficient credits to send this document!"),
+            _("Please buy more credits and retry: "),
+            url,
+            _("Buy Credits"),
+        )

--- a/addons/l10n_in/utils.py
+++ b/addons/l10n_in/utils.py
@@ -1,0 +1,26 @@
+import re
+
+
+def l10n_in_extract_digits(string):
+    if not string:
+        return ""
+    matches = re.findall(r"\d+", string)
+    return "".join(matches)
+
+
+def l10n_in_get_tax_details_by_line_code(tax_details):
+    l10n_in_tax_details = {}
+    for tax_detail in tax_details.values():
+        if tax_detail["tax"].l10n_in_reverse_charge:
+            l10n_in_tax_details.setdefault("is_reverse_charge", True)
+        line_code = tax_detail["line_code"]
+        l10n_in_tax_details.setdefault("%s_rate" % (line_code), tax_detail["tax"].amount)
+        l10n_in_tax_details.setdefault("%s_amount" % (line_code), 0.00)
+        l10n_in_tax_details.setdefault("%s_amount_currency" % (line_code), 0.00)
+        l10n_in_tax_details["%s_amount" % (line_code)] += tax_detail["tax_amount"]
+        l10n_in_tax_details["%s_amount_currency" % (line_code)] += tax_detail["tax_amount_currency"]
+    return l10n_in_tax_details
+
+
+def l10n_in_is_service_hsn(hsn_code):
+    return l10n_in_extract_digits(hsn_code).startswith('99')

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -9,7 +9,9 @@ from markupsafe import Markup
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import AccessError, LockError, UserError
 from odoo.tools import float_is_zero, float_compare
+from odoo.tools.float_utils import json_float_round
 
+from odoo.addons.l10n_in import utils
 from odoo.addons.l10n_in.models.account_invoice import EDI_CANCEL_REASON
 
 _logger = logging.getLogger(__name__)
@@ -211,7 +213,7 @@ class AccountMove(models.Model):
             message.append(_("- Email: invalid or longer than 100 characters."))
         if partner.phone and not re.match(
             r"^[0-9]{10,12}$",
-            partner.env['account.move']._l10n_in_extract_digits(partner.phone)
+            utils.l10n_in_extract_digits(partner.phone)
         ):
             message.append(_("- Phone number: must be 10–12 digits."))
         if partner.street2 and not re.match(r"^.{3,100}$", partner.street2):
@@ -307,7 +309,7 @@ class AccountMove(models.Model):
                 )
                 is_warning = any(warning_code in error_codes for warning_code in ('404', 'timeout'))
                 self.l10n_in_edi_error = (
-                    self._l10n_in_edi_get_iap_buy_credits_message()
+                    self.env['iap.account']._l10n_in_edi_get_iap_buy_credits_message()
                     if no_credit else msg
                 )
                 # avoid return `l10n_in_edi_error` because as a html field
@@ -390,7 +392,7 @@ class AccountMove(models.Model):
                     )
                 )
             if "no-credit" in error_codes:
-                self.l10n_in_edi_error = self._l10n_in_edi_get_iap_buy_credits_message()
+                self.l10n_in_edi_error = self.env['iap.account']._l10n_in_edi_get_iap_buy_credits_message()
                 return
             if error:
                 self.l10n_in_edi_error = (
@@ -449,7 +451,7 @@ class AccountMove(models.Model):
             if is_overseas is true then pin is 999999 and GSTIN(vat) is URP and Stcd is .
             if pos_state_id is passed then we use set POS
         """
-        zip_digits = self._l10n_in_extract_digits(partner.zip)
+        zip_digits = utils.l10n_in_extract_digits(partner.zip)
         partner_details = {
             'Addr1': partner.street or '',
             'Loc': partner.city or '',
@@ -467,9 +469,9 @@ class AccountMove(models.Model):
                 partner_details['Em'] = partner.email
             if (
                 partner.phone
-                and re.match(r"^[0-9]{10,12}$", self._l10n_in_extract_digits(partner.phone))
+                and re.match(r"^[0-9]{10,12}$", utils.l10n_in_extract_digits(partner.phone))
             ):
-                partner_details['Ph'] = self._l10n_in_extract_digits(partner.phone)
+                partner_details['Ph'] = utils.l10n_in_extract_digits(partner.phone)
         if pos_state_id:
             partner_details['POS'] = pos_state_id.l10n_in_tin or ''
         if set_vat:
@@ -494,7 +496,7 @@ class AccountMove(models.Model):
         Create the dictionary with line details
         """
         sign = self.is_inbound() and -1 or 1
-        tax_details_by_code = self._get_l10n_in_tax_details_by_line_code(line_tax_details['tax_details'])
+        tax_details_by_code = utils.l10n_in_get_tax_details_by_line_code(line_tax_details['tax_details'])
         quantity = line.quantity
         if line.discount == 100.00 or float_is_zero(quantity, 3):
             # Full discount or zero quantity
@@ -513,43 +515,42 @@ class AccountMove(models.Model):
             # government does not accept negative in qty or unit price
             unit_price_in_inr = -unit_price_in_inr
             quantity = -quantity
-        in_round = self._l10n_in_round_value
         line_details = {
             'SlNo': str(index),
-            'IsServc': self._l10n_in_is_service_hsn(line.l10n_in_hsn_code) and 'Y' or 'N',
-            'HsnCd': self._l10n_in_extract_digits(line.l10n_in_hsn_code),
-            'Qty': in_round(quantity or 0.0, 3),
+            'IsServc': utils.l10n_in_is_service_hsn(line.l10n_in_hsn_code) and 'Y' or 'N',
+            'HsnCd': utils.l10n_in_extract_digits(line.l10n_in_hsn_code),
+            'Qty': json_float_round(quantity or 0.0, 3),
             'Unit': (
                 line.product_uom_id.l10n_in_code
                 and line.product_uom_id.l10n_in_code.split('-')[0]
                 or 'OTH'
             ),
             # Unit price in company currency and tax excluded so its different then price_unit
-            'UnitPrice': in_round(unit_price_in_inr, 3),
+            'UnitPrice': json_float_round(unit_price_in_inr, 3),
             # total amount is before discount
-            'TotAmt': in_round(unit_price_in_inr * quantity),
-            'Discount': in_round((unit_price_in_inr * quantity) * (line.discount / 100)),
-            'AssAmt': in_round(sign * line.balance),
-            'GstRt': in_round(
+            'TotAmt': json_float_round(unit_price_in_inr * quantity),
+            'Discount': json_float_round((unit_price_in_inr * quantity) * (line.discount / 100)),
+            'AssAmt': json_float_round(sign * line.balance),
+            'GstRt': json_float_round(
                 (tax_details_by_code.get('igst_rate', 0.00)
                 or (tax_details_by_code.get('cgst_rate', 0.00) + tax_details_by_code.get('sgst_rate', 0.00))),
                 3
             ),
-            'IgstAmt': in_round(tax_details_by_code.get('igst_amount', 0.00)),
-            'CgstAmt': in_round(tax_details_by_code.get('cgst_amount', 0.00)),
-            'SgstAmt': in_round(tax_details_by_code.get('sgst_amount', 0.00)),
-            'CesRt': in_round(tax_details_by_code.get('cess_rate', 0.00), 3),
-            'CesAmt': in_round(tax_details_by_code.get('cess_amount', 0.00)),
-            'CesNonAdvlAmt': in_round(
+            'IgstAmt': json_float_round(tax_details_by_code.get('igst_amount', 0.00)),
+            'CgstAmt': json_float_round(tax_details_by_code.get('cgst_amount', 0.00)),
+            'SgstAmt': json_float_round(tax_details_by_code.get('sgst_amount', 0.00)),
+            'CesRt': json_float_round(tax_details_by_code.get('cess_rate', 0.00), 3),
+            'CesAmt': json_float_round(tax_details_by_code.get('cess_amount', 0.00)),
+            'CesNonAdvlAmt': json_float_round(
                 tax_details_by_code.get('cess_non_advol_amount', 0.00)
             ),
-            'StateCesRt': in_round(tax_details_by_code.get('state_cess_rate_amount', 0.00), 3),
-            'StateCesAmt': in_round(tax_details_by_code.get('state_cess_amount', 0.00)),
-            'StateCesNonAdvlAmt': in_round(
+            'StateCesRt': json_float_round(tax_details_by_code.get('state_cess_rate_amount', 0.00), 3),
+            'StateCesAmt': json_float_round(tax_details_by_code.get('state_cess_amount', 0.00)),
+            'StateCesNonAdvlAmt': json_float_round(
                 tax_details_by_code.get('state_cess_non_advol_amount', 0.00)
             ),
-            'OthChrg': in_round(tax_details_by_code.get('other_amount', 0.00)),
-            'TotItemVal': in_round((sign * line.balance) + line_tax_details.get('tax_amount', 0.00)),
+            'OthChrg': json_float_round(tax_details_by_code.get('other_amount', 0.00)),
+            'TotItemVal': json_float_round((sign * line.balance) + line_tax_details.get('tax_amount', 0.00)),
         }
         if line.name:
             line_details['PrdDesc'] = line.name.replace("\n", "")[:300]
@@ -576,7 +577,6 @@ class AccountMove(models.Model):
         def put_discount_on(discount_line_vals, other_line_vals):
             discount = -discount_line_vals['AssAmt']
             discount_to_allow = other_line_vals['AssAmt']
-            in_round = self._l10n_in_round_value
             amount_keys = (
                 'AssAmt', 'IgstAmt', 'CgstAmt', 'SgstAmt', 'CesAmt',
                 'CesNonAdvlAmt', 'StateCesAmt', 'StateCesNonAdvlAmt',
@@ -585,15 +585,15 @@ class AccountMove(models.Model):
             if float_compare(discount_to_allow, discount, precision_rounding=self.currency_id.rounding) < 0:
                 # Update discount line, needed when discount is more then max line, in short remaining_discount is not zero
                 discount_line_vals.update({
-                    key: in_round(discount_line_vals[key] + other_line_vals[key])
+                    key: json_float_round(discount_line_vals[key] + other_line_vals[key])
                     for key in amount_keys
                 })
-                other_line_vals['Discount'] = in_round(other_line_vals['Discount'] + discount_to_allow)
+                other_line_vals['Discount'] = json_float_round(other_line_vals['Discount'] + discount_to_allow)
                 other_line_vals.update(dict.fromkeys(amount_keys, 0.00))
                 return False
-            other_line_vals['Discount'] = in_round(other_line_vals['Discount'] + discount)
+            other_line_vals['Discount'] = json_float_round(other_line_vals['Discount'] + discount)
             other_line_vals.update({
-                key: in_round(other_line_vals[key] + discount_line_vals[key])
+                key: json_float_round(other_line_vals[key] + discount_line_vals[key])
                 for key in amount_keys
             })
             return True
@@ -624,7 +624,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         tax_details = self._l10n_in_prepare_tax_details()
         seller_buyer = self._get_l10n_in_seller_buyer_party()
-        tax_details_by_code = self._get_l10n_in_tax_details_by_line_code(tax_details['tax_details'])
+        tax_details_by_code = utils.l10n_in_get_tax_details_by_line_code(tax_details['tax_details'])
         is_intra_state = self.l10n_in_state_id == self.company_id.state_id
         is_overseas = self.l10n_in_gst_treatment == "overseas"
         line_ids = []
@@ -639,7 +639,6 @@ class AccountMove(models.Model):
         sign = self.is_inbound() and -1 or 1
         rounding_amount = sum(line.balance for line in self.line_ids if line.display_type == 'rounding') * sign
         global_discount_amount = sum(line.balance for line in global_discount_line) * -sign
-        in_round = self._l10n_in_round_value
         json_payload = {
             "Version": "1.1",
             "TranDtls": {
@@ -675,21 +674,21 @@ class AccountMove(models.Model):
                 for index, line in enumerate(lines, start=1)
             ],
             "ValDtls": {
-                "AssVal": in_round(tax_details['base_amount']),
-                "CgstVal": in_round(tax_details_by_code.get("cgst_amount", 0.00)),
-                "SgstVal": in_round(tax_details_by_code.get("sgst_amount", 0.00)),
-                "IgstVal": in_round(tax_details_by_code.get("igst_amount", 0.00)),
-                "CesVal": in_round((
+                "AssVal": json_float_round(tax_details['base_amount']),
+                "CgstVal": json_float_round(tax_details_by_code.get("cgst_amount", 0.00)),
+                "SgstVal": json_float_round(tax_details_by_code.get("sgst_amount", 0.00)),
+                "IgstVal": json_float_round(tax_details_by_code.get("igst_amount", 0.00)),
+                "CesVal": json_float_round((
                     tax_details_by_code.get("cess_amount", 0.00)
                     + tax_details_by_code.get("cess_non_advol_amount", 0.00)),
                 ),
-                "StCesVal": in_round((
+                "StCesVal": json_float_round((
                     tax_details_by_code.get("state_cess_amount", 0.00)
                     + tax_details_by_code.get("state_cess_non_advol_amount", 0.00)), # clean this up =p
                 ),
-                "Discount": in_round(global_discount_amount),
-                "RndOffAmt": in_round(rounding_amount),
-                "TotInvVal": in_round(
+                "Discount": json_float_round(global_discount_amount),
+                "RndOffAmt": json_float_round(rounding_amount),
+                "TotInvVal": json_float_round(
                     tax_details["base_amount"]
                     + tax_details["tax_amount"]
                     + rounding_amount
@@ -699,7 +698,7 @@ class AccountMove(models.Model):
         }
         if self.company_currency_id != self.currency_id:
             json_payload["ValDtls"].update({
-                "TotInvValFc": in_round(
+                "TotInvValFc": json_float_round(
                     tax_details.get("base_amount_currency") + tax_details.get("tax_amount_currency"))
             })
         if seller_buyer['seller_details'] != seller_buyer['dispatch_details']:
@@ -729,7 +728,7 @@ class AccountMove(models.Model):
             base_and_tax_amount = tax_details.get("base_amount") + tax_details.get("tax_amount")
             # For Export If with payment of Tax then we need to include Tax in Total Invoice Value
             if json_payload['TranDtls']['SupTyp'] == 'EXPWP' and json_valdtls['AssVal'] == base_and_tax_amount:
-                json_payload["ValDtls"]["TotInvVal"] = self._l10n_in_round_value(sum([
+                json_payload["ValDtls"]["TotInvVal"] = json_float_round(sum([
                     json_valdtls['TotInvVal'],
                     json_valdtls['IgstVal'],
                     json_valdtls['CgstVal'],
@@ -738,7 +737,7 @@ class AccountMove(models.Model):
                     json_valdtls['StCesVal'],
                 ]))
                 for line in json_payload["ItemList"]:
-                    line["TotItemVal"] = self._l10n_in_round_value(sum([
+                    line["TotItemVal"] = json_float_round(sum([
                         line["TotItemVal"],
                         line["IgstAmt"],
                         line["CgstAmt"],

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -9,8 +9,11 @@ from itertools import starmap
 
 from odoo import _, api, fields, models
 from odoo.exceptions import LockError, UserError
-from odoo.addons.l10n_in_ewaybill.tools.ewaybill_api import EWayBillApi, EWayBillError
 from odoo.tools import BinaryBytes
+from odoo.tools.float_utils import json_float_round
+
+from odoo.addons.l10n_in import utils
+from odoo.addons.l10n_in_ewaybill.tools.ewaybill_api import EWayBillApi, EWayBillError
 
 _logger = logging.getLogger(__name__)
 
@@ -384,12 +387,11 @@ class L10nInEwaybill(models.Model):
     def _check_lines(self):
         error_message = []
         invoice_lines = self.account_move_id.invoice_line_ids
-        AccountMove = self.env['account.move']
         if not any(l.product_id for l in invoice_lines):
             error_message.append(_("Ensure that at least one line item includes a product."))
             return error_message
         if all(
-            AccountMove._l10n_in_is_service_hsn(l.l10n_in_hsn_code)
+            utils.l10n_in_is_service_hsn(l.l10n_in_hsn_code)
             for l in invoice_lines if l.product_id
         ):
             error_message.append(_("You need at least one product having 'Product Type' as stockable or consumable."))
@@ -397,7 +399,7 @@ class L10nInEwaybill(models.Model):
         for line in invoice_lines:
             if (
                 line.display_type == 'product'
-                and not AccountMove._l10n_in_is_service_hsn(line.l10n_in_hsn_code)
+                and not utils.l10n_in_is_service_hsn(line.l10n_in_hsn_code)
                 and (hsn_error_message := line._l10n_in_check_invalid_hsn_code())
             ):
                 error_message.append(hsn_error_message)
@@ -577,20 +579,18 @@ class L10nInEwaybill(models.Model):
 
     def _get_l10n_in_ewaybill_line_details(self, line, tax_details):
         sign = self.account_move_id.is_inbound() and -1 or 1
-        extract_digits = self.env['account.move']._l10n_in_extract_digits
-        round_value = self.env['account.move']._l10n_in_round_value
-        tax_details_by_code = self.env['account.move']._get_l10n_in_tax_details_by_line_code(tax_details.get('tax_details', {}))
+        tax_details_by_code = utils.l10n_in_get_tax_details_by_line_code(tax_details.get('tax_details', {}))
         line_details = {
             'productName': line.product_id.name[:100] if line.product_id else "",
-            'hsnCode': extract_digits(line.l10n_in_hsn_code),
+            'hsnCode': utils.l10n_in_extract_digits(line.l10n_in_hsn_code),
             'productDesc': line.name[:100] if line.name else "",
             'quantity': line.quantity,
             'qtyUnit': line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split('-')[0] or 'OTH',
-            'taxableAmount': round_value(line.balance * sign),
+            'taxableAmount': json_float_round(line.balance * sign),
         }
         gst_types = {'cgst', 'sgst', 'igst'}
         gst_tax_rates = {
-            f"{gst_type}Rate": round_value(gst_tax_rate)
+            f"{gst_type}Rate": json_float_round(gst_tax_rate)
             for gst_type in gst_types
             if (gst_tax_rate := tax_details_by_code.get(f"{gst_type}_rate"))
         }
@@ -598,7 +598,7 @@ class L10nInEwaybill(models.Model):
             gst_tax_rates or dict.fromkeys({f"{gst_type}Rate" for gst_type in gst_types}, 0.00)
         )
         if tax_details_by_code.get('cess_rate'):
-            line_details.update({'cessRate': round_value(tax_details_by_code.get('cess_rate'))})
+            line_details.update({'cessRate': json_float_round(tax_details_by_code.get('cess_rate'))})
         return line_details
 
     def _prepare_ewaybill_base_json_payload(self):
@@ -678,9 +678,8 @@ class L10nInEwaybill(models.Model):
         )
 
     def _prepare_ewaybill_tax_details_json_payload(self):
-        round_value = self.env['account.move']._l10n_in_round_value
         tax_details = self.account_move_id._l10n_in_prepare_tax_details()
-        tax_details_by_code = self.env['account.move']._get_l10n_in_tax_details_by_line_code(tax_details.get("tax_details", {}))
+        tax_details_by_code = utils.l10n_in_get_tax_details_by_line_code(tax_details.get("tax_details", {}))
         invoice_line_tax_details = tax_details.get("tax_details_per_record")
         sign = self.account_move_id.is_inbound() and -1 or 1
         rounding_amount = sum(line.balance for line in self.account_move_id.line_ids if line.display_type == 'rounding') * sign
@@ -695,14 +694,14 @@ class L10nInEwaybill(models.Model):
             total_invoice_value -= adjusting_rc_amount
         return {
             "itemList": list(starmap(self._get_l10n_in_ewaybill_line_details, invoice_line_tax_details.items())),
-            "totalValue": round_value(tax_details.get("base_amount", 0.00)),
+            "totalValue": json_float_round(tax_details.get("base_amount", 0.00)),
             **{
-                f'{tax_type}Value': round_value(tax_details_by_code.get(f'{tax_type}_amount', 0.00))
+                f'{tax_type}Value': json_float_round(tax_details_by_code.get(f'{tax_type}_amount', 0.00))
                 for tax_type in ['cgst', 'sgst', 'igst', 'cess']
             },
-            "cessNonAdvolValue": round_value(tax_details_by_code.get("cess_non_advol_amount", 0.00)),
-            "otherValue": round_value(tax_details_by_code.get("other_amount", 0.00) + rounding_amount),
-            "totInvValue": round_value(total_invoice_value),
+            "cessNonAdvolValue": json_float_round(tax_details_by_code.get("cess_non_advol_amount", 0.00)),
+            "otherValue": json_float_round(tax_details_by_code.get("other_amount", 0.00) + rounding_amount),
+            "totInvValue": json_float_round(total_invoice_value),
         }
 
     def _ewaybill_generate_direct_json(self):

--- a/addons/l10n_in_ewaybill/tools/ewaybill_api.py
+++ b/addons/l10n_in_ewaybill/tools/ewaybill_api.py
@@ -123,7 +123,7 @@ class EWayBillApi:
         except EWayBillError as e:
             if "no-credit" in e.error_codes:
                 e.error_json['odoo_warning'].append({
-                    'message': self.env['account.move']._l10n_in_edi_get_iap_buy_credits_message()
+                    'message': self.env['iap.account']._l10n_in_edi_get_iap_buy_credits_message()
                 })
                 raise
 

--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -133,7 +133,7 @@ class L10nInEwaybill(models.Model):
             error_codes = [error.get('code') for error in response.get('error')]
             if 'no-credit' in error_codes:
                 response['odoo_warning'].append({
-                    'message': self.env['account.move']._l10n_in_edi_get_iap_buy_credits_message()
+                    'message': self.env['iap.account']._l10n_in_edi_get_iap_buy_credits_message()
                 })
             if '4002' in error_codes or '4026' in error_codes:
                 # Get E-waybill by details in case of IRN is already generated

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -3,6 +3,9 @@ from collections import defaultdict
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.float_utils import json_float_round
+
+from odoo.addons.l10n_in import utils
 
 
 class L10nInEwaybill(models.Model):
@@ -146,11 +149,8 @@ class L10nInEwaybill(models.Model):
     def _check_lines(self):
         if self.picking_id:
             error_message = []
-            AccountMove = self.env['account.move']
             for line in self.move_ids:
-                hsn_code = AccountMove._l10n_in_extract_digits(
-                    line.product_id.l10n_in_hsn_code
-                )
+                hsn_code = utils.l10n_in_extract_digits(line.product_id.l10n_in_hsn_code)
                 if not hsn_code:
                     error_message.append(_(
                         "HSN code is not set in product %s",
@@ -217,11 +217,10 @@ class L10nInEwaybill(models.Model):
 
     def _get_l10n_in_ewaybill_line_details(self, line, tax_details):
         if self.picking_id:
-            AccountMove = self.env['account.move']
             product = line.product_id
             line_details = {
                 'productName': product.name[:100],
-                'hsnCode': AccountMove._l10n_in_extract_digits(product.l10n_in_hsn_code),
+                'hsnCode': utils.l10n_in_extract_digits(product.l10n_in_hsn_code),
                 'productDesc': line.description_picking[:100] if line.description_picking else "",
                 'quantity': line.quantity,
                 'qtyUnit': (
@@ -229,22 +228,18 @@ class L10nInEwaybill(models.Model):
                     and line.uom_id.l10n_in_code.split('-')[0]
                     or 'OTH'
                 ),
-                'taxableAmount': AccountMove._l10n_in_round_value(tax_details['total_excluded']),
+                'taxableAmount': json_float_round(tax_details['total_excluded']),
             }
             gst_types = ('sgst', 'cgst', 'igst')
             gst_tax_rates = {}
             for tax in tax_details.get('taxes'):
                 for gst_type in gst_types:
                     if tax_rate := tax.get(f'{gst_type}_rate'):
-                        gst_tax_rates.update({
-                            f"{gst_type}Rate": AccountMove._l10n_in_round_value(tax_rate)
-                        })
+                        gst_tax_rates.update({f"{gst_type}Rate": json_float_round(tax_rate)})
                 if cess_rate := tax.get("cess_rate"):
-                    line_details['cessRate'] = AccountMove._l10n_in_round_value(cess_rate)
+                    line_details['cessRate'] = json_float_round(cess_rate)
                 if cess_non_advol := tax.get("cess_non_advol_amount"):
-                    line_details['cessNonadvol'] = AccountMove._l10n_in_round_value(
-                        cess_non_advol
-                    )
+                    line_details['cessNonadvol'] = json_float_round(cess_non_advol)
             line_details.update(
                 gst_tax_rates
                 or dict.fromkeys(
@@ -258,7 +253,6 @@ class L10nInEwaybill(models.Model):
     def _prepare_ewaybill_tax_details_json_payload(self):
         if self.picking_id:
             tax_details = self._l10n_in_tax_details_for_stock()
-            round_value = self.env['account.move']._l10n_in_round_value
             return {
                 'itemList': [
                     self._get_l10n_in_ewaybill_line_details(
@@ -266,22 +260,16 @@ class L10nInEwaybill(models.Model):
                     )
                     for line in self.move_ids
                 ],
-                'totalValue': round_value(tax_details['tax_details'].get('total_excluded', 0.00)),
+                'totalValue': json_float_round(tax_details['tax_details'].get('total_excluded', 0.00)),
                 **{
-                    f'{tax_type}Value': round_value(
+                    f'{tax_type}Value': json_float_round(
                         tax_details.get('tax_details').get(f'{tax_type}_amount', 0.00)
                     )
                     for tax_type in ['cgst', 'sgst', 'igst', 'cess']
                 },
-                'cessNonAdvolValue': round_value(
-                    tax_details.get('cess_non_advol_amount', 0.00)
-                ),
-                'otherValue': round_value(
-                    tax_details.get('other_amount', 0.00)
-                ),
-                'totInvValue': round_value(
-                    tax_details['tax_details'].get('total_included', 0.00)
-                ),
+                'cessNonAdvolValue': json_float_round(tax_details.get('cess_non_advol_amount', 0.00)),
+                'otherValue': json_float_round(tax_details.get('other_amount', 0.00)),
+                'totInvValue': json_float_round(tax_details['tax_details'].get('total_included', 0.00)),
             }
         return super()._prepare_ewaybill_tax_details_json_payload()
 

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -317,7 +317,7 @@ def float_split(value: float, precision_digits: int) -> tuple[int, int]:
 
 def json_float_round(
     value: float,
-    precision_digits: int,
+    precision_digits: int = 2,
     rounding_method: RoundingMethod = 'HALF-UP',
 ) -> float:
     """Not suitable for float calculations! Similar to float_repr except that it
@@ -328,7 +328,7 @@ def json_float_round(
     Unfortunately `json.dumps` does not allow any form of custom float representation,
     nor any custom types, everything is serialized from the basic JSON types.
 
-    :param precision_digits: number of fractional digits to round to.
+    :param precision_digits: number of fractional digits to round to, default value is 2.
     :param rounding_method: the rounding method used: 'HALF-UP', 'UP' or 'DOWN',
            the first one rounding up to the closest number with the rule that
            number>=0.5 is rounded up to 1, the second always rounding up and the


### PR DESCRIPTION
This **PR** introduces a dedicated utility file to store common functions used across multiple l10n_* modules. Previously, these functions were defined on `account_move`, requiring the creation of an `account.move` model instance just to call them. Moving them to a shared utility improves clarity and avoids unnecessary model instantiation.

Enterprise **PR** - https://github.com/odoo/enterprise/pull/100147