### PR TITLE
[IMP] website, *: improve search highlighting and refactor for extensibility

### DIFF
--- a/addons/test_website/models/model.py
+++ b/addons/test_website/models/model.py
@@ -47,6 +47,21 @@ class TestModel(models.Model):
             'order': 'name asc, id desc',
         }
 
+    def _get_search_highlight_handlers(self):
+        handlers = super()._get_search_highlight_handlers()
+        handlers['notes'] = self._search_highlight_notes
+        return handlers
+
+    def _search_highlight_notes(self, field_meta, value, term):
+        if value and 'secret' in value:
+            return True, value, 'notes'
+
+        if value and term:
+            highlighted = value.replace(term, f'/{term}/')
+            return False, highlighted, 'text'
+
+        return False, value, 'text'
+
     def open_website_url(self):
         self.ensure_one()
         return self.env['website'].get_client_action(f'/test_model/{self.id}')

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -149,3 +149,25 @@ class TestAutoComplete(TransactionCase):
         # Sub-sub-fields are currently not supported.
         # Adapt expected result if this becomes a feature.
         self._autocomplete('tagg', 0, "Not found")
+
+    def test_custom_highlight_handler(self):
+        field_meta = {'name': 'notes', 'type': 'notes', 'match': True}
+        value = "The quick brown fox jumps over the lazy dog"
+        term = "fox"
+
+        skip, result, field_type = self.env['test.model']._search_highlight_field(field_meta, value, term)
+
+        self.assertFalse(skip, "Expected field to not be skipped")
+        self.assertEqual(field_type, 'text', "Expected field_type to switch to 'text' after highlighting")
+        self.assertEqual(result, "The quick brown /fox/ jumps over the lazy dog")
+
+    def test_highlight_handler_skips_fields(self):
+        field_meta = {'name': 'notes', 'type': 'notes', 'match': True}
+        value = "The quick brown fox guards a secret note"
+        term = "fox"
+
+        skip, result, field_type = self.env['test.model']._search_highlight_field(field_meta, value, term)
+
+        self.assertTrue(skip, "Expected field to be skipped because the value contains 'secret'")
+        self.assertEqual(field_type, 'notes', "Expected field_type to remain 'notes' when highlighting is skipped")
+        self.assertEqual(result, value, "Expected result to remain unchanged when highlighting is skipped")

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -171,3 +171,34 @@ class TestAutoComplete(TransactionCase):
         self.assertTrue(skip, "Expected field to be skipped because the value contains 'secret'")
         self.assertEqual(field_type, 'notes', "Expected field_type to remain 'notes' when highlighting is skipped")
         self.assertEqual(result, value, "Expected result to remain unchanged when highlighting is skipped")
+
+    def test_tags_highlight_handler_match(self):
+        field_meta = {'name': 'tag_ids', 'type': 'tags', 'match': True}
+        value = [{'name': 'Marketing'}, {'name': 'Finance'}]
+        search_term = "market"
+
+        skip, result, field_type = self.env['test.model']._search_highlight_field(field_meta, value, search_term)
+
+        self.assertFalse(skip, "Expected field to not be skipped")
+        self.assertEqual(field_type, 'html', "Expected field_type to switch to 'html' after highlighting")
+        self.assertIn(
+            '<span class="fw-bold text-primary-emphasis">Market</span><span>ing</span>',
+            str(result),
+            "Expected matching term to be highlighted in the output"
+        )
+        self.assertIn(
+            '<span>Finance</span>',
+            str(result),
+            "Expected non-matching tags to be present without highlighting"
+        )
+
+    def test_tags_highlight_handler_no_match(self):
+        field_meta = {'name': 'tag_ids', 'type': 'tags', 'match': True}
+        value = [{'name': 'Marketing'}, {'name': 'Finance'}]
+        search_term = "random"
+
+        skip, result, field_type = self.env['test.model']._search_highlight_field(field_meta, value, search_term)
+
+        self.assertTrue(skip, "Expected field to be skipped when no tags match the search term")
+        self.assertEqual(field_type, 'tags', "Expected field_type to remain 'tags' when highlighting is skipped")
+        self.assertEqual(result, value, "Expected result to remain unchanged when highlighting is skipped")

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -29,6 +29,7 @@
                 <p t-if="description" class="mb-0" t-out="description"/>
                 <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
                 <t t-if="extra_link_html" t-out="extra_link_html"/>
+                <div t-if="result['tags']" t-out="result['tags']" class="my-2"/>
             </div>
             <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0 ms-auto">
                 <t t-if="result['detail_strike']">

--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -144,7 +144,15 @@ export class SearchBar extends Interaction {
     }
 
     getFieldsNames() {
-        return ["description", "detail", "detail_extra", "detail_strike", "extra_link", "name"];
+        return [
+            "description",
+            "detail",
+            "detail_extra",
+            "detail_strike",
+            "extra_link",
+            "name",
+            "tags",
+        ];
     }
 
     async onInput() {

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -168,6 +168,53 @@ class TestAutoComplete(TransactionCase):
         self.assertTrue(f'<span class="text-primary-emphasis">{term}</span>' in value.lower(),
                         "Term must be highlighted")
 
+    def test_shorten_around_match(self):
+        shorten_around_match = self.WebsiteController._shorten_around_match
+
+        self.assertEqual(
+            shorten_around_match("hello world", "world", 100),
+            "hello world",
+            "Should return original text when it fits within max width"
+        )
+        self.assertEqual(
+            shorten_around_match("aaa bbb ccc", "zzz", 12),
+            "aaa bbb ccc",
+            "Should return original text when keyword not found and no shortening needed"
+        )
+        self.assertEqual(
+            shorten_around_match("AAA bbb CCC ddd", "ccc", 12),
+            "...bb CCC...",
+            "Should match keyword ignoring case and center around it"
+        )
+        self.assertEqual(
+            shorten_around_match("aaa bbb ccc ddd", "b c", 12, ",,,"),
+            ",,, bbb c,,,",
+            "Should use custom placeholder in returned shortened text"
+        )
+        self.assertEqual(
+            shorten_around_match("aaa bbb ccc ddd", "ddd", 12),
+            "...b ccc ddd",
+            "Should center around match near end while respecting max width"
+        )
+        self.assertEqual(
+            shorten_around_match("hello world", "hello", 8),
+            "hello...",
+            "Should shorten from end when match is at beginning and text is too long"
+        )
+        self.assertEqual(
+            shorten_around_match("aaa bbb ccc bbb ddd", "bbb", 14),
+            "aaa bbb ccc..."
+        )
+        self.assertEqual(
+            shorten_around_match(
+                "The quick brown fox jumps over the lazy dog and runs away",
+                "fox runs",
+                20
+            ),
+            "... brown fox jum...",
+            "Should center around first token 'fox' when exact phrase 'fox runs' not found"
+        )
+
     def test_01_few_results(self):
         """ Tests an autocomplete with exact match and less than the maximum number of results """
         suggestions = self._autocomplete("few")

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -3100,6 +3100,19 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
     <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary-emphasis' if part[0] % 2 else None" t-out="part[1]"/>
 </template>
 
+<template id="search_tags_highlight" name="Website Searchbar: Tag Highlight">
+    <div class="d-flex gap-1 flex-wrap">
+        <span t-foreach="tags"
+            t-as="tag"
+            class="badge o_color_0">
+            <span t-foreach="enumerate(tag['parts'])"
+               t-as="part"
+               t-att-class="'fw-bold text-primary-emphasis' if part[0] % 2 else None"
+               t-out="part[1]" />
+        </span>
+    </div>
+</template>
+
 <template id="list_website_public_pages" name="Website Pages">
     <t t-call="website.layout">
         <div id="wrap">
@@ -3189,6 +3202,7 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
                 <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-out="extra_link"
                     t-attf-onclick="location.href='#{result.get('extra_link_url')}';return false;"/>
                 <t t-if="extra_link_html" t-out="extra_link_html"/>
+                <div t-if="result.get('tags')" t-out="result.get('tags')" class="my-2"/>
             </div>
             <div class="flex-shrink-0 ms-auto">
                 <t t-if="result.get('detail_strike')">

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -605,12 +605,13 @@ class EventEvent(models.Model):
                 if date_details[0] != 'scheduled':
                     current_date = date_details[1]
 
-        search_fields = ['name']
-        fetch_fields = ['name', 'website_url', 'address_name']
+        search_fields = ['name', 'tag_ids.name']
+        fetch_fields = ['name', 'website_url', 'address_name', 'tag_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'address_name': {'name': 'address_name', 'type': 'text', 'match': True},
+            'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True}
         }
         if with_description:
             search_fields.append('subtitle')
@@ -645,12 +646,13 @@ class EventEvent(models.Model):
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         with_date = 'detail' in mapping
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
-        if with_date:
-            for event, data in zip(self, results_data):
+        for event, data in zip(self, results_data):
+            if with_date:
                 begin = self.env['ir.qweb.field.date'].record_to_html(event, 'date_begin', {})
                 end = self.env['ir.qweb.field.date'].record_to_html(event, 'date_end', {})
                 data['range'] = (
                     Markup('{} <i class="fa fa-long-arrow-right"></i> {}').format(begin, end)
                     if begin != end else begin
                 )
+            data['tag_ids'] = event.tag_ids.read(['name'])
         return results_data

--- a/addons/website_forum/models/forum_forum.py
+++ b/addons/website_forum/models/forum_forum.py
@@ -321,11 +321,12 @@ class ForumForum(models.Model):
     @api.model
     def _search_get_detail(self, website, order, options):
         with_description = options['displayDescription']
-        search_fields = ['name']
-        fetch_fields = ['id', 'name']
+        search_fields = ['name', 'tag_ids.name']
+        fetch_fields = ['id', 'name', 'tag_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+            'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }
         if with_description:
             search_fields.append('description')
@@ -345,4 +346,5 @@ class ForumForum(models.Model):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
         for forum, data in zip(self, results_data):
             data['website_url'] = forum.website_url
+            data['tag_ids'] = forum.tag_ids.read(['name'])
         return results_data

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -853,11 +853,12 @@ class ForumPost(models.Model):
     def _search_get_detail(self, website, order, options):
         with_description = options['displayDescription']
         with_date = options['displayDetail']
-        search_fields = ['name']
-        fetch_fields = ['id', 'name', 'website_url']
+        search_fields = ['name', 'tag_ids.name']
+        fetch_fields = ['id', 'name', 'website_url', 'tag_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+            'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }
 
         domain = website.website_domain()
@@ -921,6 +922,7 @@ class ForumPost(models.Model):
         for post, data in zip(self, results_data):
             if with_date:
                 data['date'] = self.env['ir.qweb.field.date'].record_to_html(post, 'write_date', {})
+            data['tag_ids'] = post.tag_ids.read(['name'])
         return results_data
 
     def _get_related_posts(self, limit=5):

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1050,11 +1050,12 @@ class SlideChannel(models.Model):
                 domain.append([('tag_ids', 'in', tags_.ids)])
         if slide_category and 'nbr_%s' % slide_category in self:
             domain.append([('nbr_%s' % slide_category, '>', 0)])
-        search_fields = ['name']
-        fetch_fields = ['name', 'website_url']
+        search_fields = ['name', 'tag_ids.name']
+        fetch_fields = ['name', 'website_url', 'tag_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+            'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }
         if with_description:
             search_fields.append('description_short')
@@ -1071,6 +1072,12 @@ class SlideChannel(models.Model):
             'mapping': mapping,
             'icon': 'fa-graduation-cap',
         }
+
+    def _search_render_results(self, fetch_fields, mapping, icon, limit):
+        results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
+        for channel, data in zip(self, results_data):
+            data['tag_ids'] = channel.tag_ids.read(['name'])
+        return results_data
 
     def _get_placeholder_filename(self, field):
         image_fields = ['image_%s' % size for size in [1920, 1024, 512, 256, 128]]

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1281,13 +1281,14 @@ class SlideSlide(models.Model):
     @api.model
     def _search_get_detail(self, website, order, options):
         with_description = options['displayDescription']
-        search_fields = ['name']
-        fetch_fields = ['id', 'name']
+        search_fields = ['name', 'tag_ids.name']
+        fetch_fields = ['id', 'name', 'tag_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'url', 'type': 'text', 'truncate': False},
             'extra_link': {'name': 'course', 'type': 'text'},
             'extra_link_url': {'name': 'course_url', 'type': 'text', 'truncate': False},
+            'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }
         if with_description:
             search_fields.append('description')
@@ -1319,6 +1320,7 @@ class SlideSlide(models.Model):
             data['url'] = slide.website_absolute_url
             data['course'] = _('Course: %s', slide.channel_id.name)
             data['course_url'] = slide.channel_id.website_absolute_url
+            data['tag_ids'] = slide.tag_ids.read(['name'])
         return results_data
 
     def get_base_url(self):


### PR DESCRIPTION
`*` = test_website, website_blog, website_event, website_forum, website_slides

This PR improves the highlight mechanic in search results so users can
immediately see why a result matched their query, and refactors the underlying
logic for better extensibility.

**Changes:**

1. **Smart Truncation**:
   - Previously, long titles or descriptions were truncated from the start,
   often hiding the matched keyword.
   - Now, the text is shortened around the match using `_shorten_around_match`,
   ensuring the highlighted term is always visible.

2. **Refactoring for Extensibility**:
   - Moved search highlighting logic from the `autocomplete` controller to
   `website.searchable.mixin`.
   - Introduced a dispatch-based pattern using `_get_search_highlight_handlers`
   and `_search_highlight_field`.
   - This allows models to define custom highlight behavior for specific field
   types without modifying the base controller.

3. **Tag Highlighting**:
   - Added support for highlighting matching terms inside tags.
   - Previously, results matched by tags (e.g., in blogs) didn't show the tags,
   making the result feel unexplained.
   - Now, matching tags are displayed and highlighted for all models that define
   a `tag_ids` field.

<br/>

task-[5264336](https://www.odoo.com/odoo/project/974/tasks/5264336)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr