### PR TITLE
[FIX] l10n_in_withholding: allow invoicing-only users TDS/TCS alert

### DIFF
--- a/addons/l10n_in_withholding/models/account_move.py
+++ b/addons/l10n_in_withholding/models/account_move.py
@@ -121,7 +121,7 @@ class AccountMove(models.Model):
     def _get_sections_aggregate_sum_by_pan(self, section_alert, commercial_partner_id):
         self.ensure_one()
         month_start_date, month_end_date = get_month(self.date)
-        company_fiscalyear_dates = self.company_id.compute_fiscalyear_dates(self.date)
+        company_fiscalyear_dates = self.company_id.sudo().compute_fiscalyear_dates(self.date)
         fiscalyear_start_date, fiscalyear_end_date = company_fiscalyear_dates['date_from'], company_fiscalyear_dates['date_to']
         default_domain = [
             ('account_id.l10n_in_tds_tcs_section_id', '=', section_alert.id),
@@ -174,7 +174,7 @@ class AccountMove(models.Model):
         def _group_by_section_alert(invoice_lines):
             group_by_lines = {}
             for line in invoice_lines:
-                group_key = line.account_id.l10n_in_tds_tcs_section_id
+                group_key = line.account_id.sudo().l10n_in_tds_tcs_section_id
                 if group_key and not line.company_currency_id.is_zero(line.price_total):
                     group_by_lines.setdefault(group_key, [])
                     group_by_lines[group_key].append(line)


### PR DESCRIPTION
Invoicing users were unable to create or open invoices because the `l10n_in.section.alert` model (used for TDS/TCS warning on the chart of account) was restricted only to Accounting groups (Administrator and Read-only).

**Steps to Reproduce**
1. Install l10n_in,account_accountant
2. Create two users:
   - Admin user
   - Invoicing user (only invoicing rights)
3. As Admin:
   - Enable TDS/TCS module
   - Open any Chart of Account
   - Select a TDS/TCS Section
   - Save
4. As Invoicing user:
   - Try to create an Invoice/Bill with that Chart of Account → Access Error occurs

Fix Result
Invoicing-only users can now create and access invoices without access errors.

Task-5346551