### PR TITLE
[FIX] base, web, web_tour: Hide tour pointer on unwanted wizards

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.CommandPalette">
-    <Dialog header="false" footer="false" size="'md'" withBodyPadding="false" contentClass="'o_command_palette'">
+    <Dialog header="false" footer="false" size="'md'" withBodyPadding="false" contentClass="'o_command_palette hideTourPointer'">
       <div t-ref="root">
         <div class="o_command_palette_search input-group mb-2 px-4 py-3 border-bottom">
           <span t-if="state.namespace !== 'default'" class="o_namespace d-flex align-items-center me-1 fs-4 text-muted opacity-75" t-out="state.namespace"/>

--- a/addons/web_tour/static/src/js/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/js/tour_pointer/tour_pointer.js
@@ -4,7 +4,7 @@ import { browser } from "@web/core/browser/browser";
 import { usePosition } from "@web/core/position/position_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
-import { getScrollParent, isInPage } from "@web_tour/js/utils/tour_utils";
+import { getScrollParent, isInPage, hideTourPointer } from "@web_tour/js/utils/tour_utils";
 
 const oppositeSides = {
     left: "right",
@@ -224,7 +224,7 @@ export class TourPointer extends Component {
     }
 
     get isVisible() {
-        return this.trigger && isInPage(this.trigger) && this.triggerPosition !== "unknow";
+        return this.trigger && isInPage(this.trigger) && this.triggerPosition !== "unknow" && !hideTourPointer();
     }
 
     /**

--- a/addons/web_tour/static/src/js/utils/tour_utils.js
+++ b/addons/web_tour/static/src/js/utils/tour_utils.js
@@ -101,3 +101,7 @@ export function isInPage(element) {
     }
     return false;
 }
+
+export function hideTourPointer() {
+    return !!(document.querySelector(".hideTourPointer") && document.querySelector(".modal"));
+}

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -404,7 +404,7 @@
             <field name="model">res.users</field>
             <field eval="18" name="priority"/>
             <field name="arch" type="xml">
-                <form string="Users" edit="1">
+                <form string="Users" edit="1" class="hideTourPointer">
                     <sheet>
                         <widget name="notification_alert"/>
                         <div class="d-flex align-items-center">


### PR DESCRIPTION
[FIX] base, web, web_tour: Hide tour pointer on unwanted wizards

The tour pointer is displayed and not hidden when the user opens a non-related wizard (like user preferences), and it points to nothing logical.
With this commit, we add the possibility to hide the pointer when the document contains elements having 'modal' and 'hideTourPointer' as class We cannot only rely on 'modal' class because some tours could involve a modal.

task-5123177
