### PR TITLE
[IMP] purchase, *: Fix purchase catalog suggestions bugs

### DIFF
--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -10,6 +10,7 @@ export class ProductCatalogOrderLine extends Component {
         price: Number,
         productType: String,
         uomDisplayName: String,
+        uomFactor: { type: Number, optional: true },
         code: { type: String, optional: true},
         readOnly: { type: Boolean, optional: true },
         warning: { type: String, optional: true},
@@ -17,7 +18,7 @@ export class ProductCatalogOrderLine extends Component {
 
     /**
      * Focus input text when clicked
-     * @param {Event} ev 
+     * @param {Event} ev
      */
     _onFocus(ev) {
         ev.target.select();

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1217,6 +1217,7 @@ class PurchaseOrder(models.Model):
                 # The discounted price is expressed in the product's UoM, not in the vendor
                 # price's UoM, so we need to convert it into to match the displayed UoM.
                 price = product_uom._compute_price(price, seller.product_uom_id)
+                product_infos.update(uomFactor=seller.product_uom_id.factor / product_uom.factor)
             product_infos.update(
                 price=price,
                 min_qty=seller.min_qty,

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -107,7 +107,6 @@ class ProductProduct(models.Model):
     @api.depends_context('suggest_based_on', 'warehouse_id')
     def _compute_monthly_demand(self):
         based_on = self.env.context.get("suggest_based_on", "30_days")
-        warehouse_id = self.env.context.get('warehouse_id')
         start_date, limit_date = self._get_monthly_demand_range(based_on)
 
         move_domain = Domain([
@@ -120,11 +119,7 @@ class ProductProduct(models.Model):
             move_domain,
             self._get_monthly_demand_moves_location_domain(),
         ])
-        if warehouse_id:
-            move_domain = Domain.AND([
-                move_domain,
-                [('location_id.warehouse_id', '=', warehouse_id)]
-            ])
+
         move_qty_by_products = self.env['stock.move']._read_group(move_domain, ['product_id'], ['product_qty:sum'])
         qty_by_product = {product.id: qty for product, qty in move_qty_by_products}
 
@@ -140,13 +135,26 @@ class ProductProduct(models.Model):
 
     @api.model
     def _get_monthly_demand_moves_location_domain(self):
-        return Domain.OR([
-            [('location_dest_usage', 'in', ['customer', 'production'])],
-            Domain.AND([
-                [('location_final_id.usage', '=', 'customer')],
-                [('move_dest_ids', '=', False)],
+        """ Returns a domain on stock moves coming from the selected warehouse that are:
+                - going to customer locations or used in production
+                - going to other warehouses (eg. central warehouse dispatching to stores)
+            (We don't include returns in demand estimation - they come back on hand)
+        """
+        warehouse_id = self.env.context.get('warehouse_id')
+        if not warehouse_id:
+            return Domain.OR([
+                [('location_dest_usage', 'in', ['customer', 'production'])],
+                [('location_final_id.usage', 'in', ['customer', 'production'])],
             ])
-        ])
+        else:
+            return Domain.AND([
+                [('location_id.warehouse_id', '=', warehouse_id)],
+                Domain.OR([
+                    [('location_dest_id.warehouse_id', '!=', warehouse_id)],
+                    [('location_final_id.warehouse_id', '!=', warehouse_id)]
+                ]),  # includes moves going to customer or production
+                [('location_dest_id.name', '!=', 'Inventory adjustment')]  # exclude scrap
+            ])
 
     def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):
         if not location_ids:

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -153,7 +153,7 @@ class ProductProduct(models.Model):
                     [('location_dest_id.warehouse_id', '!=', warehouse_id)],
                     [('location_final_id.warehouse_id', '!=', warehouse_id)]
                 ]),  # includes moves going to customer or production
-                [('location_dest_id.name', '!=', 'Inventory adjustment')]  # exclude scrap
+                [('location_dest_id.usage', '!=', 'inventory')]  # exclude scrap
             ])
 
     def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):

--- a/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
+++ b/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
@@ -20,6 +20,10 @@ export class ProductCatalogPurchaseSuggestKanbanRecord extends ProductCatalogKan
     /** Add suggested_qty or pricelist_min_qty (the greater one) if positive, otherwise add 1. */
     addProduct() {
         const { min_qty = 1, suggested_qty = 0 } = this.productCatalogData;
-        super.addProduct(Math.max(min_qty, suggested_qty, 1));
+        let quantity_to_add = Math.max(min_qty, suggested_qty, 1);
+        if (this.productCatalogData.uomFactor) {
+            quantity_to_add = Math.ceil(quantity_to_add / this.productCatalogData.uomFactor);
+        }
+        super.addProduct(quantity_to_add);
     }
 }

--- a/addons/purchase_stock/static/tests/tours/purchase_catalog_suggest.js
+++ b/addons/purchase_stock/static/tests/tours/purchase_catalog_suggest.js
@@ -78,9 +78,9 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
          * (monthly demand, suggested_qty, forecasted + record ordering)
          * ------------------------------------------------------------------
          */
-        ...catalogSuggestion.setParameters({ basedOn: "Last 7 days", nbDays: 28, factor: 50 }), // 1 order of 12
+        ...catalogSuggestion.setParameters({ basedOn: "Last 7 days", nbDays: 28, factor: 50 }), // 1 order of 12 used in computation of demand // 28 days --> forecast uses both 50 delivery
         { trigger: "span[name='suggest_total']:visible:contains('480')" },
-        ...catalogSuggestion.assertCatalogRecord("test_product", { monthly: 52, suggest: 24 }),
+        ...catalogSuggestion.assertCatalogRecord("test_product", { monthly: 52, suggest: 24, forecast: 100 }),
         ...catalogSuggestion.checkKanbanRecordPosition("test_product", 0),
 
         ...catalogSuggestion.setParameters({ basedOn: "Last 30 days", factor: 10 }), // 2 orders of 12
@@ -92,9 +92,9 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
         ...catalogSuggestion.assertCatalogRecord("test_product", { monthly: 8, suggest: 37 }),
 
         // --- Check with Forecasted quantities
-        ...catalogSuggestion.setParameters({ basedOn: "Forecasted", factor: 100 }),
-        { trigger: "span[name='suggest_total']:visible:contains('2,000')" },
-        ...catalogSuggestion.assertCatalogRecord("test_product", { forecast: 100, suggest: 100 }),
+        ...catalogSuggestion.setParameters({ basedOn: "Forecasted", nbDays: 18, factor: 100 }),
+        { trigger: "span[name='suggest_total']:visible:contains('1,000')", pause: true },
+        ...catalogSuggestion.assertCatalogRecord("test_product", { forecast: 50, suggest: 50 }), // 18 days --> forecast uses only one 50 delivery
 
         ...catalogSuggestion.setParameters({ nbDays: 7 }),
         { trigger: "span[name='suggest_total']:visible:contains('$ 0.00')" }, // Move out of 100 in 20days, so no suggest for 7 days

--- a/addons/purchase_stock/tests/test_purchase_order_suggest.py
+++ b/addons/purchase_stock/tests/test_purchase_order_suggest.py
@@ -622,9 +622,12 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         )
         self.assertEqual(test_product.monthly_demand, 24)
 
-        # Create a and mark as todo a move in 20 days (for checking suggest/forecasted)
+        # Create and mark as todo a move in  18 & 20 days (for checking forecast on records and suggestion with Forecasted mode)
         self._create_and_process_delivery_at_date(
-            [(test_product, 100)], date=today + relativedelta(days=20), to_validate=False
+            [(test_product, 50)], date=today + relativedelta(days=18), to_validate=False
+        )
+        self._create_and_process_delivery_at_date(
+            [(test_product, 50)], date=today + relativedelta(days=20), to_validate=False
         )
         # Create a move yesterday on another warehouse
         other_warehouse = self.env.ref('stock.warehouse0')

--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -28,11 +28,13 @@
                     <span class="text-muted small me-1">Monthly Demand:</span>
                     <span class="fw-bold ms-1" t-esc="Math.round(record.monthly_demand.raw_value *100)/100" name="kanban_monthly_demand_qty"/>
                     <field name="uom_id" class="text-muted small ms-1" groups="uom.group_uom"/>
+                    <span class="text-muted small ms-1" groups="!uom.group_uom">Units</span>
                 </div>
                 <div name="kanban_purchase_suggest" t-if="record.suggested_qty.raw_value != 0">
                     <span class="text-info fw-bold fs-5 me-1">Suggest</span>
                     <span class="text-info fw-bold fs-5 me-1" t-out="record.suggested_qty.raw_value or 0" name="kanban_purchase_suggest_qty" />
-                    <span class="text-info fw-bold fs-5 me-1">units</span>
+                    <field name="uom_id" class="text-info fw-bold fs-5 me-1" groups="uom.group_uom"/>
+                    <span class="text-info fw-bold fs-5 me-1" groups="!uom.group_uom">Units</span>
                 </div>
             </div>
         </field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fixes 2 oversight in suggestions: 
- Interwarehouse transfers being excluded from demand calculation (eg in case of a central warehouse dispatching to individual stores and user replenishing the central warehouse)
- UoM not taken into account in suggestions

**Current behavior before PR:**
- Moves included in demand calculations are only the moves with final destination customer && moves going to manufacturing orders.
- Suggestion given in Units regardless of the product uom.
- If suggestion uom != purchase UoM no factor applied (eg. suggest ordering 6 units and pricelist is in Pack of 6 --> will add 6 Pack of 6 to the Purchase Order).

**Desired behavior after PR is merged:**
- Include interwarehouses move only if dest warehouse != source warehouse.
- Suggestion given in UoM of the product.
- If suggestion UoM != purchase UoM apply the factor of different rounded up (eg. if 3 units suggested -> order 1 pack of 6)

Documentation PR: odoo/documentation#15368
task#[5265507](https://www.odoo.com/odoo/project/966/tasks/5265507)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
