### PR TITLE
[FIX] hr_work_entry,hr_contract_salary_payroll: offer contract template

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -630,11 +630,12 @@ class HrVersion(models.Model):
 
     def write(self, vals):
         result = super().write(vals)
+        if self.env.context.get('salary_simulation'):
+            return result
         if vals.get('contract_date_end') or vals.get('contract_date_start') or vals.get('date_version'):
             self.sudo()._remove_work_entries()
         dependent_fields = self._get_fields_that_recompute_we()
-        salary_simulation = self.env.context.get('salary_simulation')
-        if not salary_simulation and any(key in dependent_fields for key in vals):
+        if any(key in dependent_fields for key in vals):
             for version_sudo in self.sudo():
                 date_from = max(version_sudo.date_start, version_sudo.date_generated_from.date())
                 date_to = min(version_sudo.date_end or date.max, version_sudo.date_generated_to.date())


### PR DESCRIPTION
Steps to reproduce the bug:
1. install hr_contract_salary_payroll
2. check "My US Company"
3. go on "Work Entries", then click on the arrow to view the next month. -> This will generate work entries for the next month
4. Go back to employees / Troy Cruz / Offers (smart button) -> You should be on the form view of a new offer. Do not save it.
5. Change the contract template to (e.g.) Experienced Developer -> A validation Error should appear

The validation error would tell us that we are trying to set a new contract to the employee, but the employee already had a running contract.

This happens because `self.employee_id` would be set to false just after the write of it's version's `contract_date_end`:
https://github.com/odoo/enterprise/blob/9ea4c1382a75024acacba7af1529d0c5cc762827/hr_contract_salary_payroll/models/hr_contract_salary_offer.py#L78C1-L78C7

This only happens when there are work entries after the specified end date. This is why we had to look at the next month's work entries.

The problematic code gets rolled back at some point, but `self.employee_id` stays empty if we don't save the form, since self is a `newId` in this case, which is not stored in the DB (and thus not rolled back)

The issue was that the context was supposed to have the `salary_simulation` key present, since we are doing a salary simulation.
But, the backend would still try to unlink the work entries of current_version during the simulation. Which is not needed and causes `self.current_employee_id` to be set to `False`

The context variable and a check before `_remove_work_entries()` has thus been added to fix that.

task-5207567
