### PR TITLE
[IMP] mail: improve thread previews

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -66,6 +66,7 @@ class DiscussChannelMember(models.Model):
     rtc_session_ids = fields.One2many(string="RTC Sessions", comodel_name='discuss.channel.rtc.session', inverse_name='channel_member_id')
     rtc_inviting_session_id = fields.Many2one('discuss.channel.rtc.session', string='Ringing session')
 
+    _channel_id_id_idx = models.Index("(channel_id, id)")
     _seen_message_id_idx = models.Index("(channel_id, partner_id, seen_message_id)")
 
     @api.autovacuum

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -14,8 +14,7 @@
                             <b class="o-mail-MessageInReply-author o-fw-600"><t t-out="props.message.parent_id.authorName"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">
                                 <i t-if="props.message.parent_id.hasAttachments" class="fa fa-fw me-1" t-att-class="props.message.parent_id.previewIcon" />
-                                <i t-if="props.message.parent_id.poll" class="fa fa-fw me-1 oi oi-view-cohort"/>
-                                <t t-if="!props.message.parent_id.isBodyEmpty">
+                                <t t-if="props.message.parent_id.inlineBody">
                                     <t t-out="props.message.parent_id.inlineBody"/>
                                     <em t-if="props.message.parent_id.edited" class="smaller fw-bold text-500"> (edited)</em>
                                 </t>
@@ -23,8 +22,6 @@
                                     <t t-if="props.message.parent_id.attachment_ids.length > 0">
                                         Click to see the attachments
                                     </t>
-                                    <t t-elif="props.message.parent_id.ended_poll_ids.length" t-out="props.message.parent_id.poll.pollClosedText"/>
-                                    <t t-elif="props.message.parent_id.poll" t-esc="props.message.parent_id.poll.poll_question"/>
                                 </span>
                             </span>
                         </span>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.scss
@@ -45,3 +45,7 @@
         padding: map-get($spacers, 1) / 2;
     }
 }
+
+.o-mail-DiscussSidebarCallParticipants-avatarStack {
+    margin: 1px;
+}

--- a/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.xml
@@ -23,14 +23,14 @@
             'px-2': props.compact === false,
             'rounded-3': props.compact === undefined,
             'opacity-75': props.channel.notEq(rtc.channel) and compact,
-        }" style="margin: 1px;">
+        }">
             <button class="o-mail-DiscussSidebarCallParticipants-expandBtn btn btn-link p-1 my-n1 ms-n1 me-0 align-self-start d-flex rounded-circle" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
                 <i class="oi o-xxsmaller text-muted text-dark" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>
             </button>
             <AvatarStack
                 t-if="!state.expanded"
                 direction="compact ? 'v' : 'h'"
-                containerClass="compact ? '' : 'cursor-pointer'"
+                containerClass="compact ? '' : 'cursor-pointer o-mail-DiscussSidebarCallParticipants-avatarStack'"
                 avatarClass="(p) => this.avatarClass(p)"
                 max="compact ? 1 : 7"
                 size="26"

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.js
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.js
@@ -2,27 +2,34 @@ import { Component } from "@odoo/owl";
 
 /**
  * @typedef {Object} Props
- * @prop {(persona: import("models").Persona) => string} [avatarClass]
- * Function used to determine extra classes for the avatars.
+ * @prop {(persona: import("models").Persona) => string} [avatarClass] Function
+ * used to determine extra classes for the avatars.
  * @prop {Array} personas List of personas to display in the stack.
- * @prop {"v"|"h"} [direction] Determine the direction of the
- * stack (vertical or horizontal).
+ * @prop {"v"|"h"} [direction] Determine the direction of the stack (vertical or
+ * horizontal).
  * @prop {number} [max] Maximum number of personas to display in the stack. An
  * hidden count will be displayed if there are more personas than max.
  * @prop {number} [size] Size of the avatars, in pixel.
+ * @prop {number} [total] Total number of avatars. Useful to avoid fetching
+ * every persona while keeping an accurate counter.
+ * @prop {number} [spacing] Spacing between the avatars in pixels. Will impact
+ * negative margin which is used to position the avatars (the higher, the
+ * closer).
  * @extends {Component<Props, Env>}
  */
 export class AvatarStack extends Component {
     static template = "mail.AvatarStack";
     static props = {
+        avatarClass: { type: Function, optional: true },
         containerClass: { type: String, optional: true },
         direction: { type: String, optional: true, validate: (d) => ["v", "h"].includes(d) },
-        avatarClass: { type: Function, optional: true },
         max: { type: Number, optional: true },
         onClick: { type: Function, optional: true },
         personas: Array,
         size: { type: Number, optional: true },
         slots: { optional: true },
+        spacing: { type: Number, optional: true },
+        total: { type: Number, optional: true },
     };
     static defaultProps = {
         avatarClass: () => "",
@@ -30,22 +37,27 @@ export class AvatarStack extends Component {
         max: 4,
         size: 24,
         direction: "h",
+        spacing: 8,
     };
 
     getStyle(index) {
         const styles = [
             "box-sizing: content-box",
             `height: ${this.props.size}px`,
-            "margin: 1px",
             `padding: 1.5px`,
             `width: ${this.props.size}px`,
-            `z-index: ${this.props.personas.length - index}`,
+            `z-index: ${this.props.personas.length + index}`,
         ];
         if (index !== 0) {
             // Compute cumulative offset,
             const marginDirection = this.props.direction === "v" ? "top" : "left";
-            styles.push(`margin-${marginDirection}: -${this.props.size / 4.5}px`);
+            styles.push(`margin-${marginDirection}: -${this.props.spacing}px`);
         }
         return styles.join(";");
+    }
+
+    get remainingCount() {
+        const total = this.props.total ?? this.props.personas.length;
+        return total - Math.min(this.props.personas.length, this.props.max);
     }
 }

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -7,7 +7,9 @@
                     <img t-att-src="persona.avatarUrl" t-att-title="persona.displayName or persona.name" class="w-100 h-100 rounded-circle object-fit-cover" t-attf-class="{{props.avatarClass(persona)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
-                <span t-if="props.personas.length > props.max" class="rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}; font-weight: 450;">+<t t-esc="props.personas.length - props.max"/></span>
+                <span t-if="remainingCount > 0" class="bg-inherit rounded-circle" t-attf-style="{{getStyle(props.personas.length)}};">
+                    <span class="o-mail-AvatarStack-remainingCount rounded-circle h-100 w-100 bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" style="font-weight: 450;">+<t t-esc="remainingCount"/></span>
+                </span>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/core/public_web/message_patch.scss
+++ b/addons/mail/static/src/discuss/core/public_web/message_patch.scss
@@ -1,3 +1,5 @@
+$o-mail-SubChannelPreview-width: 400px;
+
 .o-mail-Message .o-mail-SubChannelPreview {
-    max-width: $o-mail-LinkPreview-width;
+    max-width: $o-mail-SubChannelPreview-width;
 }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.js
@@ -1,9 +1,14 @@
+import { AvatarStack } from "@mail/discuss/core/common/avatar_stack";
 import { isToday } from "@mail/utils/common/dates";
+
 import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
 
 const { DateTime } = luxon;
 
 export class SubChannelPreview extends Component {
+    static components = { AvatarStack };
     static template = "mail.SubChannelPreview";
     static props = ["class?", "onClick?", "thread"];
 
@@ -20,5 +25,12 @@ export class SubChannelPreview extends Component {
 
     onClick() {
         this.props.onClick?.();
+    }
+
+    get messageCountText() {
+        if (this.thread.channel.message_count === 1) {
+            return _t("1 Message");
+        }
+        return _t("%(count)s Messages", { count: this.thread.channel.message_count });
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.scss
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.scss
@@ -8,6 +8,5 @@
 
 .o-mail-SubChannelPreview-lastMessage {
     display: -webkit-box;
-    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
 }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
@@ -2,18 +2,28 @@
 <templates xml:space="preserve">
     <t t-name="mail.SubChannelPreview">
         <t t-set="message" t-value="thread.newestPersistentOfAllMessage ?? thread.from_message_id"/>
-        <button class="o-mail-SubChannelPreview btn btn-light-subtle d-flex border border-secondary mx-1 px-2 py-1 rounded-2 align-items-center" t-attf-class="{{ props.class }}" t-on-click="onClick">
-            <div class="d-flex flex-column w-100">
-                <div class="d-flex w-100">
+        <div class="o-mail-SubChannelPreview btn btn-light-subtle d-flex border border-secondary mx-1 px-2 py-1 rounded-2 align-items-center" role="button" t-att-class="{'o-pe-1_5': env.inMessage}" t-attf-class="{{ props.class }}" t-on-click="onClick">
+            <div class="d-flex flex-column w-100 bg-inherit">
+                <div class="d-flex w-100 align-items-baseline">
                     <span class="o-fw-600 text-truncate small" t-esc="thread.displayName"/>
-                    <span class="flex-grow-1 pe-1"/>
-                    <span t-if="message" class="text-muted smaller flex-shrink-0" t-esc="dateText(message)"/>
+                    <span class="flex-grow-1"/>
+                    <span t-if="message" class="flex-shrink-0 fw-normal text-muted smaller ms-1" t-att-class="{'o-me-0_5 o-xsmaller': env.inMessage}" t-esc="message.dateSimple"/>
                 </div>
-                <div class="o-mail-SubChannelPreview-lastMessage text-start text-muted fw-normal smaller overflow-hidden ms-2">
-                    <t t-out="message?.previewText"/>
+                <div t-if="message" class="o-mail-SubChannelPreview-lastMessage text-muted fw-normal smaller overflow-hidden d-flex align-items-center bg-inherit">
+                    <img class="rounded object-fit-cover" t-att-src="message.author.avatarUrl" t-att-title="message.authorName" alt="Avatar" style="width: 20px; height: 20px;"/>
+                    <span class="ms-1 fw-bold flex-shrink-0">
+                        <t t-if="message.isSelfAuthored">You</t>
+                        <t t-else="" t-esc="message.authorName"/>:
+                    </span>
+                    <span class="text-truncate ms-1" t-out="message.bodyPreview"/>
+                    <span class="flex-grow-1"/>
+                    <AvatarStack t-if="!env.inMessage" containerClass="'ms-1'" personas="thread.channel.channel_member_ids.map((m) => m.persona)" size="22" spacing="10" total="thread.channel.member_count"/>
+                    <span t-elif="thread.channel.message_count" class="text-primary smaller flex-shrink-0 d-flex fw-bold align-items-center ms-1">
+                        <t t-esc="messageCountText"/>
+                        <i class="o-xxsmaller o-ms-0_5 oi oi-chevron-right"/>
+                    </span>
                 </div>
             </div>
-            <i t-if="env.inMessage" class="oi oi-chevron-right ms-2 opacity-50"/>
-        </button>
+        </div>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -513,7 +513,7 @@ test("expand call participants when joining a call", async () => {
     await contains("img[title='Bob']");
     await contains("img[title='Cathy']");
     await contains("img[title='David']");
-    await contains(".o-mail-DiscussSidebarCallParticipants span", { text: "+2" });
+    await contains(".o-mail-AvatarStack-remainingCount", { text: "+2" });
     await click("[title='Join Call']");
     await contains(".o-mail-DiscussSidebarCallParticipants img", { count: 10 });
     await contains("img[title='Alice']");


### PR DESCRIPTION
This commit improve the thread previews:
- Show last message author avatar and name.
- Show number of messages in thread
- Show members of the thread from the thread menu.

part of task-5227387

||Before|After|
|--|--|--|
|Thread Menu|<img width="589" height="457" alt="image" src="https://github.com/user-attachments/assets/26f275ce-0cc7-4e19-81b7-24df26349bd9" />|<img width="468" height="332" alt="image" src="https://github.com/user-attachments/assets/3bdde436-2832-4033-8e83-9bbc7c457b3a" />|
|Thread preview|<img width="565" height="220" alt="image" src="https://github.com/user-attachments/assets/3200c50a-3b14-4b7b-a90b-d6c7cb3bf17e" />|<img width="550" height="211" alt="image" src="https://github.com/user-attachments/assets/7633d6f9-506b-479e-884d-44a09a62259f" />|