### PR TITLE
[IMP] account: add new popover on tax-tag and improve form-view of tax-form

### DIFF
--- a/addons/account/static/src/components/many2x_tax_tags/tax_tag_popover.js
+++ b/addons/account/static/src/components/many2x_tax_tags/tax_tag_popover.js
@@ -1,0 +1,11 @@
+import { Component } from "@odoo/owl";
+
+export class TaxTagPopup extends Component {
+    static template = "account.tax_tag_popover_template";
+    static props = {
+        description: { type: String, optional: true },
+        invoiceLines: { type: Array, optional: true },
+        refundLines: { type: Array, optional: true },
+        close: { type: Function, optional: true },
+    };
+}

--- a/addons/account/static/src/components/many2x_tax_tags/tax_tag_popover.xml
+++ b/addons/account/static/src/components/many2x_tax_tags/tax_tag_popover.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="account.tax_tag_popover_template">
+        <div class="bg-view rounded-0 mw-100">
+
+            <div class="p-2 border-bottom bg-light d-flex justify-content-between align-items-center">
+                <span class="fw-bold">Tax Distribution</span>
+                <button type="button" class="btn-close" t-on-click="props.close" tabindex="-1"/>
+            </div>
+
+            <div class="p-3 o_invoice_tax_summary">
+
+                <t t-if="props.description">
+                    <span class="text-capitalize d-block mb-3 fs-6">
+                        <t t-esc="props.description"/>
+                    </span>
+                </t>
+
+                <div t-if="props.invoiceLines.length > 0" class="mb-2 fs-6">
+                    <div class="d-flex align-items-start">
+                        <div class="fw-bold me-2">Invoice :</div>
+
+                        <div class="d-flex flex-wrap align-items-center">
+                            <t t-foreach="props.invoiceLines" t-as="group" t-key="group.type">
+                                <t t-if="group.lines.map(line => line.tag_names).flat().length">
+                                    <div class="d-flex align-items-center me-2 mb-2">
+                                        <span class="text-capitalize me-2">
+                                            <t t-esc="group.type"/>
+                                        </span>
+
+                                        <t t-foreach="group.lines" t-as="line" t-key="line_index">
+                                            <t t-foreach="line.tag_names" t-as="tname" t-key="tname_index">
+                                                <span class="o_tag o_tag_color_0 badge rounded-pill me-1 text-dark border">
+                                                    <t t-esc="tname"/>
+                                                    <t t-if="group.type!='base' and line.factor_percent">
+                                                        (<t t-esc="line.factor_percent"/>%)
+                                                    </t>
+                                                </span>
+                                            </t>
+                                        </t>
+                                    </div>
+                                </t>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+
+                <div t-if="props.refundLines.length" class="mb-2 fs-6">
+                    <div class="d-flex align-items-start">
+                        <div class="fw-bold me-2">Credit Note :</div>
+
+                        <div class="d-flex flex-wrap align-items-center">
+                            <t t-foreach="props.refundLines" t-as="group" t-key="group.type">
+                                <t t-if="group.lines.map(line => line.tag_names).flat().length">
+                                    <div class="d-flex align-items-center me-2 mb-2">
+                                        <span class="text-capitalize me-2">
+                                            <t t-esc="group.type"/>
+                                        </span>
+
+                                        <t t-foreach="group.lines" t-as="line" t-key="line_index">
+                                            <t t-foreach="line.tag_names" t-as="tname" t-key="tname_index">
+                                                <span class="o_tag o_tag_color_0 badge rounded-pill me-1 text-dark border">
+                                                    <t t-esc="tname"/>
+                                                    <t t-if="group.type!='base' and line.factor_percent">
+                                                        (<t t-esc="line.factor_percent"/>%)
+                                                    </t>
+                                                </span>
+                                            </t>
+                                        </t>
+                                    </div>
+                                </t>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -198,17 +198,15 @@
                         <group>
                             <field name="name"/>
                             <field name="amount_type"/>
-                            <field name="active" widget="boolean_toggle"/>
-                        </group>
-                        <group>
-                            <field name="is_used" invisible="1"/>
-                            <field name="type_tax_use"/>
-                            <field name="tax_scope"/>
                             <label for="amount" invisible="amount_type not in ('fixed', 'percent', 'division')"/>
                             <div invisible="amount_type not in ('fixed', 'percent', 'division')">
                                 <field name="amount" class="oe_inline" nolabel="1"/>
                                 <span class="o_form_label oe_inline" invisible="amount_type == 'fixed'">%</span>
                             </div>
+                            <field name="description"/>
+                        </group>
+                        <group>
+                            <field name="type_tax_use"/>
                             <field name="fiscal_position_ids" widget="many2many_tags" placeholder="all"/>
                             <field name="original_tax_ids"
                                    widget="many2many_tags"
@@ -241,7 +239,7 @@
                             <group>
                                 <group>
                                     <field name="invoice_label"/>
-                                    <field name="description"/>
+                                    <field name="tax_scope"/>
                                     <field name="tax_group_id" invisible="amount_type == 'group'" required="amount_type != 'group'"/>
                                     <field name="analytic" invisible="amount_type == 'group'" groups="analytic.group_analytic_accounting" />
                                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
@@ -258,6 +256,7 @@
                                     <field name="is_base_affected"
                                            invisible="amount_type == 'group' or price_include"
                                            groups="base.group_no_one"/>
+                                    <field name="active" widget="boolean_toggle"/>
                                     <field name="hide_tax_exigibility" invisible="1"/>
                                     <field name="tax_exigibility" widget="radio" invisible="amount_type == 'group' or not hide_tax_exigibility"/>
                                     <field name="cash_basis_transition_account_id" options="{'no_create': True}" invisible="tax_exigibility == 'on_invoice'" required="tax_exigibility == 'on_payment'" groups="account.group_account_readonly"/>

--- a/addons/l10n_eg/views/account_tax.xml
+++ b/addons/l10n_eg/views/account_tax.xml
@@ -4,7 +4,7 @@
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
-            <field name="tax_scope" position="after">
+            <field name="type_tax_use" position="after">
                 <field name="l10n_eg_eta_code" invisible="country_code != 'EG'"/>
             </field>
         </field>

--- a/addons/l10n_es/views/account_tax_views.xml
+++ b/addons/l10n_es/views/account_tax_views.xml
@@ -6,7 +6,7 @@
             <field name="model">account.tax</field>
             <field name="inherit_id" ref="account.view_tax_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='tax_scope']" position="after">
+                <xpath expr="//field[@name='type_tax_use']" position="after">
                     <field name="l10n_es_type"
                            invisible="country_code != 'ES'"/>
                     <field name="l10n_es_exempt_reason"

--- a/addons/l10n_in/views/account_tax_views.xml
+++ b/addons/l10n_in/views/account_tax_views.xml
@@ -5,7 +5,7 @@
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
-            <field name="tax_scope" position="after">
+            <field name="type_tax_use" position="after">
                 <field name="l10n_in_tax_type" invisible="amount_type == 'group' or country_code != 'IN'"/>
             </field>
             <field name="is_base_affected" position="after">

--- a/addons/l10n_my_edi/views/account_tax_view.xml
+++ b/addons/l10n_my_edi/views/account_tax_view.xml
@@ -5,7 +5,7 @@
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='active']" position="after">
+            <xpath expr="//field[@name='description']" position="before">
                 <field name="l10n_my_tax_type" invisible="country_code != 'MY'"/>
                 <field name="l10n_my_tax_exemption_reason" invisible="l10n_my_tax_type != 'E'"/>
             </xpath>

--- a/addons/l10n_tr_nilvera_einvoice/views/account_tax_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_tax_views.xml
@@ -5,7 +5,7 @@
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='tax_scope']" position="after">
+            <xpath expr="//field[@name='type_tax_use']" position="after">
                 <field name="l10n_tr_tax_withholding_code_id" invisible="country_code != 'TR' or amount_type != 'percent' or amount &gt;= 0"/>
             </xpath>
         </field>


### PR DESCRIPTION
**PURPOSE**
 - Move Tax Description to the main tax form for better visibility.
 - Move Active and Tax Scope to Advanced Options.
 - Allow clicking tax tags on invoices to show a simplified, read-only 
   Tax definition for quick reference.

**SPACIFICATION**
 - Reposition Fields in Account Tax Form
        1) Move the field description from the Advanced Options tab to the 
            main form.
        2) Move the fields Active and  Tax Scope from the 
            main tax form to the Advanced Options tab.
 - Introduced a new popover, which will open when you click on the tax-tag
   which is read-only and contains information on the current tax's description 
   and its distribution over Invoice and Credit Note.

task-5180784