### PR TITLE
[FIX] hr, hr_holidays: correct underline length

### DIFF
--- a/addons/hr/README.md
+++ b/addons/hr/README.md
@@ -46,7 +46,7 @@ timesheets or check attendances for each employee. Get your analytic accounting
 posted automatically based on time spent on your projects.
 
 Time Off Management
------------------
+-------------------
 
 Keep track of the vacation days accrued by each employee. Employees enter their
 requests (paid time off, sick time off, etc), for managers to approve and

--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -10,7 +10,7 @@
     'website': 'https://www.odoo.com/app/time-off',
     'description': """
 Manage time off requests and allocations
-=====================================
+========================================
 
 This application controls the time off schedule of your company. It allows employees to request time off. Then, managers can review requests for time off and approve or reject them. This way you can control the overall time off planning for the company or department.
 


### PR DESCRIPTION
This pull request fixes improperly formatted reStructuredText section titles in the hr module documentation. The original MD file used a section underline that were shorter than the title text, which caused docutils to raise this warning:

(WARNING/2) Title underline too short.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
