### PR TITLE
[FIX] base_import: fix properties import when definition isn't access…

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -318,8 +318,13 @@ class Import(models.TransientModel):
             definition_record_field = field['definition_record_field']
 
             target_model = Model.env[Model._fields[definition_record].comodel_name]
-            if not target_model.has_access('read'):  # ignore if you cannot read target_model at all
+
+            # ignore if you cannot access to the target model or the field definition
+            if not target_model.has_access('read'):
                 continue
+            if not target_model._fields[definition_record_field].is_accessible(target_model.env):
+                continue
+
             # Do not take into account the definition of archived parents,
             # we do not import archived records most of the time.
             definition_records = target_model.search_fetch(

--- a/addons/test_import_export/tests/test_properties.py
+++ b/addons/test_import_export/tests/test_properties.py
@@ -1,5 +1,5 @@
 import json
-from odoo.tests.common import RecordCapturer, HttpCase
+from odoo.tests.common import RecordCapturer, HttpCase, new_test_user
 
 
 class TestPropertiesExportImport(HttpCase):
@@ -436,3 +436,72 @@ class TestPropertiesExportImport(HttpCase):
             {'bool_prop': True, 'tags_prop': ['bb'], 'm2m_prop': self.partners[1:].ids},
             {'bool_prop': False, 'tags_prop': ['bb', 'cc'], 'm2m_prop': False},
         ])
+
+    def test_import_properties_no_acces_acl(self):
+        model_id = self.env['ir.model']._get_id(self.ModelDefinition._name)
+
+        user = new_test_user(self.env, login='AAA', groups='base.group_system')
+        self.env['ir.model.access'].search([('model_id', '=', model_id)]).unlink()
+        self.env['ir.model.access'].create({
+            'name': "don't care",
+            'model_id': model_id,
+            'group_id': self.env.ref('base.group_system').id,
+            'perm_read': False,
+        })
+
+        values_list = [
+            [
+                "Record Definition Id", f"TextType ({self.definition_records[0].display_name})",
+            ],
+            [
+                str(self.definition_records[0].id), 'One Text',
+            ],
+        ]
+        Import = self.env['base_import.import'].with_user(user)
+
+        import_wizard = Import.create({
+            'res_model': self.ModelProperty._name,
+            'file': '\n'.join([';'.join(values) for values in values_list]),
+            'file_type': 'text/csv',
+        })
+        opts = {'quoting': '"', 'separator': ';', 'has_headers': True}
+        preview = import_wizard.parse_preview(opts)
+
+        # Don't find the properties field since the user doesn't have accept to the definition model
+        self.assertEqual(
+            preview['matches'],
+            {
+                0: ['record_definition_id'],
+            },
+        )
+
+    def test_import_properties_no_acces_groups(self):
+        user = new_test_user(self.env, login='AAA', groups='base.group_system')
+        values_list = [
+            [
+                "Record Definition Id", f"TextType ({self.definition_records[0].display_name})",
+            ],
+            [
+                str(self.definition_records[0].id), 'One Text',
+            ],
+        ]
+        Import = self.env['base_import.import'].with_user(user)
+
+        # Patch groups of properties_definition
+        self.patch(self.ModelDefinition._fields['properties_definition'], "groups", "base.NO_ACCESS")
+
+        import_wizard = Import.create({
+            'res_model': self.ModelProperty._name,
+            'file': '\n'.join([';'.join(values) for values in values_list]),
+            'file_type': 'text/csv',
+        })
+        opts = {'quoting': '"', 'separator': ';', 'has_headers': True}
+        preview = import_wizard.parse_preview(opts)
+
+        # Don't find the properties field since the user doesn't have access to the field definition
+        self.assertEqual(
+            preview['matches'],
+            {
+                0: ['record_definition_id'],
+            },
+        )


### PR DESCRIPTION
…ible

https://github.com/odoo/odoo/pull/236037 ignores the properties field if we don't have access to the definition model at all. However, we should also check field groups to avoid crashing if the user cannot access the definition field because of group restrictions.
