### PR TITLE
[FIX] hr_work_entry_holidays_enterprise: confict 24h

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.fields import Command, Domain
-from odoo.tools import ormcache
+from odoo.tools import ormcache, float_is_zero
 from odoo.tools.intervals import Intervals
 
 
@@ -451,6 +451,12 @@ class HrVersion(models.Model):
                 date_start_work_entries = max(date_start, version_start)
                 date_stop_work_entries = min(date_stop, version_stop)
                 if force:
+                    domain_to_nullify |= Domain([
+                        ('version_id', '=', version.id),
+                        ('date', '>=', date_start_work_entries.date()),
+                        ('date', '<=', date_stop_work_entries.date()),
+                        ('state', '!=', 'validated'),
+                    ])
                     intervals_to_generate[date_start_work_entries, date_stop_work_entries] |= version
                     continue
 
@@ -471,8 +477,9 @@ class HrVersion(models.Model):
             date_from, date_to = interval
             vals_list.extend(versions._get_work_entries_values(date_from, date_to))
 
-        work_entries_to_nullify = self.env['hr.work.entry'].search(domain_to_nullify)
-        work_entries_to_nullify.write(work_entry_null_vals)
+        if domain_to_nullify != Domain.FALSE:
+            work_entries_to_nullify = self.env['hr.work.entry'].search(domain_to_nullify)
+            work_entries_to_nullify.write(work_entry_null_vals)
 
         if not vals_list:
             return self.env['hr.work.entry']
@@ -592,6 +599,8 @@ class HrVersion(models.Model):
         # Now merge similar work entries on the same day
         merged_vals = {}
         for vals in vals_list:
+            if float_is_zero(vals['duration'], 3):
+                continue
             key = (
                 vals['date'],
                 vals.get('work_entry_type_id', False),

--- a/addons/hr_work_entry/tests/test_work_entry.py
+++ b/addons/hr_work_entry/tests/test_work_entry.py
@@ -60,15 +60,15 @@ class TestWorkEntry(TestWorkEntryBase):
 
     def test_outside_calendar(self):
         """ Test leave work entries outside schedule are conflicting """
-        work_entry_1, work_entry_2 = self.create_work_entries([
+        work_entries = self.create_work_entries([
             # Outside but not a leave
             (datetime(2018, 10, 13, 3, 0), datetime(2018, 10, 13, 4, 0)),
             # Outside and a leave
             (datetime(2018, 10, 13, 1, 0), datetime(2018, 10, 13, 2, 0), self.work_entry_type_leave),
         ])
-        (work_entry_1 | work_entry_2)._mark_leaves_outside_schedule()
-        self.assertEqual(work_entry_2.state, 'conflict', "It should conflict")
-        self.assertNotEqual(work_entry_1.state, 'conflict', "It should not conflict")
+        work_entries._mark_leaves_outside_schedule()
+        self.assertEqual(len(work_entries), 1, "The second work entry should not be generated. As it is a leave outside of the working schedule")
+        self.assertNotEqual(work_entries.state, 'conflict', "It should not conflict")
 
     def test_work_entry_timezone(self):
         """ Test work entries with different timezone """

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -85,9 +85,12 @@
                 <div class="alert alert-warning text-center" role="alert" invisible="state != 'validated'">
                     Note: Validated work entries cannot be modified.
                 </div>
-                <div invisible="state != 'conflict'">
-                    <div class="alert alert-warning" role="alert" invisible="work_entry_type_id" name="work_entry_undefined">
+                <div class="alert alert-warning" invisible="state != 'conflict'" role="alert" name="work_entry_undefined">
+                    <div invisible="work_entry_type_id">
                         This work entry cannot be validated. The work entry type is undefined.
+                    </div>
+                    <div invisible="not work_entry_type_id">
+                        The amount of work on the day should not exceed 24 hours.
                     </div>
                 </div>
                 <sheet>
@@ -95,17 +98,17 @@
                         <group>
                             <field name="name" string="Description" placeholder="Additional Description..." readonly="state == 'validated'"/>
                             <field name="work_entry_type_id" readonly="state == 'validated'" options="{'no_create': True, 'no_open': True}" widget="many2one_work_entry_type"/>
-                            <field name="employee_id" readonly="state != 'draft'" widget="many2one_avatar_employee"/>
+                            <field name="employee_id" readonly="state == 'validated'" widget="many2one_avatar_employee"/>
                         </group>
                         <group>
-                            <field name="date" readonly="state != 'draft'"/>
+                            <field name="date" readonly="state == 'validated'"/>
                             <label for="duration"/>
                             <div class="o_row mw-50 mw-sm-25">
                                 <field name="duration"
                                     nolabel="1"
                                     widget="float_time"
                                     class="o_hr_narrow_field"
-                                    readonly="state != 'draft'"/>
+                                    readonly="state == 'validated'"/>
                                 <span>Hours</span>
                             </div>
                             <field name="company_id" invisible="1"/>

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
@@ -110,12 +110,6 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
             valid_employees = self.employee_ids - self.validated_work_entry_employee_ids
             date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
             date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
-            work_entries = self.env['hr.work.entry'].search([
-                ('employee_id', 'in', valid_employees.ids),
-                ('date', '>=', date_from),
-                ('date', '<=', date_to),
-                ('state', '!=', 'validated')])
-            work_entries.write(write_vals)
             valid_employees.generate_work_entries(date_from, date_to, True)
         else:
             range_by_employee = defaultdict(list)


### PR DESCRIPTION
Problem
----------
Work entries on the same day were in conflict only if a work entry was created with a duration > 1000h Even if we write an existing work entry with a duration > 1000h => no conflict. Event if we create multiple work entries, it will only make the sum of work entries created and not existing ones

Solution
----------
Check the sum of duration for a day between 0 and 24 hours. Fetch all work entries matching the date of the check to make the sum of durations

task-5349515
