### PR TITLE
[FIX] hw_drivers: prevent duplicate report printing

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -35,13 +35,9 @@ class DriverController(http.Controller):
             data = json.loads(data)
 
             # Skip the request if it was already executed (duplicated action calls)
-            iot_idempotent_id = data.get("iot_idempotent_id")
-            if iot_idempotent_id:
-                idempotent_session = iot_device._check_idempotency(iot_idempotent_id, session_id)
-                if idempotent_session:
-                    _logger.info("Ignored request from %s as iot_idempotent_id %s already received from session %s",
-                                 session_id, iot_idempotent_id, idempotent_session)
-                    return False
+            if iot_device._check_idempotency(**data, session_id=session_id):
+                return False
+
             _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
             iot_device.action(data)
             return True

--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import logging
 from threading import Thread, Event
 
 from odoo.addons.hw_drivers.main import drivers, iot_devices
 from odoo.tools.lru import LRU
+
+_logger = logging.getLogger(__name__)
 
 
 class DriverMetaClass(type):
@@ -50,8 +53,7 @@ class Driver(Thread, metaclass=DriverMetaClass):
     def action(self, data):
         """Helper function that calls a specific action method on the device.
 
-        :param data: the `_actions` key mapped to the action method we want to call
-        :type data: string
+        :param dict data: the `_actions` key mapped to the action method we want to call
         """
         self._actions[data.get('action', '')](data)
 
@@ -59,17 +61,26 @@ class Driver(Thread, metaclass=DriverMetaClass):
         self._stopped.set()
         del iot_devices[self.device_identifier]
 
-    def _check_idempotency(self, iot_idempotent_id, session_id):
-        """
-        Some IoT requests for the same action might be received several times.
+    def _check_idempotency(self, iot_idempotent_id=None, session_id="unknown", **_kwargs):
+        """Some IoT requests for the same action might be received several times.
         To avoid duplicating the resulting actions, we check if the action was "recently" executed.
         If this is the case, we will simply ignore the action
 
+        :param str iot_idempotent_id: the idempotent ID received from the controller
+        :param session_id: the session ID of the current request
+        :param dict _kwargs: only here to allow providing the whole websocket/longpolling received dict
         :return: the `session_id` of the same `iot_idempotent_id` if any. False otherwise,
         which means that it is the first time that the IoT box received the request with this ID
         """
+        if not iot_idempotent_id:
+            return False
+
         cache = self._iot_idempotent_ids_cache
         if iot_idempotent_id in cache:
+            _logger.debug(
+                "Ignored request from '%s' as iot_idempotent_id '%s' already received",
+                iot_idempotent_id, cache[iot_idempotent_id]
+            )
             return cache[iot_idempotent_id]
         cache[iot_idempotent_id] = session_id
         return False

--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -56,9 +56,11 @@ def on_message(ws, messages):
                 for device in payload['iotDevice']['identifiers']:
                     device_identifier = device['identifier']
                     if device_identifier in main.iot_devices:
+                        if main.iot_devices[device_identifier]._check_idempotency(**payload):
+                            return
                         start_operation_time = time.perf_counter()
                         _logger.debug("device '%s' action started with: %s", device_identifier, pprint.pformat(payload))
-                        main.iot_devices[device_identifier]._action_default(payload)
+                        main.iot_devices[device_identifier].action(payload)
                         _logger.info("device '%s' action finished - %.*f", device_identifier, 3, time.perf_counter() - start_operation_time)
                         send_to_controller(payload['print_id'], device_identifier)
             else:


### PR DESCRIPTION
In order to prevent duplicate IoT actions, we now ensure that websocket actions have not already been called through longpolling.

odoo/enterprise#100161
