### PR TITLE
[IMP] *: rename "Cancel" to "Discard"

### DIFF
--- a/addons/account/static/src/components/currency_form/form_controller.js
+++ b/addons/account/static/src/components/currency_form/form_controller.js
@@ -21,7 +21,6 @@ export class CurrencyFormController extends FormController {
                         "This change cannot be undone without technical support."
                     ),
                     confirmLabel: _t("Confirm"),
-                    cancelLabel: _t("Cancel"),
                     confirm: () => resolve(true),
                     cancel: () => {
                         record.discard();

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -92,7 +92,7 @@
                 <field name="account_sale_tax_id" />
                 <footer>
                     <button string="Apply" class="btn btn-primary" type="object" name="action_save_onboarding_sale_tax" data-hotkey="q" />
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -29,7 +29,7 @@
                 <field name="invoice_terms_html" class="oe_account_terms" nolabel="1"/>
                 <footer>
                     <button string="Save" special="save" class="btn-primary"/>
-                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>
@@ -75,7 +75,7 @@
                 <footer>
                     <button name="action_save_onboarding_company_data" string="Save"
                             class="oe_highlight" type="object" data-hotkey="S" />
-                    <button special="cancel" data-hotkey="J" string="Discard" />
+                    <button special="cancel" data-hotkey="J"/>
                 </footer>
             </form>
         </field>

--- a/addons/account/wizard/account_automatic_entry_wizard_views.xml
+++ b/addons/account/wizard/account_automatic_entry_wizard_views.xml
@@ -45,7 +45,7 @@
                     <field name="preview_move_data" widget="grouped_view_widget" class="d-block"/>
                     <footer>
                         <button string="Create Journal Entries" name="do_action" type="object" class="oe_highlight" data-hotkey="q"/>
-                        <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account/wizard/account_merge_wizard_views.xml
+++ b/addons/account/wizard/account_merge_wizard_views.xml
@@ -31,7 +31,7 @@
                     <footer>
                         <button string="Merge" name="action_merge" type="object" class="oe_highlight" data-hotkey="q" invisible="disable_merge_button"/>
                         <button string="Merge" name="action_merge" type="object" class="oe_highlight disabled" data-hotkey="q" invisible="not disable_merge_button"/>
-                        <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account/wizard/account_move_reversal_view.xml
+++ b/addons/account/wizard/account_move_reversal_view.xml
@@ -19,7 +19,7 @@
                     <footer>
                         <button string='Reverse' name="refund_moves" type="object" class="btn-primary" data-hotkey="q"/>
                         <button string="Reverse and Create Invoice" name="modify_moves" type="object" class="btn-secondary" invisible="move_type  == 'entry'"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                </form>
             </field>

--- a/addons/account/wizard/account_move_send_batch_wizard.xml
+++ b/addons/account/wizard/account_move_send_batch_wizard.xml
@@ -23,10 +23,7 @@
                             type="object"
                             class="print btn-primary o_mail_send">
                     </button>
-                    <button string="Cancel"
-                            data-hotkey="x"
-                            special="cancel"
-                            class="btn-secondary"/>
+                    <button class="btn-secondary" data-hotkey="x" special="cancel"/>
                 </footer>
 
             </form>

--- a/addons/account/wizard/account_move_send_wizard.xml
+++ b/addons/account/wizard/account_move_send_wizard.xml
@@ -73,8 +73,7 @@
                             type="object"
                             class="btn-primary"
                             invisible="sending_methods"/>
-                    <button string="Discard"
-                            data-hotkey="x"
+                    <button data-hotkey="x"
                             special="cancel"
                             class="btn-secondary"/>
 

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -134,7 +134,7 @@
                     <footer>
                         <button string="Create Payments" name="action_create_payments" type="object" class="oe_highlight" data-hotkey="q" invisible="total_payments_amount == 1"/>
                         <button string="Create Payment" name="action_create_payments" type="object" class="oe_highlight" data-hotkey="q" invisible="total_payments_amount != 1"/>
-                        <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account/wizard/account_resequence_views.xml
+++ b/addons/account/wizard/account_resequence_views.xml
@@ -23,7 +23,7 @@
                 </group>
                 <footer>
                     <button string="Confirm" name="resequence" type="object" default_focus="1" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
             </field>

--- a/addons/account/wizard/account_secure_entries_wizard.xml
+++ b/addons/account/wizard/account_secure_entries_wizard.xml
@@ -25,7 +25,7 @@
                     </sheet>
                     <footer>
                         <button string="Secure Entries" class="btn-primary" name="action_secure_entries" type="object" data-hotkey="v"/>
-                        <button string="Discard" special="cancel" data-hotkey="z"/>
+                        <button special="cancel" data-hotkey="z"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account/wizard/account_validate_move_view.xml
+++ b/addons/account/wizard/account_validate_move_view.xml
@@ -61,7 +61,7 @@
                                 class="btn-primary"
                                 data-hotkey="q"
                                 context="{'validate_analytic': True}"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account/wizard/accrued_orders.xml
+++ b/addons/account/wizard/accrued_orders.xml
@@ -24,7 +24,7 @@
                 <field name="preview_data" widget="grouped_view_widget" class="w-100"/>
                 <footer>
                     <button string='Create Entry' name="create_entries" type="object" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -26,7 +26,7 @@
                     <footer>
                         <button name="action_save_onboarding_fiscal_year" string="Apply"
                                class="oe_highlight" type="object" data-hotkey="q" />
-                        <button special="cancel" data-hotkey="x" string="Cancel" />
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>
@@ -51,7 +51,7 @@
                     </sheet>
                     <footer>
                         <button string="Create" class="oe_highlight" type="object" name="validate" data-hotkey="q"/>
-                        <button string="Cancel" special="cancel" data-hotkey="x"/>
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>
@@ -76,7 +76,7 @@
                     </sheet>
                     <footer>
                         <button string="Create" class="oe_highlight" type="object" name="validate" data-hotkey="q"/>
-                        <button string="Cancel" special="cancel" data-hotkey="x"/>
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account_check_printing/wizard/print_prenumbered_checks_views.xml
+++ b/addons/account_check_printing/wizard/print_prenumbered_checks_views.xml
@@ -13,7 +13,7 @@
                     </group>
                     <footer>
                         <button name="print_checks" string="Print" type="object" class="oe_highlight" data-hotkey="q"/>
-                        <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/account_debit_note/wizard/account_debit_note_view.xml
+++ b/addons/account_debit_note/wizard/account_debit_note_view.xml
@@ -21,7 +21,7 @@
                     </group>
                     <footer>
                         <button string='Create Debit Note' name="create_debit" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                </form>
             </field>

--- a/addons/account_peppol/wizard/peppol_config_wizard.xml
+++ b/addons/account_peppol/wizard/peppol_config_wizard.xml
@@ -43,7 +43,7 @@
                 <footer>
                     <button string="Save" name="button_sync_form_with_peppol_proxy" type="object"
                             class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/account_peppol/wizard/peppol_registration_views.xml
+++ b/addons/account_peppol/wizard/peppol_registration_views.xml
@@ -84,7 +84,7 @@
                             class="btn-primary" data-hotkey="q" invisible="edi_mode != 'test' or not display_no_auth_buttons"/>
                     <button string="Activate Peppol (Demo)" name="button_register_peppol_participant" type="object"
                             class="btn-primary" data-hotkey="q" invisible="edi_mode != 'demo' or not display_no_auth_buttons"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.xml
+++ b/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.xml
@@ -21,7 +21,7 @@
                 </group>
                 <footer>
                     <button string="Update" class="btn-primary" name="update_amls_tax_tags" type="object" data-hotkey="v"/>
-                    <button string="Discard" special="cancel" data-hotkey="z"/>
+                    <button special="cancel" data-hotkey="z"/>
                 </footer>
             </form>
         </field>

--- a/addons/api_doc/static/src/components/doc_modal_api_key.xml
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.xml
@@ -18,7 +18,7 @@
 
             <div class="d-flex flex-nowrap flex-content-between mt-2">
                 <button class="btn me-1" t-on-click="save">Save</button>
-                <button class="btn" t-on-click="cancel">Cancel</button>
+                <button class="btn" t-on-click="cancel">Discard</button>
             </div>
         </div>
     </div>

--- a/addons/auth_passkey/views/auth_passkey_key_views.xml
+++ b/addons/auth_passkey/views/auth_passkey_key_views.xml
@@ -34,7 +34,7 @@
                 </sheet>
                 <footer>
                     <button special="save" data-hotkey="s" string="Save" class="btn-primary"/>
-                    <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>
@@ -59,7 +59,7 @@
                 </sheet>
                 <footer>
                     <button name="make_key" type="object" string="Create" class="btn-primary" data-hotkey="q"/>
-                    <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/auth_passkey_portal/static/src/js/passkeys_portal.js
+++ b/addons/auth_passkey_portal/static/src/js/passkeys_portal.js
@@ -34,7 +34,6 @@ export class PortalPasskey extends Interaction {
                     location.reload();
                 }
             },
-            cancelLabel: _t("Discard"),
             cancel: () => {},
         });
     }

--- a/addons/auth_passkey_portal/static/src/js/passkeys_portal_create.js
+++ b/addons/auth_passkey_portal/static/src/js/passkeys_portal_create.js
@@ -34,7 +34,6 @@ export class PortalPasskeyCreate extends Interaction {
                     this.createPasskey(serverOptions, name);
                 }
             },
-            cancelLabel: _t("Discard"),
             cancel: () => {},
         });
     }

--- a/addons/auth_totp/wizard/auth_totp_wizard_views.xml
+++ b/addons/auth_totp/wizard/auth_totp_wizard_views.xml
@@ -36,7 +36,7 @@
                 <footer>
                     <button type="object" name="enable" class="btn btn-primary" context="{'code': code}"
                             string="Enable Two-Factor Authentication" data-hotkey="q"/>
-                    <button string="Discard" special="cancel" data-hotkey="x"/>
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -26,7 +26,7 @@
                         <button t-if="isPreviewing" type="button" class="btn btn-secondary">Load Data File</button>
                         <button t-else="" type="button" class="btn btn-primary o_import_file">Upload Data File</button>
                     </FileInput>
-                    <button t-on-click="cancel" type="button" class="btn btn-secondary">Cancel</button>
+                    <button t-on-click="cancel" type="button" class="btn btn-secondary">Discard</button>
                 </t>
                 <t t-if="isPreviewing">
                     <ImportDataSidepanel

--- a/addons/base_import/static/tests/import_action.test.js
+++ b/addons/base_import/static/tests/import_action.test.js
@@ -601,10 +601,10 @@ describe("Import view", () => {
             "/web/dataset/call_kw/base_import.import/parse_preview",
         ]);
 
-        // Click on 'Cancel' to go back to the previous view.
+        // Click on 'Discard' to go back to the previous view.
         await waitFor(".o_import_data_content");
         expect(".o_control_panel_main_buttons button").toHaveCount(4);
-        expect(".o_control_panel_main_buttons button:nth-of-type(3)").toHaveText("Cancel");
+        expect(".o_control_panel_main_buttons button:nth-of-type(3)").toHaveText("Discard");
         await contains(".o_control_panel_main_buttons button:nth-of-type(3)").click();
         await waitFor(".o_list_view");
     });

--- a/addons/base_import_module/views/base_import_module_view.xml
+++ b/addons/base_import_module/views/base_import_module_view.xml
@@ -19,7 +19,7 @@
                     <footer>
                         <div invisible="state != 'init'">
                             <button name="import_module" string="Install" type="object" class="btn-primary" data-hotkey="q"/>
-                            <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                            <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                         </div>
                         <div invisible="state != 'done'">
                             <button special="cancel" data-hotkey="x" string="Close" class="btn-secondary"/>

--- a/addons/base_install_request/wizard/base_module_install_request_views.xml
+++ b/addons/base_install_request/wizard/base_module_install_request_views.xml
@@ -14,7 +14,7 @@
                 </group>
                 <footer>
                     <button string="Request Activation" class="btn-primary" type="object" name="action_send_request" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>
@@ -30,7 +30,7 @@
                 <field name="modules_description"/>
                 <footer>
                     <button string="Install App" class="btn-primary" type="object" name="action_install_module" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/bus/static/src/debug/bus_logs_menu_item.js
+++ b/addons/bus/static/src/debug/bus_logs_menu_item.js
@@ -26,7 +26,6 @@ export class BusLogsMenuItem extends Component {
             confirm: () => this.env.services.bus_service.downloadLogs(),
             cancel() {},
             confirmLabel: _t("Download"),
-            cancelLabel: _t("Discard"),
         });
     }
 }

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.xml
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.xml
@@ -44,8 +44,7 @@
                             name="action_delete"
                             type="object"
                             class="btn-primary mx-1"/>
-                    <button string="Discard"
-                            class="btn-secondary"
+                    <button class="btn-secondary"
                             special="cancel"/>
                 </footer>
             </form>

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.xml
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.xml
@@ -8,7 +8,7 @@
                 <field name="delete" widget="radio"/>
                 <footer>
                     <button name="close" string="Submit" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>
@@ -52,7 +52,7 @@
     </record>
 
     <record id="action_event_delete_wizard" model="ir.actions.act_window">
-        <field name="name">Event Cancel Wizard</field>
+        <field name="name">Event Delete Wizard</field>
         <field name="res_model">calendar.popover.delete.wizard</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="view_event_delete_wizard_form"/>

--- a/addons/calendar/wizard/calendar_provider_config.xml
+++ b/addons/calendar/wizard/calendar_provider_config.xml
@@ -34,7 +34,7 @@
                 </div>
                 <footer>
                     <widget name="calendar_connect_provider"/>
-                    <button string="Cancel" class="btn btn-secondary" special="cancel"/>
+                    <button class="btn btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/crm/static/src/components/lead_generation_dropdown/lead_generation_dropdown.js
+++ b/addons/crm/static/src/components/lead_generation_dropdown/lead_generation_dropdown.js
@@ -210,7 +210,6 @@ export class LeadGenerationDropdown extends Component {
             },
             cancel: () => {},
             confirmLabel: "Install",
-            cancelLabel: "Cancel",
         };
         this.dialogs.add(ConfirmationDialog, dialogProps);
     }

--- a/addons/crm/wizard/crm_lead_lost_views.xml
+++ b/addons/crm/wizard/crm_lead_lost_views.xml
@@ -13,7 +13,7 @@
                     </group>
                     <footer>
                         <button name="action_lost_reason_apply" string="Mark as Lost" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/crm/wizard/crm_lead_pls_update_views.xml
+++ b/addons/crm/wizard/crm_lead_pls_update_views.xml
@@ -17,7 +17,7 @@
                 <footer>
                     <button name="action_update_crm_lead_probabilities" type="object"
                         string="Update" class="btn-primary" data-hotkey="q"/>
-                    <button special="cancel" data-hotkey="x" string="Discard"/>
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
@@ -45,7 +45,7 @@
                 </group>
                 <footer>
                     <button string="Convert to Opportunities" name="action_mass_convert" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -56,7 +56,7 @@
                 </div>
                 <footer>
                     <button name="action_apply" string="Create Opportunity" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/crm/wizard/crm_merge_opportunities_views.xml
+++ b/addons/crm/wizard/crm_merge_opportunities_views.xml
@@ -25,7 +25,7 @@
                     </field>
                     <footer>
                         <button name="action_merge" type="object" string="Merge" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/crm_iap_mine/views/crm_iap_lead_mining_request_views.xml
+++ b/addons/crm_iap_mine/views/crm_iap_lead_mining_request_views.xml
@@ -102,7 +102,7 @@
                     </group>
                     <footer>
                         <button string="Generate Leads" name="action_submit" type="object" default_focus="1" class="btn-primary" invisible="not context.get('is_modal')" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" invisible="not context.get('is_modal')"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x" invisible="not context.get('is_modal')"/>
                     </footer>
                 </sheet>
             </form>

--- a/addons/delivery/wizard/choose_delivery_carrier_views.xml
+++ b/addons/delivery/wizard/choose_delivery_carrier_views.xml
@@ -52,7 +52,7 @@
                         string="Add"
                         class="btn-primary"
                         data-hotkey="q"/>
-                    <button string="Discard" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -53,7 +53,7 @@ patch(SaleOrderLineProductField.prototype, {
                 additionalContext: actionContext,
                 onClose: async (closeInfo) => {
                     if (!closeInfo?.eventBoothConfiguration || closeInfo.special || closeInfo.dismiss) {
-                        // wizard popup closed or 'Cancel' button triggered
+                        // wizard popup closed or 'Discard' button triggered
                         if (!this.props.record.data.event_ticket_id) {
                             // remove product if event configuration was cancelled.
                             this.props.record.update({

--- a/addons/event_booth_sale/wizard/event_booth_configurator_views.xml
+++ b/addons/event_booth_sale/wizard/event_booth_configurator_views.xml
@@ -28,7 +28,7 @@
                 </group>
                 <footer>
                     <button string="Ok" class="btn-primary" special="save"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/event_sale/static/src/js/sale_product_field.js
+++ b/addons/event_sale/static/src/js/sale_product_field.js
@@ -46,7 +46,7 @@ patch(SaleOrderLineProductField.prototype, {
                 additionalContext: actionContext,
                 onClose: async (closeInfo) => {
                     if (!closeInfo?.eventConfiguration || closeInfo.special || closeInfo.dismiss) {
-                        // wizard popup closed or 'Cancel' button triggered
+                        // wizard popup closed or 'Discard' button triggered
                         if (!this.props.record.data.event_ticket_id) {
                             // remove product if event configuration was cancelled.
                             this.props.record.update({

--- a/addons/fleet/wizard/fleet_vehicle_send_mail_views.xml
+++ b/addons/fleet/wizard/fleet_vehicle_send_mail_views.xml
@@ -17,7 +17,7 @@
                 </group>
                 <footer>
                     <button name="action_send" string="Send" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     <button name="action_save_as_template" string="Save as new template" type="object" class="btn-secondary"/>
                 </footer>
             </form>

--- a/addons/gamification/wizard/grant_badge.xml
+++ b/addons/gamification/wizard/grant_badge.xml
@@ -12,7 +12,7 @@
                 </group>
                 <footer>
                     <button string="Grant Badge" type="object" name="action_grant_badge" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/gamification/wizard/update_goal.xml
+++ b/addons/gamification/wizard/update_goal.xml
@@ -11,7 +11,7 @@
                 </group>
                 <footer>
                     <button string="Update" type="object" name="action_update_current" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -30,7 +30,6 @@ patch(AttendeeCalendarController.prototype, {
                     confirm: this.actionService.doAction.bind(this.actionService, syncResult.action),
                     confirmLabel: _t("Configure"),
                     cancel: () => {},
-                    cancelLabel: _t("Discard"),
                 });
             } else {
                 this.dialog.add(AlertDialog, {

--- a/addons/google_calendar/wizard/reset_account_views.xml
+++ b/addons/google_calendar/wizard/reset_account_views.xml
@@ -13,7 +13,7 @@
 
                 <footer>
                     <button name="reset_account" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr/static/src/xml/contract_template_button.xml
+++ b/addons/hr/static/src/xml/contract_template_button.xml
@@ -31,7 +31,7 @@
                     class="btn btn-secondary btn-sm" 
                     t-on-click="props.close"
                 >
-                    Cancel
+                    Discard
                 </button>
             </div>
         </div>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -138,7 +138,7 @@
                 <sheet position="after">
                     <footer>
                         <button string="Save" special="save" class="btn btn-primary"/>
-                        <button string="Cancel" special="cancel" class="btn btn-secondary"/>
+                        <button special="cancel" class="btn btn-secondary"/>
                     </footer>
                 </sheet>
             </field>

--- a/addons/hr/wizard/hr_bank_account_allocation_wizard.xml
+++ b/addons/hr/wizard/hr_bank_account_allocation_wizard.xml
@@ -12,7 +12,7 @@
                 </group>
                 <footer>
                     <button string="Save" type="object" name="action_save" class="btn-primary"/>
-                    <button string="Cancel" special="cancel" class="btn-secondary"/>
+                    <button special="cancel" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr/wizard/hr_departure_wizard_views.xml
+++ b/addons/hr/wizard/hr_departure_wizard_views.xml
@@ -65,7 +65,7 @@
                             invisible="apply_immediately"/>
                         <button name="action_register_departure" string="Apply" type="object" class="oe_highlight"
                             invisible="not apply_immediately"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/hr_expense/static/src/components/hr_expense_product_form_view.js
+++ b/addons/hr_expense/static/src/components/hr_expense_product_form_view.js
@@ -30,7 +30,6 @@ export class ProductExpenseFormController extends FormController {
                 body: warning,
                 confirmLabel: _t("Update cost"),
                 confirm: () => super.save(params),
-                cancelLabel: _t("Discard"),
                 cancel: () => {},
             });
         }

--- a/addons/hr_expense/wizard/hr_expense_approve_duplicate_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_approve_duplicate_views.xml
@@ -19,7 +19,7 @@
                 <footer>
                     <button string="Refuse" class="btn-primary" name="action_refuse" type="object" invisible="not expense_ids" data-hotkey="q" />
                     <button string="Approve" class="btn-secondary" name="action_approve" type="object" invisible="not expense_ids" data-hotkey="w" />
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
            </form>
         </field>

--- a/addons/hr_expense/wizard/hr_expense_post_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_post_wizard_views.xml
@@ -12,7 +12,7 @@
                     </group>
                     <footer>
                         <button name="action_post_entry" string="Post Expenses" type="object" class="oe_highlight"  data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/hr_expense/wizard/hr_expense_refuse_reason_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_refuse_reason_views.xml
@@ -11,7 +11,7 @@
                 </group>
                 <footer>
                     <button string='Refuse' name="action_refuse" type="object" class="oe_highlight" data-hotkey="q"/>
-                    <button string="Cancel" class="oe_link" special="cancel" data-hotkey="x"/>
+                    <button class="oe_link" special="cancel" data-hotkey="x"/>
                 </footer>
            </form>
         </field>

--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -48,7 +48,7 @@
                     <footer>
                         <button name="action_split_expense" invisible="split_possible" string="Split Expense" type="object" class="oe_highlight" disabled="disabled"  data-hotkey="q"/>
                         <button name="action_split_expense" string="Split Expense" invisible="not split_possible" type="object" class="oe_highlight"  data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/hr_gamification/views/gamification_views.xml
+++ b/addons/hr_gamification/views/gamification_views.xml
@@ -72,7 +72,7 @@
                                     string="Save"
                                     special="save"
                                 />
-                                <button string="Discard" special="cancel" data-hotkey="x" class="btn-secondary" />
+                                <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                             </div>
                             <button
                                 class="btn-danger w-fit"

--- a/addons/hr_gamification/wizard/gamification_badge_user_wizard_views.xml
+++ b/addons/hr_gamification/wizard/gamification_badge_user_wizard_views.xml
@@ -42,7 +42,7 @@
                     <field name="comment" nolabel="1" placeholder="Describe what they did and why it matters (will be public)" />
                     <footer>
                         <button string="Grant a badge" type="object" name="action_grant_badge" class="btn-primary" data-hotkey="q"/>
-                        <button string="Discard" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                        <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                     </footer>
                 </form>
             </field>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -122,7 +122,7 @@
                     <button string="Save" type="object" special="save" class="btn btn-primary"/>
                     <button string="Save &amp; New" type="object" name="action_save_new" class="btn btn-primary"
                             invisible="not context.get('new')"/>
-                    <button string="Discard" special="cancel" class="btn btn-secondary"/>
+                    <button special="cancel" class="btn btn-secondary"/>
                     <button string="Delete" type="object" name="unlink" class="btn btn-danger ms-auto"
                             invisible="context.get('new')"/>
                 </footer>

--- a/addons/hr_holidays/wizard/hr_holidays_cancel_leave_views.xml
+++ b/addons/hr_holidays/wizard/hr_holidays_cancel_leave_views.xml
@@ -14,7 +14,7 @@
                             class="btn-primary"
                             string="Cancel Time Off"
                             accesskey="c" />
-                    <button special="cancel" string="Discard" close="1" accesskey="j" />
+                    <button special="cancel" close="1" accesskey="j"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_holidays/wizard/hr_holidays_summary_employees_views.xml
+++ b/addons/hr_holidays/wizard/hr_holidays_summary_employees_views.xml
@@ -15,7 +15,7 @@
                     </group>
                     <footer>
                         <button name="print_report" string="Print" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
@@ -36,7 +36,7 @@
                 <field name="notes" placeholder="Add a reason..." nolabel="1"/>
                 <footer>
                     <button name="action_generate_allocations" type="object" class="btn-primary" string="Allocate Time Off" accesskey="c"/>
-                    <button special="cancel" string="Discard" close="1" accesskey="j" />
+                    <button special="cancel" close="1" accesskey="j"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
@@ -29,7 +29,7 @@
                 <field name="name" widget="text" placeholder="e.g. Extra recuperation, Company unavailability, ..."/>
                 <footer>
                     <button name="action_generate_time_off" type="object" class="btn-primary" string="Generate Time Off" accesskey="c"/>
-                    <button special="cancel" string="Discard" close="1" accesskey="j" />
+                    <button special="cancel" close="1" accesskey="j"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_holidays_attendance/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_allocation_views.xml
@@ -32,7 +32,7 @@
             <xpath expr="//sheet" position="after">
                 <footer>
                     <button string="Save" special="save" class="btn btn-primary" close="1" />
-                    <button string="Discard" special="cancel" class="btn-secondary" close="1" />
+                    <button special="cancel" class="btn-secondary" close="1"/>
                 </footer>
             </xpath>
         </field>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -261,7 +261,7 @@
                 </group>
                 <footer>
                     <button string="Create" name="%(action_hr_job_applications)d" type="action" class="btn-primary o_create_job" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
@@ -45,7 +45,7 @@
                     </div>
                     <footer>
                         <button name="action_refuse_reason_apply" string="Refuse" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                         <div class="d-flex" invisible="not send_mail">
                             <div invisible="not can_edit_body">
                                 <field name="template_id" widget="mail_composer_template_selector"/>

--- a/addons/hr_recruitment/wizard/applicant_send_mail_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_send_mail_views.xml
@@ -23,7 +23,7 @@
                 </group>
                 <footer>
                     <button name="action_send" string="Send" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_recruitment/wizard/job_add_applicants_views.xml
+++ b/addons/hr_recruitment/wizard/job_add_applicants_views.xml
@@ -16,7 +16,7 @@
                         class="btn-primary"
                         data-hotkey="q"
                     />
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_recruitment/wizard/talent_pool_add_applicants_views.xml
+++ b/addons/hr_recruitment/wizard/talent_pool_add_applicants_views.xml
@@ -32,7 +32,7 @@
                         class="btn-primary"
                         data-hotkey="q"
                     />
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_skills/wizard/hr_employee_cv_wizard_views.xml
+++ b/addons/hr_skills/wizard/hr_employee_cv_wizard_views.xml
@@ -22,7 +22,7 @@
                 </group>
                 <footer>
                     <button name="action_validate" string="Print" type="object" class="oe_highlight" data-hotkey="q"/>
-                    <button string="Discard" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
@@ -27,11 +27,11 @@
                             invisible="has_active_employee" data-hotkey="w"/>
                         <button string="See Timesheets" type="object" name="action_open_timesheets" class="btn btn-secondary" groups="hr_timesheet.group_hr_timesheet_approver"
                             invisible="not has_active_employee" data-hotkey="w"/>
-                        <button string="Discard" special="cancel" data-hotkey="x"/>
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                     <footer invisible="has_timesheet">
                         <button string="Ok" type="object" name="action_confirm_delete" class="btn btn-primary" data-hotkey="q"/>
-                        <button string="Discard" special="cancel" data-hotkey="x"/>
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard_views.xml
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard_views.xml
@@ -38,7 +38,7 @@
                             string="Regenerate Work Entries"
                             class="btn btn-primary disabled"
                             invisible="valid"/>
-                    <button name="cancel_button" string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/html_builder/static/src/sidebar/custom_inner_snippet.xml
+++ b/addons/html_builder/static/src/sidebar/custom_inner_snippet.xml
@@ -19,7 +19,7 @@
                             data-tooltip="Confirm"
                             t-on-click="onConfirmRename"/>
                     <button class="o_we_text_danger fa fa-times btn btn-outline-danger border-0"
-                            data-tooltip="Cancel"
+                            data-tooltip="Discard"
                             t-on-click="toggleRenamingState"/>
                 </div>
             </t>

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -38,7 +38,6 @@ export class SnippetViewer extends Component {
             confirm: (inputValue) => {
                 this.props.snippetModel.renameCustomSnippet(snippet, inputValue);
             },
-            cancelLabel: _t("Discard"),
             cancel: () => {},
         });
     }

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_dialog.xml
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_dialog.xml
@@ -22,7 +22,7 @@
         <t t-set-slot="footer">
             <button class="btn btn-primary" t-on-click="_confirm"
                 t-att-disabled="state.translationInProgress || state.messages[0].isError">Insert</button>
-            <button class="btn btn-secondary" t-on-click="_cancel">Cancel</button>
+            <button class="btn btn-secondary" t-on-click="_cancel">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard_view.xml
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard_view.xml
@@ -114,7 +114,7 @@
             </notebook>
             <footer>
                 <button string="Generate" name="create_fec_report_action" type="object" class="oe_highlight" data-hotkey="q"/>
-                <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
             </footer>
         </form>
     </field>

--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
@@ -47,7 +47,7 @@
                 </sheet>
                 <footer>
                     <button string="Apply TDS" type="object" name="action_create_and_post_withhold" class="btn-primary"/>
-                    <button string="Discard" special="cancel" class="btn-secondary"/>
+                    <button special="cancel" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/l10n_in_edi/wizard/l10n_in_edi_cancel_views.xml
+++ b/addons/l10n_in_edi/wizard/l10n_in_edi_cancel_views.xml
@@ -18,8 +18,7 @@
                                 type="object"
                                 class="btn-primary"
                                 data-hotkey="c"/>
-                        <button string="Discard"
-                                class="btn-secondary"
+                        <button class="btn-secondary"
                                 special="cancel"
                                 data-hotkey="x"/>
                     </footer>

--- a/addons/l10n_in_ewaybill/wizard/l10n_in_ewaybill_cancel_views.xml
+++ b/addons/l10n_in_ewaybill/wizard/l10n_in_ewaybill_cancel_views.xml
@@ -19,8 +19,7 @@
                                 type="object"
                                 class="btn-primary"
                                 data-hotkey="c"/>
-                        <button string="Discard"
-                                class="btn-secondary"
+                        <button class="btn-secondary"
                                 special="cancel"
                                 data-hotkey="x"/>
                     </footer>

--- a/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer_views.xml
+++ b/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer_views.xml
@@ -23,10 +23,7 @@
                         type="object"
                         class="oe_highlight"
                         data-hotkey="q"/>
-                    <button string="Cancel"
-                        class="btn btn-secondary"
-                        special="cancel"
-                        data-hotkey="x"/>
+                    <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/l10n_mt_pos/wizards/compliance_letter_view.xml
+++ b/addons/l10n_mt_pos/wizards/compliance_letter_view.xml
@@ -8,7 +8,7 @@
                 <field name="company_id"/>
                 <footer>
                     <button name="generate_letter" string="Print" type="object" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/l10n_ph/wizard/generate_2307_wizard_views.xml
+++ b/addons/l10n_ph/wizard/generate_2307_wizard_views.xml
@@ -22,7 +22,7 @@
                 </group>
                 <footer>
                     <button string="Generate" type="object" name="action_generate" class="btn btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" special="cancel" data-hotkey="x" class="btn btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.xml
+++ b/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.xml
@@ -14,7 +14,7 @@
                 </group>
                 <footer>
                     <button string="Confirm" type="object" name="validate" class="btn btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" special="cancel" data-hotkey="x" class="btn btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/l10n_tw_edi_ecpay/views/l10n_tw_edi_invoice_cancel_view.xml
+++ b/addons/l10n_tw_edi_ecpay/views/l10n_tw_edi_invoice_cancel_view.xml
@@ -11,7 +11,7 @@
                 </group>
                 <footer>
                     <button string="Cancel Invoice" name="button_request_cancel" type="object" default_focus="1" class="btn-primary"/>
-                    <button string="Close" special="cancel"/>
+                    <button special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/loyalty/wizard/loyalty_card_update_balance_views.xml
+++ b/addons/loyalty/wizard/loyalty_card_update_balance_views.xml
@@ -24,7 +24,7 @@
                     >
                         Confirm
                     </button>
-                    <button special="cancel" data-hotkey="x">Cancel</button>
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/loyalty/wizard/loyalty_generate_wizard_views.xml
+++ b/addons/loyalty/wizard/loyalty_generate_wizard_views.xml
@@ -51,7 +51,7 @@
                         </span>
                         <field name="program_type" nolabel="1"/>
                     </button>
-                    <button special="cancel" data-hotkey="x" string="Cancel"/>
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/lunch/static/tests/lunch_kanban.test.js
+++ b/addons/lunch/static/tests/lunch_kanban.test.js
@@ -81,7 +81,7 @@ class Order extends models.Model {
             </sheet>
             <footer>
                 <button name="add_to_cart" type="object" string="Add to cart" />
-                <button string="Discard" special="cancel"/>
+                <button special="cancel"/>
             </footer>
         </form>`,
     };

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -268,7 +268,7 @@
                 </div>
                 <footer>
                     <button string="Add To Cart" name="add_to_cart" type="object" class="oe_highlight" invisible="order_deadline_passed or not display_add_button" data-hotkey="w"/>
-                    <button string="Discard" special="cancel" data-hotkey="x"/>
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -778,7 +778,6 @@ export class Composer extends Component {
                     }
                 ),
                 confirmLabel: _t("Send Message"),
-                cancelLabel: _t("Discard"),
                 confirm: () => confirmDef.resolve(true),
                 cancel: () => confirmDef.resolve(false),
             });

--- a/addons/mail/static/src/core/common/create_poll_dialog.xml
+++ b/addons/mail/static/src/core/common/create_poll_dialog.xml
@@ -34,7 +34,7 @@
         </div>
         <t t-set-slot="footer">
             <button class="btn btn-primary me-2" t-on-click="onClickSubmit">Post</button>
-            <button class="btn btn-secondary me-2" t-on-click="props.close">Cancel</button>
+            <button class="btn btn-secondary me-2" t-on-click="props.close">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
@@ -11,7 +11,7 @@
             <t t-set-slot="footer">
                 <button class="btn btn-danger me-2" t-on-click="onClickOk">Delete</button>
                 <button t-if="props.messageLinkPreview.hasDeleteAll" class="btn btn-outline-danger me-2" t-on-click="onClickDeleteAll">Delete all previews</button>
-                <button class="btn btn-secondary me-2" t-on-click="onClickCancel">Cancel</button>
+                <button class="btn btn-secondary me-2" t-on-click="onClickCancel">Discard</button>
             </t>
         </Dialog>
     </t>

--- a/addons/mail/static/src/core/common/message_confirm_dialog.xml
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.xml
@@ -9,7 +9,7 @@
         </blockquote>
         <t t-set-slot="footer">
             <button class="btn me-2" t-att-class="props.confirmColor" t-on-click="onClickConfirm" t-out="props.confirmText"/>
-            <button class="btn btn-secondary me-2" t-on-click="props.close">Cancel</button>
+            <button class="btn btn-secondary me-2" t-on-click="props.close">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/mail/static/src/core/web/follower_subtype_dialog.xml
+++ b/addons/mail/static/src/core/web/follower_subtype_dialog.xml
@@ -21,7 +21,7 @@
                     Apply
                 </button>
                 <button class="btn btn-secondary" t-on-click="props.close">
-                    Cancel
+                    Discard
                 </button>
             </t>
         </Dialog>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -33,7 +33,7 @@
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary me-2" t-att-disabled="!state.name or state.name.trim().length === 0" t-on-click="onClickConfirm">Create Channel</button>
-                <button class="btn btn-secondary me-2" t-on-click="props.close">Cancel</button>
+                <button class="btn btn-secondary me-2" t-on-click="props.close">Discard</button>
             </t>
         </Dialog>
     </t>
@@ -48,7 +48,7 @@
         </div>
         <t t-set-slot="footer">
             <button class="btn btn-primary me-2" t-on-click="onClickConfirm" t-esc="createText"/>
-            <button class="btn btn-secondary me-2" t-on-click="props.close">Cancel</button>
+            <button class="btn btn-secondary me-2" t-on-click="props.close">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/mail/static/tests/chatter/web/follower.test.js
+++ b/addons/mail/static/tests/chatter/web/follower.test.js
@@ -127,7 +127,7 @@ test("edit follower and close subtype dialog", async () => {
     await click("[title='Edit subscription']");
     await contains(".o-mail-FollowerSubtypeDialog");
     await expect.waitForSteps(["fetch_subtypes"]);
-    await click(".o-mail-FollowerSubtypeDialog button:text('Cancel')");
+    await click(".o-mail-FollowerSubtypeDialog button:text('Discard')");
     await contains(".o-mail-FollowerSubtypeDialog", { count: 0 });
 });
 

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -173,7 +173,7 @@
                         <button invisible="chaining_type == 'trigger'" string="Mark Done" name="action_done"
                             type="object" class="btn-secondary" data-hotkey="w"
                             context="{'mail_activity_quick_update': True}"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </sheet>
             </form>

--- a/addons/mail/views/mail_scheduled_message_views.xml
+++ b/addons/mail/views/mail_scheduled_message_views.xml
@@ -29,7 +29,7 @@
                         <button string="Save" class="btn-primary" special="save" invisible="not scheduled_date" data-hotkey="S"/>
                         <button string="Send Now" invisible="is_note" type="object" name="post_message" data-hotkey="q"/>
                         <button string="Log Now" invisible="not is_note" type="object" name="post_message" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_selector"/>
                         <field name="scheduled_date" widget="datetime_scheduled_date"/>
                     </footer>

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -70,12 +70,12 @@
                             invisible="has_error or chaining_type == 'trigger'"
                             class="btn-secondary"  data-hotkey="w"
                             context="{'mail_activity_quick_update': True}"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                     <footer invisible="not plan_id">
                         <button name="action_schedule_plan" string="Schedule" type="object" class="btn-primary"
                                 invisible="has_error" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mail/wizard/mail_blacklist_remove_views.xml
+++ b/addons/mail/wizard/mail_blacklist_remove_views.xml
@@ -11,7 +11,7 @@
                 </group>
                 <footer>
                     <button name="action_unblacklist_apply" string="Remove address from blacklist" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -97,7 +97,7 @@
                                 invisible="(not subtype_is_log or composition_mode == 'comment' and not composition_batch and scheduled_date) or partner_ids_all_have_email"/>
                         <button string="Schedule" name="action_schedule_message" type="object" class="btn-primary" data-hotkey="q" disabled="1"
                                 invisible="(composition_mode != 'comment' or composition_batch or not scheduled_date) or partner_ids_all_have_email"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_selector" invisible="not can_edit_body"/>
                         <field name="template_id" widget="mail_composer_template_selector"/>
                         <field name="scheduled_date" widget="text_scheduled_date" invisible="composition_batch or composition_mode != 'comment'"/>
@@ -117,7 +117,7 @@
                     </group>
                     <footer>
                         <button name="create_mail_template" type="object" class="btn btn-primary" string="Save Template"/>
-                        <button class="btn btn-secondary" string="Discard" special="cancel"/>
+                        <button class="btn btn-secondary" special="cancel"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mail/wizard/mail_followers_edit_views.xml
+++ b/addons/mail/wizard/mail_followers_edit_views.xml
@@ -25,7 +25,7 @@
                         class="o_mail_extra_comments border p-1 ps-1 pe-5"/>
                     <footer>
                         <button string="Update Followers" name="edit_followers" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mail/wizard/mail_template_reset_views.xml
+++ b/addons/mail/wizard/mail_template_reset_views.xml
@@ -11,7 +11,7 @@
                 </div>
                 <footer>
                     <button string="Reset Template" class="btn btn-primary" type="object" name="reset_template" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mail_group/wizard/mail_group_message_reject_views.xml
+++ b/addons/mail_group/wizard/mail_group_message_reject_views.xml
@@ -27,7 +27,7 @@
                         invisible="action != 'ban' or send_email"/>
                     <button string="Send &amp; Ban" name="action_send_mail" type="object" class="btn-primary"
                         invisible="action != 'ban' or not send_email"/>
-                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/mass_mailing/wizard/mailing_contact_to_list_views.xml
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list_views.xml
@@ -12,7 +12,7 @@
                     </group>
                     <footer>
                         <button string="Add to List" name="action_add_contacts" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mass_mailing/wizard/mailing_list_merge_views.xml
+++ b/addons/mass_mailing/wizard/mailing_list_merge_views.xml
@@ -20,7 +20,7 @@
                 </field>
                 <footer>
                     <button name="action_mailing_lists_merge" type="object" string="Merge" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mass_mailing/wizard/mailing_mailing_schedule_date_views.xml
+++ b/addons/mass_mailing/wizard/mailing_mailing_schedule_date_views.xml
@@ -12,7 +12,7 @@
                 </group>
                 <footer>
                     <button string="Schedule" name="action_schedule_date" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard " class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mass_mailing/wizard/mailing_mailing_test_views.xml
+++ b/addons/mass_mailing/wizard/mailing_mailing_test_views.xml
@@ -14,7 +14,7 @@
                     </group>
                     <footer>
                         <button string="Send test" name="send_mail_test" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mass_mailing_sms/wizard/mailing_sms_test_views.xml
+++ b/addons/mass_mailing_sms/wizard/mailing_sms_test_views.xml
@@ -14,7 +14,7 @@
                 </group>
                 <footer>
                     <button string="Send Test" name="action_send_sms" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
@@ -29,7 +29,6 @@ patch(AttendeeCalendarController.prototype, {
                     confirm: this.actionService.doAction.bind(this.actionService, syncResult.action),
                     confirmLabel: _t("Configure"),
                     cancel: () => {},
-                    cancelLabel: _t("Discard"),
                 });
             } else {
                 this.dialog.add(AlertDialog, {

--- a/addons/microsoft_calendar/wizard/reset_account_views.xml
+++ b/addons/microsoft_calendar/wizard/reset_account_views.xml
@@ -13,7 +13,7 @@
 
                 <footer>
                     <button name="reset_account" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -149,7 +149,7 @@
                     </sheet>
                     <footer class="oe_edit_only">
                         <button name="action_validate" string="Unbuild" type="object" invisible="state != 'draft'" class="oe_highlight" data-hotkey="q"/>
-                        <button string="Discard" special="cancel" data-hotkey="x"/>
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mrp/wizard/change_production_qty_views.xml
+++ b/addons/mrp/wizard/change_production_qty_views.xml
@@ -26,7 +26,7 @@
                         <button name="change_prod_qty" string="Set Quantity" data-hotkey="q"
                             colspan="1" type="object" class="btn-primary"/>
                         <button name="action_split_mo" string="Split" type="object" class="btn-secondary"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mrp/wizard/mrp_production_backorder.xml
+++ b/addons/mrp/wizard/mrp_production_backorder.xml
@@ -26,7 +26,7 @@
                         <button name="action_backorder" string="Validate" data-hotkey="q"
                             colspan="1" type="object" class="btn-primary" invisible="not show_backorder_lines"/>
                         <button name="action_close_mo" type="object" string="No Backorder" invisible="show_backorder_lines" data-hotkey="w"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mrp/wizard/mrp_production_serial_numbers.xml
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.xml
@@ -25,7 +25,7 @@
                 <field name="serial_numbers" nolabel="1" placeholder="copy paste a list and/or use Generate"/>
                 <footer>
                     <button name="action_apply" string="Apply" type="object" class="btn-primary"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" />
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -18,7 +18,7 @@
                         </list>
                     </field>
                     <footer>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>
@@ -64,7 +64,7 @@
                     </div>
                     <footer>
                         <button string="Split" class="btn-primary" type="object" name="action_split" data-hotkey="q" invisible="not valid_details"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" invisible="production_split_multi_id"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x" invisible="production_split_multi_id"/>
                         <button string="Discard" class="btn-secondary" type="object" name="action_return_to_list" data-hotkey="x" invisible="not production_split_multi_id"/>
                     </footer>
                 </form>

--- a/addons/mrp/wizard/mrp_workcenter_block_view.xml
+++ b/addons/mrp/wizard/mrp_workcenter_block_view.xml
@@ -14,7 +14,7 @@
                 </group>
                 <footer>
                     <button name="button_block" string="Block" type="object" class="btn-danger" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/mrp_account/wizard/mrp_wip_accounting.xml
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.xml
@@ -28,7 +28,7 @@
                     </field>
                     <footer>
                         <button name="confirm" string="Post WIP" data-hotkey="q" colspan="1" type="object" class="btn-primary"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mrp_product_expiry/wizard/confirm_expiry_view.xml
+++ b/addons/mrp_product_expiry/wizard/confirm_expiry_view.xml
@@ -27,7 +27,6 @@
                     invisible="not production_ids"
                     class="btn-primary"/>
                 <button special="cancel" data-hotkey="x"
-                    string="Discard"
                     invisible="not production_ids"
                     class="btn-secondary"/>
                 <!-- From a Workorder -->

--- a/addons/onboarding/views/onboarding_templates.xml
+++ b/addons/onboarding/views/onboarding_templates.xml
@@ -39,7 +39,7 @@
                         >
                             Get them out of my sight!
                         </a>
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
                     </div>
                 </div>
             </div>

--- a/addons/phone_validation/wizard/phone_blacklist_remove_view.xml
+++ b/addons/phone_validation/wizard/phone_blacklist_remove_view.xml
@@ -11,7 +11,7 @@
                 </group>
                 <footer>
                     <button name="action_unblacklist_apply" string="Remove phone from blacklist" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -107,7 +107,7 @@
                 <!-- Replace the default save/discard buttons so that when any of the buttons is clicked, the modal immediately closes. -->
                 <footer invisible="not context.get('pos_config_open_modal', False)">
                     <button string="Save" special="save" class="btn-primary"/>
-                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/point_of_sale/wizard/pos_close_session_wizard.xml
+++ b/addons/point_of_sale/wizard/pos_close_session_wizard.xml
@@ -13,7 +13,7 @@
                 </group>
                 <footer>
                     <button name="close_session" string="Close Session" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary" />
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/point_of_sale/wizard/pos_confirmation_wizard.xml
+++ b/addons/point_of_sale/wizard/pos_confirmation_wizard.xml
@@ -10,7 +10,7 @@
                 </group>
                 <footer>
                     <button name="action_confirm" string="Confirm" type="object" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/point_of_sale/wizard/pos_daily_sales_reports.xml
+++ b/addons/point_of_sale/wizard/pos_daily_sales_reports.xml
@@ -11,7 +11,7 @@
 
                 <footer>
                     <button name="generate_report" string="Print" type="object" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/point_of_sale/wizard/pos_details.xml
+++ b/addons/point_of_sale/wizard/pos_details.xml
@@ -14,7 +14,7 @@
                     </group>
                     <footer>
                         <button name="generate_report" string="Print" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/point_of_sale/wizard/pos_make_invoice.xml
+++ b/addons/point_of_sale/wizard/pos_make_invoice.xml
@@ -13,7 +13,7 @@
                     <button name="action_create_invoices" type="object"
                         string="Create"
                         class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/point_of_sale/wizard/pos_payment.xml
+++ b/addons/point_of_sale/wizard/pos_payment.xml
@@ -13,7 +13,7 @@
                 </group>
                 <footer>
                     <button name="check" string="Make Payment" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
             </field>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -603,7 +603,7 @@
                                 <input type="submit" class="btn btn-danger" form="portal_deactivate_account_form"
                                     value="Delete Account"/>
                                 <button type="button" class="btn" data-bs-dismiss="modal">
-                                    Cancel
+                                    Discard
                                 </button>
                             </div>
                         </div>

--- a/addons/portal/wizard/portal_share_views.xml
+++ b/addons/portal/wizard/portal_share_views.xml
@@ -15,7 +15,7 @@
                 </group>
                 <footer>
                     <button string="Send" name="action_send_mail" invisible="access_warning != ''" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
@@ -34,7 +34,7 @@
                 </t>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-secondary" t-on-click="cancel">Discard</button>
                 <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>

--- a/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.xml
@@ -42,7 +42,7 @@
                 </t>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary" t-on-click="close">Cancel</button>
+                <button class="btn btn-secondary" t-on-click="close">Discard</button>
                 <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>

--- a/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-secondary" t-on-click="cancel">Discard</button>
                 <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -153,7 +153,7 @@ patch(PosStore.prototype, {
                     useLoadedLots = await ask(this.dialog, {
                         title: _t("SN/Lots Loading"),
                         body: _t("Do you want to load the SN/Lots linked to the Sales Order?"),
-                        cancelLabel: _t("Cancel"),
+                        cancelLabel: _t("Discard"),
                     });
                     userWasAskedAboutLoadedLots = true;
                 }

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -43,7 +43,7 @@ export function settleNthOrder(n, options = {}) {
         step.push({
             content: `Choose to auto link the lot number to the order line`,
             trigger: `.modal-content:contains('Do you want to load the SN/Lots linked to the Sales Order?') button:contains('${
-                loadSN ? "Ok" : "Cancel"
+                loadSN ? "Ok" : "Discard"
             }')`,
             run: "click",
         });

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -74,7 +74,7 @@ export class OrderWidget extends Component {
     get leftButton() {
         const back = this.shouldGoBack();
         return {
-            name: back ? _t("Back") : _t("Cancel"),
+            name: back ? _t("Back") : _t("Discard"),
             icon: back ? "oi oi-chevron-left btn-back" : "btn-close btn-cancel",
         };
     }

--- a/addons/product/wizard/product_label_layout_views.xml
+++ b/addons/product/wizard/product_label_layout_views.xml
@@ -20,7 +20,7 @@
                 </group>
                 <footer>
                     <button name="process" string="Print" type="object" class="btn-primary"/>
-                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/product/wizard/update_product_attribute_value_views.xml
+++ b/addons/product/wizard/update_product_attribute_value_views.xml
@@ -10,7 +10,7 @@
                 <field name="mode" invisible="1"/>
                 <field name="message"/>
                 <footer>
-                    <button string="Cancel" special="cancel"/>
+                    <button special="cancel"/>
                     <button
                         name="action_confirm"
                         string="Confirm"

--- a/addons/product_expiry/wizard/confirm_expiry_view.xml
+++ b/addons/product_expiry/wizard/confirm_expiry_view.xml
@@ -26,9 +26,9 @@
                         type="object"
                         data-hotkey="w"
                         class="btn-secondary"/>
-                    <button string="Discard"
-                        class="btn-secondary"
-                        special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary"
+                        special="cancel"
+                        data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/product_margin/wizard/product_margin_view.xml
+++ b/addons/product_margin/wizard/product_margin_view.xml
@@ -12,7 +12,7 @@
                     </group>
                     <footer>
                         <button name="action_open_window" string="Open Margins" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -64,7 +64,6 @@ export function showTemplateUndoConfirmationDialog(
                 );
             }
         },
-        cancelLabel: _t("Discard"),
         cancel: () => {},
     });
 }

--- a/addons/project/static/src/core/web/follower_list_patch.js
+++ b/addons/project/static/src/core/web/follower_list_patch.js
@@ -22,7 +22,6 @@ const followerListPatch = {
                     "This follower is currently a project collaborator. Removing them will revoke their portal access to the project. Are you sure you want to proceed?"
                 ),
                 confirmLabel: _t("Remove Collaborator"),
-                cancelLabel: _t("Discard"),
                 confirm: () => super.onClickRemove(ev, follower),
                 cancel: () => {},
             });

--- a/addons/project/static/src/views/analytic_account_form/analytic_account_form_controller.js
+++ b/addons/project/static/src/views/analytic_account_form/analytic_account_form_controller.js
@@ -22,7 +22,6 @@ export class AnalyticAccountFormController extends FormController {
                         }
                     ),
                     confirmLabel: _t("Archive Account"),
-                    cancelLabel: _t("Discard"),
                 });
             };
         }

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -357,7 +357,7 @@
                 <xpath expr="//div[@name='alias_def']" position="after">
                     <footer>
                         <button string="Create project" name="action_view_tasks" type="object" class="btn-primary o_open_tasks" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </xpath>
             </field>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -658,7 +658,7 @@
                     </group>
                     <footer>
                         <button string="Convert Task" class="btn-primary" special="save" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="z" />
                     </footer>
                 </form>
             </field>

--- a/addons/project/wizard/project_project_stage_delete_views.xml
+++ b/addons/project/wizard/project_project_stage_delete_views.xml
@@ -19,8 +19,8 @@
                 <footer>
                     <button string="Archive Stages" type="object" name="action_archive" class="btn btn-primary" invisible="not stages_active or projects_count == 0" data-hotkey="q"/>
                     <button string="Delete" type="object" name="action_unlink" class="btn btn-primary" invisible="projects_count &gt; 0" data-hotkey="w"/>
-                    <button string="Discard" special="cancel" data-hotkey="x" class="btn btn-primary" invisible="not (stages_active or projects_count)" />
-                    <button string="Discard" special="cancel" data-hotkey="x" invisible="stages_active or projects_count" />
+                    <button special="cancel" data-hotkey="x" class="btn btn-primary" invisible="not (stages_active or projects_count)" />
+                    <button special="cancel" data-hotkey="x" invisible="stages_active or projects_count" />
                 </footer>
             </form>
         </field>
@@ -36,7 +36,7 @@
                 </div>
                 <footer>
                     <button string="Confirm" type="object" name="action_unarchive_project" class="btn btn-primary"/>
-                    <button string="Discard" special="cancel"/>
+                    <button special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -31,7 +31,7 @@
                 <footer>
                     <button string="Share Project" name="action_share_record" type="object" class="btn-primary" data-hotkey="q" invisible="not collaborator_ids" />
                     <button string="Save" class="btn-primary" special="save" data-hotkey="q" invisible="collaborator_ids" />
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>
         </field>
@@ -47,7 +47,7 @@
                 <p>You have full control and can revoke portal access anytime. Are you ready to proceed?</p>
                 <footer>
                     <button string="Grant Portal Access" name="action_send_mail" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/project/wizard/project_task_share_wizard_views.xml
+++ b/addons/project/wizard/project_task_share_wizard_views.xml
@@ -8,7 +8,7 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//button[hasclass('btn-secondary')]" position="replace">
-                <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                <button class="btn-secondary" special="cancel" data-hotkey="x" />
             </xpath>
             <xpath expr="//button[hasclass('btn-primary')]" position="attributes">
                 <attribute name="invisible">project_privacy_visibility in ['invited_users', 'followers']</attribute>

--- a/addons/project/wizard/project_task_type_delete_views.xml
+++ b/addons/project/wizard/project_task_type_delete_views.xml
@@ -19,7 +19,7 @@
                 <footer>
                     <button string="Archive Stages" type="object" name="action_archive" class="btn btn-primary" invisible="not stages_active or tasks_count == 0" data-hotkey="q"/>
                     <button string="Delete" type="object" name="action_unlink" class="btn btn-primary" invisible="tasks_count &gt; 0" data-hotkey="w"/>
-                    <button string="Discard" special="cancel" data-hotkey="x" />
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>
@@ -41,7 +41,7 @@
                 </div>
                 <footer>
                     <button string="Confirm" type="object" name="action_confirm" class="btn btn-primary" data-hotkey="q"/>
-                    <button string="Discard" special="cancel" data-hotkey="x" />
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>
@@ -57,7 +57,7 @@
                 </div>
                 <footer>
                     <button string="Confirm" type="object" name="action_unarchive_task" class="btn btn-primary"/>
-                    <button string="Discard" special="cancel"/>
+                    <button special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/project/wizard/project_template_create_wizard.xml
+++ b/addons/project/wizard/project_template_create_wizard.xml
@@ -31,7 +31,7 @@
                 </field>
                 <footer>
                     <button string="Create project" name="create_project_from_template" type="object" class="btn-primary o_open_tasks" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/project_todo/static/tests/todo_activity_wizard_view.test.js
+++ b/addons/project_todo/static/tests/todo_activity_wizard_view.test.js
@@ -24,7 +24,7 @@ beforeEach(() => {
                 </group>
                 <footer>
                     <button class="btn btn-primary" type="object" name="create_todo_activity" close="1">Add To-Do</button>
-                    <button class="btn btn-secondary" special="cancel" close="1">Discard</button>
+                    <button class="btn btn-secondary" special="cancel" close="1"/>
                 </footer>
             </form>`,
     };

--- a/addons/project_todo/static/tests/todo_conversion_form_view.test.js
+++ b/addons/project_todo/static/tests/todo_conversion_form_view.test.js
@@ -39,7 +39,7 @@ beforeEach(() => {
                 </sheet>
                 <footer>
                     <button name="action_convert_to_task" string="Convert to Task" type="object" class="btn-primary"/>
-                    <button string="Discard" special="cancel"/>
+                    <button special="cancel"/>
                 </footer>
             </form>`,
     };

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -187,7 +187,7 @@
                 </sheet>
                 <footer>
                     <button name="action_convert_to_task" string="Convert to Task" type="object" class="btn-primary"/>
-                    <button string="Discard" special="cancel"/>
+                    <button special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/project_todo/wizard/mail_activity_todo_create.xml
+++ b/addons/project_todo/wizard/mail_activity_todo_create.xml
@@ -13,7 +13,7 @@
                 <field name="note" class="oe-bordered-editor" placeholder="Add details about your to-do..."/>
                 <footer>
                     <button class="btn btn-primary" type="object" name="create_todo_activity" close="1">Add To-Do</button>
-                    <button class="btn btn-secondary" special="cancel" close="1">Discard</button>
+                    <button class="btn btn-secondary" special="cancel" close="1"/>
                 </footer>
             </form>
         </field>

--- a/addons/purchase_alternative/wizard/purchase_alternative_create.xml
+++ b/addons/purchase_alternative/wizard/purchase_alternative_create.xml
@@ -18,7 +18,7 @@
                     </group>
                     <footer>
                         <button name="action_create_alternative" string="Create Alternative" data-hotkey="q" type="object" colspan="1" class="btn-primary"/>
-                        <button string="Cancel"  data-hotkey="x" special="cancel" colspan="1" class="btn-secondary"/>
+                        <button data-hotkey="x" special="cancel" colspan="1" class="btn-secondary"/>
                     </footer>
                 </form>
             </field>

--- a/addons/purchase_alternative/wizard/purchase_alternative_warning.xml
+++ b/addons/purchase_alternative/wizard/purchase_alternative_warning.xml
@@ -19,7 +19,7 @@
                     <footer>
                         <button name="action_cancel_alternatives" string="Cancel Alternatives" data-hotkey="q" type="object" colspan="1" class="btn-primary"/>
                         <button name="action_keep_alternatives" string="Keep Alternatives" data-hotkey="w" type="object" colspan="1" class="btn-primary"/>
-                        <button string="Discard" data-hotkey="x" special="cancel" colspan="1" class="btn-secondary"/>
+                        <button data-hotkey="x" special="cancel" colspan="1" class="btn-secondary"/>
                     </footer>
                 </form>
             </field>

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -78,7 +78,7 @@
                             class="btn btn-secondary w-100 w-lg-auto"
                             t-on-click="cancel"
                         >
-                            Cancel
+                            Discard
                         </button>
                     </div>
                     <div class="d-flex gap-3 align-items-center">

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -20,7 +20,7 @@
                     class="btn btn-secondary order-2 order-md-1"
                     t-on-click="onDiscard"
                 >
-                    Cancel
+                    Discard
                 </button>
                 <h6
                     t-if="env.showPrice"

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -298,7 +298,7 @@
                                         <i class="fa fa-times"></i> Reject
                                     </button>
                                     <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
-                                        Cancel
+                                        Discard
                                     </button>
                                 </footer>
                             </form>

--- a/addons/sale/wizard/mass_cancel_orders_views.xml
+++ b/addons/sale/wizard/mass_cancel_orders_views.xml
@@ -26,7 +26,7 @@
                             name="action_mass_cancel"
                             type="object"
                             string="Cancel"/>
-                    <button string="Discard" special="cancel"/>
+                    <button special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -49,7 +49,7 @@
                         id="create_invoice_open"
                         string="Create Draft"
                         class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/sale/wizard/sale_order_discount_views.xml
+++ b/addons/sale/wizard/sale_order_discount_views.xml
@@ -30,7 +30,7 @@
                 </sheet>
                 <footer>
                     <button type="object" string="Apply" name="action_apply_discount" class="btn btn-primary" data-hotkey="q"/>
-                    <button special="cancel" string="Discard" class="btn btn-secondary" data-hotkey="x"/>
+                    <button special="cancel" class="btn btn-secondary" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/sale_crm/wizard/crm_opportunity_to_quotation_views.xml
+++ b/addons/sale_crm/wizard/crm_opportunity_to_quotation_views.xml
@@ -19,7 +19,7 @@
                 </group>
                 <footer>
                     <button name="action_apply" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/sale_loyalty/wizard/sale_loyalty_coupon_wizard_views.xml
+++ b/addons/sale_loyalty/wizard/sale_loyalty_coupon_wizard_views.xml
@@ -14,7 +14,7 @@
                 </sheet>
                 <footer>
                     <button type="object" name="action_apply" string="Apply" class="btn btn-primary" data-hotkey="q"/>
-                    <button special="cancel" string="Discard" class="btn btn-secondary" data-hotkey="x"/>
+                    <button special="cancel" class="btn btn-secondary" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
+++ b/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
@@ -28,10 +28,10 @@
                     <!-- Has rewards -->
                     <button type="object" name="action_apply" string="Apply" class="btn btn-primary"
                         invisible="not reward_ids" data-hotkey="q"/>
-                    <button special="cancel" string="Discard" class="btn btn-secondary"
+                    <button special="cancel" class="btn btn-secondary"
                         invisible="not reward_ids" data-hotkey="x"/>
                     <!-- No rewards -->
-                    <button special="cancel" string="Discard" class="btn btn-primary"
+                    <button special="cancel" class="btn btn-primary"
                         invisible="reward_ids" data-hotkey="x"/>
                     <button type="action" name="%(loyalty.loyalty_program_discount_loyalty_action)d" string="Coupons &amp; Loyalty" class="btn btn-secondary float-end"
                         invisible="reward_ids" groups="sales_team.group_sale_manager" data-hotkey="q"/>

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -79,7 +79,7 @@
             <sheet position="after">
                 <footer>
                     <button string="Confirm &amp; Close" special="save" class="btn btn-primary"/>
-                    <button string="Discard" special="cancel" class="btn btn-secondary"/>
+                    <button special="cancel" class="btn btn-secondary"/>
                 </footer>
             </sheet>
         </field>

--- a/addons/sms/wizard/sms_account_code_views.xml
+++ b/addons/sms/wizard/sms_account_code_views.xml
@@ -11,7 +11,7 @@
                     </group>
                     <footer>
                         <button string="Register" name="action_register" type="object" class="btn btn-primary"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                        <button class="btn-secondary" special="cancel"/>
                     </footer>
                 </sheet>
             </form>

--- a/addons/sms/wizard/sms_account_phone_views.xml
+++ b/addons/sms/wizard/sms_account_phone_views.xml
@@ -12,7 +12,7 @@
                     </group>
                     <footer>
                         <button string="Send verification code" name="action_send_verification_code" type="object" class="btn btn-primary"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                        <button class="btn-secondary" special="cancel"/>
                     </footer>
                 </sheet>
             </form>

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -68,7 +68,7 @@
                         invisible="composition_mode != 'mass'"/>
                     <button string="Send now" type="object" name="action_send_sms_mass_now" data-hotkey="w"
                         invisible="composition_mode != 'mass'"/>
-                    <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/sms/wizard/sms_template_preview_views.xml
+++ b/addons/sms/wizard/sms_template_preview_views.xml
@@ -22,7 +22,7 @@
                         <field name="body" readonly="1" nolabel="1" options='{"safe": True}'/>
                     <hr/>
                     <footer>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/sms/wizard/sms_template_reset_views.xml
+++ b/addons/sms/wizard/sms_template_reset_views.xml
@@ -12,7 +12,7 @@
                 </div>
                 <footer>
                     <button string="Proceed" class="btn btn-primary" type="object" name="reset_template" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
@@ -44,7 +44,7 @@
                 </group>
                 <footer>
                     <button string="Update Account" type="object" name="action_save" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/product_replenish_views.xml
+++ b/addons/stock/wizard/product_replenish_views.xml
@@ -40,9 +40,9 @@
                         type="object"
                         data-hotkey="q"
                         class="btn-primary"/>
-                    <button string="Discard"
-                        class="btn-secondary"
-                        special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary"
+                        special="cancel"
+                        data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_backorder_confirmation_views.xml
+++ b/addons/stock/wizard/stock_backorder_confirmation_views.xml
@@ -34,7 +34,7 @@
                 <footer>
                     <button name="process" string="Create Backorder" type="object" class="oe_highlight" data-hotkey="q"/>
                     <button name="process_cancel_backorder" string="No Backorder" type="object" class="btn-danger" invisible="show_transfers" data-hotkey="w"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_inventory_adjustment_name.xml
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.xml
@@ -14,7 +14,7 @@
                 </div>
                 <footer>
                     <button name="action_apply" string="Update Quantities" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_inventory_conflict.xml
+++ b/addons/stock/wizard/stock_inventory_conflict.xml
@@ -41,7 +41,7 @@
                 <footer>
                     <button name="action_keep_counted_quantity" string="Keep Counted Quantity" type="object" class="btn-primary" data-hotkey="q"/>
                     <button name="action_keep_difference" string="Keep Difference" type="object" class="btn-primary" data-hotkey="w"/>
-                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_inventory_warning.xml
+++ b/addons/stock/wizard/stock_inventory_warning.xml
@@ -11,7 +11,7 @@
                 </div>
                 <footer>
                     <button name="action_reset" string="Continue" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>
@@ -28,7 +28,7 @@
                 </div>
                 <footer>
                     <button name="action_set" string="Continue" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_label_type.xml
+++ b/addons/stock/wizard/stock_label_type.xml
@@ -12,7 +12,7 @@
                 </group>
                 <footer>
                     <button name="process" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_lot_label_layout.xml
+++ b/addons/stock/wizard/stock_lot_label_layout.xml
@@ -13,7 +13,7 @@
                 </group>
                 <footer>
                     <button name="process" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_orderpoint_snooze_views.xml
+++ b/addons/stock/wizard/stock_orderpoint_snooze_views.xml
@@ -12,7 +12,7 @@
                 </group>
                 <footer>
                     <button string="Snooze" name="action_snooze" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_package_destination_views.xml
+++ b/addons/stock/wizard/stock_package_destination_views.xml
@@ -38,7 +38,7 @@
                 </div>
                 <footer>
                     <button string="Confirm" name="action_done" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_picking_return_views.xml
+++ b/addons/stock/wizard/stock_picking_return_views.xml
@@ -27,7 +27,7 @@
                     <button name="action_create_returns" string="Return" type="object" class="btn-primary" data-hotkey="q"/>
                     <button name="action_create_returns_all" string="Return All" type="object" class="btn-secondary"/>
                     <button name="action_create_exchanges" string="Exchange" invisible="picking_type_code not in ('incoming', 'outgoing')" type="object" class="btn-primary"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_put_in_pack_views.xml
+++ b/addons/stock/wizard/stock_put_in_pack_views.xml
@@ -15,7 +15,7 @@
                 </group>
                 <footer>
                     <button name="action_put_in_pack" type="object" string="Put in Pack" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                    <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_quant_relocate.xml
+++ b/addons/stock/wizard/stock_quant_relocate.xml
@@ -26,7 +26,7 @@
                 </div>
                 <footer>
                     <button name="action_relocate_quants" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_quantity_history.xml
+++ b/addons/stock/wizard/stock_quantity_history.xml
@@ -10,7 +10,7 @@
                 </group>
                 <footer>
                     <button name="open_at_date" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_replenishment_info.xml
+++ b/addons/stock/wizard/stock_replenishment_info.xml
@@ -92,7 +92,7 @@
                     <button name="order_all" type="object">
                         Order <field name="qty_to_order"/>
                     </button>
-                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_request_count.xml
+++ b/addons/stock/wizard/stock_request_count.xml
@@ -14,7 +14,7 @@
                 </group>
                 <footer>
                     <button name="action_request_count" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_rules_report_views.xml
+++ b/addons/stock/wizard/stock_rules_report_views.xml
@@ -21,7 +21,7 @@
                         type="object"
                         data-hotkey="q"
                         class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock/wizard/stock_warn_insufficient_qty_views.xml
+++ b/addons/stock/wizard/stock_warn_insufficient_qty_views.xml
@@ -27,7 +27,7 @@
                 <div name="description">
                 </div>
                 <footer>
-                    <button name="cancel_button" string="Discard" class="btn-primary" special="cancel" data-hotkey="x"/>
+                    <button name="cancel_button" class="btn-primary" special="cancel" data-hotkey="x"/>
                     <button string="Confirm" name="action_done" type="object" class="btn-secondary" data-hotkey="q"/>
                 </footer>
             </form>

--- a/addons/stock_picking_batch/wizard/stock_add_to_wave_views.xml
+++ b/addons/stock_picking_batch/wizard/stock_add_to_wave_views.xml
@@ -17,7 +17,7 @@
 
                 <footer>
                     <button name="attach_pickings" type="object" string="Confirm" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    <button class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock_picking_batch/wizard/stock_picking_to_batch_views.xml
+++ b/addons/stock_picking_batch/wizard/stock_picking_to_batch_views.xml
@@ -20,7 +20,7 @@
 
                 <footer>
                     <button name="attach_pickings" type="object" string="Confirm" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/stock_sms/wizard/confirm_stock_sms_views.xml
+++ b/addons/stock_sms/wizard/confirm_stock_sms_views.xml
@@ -12,7 +12,7 @@
                             string="Confirm" class="oe_highlight"/>
                     <button name="dont_send_sms" type="object" data-hotkey="w"
                             string="Disable SMS" class="btn btn-secondary"/>
-                    <button special="cancel" data-hotkey="x" string="Cancel"/>
+                    <button special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -27,7 +27,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_single_custom
             }
         },
         {
-            trigger: '.modal button:contains("Cancel")',
+            trigger: '.modal button:contains("Discard")',
             run: "click",
         },
         ...stepUtils.discardForm(),

--- a/addons/web/static/src/core/signature/signature_dialog.xml
+++ b/addons/web/static/src/core/signature/signature_dialog.xml
@@ -9,7 +9,7 @@
         </div>
         <t t-set-slot="footer">
           <button class="btn btn-primary" t-att-disabled="signature.isSignatureEmpty" t-on-click="onClickConfirm" >Adopt &amp; Sign</button>
-          <button class="btn btn-secondary" t-on-click="props.close">Cancel</button>
+          <button class="btn btn-secondary" t-on-click="props.close">Discard</button>
         </t>
       </Dialog>
     </t>

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -643,7 +643,6 @@ export class PropertiesField extends Component {
             body: message,
             confirmLabel: _t("Delete Field"),
             confirmClass: "btn-danger",
-            cancelLabel: _t("Discard"),
             confirm: () => {
                 const propertiesDefinitions = this.propertiesList;
                 propertiesDefinitions.find(

--- a/addons/web/static/src/views/list/list_confirmation_dialog.xml
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.xml
@@ -75,7 +75,7 @@
                 Update
                 </button>
                 <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel">
-                Cancel
+                Discard
                 </button>
             </t>
         </Dialog>

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 import { useDropdownCloser } from "@web/core/dropdown/dropdown_hooks";
 import { pick } from "@web/core/utils/objects";
 import { debounce as debounceFn } from "@web/core/utils/timing";
@@ -72,7 +73,7 @@ export class ViewButton extends Component {
         this.tooltip = JSON.stringify({
             debug: Boolean(odoo.debug),
             button: {
-                string: this.props.string,
+                string: this.buttonLabel,
                 help: this.clickParams.help,
                 context: this.clickParams.context,
                 invisible: this.props.attrs.invisible,
@@ -88,6 +89,13 @@ export class ViewButton extends Component {
             model: this.props.record && this.props.record.resModel,
         });
         this.dropdownControl = useDropdownCloser();
+    }
+
+    get buttonLabel() {
+        if (this.props.string === undefined && this.clickParams.special === "cancel") {
+            return _t("Discard");
+        }
+        return this.props.string;
     }
 
     get clickParams() {

--- a/addons/web/static/src/views/view_button/view_button.xml
+++ b/addons/web/static/src/views/view_button/view_button.xml
@@ -18,8 +18,8 @@
         t-att-tabindex="props.tabindex"
         t-custom-click.stop="onClick"
     >
-      <t t-if="icon" t-tag="icon.tag" t-att-class="icon.class + (props.string ? ' me-1' : '')" t-att-src="icon.src"/>
-      <t t-slot="contents"><span t-if="props.string" t-esc="props.string"/></t>
+      <t t-if="icon" t-tag="icon.tag" t-att-class="icon.class + (buttonLabel ? ' me-1' : '')" t-att-src="icon.src"/>
+      <t t-slot="contents"><span t-if="buttonLabel" t-esc="buttonLabel"/></t>
     </t>
   </t>
 

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -6,7 +6,7 @@
             <div t-esc="props.text" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="onDelete">Delete</button>
-                <button class="btn btn-secondary" t-on-click="() => props.close()">Cancel</button>
+                <button class="btn btn-secondary" t-on-click="() => props.close()">Discard</button>
             </t>
         </Dialog>
     </t>

--- a/addons/web/static/src/webclient/settings_form_view/fields/upgrade_dialog.xml
+++ b/addons/web/static/src/webclient/settings_form_view/fields/upgrade_dialog.xml
@@ -23,7 +23,7 @@
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="_confirmUpgrade">Upgrade now</button>
-                <button class="btn btn-secondary" t-on-click="this.props.close">Cancel</button>
+                <button class="btn btn-secondary" t-on-click="this.props.close">Discard</button>
             </t>
         </Dialog>
     </t>

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -542,7 +542,7 @@ test('O2M with buttons with attr "special" in dialog close the dialog', async ()
                         <form>
                             <field name="bar"/>
                             <footer>
-                                <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                                <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                             </footer>
                         </form>
                     </field>
@@ -552,7 +552,7 @@ test('O2M with buttons with attr "special" in dialog close the dialog', async ()
     await contains(".o_field_x2many_list_row_add button").click();
     expect(".o_dialog").toHaveCount(1);
 
-    expect(".modal .btn").toHaveText("Cancel");
+    expect(".modal .btn").toHaveText("Discard");
 
     await contains(".modal .btn").click();
     expect(".o_dialog").toHaveCount(0);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -12032,7 +12032,7 @@ test(`editable list view: clicking on "Discard changes" in multi edition`, async
     await contains(`.o_data_row:eq(0) .o_data_cell:eq(0)`).click();
     await contains(`.o_data_row [name=foo] input`).edit("oof", { confirm: "blur" });
 
-    await clickModalButton({ text: "Cancel" });
+    await clickModalButton({ text: "Discard" });
 
     expect(`.modal`).toHaveCount(0, { message: "should not open modal" });
     expect(`.o_data_row:eq(0) .o_data_cell:eq(0)`).toHaveText("yop");
@@ -19780,7 +19780,7 @@ test(`multi_edit: edit field with operator with localization`, async () => {
         await waitFor(`.modal table [name=${field}]`);
         expect(`.modal table [name=${field}]`).toHaveText(text);
         expect(`.modal .alert`).toHaveCount(1);
-        await contains(".modal footer button:contains(cancel)").click();
+        await contains(".modal footer button:contains(Discard)").click();
     }
     await checkFieldValue("int_field", "+=100", "Int field + 100");
     await checkFieldValue("int_field", "-=00100", "Int field - 100");
@@ -20034,7 +20034,7 @@ test(`multi edition: edit date with operation`, async () => {
         await animationFrame();
         expect(`.modal .o_modal_changes [name=datetime]`).toHaveText(`Datetime ${operation.text}`);
         expect(`.modal .alert`).toHaveCount(1);
-        await contains(`.modal-dialog button:contains(cancel)`).click();
+        await contains(`.modal-dialog button:contains(Discard)`).click();
     }
 
     await contains(`th .o-checkbox`).click();

--- a/addons/web/static/tests/views/view_button_hook.test.js
+++ b/addons/web/static/tests/views/view_button_hook.test.js
@@ -168,3 +168,21 @@ test("execute action in new window - 2", async () => {
     await contains("a[type=action]").click({ ctrlKey: true });
     expect.verifySteps([{ newWindow: true }]);
 });
+
+test("default label for button special cancel", async () => {
+    class MyComponent extends Component {
+        static components = { ViewButton };
+        static template = xml`
+                <div t-ref="root" class="myComponent">
+                    <ViewButton tag="'button'" clickParams="{ special:'cancel' }"/>
+                </div>`;
+        static props = ["*"];
+        setup() {
+            const rootRef = useRef("root");
+            useViewButtons(rootRef);
+        }
+    }
+
+    await mountWithCleanup(MyComponent);
+    expect("button[special=cancel]").toHaveText("Discard");
+});

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -997,7 +997,7 @@ test("execute_action of type object: disable buttons (2)", async () => {
     Pony._views["form,44"] = `
         <form>
             <field name="name"/>
-            <button string="Cancel" class="cancel-btn" special="cancel"/>
+            <button class="cancel-btn" special="cancel"/>
         </form>`;
 
     defineActions([

--- a/addons/web/views/base_document_layout_views.xml
+++ b/addons/web/views/base_document_layout_views.xml
@@ -38,7 +38,7 @@
                     </group>
                     <footer>
                         <button string="Continue" class="btn-primary" type="object" name="document_layout_save" data-hotkey="q"/>
-                        <button special="cancel" data-hotkey="x" string="Discard" />
+                        <button special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
@@ -93,7 +93,7 @@
                 </t>
                 Save and Reload
             </button>
-            <button class="btn btn-secondary" t-on-click="onClickCancel">Cancel</button>
+            <button class="btn btn-secondary" t-on-click="onClickCancel">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_api_key_dialog.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_api_key_dialog.xml
@@ -50,7 +50,7 @@
         </div>
         <t t-set-slot="footer">
             <button t-on-click="onClickSave" class="btn btn-primary" data-hotkey="q">Save</button>
-            <button class="btn" t-on-click="() => this.props.close()" data-hotkey="x">Cancel</button>
+            <button class="btn" t-on-click="() => this.props.close()" data-hotkey="x">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/website/static/src/components/dialog/dialog.js
+++ b/addons/website/static/src/components/dialog/dialog.js
@@ -26,7 +26,7 @@ export class WebsiteDialog extends Component {
         title: _t("Confirmation"),
         showFooter: true,
         primaryTitle: _t("Ok"),
-        secondaryTitle: _t("Cancel"),
+        secondaryTitle: _t("Discard"),
         showSecondaryButton: true,
         size: "md",
         closeOnClick: true,

--- a/addons/website/static/src/xml/website.xml
+++ b/addons/website/static/src/xml/website.xml
@@ -24,7 +24,7 @@
                     </main>
                     <footer class="modal-footer">
                         <button type="button" class="btn btn-primary btn-continue"><t t-out="btn_primary_title"/></button>
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Cancel"><t t-out="btn_secondary_title"/></button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Discard"><t t-out="btn_secondary_title"/></button>
                     </footer>
                 </div>
             </div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -3014,7 +3014,7 @@
                             </div>
                         </main>
                         <footer class="modal-footer">
-                            <button type="button" class="btn" data-bs-dismiss="modal" aria-label="Cancel">Cancel</button>
+                            <button type="button" class="btn" data-bs-dismiss="modal" aria-label="Discard">Discard</button>
                             <input type="submit" value="Confirm" class="btn btn-primary"/>
                         </footer>
                     </div>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -56,7 +56,7 @@
                 <xpath expr="//form" position="inside">
                     <footer>
                         <button name="create_and_redirect_configurator" type="object" string="Create" class="btn btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </xpath>
                 <xpath expr="//notebook" position="replace"/>

--- a/addons/website/wizard/blocked_third_party_domains.xml
+++ b/addons/website/wizard/blocked_third_party_domains.xml
@@ -19,7 +19,7 @@
             </p>
             <footer>
                 <button string="Save" name="action_save" type="object" class="oe_highlight" data-hotkey="q"/>
-                <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                <button class="btn-secondary" special="cancel" data-hotkey="x"/>
             </footer>
         </form>
     </field>

--- a/addons/website/wizard/website_robots.xml
+++ b/addons/website/wizard/website_robots.xml
@@ -18,7 +18,7 @@
                 </small>
                 <footer>
                     <button string="Save" name="action_save" type="object" class="oe_highlight" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -431,7 +431,7 @@
                             </div>
                         </main>
                         <footer class="modal-footer">
-                            <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cancel</button>
+                            <button type="button" class="btn btn-light" data-bs-dismiss="modal">Discard</button>
                             <button t-attf-class="btn btn-primary new_opp_confirm">Confirm</button>
                         </footer>
                     </form>
@@ -593,7 +593,7 @@
                                 </div>
                             </main>
                             <footer class="modal-footer">
-                                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Discard</button>
                                 <button t-attf-class="btn btn-primary interested_partner_assign_confirm">Confirm</button>
                             </footer>
                         </form>
@@ -626,7 +626,7 @@
                                 </div>
                             </main>
                             <footer class="modal-footer">
-                                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Discard</button>
                                 <button t-attf-class="btn btn-primary desinterested_partner_assign_confirm">Confirm</button>
                             </footer>
                         </form>
@@ -843,7 +843,7 @@
                                     </div>
                                 </main>
                                 <footer class="modal-footer">
-                                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Discard</button>
                                     <button t-attf-class="btn btn-primary edit_opp_confirm">Confirm</button>
                                 </footer>
                             </form>
@@ -919,7 +919,7 @@
                                     </div>
                                 </main>
                                 <footer class="modal-footer">
-                                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Discard</button>
                                     <button t-attf-class="btn btn-primary edit_contact_confirm">Confirm</button>
                                 </footer>
                             </form>

--- a/addons/website_crm_partner_assign/wizard/crm_forward_to_partner_view.xml
+++ b/addons/website_crm_partner_assign/wizard/crm_forward_to_partner_view.xml
@@ -31,7 +31,7 @@
                     </notebook>
                     <footer>
                         <button name="action_forward" string="Send" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                        <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                     </footer>
                 </form>
             </field>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -363,7 +363,7 @@
                         </div>
                     </t>
                     <div class="modal-footer border-top">
-                        <button type="button" class="btn btn-secondary js_goto_event" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-secondary js_goto_event" data-bs-dismiss="modal">Discard</button>
                         <button type="submit" class="btn btn-primary" t-if="availability_check and limit_check">Confirm Registration</button>
                     </div>
                 </div>
@@ -576,7 +576,7 @@
                         </div>
                         <div class="modal-footer flex-lg-row border-top">
                             <button type="button" class="btn btn-light js_goto_event" data-bs-dismiss="modal">
-                                <t t-if="event.is_multi_slots">Cancel</t>
+                                <t t-if="event.is_multi_slots">Discard</t>
                                 <t t-else="">Close</t>
                             </button>
                             <button type="submit" class="btn btn-primary a-submit" disabled="" t-attf-id="#{event.id}">
@@ -653,7 +653,7 @@
                         </div>
                         <div class="modal-footer flex-lg-row border-top">
                             <button type="button" class="btn btn-light js_goto_event" data-bs-dismiss="modal">
-                                <t t-if="event.is_multi_slots">Cancel</t>
+                                <t t-if="event.is_multi_slots">Discard</t>
                                 <t t-else="">Close</t>
                             </button>
                             <button type="submit" class="btn btn-primary a-submit" t-attf-id="#{event.id}" disabled="disabled">

--- a/addons/website_sale_mondialrelay/static/src/xml/website_sale_mondialrelay.xml
+++ b/addons/website_sale_mondialrelay/static/src/xml/website_sale_mondialrelay.xml
@@ -15,7 +15,7 @@
                     </div>
                     <footer class="modal-footer">
                         <button type="button" id="btn_confirm_relay" class="btn btn-primary disabled" aria-label="Choose this Parcel Point">Send to this Parcel Point</button>
-                        <button type="button" class="btn" data-bs-dismiss="modal" aria-label="Cancel">Cancel</button>
+                        <button type="button" class="btn" data-bs-dismiss="modal" aria-label="Discard">Discard</button>
                     </footer>
                 </div>
             </div>

--- a/addons/website_slides/static/src/interactions/category_add.js
+++ b/addons/website_slides/static/src/interactions/category_add.js
@@ -25,7 +25,6 @@ export class CategoryAdd extends Interaction {
                 formEl.submit();
                 return true;
             },
-            cancelLabel: _t("Cancel"),
             cancel: () => { },
             channelId,
         });

--- a/addons/website_slides/static/src/interactions/category_delete.js
+++ b/addons/website_slides/static/src/interactions/category_delete.js
@@ -26,7 +26,6 @@ export class CategoryDelete extends Interaction {
                 await this.waitFor(this.services.orm.unlink("slide.slide", [categoryId]));
                 window.location.reload();
             },
-            cancelLabel: _t("Cancel"),
             cancel: () => { },
         });
     }

--- a/addons/website_slides/static/src/interactions/enroll_email.js
+++ b/addons/website_slides/static/src/interactions/enroll_email.js
@@ -41,7 +41,6 @@ export class EnrollEmail extends Interaction {
                 this.insert(newAlertEl, alertEl, "afterend");
                 alertEl.remove();
             },
-            cancelLabel: _t("Cancel"),
             cancel: () => { },
         });
     }

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog.xml
@@ -5,7 +5,7 @@
         <Dialog size="state.size" title="state.title" contentClass="'o_w_slide_upload_dialog_content'">
             <t t-set-slot="footer">
                 <button t-if="state.page ==='select'" type="button" class="btn" t-on-click="() => this.props.close()">
-                    <span>Cancel</span>
+                    <span>Discard</span>
                 </button>
                 <t t-elif="!['select', 'upload'].includes(state.page)">
                     <div id="o_w_slide_upload_btns"/>

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -40,7 +40,7 @@
                     <footer>
                         <button string="Send" invisible="not send_email" name="action_invite" type="object" class="btn-primary" data-hotkey="q"/>
                         <button string="Close" invisible="send_email" class="btn-secondary" special="cancel" data-hotkey="x"/>
-                        <button string="Cancel" invisible="not send_email" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button invisible="not send_email" class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -323,7 +323,7 @@
                     </div>
                     <footer>
                         <button string="Restore Revision" name="restore_revision" type="object" class="btn-primary" invisible="not code_diff" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -73,7 +73,7 @@
                     <field name="expiration"/>
                 </group>
                 <footer>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     <button string="Enable profiling" type="object" name="submit" class="btn btn-primary" data-hotkey="q"/>
                 </footer>
             </form>

--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -133,7 +133,7 @@
                     </div>
                     <footer>
                         <button string="Reset View" name="reset_view_button" type="object" class="btn-primary" invisible="not has_diff" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/views/res_config_views.xml
+++ b/odoo/addons/base/views/res_config_views.xml
@@ -10,7 +10,7 @@
                     <group name="res_config_contents"/>
                     <footer>
                         <button name="action_next" type="object" string="Apply" class="btn-primary" data-hotkey="q"/>
-                        <button name="action_skip" type="object" special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                        <button name="action_skip" type="object" special="cancel" data-hotkey="x" class="btn-secondary"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/views/res_users_identitycheck_views.xml
+++ b/odoo/addons/base/views/res_users_identitycheck_views.xml
@@ -20,7 +20,7 @@
                         <button string="Confirm Password" id="password_confirm" type="object" name="run_check"
                             class="btn btn-primary" data-hotkey="q" invisible="auth_method != 'password'"
                             context="{'password': password}"/>
-                        <button string="Discard" special="cancel" data-hotkey="z" class="btn btn-secondary"/>
+                        <button special="cancel" data-hotkey="z" class="btn btn-secondary"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -506,7 +506,7 @@
                         </notebook>
                         <footer>
                             <button name="preference_save" type="object" string="Update Preferences" class="btn-primary" data-hotkey="q"/>
-                            <button name="preference_cancel" string="Discard" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                            <button name="preference_cancel" special="cancel" data-hotkey="x" class="btn-secondary"/>
                         </footer>
                     </sheet>
                 </form>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -12,7 +12,7 @@
                     </group>
                     <footer>
                         <button string="Change Password" name="change_password" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>
@@ -27,7 +27,7 @@
                     <field mode="list" name="user_ids"/>
                     <footer>
                         <button string="Change Password" name="change_password_button" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>
@@ -368,7 +368,7 @@
                     </p>
                     <footer>
                         <button name="make_key" type="object" string="Generate key" class="btn-primary" data-hotkey="q"/>
-                        <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                        <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                     </footer>
                     </sheet>
                 </form>

--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -54,7 +54,7 @@
                     </div>
                     <footer invisible="state != 'choose'">
                         <button name="act_getfile" data-hotkey="q" string="Export" type="object" class="btn-primary"/>
-                        <button special="cancel" data-hotkey="x" string="Cancel" type="object" class="btn-secondary"/>
+                        <button special="cancel" data-hotkey="x" type="object" class="btn-secondary"/>
                     </footer>
                     <footer invisible="state != 'get'">
                         <button special="cancel" data-hotkey="x" string="Close" type="object" class="btn-primary"/>

--- a/odoo/addons/base/wizard/base_import_language_views.xml
+++ b/odoo/addons/base/wizard/base_import_language_views.xml
@@ -16,7 +16,7 @@
                     </group>
                     <footer>
                         <button name="import_lang" string="Import" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/wizard/base_language_install_views.xml
+++ b/odoo/addons/base/wizard/base_language_install_views.xml
@@ -37,7 +37,7 @@
                     </group>
                     <footer>
                         <button name="lang_install" block-ui="1" string="Add" data-hotkey="q" type="object" class="btn-primary"/>
-                        <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                        <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                     </footer>
                 </form>
            </field>

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -73,7 +73,7 @@
                     </notebook>
                     <footer>
                         <button string="Uninstall" class="btn-secondary" type="object" name="action_uninstall" data-hotkey="q"/>
-                        <button string="Discard" class="btn-primary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-primary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/wizard/base_module_update_views.xml
+++ b/odoo/addons/base/wizard/base_module_update_views.xml
@@ -18,7 +18,7 @@
                     <footer>
                         <div invisible="state != 'init'" class="d-flex gap-1">
                             <button name="update_module" string="Update" type="object" class="btn-primary" data-hotkey="q"/>
-                            <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
+                            <button special="cancel" data-hotkey="x" class="btn-secondary"/>
                         </div>
                         <div invisible="state != 'done'" class="d-flex gap-1">
                             <button name="action_module_open" string="Open Apps" type="object" class="btn-primary" data-hotkey="q"/>

--- a/odoo/addons/base/wizard/base_module_upgrade_views.xml
+++ b/odoo/addons/base/wizard/base_module_upgrade_views.xml
@@ -45,7 +45,7 @@
                     <div><span class="o_form_label">We suggest to reload the menu tab to see the new menus (Ctrl+T then Ctrl+R)."</span></div>
                     <footer>
                         <button name="config" string="Start configuration" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>
             </field>

--- a/odoo/addons/base/wizard/base_partner_merge_views.xml
+++ b/odoo/addons/base/wizard/base_partner_merge_views.xml
@@ -92,7 +92,7 @@
                             type='object' data-hotkey="y"
                             confirm="Are you sure to execute the list of automatic merges of your contacts?"
                             invisible="state != 'option'" />
-                        <button special="cancel" data-hotkey="x" string="Cancel" type="object" class="btn btn-secondary oe_inline" invisible="state == 'finished'"/>
+                        <button special="cancel" data-hotkey="x" type="object" class="btn btn-secondary oe_inline" invisible="state == 'finished'"/>
                         <button special="cancel" data-hotkey="x" string="Close" type="object" class="btn btn-secondary oe_inline" invisible="state != 'finished'"/>
                     </footer>
                 </form>

--- a/odoo/addons/base/wizard/wizard_ir_model_menu_create_views.xml
+++ b/odoo/addons/base/wizard/wizard_ir_model_menu_create_views.xml
@@ -12,7 +12,7 @@
                 </group>
                 <footer>
                     <button name="menu_create" string="Create Menu" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
Purpose
=======
Rename all the "Cancel" buttons in wizards/modals/dialogs to "Discard".

Specification
=============
The "Cancel" label can be confusing for new users as they don't actually know if clicking on "Cancel" will close the wizard/modal/dialog or set the state/stage of the record to "Cancelled".
"Discard" is preferred as it does not have this confusing connotation.

=> If clicking on the cancel button actually changes the state/stage of a specific record to "Cancelled", keeping the "Cancel" label, else changing the label to "Discard".

Task-5172291
