### PR TITLE
[FIX] web: signer experience UI refresh

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.html
+++ b/addons/web/static/lib/pdfjs/web/viewer.html
@@ -147,7 +147,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <span data-l10n-id="pdfjs-next-button-label"></span>
                   </button>
                 </div>
-                <div class="toolbarHorizontalGroup">
+                <div class="toolbarHorizontalGroup hiddenSmallView">
                   <span class="loadingInput start toolbarHorizontalGroup">
                     <input type="number" id="pageNumber" class="toolbarField" value="1" min="1" tabindex="0" data-l10n-id="pdfjs-page-input" autocomplete="off">
                   </span>
@@ -155,7 +155,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                 </div>
               </div>
               <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
-                <div class="toolbarHorizontalGroup">
+                <div class="toolbarHorizontalGroup hiddenSmallView">
                   <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
                     <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
                   </button>


### PR DESCRIPTION
Before this PR, the toolbar was looking a bit old and the viewer background was to dark in LM. Now it is more harmonized.
PR Ent: https://github.com/odoo/enterprise/pull/99438 

| Before | After |
|--------|--------|
| <img width="1596" height="831" alt="Screenshot 2025-11-13 at 17 40 51" src="https://github.com/user-attachments/assets/30eae7ae-f8bb-4fe2-87f7-9151974d5d86" /> | <img width="1596" height="831" alt="Screenshot 2025-11-13 at 17 40 37" src="https://github.com/user-attachments/assets/673ba382-0bf1-4385-b669-a81438123aac" /> | 

task-5060120

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
