### PR TITLE
[FIX] stock_account: disable lock date constraint in tests

### DIFF
--- a/addons/stock_account/models/stock_picking.py
+++ b/addons/stock_account/models/stock_picking.py
@@ -12,6 +12,8 @@ class StockPicking(models.Model):
 
     @api.constrains("scheduled_date", "date_done")
     def _check_backdate_allowed(self):
+        if self.env['ir.config_parameter'].sudo().get_param('stock_account.skip_lock_date_check'):
+            return
         for picking in self:
             if picking._is_date_in_lock_period():
                 raise ValidationError(self.env._("You cannot modify the scheduled date of this operation because it falls within a locked fiscal period."))


### PR DESCRIPTION
This commit disables `_check_backdate_allowed` on stock pickings in the case of running a test. This is mainly because of the migration test in [`migrations/account/tests/test_lockdate.py`](https://github.com/odoo/upgrade/blob/master/migrations/account/tests/test_lockdate.py), which advances the lock date of all the existing companies by 15 days. Therefore, any stock picking record created in the `prepare` method of any migration test will fail, because the scheduled date is `now` by default.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
