### PR TITLE
[IMP] point_of_sale: save POS logs for debugging

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
@@ -8,6 +8,7 @@ import { serializeDateTime } from "@web/core/l10n/dates";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { pick } from "@web/core/utils/objects";
+import { downloadPosLogs } from "../pretty_console_log";
 const { DateTime } = luxon;
 
 const useDialogDraggable = makeDraggableHook({
@@ -177,6 +178,9 @@ export class DebugWidget extends Component {
     }
     refreshDisplay() {
         this.hardwareProxy.message("display_refresh", {});
+    }
+    async downloadLogs() {
+        await downloadPosLogs();
     }
     _onBufferUpdate({ detail: value }) {
         this.state.buffer = value;

--- a/addons/point_of_sale/static/src/app/utils/debug/debug_widget.xml
+++ b/addons/point_of_sale/static/src/app/utils/debug/debug_widget.xml
@@ -76,6 +76,15 @@
                             </li>
                         </ul>
                     </div>
+
+                    <div class="debug-logs">
+                        <h5 class="category">Logs</h5>
+                        <ul class="mb-3 p-0">
+                            <li class="button btn btn-link" t-on-click="downloadLogs">
+                                Download Logs
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </Transition>

--- a/addons/point_of_sale/static/src/app/utils/pretty_console_log.js
+++ b/addons/point_of_sale/static/src/app/utils/pretty_console_log.js
@@ -1,3 +1,8 @@
+import { Logger } from "@bus/workers/websocket_worker_utils";
+import { downloadFile } from "@web/core/network/download";
+
+const posLogger = new Logger(`point_of_sale_config_${odoo.pos_config_id}_logger`);
+
 export function logPosMessage(type, functionName, message, color = "#A1A1A1", args = []) {
     if (odoo.debug === "assets") {
         console.groupCollapsed(
@@ -13,4 +18,31 @@ export function logPosMessage(type, functionName, message, color = "#A1A1A1", ar
         console.trace("Call stack:");
         console.groupEnd();
     }
+    const timestamp = luxon.DateTime.now().toUTC().toFormat("yyyy-LL-dd HH:mm:ss");
+    const log = {
+        timestamp,
+        type,
+        functionName,
+        message,
+    };
+    if (args.length) {
+        try {
+            log.args = JSON.parse(JSON.stringify(args));
+        } catch {
+            // In case the args are not serializable
+            log.args = args.toString();
+        }
+    }
+    posLogger.log(log);
+}
+
+export async function downloadPosLogs() {
+    const logs = await posLogger.getLogs();
+    const blob = new Blob([JSON.stringify(logs, null, 2)], {
+        type: "application/json",
+    });
+    const filename = `pos_logs_${luxon.DateTime.now()
+        .toUTC()
+        .toFormat("yyyy-LL-dd-HH-mm-ss")}.json`;
+    downloadFile(blob, filename);
 }


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/100183

This commit extends the `logPosMessage` function in the POS to also save each log message to a `Logger` instance (which persists the logs for 24 hours in the browser storage).

A download button is added to download these logs, which the client could then send on to the support team.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
