### PR TITLE
[FIX] l10n_de: fix tax access error when changing product cost

### DIFF
--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -17,7 +17,7 @@ class ProductTemplate(models.Model):
         company = self.env.company
         if company.account_fiscal_country_id.code == "DE":
             if not self.property_account_income_id:
-                taxes = self.taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
+                taxes = self.sudo(False).taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
                 if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):
                     result_income = self.env['account.account'].with_company(company).search([
                         *self.env['account.account']._check_company_domain(company),
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
                     ], limit=1)
                     result['income'] = result_income or result['income']
             if not self.property_account_expense_id:
-                supplier_taxes = self.supplier_taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
+                supplier_taxes = self.sudo(False).supplier_taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
                 if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0] not in result['expense'].tax_ids):
                     result_expense = self.env['account.account'].with_company(company).search([
                         *self.env['account.account']._check_company_domain(company),


### PR DESCRIPTION
from v18.0 to v18.4, in a multi-company environment, when a product with no income/expense account had its cost changed, all the taxes for other companies were being fetched which caused access errors when trying to view it after a manual save.
This happens because the fetch is happening in a sudo environment because the stock valuation layer was being created as sudo, so all taxes were being fetched and probably because of cache pollution they were not being filtered properly, this is not happening in v19.0 because the stock valuation layer was removed, so everything is being called in a normal user environment, refer to this commit-08b62a4

task-5117882