### PR TITLE
[IMP] product, *: improve product catalog card design

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_record.scss
+++ b/addons/product/static/src/product_catalog/kanban_record.scss
@@ -1,0 +1,11 @@
+.o_product_catalog_kanban_record {
+    --KanbanRecord-min-width: 22rem;
+
+    .o_dropdown_kanban {
+        --background-color: #{rgba($o-view-background-color, map-get($o-opacities, 75))};
+    }
+}
+
+.o_product_catalog_favorite a {
+    --link-color-rgb: var(--dropdown-link-color);
+}

--- a/addons/product/static/src/product_catalog/kanban_record.xml
+++ b/addons/product/static/src/product_catalog/kanban_record.xml
@@ -2,11 +2,13 @@
 <templates xml:space="preserve">
     <t t-name="ProductCatalogKanbanRecord">
         <article
-             t-att-class="getRecordClasses() + (productCatalogData.quantity ? ' o_product_added' : '')"
-             t-att-data-id="props.record.id"
-             t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
-             t-on-click="onGlobalClick"
-             t-ref="root">
+            class="o_product_catalog_kanban_record"
+            t-att-class="getRecordClasses() + (productCatalogData.quantity ? ' o_product_added' : '')"
+            t-att-data-id="props.record.id"
+            t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
+            t-on-click="onGlobalClick"
+            t-ref="root"
+        >
             <div class="d-flex flex-column h-100">
                 <t t-call="{{ templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
                    t-call-context="this.renderingContext"/>

--- a/addons/product/static/src/product_catalog/order_line/order_line.scss
+++ b/addons/product/static/src/product_catalog/order_line/order_line.scss
@@ -1,5 +1,6 @@
 div.o_product_catalog_quantity {
     input[type="number"] {
+        width: 9ch;
         // Remove arrow buttons input type="number"
         appearance: textfield;
         &::-webkit-outer-spin-button,

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -21,28 +21,36 @@
         </span>
         <div t-else="" class="d-flex justify-content-end align-items-center m-2">
             <div t-if="isInOrder()"
-                    class="input-group o_product_catalog_quantity o_product_catalog_cancel_global_click w-50">
-                <div class="d-flex">
-                    <button class="btn btn-primary border"
-                            t-on-click.stop="this.env.decreaseQuantity"
-                            t-att-disabled="disableRemove"
-                            t-att-data-tooltip="disabledButtonTooltip">
-                        <i class="fa fa-minus center"/>
-                    </button>
-                    <div class="d-flex w-100">
-                        <input class="o_input text-center text-bg-light rounded-0 border border-end-0"
-                                type="number"
-                                t-att-class="this.env.displayUoM ? 'w-50' : 'w-100'"
-                                t-att-value="quantity"
-                                t-on-change="this.env.setQuantity"
-                                t-on-focus="_onFocus"/>
-                        <span class="fst-italic text-muted text-bg-light text-truncate w-50 border border-start-0 py-1" t-if="this.env.displayUoM" t-out="props.uomDisplayName"/>
-                    </div>
-                    <button class="btn btn-primary border"
-                            t-on-click.stop="(ev) => this.env.increaseQuantity()">
-                        <i class="fa fa-plus"/>
-                    </button>
-                </div>
+                class="o_product_catalog_quantity o_product_catalog_cancel_global_click input-group flex-nowrap mw-75">
+                <button
+                    class="btn btn-primary border"
+                    t-on-click.stop="this.env.decreaseQuantity"
+                    t-att-disabled="disableRemove"
+                    t-att-data-tooltip="disabledButtonTooltip"
+                    aria-label="Decrease quantity"
+                >
+                    <i class="oi oi-minus" aria-hidden="true"/>
+                </button>
+                <input
+                    class="form-control text-bg-view flex-grow-0 flex-shrink-0 text-center"
+                    name="product_catalog_quantity_input"
+                    type="number"
+                    t-att-value="quantity"
+                    t-on-change="this.env.setQuantity"
+                    t-on-focus="_onFocus"
+                />
+                <span
+                    t-if="this.env.displayUoM"
+                    class="input-group-text d-block rounded-0 text-truncate cursor-default"
+                    t-out="props.uomDisplayName" t-att-title="props.uomDisplayName"
+                />
+                <button
+                    class="btn btn-primary border"
+                    t-on-click.stop="(ev) => this.env.increaseQuantity()"
+                    aria-label="Increase quantity"
+                >
+                    <i class="oi oi-plus" aria-hidden="true"/>
+                </button>
             </div>
             <t t-elif="props.warning">
                 <i class="fa fa-warning text-warning" t-att-title="props.warning"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -663,41 +663,37 @@ action = {
                         <div class="o_product_catalog_cancel_global_click">
                             <a role="menuitem" type="open" class="dropdown-item border-top-0">Edit</a>
                         </div>
-                        <div class="container p-0">
-                            <field name="is_favorite" widget="boolean_favorite" class="col-12 pe-0"/>
-                        </div>
+                        <field name="is_favorite" widget="boolean_favorite" class="o_product_catalog_favorite dropdown-item"/>
                     </t>
                     <t t-name="card" class="p-0">
                     <!-- TODO : not getting border when select record -->
-                        <div class="d-flex flex-grow-1 m-2">
-                            <div class="ps-2 d-flex flex-column m-1 overflow-hidden"
+                        <div class="d-flex flex-grow-1 gap-1 m-2">
+                            <div class="d-flex flex-column flex-grow-1 gap-1 overflow-hidden"
                                     t-attf-id="product-{{record.id.raw_value}}">
-                                <div class="d-flex">
-                                    <field name="name" class="fw-bold fs-4 text-reset mb-1 me-2"/>
-                                    <field class="mt-1 me-1"
-                                        name="is_favorite"
+                                <div class="d-flex align-items-baseline gap-1">
+                                    <field name="is_favorite"
                                         widget="boolean_favorite"
                                         invisible="not is_favorite"
                                         nolabel="1"
                                         readonly="1"/>
+                                    <field name="name" class="fw-bold fs-4 text-reset"/>
                                 </div>
+                                <field name="product_template_attribute_value_ids"
+                                    widget="many2many_tags"
+                                    domain="[('id', 'in', parent.ids)]"
+                                    groups="product.group_product_variant"
+                                    options="{'color_field': 'color'}"
+                                    invisible="not product_template_attribute_value_ids"/>
                                 <!-- Used by @web/product/js/product_catalog/order_line to
                                         show the price using a t-portal. -->
                                 <div name="o_kanban_price"
                                         t-attf-id="product-{{record.id.raw_value}}-price"/>
-                                <field name="product_template_attribute_value_ids"
-                                        widget="many2many_tags"
-                                        domain="[('id', 'in', parent.ids)]"
-                                        groups="product.group_product_variant"
-                                        options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"
-                                        invisible="not product_template_attribute_value_ids"/>
                             </div>
                             <field
                                 name="image_128"
-                                class="ms-auto"
                                 invisible="not image_128"
                                 widget="image"
-                                options="{'size': [55, 55], 'img_class': 'object-fit-contain'}"
+                                options="{'size': [64, 64], 'img_class': 'object-fit-contain'}"
                                 alt="Product"
                             />
                         </div>

--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -24,10 +24,11 @@
                 </t>
             </t>
             <div name="o_kanban_qty_available_and_on_hand" position="after">
-                <div t-if="record.type.raw_value === 'consu' and record.monthly_demand.raw_value != 0" name="kanban_monthly_demand">
-                    <span class="text-muted small">Monthly Demand: </span>
-                    <span class="fw-bold ms-1" t-out="Math.round(record.monthly_demand.raw_value *100)/100"  name="kanban_monthly_demand_qty"/>
+                <div t-if="record.type.raw_value === 'consu' and record.monthly_demand.raw_value != 0" class="mt-n1" name="kanban_monthly_demand">
+                    <small class="text-muted">Demand: </small>
+                    <span class="fw-bold" t-out="Math.round(record.monthly_demand.raw_value *100)/100"  name="kanban_monthly_demand_qty"/>
                     <field name="uom_id" class="text-muted small ms-1" groups="uom.group_uom"/>
+                    <small class="text-muted"> / month</small>
                 </div>
                 <div name="kanban_purchase_suggest" t-if="record.suggested_qty.raw_value != 0">
                     <span class="text-info fw-bold fs-5"> Suggest </span>

--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -56,12 +56,12 @@ registry.category("web_tour.tours").add('sale_catalog', {
         },
         {
             content: "Input a custom quantity",
-            trigger: '.o_kanban_record:contains("Restricted Product") .o_input',
+            trigger: '.o_kanban_record:contains("Restricted Product") input',
             run: "edit 6",
         },
         {
             content: "Increase the quantity",
-            trigger: '.o_kanban_record:contains("Restricted Product") .fa-plus',
+            trigger: '.o_kanban_record:contains("Restricted Product") .oi-plus',
             run: 'click',
         },
         {

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -287,7 +287,7 @@
                     <field name="qty_available"/>
                     <field name="free_qty"/>
                 </field>
-                <field name="product_template_attribute_value_ids" position="after">
+                <div name="o_kanban_price" position="after">
                     <div t-if="record.is_storable.raw_value" invisible="not context.get('display_stock')"
                          name="o_kanban_qty_available_and_on_hand">
                         <t name="qty_free" t-if="record.free_qty.raw_value != record.qty_available.raw_value">
@@ -300,7 +300,7 @@
                             <span class="text-muted small"> On Hand</span>
                         </t>
                     </div>
-                </field>
+                </div>
                 <a role="menuitem" type="open" position="after">
                     <a role="menuitem" type="object" name="action_product_forecast_report" class="dropdown-item border-top-0">View Availability</a>
                 </a>

--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -7,7 +7,7 @@
     position: relative;
     display: flex;
     align-items: stretch;
-    min-width: 150px;
+    min-width: var(--KanbanRecord-min-width, 150px);
     margin: 0 0 (-$border-width);
     overflow-wrap: break-word;
     word-wrap: break-word;


### PR DESCRIPTION
*: product,purchase_stock,stock,web

The goal is to increase the min width of the kanban record, avoid the unit truncating too early and reduce noise.

Additionnaly fix the "fake" dropdown item to match dropdown styling and also fix the ellipsis sometimes being barely visible because it's displayed over the image with unpredictable colors.

task-4671411

Enterprise: https://github.com/odoo/enterprise/pull/100277


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
