### PR TITLE
[FIX] partner_autocomplete: display the placeholder of the res_partner_many2one field

### DIFF
--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -136,7 +136,7 @@ QUnit.module('partner_autocomplete', {
             `<form>
                 <field name="company_type"/>
                 <field name="name" widget="field_partner_autocomplete"/>
-                <field name="parent_id" widget="res_partner_many2one"/>
+                <field name="parent_id" widget="res_partner_many2one" placeholder="Company Name..."/>
                 <field name="website"/>
                 <field name="image_1920" widget="image"/>
                 <field name="email"/>
@@ -183,7 +183,7 @@ QUnit.module('partner_autocomplete', {
     }
 
     QUnit.test("Partner autocomplete : Company type = Individual", async function (assert) {
-        assert.expect(12);
+        assert.expect(13);
         await makeView(makeViewParams);
 
         // Set company type to Individual
@@ -194,6 +194,11 @@ QUnit.module('partner_autocomplete', {
 
         const companyInput = target.querySelector("[name='parent_id'] input");
         const autocompleteContainer = companyInput.parentElement;
+        assert.strictEqual(
+            companyInput.placeholder,
+            "Company Name...",
+            "The placeholder should be displayed"
+        );
 
         await click(companyInput, null);
         assert.containsNone(


### PR DESCRIPTION
### Steps to reproduce:

- Go to Contacts > Contacts > New
- Change it to "individual" type
#### > The "parent_id" field should have a place holder "Company Name..."

### Cause of the issue:

The `parent_id` field of the res.partner form uses the `res_partner_many2one` widget:
https://github.com/odoo/odoo/blob/58b888992f80a58fecdb92e23fea0050f2178faf/odoo/addons/base/views/res_partner_views.xml#L164-L166 and is therefore relying on the `PartnerAutoCompleteMany2XField`. However, this template tries to recover its placeholder from the `placeholder` attribute of the Component:
https://github.com/odoo/odoo/blob/58b888992f80a58fecdb92e23fea0050f2178faf/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml#L41-L50 even thought this attribute is not defined and the placeholder should be recovered from its props:
https://github.com/odoo/odoo/blob/60e0529b98098b019ade09aad97cc6e359bc0755/addons/web/static/src/views/fields/relational_utils.xml#L35-L38

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
