### PR TITLE
[FIX] website_crm_partner_assign: correct access for unsubscribe/spam

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -226,7 +226,7 @@ class CrmLead(models.Model):
             message = Markup('<p>%s</p>') % _('I am not interested by this lead. I have not contacted the lead.')
         partner_ids = self.env['res.partner'].search(
             [('id', 'child_of', self.env.user.partner_id.commercial_partner_id.id)])
-        self.message_unsubscribe(partner_ids=partner_ids.ids)
+        self.sudo().message_unsubscribe(partner_ids=partner_ids.ids)
         if comment:
             message += Markup('<p>%s</p>') % comment
         self.sudo().message_post(body=message)
@@ -236,7 +236,7 @@ class CrmLead(models.Model):
 
         if spam:
             tag_spam = self.env.ref('website_crm_partner_assign.tag_portal_lead_is_spam', False)
-            if tag_spam and tag_spam not in self.tag_ids:
+            if tag_spam and tag_spam not in self.sudo().tag_ids:
                 values['tag_ids'] = [(4, tag_spam.id, False)]
         if partner_ids:
             values['partner_declined_ids'] = [(4, p, 0) for p in partner_ids.ids]

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -134,10 +134,25 @@ class TestPartnerLeadPortal(TestCrmCommon):
 
     def test_partner_lead_decline(self):
         """ Test an integrating partner decline the lead """
+        # Add a child for the commercial partner of portal user
+        # because it will affect the message unsubscribe process.
+        self.env['res.partner'].create({
+            'name': 'Child Contact Name',
+            'parent_id': self.user_portal.partner_id.id,
+        })
         self.lead_portal.with_user(self.user_portal).partner_desinterested(comment="No thanks, I have enough leads !", contacted=True, spam=False)
 
         self.assertFalse(self.lead_portal.partner_assigned_id.id, 'The partner_assigned_id of the declined lead should be False.')
         self.assertTrue(self.user_portal.partner_id in self.lead_portal.sudo().partner_declined_ids, 'Partner who has declined the lead should be in the declined_partner_ids.')
+
+    def test_partner_lead_decline_spam(self):
+        """ Test an integrating partner decline the lead by mentioning that it is spam """
+        self.lead_portal.invalidate_recordset()
+        self.lead_portal.with_user(self.user_portal).partner_desinterested(comment="It is a spam !", contacted=True, spam=True)
+
+        self.assertFalse(self.lead_portal.partner_assigned_id.id, 'The partner_assigned_id of the declined lead should be False.')
+        self.assertTrue(self.user_portal.partner_id in self.lead_portal.sudo().partner_declined_ids, 'Partner who has declined the lead should be in the declined_partner_ids.')
+        self.assertIn(self.env.ref('website_crm_partner_assign.tag_portal_lead_is_spam'), self.lead_portal.tag_ids, 'The lead must be tagged as spam.')
 
     def test_lead_access_right(self):
         """ Test another portal user can not write on every leads """


### PR DESCRIPTION
Allow a portal user to read tags on the lead
when he mentions that it is spam.

Correct access for the unsubscribe process with child
partner for the commercial partner of the portal user.

task-5347166