### PR TITLE
[FIX] hr: hide presense status widget when archived

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -71,7 +71,7 @@
                                 <div invisible="not user_id">
                                     <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
                                 </div>
-                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
+                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id or not active" widget="hr_presence_status"/>
                             </div>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -145,7 +145,7 @@
                                 <div invisible="not user_id">
                                     <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
                                 </div>
-                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
+                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id or not active" widget="hr_presence_status"/>
                             </div>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>


### PR DESCRIPTION
**Steps to reproduce:**
Navigate to Employees -> Open an archived employee -> the presence status appears below the Archived banner

**Solution:**
Hide the presense status widget when the employee is inactive

Task: 5350479
