### PR TITLE
[FIX] {sale_,}mrp: avoid duplicate name on delivery slip

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -233,6 +233,8 @@ class StockMove(models.Model):
 
         for move in self:
             if not move.description_picking_manual and move.bom_line_id.id in bom_line_description:
+                if move.description_picking == move.product_id.display_name:
+                    move.description_picking = ''
                 move.description_picking += ('\n' if move.description_picking else '') + bom_line_description.get(move.bom_line_id.id)
 
     @api.depends('raw_material_production_id.priority')

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -149,6 +149,7 @@ class TestSaleMrpKitBom(BaseCommon):
         so.action_confirm()
         line = so.order_line
         purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
+        self.assertEqual(line.move_ids.mapped('description_picking'), ['Kit Product - 1/2', 'Kit Product - 2/2'])
         self.assertEqual(purchase_price, 92, "The purchase price must be the total cost of the components multiplied by their unit of measure")
 
     def test_sale_mrp_kit_sale_price(self):


### PR DESCRIPTION
When creating a delivery slip, if the product sold is a kit and it's component doesn't have a description, the name will be repeated.

Steps to reproduce:
-------------------
* Create a product A with a bom of type kit
* Add a product "comp" in the bom (don't give it a description)
* Create a sales order with the product A and confirm it
* Go on the delivery and create a delivery slip
-> Issue, the name of the product "comp" appears twice.

Observation:
-------------
The name is added in description_picking field, since it is considered that the fallback for the description for outgoing deliveries should be display_name:
https://github.com/odoo/odoo/blob/584f94e3246b6b59641bf83d4e707f2e872bc1e8/addons/stock/models/product.py#L293-L301

In _compute_description_picking, information about the bom will be added :
https://github.com/odoo/odoo/blob/08c5fbbb5bc44c4810cd07188b29090c3060e14f/addons/mrp/models/stock_move.py#L235-L236

This causes the issue because the filter to prevent repeating the name on the delivery slip is implemented directly in the XML:
https://github.com/odoo/odoo/blob/08c5fbbb5bc44c4810cd07188b29090c3060e14f/addons/stock/report/report_deliveryslip.xml#L83-L85
However, since we have added elements to the description (the bom information), this filter will not be applied, leading to the repeated name.

opw-5265906