### PR TITLE
[FIX] base, l10n_gcc_invoice, l10n_tr_nilvera: update translations when installing language

### DIFF
--- a/addons/l10n_gcc_invoice/__init__.py
+++ b/addons/l10n_gcc_invoice/__init__.py
@@ -2,4 +2,4 @@ from . import models
 
 
 def _l10n_gcc_invoice_post_init(env):
-    env['res.lang']._activate_lang('ar_001')
+    env['res.lang']._activate_and_update_lang('ar_001')

--- a/addons/l10n_tr_nilvera/__init__.py
+++ b/addons/l10n_tr_nilvera/__init__.py
@@ -2,4 +2,4 @@ from . import models
 
 
 def _l10n_tr_nilvera_post_init(env):
-    env['res.lang']._activate_lang('tr_TR')
+    env['res.lang']._activate_and_update_lang('tr_TR')

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -168,6 +168,17 @@ class ResLang(models.Model):
             lang.active = True
         return lang
 
+    def _activate_and_update_lang(self, code):
+        """ Activate languages and update their translations
+        :param code: code of the language to activate
+        :return: the language matching 'code' activated
+        """
+        lang = self._activate_lang(code)
+        if lang:
+            mods = self.env['ir.module.module'].search([('state', '=', 'installed')])
+            mods._update_translations(code)
+        return lang
+
     def _create_lang(self, lang, lang_name=None):
         """ Create the given language and make it active. """
         # create the language with locale information


### PR DESCRIPTION
### Issue:
When installing "l10n_gcc_invoice" on a new DB the Arabic language is installed but the translation of previously installed modules are not updated.

### Steps to reproduce:
- Install 'l10n_sa_edi' and switch to a Saudi company
- In the Settings tick the option "Gulf Cooperation Council Format"
- Set the language of a partner in Arabic
- Create an invoice for this partner and print it
- Some terms are not translated event though the text is translated in the .po file

### Cause:
When installing "l10n_gcc_invoice" the Arabic language is installed ([src](https://github.com/odoo/odoo/blob/70404624d7ea6f971182cbe4f4fe8fc064d2afd8/addons/l10n_gcc_invoice/__init__.py#L4-L5)). But the method [`_activate_lang()`](https://github.com/odoo/odoo/blob/70404624d7ea6f971182cbe4f4fe8fc064d2afd8/odoo/addons/base/models/res_lang.py#L161-L169) only activates the language, it does not update the translations.

### Solution:
Create a new method that activate the language and calls `_update_translations()` on the installed modules.

Same issue happened in 'l10n_tr_nilvera'.

opw-5219783