### PR TITLE
[IMP] mail: use sql for _search_is_member

### DIFF
--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -12,17 +12,7 @@
             />
             <field name="domain_force">
                 [
-                    "|",
-                        "&amp;",
-                            ("channel_type", "!=", "channel"),
-                            "|",
-                                ("is_member", "=", True),
-                                ("parent_channel_id.is_member", "=", True),
-                        "&amp;",
-                            ("channel_type", "=", "channel"),
-                            "|",
-                                ("group_public_id", "=", False),
-                                ("group_public_id", "in", user.all_group_ids.ids),
+                    ("is_all_member", "=", True),
                 ]
             </field>
         </record>
@@ -78,17 +68,7 @@
             />
             <field name="domain_force">
                 [
-                    "|",
-                        "&amp;",
-                            ("channel_id.channel_type", "!=", "channel"),
-                            "|",
-                                ("channel_id.is_member", "=", True),
-                                ("channel_id.parent_channel_id.is_member", "=", True),
-                        "&amp;",
-                            ("channel_id.channel_type", "=", "channel"),
-                            "|",
-                                ("channel_id.group_public_id", "=", False),
-                                ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                    ("channel_id.is_all_member", "=", True),
                 ]
             </field>
             <field name="perm_create" eval="False"/>
@@ -220,17 +200,7 @@
             />
             <field name="domain_force">
                 [
-                    "|",
-                        "&amp;",
-                            ("channel_id.channel_type", "!=", "channel"),
-                            "|",
-                                ("channel_id.is_member", "=", True),
-                                ("channel_id.parent_channel_id.is_member", "=", True),
-                        "&amp;",
-                            ("channel_id.channel_type", "=", "channel"),
-                            "|",
-                                ("channel_id.group_public_id", "=", False),
-                                ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                    ("channel_id.is_all_member", "=", True),
                 ]
             </field>
             <field name="perm_create" eval="False"/>


### PR DESCRIPTION
Before this commit, we were relying on a python step to fetch the
channel_ids of the user. This adds a computational overhead.

We remove this overhead by directly checking the membership to the
channel in the SQL query.

task-5180506

> [!WARNING]
> still needs a bit of cleaning of the code but waiting for runbot results
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
