### PR TITLE
[FIX] html_editor, website: avoid copy ancestors outside contenteditable

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -1,4 +1,9 @@
-import { isTextNode, isParagraphRelatedElement, isEmptyBlock } from "../utils/dom_info";
+import {
+    isTextNode,
+    isParagraphRelatedElement,
+    isEmptyBlock,
+    isContentEditable,
+} from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
 import { unwrapContents, wrapInlinesInBlocks, splitTextNode, fillEmpty } from "../utils/dom";
@@ -165,7 +170,9 @@ export class ClipboardPlugin extends Plugin {
             clonedContents = processor(clonedContents, selection) || clonedContents;
         }
         this.dependencies.dom.removeSystemProperties(clonedContents);
-        fillClipboardData(ev, clonedContents);
+        fillClipboardData(ev, clonedContents, {
+            fillEditorClipboard: isContentEditable(selection.commonAncestorContainer),
+        });
     }
 
     /**

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -8,6 +8,7 @@ import {
     isEmptyBlock,
     isVisibleTextNode,
     isZWS,
+    isContentEditableAncestor,
 } from "@html_editor/utils/dom_info";
 import {
     ancestors,
@@ -596,6 +597,9 @@ export class FontPlugin extends Plugin {
             ];
             // Wrap rangeContent with clones of their ancestors to keep the styles.
             for (const ancestor of ancestorsList) {
+                if (isContentEditableAncestor(ancestor)) {
+                    break;
+                }
                 // Keep the formatting by keeping inline ancestors and paragraph
                 // related ones like headings etc.
                 if (!isBlock(ancestor) || isParagraphRelatedElement(ancestor)) {

--- a/addons/html_editor/static/src/utils/clipboard.js
+++ b/addons/html_editor/static/src/utils/clipboard.js
@@ -19,12 +19,14 @@ function prependOriginToImages(doc, origin) {
  * @param {ClipboardEvent} ev copy event
  * @param {DocumentFragment} clonedContents
  */
-export function fillClipboardData(ev, clonedContents) {
+export function fillClipboardData(ev, clonedContents, { fillEditorClipboard = true } = {}) {
     const doc = ev.target.ownerDocument;
     const dataHtmlElement = doc.createElement("data");
     dataHtmlElement.append(clonedContents);
     prependOriginToImages(dataHtmlElement, doc.defaultView.location.origin);
     const htmlContent = dataHtmlElement.innerHTML;
     ev.clipboardData.setData("text/html", htmlContent);
-    ev.clipboardData.setData("application/vnd.odoo.odoo-editor", htmlContent);
+    if (fillEditorClipboard) {
+        ev.clipboardData.setData("application/vnd.odoo.odoo-editor", htmlContent);
+    }
 }

--- a/addons/html_editor/static/tests/copy.test.js
+++ b/addons/html_editor/static/tests/copy.test.js
@@ -180,4 +180,47 @@ describe("range not collapsed", () => {
             `<p><img src="${base64Img}"></p>`
         );
     });
+
+    test("should copy style and font of ancestors up to a block", async () => {
+        await setupEditor("<p>a<b>b[c]d</b>e</p>");
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+        expect(clipboardData.getData("text/plain")).toBe("c");
+        expect(clipboardData.getData("text/html")).toBe("<p><b>c</b></p>");
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe("<p><b>c</b></p>");
+    });
+
+    test("should not clone ancestors outside the contenteditable (block)", async () => {
+        await setupEditor(
+            `<div contenteditable="false"><p contenteditable="true">a<b>b[c]d</b>e</p></div>`
+        );
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+        expect(clipboardData.getData("text/plain")).toBe("c");
+        expect(clipboardData.getData("text/html")).toBe("<b>c</b>");
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe("<b>c</b>");
+    });
+
+    test("should not clone ancestors outside the contenteditable (inline)", async () => {
+        await setupEditor(
+            `<div contenteditable="false"><p>a<b contenteditable="true">b[c]d</b>e</p></div>`
+        );
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+        expect(clipboardData.getData("text/plain")).toBe("c");
+        expect(clipboardData.getData("text/html")).toBe("c");
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe("c");
+    });
+
+    test("should not copy to odoo-editor clipboard when selection is outside the contenteditable", async () => {
+        await setupEditor(
+            `<div contenteditable="false"><p>a[b<b contenteditable="true">c</b>d]e</p></div>`
+        );
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+        expect(clipboardData.getData("text/plain")).toBe("bcd");
+        expect(clipboardData.getData("text/html")).toBe(`<p>b<b contenteditable="true">c</b>d</p>`);
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe("");
+        expect(clipboardData.types).not.toInclude("application/vnd.odoo.odoo-editor");
+    });
 });

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -2,7 +2,7 @@ import { Builder } from "@html_builder/builder";
 import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
 import { insertText, pasteHtml, pasteText } from "@html_editor/../tests/_helpers/user_actions";
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, press, test } from "@odoo/hoot";
 import {
     animationFrame,
     manuallyDispatchProgrammaticEvent,
@@ -330,6 +330,21 @@ test("test that powerbox should not open in translate mode", async () => {
     await insertText(editor, "/");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
+});
+
+test("copy of a translated span should not copy branding attributes", async () => {
+    const { getEditor } = await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({ inWrap: "a<b>c</b>a" }),
+    });
+    await contains(":iframe [contenteditable=true]").focus();
+    const editor = getEditor();
+    const textNode = editor.editable.querySelector("b").firstChild;
+    expect(textNode.nodeType).toBe(Node.TEXT_NODE);
+    setSelection({ anchorNode: textNode, anchorOffset: 0, focusNode: textNode, focusOffset: 1 });
+    const clipboardData = new DataTransfer();
+    await press(["ctrl", "c"], { dataTransfer: clipboardData });
+    expect(clipboardData.getData("text/plain")).toBe("c");
+    expect(clipboardData.getData("text/html")).toBe(`<b>c</b>`);
 });
 
 describe("save translation", () => {

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -325,7 +325,6 @@ test("test that powerbox should not open in translate mode", async () => {
     const textNode = editor.editable.querySelector("span").firstChild;
     expect(textNode.nodeType).toBe(Node.TEXT_NODE);
     setSelection({ anchorNode: textNode, anchorOffset: 0 });
-    await animationFrame();
     // Simulate typing `/`
     await insertText(editor, "/");
     await animationFrame();


### PR DESCRIPTION
When the user copies a range of the html in the page, they may copy
nodes with attributes that mark them to be saved. This happens if they
select around a savable node, or if they select inside a savable node
and the format plugin include clones of the ancestors (to keep matching
style).

This commit prevents that by not copying clones at the ancestor which
sets `contenteditable` to true (if any), and by treating copy with a
selection outside of `contenteditable` the same as a foreign copy (for
which any non-whitelisted attributes are removed).

Steps to reproduce:
- Open website builder
- Select a link of the menu in the header
- Copy
- Move the selection to "normal" text (like in the footer)
- Paste
- Save
- Bug: the website cannot render

### 
- Open website builder in translate mode, on a blog post
- Select a word in the middle of a paragraph
- Copy
- Paste
- Bug: The paragraph gets replicated inside itself

### 
- Open website builder in translate mode, on a blog post
- Select from the author name to the first paragraph
- Copy
- Paste inside the paragraph
- Bug: The paragraph gets replicated inside itself

opw-5053872
task-5222402