### PR TITLE
[IMP] The moves in _fetch_duplicate_reference should have ref

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1902,7 +1902,7 @@ class AccountMove(models.Model):
             move.duplicated_ref_ids = move_to_duplicate_move.get(move._origin, self.env['account.move'])
 
     def _fetch_duplicate_reference(self, matching_states=('draft', 'posted')):
-        moves = self.filtered(lambda m: m.is_sale_document() or m.is_purchase_document() and m.ref)
+        moves = self.filtered(lambda m: (m.is_sale_document() or m.is_purchase_document()) and m.ref)
 
         if not moves:
             return {}


### PR DESCRIPTION

The filtered should only evaluate moves with a defined ref and that are purchases or sales, now evaluate any of the 3 cases: purchases, sales, and with ref

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
