### PR TITLE
[REF] mail, *: introduce Store.FieldList

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -67,5 +67,6 @@ class MailActivity(models.Model):
         events.unlink()
         return res
 
-    def _to_store_defaults(self, target):
-        return super()._to_store_defaults(target) + [Store.One("calendar_event_id", [])]
+    def _store_activity_fields(self, res: Store.FieldList):
+        super()._store_activity_fields(res)
+        res.attr("calendar_event_id")

--- a/addons/crm_livechat/models/crm_lead.py
+++ b/addons/crm_livechat/models/crm_lead.py
@@ -37,7 +37,6 @@ class CrmLead(models.Model):
         return super().write(vals)
 
     def action_open_livechat(self):
-        Store(bus_channel=self.env.user).add(
-            self.origin_channel_id,
-            extra_fields={"open_chat_window": True},
-        ).bus_send()
+        store = Store(bus_channel=self.env.user)
+        store.add(self.origin_channel_id, "_store_open_chat_window_fields")
+        store.bus_send()

--- a/addons/crm_livechat/models/discuss_channel.py
+++ b/addons/crm_livechat/models/discuss_channel.py
@@ -71,15 +71,12 @@ class DiscussChannel(models.Model):
             'source_id': utm_source and utm_source.id,
         })
 
-    def _get_livechat_session_fields_to_store(self):
-        fields_to_store = super()._get_livechat_session_fields_to_store()
+    def _store_livechat_extra_fields(self, res: Store.FieldList):
+        super()._store_livechat_extra_fields(res)
         if not self.env["crm.lead"].has_access("read"):
-            return fields_to_store
-        fields_to_store.append(
-            Store.Many(
-                "livechat_customer_partner_ids",
-                [Store.Many("opportunity_ids", ["id", "name"])],
-                only_data=True,
-            ),
+            return
+        res.many(
+            "livechat_customer_partner_ids",
+            lambda res: res.many("opportunity_ids", ["name"]),
+            only_data=True,
         )
-        return fields_to_store

--- a/addons/crm_livechat/models/res_users.py
+++ b/addons/crm_livechat/models/res_users.py
@@ -5,6 +5,6 @@ from odoo.addons.mail.tools.discuss import Store
 class ResUsers(models.Model):
     _inherit = "res.users"
 
-    def _init_store_data(self, store: Store):
-        super()._init_store_data(store)
-        store.add_global_values(has_access_create_lead=self.env.user.has_group("sales_team.group_sale_salesman"))
+    def _store_init_global_fields(self, res: Store.FieldList):
+        super()._store_init_global_fields(res)
+        res.attr("has_access_create_lead", self.has_group("sales_team.group_sale_salesman"))

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1988,25 +1988,17 @@ class HrEmployee(models.Model):
             'search_view_id': self.env.ref('hr.hr_version_search_view').id
         }
 
-    def _get_store_avatar_card_fields(self, target):
-        employee_fields = [
-            "company_id",
-            Store.One("department_id", ["name"]),
-            "work_email",
-            Store.One("work_location_id", ["location_type", "name"]),
-            "work_phone",
-        ]
-        user = target.get_user(self.env)
-        if user.has_group("hr.group_hr_user"):
+    def _store_avatar_card_fields(self, res: Store.FieldList):
+        res.attr("company_id")
+        res.one("department_id", ["name"])
+        res.attr("work_email")
+        res.one("work_location_id", ["location_type", "name"])
+        res.attr("work_phone")
+        if res.target_user().has_group("hr.group_hr_user"):
             # job_title is not a field of hr.employee.public, but it is a field of hr.employee
-            employee_fields.append("job_title")
+            res.attr("job_title")
         # HACK: fetch the employee fields from employees to retrieve hr.employee.public fields if no access to hr.employee
-        if len(self) > 0:
-            self.fetch([
-                field.field_name if isinstance(field, Store.Attr) else field
-                for field in employee_fields
-            ])
-        return employee_fields
+        self.fetch(map(Store.get_field_name, res))
 
     @api.depends('bank_account_ids')
     def _compute_primary_bank_account_id(self):

--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -102,10 +102,8 @@ class ResPartner(models.Model):
             })
         return action
 
-    def _get_store_avatar_card_fields(self, target):
-        avatar_card_fields = super()._get_store_avatar_card_fields(target)
-        if target.is_internal(self.env):
+    def _store_avatar_card_fields(self, res: Store.FieldList):
+        super()._store_avatar_card_fields(res)
+        if res.is_for_internal_users():
             # sudo: res.partner - internal users can access employee information of partner
-            employee_fields = self.sudo().employee_ids._get_store_avatar_card_fields(target)
-            avatar_card_fields.append(Store.Many("employee_ids", employee_fields, mode="ADD", sudo=True))
-        return avatar_card_fields
+            res.many("employee_ids", "_store_avatar_card_fields", mode="ADD", sudo=True)

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -10,6 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.addons.resource.models.utils import HOURS_PER_DAY
 from odoo.tools.float_utils import float_round
+from odoo.addons.mail.tools.discuss import Store
 
 
 class HrEmployee(models.Model):
@@ -627,5 +628,6 @@ class HrEmployee(models.Model):
         calendars = self._get_calendars(date_from)
         return calendars[self.id].hours_per_day if calendars[self.id] else 24
 
-    def _get_store_avatar_card_fields(self, target):
-        return [*super()._get_store_avatar_card_fields(target), "leave_date_to"]
+    def _store_avatar_card_fields(self, res: Store.FieldList):
+        super()._store_avatar_card_fields(res)
+        res.attr("leave_date_to")

--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, fields
-from odoo.addons.mail.tools.discuss import Store
 
 
 class ResPartner(models.Model):
@@ -33,11 +32,3 @@ class ResPartner(models.Model):
     @api.model
     def _get_on_leave_ids(self):
         return self.env['res.users']._get_on_leave_ids(partner=True)
-
-    def _to_store_defaults(self, target):
-        defaults = super()._to_store_defaults(target)
-        if target.is_internal(self.env):
-            defaults.append(
-                Store.One("main_user_id", Store.Many("employee_ids", "leave_date_to"))
-            )
-        return defaults

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -3,6 +3,7 @@
 from odoo import api, fields, models, Command, _
 from odoo.tools import format_date
 from odoo.addons.hr.models.res_users import field_employee
+from odoo.addons.mail.tools.discuss import Store
 
 
 class ResUsers(models.Model):
@@ -71,3 +72,8 @@ class ResUsers(models.Model):
             if user.env.context.get("formatted_display_name") and user.leave_date_to:
                 name = "%s \t ✈ --%s %s--" % (user.display_name or user.name, _("Back on"), format_date(self.env, user.leave_date_to, self.env.user.lang, "medium"))
                 user.display_name = name.strip()
+
+    def _store_main_user_fields(self, res: Store.FieldList):
+        super()._store_main_user_fields(res)
+        if res.is_for_internal_users():
+            res.many("employee_ids", ["leave_date_to"])

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -63,7 +63,7 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'channel_type': 'chat',
             'name': 'test'
         })
-        data = Store().add(channel).get_result()
+        data = Store().add(channel, "_store_channel_fields").get_result()
         partner_info = next(p for p in data["res.partner"] if p["id"] == partner.id)
         partner2_info = next(p for p in data["res.partner"] if p["id"] == partner2.id)
         user_info = next(u for u in data["res.users"] if u["id"] == partner_info["main_user_id"])

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -56,27 +56,30 @@ class TestPartner(TransactionCase):
         )
 
     @freeze_time('2024-06-04')
-    def test_res_partner_to_store(self):
+    def test_store_add_res_partner(self):
         self.leaves.write({'state': 'validate'})
+        store_1 = Store().add(self.partner, "_store_partner_fields")
         self.assertEqual(
-            Store().add(self.partner).get_result()["hr.employee"][0]["leave_date_to"],
+            store_1.get_result()["hr.employee"][0]["leave_date_to"],
             "2024-06-07",
             "Return date is the return date of the main user of the partner",
         )
         self.leaves[0].action_refuse()
+        store_2 = Store().add(self.partner, "_store_partner_fields")
         self.assertEqual(
-            Store().add(self.partner).get_result()["hr.employee"][0]["leave_date_to"],
+            store_2.get_result()["hr.employee"][0]["leave_date_to"],
             False,
             "Partner is not considered out of office if their main user is not on holiday",
         )
 
     @freeze_time("2024-06-04")
     @users("user_no_hr_access")
-    def test_res_partner_to_store_no_hr_access(self):
+    def test_store_add_res_partner_no_hr_access(self):
         self.leaves.write({"state": "validate"})
-        data = Store().add(self.partner.with_user(self.user_no_hr_access)).get_result()
+        partner = self.partner.with_user(self.user_no_hr_access)
+        store = Store().add(partner, "_store_partner_fields")
         self.assertEqual(
-            data["hr.employee"][0]["leave_date_to"],
+            store.get_result()["hr.employee"][0]["leave_date_to"],
             "2024-06-07",
             "Return date is the return date of the main user of the partner, "
             "even if the user has no access to the company",

--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -17,7 +17,7 @@ class WebClient(WebclientController):
         )
 
     @classmethod
-    def _process_request_for_internal_user(self, store: Store, name, params):
+    def _process_request_for_internal_user(cls, store: Store, name, params):
         super()._process_request_for_internal_user(store, name, params)
         if name == "im_livechat.channel":
             store.add(request.env["im_livechat.channel"].search([]), ["are_you_inside", "name"])
@@ -28,46 +28,59 @@ class WebClient(WebclientController):
             channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
             if not channel:
                 return
-            fields_to_store = channel._get_livechat_session_fields_to_store()
-            store.add(channel, fields=fields_to_store)
+            store.add(channel, "_store_livechat_extra_fields")
 
     @classmethod
-    def _process_request_for_all(self, store: Store, name, params):
+    def _process_request_for_all(cls, store: Store, name, params):
         super()._process_request_for_all(store, name, params)
         if name == "init_livechat":
-            user, guest = request.env["res.users"]._get_current_persona()
-            if user:
-                store.add_global_values(
-                    self_user=Store.One(user, Store.One("partner_id", extra_fields="email")),
-                )
-            if guest:
-                store.add_global_values(self_guest=Store.One(guest))
-            # sudo - im_livechat.channel: allow access to live chat channel to
-            # check if operators are available.
-            channel = request.env["im_livechat.channel"].sudo().search([("id", "=", params)])
-            if not channel:
-                return
-            country_id = (
-                # sudo - res.country: accessing user country is allowed.
-                request.env["res.country"].sudo().search([("code", "=", code)]).id
-                if (code := request.geoip.country_code)
-                else None
-            )
-            url = request.httprequest.headers.get("Referer")
-            if (
-                # sudo - im_livechat.channel.rule: getting channel's rule is allowed.
-                matching_rule := request.env["im_livechat.channel.rule"]
-                .sudo()
-                .match_rule(params, url, country_id)
-            ):
-                matching_rule = matching_rule.with_context(
-                    lang=request.env["chatbot.script"]._get_chatbot_language(),
-                )
-                store.add_global_values(livechat_rule=Store.One(matching_rule))
-            store.add_global_values(
-                livechat_available=matching_rule.action != "hide_button"
-                and bool(matching_rule._is_bot_configured() or channel.available_operator_ids),
-                can_download_transcript=bool(
-                    request.env.ref("im_livechat.action_report_livechat_conversation", False),
+            store.add_global_values(lambda res: cls._store_init_livechat_fields(res, params))
+
+    @classmethod
+    def _store_init_livechat_fields(cls, res: Store.FieldList, params):
+        user, guest = request.env["res.users"]._get_current_persona()
+        if user:
+            res.one(
+                "self_user",
+                lambda res: res.one(
+                    "partner_id",
+                    lambda res: (
+                        res.from_method("_store_partner_fields"),
+                        res.attr("email"),
+                    ),
                 ),
+                value=user,
             )
+        if guest:
+            res.one("self_guest", "_store_guest_fields", value=guest)
+        # sudo - im_livechat.channel: allow access to live chat channel to
+        # check if operators are available.
+        channel = request.env["im_livechat.channel"].sudo().search([("id", "=", params)])
+        if not channel:
+            return
+        country_id = (
+            # sudo - res.country: accessing user country is allowed.
+            request.env["res.country"].sudo().search([("code", "=", code)]).id
+            if (code := request.geoip.country_code)
+            else None
+        )
+        url = request.httprequest.headers.get("Referer")
+        if (
+            # sudo - im_livechat.channel.rule: getting channel's rule is allowed.
+            matching_rule := request.env["im_livechat.channel.rule"]
+            .sudo()
+            .match_rule(params, url, country_id)
+        ):
+            matching_rule = matching_rule.with_context(
+                lang=request.env["chatbot.script"]._get_chatbot_language(),
+            )
+            res.one("livechat_rule", "_store_channel_rule_fields", value=matching_rule)
+        res.attr(
+            "livechat_available",
+            matching_rule.action != "hide_button"
+            and bool(matching_rule._is_bot_configured() or channel.available_operator_ids),
+        )
+        res.attr(
+            "can_download_transcript",
+            bool(request.env.ref("im_livechat.action_report_livechat_conversation", False)),
+        )

--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -197,8 +197,9 @@ class ChatbotScript(models.Model):
     # Tooling / Misc
     # --------------------------
 
-    def _to_store_defaults(self, target):
-        return [Store.One("operator_partner_id", ["name"]), "title"]
+    def _store_script_fields(self, res: Store.FieldList):
+        res.one("operator_partner_id", ["name"])
+        res.attr("title")
 
     def _validate_email(self, email_address, discuss_channel):
         email_address = html2plaintext(email_address)

--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import textwrap
+
 from odoo import api, models, fields
 from odoo.fields import Domain
-
-import textwrap
+from odoo.addons.mail.tools.discuss import Store
 
 
 class ChatbotScriptAnswer(models.Model):
@@ -53,5 +54,5 @@ class ChatbotScriptAnswer(models.Model):
 
         return domain
 
-    def _to_store_defaults(self, target):
-        return ["name", "redirect_link"]
+    def _store_script_answer_fields(self, res: Store.FieldList):
+        res.extend(["name", "redirect_link"])

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -355,10 +355,7 @@ class ChatbotScriptStep(models.Model):
             return discuss_channel._forward_human_operator(chatbot_script_step=self)
         return discuss_channel._chatbot_post_message(self.chatbot_script_id, self.message)
 
-    def _to_store_defaults(self, target):
-        return [
-            Store.Many("answer_ids"),
-            Store.Attr("is_last", lambda step: step._is_last_step()),
-            "message",
-            "step_type",
-        ]
+    def _store_script_step_fields(self, res: Store.FieldList):
+        res.many("answer_ids", "_store_script_answer_fields")
+        res.attr("is_last", lambda step: step._is_last_step())
+        res.extend(["message", "step_type"])

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -679,9 +679,6 @@ class Im_LivechatChannelRule(models.Model):
     def _is_bot_configured(self):
         return bool(self.chatbot_script_id)
 
-    def _to_store_defaults(self, target):
-        return [
-            "action",
-            "auto_popup_timer",
-            Store.One("chatbot_script_id"),
-        ]
+    def _store_channel_rule_fields(self, res: Store.FieldList):
+        res.extend(["action", "auto_popup_timer"])
+        res.one("chatbot_script_id", "_store_script_fields")

--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -193,16 +193,14 @@ class ImLivechatChannelMemberHistory(models.Model):
         action["views"] = [view for view in action["views"] if view[1] in ("list", "form")]
         return action
 
-    def _to_store_defaults(self, target):
-        return [
-            "channel_id",
-            Store.One("guest_id", ["name"], predicate=lambda r: not r.partner_id),
-            "livechat_member_type",
-            # sudo: res.partner - reading partner related to an accessible channel member history is considered acceptable
-            Store.One(
-                "partner_id",
-                self.env["res.partner"]._get_store_livechat_username_fields(),
-                predicate=lambda r: not r.guest_id,
-                sudo=True,
-            ),
-        ]
+    def _store_member_history_fields(self, res: Store.FieldList):
+        res.attr("channel_id")
+        res.one("guest_id", ["name"], predicate=lambda r: not r.partner_id)
+        res.attr("livechat_member_type")
+        # sudo: res.partner - reading partner related to an accessible channel member history is considered acceptable
+        res.one(
+            "partner_id",
+            "_store_livechat_username_fields",
+            predicate=lambda r: not r.guest_id,
+            sudo=True,
+        )

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -149,14 +149,14 @@ class ResUsers(models.Model):
                 return result
         return super().write(vals)
 
-    def _init_store_data(self, store: Store):
-        super()._init_store_data(store)
-        store.add_global_values(has_access_livechat=self.env.user.has_access_livechat)
-        if not self.env.user._is_public():
-            store.add(
-                self.env.user,
-                Store.Attr(
-                    "is_livechat_manager",
-                    lambda u: u.has_group("im_livechat.im_livechat_group_manager"),
-                ),
+    def _store_init_global_fields(self, res: Store.FieldList):
+        super()._store_init_global_fields(res)
+        res.attr("has_access_livechat", self.has_access_livechat)
+
+    def _store_init_fields(self, res: Store.FieldList):
+        super()._store_init_fields(res)
+        if res.is_for_internal_users():
+            res.attr(
+                "is_livechat_manager",
+                lambda u: u.has_group("im_livechat.im_livechat_group_manager"),
             )

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -72,8 +72,9 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             chatbot_script_answer=self.step_dispatch_buy_software
         )
         chatbot_message = discuss_channel.chatbot_message_ids.mail_message_id[:1]
+        store = Store().add(chatbot_message, "_store_message_fields")
         self.assertEqual(
-            Store().add(chatbot_message).get_result()["mail.message"],
+            store.get_result()["mail.message"],
             [
                 {
                     "attachment_ids": [],
@@ -118,7 +119,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
         )
 
     @users('emp')
-    def test_message_to_store(self):
+    def test_store_add_message(self):
         im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
         self.env["mail.presence"]._update_presence(self.users[0])
         self.authenticate(self.users[1].login, self.password)
@@ -148,7 +149,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             rating_id=record_rating.id,
         )
         self.assertEqual(
-            Store().add(message).get_result(),
+            Store().add(message, "_store_message_fields").get_result(),
             {
                 "mail.message": self._filter_messages_fields(
                     {

--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -115,7 +115,10 @@ class PublicPageController(http.Controller):
             companyName=request.env.company.name,
             inPublicPage=True,
         )
-        store.add_singleton_values("DiscussApp", {"thread": store.One(channel)})
+        store.add_singleton_values(
+            "DiscussApp",
+            lambda res: res.one("thread", "_store_channel_fields", value=channel),
+        )
         return request.render(
             "mail.discuss_public_channel_template",
             {

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -138,11 +138,10 @@ class RtcController(http.Controller):
                 ("channel_member_id", "=", member.id),
             ]
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
-        current_rtc_sessions, outdated_rtc_sessions = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
-        return Store().add(
+        rtc_updates = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
+        store = Store().add(
             member.channel_id,
-            [
-                {"rtc_session_ids": Store.Many(current_rtc_sessions, mode="ADD")},
-                {"rtc_session_ids": Store.Many(outdated_rtc_sessions, [], mode="DELETE")},
-            ],
-        ).get_result()
+            "_store_rtc_update_fields",
+            fields_params={"added": rtc_updates[0], "removed": rtc_updates[1]},
+        )
+        return store.get_result()

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -11,30 +11,22 @@ class MailboxController(http.Controller):
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
-        return {
-            **res,
-            "data": Store().add(messages, add_followers=True).get_result(),
-            "messages": messages.ids,
-        }
+        store = Store()
+        store.add(messages, "_store_message_fields", fields_params={"add_followers": True})
+        return {**res, "data": store.get_result(), "messages": messages.ids}
 
     @http.route("/mail/history/messages", methods=["POST"], type="jsonrpc", auth="user", readonly=True)
     def discuss_history_messages(self, fetch_params=None):
         domain = [("needaction", "=", False)]
         res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
-        return {
-            **res,
-            "data": Store().add(messages).get_result(),
-            "messages": messages.ids,
-        }
+        store = Store().add(messages, "_store_message_fields")
+        return {**res, "data": store.get_result(), "messages": messages.ids}
 
     @http.route("/mail/starred/messages", methods=["POST"], type="jsonrpc", auth="user", readonly=True)
     def discuss_starred_messages(self, fetch_params=None):
         domain = [("starred_partner_ids", "in", [request.env.user.partner_id.id])]
         res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
-        return {
-            **res,
-            "data": Store().add(messages).get_result(),
-            "messages": messages.ids,
-        }
+        store = Store().add(messages, "_store_message_fields")
+        return {**res, "data": store.get_result(), "messages": messages.ids}

--- a/addons/mail/models/discuss/discuss_category.py
+++ b/addons/mail/models/discuss/discuss_category.py
@@ -22,10 +22,9 @@ class DiscussCategory(models.Model):
     # constraints
     _name_unique = models.Constraint("UNIQUE(name)", "The category name must be unique")
 
-    def _sync_field_names(self):
-        res = super()._sync_field_names()
-        res[None] += ["name", "sequence"]
-        return res
+    def _sync_field_names(self, res):
+        super()._sync_field_names(res)
+        res[None].extend(["name", "sequence"])
 
     def _bus_channel(self):
         return self.channel_ids

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -12,6 +12,7 @@ from odoo.addons.base.models.avatar_mixin import get_random_ui_color_from_seed
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.mail.tools.web_push import PUSH_NOTIFICATION_TYPE
+from odoo.addons.web.models.models import lazymapping
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tools import format_list, email_normalize, html_escape
@@ -440,7 +441,7 @@ class DiscussChannel(models.Model):
         channels = channels.with_context(mail_create_bypass_create_check=None)
         channels._subscribe_users_automatically()
         if not self.env.context.get("install_mode") and not self.env.user._is_public():
-            Store(bus_channel=self.env.user).add(channels).bus_send()
+            Store(bus_channel=self.env.user).add(channels, "_store_channel_fields").bus_send()
         return channels
 
     @api.ondelete(at_uninstall=False)
@@ -494,25 +495,17 @@ class DiscussChannel(models.Model):
             self._subscribe_users_automatically()
         return result
 
-    def _sync_field_names(self):
+    def _sync_field_names(self, res):
         # keys are bus subchannel names, values are lists of field names to sync
-        res = super()._sync_field_names()
-        res[None] += [
-            Store.Attr("avatar_cache_key", predicate=is_channel_or_group),
-            # sudo: discuss.category - guests can read categories of accessible channels
-            Store.One("discuss_category_id", ["name", "sequence"], sudo=True),
-            "channel_type",
-            "create_uid",
-            "default_display_mode",
-            Store.Attr("description", predicate=is_channel_or_group),
-            Store.Many("group_ids", [], predicate=is_channel),
-            Store.One("group_public_id", predicate=is_channel),
-            "last_interest_dt",
-            "member_count",
-            "name",
-            "uuid",
-        ]
-        return res
+        super()._sync_field_names(res)
+        res[None].attr("avatar_cache_key", predicate=is_channel_or_group)
+        # sudo: discuss.category - guests can read categories of accessible channels
+        res[None].one("discuss_category_id", ["name", "sequence"], sudo=True)
+        res[None].extend(["channel_type", "create_uid", "default_display_mode"])
+        res[None].attr("description", predicate=is_channel_or_group)
+        res[None].many("group_ids", [], predicate=is_channel)
+        res[None].one("group_public_id", ["full_name"], predicate=is_channel)
+        res[None].extend(["last_interest_dt", "member_count", "name", "uuid"])
 
     # ------------------------------------------------------------
     # MEMBERS MANAGEMENT
@@ -528,21 +521,17 @@ class DiscussChannel(models.Model):
         ]
         # sudo: discuss.channel.member - adding member of other users based on channel auto-subscribe
         new_members = self.env["discuss.channel.member"].sudo().create(to_create)
-        notifications = defaultdict(lambda: self.env["discuss.channel.member"])
+        stores = lazymapping(lambda member: Store(bus_channel=member._bus_channel()))
         for member in new_members:
-            bus_channel = member._bus_channel()
-            notifications[bus_channel] |= member
-        for bus_channel, members in notifications.items():
-            members = members.with_prefetch(new_members.ids)
-            store = Store(bus_channel=bus_channel)
-            store.add(members.channel_id).add(
-                members,
-                [
-                    Store.One("channel_id", [], as_thread=True),
-                    *self.env["discuss.channel.member"]._to_store_persona(store.target),
-                    "unpin_dt",
-                ],
-            ).bus_send()
+            stores[member].add(member.channel_id, "_store_channel_fields").add(
+                member,
+                lambda res: (
+                    res.from_method("_store_persona_default_fields"),
+                    res.attr("unpin_dt"),
+                ),
+            )
+        for store in stores.values():
+            store.bus_send()
 
     def _subscribe_users_automatically_get_members(self):
         """ Return new members per channel ID """
@@ -604,6 +593,7 @@ class DiscussChannel(models.Model):
         post_joined_message=True,
         inviting_partner=None,
     ):
+        stores = lazymapping(lambda bus_channel: Store(bus_channel=bus_channel))
         inviting_partner = inviting_partner or self.env["res.partner"]
         partners = partners or self.env["res.partner"]
         if users:
@@ -630,13 +620,13 @@ class DiscussChannel(models.Model):
             new_members = self.env['discuss.channel.member'].create(members_to_create)
             all_new_members += new_members
             for member in new_members:
+                joined_store = Store(bus_channel=member._bus_channel())
+                joined_store.add(member.channel_id, "_store_channel_fields")
+                joined_store.add(member, ["unpin_dt"])
                 payload = {
                     "channel_id": member.channel_id.id,
                     "invite_to_rtc_call": invite_to_rtc_call,
-                    "data": Store(bus_channel=member._bus_channel())
-                    .add(member.channel_id)
-                    .add(member, "unpin_dt")
-                    .get_result(),
+                    "data": joined_store.get_result(),
                 }
                 if not member.is_self and not self.env.user._is_public():
                     payload["invited_by_user_id"] = self.env.user.id
@@ -654,14 +644,16 @@ class DiscussChannel(models.Model):
                         subtype_xmlid="mail.mt_comment",
                     )
             if new_members:
-                Store(bus_channel=channel).add(channel, "member_count").add(new_members).bus_send()
+                stores[channel].add(channel, ["member_count"])
+                stores[channel].add(new_members, "_store_member_fields")
             if existing_members and (bus_channel := current_user or current_guest):
                 # If the current user invited these members but they are already present, notify the current user about their existence as well.
                 # In particular this fixes issues where the current user is not aware of its own member in the following case:
                 # create channel from form view, and then join from discuss without refreshing the page.
-                Store(
-                    bus_channel=bus_channel,
-                ).add(channel, "member_count").add(existing_members).bus_send()
+                stores[bus_channel].add(channel, ["member_count"])
+                stores[bus_channel].add(existing_members, "_store_member_fields")
+        for store in stores.values():
+            store.bus_send()
         if invite_to_rtc_call:
             for channel in self:
                 current_channel_member = self.env['discuss.channel.member'].search([('channel_id', '=', channel.id), ('is_self', '=', True)])
@@ -772,19 +764,14 @@ class DiscussChannel(models.Model):
         members = self.env['discuss.channel.member'].search(channel_member_domain)
         members.rtc_inviting_session_id = False
         if members:
-            store = Store(bus_channel=self)
-            store.add(
+            Store(bus_channel=self).add(
                 self,
-                {
-                    "invited_member_ids": Store.Many(
-                        members,
-                        [
-                            Store.One("channel_id", [], as_thread=True),
-                            *self.env["discuss.channel.member"]._to_store_persona(store.target, "avatar_card"),
-                        ],
-                        mode="DELETE",
-                    ),
-                },
+                lambda res: res.many(
+                    "invited_member_ids",
+                    "_store_avatar_card_fields",
+                    mode="DELETE",
+                    value=members,
+                ),
             ).bus_send()
             devices, private_key, public_key = self._web_push_get_partners_parameters(members.partner_id.ids)
             if devices:
@@ -922,7 +909,7 @@ class DiscussChannel(models.Model):
     def _notify_thread(self, message, msg_vals=False, **kwargs):
         # link message to channel
         rdata = super()._notify_thread(message, msg_vals=msg_vals, **kwargs)
-        store = Store(bus_channel=self).add(message)
+        store = Store(bus_channel=self).add(message, "_store_message_fields")
         if message.channel_id.parent_channel_id:
             store.add(message.channel_id, ["message_count"])
         payload = {"data": store.get_result(), "id": self.id}
@@ -1076,6 +1063,7 @@ class DiscussChannel(models.Model):
             if user := partner.main_user_id:
                 Store(bus_channel=user).add(
                     self.with_user(user).with_context(allowed_company_ids=[]),
+                    "_store_channel_fields",
                 ).bus_send()
 
     # ------------------------------------------------------------
@@ -1110,7 +1098,7 @@ class DiscussChannel(models.Model):
                             (fields.Datetime.now() if pinned else None, message_to_update.id))
         message_to_update.invalidate_recordset(['pinned_at'])
 
-        Store(bus_channel=self).add(message_to_update, "pinned_at").bus_send()
+        Store(bus_channel=self).add(message_to_update, ["pinned_at"]).bus_send()
         if pinned:
             notification_text = '''
                 <div data-oe-type="pin" class="o_mail_notification">
@@ -1183,14 +1171,20 @@ class DiscussChannel(models.Model):
                 ("channel_type", "not in", ("channel", "group")),
                 ("channel_member_ids", "any", [("is_self", "=", True), ("is_pinned", "=", True)]),
             ]
-        channels = self.env["discuss.channel"].search(member_domain)
-        channels += self.env["discuss.channel"].search(pinned_member_domain)
+        channels = self.env["discuss.channel"].search_fetch(member_domain)
+        channels += self.env["discuss.channel"].search_fetch(pinned_member_domain)
         return channels
 
-    def _get_store_target(self):
+    def _store_target(self):
         return {"bus_channel": self, "bus_subchannel": None}
 
-    def _to_store_defaults(self, target: Store.Target):
+    def _store_rtc_update_fields(self, res: Store.FieldList, *, added=None, removed=None):
+        if added:
+            res.many("rtc_session_ids", "_store_rtc_session_fields", mode="ADD", value=added)
+        if removed:
+            res.many("rtc_session_ids", [], mode="DELETE", value=removed)
+
+    def _store_channel_fields(self, res: Store.FieldList):
         # As the method uses partial recordsets with filtered (that lose the prefetch ids) it is
         # best to prefetch these computed fields once to avoid doing partial queries multiple times,
         # especially because these 2 fields are used in ACL too.
@@ -1199,7 +1193,7 @@ class DiscussChannel(models.Model):
         # channels from this optimization because they are assumed to be smaller and it's important
         # to know the member list for them.
         channels_with_all_members = self.filtered(
-            lambda channel: channel.channel_type not in self._lazy_load_members_channel_types(),
+            lambda channel: channel.channel_type not in channel._lazy_load_members_channel_types(),
         )
         all_members = (
             self.self_member_id
@@ -1210,88 +1204,73 @@ class DiscussChannel(models.Model):
             | self.channel_name_member_ids
         )
         # Prefetch all members at once. The first field accessed on a member will be channel_id
-        # (in _to_store_defaults of livechat), but the field is known for some of the members
+        # (in _store_channel_fields of livechat), but the field is known for some of the members
         # (through inverse of channels_with_all_members.channel_member_ids), so the ORM will only
         # prefetch all fields for members with unknown channel_id. The following line force a
         # single fetch for all fields of all members.
         # sudo : discuss.channel.member - prefetching member fields as sudo is acceptable,
-        # and its necessary to get channel_role in the same query as the other fields
-        all_members.sudo().mapped("create_date")  # any field in table will do except channel_id
+        # and its necessary to get channel_role in the same query as the other fields.
+        all_members.sudo().mapped("channel_role")
         # prefetch in batch, including nested relations (member, guest, ...)
-        Store(bus_channel=target.channel, bus_subchannel=target.subchannel).add(all_members)
+        prefetch_store = Store(bus_channel=res.target.channel, bus_subchannel=res.target.subchannel)
+        prefetch_store.add(all_members, "_store_member_fields")
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
-        res = [
-            Store.Attr("avatar_cache_key", predicate=is_channel_or_group),
-            # sudo: discuss.category - guests can read categories of accessible channels
-            Store.One("discuss_category_id", ["name", "sequence"], sudo=True),
-            "channel_type",
-            "create_uid",
-            Store.Many(
-                "channel_member_ids",
-                only_data=True,
-                sort="id",
-                predicate=lambda channel: channel in channels_with_all_members,
-            ),
-            "default_display_mode",
-            Store.Attr("description", predicate=is_channel_or_group),
-            Store.One("from_message_id", predicate=is_channel_or_group),
-            Store.Many("group_ids", [], predicate=is_channel, sudo=True),  # sudo: we are reading only the ids (comodel is inaccessible)
-            Store.One("group_public_id", ["full_name"], predicate=is_channel),
-            Store.Many(
-                "invited_member_ids",
-                [
-                    Store.One("channel_id", [], as_thread=True),
-                    *self.env["discuss.channel.member"]._to_store_persona(target, "avatar_card"),
-                ],
-                mode="ADD",
-            ),
-            "last_interest_dt",
-            "member_count",
-            "name",
-            Store.Many(
-                "channel_name_member_ids",
-                sort="id",
-                predicate=lambda c: c.channel_type in self._member_based_naming_channel_types(),
-            ),
-            Store.Attr("message_count", predicate=lambda c: c.parent_channel_id),
-            Store.One("parent_channel_id", predicate=is_channel_or_group),
-            # sudo: discuss.channel: reading sessions of accessible channel is acceptable
-            Store.Many(
-                "rtc_session_ids",
-                mode="ADD",
-                extra_fields=self.sudo().rtc_session_ids._get_store_extra_fields(),
-                sudo=True,
-            ),
-            "uuid",
-        ]
-        if target.is_current_user(self.env):
-            res = res + [
-                {"fetchChannelInfoState": "fetched"},
-                "is_editable",
-                "message_needaction_counter",
-                {"message_needaction_counter_bus_id": bus_last_id},
-                Store.One(
-                    "self_member_id",
-                    extra_fields=[
-                        "custom_channel_name",
-                        "custom_notifications",
-                        "last_interest_dt",
-                        "message_unread_counter",
-                        {"message_unread_counter_bus_id": bus_last_id},
-                        "mute_until_dt",
-                        "new_message_separator",
-                        # sudo: discuss.channel.rtc.session - each member can see who is inviting them
-                        Store.One("rtc_inviting_session_id", sudo=True),
-                        "unpin_dt",
-                    ],
-                    only_data=True,
+        res.attr("avatar_cache_key", predicate=is_channel_or_group)
+        # sudo: discuss.category - guests can read categories of accessible channels
+        res.one("discuss_category_id", ["name", "sequence"], sudo=True)
+        res.attr("channel_type")
+        res.attr("create_uid")
+        res.many(
+            "channel_member_ids",
+            "_store_member_fields",
+            only_data=True,
+            sort="id",
+            predicate=lambda channel: channel in channels_with_all_members,
+        )
+        res.attr("default_display_mode")
+        res.attr("description", predicate=is_channel_or_group)
+        res.one("from_message_id", "_store_message_fields", predicate=is_channel_or_group)
+        # sudo: we are reading only the ids (comodel is inaccessible)
+        res.many("group_ids", [], predicate=is_channel, sudo=True)
+        res.one("group_public_id", ["full_name"], predicate=is_channel)
+        res.many("invited_member_ids", "_store_avatar_card_fields", mode="ADD")
+        res.attr("last_interest_dt")
+        res.attr("member_count")
+        res.attr("message_count", predicate=lambda c: c.parent_channel_id)
+        res.attr("name")
+        res.many(
+            "channel_name_member_ids",
+            "_store_member_fields",
+            sort="id",
+            predicate=lambda c: c.channel_type in c._member_based_naming_channel_types(),
+        )
+        res.one("parent_channel_id", "_store_channel_fields", predicate=is_channel_or_group)
+        # sudo: discuss.channel: reading sessions of accessible channel is acceptable
+        res.many("rtc_session_ids", "_store_extra_fields", mode="ADD", sudo=True)
+        res.attr("uuid")
+        if res.is_for_current_user():
+            res.attr("fetchChannelInfoState", "fetched")
+            res.attr("is_editable")
+            res.attr("message_needaction_counter")
+            res.attr("message_needaction_counter_bus_id", bus_last_id)
+            res.one(
+                "self_member_id",
+                lambda res: (
+                    res.from_method("_store_member_fields"),
+                    res.extend(["custom_channel_name", "custom_notifications"]),
+                    res.extend(["last_interest_dt", "message_unread_counter"]),
+                    res.attr("message_unread_counter_bus_id", bus_last_id),
+                    res.extend(["mute_until_dt", "new_message_separator"]),
+                    # sudo: discuss.channel.rtc.session - each member can see who is inviting them
+                    res.one("rtc_inviting_session_id", "_store_rtc_session_fields", sudo=True),
+                    res.attr("unpin_dt"),
                 ),
-            ]
-        return res
+                only_data=True,
+            )
 
-    def _to_store(self, store: Store, fields):
-        store.add_records_fields(self, fields)
+    def _to_store(self, store: Store, res: Store.FieldList):
+        store.add_records_fields(res)
 
     # User methods
 
@@ -1383,7 +1362,7 @@ class DiscussChannel(models.Model):
         if not pinned:
             store.add(self, {"close_chat_window": True})
         else:
-            store.add(self)
+            store.add(self, "_store_channel_fields")
         store.bus_send()
 
     def _allow_invite_by_email(self):
@@ -1436,20 +1415,20 @@ class DiscussChannel(models.Model):
                     member.fetched_message_id = last_message
                     updated_members_by_channel[member.channel_id] |= member
             for channel in updated_members_by_channel:
-                store = Store(bus_channel=channel)
-                store.add(updated_members_by_channel[channel], fields=[
-                    Store.One("channel_id", []),
-                    "fetched_message_id",
-                    *cursor_self.env["discuss.channel.member"]._to_store_persona(store.target, [])
-                ]).bus_send()
+                Store(bus_channel=channel).add(
+                    updated_members_by_channel[channel],
+                    lambda res: (
+                        res.attr("fetched_message_id"),
+                        res.from_method("_store_identifying_fields"),
+                    ),
+                ).bus_send()
 
     def channel_set_custom_name(self, name):
         self.ensure_one()
         self.self_member_id.custom_channel_name = name
-        Store(bus_channel=self.self_member_id._bus_channel()).add(
-            self.self_member_id,
-            "custom_channel_name",
-        ).bus_send()
+        store = Store(bus_channel=self.self_member_id._bus_channel())
+        store.add(self.self_member_id, ["custom_channel_name"])
+        store.bus_send()
 
     def channel_rename(self, name):
         self.ensure_one()
@@ -1565,15 +1544,14 @@ class DiscussChannel(models.Model):
         """ Return 'limit'-first channels' name, channel_type and group_public_id fields such that the
             name matches a 'search' string. Exclude channels of type chat (DM) and group.
         """
-        domain = [("name", "ilike", search), ("channel_type", "=", "channel")]
-        channels = self.search(domain, limit=limit)
-        channel_fields = [
-            "name",
-            "channel_type",
-            Store.One("group_public_id", ["full_name"]),
-            Store.One("parent_channel_id", [])
-        ]
-        store = Store().add(channels, channel_fields)
+        store = Store().add(
+            self.search([("name", "ilike", search), ("channel_type", "=", "channel")], limit=limit),
+            lambda res: (
+                res.extend(["name", "channel_type"]),
+                res.one("group_public_id", ["full_name"]),
+                res.attr("parent_channel_id"),
+            ),
+        )
         return store.get_result()
 
     def _get_last_messages(self):
@@ -1605,8 +1583,8 @@ class DiscussChannel(models.Model):
         super()._clean_empty_message(message)
         message.parent_id = False
 
-    def _get_store_message_update_extra_fields(self):
-        return super()._get_store_message_update_extra_fields() + [Store.One("parent_id")]
+    def _store_message_update_extra_fields(self, res: Store.FieldList):
+        res.one("parent_id", "_store_message_fields")
 
     # ------------------------------------------------------------
     # COMMANDS

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -18,10 +18,11 @@ class IrAttachment(models.Model):
             return guest
         return super()._bus_channel()
 
-    def _to_store_defaults(self, target):
+    def _store_attachment_fields(self, res: Store.FieldList):
+        super()._store_attachment_fields(res)
         # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible
         # attachments is fine
-        return super()._to_store_defaults(target) + [Store.Many("voice_ids", [], sudo=True)]
+        res.many("voice_ids", [], sudo=True)
 
     def _post_add_create(self, **kwargs):
         super()._post_add_create(**kwargs)

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -86,24 +86,16 @@ class IrAttachment(models.Model):
             )
         self.unlink()
 
-    def _get_store_ownership_fields(self):
-        return [Store.Attr("ownership_token", lambda a: a._get_ownership_token())]
+    def _store_ownership_fields(self, res: Store.FieldList):
+        res.attr("ownership_token", lambda a: a._get_ownership_token())
 
-    def _to_store_defaults(self, target):
-        return [
-            "checksum",
-            "create_date",
-            "file_size",
-            "has_thumbnail",
-            "mimetype",
-            "name",
-            Store.Attr("raw_access_token", lambda a: a._get_raw_access_token()),
-            "res_name",
-            Store.One("thread", [], as_thread=True),
-            Store.Attr("thumbnail_access_token", lambda a: a._get_thumbnail_token()),
-            "type",
-            "url",
-        ]
+    def _store_attachment_fields(self, res: Store.FieldList):
+        res.extend(["checksum", "create_date", "file_size", "has_thumbnail", "mimetype", "name"])
+        res.attr("raw_access_token", lambda a: a._get_raw_access_token())
+        res.attr("res_name")
+        res.one("thread", [], as_thread=True)
+        res.attr("thumbnail_access_token", lambda a: a._get_thumbnail_token())
+        res.extend(["type", "url"])
 
     def _get_ownership_token(self):
         """ Returns a scoped limited access token that indicates ownership of the attachment when

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -12,14 +12,14 @@ class IrHttp(models.AbstractModel):
         """Override to add the current user data (partner or guest) if applicable."""
         result = super().session_info()
         store = Store()
-        ResUsers = self.env["res.users"]
+        user = self.env.user
         if cids := request.cookies.get("cids", False):
             allowed_company_ids = []
             for company_id in [int(cid) for cid in cids.split("-")]:
                 if company_id in self.env.user.company_ids.ids:
                     allowed_company_ids.append(company_id)
-            ResUsers = self.with_context(allowed_company_ids=allowed_company_ids).env["res.users"]
-        ResUsers._init_store_data(store)
+            user = user.with_context(allowed_company_ids=allowed_company_ids)
+        store.add_global_values(user.sudo(False)._store_init_global_fields)
         result["storeData"] = store.get_result()
         guest = self.env['mail.guest']._get_guest_from_context()
         if not request.session.uid and guest:

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -645,28 +645,18 @@ class MailActivity(models.Model):
 
     @api.readonly
     def activity_format(self):
-        return Store().add(self).get_result()
+        return Store().add(self, "_store_activity_fields").get_result()
 
-    def _to_store_defaults(self, target):
-        return [
-            "activity_category",
-            Store.One("activity_type_id", "name"),
-            "can_write",
-            "chaining_type",
-            "create_date",
-            Store.One("create_uid", Store.One("partner_id", "name")),
-            "date_deadline",
-            "date_done",
-            "icon",
-            "note",
-            "res_id",
-            "res_model",
-            "state",
-            "summary",
-            Store.One("user_id", Store.One("partner_id")),
-            Store.Many("attachment_ids", ["name"]),
-            Store.Many("mail_template_ids", ["name"]),
-        ]
+    def _store_activity_fields(self, res: Store.FieldList):
+        res.attr("activity_category")
+        res.one("activity_type_id", ["name"])
+        res.extend(["can_write", "chaining_type", "create_date"])
+        res.one("create_uid", lambda res: res.one("partner_id", ["name"]))
+        res.extend(["date_deadline", "date_done", "icon", "note"])
+        res.extend(["res_id", "res_model", "state", "summary"])
+        res.one("user_id", lambda res: res.one("partner_id", "_store_partner_fields"))
+        res.many("attachment_ids", ["name"])
+        res.many("mail_template_ids", ["name"])
 
     @api.readonly
     @api.model

--- a/addons/mail/models/mail_canned_response.py
+++ b/addons/mail/models/mail_canned_response.py
@@ -77,9 +77,9 @@ class MailCannedResponse(models.Model):
                 if delete:
                     store.delete(canned_response)
                 else:
-                    store.add(canned_response)
+                    store.add(canned_response, "_store_canned_response_fields")
             for store in stores:
                 store.bus_send()
 
-    def _to_store_defaults(self, target):
-        return ["source", "substitution"]
+    def _store_canned_response_fields(self, res: Store.FieldList):
+        res.extend(["source", "substitution"])

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -515,14 +515,9 @@ GROUP BY fol.id%s%s""" % (
     # Misc discuss
     # --------------------------------------------------
 
-    def _to_store_defaults(self, target):
-        return [
-            "display_name",
-            "email",
-            "is_active",
-            "name",
-            # sudo: res.partner - can read partners of found followers, in particular allows
-            # by-passing multi-company ACL for portal partners
-            Store.One("partner_id", sudo=True),
-            Store.One("thread", [], as_thread=True),
-        ]
+    def _store_follower_fields(self, res: Store.FieldList):
+        res.extend(["display_name", "email", "is_active", "name"])
+        # sudo: res.partner - can read partners of found followers, in particular allows
+        # by-passing multi-company ACL for portal partners
+        res.one("partner_id", "_store_partner_fields", sudo=True)
+        res.one("thread", [], as_thread=True)

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -97,9 +97,7 @@ class MailLinkPreview(models.Model):
             ]
         )
         (message.sudo().message_link_preview_ids - message_link_previews_ok)._unlink_and_notify()
-        Store(
-            bus_channel=message._bus_channel(),
-        ).add(message, message._get_store_message_link_previews_fields()).bus_send()
+        Store(bus_channel=message._bus_channel()).add(message, "_store_message_link_previews_fields").bus_send()
 
     @api.model
     def _is_link_preview_enabled(self):
@@ -128,14 +126,6 @@ class MailLinkPreview(models.Model):
             preview = self.env['mail.link.preview'].create(preview_values)
         return preview
 
-    def _to_store_defaults(self, target):
-        return [
-            "image_mimetype",
-            "og_description",
-            "og_image",
-            "og_mimetype",
-            "og_site_name",
-            "og_title",
-            "og_type",
-            "source_url",
-        ]
+    def _store_link_preview_fields(self, res: Store.FieldList):
+        res.extend(["image_mimetype", "og_description", "og_image", "og_mimetype", "og_site_name"])
+        res.extend(["og_title", "og_type", "source_url"])

--- a/addons/mail/models/mail_message_link_preview.py
+++ b/addons/mail/models/mail_message_link_preview.py
@@ -37,8 +37,6 @@ class MessageMailLinkPreview(models.Model):
             Store(bus_channel=self._bus_channel()).delete(message_link_preview).bus_send()
         self.unlink()
 
-    def _to_store_defaults(self, target):
-        return [
-            Store.One("link_preview_id", sudo=True),
-            Store.One("message_id", [], sudo=True),
-        ]
+    def _store_message_link_preview_fields(self, res: Store.FieldList):
+        res.one("link_preview_id", "_store_link_preview_fields", sudo=True)
+        res.one("message_id", [], sudo=True)

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -129,12 +129,7 @@ class MailNotification(models.Model):
 
         return self.filtered(_filter_unimportant_notifications)
 
-    def _to_store_defaults(self, target):
-        return [
-            "mail_email_address",
-            "failure_type",
-            "mail_message_id",
-            "notification_status",
-            "notification_type",
-            Store.One("res_partner_id", ["name", "email"]),
-        ]
+    def _store_notification_fields(self, res: Store.FieldList):
+        res.extend(["mail_email_address", "failure_type", "mail_message_id"])
+        res.extend(["notification_status", "notification_type"])
+        res.one("res_partner_id", ["name", "email"])

--- a/addons/mail/models/mail_poll_option.py
+++ b/addons/mail/models/mail_poll_option.py
@@ -4,6 +4,7 @@ from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.fields import Domain
 from odoo.tools import format_list
+from odoo.addons.mail.tools.discuss import Store
 
 
 class MailPollOption(models.Model):
@@ -94,13 +95,7 @@ class MailPollOption(models.Model):
         for option in self:
             option.vote_percentage = percentage_by_option[option]
 
-    def _to_store_defaults(self, target):
-        fields = [
-            "number_of_votes",
-            "poll_id",
-            "option_label",
-            "vote_percentage",
-        ]
-        if target.is_current_user(self.env):
-            fields.append("selected_by_self")
-        return fields
+    def _store_poll_option_fields(self, res: Store.FieldList):
+        res.extend(["number_of_votes", "poll_id", "option_label", "vote_percentage"])
+        if res.is_for_current_user():
+            res.attr("selected_by_self")

--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -284,12 +284,7 @@ class MailScheduledMessage(models.Model):
         if self.search_count(domain, limit=1):
             self.env.ref('mail.ir_cron_post_scheduled_message')._trigger()
 
-    def _to_store_defaults(self, target):
-        return [
-            Store.Many("attachment_ids"),
-            Store.One("author_id"),
-            "body",
-            "is_note",
-            "scheduled_date",
-            "subject",
-        ]
+    def _store_scheduled_message_fields(self, res: Store.FieldList):
+        res.many("attachment_ids", "_store_attachment_fields")
+        res.one("author_id", "_store_partner_fields")
+        res.extend(["body", "is_note", "scheduled_date", "subject"])

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3362,20 +3362,15 @@ class MailThread(models.AbstractModel):
                     ("partner_id", "in", users.partner_id.ids),
                 ]
             )
+            batch_vals = {"msg_vals": msg_vals, "add_followers": True, "followers": followers}
             for user in users:
                 store = Store(bus_channel=user).add(
                     message.with_user(user).with_context(allowed_company_ids=[]),
-                    msg_vals=msg_vals,
-                    add_followers=True,
-                    followers=followers,
+                    "_store_message_fields",
+                    fields_params=batch_vals,
                 )
-                user._bus_send(
-                    "mail.message/inbox",
-                    {
-                        "message_id": message.id,
-                        "store_data": store.get_result(),
-                    }
-                )
+                data = store.get_result()
+                user._bus_send("mail.message/inbox", {"message_id": message.id, "store_data": data})
 
     def _notify_thread_by_email(self, message, recipients_data, *, msg_vals=False,
                                 mail_auto_delete=True,  # mail.mail
@@ -4824,30 +4819,41 @@ class MailThread(models.AbstractModel):
 
     @api.readonly
     def message_get_followers(self, after=None, limit=100, filter_recipients=False):
-        self.ensure_one()
-        store = Store()
-        followers_fields = self._get_store_message_followers_fields(after, limit, filter_recipients)
-        store.add(self, followers_fields, as_thread=True)
+        store = Store().add(
+            self,
+            "_store_message_followers_fields",
+            fields_params={"after": after, "limit": limit, "filter_recipients": filter_recipients},
+            as_thread=True,
+        )
         return store.get_result()
 
-    def _get_store_message_followers_fields(self, after=None, limit=100, filter_recipients=False, reset=False):
-        domain = Domain("res_id", "in", self.id)
-        domain &= Domain("res_model", "=", self._name)
-        domain &= Domain("partner_id", "!=", self.env.user.partner_id.id)
-        if filter_recipients:
-            mt_comment_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
-            domain &= Domain("subtype_ids", "=", mt_comment_id)
-            domain &= Domain("partner_id.active", "=", True)
-        if after:
-            domain &= Domain("id", ">", after)
-        followers = self.env["mail.followers"].search_fetch(domain, limit=limit, order="id ASC")
-        followers_by_tid = defaultdict(
-            self.env["mail.followers"].browse,
-            followers.grouped("res_id"),
+    def _store_message_followers_fields(
+        self,
+        res: Store.FieldList,
+        after=None,
+        limit=100,
+        filter_recipients=False,
+        reset=False,
+    ):
+        def followers_by_thread(thread):
+            # Not batched by simplicity as it is always called on a single thread.
+            domain = Domain("res_id", "in", thread.id)
+            domain &= Domain("res_model", "=", thread._name)
+            domain &= Domain("partner_id", "!=", thread.env.user.partner_id.id)
+            if filter_recipients:
+                mt_comment_id = thread.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
+                domain &= Domain("subtype_ids", "=", mt_comment_id)
+                domain &= Domain("partner_id.active", "=", True)
+            if after:
+                domain &= Domain("id", ">", after)
+            return thread.env["mail.followers"].search_fetch(domain, limit=limit, order="id ASC")
+
+        res.many(
+            "recipients" if filter_recipients else "followers",
+            "_store_follower_fields",
+            value=followers_by_thread,
+            mode="REPLACE" if reset else "ADD",
         )
-        field_name = "recipients" if filter_recipients else "followers"
-        mode = "ADD" if not reset else "REPLACE"
-        return [Store.Many(field_name, value=lambda t: followers_by_tid[t.id], mode=mode)]
 
     # ------------------------------------------------------
     # THREAD MESSAGE UPDATE
@@ -4970,53 +4976,62 @@ class MailThread(models.AbstractModel):
             # (re)send notifications
             else:
                 self.env['mail.message.schedule'].sudo()._send_message_notifications(message)
-
-        res = [
-            Store.Many("attachment_ids", sort="id"),
-            "body",
-            Store.Many("partner_ids", [*self.env["res.partner"]._get_store_avatar_fields(), "name"]),
-            "pinned_at",
-            "write_date",
-            *message._get_store_linked_messages_fields(),
-            *self._get_store_message_update_extra_fields(),
-        ]
         if body is not None:
             # sudo: mail.message.translation - discarding translations of message after editing it
-            self.env["mail.message.translation"].sudo().search([("message_id", "=", message.id)]).unlink()
-            res.append({"translationValue": False})
-        Store(bus_channel=message._bus_channel()).add(message, res).bus_send()
+            self.env["mail.message.translation"].sudo().search(
+                [("message_id", "=", message.id)],
+            ).unlink()
+        Store(bus_channel=message._bus_channel()).add(
+            message,
+            lambda res: (
+                res.many("attachment_ids", "_store_attachment_fields", sort="id"),
+                res.attr("body"),
+                res.many("partner_ids", "_store_recipients_fields", sort="id"),
+                res.attr("pinned_at"),
+                res.attr("write_date"),
+                res.from_method("_store_linked_messages_fields"),
+                self._store_message_update_extra_fields(res),
+                res.attr("translationValue", False, predicate=lambda m: m.body is not None),
+            ),
+        ).bus_send()
 
     def _clean_empty_message(self, message):
         message.message_link_preview_ids._unlink_and_notify()
 
-    def _get_store_message_update_extra_fields(self):
-        return []
-
+    def _store_message_update_extra_fields(self, res: Store.FieldList):
+        pass
     # ------------------------------------------------------
     # STORE
     # ------------------------------------------------------
 
-    def _get_store_thread_fields(self, target: Store.Target, request_list):
-        res = []
-        if target.is_current_user(self.env):
-            res.append(Store.Attr("hasReadAccess", lambda t: t.sudo(False).has_access("read")))
-            res.append(Store.Attr("hasWriteAccess", lambda t: t.sudo(False).has_access("write")))
-            res.append({"canPostOnReadonly": self._mail_post_access == "read"})
+    def _store_thread_fields(self, res: Store.FieldList, *, request_list):
+        if res.is_for_current_user():
+            res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
+            res.attr("hasWriteAccess", lambda t: t.sudo(False).has_access("write"))
+            res.attr("canPostOnReadonly", self._mail_post_access == "read")
         if "activities" in request_list and isinstance(self, self.env.registry["mail.activity.mixin"]):
-            res.append(Store.Many("activities", value=lambda t: t.with_context(active_test=True).activity_ids))
+            res.many(
+                "activities",
+                "_store_activity_fields",
+                value=lambda t: t.with_context(active_test=True).activity_ids,
+            )
         if "attachments" in request_list:
-            res.append(Store.Many("attachments", value=lambda t: t._get_mail_thread_data_attachments()))
+            res.many(
+                "attachments",
+                "_store_attachment_fields",
+                value=lambda t: t._get_mail_thread_data_attachments(),
+            )
             res.append({"areAttachmentsLoaded": True, "isLoadingAttachments": False})
         if "contact_fields" in request_list:
-            res.append(Store.Attr("primary_email_field", lambda t: t._mail_get_primary_email_field()))
-            res.append(Store.Attr("partner_fields", lambda t: t._mail_get_partner_fields()))
+            res.attr("primary_email_field", lambda t: t._mail_get_primary_email_field())
+            res.attr("partner_fields", lambda t: t._mail_get_partner_fields())
         if "followers" in request_list:
             count_by_tid = {"groupby": ["res_id"], "aggregates": ["__count"]}
             domain = Domain("res_id", "in", self.ids) & Domain("res_model", "=", self._name)
             # follower count
             follower_count = self.env["mail.followers"]._read_group(domain, **count_by_tid)
             follower_count_by_tid = defaultdict(int, follower_count)
-            res.append(Store.Attr("followersCount", lambda t: follower_count_by_tid[t.id]))
+            res.attr("followersCount", lambda t: follower_count_by_tid[t.id])
             # follower of current user
             self_partner_domain = Domain("partner_id", "=", self.env.user.partner_id.id)
             self_followers = self.env["mail.followers"].search_fetch(domain & self_partner_domain)
@@ -5024,9 +5039,13 @@ class MailThread(models.AbstractModel):
                 self.env["mail.followers"].browse,
                 self_followers.grouped("res_id"),
             )
-            res.append(Store.One("selfFollower", value=lambda t: self_follower_by_tid[t.id]))
+            res.one(
+                "selfFollower",
+                "_store_follower_fields",
+                value=lambda t: self_follower_by_tid[t.id],
+            )
             # follower list with limit
-            res.extend(self._get_store_message_followers_fields(reset=True))
+            self._store_message_followers_fields(res, reset=True)
             # recipient count
             mt_comment_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
             recipient_count = self.env["mail.followers"]._read_group(
@@ -5037,11 +5056,11 @@ class MailThread(models.AbstractModel):
                 **count_by_tid,
             )
             recipient_count_by_tid = defaultdict(int, recipient_count)
-            res.append(Store.Attr("recipientsCount", lambda t: recipient_count_by_tid[t.id]))
+            res.attr("recipientsCount", lambda t: recipient_count_by_tid[t.id])
             # recipient list with limit
-            res.extend(self._get_store_message_followers_fields(filter_recipients=True, reset=True))
+            self._store_message_followers_fields(res, filter_recipients=True, reset=True)
         if "display_name" in request_list:
-            res.append("display_name")
+            res.attr("display_name")
         if "scheduledMessages" in request_list:
             domain = Domain("model", "=", self._name) & Domain("res_id", "in", self.ids)
             scheduled_messages = self.env["mail.scheduled.message"].search_fetch(domain)
@@ -5049,18 +5068,19 @@ class MailThread(models.AbstractModel):
                 self.env["mail.scheduled.message"].browse,
                 scheduled_messages.grouped("res_id"),
             )
-            res.append(Store.Many("scheduledMessages", value=lambda t: messages_by_tid[t.id]))
+            res.many(
+                "scheduledMessages",
+                "_store_scheduled_message_fields",
+                value=lambda t: messages_by_tid[t.id],
+            )
         if "suggestedRecipients" in request_list:
-            res.append(
-                Store.Attr(
-                    "suggestedRecipients",
-                    lambda t: t._message_get_suggested_recipients(
-                        reply_discussion=True,
-                        no_create=True,
-                    ),
+            res.attr(
+                "suggestedRecipients",
+                lambda t: t._message_get_suggested_recipients(
+                    reply_discussion=True,
+                    no_create=True,
                 ),
             )
-        return res
 
     def _get_mail_thread_data_attachments(self):
         self.ensure_one()
@@ -5074,7 +5094,7 @@ class MailThread(models.AbstractModel):
             res = res.filtered(lambda attachment: (attachment in svg_ids and attachment not in original_ids) or (attachment in non_svg_ids and attachment.original_id not in non_svg_ids))
         return res
 
-    def _get_store_target(self):
+    def _store_target(self):
         return {"bus_channel": self, "bus_subchannel": "thread"}
 
     # ------------------------------------------------------

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -49,8 +49,7 @@ class MailThreadMainAttachment(models.AbstractModel):
                     key=lambda r: (r.mimetype.endswith('pdf'), r.mimetype.startswith('image'))
                 ).id
 
-    def _get_store_thread_fields(self, target: Store.Target, request_list):
-        res = super()._get_store_thread_fields(target, request_list)
+    def _store_thread_fields(self, res: Store.FieldList, *, request_list):
+        super()._store_thread_fields(res, request_list=request_list)
         if "attachments" in request_list:
-            res.append("message_main_attachment_id")
-        return res
+            res.attr("message_main_attachment_id")

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1670,11 +1670,9 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
     def assertMessageBusNotifications(self, message, count=1):
         """Asserts that the expected notification updates have been sent on the
         bus for the given message."""
-        store = Store()
-        message._message_notifications_to_store(store)
         self.assertBusNotifications([(self.cr.dbname, 'res.partner', message.author_id.id)] * count, [{
             "type": "mail.record/insert",
-            "payload": store.get_result()
+            "payload": Store().add(message, "_store_notification_fields").get_result(),
         }], check_unique=False)
 
     def assertBusNotifications(self, channels, message_items=None, check_unique=True):

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1283,11 +1283,10 @@ class ProjectProject(models.Model):
         for partner, tasks in dict_tasks_per_partner.items():
             tasks.message_subscribe(dict_partner_ids_to_subscribe_per_partner[partner])
 
-    def _get_store_thread_fields(self, target: Store.Target, request_list):
-        res = super()._get_store_thread_fields(target, request_list)
+    def _store_thread_fields(self, res: Store.FieldList, *, request_list):
+        super()._store_thread_fields(res, request_list=request_list)
         if "followers" in request_list:
-            res.append(Store.Many("collaborator_ids", [], value=lambda p: p.collaborator_ids.partner_id))
-        return res
+            res.many("collaborator_ids", [], value=lambda p: p.collaborator_ids.partner_id)
 
     @api.depends('task_count', 'open_task_count')
     def _compute_task_completion_percentage(self):

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -208,5 +208,5 @@ class RatingRating(models.Model):
             data_by_model[rating.res_model]['record_ids'].append(rating.res_id)
         return data_by_model
 
-    def _to_store_defaults(self, target):
-        return ["rating", "rating_image_url", "rating_text"]
+    def _store_rating_fields(self, res: Store.FieldList):
+        res.extend(["rating", "rating_image_url", "rating_text"])

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -16,7 +16,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     # Queries for _query_count_init_store (in order):
     #   1: search res_partner (odooot ref exists)
     #   1: search res_groups (internalUserGroupId ref exists)
-    #   8: odoobot format:
+    #   8: store add odoobot:
     #       - fetch res_partner (_read_format)
     #       - search res_users (_compute_im_status)
     #       - search presence (_compute_im_status)
@@ -25,7 +25,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search employee (_compute_im_status hr_homeworking override)
     #       - fetch employee (_compute_im_status hr_homeworking override)
     #       - fetch res_users (_read_format)
-    #       - fetch hr_employee (res.users _to_store)
+    #       - fetch hr_employee (user)
     #   5: settings:
     #       - search res_users_settings (_find_or_create_for_user)
     #       - fetch res_users_settings (_format_settings)
@@ -43,43 +43,43 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch res_users
     #       - search discuss_channel_member
     #       - fetch discuss_channel
+    #   1: search bus_bus (_bus_last_id)
     #   1. search discuss_channel (chathub given channel ids)
     #   2: _get_channels_as_member
     #       - search discuss_channel (member_domain)
     #       - search discuss_channel (pinned_member_domain)
-    #   2: _init_messaging (discuss)
+    #   2: _init_messaging_global_fields (discuss)
     #       - fetch discuss_channel_member (is_self)
     #       - _compute_message_unread
-    #   3: _init_messaging (mail)
-    #       - search bus_bus (_bus_last_id)
+    #   2: _init_messaging_global_fields (mail)
     #       - _get_needaction_count (inbox counter)
     #       - search mail_message (starred counter)
     #   23: _process_request_for_all (discuss):
     #       - search discuss_channel (channels_domain)
-    #       22: channel add:
+    #       22: store add channel:
     #           - read group member (prefetch _compute_self_member_id from _compute_is_member)
     #           - read group member (_compute_invited_member_ids)
     #           - search discuss_channel_rtc_session
     #           - fetch discuss_channel_rtc_session
     #           - search member (channel_member_ids)
     #           - fetch discuss_channel_member (manual prefetch)
-    #           10: member _to_store:
-    #               10: partner _to_store:
-    #                   - fetch res_partner (partner _to_store)
+    #           10: member:
+    #               10: partner:
+    #                   - fetch res_partner (partner)
     #                   - fetch res_users (_compute_im_status)
     #                   - search mail_presence (_compute_im_status)
     #                   - fetch mail_presence (_compute_im_status)
     #                   - _get_on_leave_ids (_compute_im_status override)
     #                   - search hr_employee (_compute_im_status override)
     #                   - fetch hr_employee (_compute_im_status override)
-    #                   - search hr_employee (res.users._to_store override)
+    #                   - search hr_employee (user override)
     #                   - search hr_leave (leave_date_to)
     #                   - fetch res_users (_compute_main_user_id)
     #           - search bus_bus (_bus_last_id)
-    #           - search ir_attachment (_compute_avatar_128)
     #           - count discuss_channel_member (member_count)
     #           - _compute_message_needaction
     #           - search discuss_channel_res_groups_rel (group_ids)
+    #           - search_fetch ir_attachment (_compute_avatar_cache_key -> _compute_avatar_128)
     #           - fetch res_groups (group_public_id)
     _query_count_init_messaging = 35
     # Queries for _query_count_discuss_channels (in order):
@@ -89,9 +89,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search discuss_channel_member
     #       - fetch discuss_channel
     #   2: _get_channels_as_member
-    #       - search discuss_channel (member_domain)
-    #       - search discuss_channel (pinned_member_domain)
-    #   34: channel _to_store_defaults:
+    #       - search_fetch discuss_channel (member_domain)
+    #       - search_fetch discuss_channel (pinned_member_domain)
+    #   34: store add channel:
     #       - read group member (prefetch _compute_self_member_id from _compute_is_member)
     #       - read group member (_compute_invited_member_ids)
     #       - search discuss_channel_rtc_session
@@ -99,60 +99,60 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search member (channel_member_ids)
     #       - search member (channel_name_member_ids)
     #       - fetch discuss_channel_member (manual prefetch)
-    #       18: member _to_store:
+    #       17: member:
     #           - search im_livechat_channel_member_history (livechat member type)
     #           - fetch im_livechat_channel_member_history (livechat member type)
-    #           13: partner _to_store:
-    #               - fetch res_partner (partner _to_store)
+    #           13: partner:
+    #               - fetch res_partner (partner)
     #               - fetch res_users (_compute_im_status)
     #               - search mail_presence (_compute_im_status)
     #               - fetch mail_presence (_compute_im_status)
     #               - _get_on_leave_ids (_compute_im_status override)
     #               - search hr_employee (_compute_im_status override)
     #               - fetch hr_employee (_compute_im_status override)
-    #               - search hr_employee (res.users._to_store override)
+    #               - search hr_employee (user override)
     #               - search hr_leave (leave_date_to)
     #               - search res_users_settings (livechat username)
     #               - fetch res_users_settings (livechat username)
     #               - fetch res_users (_compute_main_user_id)
     #               - fetch res_country (livechat override)
-    #           3: guest _to_store:
-    #               - fetch mail_guest
+    #           2: guest:
     #               - fetch mail_presence (_compute_im_status)
-    #               - fetch res_country
-    #       - search bus_bus (_bus_last_id from _to_store_defaults)
-    #       - search ir_attachment (_compute_avatar_128)
+    #               - fetch mail_guest
+    #       - search bus_bus (_bus_last_id)
     #       - count discuss_channel_member (member_count)
     #       - _compute_message_needaction
+    #       - search ir_attachment (_compute_avatar_128)
     #       - search discuss_channel_res_groups_rel (group_ids)
     #       - fetch im_livechat_channel_member_history (requested_by_operator)
+    #       - fetch livechat_expertise_ids
     #       - fetch res_groups (group_ids)
     #       - _compute_message_unread
     #       - fetch im_livechat_channel
-    #       2: fetch livechat_expertise_ids
     #   1: _get_last_messages
-    #   20: message _to_store:
-    #       - search mail_message_schedule
+    #   22: store add message:
     #       - fetch mail_message
+    #       - search mail_message_schedule
     #       - search mail_message_res_partner_starred_rel
     #       - search message_attachment_rel
-    #       - search mail_link_preview
     #       - search mail_message_res_partner_rel
     #       - search mail_message_reaction
+    #       - search mail_poll (_compute_has_poll start_message_id)
+    #       - search mail_poll (_compute_has_poll end_message_id)
+    #       - search mail_message_link_preview
     #       - search mail_notification
+    #       - search mail_tracking_value
     #       - search rating_rating
     #       - fetch mail_notification
     #       - search mail_message_subtype
     #       - search discuss_call_history
     #       - fetch mail_message_reaction
+    #       - read_group (_compute_rating_stats)
     #       - fetch mail_message_subtype
-    #       - 'has_poll' computation: check if has mail_poll linked through o2m
-    #       - fetch partner (_author_to_store)
-    #       - search user (_author_to_store)
-    #       - fetch user (_author_to_store)
+    #       - fetch partner (author)
+    #       - search user (author)
+    #       - fetch user (author)
     #       - fetch discuss_call_history
-    #       - search mail_tracking_value
-    #       - _compute_rating_stats
     _query_count_discuss_channels = 63
 
     def setUp(self):
@@ -341,12 +341,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     @users('emp')
     @warmup
     def test_10_init_store_data(self):
-        """Test performance of `_init_store_data`."""
+        """Test performance of `_store_init_global_fields`."""
 
         def test_fn():
-            store = Store()
-            self.env["res.users"].with_user(self.users[0])._init_store_data(store)
-            return store.get_result()
+            field_list = self.users[0].with_user(self.users[0])._store_init_global_fields
+            return Store().add_global_values(field_list).get_result()
 
         self._run_test(
             fn=test_fn,

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -27,11 +27,11 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - search ir_rule (_get_rules for mail.notification)
         #       - search ir_rule (_get_rules)
         #       - search mail_message
-        #   30 message _to_store:
+        #   30 store add message:
         #       - search mail_message_schedule
         #       - fetch mail_message
         #       - search mail_followers
-        #       2 thread _to_store:
+        #       2 thread:
         #           - fetch slide_channel
         #           - fetch product_template
         #       - search mail_message_res_partner_starred_rel (_compute_starred)
@@ -54,7 +54,7 @@ class TestInboxPerformance(HttpCase, MailCommon):
         #           - search rating_rating
         #           - fetch rating_rating
         #       - search mail_tracking_value
-        #       3 _author_to_store:
+        #       3 author:
         #           - fetch res_partner
         #           - search res_users
         #           - fetch res_users

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1393,7 +1393,7 @@ class TestNoThread(MailCommon, TestRecipients):
         )
 
     @users('employee')
-    def test_message_to_store(self):
+    def test_store_add_message(self):
         """ Test formatting of messages when linked to non-thread models.
         Format could be asked notably if an inbox notification due to a
         'message_notify' happens. """
@@ -1403,13 +1403,13 @@ class TestNoThread(MailCommon, TestRecipients):
             'model': test_record._name,
             'res_id': test_record.id,
         })
-        formatted = Store().add(message).get_result()["mail.message"][0]
+        formatted = Store().add(message, "_store_message_fields").get_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], test_record.name)
         self.assertEqual(formatted['record_name'], test_record.name)
 
         test_record.write({'name': 'Just Test'})
         message.invalidate_recordset(['record_name'])
-        formatted = Store().add(message).get_result()["mail.message"][0]
+        formatted = Store().add(message, "_store_message_fields").get_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], 'Just Test')
         self.assertEqual(formatted['record_name'], 'Just Test')
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1417,8 +1417,8 @@ class TestMessageToStorePerformance(BaseMailPerformance):
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
     @warmup
-    def test_message_to_store_multi(self):
-        """Test performance of `_to_store` with multiple messages with multiple attachments,
+    def test_store_add_message_multi(self):
+        """Test performance of `store.add` with multiple messages with multiple attachments,
         different authors, various notifications, and different tracking values.
 
         Those messages might not make sense functionally but they are crafted to
@@ -1435,7 +1435,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         messages_all = self.messages_all.with_env(self.env)
 
         with self.assertQueryCount(employee=26):  # tm 25
-            res = Store().add(messages_all).get_result()
+            res = Store().add(messages_all, "_store_message_fields").get_result()
 
         self.assertEqual(len(res["mail.message"]), 2 * 2)
         for message in res["mail.message"]:
@@ -1444,11 +1444,11 @@ class TestMessageToStorePerformance(BaseMailPerformance):
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
     @warmup
-    def test_message_to_store_single(self):
+    def test_store_add_message_single(self):
         message = self.messages_all[0].with_env(self.env)
 
         with self.assertQueryCount(employee=26):  # tm 25
-            res = Store().add(message).get_result()
+            res = Store().add(message, "_store_message_fields").get_result()
 
         self.assertEqual(len(res["mail.message"]), 1)
         self.assertEqual(len(res["mail.message"][0]["attachment_ids"]), 2)
@@ -1456,7 +1456,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
     @warmup
-    def test_message_to_store_group_thread_name_by_model(self):
+    def test_store_add_message_group_thread_name_by_model(self):
         """Ensures the fetch of multiple thread names is grouped by model."""
         records = []
         for _i in range(5):
@@ -1469,18 +1469,18 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         } for record in records])
 
         with self.assertQueryCount(employee=3):
-            res = Store().add(messages).get_result()
+            res = Store().add(messages, "_store_message_fields").get_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
         with self.assertQueryCount(employee=15):  # tm: 14
-            res = Store().add(messages).get_result()
+            res = Store().add(messages, "_store_message_fields").get_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
     @warmup
-    def test_message_to_store_multi_followers_inbox(self):
+    def test_store_add_message_multi_followers_inbox(self):
         """Test query count as well as bus notifcations from sending a message to multiple followers
         with inbox."""
         record = self.env["mail.test.simple"].create({"name": "Test"})

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -50,9 +50,9 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
         }
         discuss_channel = request.env['discuss.channel'].create(discuss_channel_values)
         chatbot_script._post_welcome_steps(discuss_channel)
-        store.add(discuss_channel, {"open_chat_window": True})
-        request.env["res.users"]._init_store_data(store)
-        store.add(chatbot_script)
+        store.add(discuss_channel, "_store_open_chat_window_fields")
+        store.add_global_values(request.env.user.sudo(False)._store_init_global_fields)
+        store.add(chatbot_script, "_store_script_fields")
         return request.render("im_livechat.chatbot_test_script_page", {
             'server_url': chatbot_script.get_base_url(),
             'chatbot_script': chatbot_script,

--- a/addons/website_livechat/controllers/webclient.py
+++ b/addons/website_livechat/controllers/webclient.py
@@ -7,11 +7,9 @@ from odoo.addons.mail.tools.discuss import Store
 class WebClient(WebclientController):
     @classmethod
     def _process_request_for_all(self, store: Store, name, params):
-        if name == "init_livechat" and (
-            chat_request_channel := self._link_visitor_to_livechat(params)
-        ):
-            store.add(chat_request_channel, extra_fields={"open_chat_window": True})
-            chat_request_channel.is_pending_chat_request = False
+        if name == "init_livechat" and (channel := self._link_visitor_to_livechat(params)):
+            channel.is_pending_chat_request = False
+            store.add(channel, "_store_open_chat_window_fields")
         super()._process_request_for_all(store, name, params)
 
     @classmethod

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -163,7 +163,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         operator_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
         self.assertEqual(
-            Store().add(channel).get_result(),
+            Store().add(channel, "_store_channel_fields").get_result(),
             {
                 "discuss.channel": self._filter_channels_fields(
                     {
@@ -310,7 +310,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             },
         )
 
-    def test_channel_to_store_after_operator_left(self):
+    def test_store_add_channel_after_operator_left(self):
         channel = self._common_basic_flow()
         guest = self.env["mail.guest"].search([], order="id desc", limit=1)
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
@@ -321,9 +321,8 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.assertFalse(
             channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         )
-        data = Store().add(
-                channel.with_user(self.user_public).with_context(guest=guest),
-            ).get_result()
+        channel_w_user = channel.with_user(self.user_public).with_context(guest=guest)
+        data = Store().add(channel_w_user, "_store_channel_fields").get_result()
         self.assertEqual(
             data["discuss.channel"],
             self._filter_channels_fields(
@@ -402,7 +401,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         )
         self.assertEqual(result["Store"]["livechat_available"], False)
 
-    def test_livechat_visitor_to_store(self):
+    def test_store_add_livechat_visitor(self):
         """Test livechat_visitor_id is sent with livechat channels data even when there is no
         visitor."""
         self.target_visitor = None

--- a/addons/website_slides/models/mail_activity.py
+++ b/addons/website_slides/models/mail_activity.py
@@ -9,5 +9,6 @@ class MailActivity(models.Model):
 
     request_partner_id = fields.Many2one("res.partner", string="Requesting Partner", ondelete="cascade")
 
-    def _to_store_defaults(self, target):
-        return super()._to_store_defaults(target) + [Store.One("request_partner_id", [])]
+    def _store_rating_fields(self, res: Store.FieldList):
+        super()._store_rating_fields(res)
+        res.attr("request_partner_id")


### PR DESCRIPTION
The main goal and the power of `Store` is to be able to use it declaratively by giving it a list of fields to add and letting `Store` handle the complexity of generating the result.

Many flows therefore simply have to handle lists of field name (or more complex field description). This is currently done manually in each flow which is cumbersome.

This commit introduces `Store.FieldList`, a small helper class to handle lists of field (name/description) compatible with `Store`, and allowing to more easily add new entries (`attr`, `one`, and `many`).

Usage of `Store.Attr`, `Store.One` and `Store.Many` have been removed thanks to this commit, as well as the `extra_fields` and `kwargs` of `store.add`, the magic call of `_to_store_defaults`, and finally `_to_store` is almost removed too.

Support of passing a single field (without list) is removed to avoid confusion and to keep a single syntax.

This commit also resolves the inconsistencies between the `env` of the records and the `env` used to call the field functions. Now the function is always bound to the records, which also allows easier syntax (simply giving the function name).

https://github.com/odoo/enterprise/pull/100237

task-4676427
task-4676467
task-4676469
task-4775128