### PR TITLE
[FIX] website: only translate views for websites

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -436,7 +436,7 @@ class Web_Editor(http.Controller):
             dict: views, scss, js
         """
         # Related views must be fetched if the user wants the views and/or the style
-        views = request.env["ir.ui.view"].with_context(no_primary_children=True, __views_get_original_hierarchy=[]).get_related_views(key, bundles=bundles)
+        views = request.env["ir.ui.view"].with_context(no_primary_children=True, __views_get_original_hierarchy=[], is_customization_code=False).get_related_views(key, bundles=bundles)
         views = views.read(['name', 'id', 'key', 'xml_id', 'arch', 'active', 'inherit_id'])
 
         scss_files_data_by_bundle = []

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -727,7 +727,7 @@ class Website(Home):
 
     @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True)
     def get_switchable_related_views(self, key):
-        views = request.env["ir.ui.view"].get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
+        views = request.env["ir.ui.view"].with_context(is_customization_code=False).get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
         views = views.sorted(key=lambda v: (v.inherit_id.id, v.name))
         return views.with_context(display_website=False).read(['name', 'id', 'key', 'xml_id', 'active', 'inherit_id'])
 

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -270,10 +270,10 @@ class View(models.Model):
         # get_related_views can be called through website=False routes
         # (e.g. /web_editor/get_assets_editor_resources), so website
         # dispatch_parameters may not be added. Manually set
-        # website_id. (It will then always fallback on a website, this
-        # method should never be called in a generic context, even for
-        # tests)
-        current_website = self.env['website'].get_current_website()
+        # website_id. (In the website environment, this method should
+        # never be called in a generic context, even for tests)
+        is_customization_code = self._context.get('is_customization_code', True)
+        current_website = self.env['website'].get_current_website(fallback=is_customization_code)
         return super(View, self.with_context(
             website_id=current_website.id
         )).get_related_views(key, bundles=bundles).with_context(

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1041,6 +1041,20 @@ class TestCowViewSaving(TestViewSavingCommon):
         self.assertEqual(specific_view.with_context(lang='es_ES').arch, '<div>hola</div>',
                          "loading module translation for a specific language should not remove existing translations for other languages")
 
+    def test_view_translation_without_website(self):
+        # When get_related_views is called with no website in the
+        # context, the returned views should not be translated.
+        # All get_related_views calls in website should have a website
+        # in the context, however this is tested to simulate the
+        # behavior when called by other modules.
+        fr_BE = self.env['res.lang']._activate_lang('fr_BE')
+        self.env['website'].browse(1).default_lang_id = fr_BE
+        self.base_view.with_context(lang='en_US').arch_db = '<div>hello</div>'
+        self.base_view.update_field_translations('arch_db', {'fr_BE': {'hello': 'bonjour'}})
+
+        views = self.env['ir.ui.view'].with_context(is_customization_code=False).get_related_views(self.base_view.key)
+        self.assertEqual(views.browse(self.base_view.id).arch, '<div>hello</div>')
+
     def test_view_to_translate_tag(self):
         fr_BE = self.env['res.lang']._activate_lang('fr_BE')
         self.base_view.with_context(lang='en_US').arch_db = '<div>hello</div>'


### PR DESCRIPTION
Problem: When opening the Studio XML editor when Website is installed, the
translation terms corresponding to the Default Language of the first
website in the database are used. This behavior should only be applied
to the HTML/CSS Editor in Website.

Purpose: Modify Website's override of get_related_views to only return
translated views when called with a specific website in context.
This is done here by adding a context flag, as to not interfere with
customizations made in stable versions. This will be changed for master.

Steps to Reproduce in Runbot:

1. Activate a non-English (US) language.
2. Add this language to the Website with the lowest ID in the database,
   then set it to the Default Language of the Website.
3. Enter Studio and navigate to a view that has translation terms in its
   view (ex. Invoice PDF Report), then open the XML editor.

opw-5136124