### PR TITLE
[I18N] l10n_id_efaktur_coretax,l10n_sa: fix corrupt POT files

### DIFF
--- a/addons/l10n_id_efaktur_coretax/i18n/l10n_id_efaktur_coretax.pot
+++ b/addons/l10n_id_efaktur_coretax/i18n/l10n_id_efaktur_coretax.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-17 07:58+0000\n"
-"PO-Revision-Date: 2025-11-17 07:58+0000\n"
+"POT-Creation-Date: 2025-11-23 19:00+0000\n"
+"PO-Revision-Date: 2025-11-23 19:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -665,58 +665,6 @@ msgstr ""
 #. module: l10n_id_efaktur_coretax
 #. odoo-python
 #: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-msgid "Invoice %s does not contain any taxes"
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-msgid ""
-"Invoice %s doesn't contain the Additional info and Facility Stamp yet (Kode "
-"07)"
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-msgid ""
-"Invoice %s doesn't contain the Additional info and Facility Stamp yet (Kode "
-"08)"
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-msgid "Invoice %s is in draft state"
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-msgid "Invoice %s is not under Indonesian company"
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#: model:ir.model.fields,field_description:l10n_id_efaktur_coretax.field_res_partner__l10n_id_kode_transaksi
-#: model:ir.model.fields,field_description:l10n_id_efaktur_coretax.field_res_users__l10n_id_kode_transaksi
-msgid "Invoice Transaction Code"
-
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-#, python-format
-msgid "Invoice %s: can only have one STLG group."
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-#, python-format
-msgid "Invoice %s: can only have one tax group (excluding STLG)."
-msgstr ""
-
-#. module: l10n_id_efaktur_coretax
-#. odoo-python
-#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
 msgid ""
 "Invoice %(inv)s: line '%(line)s' contains both Luxury-Goods and Non-Luxury-"
 "Goods taxes."
@@ -751,6 +699,58 @@ msgstr ""
 #: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
 msgid ""
 "Invoice %(inv)s: transaction code %(kode)s must always have tax amount 0%%."
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid "Invoice %s does not contain any taxes"
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid ""
+"Invoice %s doesn't contain the Additional info and Facility Stamp yet (Kode "
+"07)"
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid ""
+"Invoice %s doesn't contain the Additional info and Facility Stamp yet (Kode "
+"08)"
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid "Invoice %s is in draft state"
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid "Invoice %s is not under Indonesian company"
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid "Invoice %s: can only have one STLG group."
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#. odoo-python
+#: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
+msgid "Invoice %s: can only have one tax group (excluding STLG)."
+msgstr ""
+
+#. module: l10n_id_efaktur_coretax
+#: model:ir.model.fields,field_description:l10n_id_efaktur_coretax.field_res_partner__l10n_id_kode_transaksi
+#: model:ir.model.fields,field_description:l10n_id_efaktur_coretax.field_res_users__l10n_id_kode_transaksi
+msgid "Invoice Transaction Code"
 msgstr ""
 
 #. module: l10n_id_efaktur_coretax
@@ -925,7 +925,6 @@ msgstr ""
 #. module: l10n_id_efaktur_coretax
 #. odoo-python
 #: code:addons/l10n_id_efaktur_coretax/models/account_move_line.py:0
-#, python-format
 msgid "Price for line '%s' cannot be a negative amount. Please check again."
 msgstr ""
 
@@ -1059,7 +1058,6 @@ msgstr ""
 #. module: l10n_id_efaktur_coretax
 #. odoo-python
 #: code:addons/l10n_id_efaktur_coretax/models/account_move.py:0
-#, python-format
 msgid "Unable to download E-faktur for the following reason(s):"
 msgstr ""
 

--- a/addons/l10n_sa/i18n/l10n_sa.pot
+++ b/addons/l10n_sa/i18n/l10n_sa.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-03 15:46+0000\n"
-"PO-Revision-Date: 2025-11-03 15:46+0000\n"
+"POT-Creation-Date: 2025-11-23 19:00+0000\n"
+"PO-Revision-Date: 2025-11-23 19:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -456,15 +456,15 @@ msgid "Withholding Tax on Purchased Services (Tax)"
 msgstr ""
 
 #. module: l10n_sa
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+msgid "ZATCA Issue Date"
+msgstr ""
+
+#. module: l10n_sa
 #: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_qr_code_str
 #: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_qr_code_str
 msgid "Zatka QR Code"
-
-#. module: l10n_sa
-#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
-#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
-#: model:ir.model.fields,field_description:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
-msgid "ZATCA Issue Date"
 msgstr ""
 
 #. module: l10n_sa


### PR DESCRIPTION
Two forward-port commits[^1],[^2] corrupted the POT files of these modules. They both resulted in missing `msgstr` entries causing the `msgmerge` in Weblate to fail.

This commit regenerates the POT files to fix the issue.

[^1]: https://github.com/odoo/odoo/commit/4e51a4a259bbb36dbbd7f6aa59ba30280f97cd89
[^2]: https://github.com/odoo/odoo/commit/f3286d792e17746d2330b5e06d5c5c8e01c52928