### PR TITLE
[IMP] hr{,_presence}: add launch plan and presence control

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -585,7 +585,10 @@
             <field name="model">hr.employee</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <kanban class="o_hr_employee_kanban" sample="1" duplicate="false">
+                <kanban class="o_hr_employee_kanban" sample="1" duplicate="false" js_class="hr_employee_kanban">
+                    <header>
+                        <button name="%(plan_wizard_action)d" string="Launch Plan" type="action" groups="hr.group_hr_user"/>
+                    </header>
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <field name="company_id"/>

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -80,7 +80,6 @@ class HrEmployee(models.Model):
         server_action_xmlids = [
             'action_hr_employee_presence_present',
             'action_hr_employee_presence_absent',
-            'action_hr_employee_presence_log',
             'action_hr_employee_presence_sms',
             'action_hr_employee_presence_time_off',
         ]
@@ -158,16 +157,6 @@ Thank you for your prompt attention to this matter.""")
             "name": self.env._("Send SMS"),
             "target": "new",
         }
-
-    def action_send_log(self):
-        if not self.env.user.has_group('hr.group_hr_manager'):
-            raise UserError(_("You don't have the right to do this. Please contact an Administrator."))
-
-        for employee in self:
-            employee.message_post(body=_(
-                "%(name)s has been noted as %(state)s today",
-                name=employee.name,
-                state=employee.hr_presence_state_display))
 
     @api.depends("user_id.im_status", "hr_presence_state_display")
     def _compute_presence_state(self):

--- a/addons/hr_presence/static/src/views/hr_presence_kanban_view.js
+++ b/addons/hr_presence/static/src/views/hr_presence_kanban_view.js
@@ -1,0 +1,10 @@
+import { patch } from "@web/core/utils/patch";
+import { EmployeeKanbanController } from '@hr/views/kanban_view';
+import { HrPresenceActionMenus } from "../search/hr_presence_action_menus/hr_presence_action_menus";
+
+patch(EmployeeKanbanController, {
+    components: {
+        ...EmployeeKanbanController.components,
+        ActionMenus: HrPresenceActionMenus,
+    },
+});

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -39,22 +39,9 @@
         </field>
     </record>
 
-    <record id="action_hr_employee_presence_log" model="ir.actions.server">
-        <field name="name">Add a log note</field>
-        <field name="model_id" ref="hr.model_hr_employee"/>
-        <field name="value">presence_group_2</field>
-        <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="binding_view_types">form,list,kanban</field>
-        <field name="state">code</field>
-        <field name="code">
-            action = records.action_send_log()
-        </field>
-    </record>
-
     <record id="action_hr_employee_presence_sms" model="ir.actions.server">
         <field name="name">Send a SMS</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
-        <field name="value">presence_group_2</field>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
         <field name="binding_view_types">form,list,kanban</field>
         <field name="state">code</field>


### PR DESCRIPTION
Before:
- Employee kanban view did not include "Launch Plan" and "Presence Control" buttons.
- "Add a log note" option was visible.
- "Send SMS" was not located in the actions menu.

After:
- Added "Launch Plan" and "Presence Control" buttons to the employee kanban view, consistent with the list view behavior.
- Removed the "Add a log note" option.
- Moved "Send SMS" to the actions button.

Task-5163917
