### PR TITLE
[FIX] point_of_sale: guarantee payments order in sales details report

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -107,6 +107,7 @@ class ReportSaleDetails(models.AbstractModel):
                 WHERE payment.payment_method_id = method.id
                     AND payment.id IN %s
                 GROUP BY method.name, method.is_cash_count, payment.session_id, method.id, journal_id
+                ORDER BY method.id, payment.session_id
             """, (self.env.lang, tuple(payment_ids),))
             payments = self.env.cr.dictfetchall()
         else:


### PR DESCRIPTION
Before this commit, payment order was not guaranteed and could confuse users reviewing sales details report, especially as the cash register lines are ordered before. This commit orders the results by payment method and session to make the output more readable.

opw-5240864
