### PR TITLE
[FIX] base, l10n_tr_nilvera: update translations when installing language

### DIFF
--- a/addons/l10n_tr_nilvera/__init__.py
+++ b/addons/l10n_tr_nilvera/__init__.py
@@ -2,7 +2,7 @@ from . import models
 
 
 def _l10n_tr_nilvera_post_init(env):
-    env["res.lang"]._activate_lang("tr_TR")
+    env["res.lang"]._activate_and_install_lang("tr_TR")
 
 
 def uninstall_hook(env):

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -159,6 +159,16 @@ class Lang(models.Model):
             lang.active = True
         return lang
 
+    def _activate_and_install_lang(self, code):
+        """ Activate languages and update their translations
+        :param code: code of the language to activate
+        :return: the language matching 'code' activated
+        """
+        lang = self.with_context(active_test=False).search([('code', '=', code)])
+        if lang and not lang.active:
+            lang.toggle_active()
+        return lang
+
     def _create_lang(self, lang, lang_name=None):
         """ Create the given language and make it active. """
         # create the language with locale information


### PR DESCRIPTION
### Issue:
When installing "l10n_tr_nilvera" on a new DB the Turkish language is installed but
the translation of previously installed modules are not updated.

### Steps to reproduce:
- Install 'l10n_tr_nilvera' and switch to a Saudi company
- Check the view "report_invoice_document"
- Click the translation icon on the view
- No Turkish translations are loaded

### Cause:
When installing "l10n_gcc_invoice" the Arabic language is installed ([src](https://github.com/odoo/odoo/blob/70404624d7ea6f971182cbe4f4fe8fc064d2afd8/addons/l10n_gcc_invoice/__init__.py#L4-L5)). But the method [`_activate_lang()`](https://github.com/odoo/odoo/blob/70404624d7ea6f971182cbe4f4fe8fc064d2afd8/odoo/addons/base/models/res_lang.py#L161-L169) only activates the language, it does not update the translations.

### Solution:
Create a new method that activate the language and calls `_update_translations()` on the installed modules.

opw-5219783