### PR TITLE
[FIX] html_editor: prevent selection placeholder in button or link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -49,6 +49,16 @@ export class LinkSelectionPlugin extends Plugin {
         normalize_handlers: () => this.resetLinkInSelection(),
         feff_providers: this.addFeffsToLinks.bind(this),
         system_classes: ["o_link_in_selection"],
+        selection_placeholder_container_predicates: (container) => {
+            if (container.nodeName === "BUTTON" || container.nodeName === "A") {
+                // We sometimes have buttons or links that are blocks with
+                // contenteditable=true but we never want to insert a paragraph
+                // in them.
+                // Note: this can be removed if `allowsParagraphRelatedElements`
+                // is adapted to return false in these cases.
+                return false;
+            }
+        },
     };
 
     addFeffsToLinks(root, cursors) {

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -381,3 +381,12 @@ describe("button edit", () => {
         );
     });
 });
+
+test("button should never contain selection placeholder", async () => {
+    await testEditor({
+        contentBefore:
+            '<button style="display: block" contenteditable="true"><div style="display: block" contenteditable="false">a</div></button>',
+        contentBeforeEdit:
+            '<button style="display: block" contenteditable="true"><div style="display: block" contenteditable="false">a</div></button>',
+    });
+});


### PR DESCRIPTION
The "add to cart" button in the showcase view of products in website_sale is a block with `contenteditable=true` and a selection placeholder was inserted in it, messing up its layout (alignment). It shouldn't be there in the first place, as buttons and links are not meant to contain paragraphs. This commit prevents the insertion of selection placeholders in buttons and links.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
