### PR TITLE
[FIX] analytic: Display adequate rounding

### DIFF
--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -26,6 +26,7 @@ class AccountAnalyticLine(models.Model):
         'Amount',
         required=True,
         default=0.0,
+        currency_field='currency_id',
     )
     unit_amount = fields.Float(
         'Quantity',


### PR DESCRIPTION
Before this commit, analytic lines amount would be displayed in the UI with a rounding of 2 digits, independently from the actual rounding setting of the currency.

opw-5251793