### PR TITLE
[FIX] hr_work_entry_holidays: Fix test_reset_leave_work_entries

### DIFF
--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -193,7 +193,9 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         self.employee_external.resource_calendar_id.company_id = False
         work_entries = self.employee_external.generate_work_entries(self.start.date(), self.end.date())
         work_entries.action_validate()
-        leave = self.create_leave(datetime.today(), datetime.today(), employee_id=self.employee_external.id)
+        leave_start_date = datetime(2025, 11, 24, 8)
+        leave_end_date = datetime(2025, 11, 24, 17)
+        leave = self.create_leave(leave_start_date, leave_end_date, employee_id=self.employee_external.id)
         leave.with_user(self.env.user).action_approve()
         leave_resource_calendar_leave = self.env['resource.calendar.leaves'].search([('holiday_id', '=', leave.id)])
 
@@ -202,7 +204,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         self.assertIsNotNone(leave_work_entry)
 
         self.env["hr.work.entry.regeneration.wizard"].regenerate_work_entries(
-            slots=[{"date": datetime.today(), "employee_id": self.employee_external.id}],
+            slots=[{"date": leave_start_date, "employee_id": self.employee_external.id}],
             record_ids=leave_work_entry.ids,
         )
         leave_work_entry = self.env['hr.work.entry'].search([('employee_id', '=', self.employee_external.id), ('work_entry_type_id', '=', leave.holiday_status_id.work_entry_type_id.id)])


### PR DESCRIPTION
In this commit, we fixed the failed runbot test test_reset_leave_work_entries. The test is failing during weekends since we are requesting and approving leaves using datetime.now(). As a fix, we choose a specific date for the leave (non weekend date).

task-5353513.
Related to 247070 (runbot errorr)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
