### PR TITLE
[IMP] account: Allow importing move lines with inactive accounts

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1231,7 +1231,7 @@ class AccountMoveLine(models.Model):
             account = line.account_id
             journal = line.move_id.journal_id
 
-            if account.deprecated and not self.env.context.get('skip_account_deprecation_check'):
+            if account.deprecated and not (line.is_imported or self.env.context.get('skip_account_deprecation_check')):
                 raise UserError(_('The account %(name)s (%(code)s) is deprecated.', name=account.name, code=account.code))
 
             account_currency = account.currency_id


### PR DESCRIPTION
When importing journal items, if an item targets an inactive account, the import is causing an excessive error. 

We shall ignore the active/inactive flag in such a case. 

task-5350113


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
