### PR TITLE
[FIX] web: Prevent record selector caret from changing width

### DIFF
--- a/addons/web/static/src/core/record_selectors/record_selectors.scss
+++ b/addons/web/static/src/core/record_selectors/record_selectors.scss
@@ -10,11 +10,14 @@
     .o_record_autocomplete_with_caret {
         display: flex;
         min-width: 100%;
+        position: relative;
 
         &:hover, &:focus-within {
             &::after {
                 @include o-caret-down;
                 align-self: center;
+                position: absolute;
+                right: .5rem;
             }
         }
     }


### PR DESCRIPTION
This commit fixes an issue where, when visible, the caret of the record
selector component would take space and thus change the width of the input.

Task: [5354466](https://www.odoo.com/odoo/project/133/tasks/5354466)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
