### PR TITLE
[FIX] stock: correct ordered quantity for MTO backorders

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -907,10 +907,10 @@ class StockMoveLine(models.Model):
                     qty_ordered = move_line.move_id.product_uom_qty
                     # Filters on the aggregation key (product, description and uom) to add the
                     # quantities delayed to backorders to retrieve the original ordered qty.
-                    following_move_lines = backorders.move_line_ids.filtered(
-                        lambda ml: line_key.startswith(self._get_aggregated_properties(move=ml.move_id)['line_key'])
+                    following_moves = backorders.move_ids.filtered(
+                        lambda m: line_key.startswith(self._get_aggregated_properties(move=m)['line_key'])
                     )
-                    qty_ordered += sum(following_move_lines.move_id.mapped('product_uom_qty'))
+                    qty_ordered += sum(following_moves.mapped('product_uom_qty'))
                     # Remove the done quantities of the other move lines of the stock move
                     previous_move_lines = move_line.move_id.move_line_ids.filtered(
                         lambda ml: line_key.startswith(self._get_aggregated_properties(move=ml.move_id)['line_key']) and ml.id != move_line.id


### PR DESCRIPTION
Steps To Reproduce
------------------
1- Create an MTO product.
2- Create an SO for 10 units and confirm.
3- Deliver 5 on the first picking, validate, and create the backorder. 
4- Print the delivery slip of the first (done) picking.

Issue
-----
1- MTO: Ordered = 5, Delivered = 5, Remaining = 5.
2- Normal product: Ordered = 10, Delivered = 5, Remaining = 5.
The ordered quantity for MTO products is wrong, it shows the delivered amount instead of the original order total.

Cause
-----
The delivery report calculates the "Ordered" quantity by adding what we just delivered to what is left in the backorders. I found that the code was looking for move lines in the backorders to count what is left. When I checked a backorder that is waiting for stock (like MTO), there is no reserved stock yet, so no move lines exist. Because of this, the report thought the backorder was empty and ignored the remaining quantity.

Fix
---
I changed the code to look at the `move_ids` instead of the `move_line_ids`. While debugging I found out that the `move_ids` record always holds the correct demand regardless of the product.

opw-5112467

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
