### PR TITLE
[IMP] web: Adding hide option for properties field.

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -324,6 +324,7 @@ export class PropertiesField extends Component {
                     name: property.name,
                     elements: [],
                     isFolded: property.value ?? property.fold_by_default,
+                    hidden: property.hidden,
                 });
             } else {
                 groupedProperties.at(-1).elements.push(property);

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -9,7 +9,7 @@
                 <div class="o_inner_group o_group col-lg-6 o_property_group"
                     t-att-property-name="propertiesListGroup.name || ''">
                     <div t-if="!propertiesListGroup.invisibleLabel" class="g-col-sm-2">
-                        <div class=" o_field_property_label o_field_property_group_label d-flex flex-row mb-3 mt-4 text-uppercase fw-bolder align-items-baseline small w-100"
+                        <div t-if="!propertiesListGroup.hidden" class=" o_field_property_label o_field_property_group_label d-flex flex-row mb-3 mt-4 text-uppercase fw-bolder align-items-baseline small w-100"
                             t-att-class="{'invisible': propertiesListGroup.columnSeparator, 'folded': propertiesListGroup.isFolded}"
                             t-on-click="() => this.onSeparatorClick(propertiesListGroup.name)">
                             <div t-if="foldable" class="me-2">
@@ -28,6 +28,7 @@
                         t-foreach="propertiesListGroup.elements"
                         t-as="propertyConfiguration"
                         t-key="propertyConfiguration.name"
+                        t-if="!propertyConfiguration.hidden"
                         class="o_property_field o_wrap_label text-900"
                         t-att-class="{
                             'd-flex flex-row': !env.isSmall and !propertiesListGroup.isFolded, 'o_property_folded': propertiesListGroup.isFolded,


### PR DESCRIPTION
In this commit, we added the hide property to the properties fields. This is usefull when archiving salary rules to hide them from the employee's payroll tabs without deleting them. We also included the hide_properties and show_properties method to toggle the hidden state of the current property including its related separator.

When we archive a property, it should be hidden, and if its related separator doesn't contain anymore visible properties, we hide it too.

task-5135933.

Related PR: https://github.com/odoo/enterprise/pull/96304

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
