### PR TITLE
[IMP] account,l10n_ma: Add ICE number to invoicing

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -22,6 +22,9 @@
                                     <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                                     <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
                                 </div>
+                                <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                                    ICE: <a t-field="o.partner_id.company_registry"/>
+                                </div>
                             </t>
                         </div>
                     </t>
@@ -33,6 +36,9 @@
                                     <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                                     <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
                                 </div>
+                                <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                                    ICE: <a t-field="o.partner_id.company_registry"/>
+                                </div>
                             </t>
                         </div>
                     </t>
@@ -43,6 +49,9 @@
                                 <div t-if="o.partner_id.vat" id="partner_vat_no_shipping">
                                     <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                                     <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                                </div>
+                                <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                                    ICE: <a t-field="o.partner_id.company_registry"/>
                                 </div>
                             </t>
                         </div>

--- a/addons/l10n_ma/__init__.py
+++ b/addons/l10n_ma/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/addons/l10n_ma/__manifest__.py
+++ b/addons/l10n_ma/__manifest__.py
@@ -24,6 +24,8 @@ Seddik au cours du troisième trimestre 2010.""",
         'data/account_tax_report_data.xml',
         'data/account_tax_data.xml',
         'data/account_chart_template_data.xml',
+        'views/res_partner_views.xml',
+        'views/res_company_views.xml',
     ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_ma/models/__init__.py
+++ b/addons/l10n_ma/models/__init__.py
@@ -1,0 +1,2 @@
+from . import base_document_layout
+from . import res_partner

--- a/addons/l10n_ma/models/base_document_layout.py
+++ b/addons/l10n_ma/models/base_document_layout.py
@@ -1,0 +1,15 @@
+from markupsafe import Markup
+
+from odoo import api, models
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_company_details(self):
+        # OVERRIDE web/models/base_document_layout
+        company_details = super()._default_company_details()
+        if self.env.company.country_code == 'MA':
+            company_details += Markup('<br> ICE: %s') % self.env.company.company_registry
+        return company_details

--- a/addons/l10n_ma/models/res_partner.py
+++ b/addons/l10n_ma/models/res_partner.py
@@ -1,0 +1,12 @@
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = ['res.partner']
+
+    @api.constrains('company_registry', 'country_id')
+    def _check_company_registry_ma(self):
+        for record in self:
+            if record.country_code == 'MA' and record.company_registry and (len(record.company_registry) != 15 or not record.company_registry.isdigit()):
+                raise ValidationError(_("ICE number should have exactly 15 digits."))

--- a/addons/l10n_ma/views/res_company_views.xml
+++ b/addons/l10n_ma/views/res_company_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">res.company.form.inherit.l10n_ma</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_registry']" position="attributes">
+                <attribute name="nolabel">1</attribute>
+            </xpath>
+            <field name="company_registry" position="before">
+                <label for="company_registry" attrs="{'invisible': [('country_code', '=', 'MA')]}" />
+                <label for="company_registry" string="ICE" attrs="{'invisible': [('country_code', '!=', 'MA')]}" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ma/views/res_partner_views.xml
+++ b/addons/l10n_ma/views/res_partner_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit.l10n_ma</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="company_registry" string="ICE" attrs="{'invisible': [('country_code', '!=', 'MA')]}"></field>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Backport ICE number from 18.0 to 16.0: f9d00e684b3fa395a33ae4b5b795d9fc6e4fcf0e

Reason: The ICE (Identifiant Commun de l'Entreprise) is an identification number assigned to businesses and legal entities for various administrative and legal purposes in Morocco. If the partner has one, it must be indicated on the invoice.

The ICE number is supposed to be put on all the invoices made to Moroccan companies, whatever the country of the company issuing those invoices. We hence add that directly into the account module.

task-4879950




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
