### PR TITLE
[FIX] account_peppol: fix syntax issue for Python3.7

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -161,7 +161,7 @@ class TestPeppolMessage(AccountTestInvoicingCommon):
         self.env.context = previous_context
 
     @classmethod
-    def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
+    def _request_handler(cls, s: Session, r: PreparedRequest, **kw):
         response = Response()
         response.status_code = 200
 

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -58,7 +58,7 @@ class TestPeppolParticipant(TransactionCase):
         }
 
     @classmethod
-    def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
+    def _request_handler(cls, s: Session, r: PreparedRequest, **kw):
         response = Response()
         response.status_code = 200
 


### PR DESCRIPTION
The minimal supported version in Odoo 16 is Python3.7 https://github.com/odoo/odoo/blob/6f40f3a85d4c6edf43a427d8575c5c95c3005cd4/odoo/__init__.py#L19

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
