### PR TITLE
[FIX] web: RPCCache: delete db on QuotaExceededError

### DIFF
--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -8,18 +8,18 @@ export function mockIndexedDB(_name, { fn }) {
                 this.mockIndexedDB = {};
             }
 
-            write(table, key, value) {
+            async write(table, key, value) {
                 if (!(table in this.mockIndexedDB)) {
                     this.mockIndexedDB[table] = {};
                 }
                 this.mockIndexedDB[table][key] = value;
             }
 
-            read(table, key) {
-                return Promise.resolve(this.mockIndexedDB[table]?.[key]);
+            async read(table, key) {
+                return this.mockIndexedDB[table]?.[key];
             }
 
-            invalidate(tables = null) {
+            async invalidate(tables = null) {
                 if (tables) {
                     tables = typeof tables === "string" ? [tables] : tables;
                     for (const table of tables) {


### PR DESCRIPTION
Writing in indexeddb can throw a QuotaExceededError (or a DOMError with QuotaExceededError message in firefox). Before this commit, this error was basically ignored, so it wasn't shown to the user, but from that point, all writes in idb would fail with that same error, until a database schema change or an hard reload.

This commit handles the error quite radically: when it is thrown, we delete the rpc database to start over. More elaborated strategies could be considered, like removing oldest entries, but we decided to go for the simplest solution. In master, we may introduce a more complex garbage collect strategy as for the offline mode, it might be interesting to keep some entries alive. In 19.0 though, the caches are only used to speed up the webclient, so it's not an issue to clear them completely and start over.

We also want to avoid Odoo to use an unreasonable disk space. However, the storage capacity depends on the browser (e.g. 10Gb on firefox, up to 60% of disk space on chrome). To prevent Odoo from taking tens or hundreds of gigabytes on the user's disks, we limit the storage to 2Gb.

Task~5217456

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
