### PR TITLE
[FIX] web: prevent traceback when opening file viewer repeatedly

### DIFF
--- a/addons/web/static/src/core/file_viewer/file_viewer_hook.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer_hook.js
@@ -11,6 +11,7 @@ export function createFileViewer() {
      * @param {import("@web/core/file_viewer/file_viewer").FileViewer.props.files} files
      */
     function open(file, files = [file]) {
+        close();
         if (!file.isViewable) {
             return;
         }


### PR DESCRIPTION
Before this commit, quickly triggering the opening of the file viewer multiple times (e.g. double-click on an attachment) caused a crash.

This happens because the `createFileViewer` hook generates a `fileViewerId` on initialization. When `open()` is called, it registers the component using this specific ID. If `open()` is triggered a second time while the component is still registered (or being registered), the registry throws an error because duplicate keys are not allowed.

This commit fixes the issue by calling `close()` at the beginning of the `open()` function. This ensures that any existing `FileViewer` instance associated with this hook is removed from the registry before a new one is added.

task-5262556