### PR TITLE
[FIX] mail: fix avatar card test with demo data

### DIFF
--- a/addons/test_discuss_full/tests/test_avatar_card_tour.py
+++ b/addons/test_discuss_full/tests/test_avatar_card_tour.py
@@ -119,6 +119,8 @@ class TestAvatarCardTour(MailCommon, HttpCase):
 
     @users("admin", "hr_user")
     def test_avatar_card_tour_multi_company(self):
+        # Clear existing activities to avoid interference with the test
+        self.env["mail.activity"].with_user(self.env.user).search([]).unlink()
         self._setup_channel(self.env.user)
         self.start_tour(
             f"/odoo/res.partner/{self.user_employee_c2.partner_id.id}",


### PR DESCRIPTION
Before this commit, the admin user had some pre-defined activites when installed with demo data, this was interfering with the test since it is using the count of activities to ensure the correct functioning of the multi-company activities.

Now, we simply unlink all activities in the setup of the test to ensure its stability.

fixes-runbot-234343

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
