### PR TITLE
[FIX] html_editor: disable image resize options in Studio reports

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -133,6 +133,7 @@ export class ImagePlugin extends Plugin {
                 title: _t("Resize Default"),
                 text: _t("Default"),
                 isActive: () => this.hasImageSize(""),
+                isAvailable: () => this.config.allowImageResize ?? true,
             },
             {
                 id: "resize_100",
@@ -142,6 +143,7 @@ export class ImagePlugin extends Plugin {
                 title: _t("Resize Full"),
                 text: "100%",
                 isActive: () => this.hasImageSize("100%"),
+                isAvailable: () => this.config.allowImageResize ?? true,
             },
             {
                 id: "resize_50",
@@ -151,6 +153,7 @@ export class ImagePlugin extends Plugin {
                 title: _t("Resize Half"),
                 text: "50%",
                 isActive: () => this.hasImageSize("50%"),
+                isAvailable: () => this.config.allowImageResize ?? true,
             },
             {
                 id: "resize_25",
@@ -160,6 +163,7 @@ export class ImagePlugin extends Plugin {
                 title: _t("Resize Quarter"),
                 text: "25%",
                 isActive: () => this.hasImageSize("25%"),
+                isAvailable: () => this.config.allowImageResize ?? true,
             },
             {
                 id: "image_transform",


### PR DESCRIPTION
Problem:
When resizing an image in Studio within any report, the change is not reflected in the generated PDF. This happens because `wkhtmltopdf` does not support percentage-based `width` / `height` values, which are used by the resize tool (e.g., `width: 25%`).

Solution:
Disable the image resize option in Studio when editing reports, since the resulting `%` sizing cannot be rendered correctly in PDFs.

Steps to reproduce:
1. Open Studio → Reports → open any report.
2. Add an image.
3. Resize it to 25%.
4. Save and print the PDF.
5. The image appears at its original size in the PDF.

opw-5233052

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
