### PR TITLE
[FIX] account: prevent wrong layout of invoice in pdf

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -330,10 +330,13 @@
                                                     t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                                     <span t-if="not hide_prices" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
                                                 </td>
-                                                <td name="td_discount_grouped" t-if="display_discount and grouped_line['display_type'] == 'product'" colspan="1" class="d-none d-md-table-cell"/>
+                                                <td name="td_discount_grouped"
+                                                    t-if="display_discount and grouped_line['display_type'] == 'product'"
+                                                    colspan="1"
+                                                    t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"/>
                                                 <td name="td_taxes_grouped"
                                                     colspan="1"
-                                                    t-if="(display_taxes and grouped_line['display_type'] in ('line_section', 'line_subsection') and grouped_line.get('taxes')) or grouped_line['display_type'] == 'product'"
+                                                    t-if="display_taxes and (grouped_line['display_type'] == 'product' or grouped_line.get('taxes'))"
                                                     t-attf-class="text-end {{'d-none d-md-table-cell' if report_type == 'html' else ''}}">
                                                     <span t-if="grouped_line.get('taxes')" t-out="','.join(grouped_line['taxes'])" id="grouped_line_tax_ids">Tax 15%</span>
                                                 </td>


### PR DESCRIPTION
**Steps to produce:**
- Install `Accounting` module.
- Open any invoice > add product > add section > add another product after section.
- Do `not set any tax` on both products > go to 3 dots of section > click on `Hide composition`.
- Print the invoice.

**Isuue:**
- The tax column displayed even if there is no tax.

**Root cause:**
- At [1], `display_taxes` is checked in first condition but not in OR condition.

**Solution:**
- We first check `display_taxes` and then other conditions.

[1]: https://github.com/odoo/odoo/blob/90a4e374d49fd482257b52b8a8c12c09d07daa1d/addons/account/views/report_invoice.xml#L336

Before:
<img width="500" height="500" alt="report_invoice_before" src="https://github.com/user-attachments/assets/215e76ba-ab4c-4704-9878-e63af3a4329b" />
After:
<img width="500" height="500" alt="report_invoice_after" src="https://github.com/user-attachments/assets/25706fdc-2f3a-4135-95d9-c344d1339c36" />

**opw-5268098**