### PR TITLE
[FIX] account: don't show entries in filtered invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1622,14 +1622,15 @@
                     <filter string="To Check" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
                     <!-- not_paid & partial -->
-                    <filter name="open" string="To pay" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial'))]"/>
+                    <filter name="open" string="To pay" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial')), ('move_type', '!=', 'entry')]"/>
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->
                     <filter name="late" string="Overdue" domain="[
                         ('invoice_date_due', '&lt;', time.strftime('%Y-%m-%d')),
                         ('state', '=', 'posted'),
-                        ('payment_state', 'in', ('not_paid', 'partial'))
+                        ('payment_state', 'in', ('not_paid', 'partial')),
+                        ('move_type', '!=', 'entry')
                     ]" help="Overdue invoices, maturity date passed"/>
                     <separator/>
                     <filter name="invoice_date" string="Invoice Date" date="invoice_date"/>


### PR DESCRIPTION
Error steps:
- Create or import "miscellaneous" entries in a sales journal (through the FEC import e.g.)
- Have at least one late or unpaid invoice in the same journal.
- The journal dashboard view should display a "X Unpaid" or "X Late" suggestion -> click on it
=> The filtered view shows the correct unpaid or overdue invoices/bills AS WELL as the imported entries, even if the latter are fully reconciled already.

Now the filters correctly filter out the entries.

opw-5215997