### PR TITLE
[IMP] account: Improve tooltip for Prices setting

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -56,7 +56,7 @@
                                     <div class="row">
                                         <div class="col-lg-3">
                                             <label string="Prices" for="account_price_include" class="o_light_label"/>
-                                            <div class="fa fa-question-circle" title="This setting cannot be changed after an invoice is created."/>
+                                            <div class="fa fa-question-circle" title="This setting locks once a journal entry is created."/>
                                         </div>
                                         <field name="account_price_include" readonly="has_accounting_entries"/>
                                     </div>


### PR DESCRIPTION
This commit improves the tooltip of the Prices setting in configuration. The old tooltip
"This setting cannot be changed after an invoice is created." is changed to
"This setting locks once a journal entry is created."

task-5354382





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
