### PR TITLE
[FIX] stock_account: prevent error when click on Adjust Valuation button

### DIFF
--- a/addons/stock_account/models/product_value.py
+++ b/addons/stock_account/models/product_value.py
@@ -50,7 +50,7 @@ class ProductValue(models.Model):
 
     def _compute_current_value_details(self):
         for product_value in self:
-            if not product_value.move_id:
+            if not (product_value.move_id and product_value.move_id.quantity):
                 product_value.current_value_details = False
                 continue
             move = product_value.move_id

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2935,3 +2935,16 @@ class TestStockValuation(TestStockValuationCommon):
         move.picked = True
         move.with_user(self.inventory_user)._action_done()
         self.assertEqual(move.state, 'done')
+
+    def test_product_value_details_computation_with_move_zero_quantity(self):
+        """Test that the current value details computation is skipped when the move quantity is zero."""
+        move = self._make_in_move(self.product_avco, 0.0)
+        self.assertEqual(move.quantity, 0.0)
+
+        product_value = self.env['product.value'].create({
+            'move_id': move.id,
+            'value': move.value_manual,
+        })
+        product_value_form = Form(product_value)
+
+        self.assertFalse(product_value_form.current_value_details)


### PR DESCRIPTION
Currently, an error occurs when a user clicks on the Adjust Valuation button.

Steps to Reproduce:

 - Install the `stock_account` module.
 - Go to `Receipts` and create a `receipt` by adding a product with `zero demand`.
 - Go to `Moves Analysis` > switch to `Kanban view` and remove the `Done filter`.
 - Click on the `selected product move` > click the `gear icon` > click `Adjust Valuation`.

`ZeroDivisionError: float division by zero.`

After [this commit], when the user clicks on the Adjust Valuation button, the compute method runs to compute the current value details. When it tries to calculate the unit price based on the move quantity and value, and the quantity is zero, it raises the error[1].

This commit ensures that if the move quantity is 0, then the unit price for the current value details is also set to 0.

[this commit]: https://github.com/odoo/odoo/pull/224033/commits/e9e7a1ff63f5ee1f54d21b1768abb93a121a7a92#diff-2623d0e4c393b65afe1c6d00f55af80d19f022aaeb0da0e5e173e37a84138159R47-R57

[1]- https://github.com/odoo/odoo/blob/0581b7fb6abc8e856cedf13254ba1f9d362d6d34/addons/stock_account/models/product_value.py#L59

sentry-7059220177

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
