### PR TITLE
[IMP] account: show amount_residual_signed by default on sale/purch jrnl

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -544,7 +544,7 @@
                     <field name="amount_untaxed_in_currency_signed" string="Tax Excluded" sum="Total" optional="show"/>
                     <field name="amount_tax_signed" string="Tax" sum="Total" optional="hide"/>
                     <field name="amount_total_in_currency_signed" string="Total" sum="Total" optional="show" decoration-bf="1" decoration-warning="abnormal_amount_warning"/>
-                    <field name="amount_residual_signed" string="Amount Due" sum="Amount Due" optional="hide"/>
+                    <field name="amount_residual_signed" string="Amount Due" sum="Amount Due" optional="show"/>
                     <field name="currency_id" optional="hide" readonly="state in ['cancel', 'posted']"/>
                     <field name="company_currency_id" column_invisible="True"/>
                     <field name="review_state" optional="hide" groups="account.group_account_user"


### PR DESCRIPTION
As the title say, when coming in a sales or purchases journal, the column Amount Due should be displayed by default to show the current state of the invoices and bills, which can be partially paid.
