### PR TITLE
[FIX] web: kanban view: data-tooltip on field

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -107,6 +107,7 @@ export class KanbanCompiler extends ViewCompiler {
             compiled = createElement("span", {
                 "t-out": params.formattedValueExpr || `__comp__.getFormattedValue("${fieldId}")`,
             });
+            this.copyFieldAttributes(compiled, el);
         } else {
             compiled = super.compileField(el, params);
             const fieldId = el.getAttribute("field_id");

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -206,6 +206,7 @@ export class ViewCompiler {
             { selector: "field", fn: this.compileField },
             { selector: "widget", fn: this.compileWidget },
         ];
+        this.allowedFieldAttributes = ["data-tooltip"];
         this.templates = templates;
         this.ctx = { readonly: "__comp__.props.readonly" };
 
@@ -364,6 +365,24 @@ export class ViewCompiler {
     }
 
     /**
+     * Copies allowed attributes from a source element to a target element.
+     *
+     * For each attribute listed in `this.allowedFieldAttributes`, if the source
+     * element `el` has that attribute, its value is copied to `field`.
+     *
+     * @param {Element} field - The target DOM element to set attributes on.
+     * @param {Element} el - The source DOM element to read attributes from.
+     */
+    copyFieldAttributes(field, el) {
+        for (const attr of this.allowedFieldAttributes) {
+            const value = el.getAttribute(attr);
+            if (value !== null) {
+                field.setAttribute(attr, value);
+            }
+        }
+    }
+
+    /**
      * @param {Element} el
      * @returns {Element}
      */
@@ -382,7 +401,7 @@ export class ViewCompiler {
         if (el.hasAttribute("widget")) {
             field.setAttribute("type", `'${el.getAttribute("widget")}'`);
         }
-
+        this.copyFieldAttributes(field, el);
         return field;
     }
 

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -9652,3 +9652,25 @@ test(`groupby use odoomark`, async () => {
     expect(`.o_kanban_group b`).toHaveCount(2);
     expect(`.o_kanban_group span.o_badge`).toHaveCount(2);
 });
+
+test.tags("desktop");
+test("kanban: fields with data-tooltip attribute", async () => {
+    await mountView({
+        resModel: "partner",
+        type: "kanban",
+        arch: `
+            <kanban sample="1">
+                <templates>
+                    <t t-name="card">
+                        <field name="foo" data-tooltip="pipu" />
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+
+    expect(".o-tooltip").toHaveCount(0);
+    await hover("article:contains(gnap) span");
+    await advanceTime(500);
+    expect(".o-tooltip").toHaveCount(1);
+});

--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -67,6 +67,9 @@ registerWebsitePreviewTour(
             content: "Check that modal has disappeared",
             trigger: "body:not(:has(.modal))",
         },
+        {
+            trigger: `:iframe .o_homepage_editor_welcome_message:contains(welcome to your homepage)`,
+        },
         ...clickOnEditAndWaitEditMode(),
         getTheLayoutChildren,
         {

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2204,7 +2204,7 @@ actual arch.
                 msg = "attribute 'group' is not valid.  Did you mean 'groups'?"
                 self._log_view_warning(msg, node)
 
-            elif (re.match(r'^(t\-att\-|t\-attf\-)?data-tooltip(-template|-info)?$', attr)):
+            elif (re.match(r'^(t\-att\-|t\-attf\-)?data-tooltip(-template|-info)$', attr)):
                 self._raise_view_error(_("Forbidden attribute used in arch (%s).", attr), node)
 
             elif (attr.startswith("t-")):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3621,14 +3621,6 @@ Forbidden owl directive used in arch (t-on-click).""",
         arch = "<form>%s</form>"
 
         self.assertInvalid(
-            arch % ('<span data-tooltip="Test"/>'),
-            """Error while validating view near:
-
-<form __validate__="1"><span data-tooltip="Test"/></form>
-Forbidden attribute used in arch (data-tooltip)."""
-        )
-
-        self.assertInvalid(
             arch % ('<span data-tooltip-template="test"/>'),
             """Error while validating view near:
 
@@ -3641,27 +3633,11 @@ Forbidden attribute used in arch (data-tooltip-template)."""
         arch = "<kanban><templates><t t-name='card'>%s</t></templates></kanban>"
 
         self.assertInvalid(
-            arch % ('<span data-tooltip="Test"/>'),
-            """Error while validating view near:
-
-<kanban __validate__="1"><templates><t t-name="card"><span data-tooltip="Test"/></t></templates></kanban>
-Forbidden attribute used in arch (data-tooltip)."""
-        )
-
-        self.assertInvalid(
             arch % ('<span data-tooltip-template="test"/>'),
             """Error while validating view near:
 
 <kanban __validate__="1"><templates><t t-name="card"><span data-tooltip-template="test"/></t></templates></kanban>
 Forbidden attribute used in arch (data-tooltip-template)."""
-        )
-
-        self.assertInvalid(
-            arch % ('<span t-att-data-tooltip="test"/>'),
-            """Error while validating view near:
-
-<kanban __validate__="1"><templates><t t-name="card"><span t-att-data-tooltip="test"/></t></templates></kanban>
-Forbidden attribute used in arch (t-att-data-tooltip)."""
         )
 
         self.assertInvalid(


### PR DESCRIPTION
With this commit, we authorize attributes on field in a kanban view.

task~5346474

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
