### PR TITLE
[IMP] web: detect online/offline more quickly

### DIFF
--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -82,6 +82,17 @@ export const offlineService = {
             status.offline = ev.detail.error instanceof ConnectionLostError;
         });
 
+        browser.addEventListener("offline", () => {
+            if (!status.offline) {
+                checkConnection();
+            }
+        });
+        browser.addEventListener("online", () => {
+            if (status.offline) {
+                checkConnection();
+            }
+        });
+
         return {
             status,
             checkConnection,

--- a/addons/web/static/src/core/offline/offline_systray.xml
+++ b/addons/web/static/src/core/offline/offline_systray.xml
@@ -9,7 +9,7 @@
                 aria-label="Working offline"
                 data-tooltip="Working offline"/>
             <button t-else=""
-                class="o_nav_entry px-2 o_tag opacity-75 rounded-pill text-bg-danger"
+                class="o_nav_entry px-2 o_tag text-bg-danger"
                 data-available-offline=""
                 data-tooltip="Click to check connection">
                 <i class="fa fa-chain-broken me-1"></i> Working offline

--- a/addons/web/static/src/webclient/navbar/navbar.variables.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.variables.scss
@@ -1,14 +1,14 @@
 // = Main Navbar Variables
 // ============================================================================
 $o-navbar-height: 46px !default;
-$o-navbar-padding-v: 0px !default;
+$o-navbar-padding-v: 10px !default;
 $o-navbar-font-size: $o-font-size-base !default;
 
 $o-navbar-background: $o-brand-odoo !default;
 
 $o-navbar-entry-margin-h: 0 !default;
 $o-navbar-entry-padding-h: $o-spacer * .5 !default;
-$o-navbar-entry-border-radius: 0 !default;
+$o-navbar-entry-border-radius: $o-border-radius !default;
 $o-navbar-entry-color: rgba($o-white, .9) !default;
 $o-navbar-entry-color--hover: $o-white !default;
 $o-navbar-entry-font-size: 1em !default;


### PR DESCRIPTION
This commit uses the "online" and "offline" events [1] to proactively detect that we lost the connection/we're back online. Before this commit, we waited for an RPC to fail with a ConnectionLostError (resp. to succeed) to enable the offline (resp. online) mode. Now, when those events are fired, we do a server ping to confirm, which then toggles the correct mode. Note that if the connection lost is due to the server being down, we still don't detect it directly. We have to wait for a real RPC to be done to detect the lost of connection.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Window/offline_event

task~5227317

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
