### PR TITLE
[FIX] purchase_requisition: ensure parent company taxes from agreements are applied on child PO

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -88,7 +88,7 @@ class PurchaseOrder(models.Model):
                 name += '\n' + product_lang.description_purchase
 
             # Compute taxes
-            taxes_ids = fpos.map_tax(line.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id == requisition.company_id)).ids
+            taxes_ids = fpos.map_tax(line.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id in requisition.company_id.parent_ids)).ids
 
             # Compute quantity and price_unit
             if line.product_uom_id != line.product_id.uom_po_id:

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -595,3 +595,39 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         merger_alternative_orders = po_orders[0] | po_orders[1]
         merger_alternative_orders.action_merge()
         self.assertEqual(len(po_orders[0].alternative_po_ids), 4)
+
+    def test_purchase_order_taxes_from_purchase_agreement_in_child_company(self):
+        """
+        Ensure that the taxes of the parent company are applied to the PO generated from purchase agreement in the child company.
+        """
+        child_company = self.env['res.company'].create({
+            'name': 'My Branch',
+            'parent_id': self.env.company.id,
+        })
+        # Ensure all the tax on the product are from the parent company
+        self.product_09.supplier_taxes_id = self.env['account.tax'].create({
+            'name': 'Test Tax 10%',
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'type_tax_use': 'purchase',
+            'company_id': self.env.company.id,
+        })
+
+        purchase_requisition = self.env['purchase.requisition'].with_company(child_company.id).create({
+            'vendor_id': self.res_partner_1.id,
+            'line_ids': [
+                Command.create({
+                    'product_id': self.product_09.id,
+                    'product_qty': 5.0,
+                    'price_unit': 20,
+                }),
+            ],
+        })
+        purchase_requisition.action_confirm()
+
+        po_form = Form(self.env['purchase.order'].with_company(child_company.id))
+        po_form.requisition_id = purchase_requisition
+        po = po_form.save()
+        self.assertEqual(po.partner_id, purchase_requisition.vendor_id, 'The partner should have been set from the purchase requisition')
+        self.assertEqual(po.order_line.price_unit, purchase_requisition.line_ids.price_unit, 'The unit price should have been set from the purchase requisition')
+        self.assertEqual(po.order_line.taxes_id, purchase_requisition.line_ids.product_id.supplier_taxes_id, 'The blanket order taxes should have been set')


### PR DESCRIPTION
### Issue:
In a child company, adding a product from a Purchase Agreement
to a Purchase Order does not apply the associated parent company's purchase taxes

### Cause:
In the onchange, taxes were filtered by company:
```python
taxes_ids = fpos.map_tax(line.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id == requisition.company_id)).ids
```
This filter fails for taxes belonging to the parent company, so they were not applied on the child company purchase order

### Steps to reproduce:
- Create a company branch and switch to it
- Enable `Purchase Agreements` in Settings
- Create a product with a Purchase Taxes (ex. 15%)
- Create a Purchase Agreement for any vendor with this product
- Create a RFQ for the vendor and add the agreement
- Observe that the tax is not applied

opw-5121243