### PR TITLE
[FIX] website_sale: prevent alternative products to be shown when not available

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -1,6 +1,12 @@
 // class name are dynamically added.
 // If you don't find it with a grep, don't consider it as useless without extra check.
 
+.s_dynamic_snippet_products {
+    &:not(:has(.s_dynamic_snippet_row)) {
+        display: none !important;
+    }
+}
+
 .s_product_product_centered {
     .card {
         overflow: visible;

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -1,4 +1,8 @@
-import { clickOnSave, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import {
+    clickOnEditAndWaitEditMode,
+    clickOnSave,
+    registerWebsitePreviewTour,
+} from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("shop_editor", {
     url: "/shop",
@@ -49,3 +53,42 @@ registerWebsitePreviewTour("shop_editor_set_product_ribbon", {
     content: "Check that the ribbon was properly saved",
     trigger: ':iframe .oe_product:first .o_ribbon:contains("Sale")',
 }]);
+
+registerWebsitePreviewTour("shop_editor_no_alternative_products_visibility_tour", {
+    url: "/shop",
+    edition: false,
+}, () => [
+    {
+        content: "Select the product with alternative products",
+        trigger: ':iframe form.oe_product_cart:has(.o_wsale_product_information_text a[content="product_with_alternative"]) a',
+        run: "click",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    {
+        trigger: ':iframe .s_dynamic_snippet_title h4',
+        run: "click",
+    },
+    {
+        content: "Edit the alternative products section header",
+        trigger: `:iframe .container[contenteditable="true"] h4`,
+        run: function () {
+            this.anchor.textContent = "Edited Alternative"
+            this.anchor.dispatchEvent(new Event("input", { bubbles: true }));
+        },
+    },
+    ...clickOnSave(),
+    {
+        content: "Navigate back to shop page",
+        trigger: ':iframe .breadcrumb-item a',
+        run: "click",
+    },
+    {
+        content: "Select the product without alternative products",
+        trigger: ':iframe form.oe_product_cart:has(.o_wsale_product_information_text a[content="product_without_alternative"]) a',
+        run: "click",
+    },
+    {
+        content: "Ensure alternative products section is hidden",
+        trigger: ':iframe .s_dynamic_snippet_products:not(:visible)',
+    }
+]);

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -405,3 +405,15 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         })
 
         self.start_tour("/", 'tour_shop_multi_checkbox_single_value', login="website_user")
+
+    def test_shop_editor_no_alternative_products_visibility(self):
+        product_no_alternative = self.env['product.template'].create({
+            'name': 'product_without_alternative',
+            'is_published': True,
+        })
+        self.env['product.template'].create({
+            'name': 'product_with_alternative',
+            'is_published': True,
+            'alternative_product_ids': product_no_alternative.ids,
+        })
+        self.start_tour('/', 'shop_editor_no_alternative_products_visibility_tour', login="admin")


### PR DESCRIPTION
### Issue:
In this issue, alternative products section will continue to be shown in website_sale, even if the product has no alternative products, due to editing alternative products using Editor.


#### To reproduce:
1- Create a product with an at least one alternative product.
2- On product shop page, using Editor, edit the description of alternative products section.
3- Remove alternative products of the product.
4- As seen, the alternative products section is still shown, even though it is empty.

#### Cause:
This is caused due to 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2 which commented out `display: none` for empty snippets.
https://github.com/odoo/odoo/blob/d985ec2e9b61b5e6c36a278654d526aaa5b512e2/addons/website/static/src/snippets/s_dynamic_snippet/000.scss#L2-L5

opw-5253884
