### PR TITLE
[FIX] stock_account: compute correct cogs partially delivered SO

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
         # Post entries.
         res = super()._post(soft)
 
-        self.line_ids._get_stock_moves()._set_value()
+        self.line_ids._get_stock_moves().filtered(lambda m: m.is_in)._set_value()
 
         return res
 


### PR DESCRIPTION
**Problem:**
partial cogs are not correctly computed
(no test in the commit, waiting for the new setup
https://github.com/odoo/odoo/blob/a3db18acf8010c989c17ea69ad8eb1f0d6bd6116/addons/sale_stock/tests/test_anglo_saxon_valuation.py#L15) 

**Steps to reproduce:**
- create a storable product FIFO/Perpetual
- Order 1 unit of product at 7
- Receive
- Order a second unit at 10
- Receive
- Create SO of 2 units
- Deliver 1 with a backorder
- Invoice one
- Deliver the second
- Invoice remaining

**Current Behavior**:
The first invoice will show double the COGS it is
supposed to (14 instead of 7).
The second invoice shows proper COGS (10)

**Expected behavior:**
Either both cogs should be 8.5 or the first one 7 and
the second one 10.

**Cause of the issue:**
There is two issues here :
- *The first issue* is that when confirming the invoice,
_post() calls _set_value() on the moves.
https://github.com/odoo/odoo/blob/3ce8e3e4e8049eb009ed05bdc3a33275c9eec0d6/addons/stock_account/models/account_move.py#L42
In the case of a fifo move this is a problem because
run_fifo is going to be called and the value of the move
is going to be wrongly recomputed based on the current
fifo stack.
This issue can be illustrated by a simpler use case:
       - fifo product
       - one move in at 7, one move in at 10
       - SO for one product and validate the delivery
       - the value of the move is 7
       - create and confirm invoice -> the value of the move is now 10


- *The second issue* is about the cogs computation :
in the case of a fifo product,  _get_cogs_value() calls 
_get_price_unit() on the moves of the sale order line 
(fetched via _get_stock_moves()) to compute the unit price.
https://github.com/odoo/odoo/blob/a3db18acf8010c989c17ea69ad8eb1f0d6bd6116/addons/stock_account/models/account_move_line.py#L73
So when computing the cogs for the first invoice:
Inside _get_price_unit(), the value of our back order 
move (not yet validated) will be taken into account 
in the computation of total_value. 
But because the stock move lines of this move are not 
picked yet, it's quantity will not be taken into account in 
the computation of total_qty (because get_valued_qty() calls
_get_out_move_line() which does not return the unpicked lines).
https://github.com/odoo/odoo/blob/a3db18acf8010c989c17ea69ad8eb1f0d6bd6116/addons/stock_account/models/stock_move.py#L217-L218
So the return value will be 14 (the value of the 2 moves) 
divided by 1 (the quantity of only the first move)

**Fix**
There is two possibility for the cogs in this situation : 
1) cogs of 7 on the first invoice and then later cogs of 10
on the second invoice
 2) cogs of 8.5 on both invoices 

In the current state of the code, the value of the second fifo 
move (10) is not yet set, it will be set when the move is validated.
Therefore we have to go for option 1).
The first part of the fix is to be sure to fetch only 'done' moves
before using _get_unit_price.
The second part of the fix is to deduce the cogs already posted.

opw-5342803