### PR TITLE
[FIX] mail: correct reaction spacing on message type notification

### DIFF
--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="mail.MessageReactions">
-    <div class="o-mail-MessageReactions position-relative d-flex flex-wrap mt-n1"
+    <div class="o-mail-MessageReactions position-relative d-flex flex-wrap"
         t-att-class="{
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
             'o-emojiPickerOpen': emojiPicker.isOpen,
+            'mt-n1': props.message.message_type === 'comment',
         }">
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -10,9 +10,9 @@
                         </p>
                     </t>
                     <t t-if="message.trackingValues.length">
-                        <ul class="mb-0 ps-4">
+                        <ul class="mb-0 ps-4 d-flex flex-column gap-1">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
-                                <li class="o-mail-Message-tracking mb-1" role="group">
+                                <li class="o-mail-Message-tracking" role="group">
                                     <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.oldValue)"/>
                                     <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
                                     <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.newValue)"/>


### PR DESCRIPTION
Before this commit, the spacing between the text content of a message of type notification and the reactions was too small and resulted in the UI feeling cramped.
This commit fixes the issue by removing the negative top margin in message reactions for messages that don't have enough padding.


| Before  | After |
| ------------- | ------------- |
| <img width="207" height="223" alt="Pasted image 20251124144956" src="https://github.com/user-attachments/assets/f23c070c-6253-440a-8b93-7b546daabda3" />  | <img width="202" height="236" alt="image" src="https://github.com/user-attachments/assets/e366a2ba-f851-4676-b108-bebf2fb12ec8" />  |

task-5344759