### PR TITLE
[FIX] base: make the domain to get default views overrideable

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -691,8 +691,11 @@ actual arch.
         :return: id of the default view of False if none found
         :rtype: int
         """
-        domain = [('model', '=', model), ('type', '=', view_type), ('mode', '=', 'primary')]
-        return self.search(domain, limit=1).id
+        return self.search(self._get_default_view_domain(model, view_type), limit=1).id
+
+    @api.model
+    def _get_default_view_domain(self, model, view_type):
+        return Domain([('model', '=', model), ('type', '=', view_type), ('mode', '=', 'primary')])
 
     #------------------------------------------------------
     # Inheritance mecanism


### PR DESCRIPTION
Task: [#5191154](https://www.odoo.com/odoo/project/1737/tasks/5191154)

---

When activating some views with Studio, we could end up loading a POS view because it has a lower sequence. As a result, Studio selects this view.
However, these POS views may not be loaded in the backend bundle (`web.assets_backend`), and thus are missing at runtime. Example: "Cannot find key 'pos_kanban' in the 'views' registry".

This commit creates a hook to get the domain used to fetch default views (`_get_default_view_domain()`). This way, modules can override the domain of `_get_default_view_domain()` method in order to exclude some views from being selected as default ones no matter the sequence.
