### PR TITLE
[MOV] html_editor: move signature plugin from `sign` to `html_editor`

### DIFF
--- a/addons/html_editor/static/src/main/media/signature_plugin.js
+++ b/addons/html_editor/static/src/main/media/signature_plugin.js
@@ -1,0 +1,47 @@
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { Plugin } from "@html_editor/plugin";
+import { _t } from "@web/core/l10n/translation";
+import { SignatureDialog } from "@web/core/signature/signature_dialog";
+import { user } from "@web/core/user";
+
+export class SignaturePlugin extends Plugin {
+    static id = "signature";
+    static dependencies = ["dom", "history", "media"];
+    resources = {
+        user_commands: [
+            {
+                id: "insertSignature",
+                title: _t("Signature"),
+                description: _t("Insert your signature"),
+                icon: "fa-pencil-square-o",
+                run: this.insertSignature.bind(this),
+                isAvailable: (selection) =>
+                    this.config.allowImage && isHtmlContentSupported(selection),
+            },
+        ],
+        powerbox_items: [
+            {
+                categoryId: "media",
+                commandId: "insertSignature",
+            },
+        ],
+    };
+
+    insertSignature() {
+        this.services.dialog.add(SignatureDialog, {
+            defaultName: user.name,
+            nameAndSignatureProps: {
+                displaySignatureRatio: 3,
+            },
+            uploadSignature: (signature) => {
+                const img = document.createElement("img");
+                img.classList.add("img", "img-fluid", "o_we_custom_image");
+                img.style = "width: 50%";
+                img.src = signature.signatureImage;
+                this.dependencies.dom.insert(img);
+                this.dependencies.history.addStep();
+                close();
+            },
+        });
+    }
+}

--- a/addons/mass_mailing/static/src/builder/plugins/signature_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/signature_plugin.js
@@ -1,0 +1,4 @@
+import { registry } from "@web/core/registry";
+import { SignaturePlugin } from "@html_editor/main/media/signature_plugin";
+
+registry.category("mass_mailing-plugins").add(SignaturePlugin.id, SignaturePlugin);


### PR DESCRIPTION
This PR moves the signature plugin from `sign` to `html_editor`. With this move, the `sign` module will no longer be required to insert signatures in Knowledge and Mass Mailing.

ENT: odoo/enterprise#100288

Task-5347434

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
