### PR TITLE
[IMP] account_peppol: update the SMS verification message

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -241,7 +241,7 @@ class ResConfigSettings(models.TransientModel):
 
         self._call_peppol_proxy(
             endpoint='/api/peppol/1/send_verification_code',
-            params={'message': _("Your confirmation code is")},
+            params={'message': _("Your Peppol activation code in Odoo is")},
         )
         self.account_peppol_proxy_state = 'sent_verification'
 


### PR DESCRIPTION
Before this commit:
In v17, the Peppol SMS verification message starts with "Your confirmation code is .." which could be confusing, as users might not know the code was related to Peppol in Odoo.

After this commit:
The SMS verification message was changed and now it starts with "Your Peppol activation code in Odoo is ...", providing clearer context for users.

task-5353425
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
