### PR TITLE
[FIX] html_editor: properly align syntax highlighting textarea with pre

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -27,5 +27,6 @@
         outline: none;
         background: transparent;
         resize: none;
+        white-space: pre;
     }
 }


### PR DESCRIPTION
When writing in a code block, we need to ensure its textarea's contents are aligned with its pre's. This could get broken when the textarea's contents would wrap and the pre's wouldn't. To fix this, we set the css property `white-space` of the textarea to 'pre' (as is done for the pre element), so that both elements behave the same way.

task-5354848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
