### PR TITLE
[FIX] web: load google italic font files correctly

### DIFF
--- a/addons/web/static/fonts/fonts.scss
+++ b/addons/web/static/fonts/fonts.scss
@@ -73,7 +73,7 @@ $google-font-path: './google';
 
 @mixin google-font($family, $type, $weight, $style, $file_type) {
     @font-face {
-        $style_name: if($weight == 400 and $style == italic, "Italic", "#{$type}#{if($style != normal, $style, "")}");
+        $style_name: if($weight == 400 and $style == italic, "Italic", "#{$type}#{if($style != normal, 'Italic', '')}");
         $format: if($file_type == 'ttf', 'truetype', $file_type);
         $file_name: "#{$family}-#{$style_name}.#{$file_type}";
 


### PR DESCRIPTION
Steps to reproduce:
- Open the website builder with the network tab opened.
- Click the theme tab.
- Change the background image (page layout > background).
- See the Roboto-MediumItalic font request fail with 404.

Before this commit (since this commit [1])
- The google font mixin built italic file names with lowercase italic, which does not match the bundled font files, so the editor assets triggered 404 errors for italic weights.

After this commit
- The mixin uses the expected Italic casing, so the requested files exist and load without console errors.

[1]: https://github.com/odoo/odoo/commit/8171d2988df4c9a4b6ffa4e0e63863114c3dba55