### PR TITLE
[FIX] mail: mention suggestion prioritizes followers over recent chats

### DIFF
--- a/addons/mail/static/src/core/common/partner_compare.js
+++ b/addons/mail/static/src/core/common/partner_compare.js
@@ -59,7 +59,7 @@ partnerCompareRegistry.add(
             }
         }
     },
-    { sequence: 45 }
+    { sequence: 25 }
 );
 
 partnerCompareRegistry.add(

--- a/addons/mail/static/src/discuss/core/common/partner_compare.js
+++ b/addons/mail/static/src/discuss/core/common/partner_compare.js
@@ -23,7 +23,7 @@ partnerCompareRegistry.add(
             return 1;
         }
     },
-    { sequence: 25 }
+    { sequence: 45 }
 );
 
 partnerCompareRegistry.add(


### PR DESCRIPTION
Before this commit, mention suggestions prioritized partners from recent chats over the record's followers.
This commit fixes the behavior by reordering the sequence numbers to have the following priority order:
Thread followers > Internal users > Recent chat partners.

<img width="1051" height="316" alt="image" src="https://github.com/user-attachments/assets/04b80028-07b5-40b2-8972-e80f933980c7" />

task-5313114