### PR TITLE
[IMP] point_of_sale: use_lna support for IoT requests

### DIFF
--- a/addons/iot_base/static/src/network_utils/http.js
+++ b/addons/iot_base/static/src/network_utils/http.js
@@ -18,37 +18,38 @@ export function uuid() {
  * Format the endpoint to send the request to
  * Used to ensure the request is sent with the same protocol as the current page
  * (e.g. if the current page is HTTPS, the request will be sent to the IoT Box using HTTPS)
- * @param ip IP Address of the IoT Box
- * @param route Route to send the request to
+ * @param {string} ip IP Address of the IoT Box
+ * @param {string} route Route to send the request to
+ * @param {boolean} forceHttp If true, always use HTTP even in HTTPS context (for browser supporting LNA)
  * @returns {string} The formatted endpoint
  */
-export function formatEndpoint(ip, route) {
-    const url = new URL(window.location.href);
-    url.search = "";
-    url.hostname = ip;
+export function formatEndpoint(ip, route, forceHttp = false) {
+    const protocol = forceHttp ? "http:" : window.location.protocol;
+    const url = new URL(`${protocol}//${ip}`);
     url.pathname = route;
-    if (url.port) url.port = "8069";
     return url.toString();
 }
 
 /**
  * Send a POST request to the IoT Box
- * @param ip IP Address of the IoT Box
- * @param route Endpoint to send the request to
- * @param params Parameters to send with the request (optional)
- * @param timeout Time before the request times out (default: 6000ms)
- * @param headers HTTP headers to send with the request (optional)
- * @param abortSignal AbortSignal used to cancel the request early (optional)
+ * @param {string} ip IP Address of the IoT Box
+ * @param {string} route Endpoint to send the request to
+ * @param {Record<string, unknown>} params Parameters to send with the request (optional)
+ * @param {number} timeout Time before the request times out (default: 6000ms)
+ * @param {Record<string, unknown>} headers HTTP headers to send with the request (optional)
+ * @param {AbortSignal} abortSignal AbortSignal used to cancel the request early (optional)
+ * @param {boolean} useLna If true, use local targetAddressSpace + Force HTTP
  * @returns {Promise<any>}
  */
-export async function post(ip, route, params = {}, timeout = 6000, headers = {}, abortSignal = null) {
-    const endpoint = formatEndpoint(ip, route);
+export async function post(ip, route, params = {}, timeout = 6000, headers = {}, abortSignal = null, useLna = false) {
+    const endpoint = formatEndpoint(ip, route, useLna);
     const timeoutSignal = AbortSignal.timeout(timeout);
     const response = await browser.fetch(endpoint, {
         body: JSON.stringify({'params': params}),
         method: "POST",
         headers: {"Content-Type": "application/json", ...headers},
         signal: abortSignal ? AbortSignal.any([abortSignal, timeoutSignal]) : timeoutSignal,
+        targetAddressSpace: useLna ? "local" : undefined,
     });
 
     return response.json();

--- a/addons/iot_base/static/src/network_utils/longpolling.js
+++ b/addons/iot_base/static/src/network_utils/longpolling.js
@@ -25,6 +25,7 @@ export class IoTLongpolling {
         this._delayedStartPolling(this.rpcDelay);
         this.notification = notification;
         this.orm = orm;
+        this.useLna = false;
     }
 
     /**
@@ -144,7 +145,7 @@ export class IoTLongpolling {
             if (this._listeners[iot_ip] && route === this.pollRoute) {
                 this._listeners[iot_ip].abortController = abortController;
             }
-            return await post(iot_ip, route, params, timeout, headers, abortController.signal);
+            return await post(iot_ip, route, params, timeout, headers, abortController.signal, this.useLna);
         } catch (error) {
             if (!fallback && error?.name !== "AbortError") {
                 this._doWarnFail(iot_ip);
@@ -213,6 +214,15 @@ export class IoTLongpolling {
                 type: "danger",
             }
         );
+    }
+
+    /**
+     * Enable/disable using Local Network Access.
+     * This forces HTTP on all IoT requests.
+     * @param {boolean} isLnaEnabled
+     */
+    setLna(isLnaEnabled) {
+        this.useLna = isLnaEnabled;
     }
 }
 

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -202,6 +202,7 @@ export class ClosePosPopup extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({ params: { action: "close" } }),
+                targetAddressSpace: odoo.use_lna ? "local" : undefined,
             }).catch((error) => {
                 logPosMessage(
                     "ClosePosPopup",

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -35,6 +35,7 @@ export class CustomerDisplayPosAdapter {
                         data: this.data,
                     },
                 }),
+                targetAddressSpace: odoo.use_lna ? "local" : undefined,
             }).catch(() => {
                 console.log("Failed to send data to customer display");
             });

--- a/addons/point_of_sale/static/src/app/service_worker.js
+++ b/addons/point_of_sale/static/src/app/service_worker.js
@@ -33,6 +33,7 @@ self.addEventListener("fetch", (event) => {
     if (
         url.includes("extension") ||
         url.includes("web/dataset") ||
+        url.includes("hw_proxy/hello") ||
         event.request.method !== "GET"
     ) {
         return;

--- a/addons/point_of_sale/static/src/app/services/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/services/hardware_proxy_service.js
@@ -148,6 +148,7 @@ export class HardwareProxy extends EventBus {
             const response = await browser
                 .fetch(`${url}/hw_proxy/hello`, {
                     signal: timeoutController.signal,
+                    targetAddressSpace: odoo.use_lna ? "local" : undefined,
                 })
                 .catch(() => ({}));
             if (response.ok) {

--- a/addons/point_of_sale/static/src/customer_display/utils.js
+++ b/addons/point_of_sale/static/src/customer_display/utils.js
@@ -25,6 +25,7 @@ export function openProxyCustomerDisplay(
                 pos_id: configId,
             },
         }),
+        targetAddressSpace: odoo.use_lna ? "local" : undefined,
     })
         .then(() => {
             notificationService?.add(_t("Connection successful"), { type: "success" });

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -23,7 +23,7 @@ export function uuidv4() {
  * @returns {string}
  */
 export function deduceUrl(url) {
-    const { protocol } = window.location;
+    const protocol = odoo.use_lna ? "http:" : window.location.protocol;
     if (!url.includes("//")) {
         url = `${protocol}//${url}`;
     }


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/100331

**This PR contains 2 commits:**

- **[IMP] iot_base: allow use of LNA for IoT requests**
Chromium 142 added support for HTTPS -> HTTP requests on the local network (Local Network Access). This commit adds a flag to the IoT longpolling class to enable LNA support. The flag forces all requests to use HTTP even in an HTTPS environment. It also sets the `targetAddressSpace` option to `local` in the `fetch` request.

- **[IMP] point_of_sale: use_lna support for IoT requests**
Since https://github.com/odoo/odoo/pull/235702, there is a `point_of_sale.use_lna` system parameter. When it is set, ePOS requests will use HTTP instead of HTTPS, and the `targetAddressSpace: "local"` option is used in the `fetch` request. This bypasses the need for a HTTPS certificate.

This commit adds the same functionality to all IoT requests from the POS. This should allow the IoT box to function correctly without a HTTPS certificate.

task-5353672

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
