### PR TITLE
[FIX] portal: prevent AttributeError when comparing names

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -522,7 +522,7 @@ class CustomerPortal(Controller):
             ).create(address_values)
         elif not self._are_same_addresses(address_values, partner_sudo):
             # If name is not changed then pop it from the address_values, as it affects the bank account holder name
-            if address_values['name'].strip() == partner_sudo.name.strip():
+            if address_values['name'].strip() == (partner_sudo.name or '').strip():
                 address_values.pop('name')
             partner_sudo.write(address_values)  # Keep the same partner if nothing changed.
 


### PR DESCRIPTION
When registering to an event, customers are asked questions before reaching the payment page. By default, a *Name* question is included, but it can be removed by the organizer of the event. If the *Name* question is removed, but a name is asked in the delivery form, Odoo will try to compare the (missing) name from the event's questions with the (required) name from the delivery form.

https://github.com/odoo/odoo/blob/828a9504c7d43aa35ed91141268d04e0a55782c3/addons/portal/controllers/portal.py#L551

The issue is that if there's no *Name* question among the event's questions, a `res.partner` with its `name` field set to `False` is created. When attempting to call `.strip()` on its name, an `AttributeError` is raised (*'bool' object has no attribut 'strip'*).

This fix prevents the error by considering the name field as an empty string in case no name is provided.

### Steps to reproduce:
1. Install *Online Event Ticketing* (`website_event_sale`)
2. In Settings > Website, set *Sign in/up at checkout* to *Disabled (buy as guest)*
3. In Events, create a new Event
    - Give it any name
    - Add a product line for the Event Registration with a price greater than 0
    - In the *Questions* tab, remove the *Name* question
    - Click the *Go to website* smart button and publish the event
4. On the website, in incognito mode:
    - Click *Events*
    - Click the new event we created in Step 3
    - Click *Register*, (set the quantity to one ticket,) click *register*
    - Answer the questions (there should **not** be a *Name* question) and click *Confirm Registration*
    - Fill out the required fields of the delivery form (there **should** be a *Name* field)
    - Open the console, then click *Confirm* in the delivery form: An error appears, and the Payment page does not appear

opw-5259781