### PR TITLE
[IMP] l10n_de: display codes on tax report cells

### DIFF
--- a/addons/l10n_de/data/account_account_tags_data.xml
+++ b/addons/l10n_de/data/account_account_tags_data.xml
@@ -86,10 +86,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-35</field>
                             </record>
-                             <record id="tax_report_de_tag_36_tag" model="account.report.expression">
+                            <record id="tax_report_de_tag_35_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">35</field>
+                            </record>
+                            <record id="tax_report_de_tag_36_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-36</field>
+                            </record>
+                            <record id="tax_report_de_tag_36_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">36</field>
                             </record>
                         </field>
                     </record>
@@ -117,10 +127,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-76</field>
                             </record>
+                            <record id="tax_report_de_tag_76_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">76</field>
+                            </record>
                             <record id="tax_report_de_tag_80_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-80</field>
+                            </record>
+                            <record id="tax_report_de_tag_80_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">80</field>
                             </record>
                         </field>
                     </record>
@@ -297,10 +317,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">95</field>
                             </record>
+                            <record id="tax_report_de_tag_95_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">95</field>
+                            </record>
                             <record id="tax_report_de_tag_98_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-98</field>
+                            </record>
+                            <record id="tax_report_de_tag_98_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">98</field>
                             </record>
                         </field>
                     </record>
@@ -315,10 +345,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">94</field>
                             </record>
+                            <record id="tax_report_de_tag_94_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">94</field>
+                            </record>
                             <record id="tax_report_de_tag_96_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-96</field>
+                            </record>
+                            <record id="tax_report_de_tag_96_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">96</field>
                             </record>
                         </field>
                     </record>
@@ -353,10 +393,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">46</field>
                             </record>
+                            <record id="tax_report_de_tag_46_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">46</field>
+                            </record>
                             <record id="tax_report_de_tag_47_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-47</field>
+                            </record>
+                            <record id="tax_report_de_tag_47_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">47</field>
                             </record>
                         </field>
                     </record>
@@ -371,10 +421,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">73</field>
                             </record>
+                            <record id="tax_report_de_tag_73_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">73</field>
+                            </record>
                             <record id="tax_report_de_tag_74_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-74</field>
+                            </record>
+                            <record id="tax_report_de_tag_74_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">74</field>
                             </record>
                         </field>
                     </record>
@@ -389,10 +449,20 @@
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">84</field>
                             </record>
+                            <record id="tax_report_de_tag_84_label" model="account.report.expression">
+                                <field name="label">_cell_label_base</field>
+                                <field name="engine">text</field>
+                                <field name="formula">84</field>
+                            </record>
                             <record id="tax_report_de_tag_85_tag" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">-85</field>
+                            </record>
+                            <record id="tax_report_de_tag_85_label" model="account.report.expression">
+                                <field name="label">_cell_label_tax</field>
+                                <field name="engine">text</field>
+                                <field name="formula">85</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
The German tax report contains lines with multiple columns where each cell corresponds to a code, making line-level codes insufficient.

This commit displays these codes next to their corresponding cell values.

task-5233075

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
