### PR TITLE
[FIX] stock_account: allow mrp user to valide MO with project

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -549,7 +549,7 @@ class StockMove(models.Model):
 
     def _account_analytic_entry_move(self):
         for move in self:
-            analytic_line_vals = move._prepare_analytic_lines()
+            analytic_line_vals = move.sudo()._prepare_analytic_lines()
             if analytic_line_vals:
                 move.analytic_account_line_ids += self.env['account.analytic.line'].sudo().create(analytic_line_vals)
 


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product with the following BoM:
    - Tracking: Serial number
    - Component “C1”:
        - Sales price: $10
        - Cost: $20
    - Operation: OP1 (60 min)
    - Add any analytic distribution
- Give the following access rights to Marc Demo:
    - Manufacturing: User
    - Timesheets: User
- Log in as Marc Demo
- Confirm the MO
- Start the work order
- Try to assign a new serial number using the "+" button

Problem:
```An access error is raised:
Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, Marc Demo (id=6) doesn't have 'write' access to:

Analytic Line (account.analytic.line)
```

Since the user has no access to analytic accounts, calling
`_prepare_analytic_lines()` attempts to modify an existing analytic line
amount, which triggers the access error.

Solution:
Because analytic lines are created using `sudo()`, we also need to
call `_prepare_analytic_lines()` with `sudo()` to avoid write-access
violations.

opw-5258044