### PR TITLE
[IMP] project: use fully qualified column names

### DIFF
--- a/addons/project_account/models/project_project.py
+++ b/addons/project_account/models/project_project.py
@@ -37,7 +37,7 @@ class Project(models.Model):
                 self.env['account.move.line'].sudo()._query_analytic_accounts(),
             )
         )
-        query_string, query_param = query.select('balance', 'parent_state', 'account_move_line.company_currency_id', 'account_move_line.analytic_distribution', 'move_id', 'account_move_line.date')
+        query_string, query_param = query.select('account_move_line.balance', 'account_move_line.parent_state', 'account_move_line.company_currency_id', 'account_move_line.analytic_distribution', 'account_move_line.move_id', 'account_move_line.date')
         self._cr.execute(query_string, query_param)
         bills_move_line_read = self._cr.dictfetchall()
         if bills_move_line_read:


### PR DESCRIPTION
Use fully qualified column names when constructing a query, more specifically, include the table that the column is originating from.

The rule of thumb is that we always include the table name alongside the column name.

In this particular case, the query will do a `JOIN` on `account_move` and there may be ambiguousness as to whether to take the `balance` column from `account_move` or `account_move_line`. The former column used to exist in the past and was likely kept for data retention purposes. Hence, there are still databases in 17.0 where `account_move.balance` exists.

Another reason to include the table name is to prevent confusion with columns coming from custom modules.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
