### PR TITLE
[FIX] Website: o_bg_video_container  youtube referrerpolicy.

### DIFF
--- a/addons/website/static/src/js/content/generate_video_iframe.js
+++ b/addons/website/static/src/js/content/generate_video_iframe.js
@@ -46,6 +46,7 @@ export function generateVideoIframe(parentEl) {
     const iframeEl = document.createElement("iframe");
     iframeEl.setAttribute("frameborder", "0");
     iframeEl.setAttribute("allowfullscreen", "allowfullscreen");
+    iframeEl.setAttribute("referrerpolicy", "strict-origin-when-cross-origin");
     parentEl.appendChild(iframeEl);
 
     _manageIframeSrc(parentEl, src);

--- a/addons/website/static/src/xml/website.background.video.xml
+++ b/addons/website/static/src/xml/website.background.video.xml
@@ -12,7 +12,8 @@
                     class="o_bg_video_iframe fade"
                     frameBorder="0"
                     t-att-src="videoSrc"
-                    aria-label="Background video"/>
+                    aria-label="Background video"
+                    referrerpolicy="strict-origin-when-cross-origin"/>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
Issue: YouTube has changed its referrer policy to enforce "strict-origin-when-cross-origin". 
Without this, it can throw a 153 error and block the video.

To replicate in runbot ,add "<meta name="referrer" content="no-referrer"/>" to any major page like the main layout or footer. This sets it for the entire page. 
Therefore, to enforce YouTube's calls to have the proper referrerpolicy, I hardcoded it directly.

Fix:
added 'referrerpolicy="strict-origin-when-cross-origin"' to the iframe.

opw-5239363


Description of the issue/feature this PR addresses:
Our website allows for customization, including the ability to modify meta tags. In ticket#523963, the customer added "<meta name="referrer" content="no-referrer" />" which forced all calls to be set with referrerpolicy="no-referrer" when it's required to have 'referrerpolicy="strict-origin-when-cross-origin"' for embeded videos to youtube

Current behavior before PR:
If a customer sets "<meta name="referrer" content="no-referrer" />" on any page, YouTube blocks it on that page; if it's in the header or footer, the entire website is then blocked. 

Desired behavior after PR is merged:
After it now enforces the call to have 'referrerpolicy="strict-origin-when-cross-origin"' even if the tag <meta name="referrer" content="no-referrer" />". Allowing YouTube to be used. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
