### PR TITLE
[FIX] point_of_sale: show change correctly in different languages

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -143,7 +143,7 @@ export class PosOrderAccounting extends Base {
             this.payment_ids.reduce(function (sum, paymentLine) {
                 // Return lines are created after the sync, should not be taken into account in
                 // the paid amount otherwise, the change would be wrong.
-                if (paymentLine.isDone() && paymentLine.name !== "return") {
+                if (paymentLine.isDone() && !paymentLine.is_change) {
                     sum += paymentLine.getAmount();
                 }
                 return sum;

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -252,3 +252,18 @@ registry.category("web_tour.tours").add("test_auto_validate_force_done", {
             ReceiptScreen.receiptIsThere(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_valid_change_on_receipt", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm(),
+            ProductScreen.addOrderline("Test Product", "1"),
+            inLeftSide(Order.hasLine({ productName: "Test Product", price: "10,0" })),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickNumpad("+10"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptChangeAmountIs("-10"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3169,6 +3169,18 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.start_pos_tour("test_sync_from_ui_one_by_one", login="pos_user")
             self.assertEqual(sync_counter['count'], 6)
 
+    def test_valid_change_on_receipt(self):
+        self.env['res.lang']._activate_lang('fr_FR')
+        self.pos_user.write({'lang': 'fr_FR'})
+        self.env['product.template'].create({
+            'name': 'Test Product',
+            'available_in_pos': True,
+            'list_price': 10,
+            'taxes_id': False,
+        })
+
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, "test_valid_change_on_receipt", login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Currently, if a user overpays while using a different language, like French, the receipt does not show the change.

**Steps to replicate:**
* Install POS with demo data and change language to French .
* POS > Furniture Shop > Open the register
* Select a product, overpay with cash, and validate.

**Issue:**
* As seen in [1], the `Change` field doesn’t appear when overpaying with cash, even though it shows in the English version.

**Root cause:**
* The issue happens because changing the language translates the payment line name at [2] (coming from the translated return at [3]). This makes it get included in the sum at [4], which incorrectly subtracts it from the total cash paid and causes the change amount to disappear on the receipt.

**Solution:**
* Check and add up the payment lines where `is_change` is `false`, and use that instead of relying on the payment line’s name at [3].

**Before:**
<img width="830" height="556" alt="image" src="https://github.com/user-attachments/assets/5aaddfe0-fe46-49e1-a877-4fe4de2fb5c7" />

**After:**
<img width="931" height="596" alt="image" src="https://github.com/user-attachments/assets/4215d6b8-14b4-4e59-85bc-4d0f43f1d09c" />

[1]:
https://www.odoo.com/web/image/91240289?access_token=bef22d9abd1232e34f510648a34f7709d82b848ed852fccdb893f2d1149067abo0x69505fa6&filename=image.png&unique=dd2a62fbe180532cf5cf00c27adc60742f113ddc 
[2]:
https://github.com/odoo/odoo/blob/0581b7fb6abc8e856cedf13254ba1f9d362d6d34/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js#L146 
[3]:
https://github.com/odoo/odoo/blob/0581b7fb6abc8e856cedf13254ba1f9d362d6d34/addons/point_of_sale/models/pos_order.py#L188-L195 
[4]:
https://github.com/odoo/odoo/blob/0581b7fb6abc8e856cedf13254ba1f9d362d6d34/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js#L147

opw-5344903
