### PR TITLE
[IMP] spreadsheet_dashboard: improve dashboards and sections usability

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -11,7 +11,7 @@ class SpreadsheetDashboard(models.Model):
     _order = 'sequence'
 
     name = fields.Char(required=True, translate=True)
-    dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True, index=True)
+    dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True, index=True, string="Section")
     sequence = fields.Integer()
     sample_dashboard_file_path = fields.Char(export_string_translation=False)
     is_published = fields.Boolean(default=True)
@@ -80,3 +80,14 @@ class SpreadsheetDashboard(models.Model):
             for dashboard, vals in zip(self, vals_list):
                 vals['name'] = _("%s (copy)", dashboard.name)
         return vals_list
+
+    def action_open_dashboard(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.client",
+            "tag": "action_spreadsheet_dashboard",
+            "name": self.name,
+            "params": {
+                "dashboard_id": self.id,
+            },
+        }

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard_group.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard_group.py
@@ -12,6 +12,14 @@ class SpreadsheetDashboardGroup(models.Model):
     published_dashboard_ids = fields.One2many('spreadsheet.dashboard', 'dashboard_group_id', domain=[('is_published', '=', True)])
     sequence = fields.Integer()
 
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for group, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", group.name)
+        return vals_list
+
     @api.ondelete(at_uninstall=False)
     def _unlink_except_spreadsheet_data(self):
         external_ids = self.get_external_id()

--- a/addons/spreadsheet_dashboard/tests/test_spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/tests/test_spreadsheet_dashboard.py
@@ -41,6 +41,14 @@ class TestSpreadsheetDashboard(DashboardTestCommon):
         copy = dashboard.copy({"name": "a copy"})
         self.assertEqual(copy.name, "a copy")
 
+    def test_copy_group_name(self):
+        group = self.env["spreadsheet.dashboard.group"].create(
+            {"name": "My section"}
+        )
+
+        copy = group.copy()
+        self.assertEqual(copy.name, "My section (copy)")
+
     def test_unlink_prevent_spreadsheet_group(self):
         group = self.env["spreadsheet.dashboard.group"].create(
             {"name": "a_group"}

--- a/addons/spreadsheet_dashboard/views/menu_views.xml
+++ b/addons/spreadsheet_dashboard/views/menu_views.xml
@@ -28,8 +28,15 @@
 
     <record id="spreadsheet_dashboard_action_configuration_dashboards" model="ir.actions.act_window">
         <field name="name">Dashboards</field>
-        <field name="res_model">spreadsheet.dashboard.group</field>
+        <field name="res_model">spreadsheet.dashboard</field>
         <field name="view_mode">list,form</field>
+        <field name="context">{"search_default_groupby_dashboard_group_id" : True}</field>
+    </record>
+
+    <record id="spreadsheet_dashboard_group_action_configuration_sections" model="ir.actions.act_window">
+        <field name="name">Sections</field>
+        <field name="res_model">spreadsheet.dashboard.group</field>
+        <field name="view_mode">list</field>
     </record>
 
     <menuitem
@@ -39,6 +46,11 @@
         action="spreadsheet_dashboard_action_configuration_dashboards"
         sequence="10"/>
 
-
+    <menuitem
+        id="spreadsheet_dashboard_group_menu_configuration_sections"
+        name="Sections"
+        parent="spreadsheet_dashboard_menu_configuration"
+        action="spreadsheet_dashboard_group_action_configuration_sections"
+        sequence="20"/>
 
 </odoo>

--- a/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
+++ b/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
@@ -5,15 +5,29 @@
         <field name="name">spreadsheet.dashboard.view.list</field>
         <field name="model">spreadsheet.dashboard</field>
         <field name="arch" type="xml">
-            <list create="false" editable="bottom">
+            <list create="false">
                 <field name="sequence" widget="handle" groups="base.group_system"/>
                 <field name="name"/>
                 <field name="group_ids" widget="many2many_tags" required="1"/>
                 <field name="company_ids" options="{'no_create': True}" widget="many2many_tags" groups="base.group_multi_company" placeholder="Visible to all"/>
                 <field name="spreadsheet_binary_data" groups="base.group_no_one" widget="binary_spreadsheet" filename="spreadsheet_file_name" string="Data" />
                 <field name="is_published" widget="boolean_toggle"/>
-                <field name="dashboard_group_id" optional="hidden"/>
+                <button name="action_open_dashboard" type="object" string="View" icon="fa-eye"/>
             </list>
+        </field>
+    </record>
+
+    <record id="spreadsheet_dashboard_view_search" model="ir.ui.view">
+        <field name="name">spreadsheet.dashboard.search</field>
+        <field name="model">spreadsheet.dashboard</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" string="Dashboard"/>
+                <filter string="Published" name="filter_published" domain="[('is_published', '=', True)]"/>
+                <group>
+                    <filter string="Section" name="groupby_dashboard_group_id" context="{'group_by': 'dashboard_group_id'}"/>
+                </group>
+            </search>
         </field>
     </record>
 
@@ -21,31 +35,10 @@
         <field name="name">spreadsheet.dashboard.group.view.list</field>
         <field name="model">spreadsheet.dashboard.group</field>
         <field name="arch" type="xml">
-            <list string="Dashboards">
+            <list string="Dashboards" editable="bottom">
                 <field name="sequence" widget="handle" groups="base.group_system"/>
                 <field name="name"/>
             </list>
-        </field>
-    </record>
-
-    <record id="spreadsheet_dashboard_container_view_form" model="ir.ui.view">
-        <field name="name">spreadsheet.dashboard.group.view.form</field>
-        <field name="model">spreadsheet.dashboard.group</field>
-        <field name="arch" type="xml">
-            <form>
-                <sheet>
-                    <div class="oe_title">
-                        <h1>
-                            <field name="name"/>
-                        </h1>
-                    </div>
-                    <notebook>
-                        <page string="Spreadsheets" name="spreadsheets">
-                            <field name="dashboard_ids" context="{'list_view_ref': 'spreadsheet_dashboard.spreadsheet_dashboard_view_list'}"/>
-                        </page>
-                    </notebook>
-                </sheet>
-            </form>
         </field>
     </record>
 
@@ -54,13 +47,21 @@
         <field name="model">spreadsheet.dashboard</field>
         <field name="arch" type="xml">
             <form>
-                <group>
-                    <field name="name"/>
-                    <field name="dashboard_group_id"/>
-                    <field name="company_ids" options="{'no_create': True}" widget="many2many_tags" groups="base.group_multi_company" placeholder="Visible to all"/>
-                    <field name="group_ids" widget="many2many_tags"/>
-                    <field name="spreadsheet_binary_data"/>
-                </group>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" string="Dashboard name"/>
+                        <h1>
+                            <field name="name" placeholder="e.g. Sales operations"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <field name="dashboard_group_id" string="Dashboard Section" placeholder="Choose a dashboard section..."/>
+                        <field name="group_ids" string="Access Groups" widget="many2many_tags" required="1"/>
+                        <field name="company_ids" string="Companies" options="{'no_create': True}" widget="many2many_tags" groups="base.group_multi_company" placeholder="Visible to all"/>
+                        <field name="is_published" widget="boolean_toggle"/>
+                        <field name="spreadsheet_binary_data" string="Spreadsheet file" invisible="not id" widget="binary_spreadsheet" class="w-50"/>
+                    </group>
+                </sheet>
             </form>
         </field>
     </record>


### PR DESCRIPTION
### Description

Previously, if the user did not know in which section a dashboard was located, it was difficult to find it without opening each section one by one.

This PR improves the overall navigation and discoverability of dashboards:

- Add a dedicated list view to browse all dashboards within a section.
- Force a default grouping by `dashboard_group_id` to better structure the dashboards view.
- Add a search view on `spreadsheet.dashboard` with useful filters.
- Add `action_open_dashboard` method to open dashboards directly via the spreadsheet client action.
- Add a "View" button in the dashboards list to quickly open a dashboard without entering its form.

These enhancements make dashboard navigation more intuitive, improve searchability, and reduce the number of steps required to locate and open dashboards.

Task: [5259227](https://www.odoo.com/odoo/project/2328/tasks/5259227)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
