### PR TITLE
[FIX] hr_skills: show traceback when downloading resume with invalid template

### DIFF
--- a/addons/hr_skills/controllers/main.py
+++ b/addons/hr_skills/controllers/main.py
@@ -5,6 +5,8 @@ import re
 
 from odoo import _
 
+from odoo.addons.base.models.ir_qweb import QWebException
+from odoo.exceptions import UserError
 from odoo.http import request, route, Controller, content_disposition
 
 
@@ -25,16 +27,19 @@ class HrEmployeeCV(Controller):
 
         report = request.env.ref('hr_skills.action_report_employee_cv', False)
 
-        pdf_content, dummy = request.env['ir.actions.report'].sudo()._render_qweb_pdf(
-            report, employees.ids, data={
-            'color_primary': color_primary,
-            'color_secondary': color_secondary,
-            'resume_type_education': resume_type_education,
-            'skill_type_language': skill_type_language,
-            'show_skills': 'show_skills' in post,
-            'show_contact': 'show_contact' in post,
-            'show_others': 'show_others' in post,
-        })
+        try:
+            pdf_content, _dummy = request.env['ir.actions.report'].sudo()._render_qweb_pdf(
+                report, employees.ids, data={
+                'color_primary': color_primary,
+                'color_secondary': color_secondary,
+                'resume_type_education': resume_type_education,
+                'skill_type_language': skill_type_language,
+                'show_skills': 'show_skills' in post,
+                'show_contact': 'show_contact' in post,
+                'show_others': 'show_others' in post,
+            })
+        except QWebException as error:
+            raise UserError(error)
 
         if len(employees) == 1:
             report_name = _('Resume %s', employees.name)

--- a/addons/hr_skills/tests/__init__.py
+++ b/addons/hr_skills/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_ui
+from . import test_report

--- a/addons/hr_skills/tests/test_report.py
+++ b/addons/hr_skills/tests/test_report.py
@@ -1,0 +1,52 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import HttpCase
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class SkillsTestReport(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Partner Test"})
+        cls.company_A = cls.env["res.company"].create({"name": "company_A"})
+        cls.employee = cls.env["hr.employee"].create(
+            {
+                "name": "employee_A",
+                "work_contact_id": cls.partner.id,
+                "company_id": cls.company_A.id,
+            }
+        )
+
+    @mute_logger("odoo.http")
+    def test_cv_report_traceback(self):
+        template = """
+        <t t-name="hr_skills.report_employee_cv">
+            <t t-set="full_width" t-value="True"/>
+            <t t-call="web.basic_layout">
+            <div t-if ="o.no"/>
+            <t t-foreach="docs" t-as="o">
+                <div class="o_employee_cv page">
+                    <t t-call="hr_skills.report_employee_cv_company"/>
+                    <t t-call="hr_skills.report_employee_cv_sidepanel"/>
+                    <t t-call="hr_skills.report_employee_cv_main_panel"/>
+                    <p class="o_new_page"/>
+                </div>
+            </t>
+            </t>
+        </t>"""
+
+        report_view = self.env.ref(
+            "hr_skills.report_employee_cv", raise_if_not_found=False
+        )
+        self.assertTrue(report_view)
+        report_view.arch = template
+        wizard = self.env["hr.employee.cv.wizard"].create(
+            {"employee_ids": [self.employee.id]}
+        )
+        view = wizard.action_validate()
+        self.authenticate("admin", "admin")
+        response = self.url_open(view["url"])
+        self.assertRegex(response.content.decode(), "KeyError")


### PR DESCRIPTION
Currently, when a user tries to print a resume with an invalid template there’s no traceback to show what went wrong.

**Steps to produce:**
* Install `hr` with demo data
* Modify the view `report_employee_cv`  by adding `<div t-if=o.no/>`
* Print resume of any employee

**Observed Behavior:**
Currently it only shows the error in [1], with no context or traceback to explain what went wrong.

**Root cause:**
* This happens because the route doesn’t include the website parameter. Without it, the system treats the route as non–front end [2], so the error handler never reaches [3].That means [4] never loads the templates [5], and the browser just gets a plain response at [6].

**Solution:**
* Catching and raising UserError shows appropriate traceback.

**Before:**
<img width="1606" height="796" alt="image" src="https://github.com/user-attachments/assets/d5432fbf-d016-46a9-bade-8e8408848c66" />

**After:**
<img width="1832" height="928" alt="image" src="https://github.com/user-attachments/assets/6f0413ca-a82a-487d-888f-81be6f0fab03" />

[1]:
https://drive.google.com/file/d/1qJLkFGw4bEclqKihdUI-4bjJofdFArEc/view?usp=sharing 
[2]:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/http_routing/models/ir_http.py#L386 
[3]:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/http_routing/models/ir_http.py#L611 
[4]:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/http_routing/models/ir_http.py#L573-L576 
[5]:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/http_routing/views/http_routing_template.xml#L139 
[6]:
https://github.com/odoo/odoo/blob/e4e2dca73213c33c487033dd404a7ca335960a66/addons/http_routing/models/ir_http.py#L575
Related: https://github.com/odoo/enterprise/pull/100142

opw-5167898
