### PR TITLE
[18.0][IMP] sale: Add kwargs to _get_page_view_values()

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -183,7 +183,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             history_session_key = 'my_orders_history'
 
         values = self._get_page_view_values(
-            order_sudo, access_token, values, history_session_key, False)
+            order_sudo, access_token, values, history_session_key, False, **kw)
 
         return request.render('sale.sale_order_portal_template', values)
 


### PR DESCRIPTION
kwargs is added to the `_get_page_view_values()` method in other modules: `account` (https://github.com/odoo/odoo/blob/fdfa573fef5de83a77310e650dd950bddd7b0554/addons/account/controllers/portal.py#L47), `project` (https://github.com/odoo/odoo/blob/fdfa573fef5de83a77310e650dd950bddd7b0554/addons/project/controllers/portal.py#L58), or `purchase` (https://github.com/odoo/odoo/blob/fdfa573fef5de83a77310e650dd950bddd7b0554/addons/purchase/controllers/portal.py#L110).

@Tecnativa TT57124

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
