### PR TITLE
[IMP] account, *: match optional='hide' columns

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1192,12 +1192,12 @@
                                                options="{'no_create': True}"
                                                optional="show"/>
                                         <field name="deductible_amount"
-                                               column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
+                                               column_invisible="parent.move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
                                                string="Professional %"
                                                optional="hide"
                                                groups="!account.group_partial_purchase_deductibility"/>
                                         <field name="deductible_amount"
-                                               column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
+                                               column_invisible="parent.move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
                                                string="Professional %"
                                                optional="show"
                                                groups="account.group_partial_purchase_deductibility"/>

--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -8,11 +8,11 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' column_invisible="True"/>
-                <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>
+                <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund', 'in_receipt')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' column_invisible="True"/>
-                <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>
+                <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund', 'in_receipt')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>
             </xpath>
         </field>
     </record>

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -34,7 +34,7 @@
             <!-- Add link to purchase_line_id to account.move.line -->
             <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='company_id']" position="after">
                 <field name="purchase_line_id" groups="purchase.group_purchase_user" column_invisible="True"/>
-                <field name="purchase_order_id" groups="purchase.group_purchase_user" column_invisible="parent.move_type != 'in_invoice'" optional="hide"/>
+                <field name="purchase_order_id" groups="purchase.group_purchase_user" column_invisible="parent.move_type not in ('in_invoice', 'in_receipt')" optional="hide"/>
             </xpath>
             <xpath expr="//field[@name='line_ids']/list/field[@name='company_id']" position="after">
                 <field name="purchase_line_id" groups="purchase.group_purchase_user" column_invisible="True"/>

--- a/addons/stock_landed_costs/views/account_move_views.xml
+++ b/addons/stock_landed_costs/views/account_move_views.xml
@@ -24,7 +24,7 @@
 
             <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='quantity']" position="before">
                 <field name="product_type" column_invisible="True" groups="stock.group_stock_manager"/>
-                <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type != 'in_invoice'" readonly="product_type != 'service'" optional="hide" groups="stock.group_stock_manager"/>
+                <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type not in ('in_invoice', 'in_receipt')" readonly="product_type != 'service'" optional="hide" groups="stock.group_stock_manager"/>
             </xpath>
 
             <xpath expr="//field[@name='line_ids']/list/field[@name='name']" position="after">


### PR DESCRIPTION
Modules modified - account, account_fleet, stock_landed_costs, purchase

This commit ensures that the same optional fields are displayed consistently on both Receipts and Vendor Bills.

Updated the visibility of the following fields:
  - deductible_amount (Professional %)
  - vehicle_id (Vehicle)
  - is_landed_costs_line (Landed Costs)
  - purchase_order_id (Purchase Order)

task-5349202
