### PR TITLE
[FIX] account: fix hide sections and notes in journal items tab

### DIFF
--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='line_ids']//field[@name='account_id']" position="after">
+            <xpath expr="//field[@name='journal_line_ids' or @name='line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' column_invisible="True"/>
                 <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>
             </xpath>

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -64,7 +64,7 @@
             <xpath expr="//field[@name='invoice_line_ids']/list//field[@name='product_id']" position="after">
                 <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
             </xpath>
-            <xpath expr="//field[@name='line_ids']/list//field[@name='name']" position="after">
+            <xpath expr="//field[@name='journal_line_ids' or @name='line_ids']/list//field[@name='name']" position="after">
                 <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
             </xpath>
             <xpath expr="//header" position="inside">

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -32,7 +32,7 @@
                 <field name="purchase_line_id" groups="purchase.group_purchase_user" column_invisible="True"/>
                 <field name="purchase_order_id" groups="purchase.group_purchase_user" column_invisible="parent.move_type != 'in_invoice'" optional="hide"/>
             </xpath>
-            <xpath expr="//field[@name='line_ids']/list/field[@name='company_id']" position="after">
+            <xpath expr="//field[@name='journal_line_ids' or @name='line_ids']/list/field[@name='company_id']" position="after">
                 <field name="purchase_line_id" groups="purchase.group_purchase_user" column_invisible="True"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">

--- a/addons/stock_landed_costs/views/account_move_views.xml
+++ b/addons/stock_landed_costs/views/account_move_views.xml
@@ -27,7 +27,7 @@
                 <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type != 'in_invoice'" readonly="product_type != 'service'" optional="hide" groups="stock.group_stock_manager"/>
             </xpath>
 
-            <xpath expr="//field[@name='line_ids']/list/field[@name='name']" position="after">
+            <xpath expr="//field[@name='journal_line_ids' or @name='line_ids']/list/field[@name='name']" position="after">
                 <field name="product_type" column_invisible="True" groups="stock.group_stock_manager"/>
                 <field name="is_landed_costs_line" column_invisible="True" groups="stock.group_stock_manager"/>
             </xpath>


### PR DESCRIPTION
Steps to reproduce:
---
- Revert the commits
- Install `account` module
- Undo revert commits and install `l10n_pe_edi` module

This error occurs because the field name was changed in stable from `journal_line_ids` to `line_ids`. We cannot do this in a stable version, as older databases still reference the old field name, and renaming it in stable will cause errors.

Followup of: https://github.com/odoo/enterprise/pull/99875, https://github.com/odoo/odoo/pull/236457

sentry-7059309576, 7059890988


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
