### PR TITLE
[FIX] mrp: ensure correct timezone in test_replan_mo_after_updating_bom

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3395,6 +3395,7 @@ class TestMrpOrder(TestMrpCommon):
         """
 
         self.bom_3.write({'product_uom_id': self.uom_unit.id})
+        self.env.company.resource_calendar_id.tz = 'UTC'
 
         # Create an MO.
         mo_form = Form(self.env['mrp.production'])


### PR DESCRIPTION
The `test_replan_mo_after_updating_bom`, introduced in [PR](https://github.com/odoo/odoo/pull/223415),
test was failing because the workcenter's resource calendar used
during the test ended up with a different timezone when DB was
installed with demo data, which shifted the planned times and
caused the assertion to fail.

This commit sets the workcenter’s resource calendar timezone
explicitly in the test so it gives consistent results
across all test environments.

runbot - 234339