### PR TITLE
[FIX] point_of_sale: better quantity change handling

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -179,7 +179,7 @@ export class PosOrder extends Base {
             preset.fiscal_position_id || this.config.default_fiscal_position_id;
         this.preset_id = preset;
         if (preset.is_return) {
-            this.lines.forEach((l) => l.setQuantity(-Math.abs(l.getQuantity())));
+            this.lines.forEach((l) => l.setQuantity(-Math.abs(l.getQuantity()), true));
         }
     }
 

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -244,6 +244,7 @@ export class PosOrderline extends Base {
     // product's unity of measure properties. Quantities greater than zero will not get
     // rounded to zero
     setQuantity(quantity, keep_price) {
+        const oldQty = this.qty;
         if (this.order_id.preset_id?.is_return) {
             quantity = -Math.abs(quantity);
         }
@@ -313,6 +314,10 @@ export class PosOrderline extends Base {
                     )
                 );
             }
+        }
+        for (const comboLine of this.combo_line_ids) {
+            // If each combo contains 2 qty of a product, we wanna keep this ratio after setting the new quantity on the parent product.
+            comboLine.setQuantity((comboLine.qty / oldQty || 1) * quantity, true);
         }
         return true;
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -245,9 +245,6 @@ export class OrderSummary extends Component {
                         val,
                         Boolean(selectedLine.combo_line_ids?.length)
                     );
-                    for (const line of selectedLine.combo_line_ids) {
-                        line.setQuantity(val, true);
-                    }
                     if (result !== true) {
                         this.dialog.add(AlertDialog, result);
                         this.numberBuffer.reset();
@@ -278,10 +275,13 @@ export class OrderSummary extends Component {
     }
     async updateQuantityNumber(newQuantity) {
         if (newQuantity !== null) {
-            const selectedLine = this.currentOrder.getSelectedOrderline();
+            let selectedLine = this.currentOrder.getSelectedOrderline();
+            if (selectedLine.combo_parent_id) {
+                selectedLine = selectedLine.combo_parent_id;
+            }
             const currentQuantity = selectedLine.getQuantity();
             if (newQuantity >= currentQuantity) {
-                selectedLine.setQuantity(newQuantity);
+                selectedLine.setQuantity(newQuantity, Boolean(selectedLine.combo_line_ids?.length));
             } else if (newQuantity >= selectedLine.uiState.savedQuantity) {
                 await this.handleDecreaseUnsavedLine(newQuantity);
             } else {
@@ -292,13 +292,19 @@ export class OrderSummary extends Component {
         return false;
     }
     async handleDecreaseUnsavedLine(newQuantity) {
-        const selectedLine = this.currentOrder.getSelectedOrderline();
+        let selectedLine = this.currentOrder.getSelectedOrderline();
+        if (selectedLine.combo_parent_id) {
+            selectedLine = selectedLine.combo_parent_id;
+        }
         const decreaseQuantity = selectedLine.getQuantity() - newQuantity;
-        selectedLine.setQuantity(newQuantity);
+        selectedLine.setQuantity(newQuantity, Boolean(selectedLine.combo_line_ids?.length));
         return decreaseQuantity;
     }
     async handleDecreaseLine(newQuantity) {
-        const selectedLine = this.currentOrder.getSelectedOrderline();
+        let selectedLine = this.currentOrder.getSelectedOrderline();
+        if (selectedLine.combo_parent_id) {
+            selectedLine = selectedLine.combo_parent_id;
+        }
         let current_saved_quantity = 0;
         for (const line of this.currentOrder.lines) {
             if (line === selectedLine) {
@@ -316,12 +322,18 @@ export class OrderSummary extends Component {
             newLine.setQuantity(-decreasedQuantity + newLine.getQuantity(), true);
         }
         if (newLine !== selectedLine && selectedLine.uiState.savedQuantity != 0) {
-            selectedLine.setQuantity(selectedLine.uiState.savedQuantity);
+            selectedLine.setQuantity(
+                selectedLine.uiState.savedQuantity,
+                Boolean(selectedLine.combo_line_ids?.length)
+            );
         }
         return decreasedQuantity;
     }
     getNewLine() {
-        const selectedLine = this.currentOrder.getSelectedOrderline();
+        let selectedLine = this.currentOrder.getSelectedOrderline();
+        if (selectedLine.combo_parent_id) {
+            selectedLine = selectedLine.combo_parent_id;
+        }
         const sign = selectedLine.getQuantity() > 0 ? 1 : -1;
         let newLine = selectedLine;
         if (selectedLine.uiState.savedQuantity != 0) {

--- a/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
@@ -11,6 +11,10 @@ function getAllPricesData(otherData = {}) {
                 id: 1,
                 name: "Test Order",
             },
+            {
+                id: 2,
+                name: "Test Combo order",
+            },
         ],
         "pos.order.line": [
             {
@@ -20,6 +24,33 @@ function getAllPricesData(otherData = {}) {
                 price_unit: 100.0,
                 qty: 2,
                 tax_ids: [1],
+            },
+            {
+                id: 2,
+                order_id: 2,
+                product_id: 7,
+                price_unit: 0.0,
+                qty: 1,
+                combo_line_ids: [3, 4],
+                tax_ids: [],
+            },
+            {
+                id: 3,
+                order_id: 2,
+                product_id: 8,
+                price_unit: 1,
+                qty: 2,
+                combo_parent_id: 2,
+                tax_ids: [],
+            },
+            {
+                id: 4,
+                order_id: 2,
+                product_id: 10,
+                price_unit: 8,
+                qty: 1,
+                combo_parent_id: 2,
+                tax_ids: [],
             },
         ],
         ...otherData,
@@ -165,6 +196,30 @@ test("[setQuantity] Base test", async () => {
     expect(orderLine.qty).toBe(2.78);
     orderLine.setQuantity(2.771);
     expect(orderLine.qty).toBe(2.77);
+
+    const comboOrderline = data["pos.order.line"][1];
+    const comboChild1 = data["pos.order.line"][2];
+    const comboChild2 = data["pos.order.line"][3];
+    expect(comboOrderline.qty).toBe(1);
+    expect(comboChild1.qty).toBe(2);
+    expect(comboChild2.qty).toBe(1);
+    expect(comboOrderline.price_unit).toBe(0);
+    expect(comboChild1.price_unit).toBe(1);
+    expect(comboChild2.price_unit).toBe(8);
+    comboOrderline.setQuantity(3, true);
+    expect(comboOrderline.qty).toBe(3);
+    expect(comboChild1.qty).toBe(6);
+    expect(comboChild2.qty).toBe(3);
+    expect(comboOrderline.price_unit).toBe(0);
+    expect(comboChild1.price_unit).toBe(1);
+    expect(comboChild2.price_unit).toBe(8);
+    comboOrderline.setQuantity(2, true);
+    expect(comboOrderline.qty).toBe(2);
+    expect(comboChild1.qty).toBe(4);
+    expect(comboChild2.qty).toBe(2);
+    expect(comboOrderline.price_unit).toBe(0);
+    expect(comboChild1.price_unit).toBe(1);
+    expect(comboChild2.price_unit).toBe(8);
 });
 
 test("[canBeMergedWith]: Base test", async () => {


### PR DESCRIPTION
Before this commit, when changing the quantities of a line, we would not automatically change the quantities of the children lines if any. This is now the case. We also handle the prices in a better way such that changing the quantities of a combo product does not affect the price unit of the lines computed previously.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
