### PR TITLE
[FIX] mail: no name in the channel invite dialog opened from sidebar

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -118,7 +118,7 @@ threadActionsRegistry
         open(component, action) {
             if (action.sidebar) {
                 action.dialogService?.add(ChannelActionDialog, {
-                    title: component.thread.name,
+                    title: component.thread.displayName,
                     contentComponent: ChannelInvitation,
                     contentProps: {
                         autofocus: true,

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -174,3 +174,20 @@ test("unnamed group chat should display correct name just after being invited", 
         text: "You have been invited to #Jane and Mitchell Admin",
     });
 });
+
+test("Invite sidebar action has the correct title for group chats", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "group",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click("button[title='Chat Actions']");
+    await click(".o-dropdown-item", { text: "Invite People" });
+    await contains("h4.modal-title", { text: "Mitchell Admin and Demo" });
+});


### PR DESCRIPTION
Before this commit, certain channels whose names were computed on the client side did not appear correctly as the title of the invite dialog when opened via the sidebar actions.

This commit resolves the issue by using the channel’s displayName instead of the thread.name to ensure the correct title is shown in the invite dialog.

task-5357104
