### PR TITLE
[IMP] stock: add correct group to `location_id`

### DIFF
--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -48,7 +48,7 @@
                             <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom"
                                    options="{'no_open': True}" class="oe_inline"/>
                         </div>
-                        <field name="location_id" invisible="not location_id" groups="stock.group_stock_manager"/>
+                        <field name="location_id" invisible="not location_id" groups="stock.group_stock_multi_locations"/>
                     </group>
                     <field name="lot_properties" nolabel="1" columns="2" hideAddButton="1"/>
                 </group>


### PR DESCRIPTION
`location_id` always showed on `view_production_lot_form` even when disabled.
By adding `group_stock_multi_locations`, it works as expected.

Task: 4910195




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
