### PR TITLE
[FIX] base: respect 0 margins/spacing overrides for wkhtmltopdf

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -286,7 +286,7 @@ class IrActionsReport(models.Model):
                 command_args.extend(['--page-width', str(paperformat_id.page_width) + 'mm'])
                 command_args.extend(['--page-height', str(paperformat_id.page_height) + 'mm'])
 
-            if specific_paperformat_args and specific_paperformat_args.get('data-report-margin-top'):
+            if specific_paperformat_args and 'data-report-margin-top' in specific_paperformat_args:
                 command_args.extend(['--margin-top', str(specific_paperformat_args['data-report-margin-top'])])
             else:
                 command_args.extend(['--margin-top', str(paperformat_id.margin_top)])
@@ -305,14 +305,14 @@ class IrActionsReport(models.Model):
                 if wkhtmltopdf_dpi_zoom_ratio:
                     command_args.extend(['--zoom', str(96.0 / dpi)])
 
-            if specific_paperformat_args and specific_paperformat_args.get('data-report-header-spacing'):
+            if specific_paperformat_args and 'data-report-header-spacing' in specific_paperformat_args:
                 command_args.extend(['--header-spacing', str(specific_paperformat_args['data-report-header-spacing'])])
             elif paperformat_id.header_spacing:
                 command_args.extend(['--header-spacing', str(paperformat_id.header_spacing)])
 
             command_args.extend(['--margin-left', str(paperformat_id.margin_left)])
 
-            if specific_paperformat_args and specific_paperformat_args.get('data-report-margin-bottom'):
+            if specific_paperformat_args and 'data-report-margin-bottom' in specific_paperformat_args:
                 command_args.extend(['--margin-bottom', str(specific_paperformat_args['data-report-margin-bottom'])])
             else:
                 command_args.extend(['--margin-bottom', str(paperformat_id.margin_bottom)])

--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -525,6 +525,46 @@ class TestReportsRendering(TestReportsRenderingCommon):
         pages_contents = [[elem[1] for elem in page] for page in pages]
         self.assertEqual(pages_contents, expected_pages_contents)
 
+    def test_report_specific_paperformat_args(self):
+        """
+            Verify that the values defined in `specific_paperformat_args` take
+            precedence over those in the paperformat when building the wkhtmltopdf
+            command arguments.
+        """
+        command_args = self.env['ir.actions.report']._build_wkhtmltopdf_args(
+            self.env['report.paperformat'].new({
+                'format': 'A4',
+                'margin_top': 25,
+                'margin_left': 50,
+                'margin_bottom': 75,
+                'margin_right': 100,
+                'dpi': 90,
+                'header_spacing': 125,
+                'orientation': 'portrait'
+            }),
+            landscape=None,
+            specific_paperformat_args={
+                'data-report-landscape': True,
+                'data-report-margin-top': 0,
+                'data-report-margin-bottom': 0,
+                'data-report-header-spacing': 0,
+                'data-report-dpi': 96
+            })
+        self.assertEqual(command_args, [
+            '--disable-local-file-access',
+            '--quiet',
+            '--page-size', 'A4',
+            '--margin-top', '0',
+            '--dpi', '96',
+            '--zoom', '1.0',
+            '--header-spacing', '0',
+            '--margin-left', '50.0',
+            '--margin-bottom', '0',
+            '--margin-right', '100.0',
+            '--javascript-delay', '1000',
+            '--orientation', 'landscape',
+        ])
+
 
 @odoo.tests.tagged('post_install', '-at_install', '-standard', 'pdf_rendering')
 class TestReportsRenderingLimitations(TestReportsRenderingCommon):


### PR DESCRIPTION
When constructing the wkhtmltopdf command arguments, the system retrieves values from the `specific_paperformat_args` dictionary using get and checks whether the returned value is falsy.

Because 0 is a falsy value in Python, margin and header spacing values explicitly set to 0 are mistakenly ignored. As a result, the system incorrectly falls back to the default paperformat values instead of honoring the overrides provided in `specific_paperformat_args`.

This commit updates the conditional checks so that values from `specific_paperformat_args` correctly override the paperformat defaults even when the override is 0. This allows users to intentionally remove all margins and spacing defined on the report.

Task-5079740

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
