### PR TITLE
[IMP] account: assert or save XML test helpers

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -2,7 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import fields, Command
 from odoo.models import BaseModel
-from odoo.tests import Form, HttpCase, new_test_user
+from odoo.tests import Form, HttpCase, new_test_user, save_test_file
+from odoo.tools import config, file_path, file_open
 from odoo.tools.float_utils import float_round
 
 from odoo.addons.product.tests.common import ProductCommon
@@ -10,6 +11,8 @@ from odoo.addons.product.tests.common import ProductCommon
 import json
 import base64
 import logging
+import re
+
 from contextlib import contextmanager
 from functools import wraps
 from lxml import etree
@@ -23,6 +26,7 @@ class AccountTestInvoicingCommon(ProductCommon):
     # to override by the helper methods setup_country and setup_chart_template to adapt to a localization
     chart_template = False
     country_code = False
+    extra_tags = ('-standard', 'external') if 'EXTERNAL_MODE' in (config['test_tags'] or {}) else ()
 
     @classmethod
     def safe_copy(cls, record):
@@ -940,7 +944,288 @@ class AccountTestInvoicingCommon(ProductCommon):
     # Xml Comparison
     ####################################################
 
-    def _turn_node_as_dict_hierarchy(self, node, path=''):
+    @classmethod
+    def _get_xml_ignore_schema(cls, subfolder: str) -> etree._Element | None:
+        """
+        Recursively look for the closest `ignore_schema.xml` from the given `subfolder`, and
+        return its content as an XML element object if found.
+
+        For example, if the given `subfolder` parameter is `foo/bar/egg`, this method will search for
+        an `ignore_schema.xml` file from these paths, in order:
+
+        - /tests/test_files/foo/bar/egg/ignore_schema.xml
+        - /tests/test_files/foo/bar/ignore_schema.xml
+        - /tests/test_files/foo/ignore_schema.xml
+        - /tests/test_files/ignore_schema.xml
+
+        :param subfolder: the subfolder of the path of XML file to save/assert. (e.g. "folder_1", "folder_outer/folder_inner")
+        :return: _Element object if an `ignore_schema.xml` file is found, otherwise nothing will be returned.
+        """
+        subfolders = subfolder.split('/')
+        ignore_schema_paths = []
+        while subfolders:
+            ignore_schema_paths.append(f"{cls.test_module}/tests/test_files/{'/'.join(subfolders)}/ignore_schema.xml")
+            subfolders.pop()
+        ignore_schema_paths.append(f"{cls.test_module}/tests/test_files/ignore_schema.xml")
+
+        for ignore_schema_path in ignore_schema_paths:
+            try:
+                with file_open(ignore_schema_path, 'rb') as f:
+                    return etree.fromstring(f.read())
+            except FileNotFoundError:
+                pass
+
+    @classmethod
+    def _clear_xml_content(cls, xml_element: etree._Element, clean_namespaces=True):
+        """
+        Clears an _Element object by removing all its children and deleting all of their attributes and namespaces.
+        """
+        for child in xml_element:
+            xml_element.remove(child)
+
+        for attrib_key in xml_element.attrib:
+            del xml_element.attrib[attrib_key]
+
+        if clean_namespaces:
+            etree.cleanup_namespaces(xml_element)
+
+    @classmethod
+    def _merge_two_xml(
+            cls,
+            primary_xml: etree._Element,
+            secondary_xml: etree._Element,
+            overwrite_on_conflict=True,
+            add_on_absent=True,
+    ):
+        """
+        This method takes two _Element objects, and merge the content of the second _Element to the first one recursively.
+        Here, we go through every text, and attribute of the secondary_xml and its children; and apply the following operation:
+
+        - Search for a matching child element / attribute on the `primary_xml`
+        - If a match is found, overwrite the matching `primary_xml` attribute/child/text if `overwrite_on_conflict` is True
+        - If a match is not found, add on `primary_xml` if `add_on_absent` is True
+
+        Warning: The `tag` of the two `_Element` object must be the same.
+
+        For example:
+        Before calling this method,
+        primary_xml
+        <a attr_1="old_attr_1">
+            <b>old b text</b>
+        </a>
+
+        secondary_xml
+        <a attr_1="new_attr_1" attr_2="new_attr_2>
+            <b attr_b="new_attr_b">new text</b>
+            <c>new element</c>
+        </a>
+
+        [#1] Resulting primary_xml post call with default optional parameters (overwrite_on_conflict True, add_on_absent True)
+        <a attr_1="new_attr_1" attr_2="new_attr_2>
+            <b attr_b="new_attr_b">new text</b>
+            <c>new element</c>
+        </a>
+
+        [#2] Resulting primary_xml post call with (overwrite_on_conflict True, add_on_absent False)
+        <a attr_1="new_attr_1">
+            <b>new text</b>
+        </a>
+
+        [#3] Resulting primary_xml post call with (overwrite_on_conflict False, add_on_absent True)
+        <a attr_1="old_attr_1" attr_2="new_attr_2>
+            <b attr_b="new_attr_b">old b text</b>
+            <c>new element</c>
+        </a>
+
+        [#4] Resulting primary_xml post call with (overwrite_on_conflict False, add_on_absent False)
+        No change will be made with these configuration.
+
+        :param primary_xml: The primary _Element object to be written on to.
+        :param secondary_xml: The second _Element object in which content is used as reference.
+        :param overwrite_on_conflict: If True and matching attribute/child element is found, the original content is overwritten.
+        :param add_on_absent: If True and matching attribute/child element is not found, it will be added on the primary_xml.
+        :return:
+        """
+        if primary_xml.tag != secondary_xml.tag:
+            return
+
+        for new_attrib_key, new_attrib_val in secondary_xml.items():
+            if (new_attrib_key not in primary_xml.attrib and add_on_absent) or (new_attrib_key in primary_xml.attrib and overwrite_on_conflict):
+                primary_xml.attrib[new_attrib_key] = new_attrib_val
+
+        if secondary_xml.text and ((not primary_xml.text and overwrite_on_conflict) or (primary_xml.text and overwrite_on_conflict)):
+            primary_xml.text = secondary_xml.text
+
+        for new_child in secondary_xml.getchildren():
+            found_match = False
+            for current_child in primary_xml.getchildren():
+                if current_child.tag == new_child.tag:
+                    cls._merge_two_xml(
+                        current_child,
+                        new_child,
+                        overwrite_on_conflict=overwrite_on_conflict,
+                        add_on_absent=add_on_absent,
+                    )
+                    found_match = True
+
+            if not found_match and add_on_absent:
+                primary_xml.append(new_child)
+
+    @classmethod
+    def _prepare_xml_ignore_schema(cls, xml_schema: etree._Element):
+        """
+        Hook method called on a found ignore schema XML element before we apply them to the main XML element to save.
+        Here, we preprocess the `___inherit___` attribute of the main schema XML and process them,
+        so that the final `xml_schema` contains the schema of the parent schema(s) too.
+
+        This method can optionally be extended to modify the schema manually python-side.
+        """
+        # TO EXTEND
+        if '___inherit___' in xml_schema.attrib:
+            # Merge current XML schema with the parent(s)
+            next_inherit = xml_schema.attrib['___inherit___']
+
+            while next_inherit:
+                with file_open(next_inherit, 'rb') as f:
+                    xml_main_schema = etree.fromstring(f.read())
+                next_inherit = xml_main_schema.attrib.get('___inherit___')
+
+                cls._merge_two_xml(xml_main_schema, xml_schema)
+                cls._clear_xml_content(xml_schema)
+                cls._merge_two_xml(xml_schema, xml_main_schema)
+
+    @classmethod
+    def _rebuild_xml_with_sorted_namespaces(cls, root: etree._Element) -> etree._Element:
+        # Collect all namespaces and prefixes
+        all_nsmap = {
+            prefix: uri
+            for elem in root.iter()
+            for prefix, uri in elem.nsmap.items()
+        }
+
+        # Sort all namespaces
+        nsmap_str_keys = [key for key in all_nsmap if isinstance(key, str)]
+        sorted_nsmap_keys = [
+            *((None,) if None in all_nsmap else ()),
+            *sorted(nsmap_str_keys),
+        ]
+        sorted_nsmap = {
+            nsmap_key: all_nsmap[nsmap_key]
+            for nsmap_key in sorted_nsmap_keys
+        }
+
+        # Build a new root element with the sorted namespaces and all original root attrib & children
+        new_root = etree.Element(root.tag, nsmap=sorted_nsmap)
+        new_root.text = root.text
+        for attrib_key, attrib_val in root.attrib.items():
+            new_root.attrib[attrib_key] = attrib_val
+        for child in root.getchildren():
+            new_root.append(child)
+
+        return new_root
+
+    def _get_test_file_path(self, file_name: str, subfolder=''):
+        optional_subfolder = f"{subfolder}/" if subfolder else ''
+        return file_path(f"{self.test_module}/tests/test_files/{optional_subfolder}{file_name}")
+
+    def assert_json(self, content_to_assert: dict, test_name: str, subfolder=''):
+        """
+        Helper to save/assert a dictionary to a JSON file located in the corresponding module `test_files`.
+        By default, this method will assert the dictionary with the JSON content.
+        To switch to save mode, add a `SAVE_JSON` tag when calling the test;
+        the `content_to_assert` dictionary will then be written in to the test file.
+
+        Before asserting, the dictionary will first be serialized to ensure it is in the same format of the saved JSON.
+        This means that for example: all tuples within the dictionary will be converted to list, etc.
+
+        :param content_to_assert: dictionary to save or assert to the corresponding test file
+        :param test_name: the test file name
+        :param subfolder: the test file subfolder(s), separated by `/` if there is more than one
+        """
+        json_path = self._get_test_file_path(f"{test_name}.json", subfolder=subfolder)
+
+        if 'SAVE_JSON' in config['test_tags']:
+            with file_open(json_path, 'w') as f:
+                json.dump(content_to_assert, f, indent=4)
+        else:
+            with file_open(json_path, 'rb') as f:
+                expected_content = json.loads(f.read())
+
+            content_to_assert = json.loads(json.dumps(content_to_assert))
+            self.assertDictEqual(content_to_assert, expected_content)
+
+    def assert_xml(
+            self,
+            xml_element: str | bytes | etree._Element,
+            test_name: str,
+            subfolder='',
+    ):
+        """
+        Helper to save/assert an XML element/string/bytes to an XML file.
+        By default, this method will assert the passed XML content to the test XML file.
+        To switch to save mode, add a `SAVE_XML` tag when calling the test;
+        This mode will instead do the following:
+
+        - Reindent the XML element by `\t`
+        - Save the XML element to a temporary folder for potential external testing
+        - Patch the XML element with `___ignore___` values, following the corresponding schema on the closest `ignore_schema.xml`
+        - Canonicalize the XML element to ensure consistency in their namespaces & attributes order
+        - Save the XML element content to the test file
+
+        :param xml_element: the _Element/str/bytes content to be saved or asserted
+        :param test_name: the test file name
+        :param subfolder: the test file subfolder(s), separated by `/` if there is more than one
+        :return:
+        """
+        file_name = f"{test_name}.xml"
+        test_file_path = self._get_test_file_path(file_name, subfolder=subfolder)
+        if isinstance(xml_element, str):
+            xml_element = xml_element.encode()
+        if isinstance(xml_element, bytes):
+            xml_element = etree.fromstring(xml_element)
+
+        if 'SAVE_XML' in config['test_tags']:
+            # Save the XML to tmp folder before modifying some elements with `___ignore___`
+            etree.indent(xml_element, space='\t')
+            with patch.object(re, 'fullmatch', lambda _arg1, _arg2: True):
+                save_test_file(
+                    test_name=test_name,
+                    content=etree.tostring(xml_element, pretty_print=True, encoding='UTF-8'),
+                    prefix=f"{self.test_module}",
+                    extension='xml',
+                    document_type='Invoice XML',
+                    date_format='',
+                )
+            # Search for closest `ignore_schema.xml` from the file path and apply the change to xml_element
+            xml_ignore_schema = self._get_xml_ignore_schema(subfolder)
+            if xml_ignore_schema is not None:
+                self._prepare_xml_ignore_schema(xml_ignore_schema)
+                self._merge_two_xml(
+                    xml_element,
+                    xml_ignore_schema,
+                    overwrite_on_conflict=True,
+                    add_on_absent=False,
+                )
+                etree.indent(xml_element, space='\t')
+
+            # Canonicalize & re-sort the namespaces
+            canonicalized_xml_str = etree.canonicalize(xml_element)
+            xml_element = etree.fromstring(canonicalized_xml_str)
+            xml_element = self._rebuild_xml_with_sorted_namespaces(xml_element)
+
+            # Save the xml_element content
+            with file_open(test_file_path, 'wb') as f:
+                f.write(etree.tostring(xml_element, pretty_print=True, encoding='UTF-8'))
+                _logger.info("Saved the generated xml content to %s", file_name)
+        else:
+            with file_open(test_file_path, 'rb') as f:
+                expected_xml_str = f.read()
+
+            expected_xml_tree = etree.fromstring(expected_xml_str)
+            self.assertXmlTreeEqual(xml_element, expected_xml_tree)
+
+    @classmethod
+    def _turn_node_as_dict_hierarchy(cls, node, path=''):
         ''' Turn the node as a python dictionary to be compared later with another one.
         :param node:    A node inside an xml tree.
         :param path:    The optional path of tags for recursive call.
@@ -957,7 +1242,7 @@ class AccountTestInvoicingCommon(ProductCommon):
             'text': (node.text or '').strip(),
             'attrib': dict(node.attrib.items()),
             'children': [
-                self._turn_node_as_dict_hierarchy(child_node, path=full_path)
+                cls._turn_node_as_dict_hierarchy(child_node, path=full_path)
                 for child_node in node.getchildren()
             ],
         }
@@ -1022,23 +1307,26 @@ class AccountTestInvoicingCommon(ProductCommon):
             self._turn_node_as_dict_hierarchy(expected_xml_tree),
         )
 
-    def with_applied_xpath(self, xml_tree, xpath):
+    @classmethod
+    def with_applied_xpath(cls, xml_tree, xpath):
         ''' Applies the xpath to the xml_tree passed as parameter.
         :param xml_tree:    An instance of etree.
         :param xpath:       The xpath to apply as a string.
         :return:            The resulting etree after applying the xpaths.
         '''
         diff_xml_tree = etree.fromstring('<data>%s</data>' % xpath)
-        return self.env['ir.ui.view'].apply_inheritance_specs(xml_tree, diff_xml_tree)
+        return cls.env['ir.ui.view'].apply_inheritance_specs(xml_tree, diff_xml_tree)
 
-    def get_xml_tree_from_attachment(self, attachment):
+    @classmethod
+    def get_xml_tree_from_attachment(cls, attachment):
         ''' Extract an instance of etree from an ir.attachment.
         :param attachment:  An ir.attachment.
         :return:            An instance of etree.
         '''
         return etree.fromstring(base64.b64decode(attachment.with_context(bin_size=False).datas))
 
-    def get_xml_tree_from_string(self, xml_tree_str):
+    @classmethod
+    def get_xml_tree_from_string(cls, xml_tree_str):
         ''' Convert the string passed as parameter to an instance of etree.
         :param xml_tree_str:    A string representing an xml.
         :return:                An instance of etree.


### PR DESCRIPTION
> This is a backport of the merged https://github.com/odoo/odoo/pull/235565 - with a couple of improvements & adaptations to the test files.

This commit adds helpers and improves on the way we assert XML files in `AccountTestInvoicingCommon` and all accounting test that extend from it. From now on, all accounting test code that assert an XML tree/string to an XML file should call the `assert_xml` helper, and design their test file name/location/etc. around this framework.

This approach has a few major benefits:

Assert / Save XML

When testing XML files, we often need to perform create/read/update operations on the asserted XML to make sure it corresponds to the most updated/intended data. Previously, to save something to an XML, a developer would need to write their own local helpers to save the XML in the right directory. This was cumbersome and error-prone, so we decided to design a helper that allows developer to immediately save AND/OR update the asserted XML: to save/update an XML, we can simply add `SAVE_XML` as an additional test tags.

Better test naming and optional subfolder management

To better organize test files, the `assert_xml` method allows us to write just the test key name (without `.xml`), and the framework will automatically get the XML to assert/save from the `test_files` directory. An optional `subfolder` parameter is also added to allow writing to specific subfolder within `test_files`.

Better `___ignore___` management in assertion XMLs

Sometimes, we want to ignore a few XML node that are not relevant, or have content that are not deterministic (changes on every test run). To handle this, previously, developers would need to modify the assertion XML content by hand or write their own local script to do so.

With this new framework, we just need to add an `ignore_schema.xml` file somewhere in the `test_files` directory. If put inside a subfolder, it will be applied with more priority towards the XML that are put on that specific subfolder.

Save "pure" XML (before applying `___ignore___`) in temporary folder

When calling `SAVE_XML`, before applying the ignore patches, the XML will be saved in a temporary folder (same folder as the screenshots for tours), so that developers can use them in external tests in the future, and for any other saving reasons.

In addition, this commit also:

- add `extra_tags` helper to save all the common tags for EDIs, for a better way to enable `EXTERNAL_MODE` testing inspired by `l10n_mx_edi`
- convert some non-assert XML test helpers into a class method
- canonicalize the XML to ensure consistency of the generated test files following the C14N Version 2 standard. (Deterministic namespaces location, sorted attributes, etc.)

task-4891206
