### PR TITLE
[FIX] stock_dropship: skip non dropshipped lines for computations

### DIFF
--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -30,3 +30,14 @@ class PurchaseOrder(models.Model):
         if len(sale_orders) == 1:
             res['sale_ids'] = [Command.link(sale_orders.id)]
         return res
+
+    def _is_dropshipped(self):
+        self.ensure_one()
+        return self.picking_type_id and self.picking_type_id.code == 'dropship'
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def _is_dropshipped(self):
+        return self.order_id._is_dropshipped()

--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -43,7 +43,8 @@ class SaleOrderLine(models.Model):
         # People without purchase rights should be able to do this operation
         purchase_lines_sudo = self.sudo().purchase_line_ids
         # We make sure that it's not a kit with dropshipped components
-        if self.product_id == purchase_lines_sudo.product_id and purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
+        if any(pol._is_dropshipped() and pol.state != 'cancel' for pol in purchase_lines_sudo) and\
+            self.product_id == purchase_lines_sudo.product_id:
             qty = 0.0
             for po_line in purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
                 qty += po_line.product_uom_id._compute_quantity(po_line.product_qty, self.product_uom_id, rounding_method='HALF-UP')


### PR DESCRIPTION
Issue
-----
Procurement quantities are computed wrong (for non-dropshipped sales) when the dropship module is installed.

Steps to reproduce
-----
- Enable dropshipping & multi step route
- Set delivery rule as MTSO
- Create a product
    - Stock of 5
    - Add a vendor
- Create a SO
- Sell 6 of the product
- Confirm SO
- Open linked PO and confirm it
- Go back to the SO and change quantity of the product to 8
- Open the second linked PO

> Quantity is 7 instead of 2

Cause
-----
Writing the new quantity triggers `action_launch_stock_rule`

https://github.com/odoo/odoo/blob/3ce8e3e4e8049eb009ed05bdc3a33275c9eec0d6/addons/sale_stock/models/sale_order_line.py#L255

in which we call `_get_qty_procurement` to get the 'already handled' quantity

https://github.com/odoo/odoo/blob/3ce8e3e4e8049eb009ed05bdc3a33275c9eec0d6/addons/sale_stock/models/sale_order_line.py#L384

The problem is that this function is overriden in `stock_dropshipping`

https://github.com/odoo/odoo/blob/3ce8e3e4e8049eb009ed05bdc3a33275c9eec0d6/addons/stock_dropshipping/models/sale.py#L42-L52

Because the condition is true, we use the purchase line's `po_line.product_qty` instead of calling `super()`. Since `po_line.product_qty == 1`, we simply return 1.

With this, we end up creating a procurement of 8 - 1 = 7 units as if we were doing a dropship, instead of the expected 2 units.

-----
Ticket:
opw-5121035
