### PR TITLE
[FIX] mail: correct start subtitle message for group chats

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -659,7 +659,7 @@ export class Thread extends Component {
                 channelName: this.props.thread.name,
             });
         }
-        if (this.props.thread.channel_type === "channel") {
+        if (this.props.thread.channel_type === "group") {
             return _t("This is the start of %(conversationName)s group", {
                 conversationName: this.props.thread.displayName,
             });


### PR DESCRIPTION
Before this commit, 
The start message subtitle condition was incorrect for group chats, 
this commit corrects that condition and also add a test to cover all 
the channel types to show correct start message and subtitle.

Before:
<img width="625" height="109" alt="image" src="https://github.com/user-attachments/assets/830f9574-573f-4448-b54f-b70c8a4685ef" />


After:
<img width="640" height="133" alt="image" src="https://github.com/user-attachments/assets/bcba270a-88fc-446d-9015-1125872c5748" />

