### PR TITLE
[FIX] mrp: make `route_ids` visible in test setup

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -33,9 +33,11 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         product_form.name = 'Stick'
         product_form.uom_id = cls.uom_unit
         product_form.is_storable = True
-        product_form.route_ids.clear()
-        product_form.route_ids.add(cls.warehouse.mto_pull_id.route_id)
         cls.finished_product = product_form.save()
+        # Assign the MTO route directly to avoid requiring route_ids to be
+        # visible in the form (which would need product_selectable routes to
+        # be present, an assumption that doesn't hold on DBs without demo data)
+        cls.finished_product.route_ids = cls.warehouse.mto_pull_id.route_id
 
         # Create raw product for manufactured product
         product_form = Form(cls.env['product.product'])


### PR DESCRIPTION
The setup in `TestMultistepManufacturingWarehouse` was failing with:
```
AssertionError: field 'route_ids' is not visible
```
This happens because the `route_ids` field on the product form view is only visible when `has_available_route_ids` is True, which depends on having at least one `product_selectable` route.

This commit enables `product_selectable` on those routes in the test setup, so that `route_ids` becomes visible and the Form helper can access it safely.

[RB-232576](https://runbot.odoo.com/odoo/error/232576)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
