### PR TITLE
[FIX] l10n_it_edi: fix storing errors sent from Italian e-invoicing

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -99,7 +99,7 @@ class AccountMoveSend(models.AbstractModel):
                     attachment['raw'] = signed_data
                 # Show that those moves couldn't be sent
                 if 'error_message' in attachment_data:
-                    moves_data[move]['error'] = attachment_data['error_message']
+                    moves_data[move]['error'] = {'error_title': attachment_data['error_message']}
 
     def _link_invoice_documents(self, invoices_data):
         # EXTENDS 'account'


### PR DESCRIPTION
Before this commit:
Steps
1) When clients try to send their invoice to Italian e-invoicing 
2) If it's got rejected, they replied with an error message

=> A Traceback Error is raised with the message:
`errors = '\n- '.join(error.get('errors', ''))
^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'`,

This occurs because the `_call_web_service_after_invoice_pdf_render()` method in l10n_it_edi is setting `moves_data[move]['error']` to a string while `_generate_and_send_invoices()` that calls `_hook_if_errors()` expects it to be a dict.

After this commit:
If the Italian e-invoicing rejects the request with `error_message` in the response, Odoo stores and displays it to the client correctly.

opw-5271525