### PR TITLE
[FIX] stock_account: avoid zero-division in FIFO valuation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -227,7 +227,10 @@ class ProductProduct(models.Model):
             return self.standard_price
         if (product_value and last_in and product_value.date > last_in.date) or not last_in:
             return product_value.value
-        return last_in._get_value(at_date=date) / last_in._get_valued_qty()
+        valued_qty = last_in._get_valued_qty()
+        if not valued_qty:
+            return self.standard_price
+        return last_in._get_value(at_date=date) / valued_qty
 
     def _get_value_from_lots(self):
         lots = self.env['stock.lot'].search([

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -618,6 +618,17 @@ class TestStockValuationFIFO(TestStockValuationCommon):
         finally:
             self.env.user.company_id = old_company
 
+    def test_fifo_avg_cost_fallback_zero_valued_qty(self):
+        self.product.standard_price = 42.0
+        move = self._make_in_move(self.product, 1)
+        self._make_out_move(self.product, 1)
+        move.move_line_ids.owner_id = self.env['res.partner'].create({'name': 'External Owner'})
+        self.assertEqual(move._get_valued_qty(), 0.0)
+        self.product.invalidate_recordset(['total_value', 'avg_cost'])
+        self.product._compute_value()
+        self.assertEqual(self.product.total_value, 0.0)
+        self.assertEqual(self.product.avg_cost, 42.0)
+
 
 class TestStockValuationChangeCostMethod(TestStockValuationCommon):
     def test_standard_to_fifo_1(self):


### PR DESCRIPTION
In some cases an incoming FIFO move can end up with a valued quantity of 0 (e.g. partial receipts or leftover move lines).
The valuation code was still trying to compute `value / qty`, which caused a `ZeroDivisionError`.

```py
File "/home/odoo/src/odoo/19.0/addons/stock_account/models/product.py", line 169, in _compute_value
    product.avg_cost = product._get_standard_price_at_date()
   File "/home/odoo/src/odoo/19.0/addons/stock_account/models/product.py", line 230, in _get_standard_price_at_date
    return last_in._get_value(at_date=date) / last_in._get_valued_qty()
 ZeroDivisionError: float division by zero
```

Fallback to the product’s standard price when the last incoming move has no valued quantity.

opw-5223443
upg-3275142
tbg-2284



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
