### PR TITLE
[FIX] mail: assigning category to channel fails

### DIFF
--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -3,6 +3,7 @@
 from . import test_avatar_acl
 from . import test_discuss_attachment_controller
 from . import test_discuss_binary_controller
+from . import test_discuss_category
 from . import test_discuss_channel_invite
 from . import test_discuss_action
 from . import test_discuss_channel

--- a/addons/mail/tests/discuss/test_discuss_category.py
+++ b/addons/mail/tests/discuss/test_discuss_category.py
@@ -1,0 +1,49 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests import HttpCase
+
+
+class TestDiscussCategory(MailCommon, HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Test channel")
+
+    def test_assign_channel_categories(self):
+        self.authenticate("admin", "admin")
+        category_id = self.env["discuss.category"].create({"name": "Services"})
+
+        def get_assign_channel_category_bus():
+            return (
+                [
+                    (self.cr.dbname, "discuss.channel", self.channel.id),
+                    (self.cr.dbname, "discuss.channel", self.channel.id),
+                ],
+                [
+                    {
+                        "type": "mail.record/insert",
+                        "payload": {
+                            "discuss.category": [
+                                {"id": category_id.id, "name": category_id.name, "sequence": category_id.sequence},
+                            ],
+                            "discuss.channel": [
+                                {
+                                    "id": self.channel.id,
+                                    "discuss_category_id": category_id.id,
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "type": "mail.record/insert",
+                        "payload": {
+                            "discuss.category": [
+                                {"id": category_id.id, "name": category_id.name, "sequence": category_id.sequence},
+                            ],
+                        },
+                    },
+                ],
+            )
+
+        with self.assertBus(get_params=get_assign_channel_category_bus):
+            category_id.channel_ids = [(4, self.channel.id)]


### PR DESCRIPTION
In the bus_sync_mixin, when comparing old and new values, the key (channels, bus_target) is problematic when having multiple channels. This can lead to KeyError if one of the channels is missing in the new values so that all the channels in the new values might be ignroed.

Also, when comparing old and new values, using .get() is safer if any channel in new values is missing in old values.

This fix the problem of assigning category to channels. Before this commit, when the new channel did not have any category, an exception was raised preventing the assignment due to missing the key in old values.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
