### PR TITLE
[IMP] l10n_in_withholding: remove Apply Higher TCS button

### DIFF
--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -71,8 +71,6 @@
             <xpath expr="//header" position="inside">
                 <button name="%(l10n_in_withholding_entry_form_action)d" string="TDS Entry" type="action" class="btn btn-secondary float-end"
                         invisible="country_code != 'IN' or l10n_in_tds_deduction == 'no' or not l10n_in_tds_feature_enabled or move_type not in ('out_invoice', 'in_invoice', 'out_refund', 'in_refund') or state != 'posted'"/>
-                <button name="action_l10n_in_apply_higher_tax" string="Apply Higher TCS" type="object" class="btn btn-secondary float-end"
-                        invisible="not l10n_in_display_higher_tcs_button or not l10n_in_tcs_feature_enabled"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_l10n_in_withholding_entries"


### PR DESCRIPTION
The button was originally introduced to support workflows where a higher TCS rate had to be manually applied, and it was most widely used for Section 206C(1H). Since Section 206C(1H) has been removed by the Government effective 01-Apr-2025, this button is no longer required.

Before:
Users could manually click the button from invoices to apply higher TCS rates on relevant lines.

After:
The button and its supporting logic have been removed to streamline the UI.

Task - 5325848

Upgrade PR - https://github.com/odoo/upgrade/pull/8926
