### PR TITLE
[FIX] mail: clicking message link should not open new tab

### DIFF
--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -178,7 +178,7 @@ const ThreadPatch = {
         if (this.store.fullscreenChannel?.notEq(this)) {
             this.store.rtc.exitFullscreen();
         }
-        super.open(...arguments);
+        return super.open(...arguments);
     },
     /**
      * @param {import("models").RtcSession} session

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -38,6 +38,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
+import { patch } from "@web/core/utils/patch";
 import { getOrigin, url } from "@web/core/utils/urls";
 
 const { DateTime } = luxon;
@@ -2207,6 +2208,31 @@ test("Prettify message links", async () => {
     await contains(".o-mail-Message", { text: "TestPartner" });
     await contains(".o-mail-Message .fa.fa-comment");
     await contains(".o-mail-Message", { text: url(`/mail/message/100`) });
+});
+
+test("Clicking message link does not open a new tab", async () => {
+    patch(window, {
+        open() {
+            expect.step("new_window");
+            super.open();
+        },
+    });
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "Channel" });
+    const otherChannelId = pyEnv["discuss.channel"].create({ name: "Other Channel" });
+    const messageId = pyEnv["mail.message"].create({
+        body: "Message on other channel",
+        res_id: otherChannelId,
+        model: "discuss.channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", `${url(`/mail/message/${messageId}`)}`);
+    await press("Enter");
+    await click(".o_message_redirect");
+    await contains(".o-mail-DiscussContent-threadName[title='Other Channel']");
+    await contains(".o-mail-Message", { text: "Message on other channel" });
+    expect.verifySteps([]);
 });
 
 test("should delete link preview along with message", async () => {


### PR DESCRIPTION
Before this commit, clicking on a message link for a message outside of the current thread would open a new tab.

This unwanted behavior is caused by a missing return value on an override of Thread's `open` introduced in [1], breaking the chain of returns.

This commit fixes the issue by correctly returning the super call in said override.

[1] https://github.com/odoo/odoo/pull/223004

task-5268790