### PR TITLE
[FIX] account:  _split* functions not dispatching to the right lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1805,7 +1805,6 @@ class AccountTax(models.Model):
         :return:                    A list of tuple <index, normalized_factor> for each 'target_factors' passed as parameter.
         """
         factors = [(i, abs(target_factor['factor'])) for i, target_factor in enumerate(target_factors)]
-        factors.sort(key=lambda x: x[1], reverse=True)
         sum_of_factors = sum(x[1] for x in factors)
         return [(i, factor / sum_of_factors if sum_of_factors else 0.0) for i, factor in factors]
 
@@ -1843,6 +1842,8 @@ class AccountTax(models.Model):
 
         # Distribute using the factor first.
         factors = self._normalize_target_factors(target_factors)
+        factors.sort(key=lambda x: x[1], reverse=True)
+
         for i, factor in factors:
             if not remaining_errors:
                 break

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -768,7 +768,6 @@ export const accountTaxHelpers = {
      */
     normalize_target_factors(target_factors) {
         const factors = target_factors.map((x, i) => [i, Math.abs(x.factor)]);
-        factors.sort((a, b) => b[1] - a[1]);
         const sum_of_factors = factors.reduce((sum, x) => sum + x[1], 0.0);
         return factors.map((x) => [x[0], sum_of_factors ? x[1] / sum_of_factors : 0.0]);
     },
@@ -790,6 +789,7 @@ export const accountTaxHelpers = {
 
         // Distribute using the factor first.
         const factors = this.normalize_target_factors(target_factors);
+        factors.sort((a, b) => b[1] - a[1]);
         for (const [i, factor] of factors) {
             if (!remaining_errors) {
                 break;


### PR DESCRIPTION
**PROBLEM**
With a Mexican company, when trying to send a CFDI with a global discount, it can happen that after the repartition of the discount we have lines with a negative amount, so we can't send the CFDI.

**STEP TO REPRODUCE**
1. Take a Mexican company
2. create a quotation with, product A = 1$, product B = 100$, global discount of 15%
3. create an invoice using this quotation, confirm it and try sending the CDFI.
4. the following error will appear : "Error when sending the CFDI to the PAC: Failed to distribute some negative lines"

**CAUSE**
In account, the function `_normalize_target_factor()` takes a list of dictionary `target_factors`, with the keys being invoice lines (the targets) and the keys being weights (the factors). It is used to normalize the weight associated with the lines, to later use them to dispatch things like discounts to those lines. This function also does a sort on the weight, and return a list containing pairs of index and weights. This is useful only in the function `_distribute_delta_amount_smoothly()`, other functions doesn't work well with the sorted returned list: they don't use the index, and dispatch discounts to the wrong lines.

https://github.com/odoo/enterprise/pull/101109 adds a test in l10n_mx to reproduce the client use case.