### PR TITLE
[FIX] html_editor: use document selection for powerbuttons

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -497,14 +497,15 @@ export class SelectionPlugin extends Plugin {
     getSelectionData() {
         const selection = this.document.getSelection();
         const documentSelectionIsInEditable = selection && this.isSelectionInEditable(selection);
+        let collapsed;
         const documentSelection =
             selection?.anchorNode && selection?.focusNode
                 ? Object.freeze({
                       get isCollapsed() {
-                          if (this.collapsed === undefined) {
-                              this.collapsed = selection.isCollapsed;
+                          if (collapsed === undefined) {
+                              collapsed = selection.isCollapsed;
                           }
-                          return this.collapsed;
+                          return collapsed;
                       },
                       anchorNode: selection.anchorNode,
                       anchorOffset: selection.anchorOffset,

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -121,30 +121,29 @@ export class PowerButtonsPlugin extends Plugin {
 
     updatePowerButtons() {
         this.powerButtonsContainer.classList.add("d-none");
-        const { editableSelection, currentSelectionIsInEditable } =
+        const { documentSelection, editableSelection, currentSelectionIsInEditable } =
             this.dependencies.selection.getSelectionData();
         if (!currentSelectionIsInEditable) {
             return;
         }
-        const block = closestBlock(editableSelection.anchorNode);
-        const element = closestElement(editableSelection.anchorNode);
+        const block = closestBlock(documentSelection.anchorNode);
         const blockRect = block.getBoundingClientRect();
         const editableRect = this.editable.getBoundingClientRect();
         if (
-            editableSelection.isCollapsed &&
+            documentSelection.isCollapsed &&
             block?.matches(baseContainerGlobalSelector) &&
             editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
             !descendants(block).some(isEditorTab) &&
             !this.services.ui.isSmall &&
-            !closestElement(editableSelection.anchorNode, "td, th, li") &&
+            !closestElement(documentSelection.anchorNode, "td, th, li") &&
             !block.style.textAlign &&
             this.getResource("power_buttons_visibility_predicates").every((predicate) =>
-                predicate(editableSelection)
+                predicate(documentSelection)
             )
         ) {
             this.powerButtonsContainer.classList.remove("d-none");
-            const direction = closestElement(element, "[dir]")?.getAttribute("dir");
+            const direction = closestElement(block, "[dir]")?.getAttribute("dir");
             this.powerButtonsContainer.setAttribute("dir", direction);
             // Hide/show buttons based on their availability.
             for (const [{ isAvailable }, buttonElement] of this.descriptionToElementMap.entries()) {

--- a/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="html_editor.EmbeddedToggleBlock">
        <div class="d-flex flex-row align-items-center">
-            <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" t-on-click="onToggle" type="button">
+            <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" t-on-click="onToggle" t-on-pointerdown.prevent="" type="button">
                 <i t-attf-class="fa align-self-center fa-caret-{{this.state.showContent ? 'down' : 'right'}}"/>
             </button>
             <div class="flex-fill ms-1" t-ref="title"/>

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -864,6 +864,49 @@ describe("Hide and show toggle content", () => {
             queryOne("[data-embedded-editable='content']").parentElement.matches(".d-none")
         ).toBe(false);
     });
+    test.tags("desktop");
+    test("Changing toggle state should update power buttons position", async () => {
+        const { el } = await setupEditor(
+            unformat(
+                `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
+                    <div data-embedded-editable="title">
+                        <p>Hello World</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>asdf</p>
+                    </div>
+                </div>
+                <p>[]<br></p>
+            `
+            ),
+            {
+                config: getConfig([toggleBlockEmbedding]),
+            }
+        );
+        el.style.minHeight = "600px";
+        const powerButtons = queryOne(".o_we_power_buttons");
+        const p = el.lastChild;
+        await embeddedToggleMountedPromise;
+        expect(
+            queryOne("[data-embedded-editable='content']").parentElement.matches(".d-none")
+        ).toBe(true);
+        await contains("[data-embedded='toggleBlock'] button").click();
+        await animationFrame();
+        expect(
+            queryOne("[data-embedded-editable='content']").parentElement.matches(".d-none")
+        ).toBe(false);
+        let pRect = p.getBoundingClientRect();
+        let powerButtonsRect = powerButtons.getBoundingClientRect();
+        expect(pRect.top).toEqual(powerButtonsRect.top);
+        await contains("[data-embedded='toggleBlock'] button").click();
+        await animationFrame();
+        expect(
+            queryOne("[data-embedded-editable='content']").parentElement.matches(".d-none")
+        ).toBe(true);
+        pRect = p.getBoundingClientRect();
+        powerButtonsRect = powerButtons.getBoundingClientRect();
+        expect(pRect.top).toEqual(powerButtonsRect.top);
+    });
 });
 describe("Insert (paste, drop) inside toggle title", () => {
     test("Only allow one paragraph related element inside title", async () => {


### PR DESCRIPTION
Description of the issue this PR addresses:

Powerbuttons were previously relying on the editable selection to decide whether they should be shown. However, this also displayed powerbutton when selection was not in editable.
Powerbuttons now uses the document selection, ensuring powerbuttons only appear when the selection is actually inside the relevant elements.

task-5240942

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
