### PR TITLE
[FIX] delivery: fix MemoryError on move product fetch

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -206,7 +206,7 @@ class DeliveryCarrier(models.Model):
         if source._name == 'sale.order':
             products = source.order_line.product_id
         elif source._name == 'stock.picking':
-            products = source.move_ids.product_id
+            products = source.move_ids.with_prefetch().mapped('product_id')
         else:
             raise UserError(_("Invalid source document type"))
         return not self.must_have_tag_ids or any(
@@ -219,7 +219,7 @@ class DeliveryCarrier(models.Model):
         if source._name == 'sale.order':
             products = source.order_line.product_id
         elif source._name == 'stock.picking':
-            products = source.move_ids.product_id
+            products = source.move_ids.with_prefetch().mapped('product_id')
         else:
             raise UserError(_("Invalid source document type"))
         return not any(tag in products.all_product_tag_ids for tag in self.excluded_tag_ids)


### PR DESCRIPTION
During v19 upgrade mock crawl, accessing `source.move_ids.product_id` triggered a huge relational prefetch, crashing with:

```py
   File "/home/odoo/src/odoo/19.0/addons/delivery/models/delivery_carrier.py", line 209, in _match_must_have_tags
    products = source.move_ids.product_id
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields_relational.py", line 75, in __get__
    super().__get__(remaining, owner)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1692, in __get__
    recs._fetch_field(self)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3769, in _fetch_field
    self.fetch(fnames)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3809, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3930, in _fetch_query
    field._insert_cache(fetched, values)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1599, in _insert_cache
    collections.deque(map(field_cache.setdefault, records._ids, values), maxlen=0)
 MemoryError
```
Full traceback: https://pad.odoo.com/p/aTIGHsnDMrfMENfmU5TK

Use a controlled lookup instead.

opw-5223443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
