### PR TITLE
[FIX] project: fix My Tasks path

### DIFF
--- a/addons/project/tests/test_task_link_preview_name.py
+++ b/addons/project/tests/test_task_link_preview_name.py
@@ -9,8 +9,7 @@ class TestTaskLinkPreviewName(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        admin_user = new_test_user(cls.env, login='admin_user', groups='base.group_user,base.group_system')
-        cls.admin = admin_user.login
+        cls.admin = new_test_user(cls.env, login='admin_user', groups='base.group_user,base.group_system')
 
         cls.project_internal_link_display = cls.env['project.project'].create({
             'name': 'project',
@@ -23,16 +22,31 @@ class TestTaskLinkPreviewName(HttpCase):
             'link_preview_name': 'test1 | test parent',
             'project_id': cls.project_internal_link_display.id,
             'description': 'task1_description',
+            'user_ids': [(6, 0, [cls.admin.id])],
         })
 
     def test_01_task_link_preview_name(self):
-        self.authenticate(self.admin, self.admin)
+        self.authenticate(self.admin.login, self.admin.login)
         # retrieve metadata of an record with customerized link_preview_name
         response_with_preview_name = self.url_open(
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
                     "preview_url": f"/odoo/all-tasks/{self.task_internal_link_customized.id}",
+                }
+            }),
+            headers={"Content-Type": "application/json"}
+        )
+        self.assertEqual(200, response_with_preview_name.status_code)
+        self.assertTrue('link_preview_name' in response_with_preview_name.text)
+
+    def test_my_tasks_path(self):
+        self.authenticate(self.admin.login, self.admin.login)
+        response_with_preview_name = self.url_open(
+            '/html_editor/link_preview_internal',
+            data=json_safe.dumps({
+                "params": {
+                    "preview_url": f"/odoo/my-tasks/{self.task_internal_link_customized.id}",
                 }
             }),
             headers={"Content-Type": "application/json"}

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1038,6 +1038,7 @@
         <record id="action_view_my_task" model="ir.actions.act_window">
             <field name="name">My Tasks</field>
             <field name="res_model">project.task</field>
+            <field name="path">my-tasks</field>
             <field name="view_mode">kanban,list,form,calendar,activity,pivot,graph</field>
             <field name="context">{
                 'search_default_open_tasks': 1,


### PR DESCRIPTION
after https://github.com/odoo/odoo/commit/bc6b363f556104e86a635325690a8061a9e9ff91 all `/my-tasks/<task-id>` links are broken because of missing path field in the corresponding action.
this commit should fix the issue and add a test to avoid regression.

opw-5342898

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
