### PR TITLE
[FIX] mail: prevent long participant names from overflowing call sidebar

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -55,7 +55,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.list">
-        <div class="d-flex flex-column gap-1 flex-grow-1" style="padding: 1.5px;">
+        <div class="d-flex flex-column gap-1 flex-grow-1 overflow-hidden" style="padding: 1.5px;">
             <t t-foreach="sessions" t-as="session" t-key="session.localId">
                 <t t-call="mail.DiscussSidebarCallParticipants.participant">
                     <t t-set="session" t-value="session"/>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Prevent call participant name overflow

**Current behavior before PR:**
Before this PR, long participant names in the call sidebar could overflow 
their container, distorting the layout and causing the call action icons to 
shift incorrectly.

**Desired behavior after PR is merged:**
This PR ensures long names are now handled safely, preventing any layout 
breakage in the call participants sidebar.

Before:
<img width="302" height="125" alt="image" src="https://github.com/user-attachments/assets/309d3a0e-8304-43ee-ab22-0d7ee2883fc1" />  

After:
<img width="289" height="119" alt="image" src="https://github.com/user-attachments/assets/6c838fff-70d2-443a-b651-b985afe9cea6" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
