### PR TITLE
[FIX] html_builder: consider system nodes as not visible

### DIFF
--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -56,9 +56,11 @@ export class VisibilityPlugin extends Plugin {
     }
 
     getVisibleSibling(target, direction) {
+        const systemNodeSelectors = this.getResource("system_node_selectors").join(",");
         const siblingEls = [...target.parentNode.children];
         const visibleSiblingEls = siblingEls.filter(
-            (el) => window.getComputedStyle(el).display !== "none"
+            (el) =>
+                window.getComputedStyle(el).display !== "none" && !el.closest(systemNodeSelectors)
         );
         const targetMobileOrder = target.style.order;
         // On mobile, if the target has a mobile order (which is independent

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -65,6 +65,56 @@ test("Use the 'move arrows' overlay buttons", async () => {
     expect(".overlay .fa-angle-left").toHaveCount(0);
 });
 
+test("Use the 'move arrows' overlay buttons within an editable div", async () => {
+    await setupWebsiteBuilder(`
+        <div contenteditable="true">
+        <section>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-5">
+                        <p>TEST</p>
+                    </div>
+                    <div class="col-lg-4">
+                        <p>TEST</p>
+                    </div>
+                    <div class="col-lg-3">
+                        <p>TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <section>
+            <p>TEST</p>
+        </section>
+        </div>
+    `);
+
+    await contains(":iframe section").click();
+    expect(".overlay .o_overlay_options").toHaveCount(1);
+    expect(".overlay .fa-angle-down").toHaveCount(1);
+    expect(".overlay .fa-angle-up").toHaveCount(0);
+    expect(".overlay .fa-angle-left, .overlay .fa-angle-right").toHaveCount(0);
+
+    await contains(":iframe .col-lg-5").click();
+    expect(".overlay .o_overlay_options").toHaveCount(1);
+    expect(".overlay .fa-angle-right").toHaveCount(1);
+    expect(".overlay .fa-angle-left").toHaveCount(0);
+    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(0);
+
+    await contains(":iframe .col-lg-3").click();
+    expect(".overlay .fa-angle-right").toHaveCount(0);
+    expect(".overlay .fa-angle-left").toHaveCount(1);
+
+    await contains(":iframe .col-lg-4").click();
+    expect(".overlay .fa-angle-right").toHaveCount(1);
+    expect(".overlay .fa-angle-left").toHaveCount(1);
+
+    await contains(".overlay .fa-angle-left").click();
+    expect(":iframe .col-lg-4:nth-child(1)").toHaveCount(1);
+    expect(".overlay .fa-angle-right").toHaveCount(1);
+    expect(".overlay .fa-angle-left").toHaveCount(0);
+});
+
 test("Use the 'grid' overlay buttons", async () => {
     await setupWebsiteBuilder(`
         <section>


### PR DESCRIPTION
Since [1] placeholder paragraphs are inserted between sections when editing HTML fields with the website builder.
Because of this the move operation up/down using the overlay button on sections swaps the section with that paragraph instead of the neighbour section.

This commit solves this by making the `getVisibleSibling` shared method of the visibility plugin ignore system nodes.

Steps to reproduce:
- Go to `/jobs`
- Pick an offer
- Edit
- Select a section
- Click on the overlay's move up/down arrow

=> The block the not move.

[1]: https://github.com/odoo/odoo/commit/edf7f7bb0c62978640c181eccb4934855d5d872d

task-5358358
