### PR TITLE
[FIX] l10n_sa_edi: handle 400 response when requesting PCSID

### DIFF
--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-28 10:17+0000\n"
-"PO-Revision-Date: 2025-10-28 10:17+0000\n"
+"POT-Creation-Date: 2025-11-27 08:56+0000\n"
+"PO-Revision-Date: 2025-11-27 08:56+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,6 +23,13 @@ msgid ""
 "\n"
 "Building Number: %s, Plot Identification: %s\n"
 "Neighborhood: %s"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "%(code)s Server returned an unexpected error: %(error)s"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -425,11 +432,6 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model:ir.model,name:l10n_sa_edi.model_account_tax
-msgid "ETA tax codes mixin"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -907,13 +909,6 @@ msgid "Serial Number"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-#, python-format
-msgid "Server returned an unexpected error: %(error)s"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid "Set whether the system should use the Production API"
 msgstr ""
@@ -966,6 +961,11 @@ msgstr ""
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Supplier"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model:ir.model,name:l10n_sa_edi.model_account_tax
+msgid "Tax"
 msgstr ""
 
 #. module: l10n_sa_edi


### PR DESCRIPTION
Previously, only an `error` key was expected when ZATCA returns a 400 response to PCSID request. However, ZATCA can also return an `errors` array, which would go by unnoticed and cause a traceback to be shown to the user down the line.

This commit accounts for both error keys and raises a human readable UserError if either is found

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
