### PR TITLE
[IMP] mail: cleanup mention plugin

### DIFF
--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -4,7 +4,7 @@ import { generateThreadMentionElement } from "@mail/utils/common/format";
 
 export class MentionPlugin extends Plugin {
     static id = "mention";
-    static dependencies = ["baseContainer", "selection", "history", "protectedNode"];
+    static dependencies = ["baseContainer", "selection", "history"];
     resources = {
         selectionchange_handlers: this.detectMentions.bind(this),
         is_node_editable_predicates: (node) => {
@@ -65,14 +65,6 @@ export class MentionPlugin extends Plugin {
                 selector: "a.o-discuss-mention",
                 checker: (el) => true,
             },
-            {
-                selector: "a.o_mail_redirect",
-                checker: () => true,
-            },
-            {
-                selector: "a.o-discuss-mention",
-                checker: () => true,
-            },
         ];
     }
 
@@ -96,7 +88,6 @@ export class MentionPlugin extends Plugin {
 
     prepareValidMentionLinks(validMentionLinks) {
         for (const el of validMentionLinks) {
-            this.dependencies.protectedNode.setProtectingNode(el, true);
             // if el's parent is odoo-editor-editable, which happens when the html is computed or set with setContent,
             // considering the mention blocks are protected and not editable.
             // This will lead to issues where the mention cannot be deleted or edited properly.

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -181,7 +181,6 @@ function generateMentionElement({ className, id, model, text }) {
         class: className,
         "data-oe-id": id,
         "data-oe-model": model,
-        "data-oe-protected": "true",
         target: "_blank",
         contenteditable: "false",
     });
@@ -217,7 +216,6 @@ export function generateSpecialMentionElement(label) {
     const link = document.createElement("a");
     setAttributes(link, {
         class: "o-discuss-mention",
-        "data-oe-protected": "true",
         contenteditable: "false",
     });
     link.textContent = `@${label}`;

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -52,6 +52,13 @@ beforeEach(() => {
     });
 });
 
+function cut(editor) {
+    const clipboardData = new DataTransfer();
+    const cutEvent = new ClipboardEvent("cut", { clipboardData });
+    editor.editable.dispatchEvent(cutEvent);
+    return clipboardData;
+}
+
 test("composer text input: basic rendering when posting a message", async () => {
     await startServer();
     await start();
@@ -1726,6 +1733,91 @@ test("mentions can be correctly selected with ctrl+A and deleted", async () => {
     await focus(editor.editable);
     await press("Control+a");
     await press("Backspace");
+    await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
+    await contains(editor.editable, { textContent: "" });
+});
+
+test.tags("html composer");
+test("mentions can be correctly cut with ctrl+A and ctrl+X", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    // partner beginning of the message
+    await htmlInsertText(editor, "@admin");
+    await click(".o-mail-NavigableList-item:text('Mitchell Admin')");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('@Mitchell Admin')");
+    await htmlInsertText(editor, "Hello");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('@Mitchell Admin Hello')");
+    await focus(editor.editable);
+    await press("Control+a");
+    cut(editor);
+    await contains(editor.editable, { textContent: "" });
+
+    // thread with an icon beginning of the message
+    await htmlInsertText(editor, "#general");
+    await click(".o-mail-NavigableList-item:text('General')");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('General')");
+    await contains(editor.editable.querySelector("i.fa-hashtag"));
+    await htmlInsertText(editor, "Hello");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('General Hello')");
+    await focus(editor.editable);
+    await press("Control+a");
+    cut(editor);
+    await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
+    await contains(editor.editable, { textContent: "" });
+
+    // partner in the middle of the message
+    await htmlInsertText(editor, "Hello @admin");
+    await click(".o-mail-NavigableList-item:text('Mitchell Admin')");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello @Mitchell Admin')");
+    await htmlInsertText(editor, "nice to meet you!");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello @Mitchell Admin nice to meet you!')");
+    await focus(editor.editable);
+    await press("Control+a");
+    cut(editor);
+    await contains(editor.editable, { textContent: "" });
+
+    // thread with an icon in the middle of the message
+    await htmlInsertText(editor, "Hello #general");
+    await click(".o-mail-NavigableList-item:text('General')");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello General')");
+    await contains(editor.editable.querySelector("i.fa-hashtag"));
+    await htmlInsertText(editor, "nice to meet you!");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello General nice to meet you!')");
+    await focus(editor.editable);
+    await press("Control+a");
+    cut(editor);
+    await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
+    await contains(editor.editable, { textContent: "" });
+
+    // partner at the end of the message
+    await htmlInsertText(editor, "Hello @admin");
+    await click(".o-mail-NavigableList-item:text('Mitchell Admin')");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello @Mitchell Admin')");
+    await focus(editor.editable);
+    await press("Control+a");
+    cut(editor);
+    await contains(editor.editable, { textContent: "" });
+
+    // thread with an icon at the end of the message
+    await htmlInsertText(editor, "Hello #general");
+    await click(".o-mail-NavigableList-item:text('General')");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('Hello General')");
+    await contains(editor.editable.querySelector("i.fa-hashtag"));
+    await focus(editor.editable);
+    await press("Control+a");
+    cut(editor);
     await contains(editor.editable.querySelector("i.fa-hashtag"), { count: 0 });
     await contains(editor.editable, { textContent: "" });
 });


### PR DESCRIPTION
Currently, mention nodes are protected using the ProtectedNode plugin
to avoid issues when editing the content of the composer.

Considering we don't nessecarily need to protect mention
nodes with no mutation allowed on them, we can remove the protection
on mention nodes.

Also, remove reduntant MENTION_SELECTORS

task-5264818



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
