### PR TITLE
[FIX] html_editor: properly preserve selection in textareas

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -622,7 +622,7 @@ export class DomPlugin extends Plugin {
                 if (newCandidate.matches(baseContainerGlobalSelector) && isListItemElement(block)) {
                     continue;
                 }
-                this.dispatchTo("before_set_tag_handlers", block);
+                this.dispatchTo("before_set_tag_handlers", block, tagName, cursors);
                 const newEl = this.setTagName(block, tagName);
                 cursors.remapNode(block, newEl);
                 // We want to be able to edit the case `<h2 class="h3">`

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1138,10 +1138,10 @@ export class HistoryPlugin extends Plugin {
             revertedStep = this.steps[pos];
             this.revertedSteps.add(revertedStep.id);
             this.revertMutations(revertedStep.mutations, { forNewStep: true });
-            this.setSerializedSelection(revertedStep.selection);
-            this.currentStep.selection = revertedStep.selectionAfter;
             this.setSerializedFocus(revertedStep.activeElementId);
             this.stageFocus();
+            this.setSerializedSelection(revertedStep.selection);
+            this.currentStep.selection = revertedStep.selectionAfter;
             this.addStep({ type: "undo", extraStepInfos: revertedStep.extraStepInfos });
             // Consider the last position of the history as an undo.
         }
@@ -1164,10 +1164,10 @@ export class HistoryPlugin extends Plugin {
             revertedStep = this.steps[pos];
             this.revertedSteps.add(revertedStep.id);
             this.revertMutations(revertedStep.mutations, { forNewStep: true });
-            this.setSerializedSelection(revertedStep.selection);
-            this.currentStep.selection = revertedStep.selectionAfter;
             this.setSerializedFocus(revertedStep.activeElementId);
             this.stageFocus();
+            this.setSerializedSelection(revertedStep.selection);
+            this.currentStep.selection = revertedStep.selectionAfter;
             this.addStep({ type: "redo", extraStepInfos: revertedStep.extraStepInfos });
         }
         this.dispatchTo("post_redo_handlers", revertedStep);
@@ -1203,10 +1203,10 @@ export class HistoryPlugin extends Plugin {
     setSerializedFocus(activeElementId) {
         const elementToFocus =
             activeElementId === "root"
-                ? this.document.body
+                ? this.editable
                 : activeElementId && this.nodeMap.getNode(activeElementId);
-        if (elementToFocus !== this.document.activeElement) {
-            elementToFocus?.focus();
+        if (elementToFocus?.isConnected && elementToFocus !== this.document.activeElement) {
+            elementToFocus.focus();
         }
     }
     /**

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -660,6 +660,8 @@ export class SelectionPlugin extends Plugin {
      * @returns {() => void}
      */
     preserveTextareaSelections() {
+        const focusedTextarea =
+            this.document.activeElement?.nodeName === "TEXTAREA" && this.document.activeElement;
         const selections = [...this.editable.querySelectorAll("textarea")].map((textarea) => ({
             textarea,
             start: textarea.selectionStart,
@@ -667,12 +669,9 @@ export class SelectionPlugin extends Plugin {
             direction: textarea.selectionDirection,
         }));
         return () => {
-            if (
-                this.activeSelection?.isCollapsed &&
-                this.activeSelection.anchorNode?.nodeName === "TEXTAREA"
-            ) {
+            if (focusedTextarea) {
                 // If a textarea is targeted, focus it so its selection is active.
-                this.activeSelection.anchorNode.focus();
+                focusedTextarea.focus();
             }
             for (const { textarea, start, end, direction } of selections) {
                 textarea.setSelectionRange(start, end, direction);

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -821,6 +821,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     // Write in the P again.
     actions.push("type: insert 'o' into the paragraph", "type: insert 'k' into the paragraph");
     const p = queryOne("p:not([data-selection-placeholder])");
+    await click(p);
     editor.shared.selection.setCursorEnd(p);
     await insertText(editor, "ok"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok[]</p>
     await compareHighlightedContent(
@@ -1095,5 +1096,41 @@ test("invisible whitespace gets trimmed before changing tag to pre", async () =>
         </p>`,
         stepFunction: insertPre,
         contentAfter: `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">hello</pre>[]`,
+    });
+});
+
+test("can write in a highlighted code block within a nested list", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: unformat(
+            `<p>a</p>
+            <ul>
+                <li class="oe-nested">
+                    <ul>
+                        <li>
+                            <pre>some code</pre>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+            <p>b</p>`
+        ),
+        stepFunction: async () => {
+            await click("textarea");
+            await pressAndWait("x");
+            await pressAndWait("y");
+        },
+        contentAfter: unformat(
+            `<p>a</p>
+            <ul>
+                <li class="oe-nested">
+                    <ul>
+                        <li>
+                            <pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">some codexy</pre>[]
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+            <p>b</p>`
+        ),
     });
 });

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1087,3 +1087,13 @@ test("can copy/paste a highlighted code block", async () => {
         ),
     });
 });
+
+test("invisible whitespace gets trimmed before changing tag to pre", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: `<p>
+            hel[]lo
+        </p>`,
+        stepFunction: insertPre,
+        contentAfter: `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">hello</pre>[]`,
+    });
+});

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { setupEditor } from "../_helpers/editor";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import {
     cleanTextNode,
     fillEmpty,
+    removeInvisibleWhitespace,
     splitTextNode,
     wrapInlinesInBlocks,
 } from "@html_editor/utils/dom";
@@ -409,5 +410,34 @@ describe("fillEmpty", () => {
         const div = el.firstChild;
         fillEmpty(div);
         expect(el.innerHTML).toBe('<div class="o-paragraph"><canvas></canvas></div>');
+    });
+});
+
+describe("removeInvisibleWhitespace", () => {
+    test("should remove invisible whitespace from an element and preserve the selection", async () => {
+        await testEditor({
+            contentBefore: `<p>
+                <u>
+                    abc
+                </u>
+                def
+                <span>
+                    <b>
+                        ghi
+                    </b>
+                    jkl
+                </span>
+                mno
+                <i>
+                    pqr
+                </i>
+            </p>`,
+            stepFunction: (editor) => {
+                const cursors = editor.shared.selection.preserveSelection();
+                removeInvisibleWhitespace(editor.editable.querySelector("p"), cursors);
+                cursors.restore();
+            },
+            contentAfter: `<p><u>abc</u> def<span><b> ghi</b> jkl</span> mno<i> pqr</i></p>`,
+        });
     });
 });


### PR DESCRIPTION
This PR addresses a bug that can be reproduced as follows:

1. Create a list before or after a paragraph
2. Indent the list
3. Insert a code block in it
4. Type in the code block

-> the selection is ejected from the code block.

The issue was due to `preserveTextareaSelections`: its condition to restore the focus within a textarea was never met. As a result, when the active selection was changed during normalization, the focus was lost.

Fixing this revealed a double issue with the `undo` and `redo` functions:
1. the focus should be set _before_ setting the selection (otherwise changing the focus might change the selection back)
2. `body.focus()` doesn't do anything, we need to do `editable.focus()`.

While fixing the issue, an unrelated problem was noticed and also addressed here: invisible whitespace that would become visible in a `<pre>` element should be removed before turning a block into a `<pre>`.

task-5262154