### PR TITLE
[REF] hr_holidays: remove obsolete fields

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -197,7 +197,7 @@ class ResourceResource(models.Model):
         holiday_id = leave_record.holiday_id
         tz = ZoneInfo(self.tz or self.env.user.tz)
 
-        if holiday_id.request_unit_half:
+        if holiday_id.leave_type_request_unit == 'half_day':
             # Half day leaves are limited to half a day within a single day
             leave_day = leave_start.date()
             half_start_datetime = datetime.combine(leave_day, datetime.min.time() if holiday_id.request_date_from_period == "am" else time(12), tzinfo=tz)
@@ -210,7 +210,7 @@ class ResourceResource(models.Model):
                     resource_hours_per_day[self.id][leave_day] -= holiday_id.number_of_hours
                 week = weeknumber(babel_locale_parse(locale), leave_day)
                 resource_hours_per_week[self.id][week] -= holiday_id.number_of_hours
-        elif holiday_id.request_unit_hours:
+        elif holiday_id.leave_type_request_unit == 'hour':
             # Custom leaves are limited to a specific number of hours within a single day
             leave_day = leave_start.date()
             range_start_datetime = leave_record.date_from.replace(tzinfo=UTC).astimezone(tz)

--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -40,7 +40,7 @@ export class TimeOffCalendarModel extends CalendarModel {
             const dateTo = DateTime.fromSQL(rawRecord.date_to);
             result.sameDay = dateFrom.hasSame(dateTo, 'day');
         }
-        if (rawRecord.request_unit_half) {
+        if (rawRecord.leave_type_request_unit === "half") {
             result.requestDateFromPeriod = rawRecord.request_date_from_period;
             result.requestDateToPeriod = rawRecord.request_date_to_period;
         }
@@ -61,7 +61,7 @@ export class TimeOffCalendarModel extends CalendarModel {
             return str.length > 10 ? deserializeDateTime(str) : deserializeDate(str);
         }
         if (["week", "day"].includes(this.scale)) {
-            context["default_request_unit_hours"] = true;
+            context["default_leave_type_request_unit"] = "hour";
             const hour_from = deserialize(context['default_date_from']??this.date);
             const hour_to = deserialize(context['default_date_to']??this.date);
             context['default_request_hour_from'] = hour_from.hour + hour_from.minute / 60;
@@ -129,7 +129,7 @@ export class TimeOffCalendarModel extends CalendarModel {
         if (!this.employeeId) {
             context["short_name"] = 1;
         }
-        const fieldNamesToAdd = resModel === "hr.leave" ? ["request_unit_half", "request_date_from_period", "request_date_to_period", "request_unit_hours"] : [];
+        const fieldNamesToAdd = resModel === "hr.leave" ? ["leave_type_request_unit", "request_date_from_period", "request_date_to_period"] : [];
         return this.orm.searchRead(resModel, this.computeDomain(data), [...fieldNames, ...fieldNamesToAdd], { context });
     }
 

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -81,7 +81,7 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
             }
         }
         // handling half pill UX for custom_hours
-        if (record?.rawRecord?.request_unit_hours && record.sameDay) {
+        if (record?.rawRecord?.leave_type_request_unit === "hour" && record.sameDay) {
             if (record.end.c.hour < 12) {
                 classesToAdd.push("o_event_half_left");
             } else if (record.end.c.hour >= 12 && record.start.c.hour >= 12) {

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1675,19 +1675,19 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         hr_leave_default_value = self.env['hr.leave'].with_context({
-            'default_request_unit_hours': True,
+            'default_leave_type_request_unit': 'hour',
         }).default_get(list(self.env['hr.leave'].fields_get()) + ['holiday_status_id'])
         self.assertEqual(hr_leave_default_value.get('holiday_status_id'), hour_leave_type.id)
 
         self.env['hr.leave.type'].search([('id', '=', hour_leave_type.id)]).unlink()
         hr_leave_default_value = self.env['hr.leave'].with_context({
-            'default_request_unit_hours': True,
+            'default_leave_type_request_unit': 'hour',
         }).default_get(list(self.env['hr.leave'].fields_get()) + ['holiday_status_id'])
         self.assertEqual(hr_leave_default_value.get('holiday_status_id'), half_day_leave_type.id)
 
         self.env['hr.leave.type'].search([('id', '=', half_day_leave_type.id)]).unlink()
         hr_leave_default_value = self.env['hr.leave'].with_context({
-            'default_request_unit_hours': True,
+            'default_leave_type_request_unit': 'hour',
         }).default_get(list(self.env['hr.leave'].fields_get()) + ['holiday_status_id'])
         self.assertEqual(hr_leave_default_value.get('holiday_status_id'), False)
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -104,8 +104,6 @@
                 <field name="state"/>
                 <field name="employee_id"/>
                 <field name="leave_type_request_unit"/>
-                <field name="request_unit_hours"/>
-                <field name="request_unit_half"/>
                 <field name="request_date_from"/>
                 <field name="request_hour_from"/>
                 <field name="request_hour_to"/>
@@ -366,8 +364,8 @@
                                 context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
                                 options="{'no_create': True, 'request_type': 'leave'}"
                                 readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
-                            <label for="request_date_from" invisible="not request_unit_half and not request_unit_hours" string="Date" />
-                            <label for="request_date_from" invisible="request_unit_half or request_unit_hours" string="Dates" />
+                            <label for="request_date_from" invisible="leave_type_request_unit not in('hour', 'half_day')" string="Date" />
+                            <label for="request_date_from" invisible="leave_type_request_unit in ('half_day', 'hour')" string="Dates" />
                             <div id="full_date" class="o_row">
                                 <field
                                     name="request_date_from"
@@ -381,23 +379,23 @@
                                 </div>
                             </div>
                             <!-- half day or custom hours-->
-                            <label for="request_date_from_period" invisible="not request_unit_half" string="Day Period"/>
-                            <div class="o_row" invisible="not request_unit_half">
-                                <field name="request_date_from_period" invisible="not request_unit_half" required="request_unit_half" readonly="state != 'confirm'" class="o_hr_narrow_field me-2"/>
-                                <field name="request_date_to_period" invisible="not request_unit_half" required="request_unit_half" readonly="state != 'confirm'" class="o_hr_narrow_field"/>
+                            <label for="request_date_from_period" invisible="leave_type_request_unit != 'half_day'" string="Day Period"/>
+                            <div class="o_row" invisible="leave_type_request_unit != 'half_day'">
+                                <field name="request_date_from_period" invisible="leave_type_request_unit != 'half_day'" required="leave_type_request_unit == 'half_day'" readonly="state != 'confirm'" class="o_hr_narrow_field me-2"/>
+                                <field name="request_date_to_period" invisible="leave_type_request_unit != 'half_day'" required="leave_type_request_unit == 'half_day'" readonly="state != 'confirm'" class="o_hr_narrow_field"/>
                             </div>
-                            <label for="request_hour_from" invisible="not request_unit_hours" string="Hours"/>
-                            <div class="o_row" invisible="not request_unit_hours">
-                                <field name="request_hour_from" readonly="state == 'validate'" required="request_unit_hours" widget="float_time_selection" class="o_hr_narrow_field me-2"/>
-                                <field name="request_hour_to" readonly="state == 'validate'" required="request_unit_hours" widget="float_time_selection" class="o_hr_narrow_field"/>
+                            <label for="request_hour_from" invisible="leave_type_request_unit != 'hour'" string="Hours"/>
+                            <div class="o_row" invisible="leave_type_request_unit != 'hour'">
+                                <field name="request_hour_from" readonly="state == 'validate'" required="leave_type_request_unit == 'hour'" widget="float_time_selection" class="o_hr_narrow_field me-2"/>
+                                <field name="request_hour_to" readonly="state == 'validate'" required="leave_type_request_unit == 'hour'" widget="float_time_selection" class="o_hr_narrow_field"/>
                             </div>
-                            <div colspan="2" class="alert alert-info" role="alert" invisible="not request_unit_hours or not tz_mismatch or dashboard_warning_message">
+                            <div colspan="2" class="alert alert-info" role="alert" invisible="leave_type_request_unit != 'hour' or not tz_mismatch or dashboard_warning_message">
                                 <span>The employee has a different timezone than yours! Here dates and times are displayed in the employee's work timezone</span>
                                 (<field name="tz" class="oe_inline fw-bold"/>).
                                 <div>For your reference, the equivalent times in your timezone are displayed below.</div>
                             </div>
-                            <label for="date_from" string="Your Timezone" invisible="not request_unit_hours or not tz_mismatch"/>
-                            <div class="o_row o_row_readonly" invisible="not request_unit_hours or not tz_mismatch">
+                            <label for="date_from" string="Your Timezone" invisible="leave_type_request_unit != 'hour' or not tz_mismatch"/>
+                            <div class="o_row o_row_readonly" invisible="leave_type_request_unit != 'hour' or not tz_mismatch">
                                 <label for="date_from" string="From" />
                                 <field name="date_from" readonly="1" widget="datetime"/>
                                 <label for="date_to" string="To" />

--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -35,7 +35,7 @@ class HrLeave(models.Model):
         self.ensure_one()
         default_hours = default_hours or self._l10n_in_get_default_leave_hours()
         hours = hours if hours is not None else (self.number_of_hours or 0.0)
-        if not self.request_unit_hours or not default_hours:
+        if self.leave_type_request_unit != 'hour' or not default_hours:
             return True
         return float_compare(hours, default_hours, precision_digits=2) >= 0
 
@@ -93,7 +93,7 @@ class HrLeave(models.Model):
             if self._l10n_in_is_working(current_date, public_holiday_dates, resource_calendar):
                 break
         linked_leave = leaves_by_date.get(current_date, self.env["hr.leave"])
-        if linked_leave and linked_leave.request_unit_half:
+        if linked_leave and linked_leave.leave_type_request_unit == 'half_day':
             return self.env["hr.leave"]
         return linked_leave
 
@@ -122,7 +122,7 @@ class HrLeave(models.Model):
         indian_leaves = self.filtered(
             lambda leave: leave.company_id.country_id.code == "IN"
             and leave.holiday_status_id.l10n_in_is_sandwich_leave
-            and not leave.request_unit_half
+            and leave.leave_type_request_unit != 'half_day'
         )
         if not indian_leaves:
             return (indian_leaves, {}, {})
@@ -133,7 +133,7 @@ class HrLeave(models.Model):
                 ('id', 'not in', self.ids),
                 ('employee_id', 'in', self.employee_id.ids),
                 ('state', 'not in', ['cancel', 'refuse']),
-                ('request_unit_half', '=', False),
+                ('leave_type_request_unit', '!=', 'half_day'),
                 ('holiday_status_id.l10n_in_is_sandwich_leave', '=', True),
             ],
             groupby=['employee_id'],

--- a/addons/project_timesheet_holidays/models/hr_leave.py
+++ b/addons/project_timesheet_holidays/models/hr_leave.py
@@ -39,11 +39,11 @@ class HrLeave(models.Model):
 
             calendar_timezone = ZoneInfo(calendar.tz)
 
-            if calendar.flexible_hours and (leave.request_unit_hours or leave.request_unit_half or leave.date_from.date() == leave.date_to.date()):
+            if calendar.flexible_hours and (leave.leave_type_request_unit == 'hour' or leave.leave_type_request_unit == 'half_day' or leave.date_from.date() == leave.date_to.date()):
                 leave_date = leave.date_from.astimezone(calendar_timezone).date()
-                if leave.request_unit_hours:
+                if leave.leave_type_request_unit == 'hour':
                     hours = leave.request_hour_to - leave.request_hour_from
-                elif leave.request_unit_half:
+                elif leave.leave_type_request_unit == 'half_day':
                     hours = calendar.hours_per_day / 2
                 else:  # Single-day leave
                     hours = calendar.hours_per_day


### PR DESCRIPTION
The boolean fields `request_unit_half` and `request_unit_hours` are now unused, as their functionality is fully covered by `leave_type_request_unit`. They are therefore removed.

task-5262190

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
