### PR TITLE
[FIX] website: update favicon when switching websites

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -344,6 +344,10 @@ export class WebsiteBuilderClientAction extends Component {
         const currentTitle = iframe.contentDocument.title;
         history.replaceState(history.state, currentTitle, iframe.contentDocument.location.href);
         this.title.setParts({ action: currentTitle });
+        const frontendIconEl = iframe.contentDocument.querySelector("link[rel~='icon']");
+        if (frontendIconEl) {
+            document.querySelector("link[rel~='icon']").href = frontendIconEl.href;
+        }
     }
 
     onIframeLoad(ev) {


### PR DESCRIPTION
When editing a website favicon in settings or switching between websites with different favicons, the browser tab always displayed the default Odoo favicon instead of the specific website's favicon. the favicon were not immediately reflected due to browser caching.

The browser is responsible for caching the favicon. When you load a page, the browser sees `<link rel="shortcut icon" href="...">`. If it has already downloaded the image at that URL, it will use the stored (cached) copy instead of asking the server for it again. This improves performance. but also it's responsible for the bug.

Steps to reproduce:
===================
1. Set a custom favicon for your website in Settings.
2. Open the Website app.
3. Observe that the browser tab shows the default Odoo favicon instead of the custom one.

Solution:
=========
Retrieve the favicon URL directly from the iframe's document content
(link[rel~='icon']) and update the main window's favicon

opw-5126299

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
