### PR TITLE
[FIX] resource: compute date_to from date_from on a resource time off

### DIFF
--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -66,8 +66,9 @@ class ResourceCalendarLeaves(models.Model):
         for leave in self:
             if not leave.date_from:
                 continue
-            date_to_tz = user_tz.localize(leave.date_from) + relativedelta(hour=23, minute=59, second=59)
-            leave.date_to = date_to_tz.astimezone(utc).replace(tzinfo=None)
+            local_date_from = leave.date_from.replace(tzinfo=utc).astimezone(user_tz)
+            local_date_to = local_date_from + relativedelta(hour=23, minute=59, second=59)
+            leave.date_to = local_date_to.astimezone(utc).replace(tzinfo=None)
 
     @api.constrains('date_from', 'date_to')
     def check_dates(self):

--- a/addons/resource/tests/test_utils.py
+++ b/addons/resource/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from dateutil.relativedelta import relativedelta
+from datetime import datetime
 
 from odoo.fields import Datetime
 from odoo.tests.common import TransactionCase
@@ -82,3 +83,9 @@ class TestExpression(TransactionCase):
             self.assertTrue(res.id, 'The resource was successfully created')
             self.assertEqual(res.date_from, Datetime.to_string(date_from))
             self.assertEqual(res.date_to, Datetime.to_string(date_to))
+
+    def test_compute_date_to_time_off(self):
+        """Test that checks if the date_to is correctly computed from the date_from on a Resource Time Off"""
+        with Form(self.env['resource.calendar.leaves'].with_context(tz="Europe/Brussels")) as res:
+            res.date_from = datetime.strptime('2025-11-23 00:00:00', '%Y-%m-%d %H:%M:%S')
+        self.assertEqual(res.record.date_to, datetime(2025, 11, 23, 22, 59, 59))


### PR DESCRIPTION
## Short functional explanation of the error
When creating a public Time off for a Working Schedule, the end date will automatically set to a moment earlier than the set start date if the start date hour is set to midnight sharp.

## Reproduction Steps
1. Go to Employees.
2. Click on Configuration tab > Working Schedules.
3. Select a Working Schedule.
4. A smart button Public Time Off should appear. Click on it.
5. Click New and select a Start Date with a random date but 00:00:00 as hours:minutes:seconds.

### Expected behavior
The End date should automatically set 23 hours 59 minutes and 59 seconds later.

### Unexpected behavior
A Validation error occurs and the end date is set 1 second before the start date.

## Origin of the issue
When setting automatically the end date of a leave, it is set to 23:59:59. With our timezone, if we select midnight, this time will be converted to 23:00:00, the day before:
https://github.com/odoo/odoo/blob/e85f1a182ee60a25905369c84ced05480c5a3360/addons/resource/models/resource_calendar_leaves.py#L69-L70 Thus, the resulting end date will be set to the day before, at 23:59:59.
Additionally, we have to take into account the timezone of the user to set a consistent end date, and not the generic utc one.

__
opw-5187977



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
