### PR TITLE
[IMP] html_editor: improve buttons in remove image dialog

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -58,6 +58,9 @@ export class Attachment extends Component {
     remove() {
         this.dialogs.add(ConfirmationDialog, {
             body: _t("Are you sure you want to delete this file?"),
+            confirmLabel: _t("Delete"),
+            confirmClass: "btn-danger",
+            cancel: () => {},
             confirm: async () => {
                 const prevented = await rpc("/html_editor/attachment/remove", {
                     ids: [this.props.id],


### PR DESCRIPTION
The wording in the file selector when removing an image is not clear. This PR adds a discard button and reword the confirmation button.

task-5357506


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
