### PR TITLE
[IMP] api_doc: Error reporting and traceback support

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -42,11 +42,11 @@ class DocController(http.Controller):
         res.headers['X-Frame-Options'] = 'deny'
         return res
 
-    @http.route('/doc-bearer/index.json', type='http', auth='bearer')
+    @http.route('/doc-bearer/index.json', type='json2', auth='bearer')
     def doc_bearer_index(self):
         return self.doc_index()
 
-    @http.route('/doc/index.json', type='http', auth='user')
+    @http.route('/doc/index.json', type='json2', auth='user')
     def doc_index(self):
         """
         Get a listing of all modules, models, methods and fields. But
@@ -153,11 +153,11 @@ class DocController(http.Controller):
         ]
         return modules, models
 
-    @http.route('/doc-bearer/<model_name>.json', type='http', auth='bearer', readonly=True)
+    @http.route('/doc-bearer/<model_name>.json', type='json2', auth='bearer', readonly=True)
     def doc_bearer_modec(self, model_name):
         return self.doc_model(model_name)
 
-    @http.route('/doc/<model_name>.json', type='http', auth='user', readonly=True)
+    @http.route('/doc/<model_name>.json', type='json2', auth='user', readonly=True)
     def doc_model(self, model_name):
         """
         Get a complete listing of all the methods and fields for a

--- a/addons/api_doc/static/src/components/doc_error_dialog.js
+++ b/addons/api_doc/static/src/components/doc_error_dialog.js
@@ -1,0 +1,51 @@
+import { Component, useState, xml } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+
+export class DocErrorDialog extends Component {
+    static template = xml`
+        <div class="alert error mt-1 d-flex flex-column" role="alert">
+            <div class="d-flex align-items-center mb-2">
+                <i class="pe-2 fa fa-exclamation-triangle fa-lg" aria-hidden="true"/>
+                <h5 class="m-0 text-danger">Error while loading models: <strong t-out="props.name"/></h5>
+            </div>
+            <t t-if="props.traceback">
+                <div t-if="state.showTraceback" class="overflow-auto position-relative" style="max-height: 500px;">
+                    <button
+                        class="btn bg-100 position-absolute top-0 end-0"
+                        t-ref="copyButton"
+                        t-on-click="onClickClipboard"
+                    >
+                        <span class="fa fa-clipboard"/>
+                    </button>
+                    <pre class="small text-break p-4" t-out="props.traceback"/>
+                </div>
+                <button
+                    class="btn btn-sm mt-2 align-self-center"
+                    t-on-click="toggleTraceback"
+                    t-out="state.showTraceback ? 'Hide Details' : 'Show Technical Details'"
+                />
+            </t>
+        </div>
+    `;
+    static props = {
+        name: {type: String},
+        status: {type: Number, optional: true},
+        traceback: {type: String, optional: true},
+    };
+
+    setup() {
+        this.state = useState({
+            showTraceback: false
+        });
+    }
+
+    toggleTraceback() {
+        this.state.showTraceback = !this.state.showTraceback;
+    }
+
+    onClickClipboard() {
+        browser.navigator.clipboard.writeText(
+            `${this.props.name}\n\n${this.props.message}\n\n${this.contextDetails}\n\n${this.props.traceback}`
+        );
+    }
+}

--- a/addons/api_doc/static/src/components/doc_model.js
+++ b/addons/api_doc/static/src/components/doc_model.js
@@ -4,6 +4,7 @@ import { getCrudMethodsExamples } from "@api_doc/utils/doc_model_utils";
 import { DocMethod } from "@api_doc/components/doc_method";
 import { DocLoadingIndicator } from "@api_doc/components/doc_loading_indicator";
 import { useDocUI } from "@api_doc/utils/doc_ui_store";
+import { DocErrorDialog } from "@api_doc/components/doc_error_dialog";
 
 const TYPE_COLORS = {
     "text-success": ["integer", "char", "boolean", "selection", "float"],
@@ -46,6 +47,7 @@ export class DocModel extends Component {
         DocTable,
         DocMethod,
         DocLoadingIndicator,
+        DocErrorDialog,
     };
     static props = {};
 

--- a/addons/api_doc/static/src/components/doc_model.xml
+++ b/addons/api_doc/static/src/components/doc_model.xml
@@ -76,14 +76,15 @@
         </a>
     </aside>
 
-    <div t-if="state.error" class="d-flex flex-nowrap align-items-center justify-content-center w-100 h-100">
-        <div class="alert error mt-1 d-flex flex-nowrap flex-column">
-            <h5 class="mb-2 d-flex flex-nowrap align-items-center">
-                <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
-                <span>Error while loading model</span>
-            </h5>
-            <div t-out="state.error.message"></div>
-        </div>
+    <div
+        t-if="state.error and !modelStore.activeModel"
+        class="d-flex flex-nowrap align-items-center justify-content-center w-100 h-100"
+    >
+        <DocErrorDialog
+            name="modelStore.error.name"
+            status="modelStore.error.status"
+            traceback="modelStore.error.traceback"
+        />
     </div>
 </t>
 

--- a/addons/api_doc/static/src/doc_client.css
+++ b/addons/api_doc/static/src/doc_client.css
@@ -250,7 +250,11 @@ pre {
     transition: opacity 0.2s ease-in-out;
 }
 
-.btn {
+.btn-sm {
+    color: var(--text-light);
+}
+
+.btn:not(.btn-sm) {
     background: var(--bs-btn-bg);
     padding: .5rem .75rem;
     color: var(--text) !important;

--- a/addons/api_doc/static/src/doc_client.js
+++ b/addons/api_doc/static/src/doc_client.js
@@ -5,6 +5,7 @@ import { ApiKeyModal } from "@api_doc/components/doc_modal_api_key";
 import { SearchModal } from "@api_doc/components/doc_modal_search";
 import { DocSidebar } from "@api_doc/components/doc_sidebar";
 import { DocModel } from "@api_doc/components/doc_model";
+import { DocErrorDialog } from "@api_doc/components/doc_error_dialog";
 
 export class DocClient extends Component {
     static template = "api_doc.DocClient";
@@ -14,6 +15,7 @@ export class DocClient extends Component {
         DocModel,
         ApiKeyModal,
         SearchModal,
+        DocErrorDialog,
     };
     static props = {};
 

--- a/addons/api_doc/static/src/doc_client.xml
+++ b/addons/api_doc/static/src/doc_client.xml
@@ -30,14 +30,12 @@
             <div>Loading Models</div>
         </div>
 
-        <div t-if="modelStore.error" class="d-flex flex-nowrap align-items-center justify-content-center w-100 h-100">
-            <div class="alert error mt-1 d-flex flex-nowrap d-flex flex-nowrap-column">
-                <h5 class="mb-2 d-flex flex-nowrap align-items-center">
-                    <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
-                    <span>Error while loading models</span>
-                </h5>
-                <div t-out="modelStore.error.message"></div>
-            </div>
+        <div t-if="modelStore.error" class="d-flex flex-column align-items-center justify-content-center w-100 h-100">
+            <DocErrorDialog
+                name="modelStore.error.name"
+                status="modelStore.error.status"
+                traceback="modelStore.error.traceback"
+            />
         </div>
     </main>
     <ApiKeyModal t-if="modelStore.showApiKeyModal"/>

--- a/odoo/addons/test_http/tests/test_webjson2.py
+++ b/odoo/addons/test_http/tests/test_webjson2.py
@@ -80,7 +80,7 @@ class TestHttpWebJson_2(TestHttpBase):
         res = self.db_url_open(
             # application/x-www-form-urlencoded
             '/json/2/res.users/search',
-            data={"domain": []},
+            data=r"bad content type",
             headers=self.bearer_header,
         )
         self.assertEqual(res.text, Like("""

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2591,7 +2591,7 @@ class Json2Dispatcher(Dispatcher):
 
     @classmethod
     def is_compatible_with(cls, request):
-        return request.httprequest.mimetype in cls.mimetypes
+        return request.httprequest.mimetype in cls.mimetypes or not request.httprequest.content_length
 
     def dispatch(self, endpoint, args):
         # "args" are the path parameters, "id" in /web/image/<id>


### PR DESCRIPTION
This commit updates the /doc controllers from 'http' type to 'json2' to
allow the frontend to receive the full server traceback on errors. This
change required modifying `http.Json2Dispatcher.is_compatible_with` to
also accept requests with no content-type when content-length is 0.

It introduces a new component, `DocErrorDialog`, to manage error display
and server traceback. The general error handling flow for the api_doc
fetch calls is also improved.

task-5172546
task-5349157