### PR TITLE
[IMP] account: new helper for matched_debit|credit_ids

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2954,6 +2954,10 @@ class AccountMoveLine(models.Model):
                         account.reconcile = True
                     lines.with_context(no_exchange_difference=True, no_cash_basis=True).reconcile()
 
+    def _get_matched_move_ids(self):
+        """ Return a record set with both self.matched_debit_ids & self.matched_credit_ids """
+        return self.matched_debit_ids | self.matched_credit_ids
+
     # -------------------------------------------------------------------------
     # ANALYTIC
     # -------------------------------------------------------------------------


### PR DESCRIPTION
This commit add a new helper to easily get matched_debit_ids and matched_credit_ids from
an account.move.line.

Linked:https://github.com/odoo/enterprise/pull/100493

opw-5184679
