### PR TITLE
[FIX] sale: Fix Reverse Charge Tax With Down Payment

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -232,7 +232,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
         return so_line._prepare_invoice_line(
             name=name,
-            quantity=1.0,
+            quantity=-1.0,
+            extra_tax_data=self.env['account.tax']._reverse_quantity_base_line_extra_tax_data(so_line.extra_tax_data),
             **({'account_id': account.id} if account else {}),
         )
 


### PR DESCRIPTION
When creating an invoice with down payment from a sales order, the reverse charge tax amount goes into the debit side.

Make sure the reverse charge tax amount goes into the credit side.

opw-5172402

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
