### PR TITLE
[FIX] crm: fix nighly counter due to lead stage compute

### DIFF
--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -54,10 +54,10 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
-        # randomness: at least 1 query, +3 for demo -> 955 + 5
+        # randomness: at least 1 query, +3 for demo -> 957 + 5
         with self.with_user('user_sales_manager'):
             self.env.user._is_internal()  # warmup the cache to avoid inconsistency between community an enterprise
-            with self.assertQueryCount(user_sales_manager=960):
+            with self.assertQueryCount(user_sales_manager=962):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads()
 
         # teams assign


### PR DESCRIPTION
**Issue:**
Query count increases as `lead.stage_id.team_ids` needs to be used to ensure the current `stage_id` is related to the current lead `team_id`.

```py
@api.depends('team_id', 'type')
def _compute_stage_id(self):
    for lead in self:
        if not lead.stage_id or (lead.team_id and lead.stage_id.team_ids and lead.team_id not in lead.stage_id.team_ids):
            lead.stage_id = lead._stage_find(domain=[('fold', '=', False)]).id
```

related: https://github.com/odoo/odoo/commit/ce8fdbb1989703715663d334662a87d1900a28fe
