### PR TITLE
[FIX] web: Allow users to empty selection field on list view

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -341,6 +341,9 @@ export class SelectMenu extends Component {
             }
         } else if (!this.selectedChoice || this.selectedChoice.value !== value) {
             this.props.onSelect(value);
+            if (this.inputRef.el) {
+                this.inputRef.el.value = this.state.choices.find((c) => c.value === value).label;
+            }
         }
         this.state.searchValue = null;
     }

--- a/addons/web/static/src/views/fields/selection/selection_field.js
+++ b/addons/web/static/src/views/fields/selection/selection_field.js
@@ -95,7 +95,7 @@ export class SelectionField extends Component {
                 break;
             case "selection":
                 this.props.record.update(
-                    { [this.props.name]: value },
+                    { [this.props.name]: value ?? false },
                     { save: this.props.autosave }
                 );
                 break;

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -86,6 +86,32 @@ test("SelectionField in a list view", async () => {
     expect(td.children).toHaveCount(1, { message: "select tag should be only child of td" });
 });
 
+test.tags("desktop");
+test("SelectionField in a list view with multi_edit", async () => {
+    Partner._records.forEach((r) => (r.color = "red"));
+    onRpc("has_group", () => true);
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: '<list string="Colors" multi_edit="1"><field name="color"/></list>',
+    });
+    // select two records and edit them
+    await click(".o_data_row:eq(0) .o_list_record_selector input:first");
+    await animationFrame();
+    await click(".o_data_row:eq(1) .o_list_record_selector input:first");
+    await animationFrame();
+
+    await contains(".o_field_cell[name='color']").click();
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "" });
+    await contains(".o_dialog footer button").click();
+    expect(queryAllTexts(".o_field_cell")).toEqual(["", "", "Red"]);
+
+    await contains(".o_field_cell[name='color']").click();
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
+    await contains(".o_dialog footer button").click();
+    expect(queryAllTexts(".o_field_cell")).toEqual(["Black", "Black", "Red"]);
+});
+
 test("SelectionField, edition and on many2one field", async () => {
     Partner._onChanges.product_id = () => {};
     Partner._records[0].product_id = 37;


### PR DESCRIPTION
Steps:
- Install studio
- Open any list view
- Make sure multi_edit is enabled (or edit the view with debug menu)
- Add a new selection field to the list view with studio with several values
- Get back to the list view, select at least two record and edit the new
selection field
- Put any value, it will edit all selected record correctly
- select at least two record and edit the field again
- Try to clear the value (to have it empty)
- Traceback

Since this change https://github.com/odoo/odoo/pull/214422, selection
fields no longer display “empty” values, to be consistent with many2one
fields.
Now, to set a selection field to a null value, you have to clear it,
just as you would clear a many2one field.
The problem arose because when you clear an input, `onInputClear` is
called and triggers an onchange with the value `null`, but the
`selection_field` code expects to receive a `false` if there is no value
otherwise it searches for the value in the list of possible choices
which is why the traceback is raised when `null` is received, because it
is not in the list of choices.

This comimt change the onchange of `selection_field` to change the value
to `false` if it is equal to `null`.

opw-5226200