### PR TITLE
[18.0][FIX] point_of_sale: Do not allow users with Point of Sale > User permissions to modify pos.config data

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -17,10 +17,13 @@
 
                     <div class="oe_title" id="title">
                         <label for="name"/>
-                        <h1><field name="name" placeholder="e.g. NYC Shop"/></h1>
+                        <h1>
+                            <field name="name" groups="point_of_sale.group_pos_manager" placeholder="e.g. NYC Shop"/>
+                            <field name="name" groups="!point_of_sale.group_pos_manager" readonly="1" placeholder="e.g. NYC Shop"/>
+                        </h1>
                     </div>
                     <!-- HIDE this div in create_mode (when '+ New Shop' is clicked in the general settings.) -->
-                    <div invisible="context.get('pos_config_create_mode', False)">
+                    <div invisible="context.get('pos_config_create_mode', False)" groups="point_of_sale.group_pos_manager">
                         <div class="o_notification_alert alert alert-warning" invisible="not has_active_session" role="alert">
                             A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
                             <button class="btn" style="padding:0" name="open_ui" type="object">Click here to close the session</button>
@@ -31,14 +34,14 @@
                     </div>
 
                     <!-- SHOW this div in create_mode (when '+ New Shop' is clicked in the general settings.) -->
-                    <div id="restaurant_on_create" class="row mt16 o_settings_container" invisible="not context.get('pos_config_create_mode', False)">
+                    <div id="restaurant_on_create" class="row mt16 o_settings_container" invisible="not context.get('pos_config_create_mode', False)" groups="point_of_sale.group_pos_manager">
                         <setting>
                                 <field name="module_pos_restaurant" />
                         </setting>
                     </div>
 
                     <!-- HIDE this div in create_mode (when '+ New Shop' is clicked in the general settings.) -->
-                    <div class="row mt16 o_settings_container" invisible="context.get('pos_config_create_mode', False)">
+                    <div class="row mt16 o_settings_container" invisible="context.get('pos_config_create_mode', False)" groups="point_of_sale.group_pos_manager">
                         <setting
                                 title="Employees can scan their badge or enter a PIN to log in to a PoS session. These credentials are configurable in the *HR Settings* tab of the employee form."
                                 string="Log in with Employees"


### PR DESCRIPTION
Do not allow users with Point of Sale > User permissions to modify `pos.config` data

Example use case:
- Create a user with Point of Sale > User permissions
- Access Point of Sale and click on the list view type
- Enter a record
- You should not be able to modify any data and/or activate new features

**Before**
![antes](https://github.com/user-attachments/assets/78fcff95-69e9-484d-8d93-ec69b31f2d7c)

**After**
<img width="997" height="254" alt="despues" src="https://github.com/user-attachments/assets/e7d7de4e-95d9-4d4e-a41e-61aee6a08b1a" />

@Tecnativa TT59071

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
