### PR TITLE
[FIX] website: fix appearance issue of carousel with indicators outside

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1217,17 +1217,39 @@ $-o-carousel-controllers-size: map-get($spacers, 5);
 
     // Style - Indicators outside
     &.s_carousel_controllers_indicators_outside {
-        .carousel-control-prev, .carousel-control-next {
-            margin-bottom: $-o-carousel-controllers-size;
+        &:not(:has(.s_carousel_indicators_hidden)) {
+            .carousel-control-prev, .carousel-control-next {
+                margin-bottom: $-o-carousel-controllers-size;
+            }
         }
 
         .carousel-indicators {
             position: relative;
             margin-bottom: 0;
 
-            button {
+            &:not(.s_carousel_indicators_numbers) button {
                 background-color: currentColor;
+            }
+
+            button {
                 color: inherit;
+            }
+            
+            &.s_carousel_indicators_numbers {
+                // For large screen, use the same size as the margin-bottom of
+                // the prev/next buttons (like other indicators; instead of
+                // "auto"), so that the bottom of the buttons is aligned with
+                // the bottom of the slides. For smaller screen, the buttons do
+                // not have the same appearance and their bottoms do not need
+                // to align, and also the numbers may need to go on a second
+                // line if there is many slides, so we keep "auto"
+                @include media-breakpoint-up(md) {
+                    height: $-o-carousel-controllers-size;
+                }
+
+                button:after {
+                    border-top-color: currentColor;
+                }
             }
         }
     }


### PR DESCRIPTION
The css rules for indicators outside the carousel were not adapted for number indicators, and used the button color intended for dots and bar as background of the numbers, making them unreadable and ugly.

The height of the indicators when outside influences the margin needed to align the bottom of the prev/next buttons. That caused the bottom of the next/prev buttons to not reach the bottom of the slide with "Numbers" or "Hidden" as indicators.

This commit adds the necessary css rules to correctly size and colors the number indicators (and the hidden one) when positioned outside.

Steps to reproduce
- Add a carousel
- Set "Indicators" to "Numbers"
- Set "Style" to "Indicators outside"
- Bug: The colors are all wrong, we cannot see the numbers
- Bug: The bottom of the previous/next buttons do not reach the bottom of the carousel
- Set "Indicators" to "Hidden"
- Bug: The bottom of the previous/next buttons is even further from the bottom of the carousel

task- 5358507