### PR TITLE
[REF] website_profile, gamification: refactor karma ranking logic

### DIFF
--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -124,138 +124,66 @@ class ResUsers(models.Model):
         return True
 
     @api.model
-    def _get_user_ids_ranked_by_karma(self, user_domain, from_date=None, to_date=None, limit=30, offset=0):
-        """ Return the list of user_ids satisfying the domain, sorted by their
-        karma gain during the specified period.
-
-        This method is designed for the website leaderboard pagination. It
-        computes the ranking based on the sum of gamification.karma.tracking
-        values within the given dates."""
-
-        where_query = self.env['res.users']._search(user_domain, bypass_access=True)
-
-        sql = SQL("""
-            SELECT "res_users".id as user_id
-            FROM %s
-            LEFT JOIN "gamification_karma_tracking" as "tracking"
-                ON "res_users".id = "tracking".user_id
-            WHERE %s %s %s
-            GROUP BY "res_users".id
-            ORDER BY COALESCE(SUM("tracking".new_value - "tracking".old_value), 0) DESC, "res_users".id DESC
-            LIMIT %s OFFSET %s
-        """,
-            where_query.from_clause,
-            where_query.where_clause or SQL("TRUE"),
-            SQL("AND tracking.tracking_date >= %s::DATE", from_date) if from_date else SQL(),
-            SQL("AND tracking.tracking_date < %s::DATE + interval '1' day", to_date) if to_date else SQL(),
-            limit,
-            offset,
-        )
-
-        self.env.cr.execute(sql)
-        res = self.env.cr.fetchall()
-        return [r[0] for r in res]
-
-    def _get_tracking_karma_gain_position(self, user_domain, from_date=None, to_date=None):
-        """ Get absolute position in term of gained karma for users. First a ranking
-        of all users is done given a user_domain; then the position of each user
-        belonging to the current record set is extracted.
-
-        Example: in website profile, search users with name containing Norbert. Their
-        positions should not be 1 to 4 (assuming 4 results), but their actual position
-        in the karma gain ranking (with example user_domain being karma > 1,
-        website published True).
-
-        :param user_domain: general domain (i.e. active, karma > 1, website, ...)
-          to compute the absolute position of the current record set
-        :param from_date: compute karma gained after this date (included) or from
-          beginning of time;
-        :param to_date: compute karma gained before this date (included) or until
-          end of time;
-
-        :rtype: list[dict]
-        :return:
-          ::
-
-            [{
-                'user_id': user_id (belonging to current record set),
-                'karma_gain_total': integer, karma gained in the given timeframe,
-                'karma_position': integer, ranking position
-            }, {..}]
-
-          ordered by descending karma position
+    def _get_users_karma_ranking(self, user_domain, from_date=None, to_date=None, limit=30, offset=0, always_include_user_id=None):
+        """ Ranks users based on karma.
+        If dates are provided, ranking is based on tracking lines gain in `gamification_karma_tracking`.
+        Otherwise, it falls back to total lifetime karma in `res_users`.
         """
-        if not self:
-            return []
+        query_obj = self.env['res.users']._search(user_domain, bypass_access=True)
 
-        where_query = self.env['res.users']._search(user_domain, bypass_access=True)
+        if from_date or to_date:
+            base_query = SQL("""
+                SELECT "res_users".id as user_id,
+                       COALESCE(SUM("tracking".new_value - "tracking".old_value), 0) as karma_gain
+                  FROM %(from_clause)s
+             LEFT JOIN "gamification_karma_tracking" as "tracking"
+                    ON "res_users".id = "tracking".user_id AND "res_users"."active" = TRUE
+                 WHERE %(where_clause)s %(date_from)s %(date_to)s
+              GROUP BY "res_users".id
+                HAVING SUM("tracking".new_value - "tracking".old_value) > 0
+            """,
+                from_clause=query_obj.from_clause,
+                where_clause=query_obj.where_clause or SQL("TRUE"),
+                date_from=SQL(" AND tracking.tracking_date >= %s::DATE", from_date) if from_date else SQL(),
+                date_to=SQL(" AND tracking.tracking_date < %s::DATE + interval '1 day'", to_date) if to_date else SQL(),
+            )
+        else:
+            base_query = SQL("""
+                SELECT "res_users".id as user_id,
+                       COALESCE("res_users".karma, 0) as karma_gain
+                  FROM %(from_clause)s
+                 WHERE %(where_clause)s
+            """,
+                from_clause=query_obj.from_clause,
+                where_clause=query_obj.where_clause or SQL("TRUE")
+            )
 
-        sql = SQL("""
-SELECT final.user_id, final.karma_gain_total, final.karma_position
-FROM (
-    SELECT intermediate.user_id, intermediate.karma_gain_total, row_number() OVER (ORDER BY intermediate.karma_gain_total DESC) AS karma_position
-    FROM (
-        SELECT "res_users".id as user_id, COALESCE(SUM("tracking".new_value - "tracking".old_value), 0) as karma_gain_total
-        FROM %s
-        LEFT JOIN "gamification_karma_tracking" as "tracking"
-        ON "res_users".id = "tracking".user_id AND "res_users"."active" IS TRUE
-        WHERE %s %s %s
-        GROUP BY "res_users".id
-        ORDER BY karma_gain_total DESC
-    ) intermediate
-) final
-WHERE final.user_id IN %s""",
-            where_query.from_clause,
-            where_query.where_clause or SQL("TRUE"),
-            SQL("AND tracking.tracking_date::DATE >= %s::DATE", from_date) if from_date else SQL(),
-            SQL("AND tracking.tracking_date::DATE <= %s::DATE", to_date) if to_date else SQL(),
-            tuple(self.ids),
-        )
+        where_clause = SQL("karma_position > %s AND karma_position <= %s", offset, offset + limit)
+        if always_include_user_id:
+            where_clause = SQL("%s OR user_id = %s", where_clause, always_include_user_id)
 
-        self.env.cr.execute(sql)
-        return self.env.cr.dictfetchall()
-
-    def _get_karma_position(self, user_domain):
-        """ Get absolute position in term of total karma for users. First a ranking
-        of all users is done given a user_domain; then the position of each user
-        belonging to the current record set is extracted.
-
-        Example: in website profile, search users with name containing Norbert. Their
-        positions should not be 1 to 4 (assuming 4 results), but their actual position
-        in the total karma ranking (with example user_domain being karma > 1,
-        website published True).
-
-        :param user_domain: general domain (i.e. active, karma > 1, website, ...)
-          to compute the absolute position of the current record set
-
-        :rtype: list[dict]
-        :return:
-
-            ::
-
-                [{
-                    'user_id': user_id (belonging to current record set),
-                    'karma_position': integer, ranking position
-                }, {..}] ordered by karma_position desc
-        """
-        if not self:
-            return {}
-
-        where_query = self.env['res.users']._search(user_domain, bypass_access=True)
-
-        # we search on every user in the DB to get the real positioning (not the one inside the subset)
-        # then, we filter to get only the subset.
-        sql = SQL("""
-SELECT sub.user_id, sub.karma_position
-FROM %s AS sub
-WHERE sub.user_id IN %s""",
-            where_query.subselect(
-                SQL("%s as user_id", where_query.table.id),
-                SQL("row_number() OVER (ORDER BY res_users.karma DESC) AS karma_position"),
+        query = SQL("""
+            WITH users_with_karma_gain AS (
+                %(base_query)s
             ),
-            tuple(self.ids),
+            users_with_karma_position as (
+                SELECT user_id,
+                       karma_gain,
+                       ROW_NUMBER() OVER (ORDER BY karma_gain DESC, user_id DESC) AS karma_position
+                  FROM "users_with_karma_gain"
+            )
+            SELECT user_id,
+                   karma_gain,
+                   karma_position
+              FROM "users_with_karma_position"
+             WHERE %(final_condition)s
+        """,
+            base_query=base_query,
+            final_condition=where_clause
         )
-        return self.env.execute_query_dict(sql)
+
+        self.env.cr.execute(query)
+        return {row['user_id']: row for row in self.env.cr.dictfetchall()}
 
     def _rank_changed(self):
         """

--- a/addons/gamification/tests/test_karma_tracking.py
+++ b/addons/gamification/tests/test_karma_tracking.py
@@ -51,66 +51,43 @@ class TestKarmaTrackingCommon(common.TransactionCase):
             old_value = new_value
             track_date = track_date + relativedelta(days=days_delta)
 
-    def test_get_user_ids_ranked_by_karma(self):
-        """Test the optimized raw SQL ranking method with various timeframes and pagination."""
-        self._create_trackings(self.test_user, 20, 2, self.test_date, days_delta=30)
-        self._create_trackings(self.test_user_2, 10, 20, self.test_date, days_delta=2)
-        domain = [("id", "in", (self.test_user.id, self.test_user_2.id))]
-
-        # All-time: test_user_2 (200) > test_user (40)
-        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(domain)
-        self.assertEqual(user_ids, [self.test_user_2.id, self.test_user.id])
-
-        # Before specific date: test_user (20) > test_user_2 (10)
-        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(
-            domain, to_date=self.test_date + relativedelta(day=2)
-        )
-        self.assertEqual(user_ids, [self.test_user.id, self.test_user_2.id])
-
-        # After specific date: test_user_2 (50) > test_user (20)
-        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(
-            domain, from_date=self.test_date + relativedelta(months=1, day=1)
-        )
-        self.assertEqual(user_ids, [self.test_user_2.id, self.test_user.id])
-
-        # Limit: Returns only the top overall user (test_user_2 with 200)
-        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(domain, limit=1)
-        self.assertEqual(user_ids, [self.test_user_2.id])
-
-        # Offset: Skips the top user, returns the 2nd overall user (test_user with 40)
-        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(domain, limit=1, offset=1)
-        self.assertEqual(user_ids, [self.test_user.id])
-
     def test_computation_gain(self):
         self._create_trackings(self.test_user, 20, 2, self.test_date, days_delta=30)
         self._create_trackings(self.test_user_2, 10, 20, self.test_date, days_delta=2)
+        self.env.flush_all()
 
-        results = (self.test_user | self.test_user_2)._get_tracking_karma_gain_position([])
-        self.assertEqual(results[0]['user_id'], self.test_user_2.id)
-        self.assertEqual(results[0]['karma_gain_total'], 200)
-        self.assertEqual(results[0]['karma_position'], 1)
-        self.assertEqual(results[1]['user_id'], self.test_user.id)
-        self.assertEqual(results[1]['karma_gain_total'], 40)
-        self.assertEqual(results[1]['karma_position'], 2)
+        # Format: ( kwargs_dict, { user_id: (expected_position, expected_gain) } )
+        test_cases = [
+            ({}, {
+                self.test_user_2.id: (1, 200),
+                self.test_user.id: (2, 40),
+            }),
+            ({'to_date': self.test_date + relativedelta(day=2)}, {
+                self.test_user.id: (1, 20),
+                self.test_user_2.id: (2, 10),
+            }),
+            ({'from_date': self.test_date + relativedelta(months=1, day=1)}, {
+                self.test_user_2.id: (1, 50),
+                self.test_user.id: (2, 20),
+            }),
+            ({'from_date': self.test_date + relativedelta(months=1, day=1), 'limit': 1, 'offset': 1}, {
+                self.test_user.id: (2, 20),
+            }),
+            ({'limit': 1, 'offset': 0, 'always_include_user_id': self.test_user.id}, {
+                self.test_user_2.id: (1, 200),
+                self.test_user.id: (2, 40),
+            }),
+        ]
 
-        results = (self.test_user | self.test_user_2)._get_tracking_karma_gain_position([], to_date=self.test_date + relativedelta(day=2))
-        self.assertEqual(results[0]['user_id'], self.test_user.id)
-        self.assertEqual(results[0]['karma_gain_total'], 20)
-        self.assertEqual(results[0]['karma_position'], 1)
-        self.assertEqual(results[1]['user_id'], self.test_user_2.id)
-        self.assertEqual(results[1]['karma_gain_total'], 10)
-        self.assertEqual(results[1]['karma_position'], 2)
-
-        results = (self.test_user | self.test_user_2)._get_tracking_karma_gain_position([], from_date=self.test_date + relativedelta(months=1, day=1))
-        self.assertEqual(results[0]['user_id'], self.test_user_2.id)
-        self.assertEqual(results[0]['karma_gain_total'], 50)
-        self.assertEqual(results[0]['karma_position'], 1)
-        self.assertEqual(results[1]['user_id'], self.test_user.id)
-        self.assertEqual(results[1]['karma_gain_total'], 20)
-        self.assertEqual(results[1]['karma_position'], 2)
-
-        results = self.env['res.users']._get_tracking_karma_gain_position([])
-        self.assertEqual(len(results), 0)
+        domain = [("id", "in", (self.test_user.id, self.test_user_2.id))]
+        for kwargs, expected in test_cases:
+            with self.subTest(**kwargs):
+                results = self.env['res.users']._get_users_karma_ranking(domain, **kwargs)
+                self.assertEqual(len(results), len(expected), "Returned record count mismatch")
+                for user_id, (expected_pos, expected_gain) in expected.items():
+                    self.assertIn(user_id, results, f"Missing expected user_id: {user_id}")
+                    self.assertEqual(results[user_id]['karma_position'], expected_pos)
+                    self.assertEqual(results[user_id]['karma_gain'], expected_gain)
 
     @freeze_time('2021-02-02')
     def test_consolidation_cron(self):

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -1,14 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from urllib.parse import urlsplit
-import werkzeug
 import werkzeug.exceptions
-import werkzeug.urls
-import werkzeug.wrappers
 import math
 
 from dateutil.relativedelta import relativedelta
-from operator import itemgetter
 
 from odoo import _, fields, http, tools
 from odoo.exceptions import UserError
@@ -226,92 +222,54 @@ class WebsiteProfile(http.Controller):
 
         user_count = User.sudo().search_count(dom)
         my_user = request.env.user
-        current_user_values = False
+        current_user_value = False
+        user_values = []
+        pager = {'page_count': 0}
         if user_count:
             page_count = math.ceil(user_count / self._users_per_page)
             pager = request.website.pager(url="/profile/users", total=user_count, page=page, step=self._users_per_page,
                                           scope=page_count if page_count < self._pager_max_pages else self._pager_max_pages,
                                           url_args=kwargs)
 
-            # Get karma position for users (only website_published)
-            position_domain = [('karma', '>', 1), ('website_published', '=', True)]
-
-            if group_by:
+            from_date = to_date = None
+            if group_by in ('week', 'month'):
                 to_date = fields.Date.today()
                 if group_by == 'week':
                     from_date = to_date - relativedelta(weeks=1)
                 elif group_by == 'month':
                     from_date = to_date - relativedelta(months=1)
-                else:
-                    from_date = None
-                user_ids = request.env['res.users']._get_user_ids_ranked_by_karma(
-                    dom,
-                    from_date=from_date,
-                    to_date=to_date,
-                    limit=self._users_per_page,
-                    offset=pager['offset'],
-                )
-                users = User.sudo().browse(user_ids)
-            else:
-                users = User.sudo().search(
-                    dom,
-                    limit=self._users_per_page,
-                    offset=pager['offset'],
-                    order='karma DESC, id DESC',
-                )
 
-            user_values = self._prepare_all_users_values(users)
-            position_map = self._get_position_map(position_domain, users, group_by)
+            ranking_map = User._get_users_karma_ranking(
+                user_domain=dom,
+                from_date=from_date,
+                to_date=to_date,
+                limit=self._users_per_page,
+                offset=pager['offset'],
+                always_include_user_id=my_user.id if my_user else None,
+            )
 
-            max_position = max([user_data['karma_position'] for user_data in position_map.values()], default=1)
-            for user in user_values:
-                user_data = position_map.get(user['id'], dict())
-                user['position'] = user_data.get('karma_position', max_position + 1)
-                user['karma_gain'] = user_data.get('karma_gain_total', 0)
-            user_values.sort(key=itemgetter('position'))
+            base_infos = self._prepare_all_users_values(User.sudo().browse(ranking_map.keys()))
 
-            if my_user.website_published and my_user.karma and my_user.id not in users.ids:
-                # Need to keep the dom to search only for users that appear in the ranking page
-                current_user = User.sudo().search(Domain.AND([[('id', '=', my_user.id)], dom]))
-                if current_user:
-                    current_user_values = self._prepare_all_users_values(current_user)[0]
+            for user_info in base_infos:
+                rank_info = ranking_map[user_info['id']]
+                user_info['position'] = rank_info.get('karma_position', 0)
+                user_info['karma_gain'] = rank_info.get('karma_gain', 0) if group_by in ('week', 'month') else 0
 
-                    user_data = self._get_position_map(position_domain, current_user, group_by).get(current_user.id, {})
-                    current_user_values['position'] = user_data.get('karma_position', 0)
-                    current_user_values['karma_gain'] = user_data.get('karma_gain_total', 0)
+                if pager['offset'] < user_info['position'] <= pager['offset'] + self._users_per_page:
+                    user_values.append(user_info)
+                elif user_info['id'] == my_user.id and my_user.website_published and my_user.karma:
+                    current_user_value = user_info
 
-        else:
-            user_values = []
-            pager = {'page_count': 0}
+            user_values.sort(key=lambda x: x['position'])
+
         render_values.update({
             'top3_users': user_values[:3] if not search_term and page == 1 else [],
             'users': user_values,
-            'my_user': current_user_values,
+            'my_user': current_user_value,
             'pager': pager,
             **self._prepare_url_from_info(),
         })
         return request.render("website_profile.users_page_main", render_values)
-
-    def _get_position_map(self, position_domain, users, group_by):
-        if group_by:
-            position_map = self._get_user_tracking_karma_gain_position(position_domain, users.ids, group_by)
-        else:
-            position_results = users._get_karma_position(position_domain)
-            position_map = dict((user_data['user_id'], dict(user_data)) for user_data in position_results)
-        return position_map
-
-    def _get_user_tracking_karma_gain_position(self, domain, user_ids, group_by):
-        """ Helper method computing boundaries to give to _get_tracking_karma_gain_position.
-        See that method for more details. """
-        to_date = fields.Date.today()
-        if group_by == 'week':
-            from_date = to_date - relativedelta(weeks=1)
-        elif group_by == 'month':
-            from_date = to_date - relativedelta(months=1)
-        else:
-            from_date = None
-        results = request.env['res.users'].browse(user_ids)._get_tracking_karma_gain_position(domain, from_date=from_date, to_date=to_date)
-        return dict((item['user_id'], dict(item)) for item in results)
 
     # User and validation
     # --------------------------------------------------

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -223,92 +223,54 @@ class WebsiteProfile(http.Controller):
 
         user_count = User.sudo().search_count(dom)
         my_user = request.env.user
-        current_user_values = False
+        current_user_value = False
+        user_values = []
+        pager = {'page_count': 0}
         if user_count:
             page_count = math.ceil(user_count / self._users_per_page)
             pager = request.website.pager(url="/profile/users", total=user_count, page=page, step=self._users_per_page,
                                           scope=page_count if page_count < self._pager_max_pages else self._pager_max_pages,
                                           url_args=kwargs)
 
-            # Get karma position for users (only website_published)
-            position_domain = [('karma', '>', 1), ('website_published', '=', True)]
-
-            if group_by:
+            from_date = to_date = None
+            if group_by in ('week', 'month'):
                 to_date = fields.Date.today()
                 if group_by == 'week':
                     from_date = to_date - relativedelta(weeks=1)
                 elif group_by == 'month':
                     from_date = to_date - relativedelta(months=1)
-                else:
-                    from_date = None
-                user_ids = request.env['res.users']._get_user_ids_ranked_by_karma(
-                    dom,
-                    from_date=from_date,
-                    to_date=to_date,
-                    limit=self._users_per_page,
-                    offset=pager['offset'],
-                )
-                users = User.sudo().browse(user_ids)
-            else:
-                users = User.sudo().search(
-                    dom,
-                    limit=self._users_per_page,
-                    offset=pager['offset'],
-                    order='karma DESC, id DESC',
-                )
 
-            user_values = self._prepare_all_users_values(users)
-            position_map = self._get_position_map(position_domain, users, group_by)
+            ranking_map = User._get_users_karma_ranking(
+                user_domain=dom,
+                from_date=from_date,
+                to_date=to_date,
+                limit=self._users_per_page,
+                offset=pager['offset'],
+                always_include_user_id=my_user.id if my_user else None,
+            )
 
-            max_position = max([user_data['karma_position'] for user_data in position_map.values()], default=1)
-            for user in user_values:
-                user_data = position_map.get(user['id'], dict())
-                user['position'] = user_data.get('karma_position', max_position + 1)
-                user['karma_gain'] = user_data.get('karma_gain_total', 0)
-            user_values.sort(key=itemgetter('position'))
+            base_infos = self._prepare_all_users_values(User.sudo().browse(ranking_map.keys()))
 
-            if my_user.website_published and my_user.karma and my_user.id not in users.ids:
-                # Need to keep the dom to search only for users that appear in the ranking page
-                current_user = User.sudo().search(Domain.AND([[('id', '=', my_user.id)], dom]))
-                if current_user:
-                    current_user_values = self._prepare_all_users_values(current_user)[0]
+            for user_info in base_infos:
+                rank_info = ranking_map[user_info['id']]
+                user_info['position'] = rank_info.get('karma_position', 0)
+                user_info['karma_gain'] = rank_info.get('karma_gain', 0) if group_by in ('week', 'month') else 0
 
-                    user_data = self._get_position_map(position_domain, current_user, group_by).get(current_user.id, {})
-                    current_user_values['position'] = user_data.get('karma_position', 0)
-                    current_user_values['karma_gain'] = user_data.get('karma_gain_total', 0)
+                if pager['offset'] < user_info['position'] <= pager['offset'] + self._users_per_page:
+                    user_values.append(user_info)
+                elif user_info['id'] == my_user.id and my_user.website_published and my_user.karma:
+                    current_user_value = user_info
 
-        else:
-            user_values = []
-            pager = {'page_count': 0}
+            user_values.sort(key=lambda x: x['position'])
+
         render_values.update({
             'top3_users': user_values[:3] if not search_term and page == 1 else [],
             'users': user_values,
-            'my_user': current_user_values,
+            'my_user': current_user_value,
             'pager': pager,
             **self._prepare_url_from_info(),
         })
         return request.render("website_profile.users_page_main", render_values)
-
-    def _get_position_map(self, position_domain, users, group_by):
-        if group_by:
-            position_map = self._get_user_tracking_karma_gain_position(position_domain, users.ids, group_by)
-        else:
-            position_results = users._get_karma_position(position_domain)
-            position_map = dict((user_data['user_id'], dict(user_data)) for user_data in position_results)
-        return position_map
-
-    def _get_user_tracking_karma_gain_position(self, domain, user_ids, group_by):
-        """ Helper method computing boundaries to give to _get_tracking_karma_gain_position.
-        See that method for more details. """
-        to_date = fields.Date.today()
-        if group_by == 'week':
-            from_date = to_date - relativedelta(weeks=1)
-        elif group_by == 'month':
-            from_date = to_date - relativedelta(months=1)
-        else:
-            from_date = None
-        results = request.env['res.users'].browse(user_ids)._get_tracking_karma_gain_position(domain, from_date=from_date, to_date=to_date)
-        return dict((item['user_id'], dict(item)) for item in results)
 
     # User and validation
     # --------------------------------------------------


### PR DESCRIPTION
A previous commit fixed the pagination logic for time-based leaderboards (Weekly/Monthly) by introducing a dedicated method to calculate ranks based on tracking lines. While functionally correct, that implementation was designed to strictly preserve stable compatibility, resulting in duplicated logic.

This commit refactors the leaderboard mechanism to be cleaner and performance-optimized.

Taskid: 5359263
Taskid of initial fix: 5344657
