### PR TITLE
[FIX] website: wait for tab change on `clickOnText` in tours

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -372,6 +372,9 @@ export function clickOnText(snippet, element, position = "bottom") {
             tooltipPosition: position,
             run: "click",
         },
+        {
+            trigger: "#customize-tab.active",
+        },
     ];
 }
 


### PR DESCRIPTION
__Before this commit:__
[The `homepage` tour][1] (including all tours calling `registerThemeHomepageTour` in `design-themes`) fails in a non-deterministic way. It is possible to reproduce the error by adding a delay [at this line][2] in
`change_current_options_containers_listeners`.

__Cause:__
When the tour runs `clickOnText`, the "Style" tab automatically opens. The next step is `goBackToBlocks` which directly switches back to the "Blocks" tab. However if the switch to the "Style" tab takes a bit longer than usual, `goBackToBlocks` will click on "Blocks" before and the "Style" tab will opens after it. The following `insertSnippet` step will then be stuck waiting indefinitely for the snippet block to appear.

__Fix:__
Wait for the "Style" tab to be active after `clickOnText` to make sure that the call to `goBackToBlocks` actually switch to it.

[1]: https://github.com/odoo/odoo/blob/21d827bb0849208efb641951ceb71437f958c34e/addons/website/static/src/js/tours/homepage.js#L53
[2]: https://github.com/odoo/odoo/blob/21d827bb0849208efb641951ceb71437f958c34e/addons/html_builder/static/src/builder.js#L165

Runbot error: https://runbot.odoo.com/odoo/runbot.build.error/233472