### PR TITLE
[FIX] mail,test_mail: apply search filters without search term in chatter

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -952,6 +952,7 @@ class MailMessage(models.Model):
                 accessible_tracking_value_ids = tracking_values._filter_has_field_access(self.env)
                 message_domain |= Domain("id", "in", accessible_tracking_value_ids.mail_message_id.ids)
             domain &= message_domain
+        if search_term or is_notification is not None:
             res["count"] = self.search_count(domain)
         if around is not None:
             messages_before = self.search(domain & Domain('id', '<=', around), limit=limit // 2, order="id DESC")

--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -69,7 +69,7 @@ export function useMessageSearch(thread) {
     const state = useState({
         thread,
         async search(before = false) {
-            if (this.searchTerm) {
+            if (this.searchTerm || this.is_notification !== undefined) {
                 this.searching = true;
                 const data = await sequential(() =>
                     store.searchMessagesInThread(
@@ -98,6 +98,7 @@ export function useMessageSearch(thread) {
         },
         count: 0,
         clear() {
+            this.is_notification = undefined;
             this.messages = [];
             this.searched = false;
             this.searching = false;

--- a/addons/mail/static/src/core/common/search_message_input.js
+++ b/addons/mail/static/src/core/common/search_message_input.js
@@ -68,9 +68,7 @@ export class SearchMessageInput extends Component {
     onChangeSearchFilter(searchFilter) {
         if (searchFilter.is_notification !== this.props.messageSearch.is_notification) {
             this.props.messageSearch.is_notification = searchFilter.is_notification;
-            if (this.state.searchTerm) {
-                this.search();
-            }
+            this.search();
         }
     }
 

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -524,6 +524,8 @@ export class MailMessage extends models.ServerModel {
                 ]);
             }
             domain = Domain.and([domain, message_domain]).toList();
+        }
+        if (search_term || is_notification !== undefined) {
             res.count = this.search_count(domain);
         }
         if (around !== undefined) {

--- a/addons/test_mail/static/tests/tracking_value.test.js
+++ b/addons/test_mail/static/tests/tracking_value.test.js
@@ -374,4 +374,12 @@ test("Search message with filter in chatter", async () => {
     await click("button[title='Filter Messages']");
     await click("span", { text: "All" });
     await contains(".o-mail-SearchMessageResult .o-mail-Message", { count: 2 });
+    // works when no search term
+    await insertText(".o_searchview_input", "", { replace: true });
+    await click("button[title='Filter Messages']");
+    await click("span", { text: "Conversations" });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message:has(:text(Hermit))");
+    await click("button[title='Filter Messages']");
+    await click("span", { text: "Tracked Changes" });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message:has(:text(NoneHermit(Many2one)))");
 });


### PR DESCRIPTION
**Current behavior before PR:**

Search filters in the chatter only applied when a search term was entered, so filtering did not affect the displayed content unless text was searched.

**Desired behavior after PR is merged:**

Search filters are now applied even when no search term is provided, ensuring the chatter content updates based on filters alone.

**Task**-5118906


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
