### PR TITLE
[FIX] html_builder: Improve BuilderList rendering performance

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -57,7 +57,7 @@ export class BuilderList extends Component {
             id: this.props.id,
             defaultValue: this.parseDisplayValue([]),
             parseDisplayValue: this.parseDisplayValue,
-            formatRawValue: this.formatRawValue,
+            formatRawValue: this.formatRawValue.bind(this),
         });
         this.state = state;
         this.commit = commit;
@@ -94,11 +94,9 @@ export class BuilderList extends Component {
         }
     }
 
-    get availableRecords() {
-        const items = this.formatRawValue(this.state.value);
-        return this.allRecords.filter(
-            (record) => !items.some((item) => item.id === Number(record.id))
-        );
+    getAvailableRecords() {
+        const itemIds = new Set(this.formatRawValue(this.state.value).map((i) => i.id));
+        return this.allRecords.filter((record) => !itemIds.has(record.id));
     }
 
     parseDisplayValue(displayValue) {
@@ -107,9 +105,11 @@ export class BuilderList extends Component {
 
     formatRawValue(rawValue) {
         const items = rawValue ? JSON.parse(rawValue) : [];
+        let nextAvailableId = items ? this.getNextAvailableItemId(items) : 0;
         for (const item of items) {
             if (!("_id" in item)) {
-                item._id = this.getNextAvailableItemId(items);
+                item._id = nextAvailableId.toString();
+                nextAvailableId += 1;
             }
         }
         return items;
@@ -154,7 +154,7 @@ export class BuilderList extends Component {
         return {
             ...this.props.defaultNewValue,
             ...this.props.default,
-            _id: this.getNextAvailableItemId(),
+            _id: this.getNextAvailableItemId().toString(),
         };
     }
 
@@ -164,7 +164,7 @@ export class BuilderList extends Component {
             .map((item) => parseInt(item._id))
             .reduce((acc, id) => (id > acc ? id : acc), -1);
         const nextAvailableId = biggestId + 1;
-        return nextAvailableId.toString();
+        return nextAvailableId;
     }
 
     onInput(e) {

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -54,18 +54,19 @@
                 </div>
             </t>
             <div class="o-hb-select-wrapper" t-if="this.allRecords and this.allRecords.length" >
+                <t t-set="availableRecords" t-value="this.getAvailableRecords()"></t>
                 <Dropdown state="this.dropdown" menuClass="'o-hb-select-dropdown mt-1'">
                     <button class="bl-dropdown-toggle o-hb-select-toggle o-hb-btn btn btn-secondary text-start o-dropdown-caret w-100 mx-auto"
-                        t-att-disabled="!this.availableRecords.length">
+                        t-att-disabled="!availableRecords.length">
                         <t t-set="noAvailableRecordLabel">You don't have any record to add</t>
                         <span class="w-100"
-                            t-att-title="!this.availableRecords.length ? noAvailableRecordLabel : ''"
-                            t-att-style="!this.availableRecords.length ? 'pointer-events: auto; display: inline-block;' : ''">
+                            t-att-title="!availableRecords.length ? noAvailableRecordLabel : ''"
+                            t-att-style="!availableRecords.length ? 'pointer-events: auto; display: inline-block;' : ''">
                             <t t-out="props.addItemTitle" />
                         </span>
                     </button>
                     <t t-set-slot="content">
-                        <t t-foreach="this.availableRecords" t-as="item" t-key="item.id">
+                        <t t-foreach="availableRecords" t-as="item" t-key="item.id">
                                 <t t-foreach="Object.entries(props.itemShape).filter(([key, value]) => !value.endsWith('boolean'))" t-as="entry" t-key="entry[0]">
                                     <div class="o-hb-select-dropdown-item d-flex flex-column cursor-pointer o-dropdown-item dropdown-item o-navigable w-100 mx-auto"
                                         style="max-height: 50vh;"


### PR DESCRIPTION
Before this commit, rendering BuilderList with many elements caused noticeable delays.

How to reproduce:
=======================
- Use a runbot with all demo data
- Switch to edit mode in the website builder
- Add a form
- Link the form to the Contact model
- Add the "State" field

Before this commit:
The options related to the "State" field took more than one second to render.

After this commit:
Rendering is several hundred milliseconds faster. Additional commits will follow to further improve the situation.

Reason for the slowdown:
=======================
BuilderList is not optimized to render several thousand records (about 1900 in this example). This commit addresses the identified bottlenecks to reduce rendering time.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
