### PR TITLE
[FIX] l10n_vn: Change account 3387 type from payable to current liability

### DIFF
--- a/addons/l10n_vn/data/template/account.account-vn.csv
+++ b/addons/l10n_vn/data/template/account.account-vn.csv
@@ -100,7 +100,7 @@
 "chart3384","Health insurance","3384","liability_payable","True","Bảo hiểm y tế"
 "chart3385","Payables on equitization","3385","liability_payable","True","Phải trả về cổ phần hóa"
 "chart3386","Unemployment insurance","3386","liability_payable","True","Bảo hiểm thất nghiệp"
-"chart3387","Unearned revenue","3387","liability_payable","True","Doanh thu chưa thực hiện"
+"chart3387","Unearned revenue","3387","liability_current","True","Doanh thu chưa thực hiện"
 "chart3388","Other payables","3388","liability_payable","True","Phải trả, phải nộp khác"
 "chart3411","Borrowing loans liabilities","3411","liability_current","False","Các khoản đi vay"
 "chart3412","Finance lease liabilities","3412","liability_current","False","Nợ thuê tài chính"


### PR DESCRIPTION
When posting an invoice, the system creates:
- Journal Entry: Dr 131 (Receivable) / Cr 511

Then the system creates a deferral entry:
- Deferral entry: Dr 511 / Cr 3387 (Payable)

Falsifying the Balance sheet report, in the accounts receivable and accounts payable indicators

The issue was that account 3387 was configured as `Payable`, which caused the system to generate both Receivable (131) and Payable (3387) for the same partner. This is incorrect because account 3387 represents "Unearned Revenue", which is a  current liability, not a payable account.

By changing the account type from `Payable` to `Current Liabilities`,
the deferral entry now correctly reflects that 3387 is a current liability account, preventing the incorrect reconciliation behavior where both receivable and payable entries were created for the same partner.

After this fix:
- Entry: Dr 131 (Receivable) / Cr 511
- Deferral: Dr 511 / Cr 3387 (Current Liabilities)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
