### PR TITLE
[FIX] website: escape single quote in technical page title

### DIFF
--- a/addons/website/models/website_technical_page.py
+++ b/addons/website/models/website_technical_page.py
@@ -42,11 +42,14 @@ class WebsiteTechnicalPage(models.Model):
     @property
     def _table_query(self):
         routes = self.get_static_routes()
-        values = ", ".join(str(route) for route in routes)
+        values = SQL(", ").join(
+            SQL('(%s, %s)', route_title, route_path)
+            for route_title, route_path in routes
+        )
 
         return SQL("""
             SELECT row_number() OVER () AS id,
                 column1 AS name,
                 column2 AS website_url
             FROM (VALUES %s) AS t(column1, column2)
-        """ % values)
+        """, values)

--- a/addons/website/tests/test_website_technical_page.py
+++ b/addons/website/tests/test_website_technical_page.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+from odoo.addons.website.models.website_technical_page import WebsiteTechnicalPage
 from odoo.tests import TransactionCase, tagged
 
 
@@ -20,3 +23,12 @@ class TestWebsiteTechnicalPage(TransactionCase):
             "/web/reset_password",
             "/website/info",
         ])
+
+    def test_load_website_escaping_title(self):
+        patched_route = [
+            ("H'\\e\"l/l\\'\\\"o", "/w'\\o\"r/l\\'\\\"d"),
+        ]
+        with patch.object(WebsiteTechnicalPage, 'get_static_routes', return_value=patched_route):
+            page = self.env["website.technical.page"].search([])
+            self.assertEqual(page.name, patched_route[0][0])
+            self.assertEqual(page.website_url, patched_route[0][1])


### PR DESCRIPTION
**Steps to reproduce:**
* Install **Website Sale** modules with demo data.
* Change the language to **French (fr)** from settings.
* Open  **Website → Site → Technical Page**.
* The technical pages view fails to load.

**Observed behavior:**

An Odoo **RPC_ERROR** is raised.

```
self._obj.execute(query, params)
psycopg2.errors.UndefinedColumn: column ''S'inscrire'' does not exist
LINE 5: ...'), ('Tableau de bord utilisateur', '/my/home'), (''S'inscrir...
```

**Cause:**
* Method `website.technical.page()._table_query` uses raw values without
  correctly escaping them since 25efaf49b6691d1b5aeba40a016134660fe2358c
* A new route title translation ("S'inscrire" for "Sign Up") was added
  as french translation.

**Fix:**

Use SQL class to correctly escape litterals when using them.

opw-5354982