### PR TITLE
[IMP] web: remove zoom-out effect on body

### DIFF
--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -188,34 +188,6 @@
             }
         }
     }
-
-    // When bottom sheet is open, apply styles to the body
-    @at-root .bottom-sheet-open {
-        overflow: hidden;
-
-        // Scale down the main content
-        .o_navbar, .o_action_manager {
-            @media (prefers-reduced-motion: no-preference) {
-                transition: transform $o_BottomSheet_slideIn_duration ease;
-            }
-            transform: scale(.95) translateZ(0);
-            transform-origin: center top;
-        }
-
-        // Avoid blank on the side
-        &:not(.o_home_menu_background) .o_main_navbar {
-            box-shadow: 20px 0 0 $o-navbar-background, -20px 0 0 $o-navbar-background;
-        }
-
-        &:not(.bottom-sheet-open-multiple):has(.o_bottom_sheet_dismissing) {
-            .o_navbar, .o_action_manager {
-                @media (prefers-reduced-motion: no-preference) {
-                    transition: transform $o_BottomSheet_slideOut_duration ease;
-                }
-                transform: scale(1) translateZ(0);
-            }
-        }
-    }
 }
 
 // =============================================


### PR DESCRIPTION
This commit removes the style that was applied to the main content, when the BottomSheet component opens.

The effect created a useless distraction, with no real UX gain.

task-5359036
