### PR TITLE
[FIX] l10n_sa: adding 'Simplified' to B2C invoices in phase 1

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -84,3 +84,16 @@ class AccountMove(models.Model):
         for move in self.filtered('l10n_sa_confirmation_datetime'):
             move.l10n_sa_confirmation_datetime = datetime.combine(fields.Date.from_string(invoice_date), move.l10n_sa_confirmation_datetime.time())
         return result
+
+    def _l10n_sa_is_simplified(self):
+        """
+            Returns True if the customer is an individual, i.e: The invoice is B2C
+        :return:
+        """
+        self.ensure_one()
+
+        return (
+            self.partner_id.commercial_partner_id.company_type == "person"
+            if self.partner_id.commercial_partner_id
+            else self.partner_id.company_type == "person"
+        )

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -1,6 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="arabic_english_invoice" inherit_id="l10n_gcc_invoice.arabic_english_invoice">
+        <xpath expr="//div[hasclass('col-4')]//span[@t-if=&quot;o.move_type == &apos;out_invoice&apos; and o.state == &apos;posted&apos;&quot;]" position="replace">
+            <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
+                <t t-if="o._l10n_sa_is_simplified()">
+                    Simplified Tax Invoice
+                </t>
+                <t t-else="">
+                    Tax Invoice
+                </t>
+            </span>
+        </xpath>
+        <xpath expr="//div[hasclass('col-4')][3]//span[@t-if=&quot;o.move_type == &apos;out_invoice&apos; and o.state == &apos;posted&apos;&quot;]" position="replace">
+            <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
+                <t t-if="o._l10n_sa_is_simplified()">
+                    فاتورة ضريبية مبسطة
+                </t>
+                <t t-else="">
+                    فاتورة ضريبية
+                </t>
+            </span>
+        </xpath>
         <xpath expr="//div[@name='due_date']" position="after">
             <div class="row" t-if="o.delivery_date" name="delivery_date">
                 <div class="col-6"></div>

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -24,6 +24,7 @@ class AccountMove(models.Model):
     )
 
     def _l10n_sa_is_simplified(self):
+        # DEPRECATED - to be removed in master
         """
             Returns True if the customer is an individual, i.e: The invoice is B2C
         :return:

--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -46,6 +46,7 @@
                 </div>
             </xpath>
             <xpath expr="//div[hasclass('col-4')]//span[@t-if=&quot;o.move_type == &apos;out_invoice&apos; and o.state == &apos;posted&apos;&quot;]" position="replace">
+                <!-- DEPRECATED - to be removed in master  -->
                 <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
                     <t t-if="o._l10n_sa_is_simplified()">
                         Simplified Tax Invoice
@@ -56,6 +57,7 @@
                 </span>
             </xpath>
             <xpath expr="//div[hasclass('col-4')][3]//span[@t-if=&quot;o.move_type == &apos;out_invoice&apos; and o.state == &apos;posted&apos;&quot;]" position="replace">
+                <!-- DEPRECATED - to be removed in master -->
                 <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
                     <t t-if="o._l10n_sa_is_simplified()">
                         فاتورة ضريبية مبسطة


### PR DESCRIPTION
For B2C invoices, the invoice's title must be "Simplified Tax Invoice". This was only applied to phase 2 ZATCA in "l10n_sa_edi". This change makes sure to apply the same requirement for phase 1 invoices.

Task-5322118

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
