### PR TITLE
[FIX] spreadsheet: freeze empty strings

### DIFF
--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -71,15 +71,7 @@ export async function freezeOdooData(model) {
             const position = { sheetId, col, row };
             const evaluatedCell = model.getters.getEvaluatedCell(position);
             if (containsOdooFunction(cell.content)) {
-                if (
-                    evaluatedCell.type === "text" &&
-                    (isNumber(evaluatedCell.value, DEFAULT_LOCALE) ||
-                        isDateTime(evaluatedCell.value, DEFAULT_LOCALE))
-                ) {
-                    cell.content = `="${evaluatedCell.value}"`;
-                } else {
-                    cell.content = evaluatedCell.value.toString();
-                }
+                cell.content = toFrozenContent(evaluatedCell);
                 if (evaluatedCell.format) {
                     cell.format = getItemId(evaluatedCell.format, data.formats);
                 }
@@ -90,7 +82,7 @@ export async function freezeOdooData(model) {
                         const evaluatedCell = model.getters.getEvaluatedCell(spreadPosition);
                         sheet.cells[xc] = {
                             ...sheet.cells[xc],
-                            content: evaluatedCell.value.toString(),
+                            content: toFrozenContent(evaluatedCell),
                         };
                         if (evaluatedCell.format) {
                             sheet.cells[xc].format = getItemId(evaluatedCell.format, data.formats);
@@ -116,6 +108,19 @@ export async function freezeOdooData(model) {
     }
     exportGlobalFiltersToSheet(model, data);
     return data;
+}
+
+function toFrozenContent(evaluatedCell) {
+    const value = evaluatedCell.value;
+    if (
+        evaluatedCell.type === "text" &&
+        (isNumber(value, DEFAULT_LOCALE) || isDateTime(value, DEFAULT_LOCALE))
+    ) {
+        return `="${value}"`;
+    } else if (value === "") {
+        return '=""';
+    }
+    return value.toString();
 }
 
 function exportGlobalFiltersToSheet(model, data) {


### PR DESCRIPTION
Steps to reproduce:
- insert a list
- expand the list beyond the number of records in order to have ODOO.LIST with no result
- add =ISTEXT( <a reference to an empty ODOO.LIST> ) ->  the result is TRUE
- Freeze and share the spreadsheet

=> the result of ISTEXT is FALSE in the frozen version

task-5360561
opw-5359100

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
