### PR TITLE
[FIX] stock: prevent error when report not found

### DIFF
--- a/addons/stock/wizard/stock_lot_label_layout.py
+++ b/addons/stock/wizard/stock_lot_label_layout.py
@@ -2,7 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductLabelLayout(models.TransientModel):
@@ -37,6 +38,11 @@ class ProductLabelLayout(models.TransientModel):
             docids = []
             for lot_id, qty in quantity_by_lot.items():
                 docids.extend([lot_id] * qty)
-        report_action = self.env.ref(xml_id).report_action(docids, config=False)
+        record = self.env.ref(xml_id, raise_if_not_found=False)
+        if not record:
+            raise ValidationError(_(
+                'Unable to find report template for %(template)s format', template=self.print_format
+            ))
+        report_action = record.report_action(docids, config=False)
         report_action.update({'close_on_report_download': True})
         return report_action


### PR DESCRIPTION
This error occurs when the user deletes the `Lot/Serial Number (PDF)` report and then attempts to print report.

Steps to reproduce:
---
- Install `stock` module(without demo)
- Search `Lot/Serial Number (PDF)` in `..Actions/Reports` > Delete it
- Enable `Lots & Serial Numbers` in settings.
- Create a Picking and `Mark as TODO`
- Set a `Serial Numbers` in order line
- In cog menu `Print Labels` > `Lot/SN labels` > `Confirm` > `Confirm`

Traceback:
---
`ValueError: External ID not found in the system: stock.action_report_lot_label`

At [1], when we try to access any report XML ID, we encounter an error because the corresponding report has been deleted.

[1]- https://github.com/odoo/odoo/blob/b6b37a794f9e3e724a32a3529ce2ef7361b8046e/addons/stock/wizard/stock_lot_label_layout.py#L40

sentry-7064566500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
