### PR TITLE
[FIX] website: test_auto_hide_menu tour

### DIFF
--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -67,6 +67,9 @@ registerWebsitePreviewTour(
             content: "Check that modal has disappeared",
             trigger: "body:not(:has(.modal))",
         },
+        {
+            trigger: `:iframe .o_homepage_editor_welcome_message:contains(welcome to your homepage)`,
+        },
         ...clickOnEditAndWaitEditMode(),
         getTheLayoutChildren,
         {


### PR DESCRIPTION
In this commit, we fix a non deterministic behavior by ensuring the iframe is loaded before set and attribute on iframe content element.

runbot-error-id~233039

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
