### PR TITLE
[FIX] website: clear timeout for header fade out animation

### DIFF
--- a/addons/website/static/src/interactions/header/header_fade_out.js
+++ b/addons/website/static/src/interactions/header/header_fade_out.js
@@ -9,10 +9,14 @@ export class HeaderFadeOut extends BaseHeaderSpecial {
         this.isAnimated = true;
         this.el.style.transitionDuration = "400ms";
         this.el.style.transitionProperty = 'opacity';
+        this.fadeTimeout = null;
     }
 
     transformShow() {
         this.el.style.opacity = 1;
+        if (this.fadeTimeout) {
+            clearTimeout(this.fadeTimeout);
+        }
         super.transformShow();
     }
 
@@ -20,7 +24,10 @@ export class HeaderFadeOut extends BaseHeaderSpecial {
         this.el.style.opacity = 0;
         this.isVisible = false;
         // We want to translate the header after the transition is complete
-        this.waitForTimeout(() => this.el.style.transform = "translate(0, -100%)", 400);
+        this.fadeTimeout = this.waitForTimeout(
+            () => (this.el.style.transform = "translate(0, -100%)"),
+            400
+        );
         this.adaptToHeaderChangeLoop(1);
     }
 }


### PR DESCRIPTION
Steps to reproduce the issue:
- Go to Edit mode
- Click on the Header
- In the "Scroll Effect" dropdown, select "Fade Out"
- Drop some snippets to allow scrolling on the page
- Scroll down then scroll to top QUICKLY

The timeout to hide the header after the fade animation end is not cleared. Therefore, after 400ms, the header is shifted upward and disappears, even if the user scrolled up and made the header reappear.

task-5357217