### PR TITLE
[FIX] loyalty: Mark service product noupdate

### DIFF
--- a/addons/loyalty/data/loyalty_data.xml
+++ b/addons/loyalty/data/loyalty_data.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Basic product for gift card program -->
-    <record id="gift_card_product_50" model="product.product">
-        <field name="name">Gift Card</field>
-        <field name="list_price">50</field>
-        <field name="detailed_type">service</field>
-        <field name="purchase_ok" eval="False"/>
-        <field name="image_1920" type="base64" file="loyalty/static/img/gift_card.png"/>
-    </record>
-    <!-- Basic product for eWallet programs -->
-    <record id="ewallet_product_50" model="product.product">
-        <field name="name">Top-up eWallet</field>
-        <field name="list_price">50</field>
-        <field name="detailed_type">service</field>
-        <field name="purchase_ok" eval="False"/>
-    </record>
-
     <data noupdate="1">
+        <!-- Basic product for gift card program -->
+        <record id="gift_card_product_50" model="product.product">
+            <field name="name">Gift Card</field>
+            <field name="list_price">50</field>
+            <field name="detailed_type">service</field>
+            <field name="purchase_ok" eval="False"/>
+            <field name="image_1920" type="base64" file="loyalty/static/img/gift_card.png"/>
+        </record>
+        <!-- Basic product for eWallet programs -->
+        <record id="ewallet_product_50" model="product.product">
+            <field name="name">Top-up eWallet</field>
+            <field name="list_price">50</field>
+            <field name="detailed_type">service</field>
+            <field name="purchase_ok" eval="False"/>
+        </record>
+
         <record forcecreate="0" id="config_online_sync_proxy_mode" model="ir.config_parameter">
             <field name="key">loyalty.compute_all_discount_product_ids</field>
             <field name="value">False</field>


### PR DESCRIPTION
The customer changed the service-type
products “Gift Card” and “E-Wallet” to storable products and used them in stock. May be they could use as physical gift cards, and physical e-wallets for  company.
As a result, these products now have on-hand quantities, which creates an issue. After the upgrade, they will be converted back to
service-type products, causing an on-hand quantity inconsistency in the test case.

To avoid this error, we need to keep these products as storable. TO do that we have to mark them noupdate.

This is a customer-specific change,
but since we have received many similar requests,
we should consider making a generic fix if possible.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
