### PR TITLE
[FIX] web: Typo leading to wrong grouped list offset

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -582,7 +582,7 @@ export class RelationalModel extends Model {
                     }
                 }
                 if (Object.hasOwn(groupData, "__offset")) {
-                    groupConfig.list.offset = group.__offset;
+                    groupConfig.list.offset = groupData.__offset;
                 }
                 if (groupRecordConfig) {
                     groupConfig.record = {


### PR DESCRIPTION
This commit fixes a typo in relational_model causing the grouped list offset to be undefined and crashing when rendering pagers.
