### PR TITLE
[IMP] web: graph: improve measure name display and legend behavior

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -7,6 +7,7 @@
                 measures="model.metaData.measures"
                 activeMeasures="[model.metaData.measure]"
                 onMeasureSelected.bind="this.onMeasureSelected"
+                multiSelect="false"
             />
         </div>
         <div class="btn-group" role="toolbar" aria-label="Change graph">

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -401,7 +401,7 @@ export class GraphRenderer extends Component {
      * @returns {Object}
      */
     getLegendOptions() {
-        const { mode } = this.model.metaData;
+        const { mode, groupBy } = this.model.metaData;
         const legendOptions = {
             onHover: this.onLegendHover.bind(this),
             onLeave: this.onLegendLeave.bind(this),
@@ -432,11 +432,15 @@ export class GraphRenderer extends Component {
                     }),
             };
         } else {
-            legendOptions.position = "top";
-            legendOptions.align = "end";
+            legendOptions.position = "bottom";
+            legendOptions.align = "middle";
             const referenceColor = mode === "bar" ? "backgroundColor" : "borderColor";
             legendOptions.labels = {
                 generateLabels: (chart) => {
+                    // if no more than one groupBy, the legend is implicitly displayed inside the measure
+                    if (groupBy.length <= 1) {
+                        return [];
+                    }
                     const { data } = chart;
                     const labels = data.datasets.map((dataset, index) => ({
                         text: shortenLabel(dataset.label),

--- a/addons/web/static/src/views/view_components/report_view_measures.js
+++ b/addons/web/static/src/views/view_components/report_view_measures.js
@@ -11,6 +11,10 @@ export class ReportViewMeasures extends Component {
     static props = {
         measures: true,
         activeMeasures: { type: Array, optional: true },
+        multiSelect: { type: Boolean, optional: true },
         onMeasureSelected: { type: Function, optional: true },
+    };
+    static defaultProps = {
+        multiSelect: true,
     };
 }

--- a/addons/web/static/src/views/view_components/report_view_measures.xml
+++ b/addons/web/static/src/views/view_components/report_view_measures.xml
@@ -3,14 +3,15 @@
 
     <t t-name="web.ReportViewMeasures">
       <Dropdown>
-        <button class="btn btn-primary">
-          Measures <i class="fa fa-caret-down ms-1"/>
+        <button class="btn btn-primary o_report_measures">
+          <t t-if="!props.multiSelect and props.activeMeasures.length" t-esc="props.measures[props.activeMeasures[0]].string"/>
+          <t t-else="">Measures</t> <i class="fa fa-caret-down ms-1"/>
         </button>
         <t t-set-slot="content">
           <t t-foreach="props.measures" t-as="measure" t-key="measure_value.name">
             <div t-if="!measure_first and measure == '__count'" role="separator" class="dropdown-divider"/>
             <DropdownItem class="{ o_menu_item: true, selected: this.props.activeMeasures.includes(measure) }"
-              closingMode="'none'"
+              closingMode="props.multiSelect ? 'none' : 'all'"
               t-esc="props.measures[measure].string"
               onSelected="() => this.props.onMeasureSelected({ measure: measure_value.name })"
             />

--- a/addons/web/static/tests/views/graph/graph_test_helpers.js
+++ b/addons/web/static/tests/views/graph/graph_test_helpers.js
@@ -146,6 +146,12 @@ export function checkLegend(view, expectedLabels) {
     });
 }
 
+export function checkMeasure(expectedMeasure) {
+    expect(`.o_report_measures`).toHaveText(expectedMeasure, {
+        message: `Measure should be ${expectedMeasure}`,
+    });
+}
+
 /**
  * @param {GraphView} view
  */


### PR DESCRIPTION
This commit updates the Graph view so that the measure selection button now displays the active measure instead of leaving that information only inside the dropdown and closes on measure selection.

Additionally, the legend is now hidden when there is no more than one active `groupBy`, since in that case it only repeats the active measure and provides no useful information. It also got moved to the bottom center of the graph.

task-5355048
