### PR TITLE
[FIX] pos_self_order: demo kiosk uses wrong pay after mode

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -365,6 +365,7 @@ class PosConfig(models.Model):
             'iface_splitbill': True,
             'module_pos_restaurant': True,
             'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
         })
 
     def __generate_single_qr_code(self, url):


### PR DESCRIPTION
The field `self_ordering_pay_after` should always be `each` when the `self_ordering_mode` is set to `kiosk`. This is enforced in the `write` method. However, the demo kiosk is created with a
`self_ordering_pay_after` value of `meal`, until the `write` method is run. This results in behaviour such as the payment screen being skipped when it is not expected to.

This commit sets the correct `self_ordering_pay_after` value of `each` when creating the demo kiosk.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
