### PR TITLE
[FIX] point_of_sale: keep receipt change when payment line is translated

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -143,7 +143,7 @@ export class PosOrderAccounting extends Base {
             this.payment_ids.reduce(function (sum, paymentLine) {
                 // Return lines are created after the sync, should not be taken into account in
                 // the paid amount otherwise, the change would be wrong.
-                if (paymentLine.isDone() && paymentLine.name !== "return") {
+                if (paymentLine.isDone() && !paymentLine.is_change) {
                     sum += paymentLine.getAmount();
                 }
                 return sum;

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -271,3 +271,27 @@ test("[get prices] check prices and taxes", async () => {
     expect(line1DataWDiscount.no_discount_total_included).toBe(10.35);
     expect(line1DataWDiscount.no_discount_taxes_data[0].tax_amount).toBe(1.35);
 });
+
+test("showChange remains true when change line name is translated", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+    const cashPaymentMethod = store.models["pos.payment.method"].get(1);
+
+    const { data: paymentLine } = order.addPaymentline(cashPaymentMethod);
+    const overpaidAmount = order.totalDue + 5;
+    paymentLine.setAmount(overpaidAmount);
+
+    const changeAmount = paymentLine.getAmount() - order.totalDue;
+    const changeLine = order.models["pos.payment"].create({
+        pos_order_id: order,
+        payment_method_id: cashPaymentMethod,
+    });
+    changeLine.setAmount(-changeAmount);
+    changeLine.name = "Retour"; // Simulate translated "return"
+    changeLine.is_change = true;
+
+    order.state = "paid";
+
+    expect(order.change).toBe(-changeAmount);
+    expect(order.showChange).toBe(true);
+});


### PR DESCRIPTION
When using another language than english, the change line wasn't displayed on the receipt.

Steps to reproduce:
-------------------
* Set the POS user language to fr_BE (or any none english)
* Pay an order in cash with an amount greater than the total.

> Observation:
Change line was not visible on the receipt

Why the fix:
------------
The frontend was checking `paymentLine.name !== "return"`, so once the backend translated the name to “Retour”, the change line was skipped. By checking `is_change` we get the correct amount and we ensure `order.showChange` still returns true even when the “return” payment line is translated (e.g. in fr_BE).

opw-5247079
