### PR TITLE
[18.0] [FIX] product: _compute_write_date when launched on product template NewId

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -149,8 +149,9 @@ class ProductProduct(models.Model):
         compute method is not subject to this restriction.  It therefore
         works as intended :-)
         """
+        now = self.env.cr.now()
         for record in self:
-            record.write_date = max(record.write_date or self.env.cr.now(), record.product_tmpl_id.write_date)
+            record.write_date = max(record.write_date or now, record.product_tmpl_id.write_date or now)
 
     def _compute_image_1920(self):
         """Get the image from the template if no image is set on the variant."""


### PR DESCRIPTION
If _compute_write_date is launched when creating a product.product without starting from an existing product.template, the compute may be launched before the product.template is created, hence record.product_tmpl_id.write_date is False, and comparing datetime and bool leads to an error.

This completes the fix proposed https://github.com/odoo/odoo/pull/138177


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
