### PR TITLE
[16.0][l10n_mt] Create default accounting addon for Malta account chart

### DIFF
--- a/addons/l10n_mt/__manifest__.py
+++ b/addons/l10n_mt/__manifest__.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    "name": "Malta - Accounting",
+    "version": "1.0",
+    "author": "Odoo S.A.",
+    "license": "LGPL-3",
+    'category': 'Accounting/Localizations/Account Charts',
+    "description": """This is the module to manage the accounting chart for Malta.""",
+    "depends": ["account"],
+    "data": [],
+    "demo": [],
+}

--- a/addons/l10n_mt_pos/__manifest__.py
+++ b/addons/l10n_mt_pos/__manifest__.py
@@ -5,6 +5,7 @@
     "category": "Accounting/Localizations/Point of Sale",
     "description": """Malta Compliance Letter for EXO Number""",
     "depends": [
+        "l10n_mt",
         "point_of_sale",
     ],
     "data": [


### PR DESCRIPTION
Create default accounting addon for Malta account chart to avoid auto install from l10n_mt_pos when point_of_sale addon is installed

Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/237536

Current behavior before PR:

When the addon `point_of_sale` is installed, it triggers the installation of the `l10n_mt_pos` (auto_install), whereas this module should only be installed if Malta accounting is required.

Desired behavior after PR is merged:

I added an intermediate module `l10n_mt` to explicitly request the installation of Malta accounting. This will prevent the addon `l10n_mt_pos` from being installed automatically, but will not prevent automatic installation in a desired Malta accounting configuration.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
