### PR TITLE
[FIX] hr_timesheet: correct timesheet value conversion in project update

### DIFF
--- a/addons/hr_timesheet/models/project_update.py
+++ b/addons/hr_timesheet/models/project_update.py
@@ -33,7 +33,7 @@ class ProjectUpdate(models.Model):
             project.sudo().last_update_id = update
             update.write({
                 "uom_id": encode_uom,
-                "allocated_time": round(project.allocated_hours / ratio),
-                "timesheet_time": round(project.sudo().total_timesheet_time / ratio),
+                "allocated_time": round(project.allocated_hours * ratio),
+                "timesheet_time": round(project.sudo().total_timesheet_time),
             })
         return updates

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -653,12 +653,26 @@ class TestTimesheet(TestCommonTimesheet):
             'unit_amount': 8,
             'employee_id': self.empl_employee2.id
         })
+        project_update_hrs = self.env['project.update'].create({
+            'name': 'Project update 1',
+            'project_id': project.id,
+            'status': 'on_track',
+        })
+        self.assertEqual(project_update_hrs.timesheet_time, 8, "Timesheet time should be 8 hours for new project update")
+        # Clear cached computed project values before the UoM change
+        self.env['project.project'].invalidate_model()
         self.env.company.timesheet_encode_uom_id = self.env.ref('uom.product_uom_day')
         self.assertEqual(project.total_timesheet_time, 1, "Total timesheet time should be 1 day")
         project.allocated_hours = 0.0
         panel_data = project.get_panel_data()
         self.assertEqual(panel_data['buttons'][1]['number'], "1 Days", "Should display '1 Days'")
         self.assertEqual(project.timesheet_encode_uom_id, self.env.company.timesheet_encode_uom_id, "Timesheet encode uom should be the one from the company of the env, since the project has no company.")
+        project_update_days = self.env['project.update'].create({
+            'name': 'Project update 2',
+            'project_id': project.id,
+            'status': 'on_track',
+        })
+        self.assertEqual(project_update_days.timesheet_time, 1, "Timesheet time should be 1 day for new project update")
 
     def test_unlink_task_with_timesheet(self):
         self.env['account.analytic.line'].create({


### PR DESCRIPTION
Similar to: 0104cee

Steps to reproduce:
--------------------
1. Install hr_timesheet
2. Create a new project and a task
3. On the task, add a timesheet line with some time (e.g., 16 hours)
4. Open the project dashboard > create a new project update >
observe the timesheet time
5. Go to Timesheets > Configuration > Settings
6. Set "Encoding method" to "Days/Half-days"
7. Reopen the project dashboard > create another project update >
observe the timesheet time again

Issue:
------
Incorrect value displayed in the Timesheets. (e.g., 16 Days instead of 2 Days)

Cause:
-------
After commit 28b69da, the UoM model was restructured, changing how conversions 
between hours and days are computed. https://github.com/odoo/odoo/blob/aeda822db05b218fd1271c7666307950b7a98512/addons/hr_timesheet/models/project_project.py#L137-L143

The `total_timesheet_time` value is now already stored in the final unit (e.g., days). 
Whenever a new project update is created, the division in `create()` performs an
unnecessary second conversion on an already converted value, causing the incorrect display.
https://github.com/odoo/odoo/blob/583bacdc8ad2b87b99b11d1e12dacf6e42edf22b/addons/hr_timesheet/models/project_update.py#L36-L37

Solution:
----------
This commit ensures accurate conversion of timesheet values between hours and days.

opw-5184077

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
