### PR TITLE
[FIX] l10n_eg_edi_eta: derive rate from first product line

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -121,7 +121,8 @@ class AccountMove(models.Model):
         from_currency = self.currency_id
         to_currency = self.company_id.currency_id
         if from_currency != to_currency and self.invoice_line_ids:
-            amount_currency = self.invoice_line_ids[0].amount_currency
+            first_product_line = self.invoice_line_ids.filtered(lambda line: line.display_type == "product")[:1]
+            amount_currency = first_product_line.amount_currency
             if not float_is_zero(amount_currency, precision_rounding=from_currency.rounding):
-                return abs(self.invoice_line_ids[0].balance / amount_currency)
+                return abs(first_product_line.balance / amount_currency)
         return 1.0

--- a/addons/l10n_eg_edi_eta/tests/test_edi_json.py
+++ b/addons/l10n_eg_edi_eta/tests/test_edi_json.py
@@ -569,6 +569,12 @@ class TestEdiJson(TestEGEdiCommon):
                 currency_id=self.currency_aed_id.id,
                 partner_id=self.partner_b.id,
                 invoice_line_ids=[
+                    # Non-product lines (e.g., sections) must be removed when sending to ETA.
+                    # This also verifies that currency rates are calculated based on the first product line.
+                    {
+                        'name': 'Section line',
+                        'display_type': 'line_section',
+                    },
                     {
                         'product_id': self.product_a.id,
                         'price_unit': 120.99,


### PR DESCRIPTION
The currency rate was previously computed using the first invoice line, regardless of its type. This caused incorrect rate calculation when the first line was not a product line (e.g., section, note, or display-only lines).

This fix filters invoice_line_ids to use the first actual product line when extracting amount_currency and balance, ensuring that the derived rate reflects a valid monetary line.

opw-5208724

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
