### PR TITLE
[FIX] pos_viva_com: fix authentication in kiosk

### DIFF
--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -46,9 +46,9 @@ export class PaymentVivaCom extends PaymentInterface {
     }
 
     _call_viva_com(data, action, paymentLine) {
-        return this.env.services.orm.silent
-            .call("pos.payment.method", action, [[this.payment_method_id.id], data])
-            .catch(this._handleOdooConnectionFailure.bind(this, paymentLine));
+        return this.callPaymentMethod(action, [[this.payment_method_id.id], data]).catch(
+            this._handleOdooConnectionFailure.bind(this, paymentLine)
+        );
     }
 
     _handleOdooConnectionFailure(paymentLine, data = {}) {


### PR DESCRIPTION
Steps to reproduce:
1. Configure a Kiosk with a Viva.com terminal.
2. Open the Kiosk in an Incognito window to ensure there is no saved session.
3. Attempt to pay for an order.

Expected behaviour:
- The payment goes through to the terminal.

Actual behaviour:
- There is a connection error message shown.

This is due to a missed `orm.call` in the Viva.com payment code, resulting in an authentication error as the public user does not have access to the payment terminal record. The fix is to use the `callPaymentMethod` method instead.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
