### PR TITLE
[FIX] hr_holidays: avoid counting unexpected global leaves in test

### DIFF
--- a/addons/hr_holidays/tests/test_calendar_leaves_count.py
+++ b/addons/hr_holidays/tests/test_calendar_leaves_count.py
@@ -12,6 +12,8 @@ class TestResourceCalendarLeaves(TestHrHolidaysCommon):
         """
         calendar_a = self.env['resource.calendar'].create({'name': 'Calendar A'})
         calendar_b = self.env['resource.calendar'].create({'name': 'Calendar B'})
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        base_global_count = calendar_a.associated_leaves_count
 
         leave_a_1 = self.env['resource.calendar.leaves'].create({
             'name': 'CalendarA Specific Leave_1',
@@ -36,8 +38,8 @@ class TestResourceCalendarLeaves(TestHrHolidaysCommon):
 
         # 1. Initial check: calendar_a (1 specific + 1 global = 2), calendar_b (1 specific + 1 global = 2)
         (calendar_a | calendar_b)._compute_associated_leaves_count()
-        self.assertEqual(calendar_a.associated_leaves_count, 2, "Calendar A should have 1 specific + 1 global leave.")
-        self.assertEqual(calendar_b.associated_leaves_count, 2, "Calendar B should have 1 specific + 1 global leave.")
+        self.assertEqual(calendar_a.associated_leaves_count, base_global_count + 2, "Calendar A should have baseline global leaves + 1 specific + 1 global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, base_global_count + 2, "Calendar B should have baseline global leaves + 1 specific + 1 global leave.")
 
         self.env['resource.calendar.leaves'].create({
             'name': 'Global Leave 2',
@@ -48,8 +50,8 @@ class TestResourceCalendarLeaves(TestHrHolidaysCommon):
 
         # 2. Test updated counts: calendar_a (1 specific + 2 global = 3), calendar_b (1 specific + 2 global = 3)
         (calendar_a | calendar_b)._compute_associated_leaves_count()
-        self.assertEqual(calendar_a.associated_leaves_count, 3, "Calendar A should have 1 specific + 2 global leaves.")
-        self.assertEqual(calendar_b.associated_leaves_count, 3, "Calendar B should have 1 specific + 2 global leaves.")
+        self.assertEqual(calendar_a.associated_leaves_count, base_global_count + 3, "Calendar A should have baseline global leaves + 1 specific + 2 global leaves.")
+        self.assertEqual(calendar_b.associated_leaves_count, base_global_count + 3, "Calendar B should have baseline global leaves + 1 specific + 2 global leaves.")
 
         self.env['resource.calendar.leaves'].create({
             'name': 'CalendarA Specific Leave_2',
@@ -60,24 +62,24 @@ class TestResourceCalendarLeaves(TestHrHolidaysCommon):
 
         # 3. Test updated counts: calendar_a (2 specific + 2 global = 4), calendar_b (1 specific + 2 global = 3)
         (calendar_a | calendar_b)._compute_associated_leaves_count()
-        self.assertEqual(calendar_a.associated_leaves_count, 4, "Calendar A should have 2 specific + 2 global leaves.")
-        self.assertEqual(calendar_b.associated_leaves_count, 3, "Calendar B should have 1 specific + 2 global leaves.")
+        self.assertEqual(calendar_a.associated_leaves_count, base_global_count + 4, "Calendar A should have baseline global leaves + 2 specific + 2 global leaves.")
+        self.assertEqual(calendar_b.associated_leaves_count, base_global_count + 3, "Calendar B should have baseline global leaves + 1 specific + 2 global leaves.")
 
         # 4. Test Remove a global leave: calendar_a (2 specific + 1 global = 3), calendar_b (1 specific + 1 global = 2)
         global_leave_1.unlink()
         (calendar_a | calendar_b)._compute_associated_leaves_count()
-        self.assertEqual(calendar_a.associated_leaves_count, 3, "Calendar A should have 2 specific + 1 remaining global leave.")
-        self.assertEqual(calendar_b.associated_leaves_count, 2, "Calendar B should have 1 specific + 1 remaining global leave.")
+        self.assertEqual(calendar_a.associated_leaves_count, base_global_count + 3, "Calendar A should have baseline global leaves + 2 specific + 1 remaining global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, base_global_count + 2, "Calendar B should have baseline global leaves + 1 specific + 1 remaining global leave.")
 
         # 5. Test Remove a specific leave to have no leaves specific to calendar_b:
         # calendar_a (2 specific + 1 global = 3), calendar_b (0 specific + 1 global = 1)
         leave_b_1.unlink()
         (calendar_a | calendar_b)._compute_associated_leaves_count()
-        self.assertEqual(calendar_a.associated_leaves_count, 3, "Calendar A should still have 2 specific + 1 global leave.")
-        self.assertEqual(calendar_b.associated_leaves_count, 1, "Calendar B should have 0 specific + 1 global leave.")
+        self.assertEqual(calendar_a.associated_leaves_count, base_global_count + 3, "Calendar A should still have baseline global leaves + 2 specific + 1 global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, base_global_count + 1, "Calendar B should have baseline global leaves + 0 specific + 1 global leave.")
 
         # 6. Test Remove a specific leave calendar_a: calendar_a (1 specific + 1 global = 2), calendar_b (0 specific + 1 global = 1)
         leave_a_1.unlink()
         (calendar_a | calendar_b)._compute_associated_leaves_count()
-        self.assertEqual(calendar_a.associated_leaves_count, 2, "Calendar A should still have 2 specific + 1 global leave.")
-        self.assertEqual(calendar_b.associated_leaves_count, 1, "Calendar B should have 0 specific + 1 global leave.")
+        self.assertEqual(calendar_a.associated_leaves_count, base_global_count + 2, "Calendar A should still have baseline global leaves + 2 specific + 1 global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, base_global_count + 1, "Calendar B should have baseline global leaves + 0 specific + 1 global leave.")


### PR DESCRIPTION
The test `test_compute_associated_leaves_count` was failing with:
```
AssertionError: 3 != 2 : Calendar A should have 1 specific + 1 global leave.
```
The test assumed that only one global leave (`calendar_id=False`) existed in the database. However, the `TestHrHolidaysCommon` setup creates additional global leaves, causing the compute method to return:
```
{calendar_a: 1, calendar_b: 1, global: 2}
```
As a result, `associated_leaves_count` became 3 instead of the expected 2. The test was updated to detect the baseline number of global leaves before creating new ones.

[RB-233599](https://runbot.odoo.com/odoo/error/233599)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
