### PR TITLE
[FIX] web: remove spacing in `control_panel` buttons

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel_mobile.css
+++ b/addons/web/static/src/search/control_panel/control_panel_mobile.css
@@ -15,6 +15,11 @@
         }
     }
 
+    /* hide the main buttons if the dropdown is empty to not render the gap */
+    .o_control_panel_main_buttons:has(> .o-control-panel-adaptive-dropdown:only-child) {
+        display: none !important;
+    }
+
     /* hide the first element in the ellipsis dropdown menu */
     .o-control-panel-adaptive-dropdown.dropdown-menu > :nth-child(1 of :not(.d-none, .o_hidden)) {
         display: none !important;


### PR DESCRIPTION
On mobile when the `o-control-panel-adaptive-dropdown` doesn't have any `control-panel-buttons` to render in its slot, the `o_control_panel_main_buttons` is still rendered.

This results in the `gap-1` being applied and visible before the `o_control_panel_breadcrumbs_actions` which misaligns it.

This commit applies a `display: none` when the dropdown has only one child to not render the `o_control_panel_main_buttons` when it's not used.

(Note the class `d-empty-none` can't account for `d-none` children).

task-5357485

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
