### PR TITLE
[FIX] website: avoid scrollbar when some elements are hidden

### DIFF
--- a/addons/website/static/src/builder/plugins/options/chart_option.scss
+++ b/addons/website/static/src/builder/plugins/options/chart_option.scss
@@ -30,4 +30,8 @@ table.o_builder_matrix {
             width: 28px;
         }
     }
+
+    .visually-hidden-focusable:not(:focus, :focus-within) {
+        position: static !important;
+    }
 }


### PR DESCRIPTION
Before [1], .o_web_client had the property "overflow: hidden", which allowed elements to be moved outside of the screen.

Hovewer, since the property was removed, there would be issues with the bootstrap class "visually-hidden-focusable". A scrollbar would appear when the screen size was small enough, but it shouldn't be the case.

Steps to see the issue:
- Go to Edit mode
- Drop a snippet with a chart
- Click on the chart
- Reduce the screen size -> at some point, a scrollbar should appear on the right of the sidebar.

task-5347481

-----------------------------------------------------------------------

[1] odoo#231251