### PR TITLE
[FIX] project:  Correct New button shortcut mapping

### DIFF
--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -23,7 +23,7 @@ export class ProjectTaskTemplateDropdown extends Component {
         },
     };
     static defaultProps = {
-        hotkey: "r",
+        hotkey: "c",
         projectId: null,
     };
 


### PR DESCRIPTION
Steps to Reproduce:
-

 - Open Project → Tasks.
 - Press Alt key to view shortcut hints.
 - New button control show Alt+R.
 - Pressing Alt+R triggers priority change instead of creating a new record.

Issue:
-

Pressing the shortcut displayed on the New button (Alt+R) does not create a new task but instead changes the task priority.

Cause:
-

 The New button and the Priority widget share the same shortcut (Alt+R), causing the wrong action to trigger.

Solution:
-

 Changed the shortcut for the New button from Alt+R to Alt+C to avoid conflict and ensure correct behavior.

task-5270075