### PR TITLE
[FIX] sale: Reverse Charge Tax With Down Payment

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3192,6 +3192,8 @@ class AccountTax(models.Model):
             )
             base_line['manual_tax_amounts'] = {}
             for tax_data in taxes_data:
+                if tax_data['is_reverse_charge']:
+                    continue
                 tax = tax_data['tax']
                 tax_id_str = str(tax.id)
                 base_line['manual_tax_amounts'][tax_id_str] = {}

--- a/addons/account/static/src/components/tests_shared_js_python/tests_shared_js_python.js
+++ b/addons/account/static/src/components/tests_shared_js_python/tests_shared_js_python.js
@@ -115,26 +115,16 @@ export class TestsSharedJsPython extends Component {
                 document.company,
                 {cash_rounding: document.cash_rounding}
             );
-            return {tax_totals: taxTotals, soft_checking: params.soft_checking};
+            return {
+                tax_totals: taxTotals,
+                soft_checking: params.soft_checking,
+                base_lines_tax_details: this.extractBaseLinesDetails(document),
+            };
         }
         if (params.test === "base_lines_tax_details") {
             const document = this.populateDocument(params.document);
             return {
-                base_lines_tax_details: document.lines.map(line => ({
-                    total_excluded_currency: line.tax_details.total_excluded_currency,
-                    total_excluded: line.tax_details.total_excluded,
-                    total_included_currency: line.tax_details.total_included_currency,
-                    total_included: line.tax_details.total_included,
-                    delta_total_excluded_currency: line.tax_details.delta_total_excluded_currency,
-                    delta_total_excluded: line.tax_details.delta_total_excluded,
-                    taxes_data: line.tax_details.taxes_data.map(tax_data => ({
-                        tax_id: tax_data.tax.id,
-                        tax_amount_currency: tax_data.tax_amount_currency,
-                        tax_amount: tax_data.tax_amount,
-                        base_amount_currency: tax_data.base_amount_currency,
-                        base_amount: tax_data.base_amount,
-                    })),
-                })),
+                base_lines_tax_details: this.extractBaseLinesDetails(document),
             };
         }
     }
@@ -154,6 +144,27 @@ export class TestsSharedJsPython extends Component {
             ...document,
             lines: base_lines,
         }
+    }
+
+    extractBaseLinesDetails(document) {
+        return document.lines.map(line => ({
+            total_excluded_currency: line.tax_details.total_excluded_currency,
+            total_excluded: line.tax_details.total_excluded,
+            total_included_currency: line.tax_details.total_included_currency,
+            total_included: line.tax_details.total_included,
+            delta_total_excluded_currency: line.tax_details.delta_total_excluded_currency,
+            delta_total_excluded: line.tax_details.delta_total_excluded,
+            manual_total_excluded_currency: line.manual_total_excluded_currency,
+            manual_total_excluded: line.manual_total_excluded,
+            manual_tax_amounts: line.manual_tax_amounts,
+            taxes_data: line.tax_details.taxes_data.map(tax_data => ({
+                tax_id: tax_data.tax.id,
+                tax_amount_currency: tax_data.tax_amount_currency,
+                tax_amount: tax_data.tax_amount,
+                base_amount_currency: tax_data.base_amount_currency,
+                base_amount: tax_data.base_amount,
+            })),
+        }));
     }
 }
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -1702,6 +1702,9 @@ export const accountTaxHelpers = {
                 tax_details.total_excluded + tax_details.delta_total_excluded;
             base_line.manual_tax_amounts = {};
             for (const tax_data of taxes_data) {
+                if (tax_data.is_reverse_charge) {
+                    continue;
+                }
                 const tax = tax_data.tax;
                 const tax_id_str = tax.id.toString();
                 base_line.manual_tax_amounts[tax_id_str] = {};

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -1827,35 +1827,40 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
     # base_lines_tax_details
     # -------------------------------------------------------------------------
 
+    def _extract_base_lines_details(self, document):
+        return [
+            {
+                'total_excluded_currency': base_line['tax_details']['total_excluded_currency'],
+                'total_excluded': base_line['tax_details']['total_excluded'],
+                'total_included_currency': base_line['tax_details']['total_included_currency'],
+                'total_included': base_line['tax_details']['total_included'],
+                'delta_total_excluded_currency': base_line['tax_details']['delta_total_excluded_currency'],
+                'delta_total_excluded': base_line['tax_details']['delta_total_excluded'],
+                'manual_total_excluded': base_line['manual_total_excluded'],
+                'manual_total_excluded_currency': base_line['manual_total_excluded_currency'],
+                'manual_tax_amounts': base_line['manual_tax_amounts'],
+                'taxes_data': [
+                    {
+                        'tax_id': tax_data['tax'].id,
+                        'tax_amount_currency': tax_data['tax_amount_currency'],
+                        'tax_amount': tax_data['tax_amount'],
+                        'base_amount_currency': tax_data['base_amount_currency'],
+                        'base_amount': tax_data['base_amount'],
+                    }
+                    for tax_data in base_line['tax_details']['taxes_data']
+                ],
+            }
+            for base_line in document['lines']
+        ]
+
     def _assert_sub_test_base_lines_tax_details(self, results, expected_values):
         self.assertEqual(len(results['base_lines_tax_details']), len(expected_values['base_lines_tax_details']))
         for result, expected in zip(results['base_lines_tax_details'], expected_values['base_lines_tax_details']):
             self.assertDictEqual(result, expected)
 
     def _create_py_sub_test_base_lines_tax_details(self, document):
-        base_lines = document['lines']
         return {
-            'base_lines_tax_details': [
-                {
-                    'total_excluded_currency': base_line['tax_details']['total_excluded_currency'],
-                    'total_excluded': base_line['tax_details']['total_excluded'],
-                    'total_included_currency': base_line['tax_details']['total_included_currency'],
-                    'total_included': base_line['tax_details']['total_included'],
-                    'delta_total_excluded_currency': base_line['tax_details']['delta_total_excluded_currency'],
-                    'delta_total_excluded': base_line['tax_details']['delta_total_excluded'],
-                    'taxes_data': [
-                        {
-                            'tax_id': tax_data['tax'].id,
-                            'tax_amount_currency': tax_data['tax_amount_currency'],
-                            'tax_amount': tax_data['tax_amount'],
-                            'base_amount_currency': tax_data['base_amount_currency'],
-                            'base_amount': tax_data['base_amount'],
-                        }
-                        for tax_data in base_line['tax_details']['taxes_data']
-                    ],
-                }
-                for base_line in base_lines
-            ]
+            'base_lines_tax_details': self._extract_base_lines_details(document),
         }
 
     def _create_js_sub_test_base_lines_tax_details(self, document):
@@ -1973,9 +1978,11 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
     def _assert_sub_test_down_payment(self, results, expected_results):
         self._assert_tax_totals_summary(
             results['tax_totals'],
-            expected_results,
+            expected_results['tax_totals'],
             soft_checking=results['soft_checking'],
         )
+        if 'base_lines_tax_details' in expected_results:
+            self._assert_sub_test_base_lines_tax_details(results, expected_results)
 
     def _create_py_sub_test_down_payment(self, document, amount_type, amount, soft_checking):
         AccountTax = self.env['account.tax']
@@ -1996,7 +2003,11 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             company=self.env.company,
             cash_rounding=new_document['cash_rounding'],
         )
-        return {'tax_totals': tax_totals, 'soft_checking': soft_checking}
+        return {
+            'tax_totals': tax_totals,
+            'soft_checking': soft_checking,
+            'base_lines_tax_details': self._extract_base_lines_details(new_document),
+        }
 
     def _create_js_sub_test_down_payment(self, document, amount_type, amount, soft_checking):
         return {

--- a/addons/account/tests/test_taxes_base_lines_tax_details.py
+++ b/addons/account/tests/test_taxes_base_lines_tax_details.py
@@ -25,6 +25,9 @@ class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
             'total_included_currency': 10.94,
             'delta_total_excluded': 0.0,
             'delta_total_excluded_currency': 0.0,
+            'manual_total_excluded': None,
+            'manual_total_excluded_currency': None,
+            'manual_tax_amounts': None,
             'taxes_data': [
                 {
                     'tax_id': tax_21.id,
@@ -42,6 +45,9 @@ class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
             'total_included_currency': 1.14,
             'delta_total_excluded': 0.0,
             'delta_total_excluded_currency': 0.0,
+            'manual_total_excluded': None,
+            'manual_total_excluded_currency': None,
+            'manual_tax_amounts': None,
             'taxes_data': [
                 {
                     'tax_id': tax_21.id,
@@ -87,3 +93,4 @@ class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
         }
 
         self.assert_base_lines_tax_details(document, expected_values)
+        self._run_js_tests()

--- a/addons/account/tests/test_taxes_downpayment.py
+++ b/addons/account/tests/test_taxes_downpayment.py
@@ -1008,7 +1008,7 @@ class TestTaxesDownPayment(TestTaxCommon):
     def test_taxes_l10n_in_generic_helpers(self):
         for test_mode, document, soft_checking, amount_type, amount, expected_values in self._test_taxes_l10n_in():
             with self.subTest(test_code=test_mode, amount=amount):
-                self.assert_down_payment(document, amount_type, amount, expected_values, soft_checking=soft_checking)
+                self.assert_down_payment(document, amount_type, amount, {'tax_totals': expected_values}, soft_checking=soft_checking)
         self._run_js_tests()
 
     def _test_taxes_l10n_br(self):
@@ -1624,7 +1624,7 @@ class TestTaxesDownPayment(TestTaxCommon):
     def test_taxes_l10n_br_generic_helpers(self):
         for test_mode, document, soft_checking, amount_type, amount, expected_values in self._test_taxes_l10n_br():
             with self.subTest(test_code=test_mode, amount=amount):
-                self.assert_down_payment(document, amount_type, amount, expected_values, soft_checking=soft_checking)
+                self.assert_down_payment(document, amount_type, amount, {'tax_totals': expected_values}, soft_checking=soft_checking)
         self._run_js_tests()
 
     def _test_taxes_l10n_be(self):
@@ -1985,7 +1985,7 @@ class TestTaxesDownPayment(TestTaxCommon):
     def test_taxes_l10n_be_generic_helpers(self):
         for test_mode, document, soft_checking, amount_type, amount, expected_values in self._test_taxes_l10n_be():
             with self.subTest(test_code=test_mode, amount=amount):
-                self.assert_down_payment(document, amount_type, amount, expected_values, soft_checking=soft_checking)
+                self.assert_down_payment(document, amount_type, amount, {'tax_totals': expected_values}, soft_checking=soft_checking)
         self._run_js_tests()
 
     def _test_taxes_fixed_tax_last_position(self):
@@ -2027,7 +2027,7 @@ class TestTaxesDownPayment(TestTaxCommon):
     def test_taxes_fixed_tax_last_position_generic_helpers(self):
         for test_mode, document, amount_type, amount, expected_values in self._test_taxes_fixed_tax_last_position():
             with self.subTest(test_code=test_mode, amount=amount):
-                self.assert_down_payment(document, amount_type, amount, expected_values)
+                self.assert_down_payment(document, amount_type, amount, {'tax_totals': expected_values})
         self._run_js_tests()
 
     def _test_no_taxes(self):
@@ -2059,7 +2059,7 @@ class TestTaxesDownPayment(TestTaxCommon):
 
     def test_no_taxes_generic_helpers(self):
         document, amount_type, amount, expected_values = self._test_no_taxes()
-        self.assert_down_payment(document, amount_type, amount, expected_values)
+        self.assert_down_payment(document, amount_type, amount, {'tax_totals': expected_values})
         self._run_js_tests()
 
     def _test_reverse_charge_tax(self):
@@ -2081,7 +2081,7 @@ class TestTaxesDownPayment(TestTaxCommon):
         ])
         document = self.populate_document(document_params)
 
-        expected_values = {
+        expected_tax_totals_values = {
             'same_tax_base': True,
             'currency_id': self.currency.id,
             'base_amount_currency': 3.0,
@@ -2103,7 +2103,46 @@ class TestTaxesDownPayment(TestTaxCommon):
                 },
             ],
         }
-        return document, 'fixed', 3.0, expected_values
+        expected_base_line_tax_details_values = [
+            {
+                'total_excluded': 3.0,
+                'total_excluded_currency': 3.0,
+                'total_included': 3.0,
+                'total_included_currency': 3.0,
+                'delta_total_excluded': 0.0,
+                'delta_total_excluded_currency': 0.0,
+                'manual_total_excluded': 3.0,
+                'manual_total_excluded_currency': 3.0,
+                'manual_tax_amounts': {
+                    str(tax.id): {
+                        'tax_amount': 0.63,
+                        'tax_amount_currency': 0.63,
+                        'base_amount': 3.0,
+                        'base_amount_currency': 3.0,
+                    },
+                },
+                'taxes_data': [
+                    {
+                        'tax_id': tax.id,
+                        'tax_amount': 0.63,
+                        'tax_amount_currency': 0.63,
+                        'base_amount': 3.0,
+                        'base_amount_currency': 3.0,
+                    },
+                    {
+                        'tax_id': tax.id,
+                        'tax_amount': -0.63,
+                        'tax_amount_currency': -0.63,
+                        'base_amount': 3.0,
+                        'base_amount_currency': 3.0,
+                    },
+                ],
+            }
+        ]
+        return document, 'fixed', 3.0, {
+            'tax_totals': expected_tax_totals_values,
+            'base_lines_tax_details': expected_base_line_tax_details_values,
+        }
 
     def test_reverse_charge_generic_helpers(self):
         document, amount_type, amount, expected_values = self._test_reverse_charge_tax()


### PR DESCRIPTION
When creating an invoice with down payment from a sales order, the reverse charge tax amount goes into the debit side.

Make sure the reverse charge tax amount goes into the credit side.

opw-5172402

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
