### PR TITLE
[FIX] onboarding: prevent traceback on setting accounting period for tax returns

### DIFF
--- a/addons/onboarding/models/onboarding_onboarding.py
+++ b/addons/onboarding/models/onboarding_onboarding.py
@@ -124,6 +124,8 @@ class OnboardingOnboarding(models.Model):
 
     def _prepare_rendering_values(self):
         self.ensure_one()
+        if not self.current_progress_id:
+            self._search_or_create_progress()
         values = {
             'close_method': self.panel_close_action_name,
             'close_model': 'onboarding.onboarding',


### PR DESCRIPTION
Currently, an error is produced when configuring the **Accounting Period** on the "**Tax Returns**" journal.

Steps to Reproduce:
1. Install `accountant` module without demo data using `-i` command.
2. Accounting > Dashboard > "**Tax Returns**" Journal, click on “Tax Returns” button.
3. Set an _Opening Date_ in the wizard and try to apply the **Accounting Periods**.

**Error:**
`ValueError - Expected singleton: onboarding.progress()`

**Cause:**
**Until saas-18.2,** 
The onboarding record’s `current_progress_id` was created by method `_search_or_create_progress()` - ([1]) during module initialization. This method was triggered through `_initiate_account_onboardings()`, which was called in the `_accounting_post_init()` hook for all companies - ([2]).

**From saas-18.3,** 
`_accounting_post_init()` was modified to call `_initiate_account_onboardings()` only for companies having a `chart_template` - ([3]).

As a result, companies without a chart template never receive a default progress record, leaving `current_progress_id` unset. When rendering onboarding values, this leads to a singleton error.

**Fix:**
This commit ensures that a progress record exists by creating it when missing before rendering onboarding values.

[1]:  https://github.com/odoo/odoo/blob/b2558e92e627a0efd975a402b77a6b53810c4c41/addons/onboarding/models/onboarding_onboarding.py#L107-L111
[2]: https://github.com/odoo/enterprise/blob/2f2b53f1c6f31ae22351d22cf4bf59ef01a63691/accountant/__init__.py#L22-L25
[3]: https://github.com/odoo/enterprise/blob/37dd63580967c1186618d7340a21539a6c98dbba/accountant/__init__.py#L22-L24

sentry-7064593163