### PR TITLE
[IMP] website_mass_mailing, *: display thanks message in translation

### DIFF
--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -1,4 +1,3 @@
-import { Builder } from "@html_builder/builder";
 import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
 import { insertText, pasteText } from "@html_editor/../tests/_helpers/user_actions";
@@ -14,35 +13,15 @@ import {
     defineWebsiteModels,
     getStructureSnippet,
     invisibleEl,
+    setupSidebarBuilderForTranslation,
     setupWebsiteBuilder,
+    websiteServiceInTranslateMode,
 } from "./website_helpers";
 import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 import { uniqueId } from "@web/core/utils/functions";
 import { TranslationPlugin } from "@website/builder/plugins/translation/translation_plugin";
 
 defineWebsiteModels();
-
-const websiteServiceInTranslateMode = {
-    currentWebsite: {
-        metadata: {
-            lang: "fr_BE",
-            langName: " Français (BE)",
-            translatable: true,
-            defaultLangName: "English (US)",
-        },
-        default_lang_id: {
-            code: "en_US",
-        },
-    },
-    // Minimal context to avoid crashes.
-    context: {},
-    websites: [
-        {
-            id: 1,
-            metadata: {},
-        },
-    ],
-};
 
 test("systray in translate mode", async () => {
     mockService("website", {
@@ -465,32 +444,4 @@ function getTranslateEditable({
                 </p>
             </div>
         </main>`;
-}
-
-async function setupSidebarBuilderForTranslation(options) {
-    const { websiteContent } = options;
-    // Hack: configure the snippets menu as in translate mode when clicking
-    // on the "Edit" button of the systray. The goal of this hack is to avoid
-    // the handling of an extra reload of the action to arrive in translate
-    // mode.
-    patchWithCleanup(Builder.prototype, {
-        setup() {
-            super.setup();
-            this.env.services.website = websiteServiceInTranslateMode;
-            this.websiteService = websiteServiceInTranslateMode;
-            this.websiteContext = this.websiteService.context;
-        },
-    });
-    const { getEditor, getEditableContent, openBuilderSidebar } = await setupWebsiteBuilder(
-        websiteContent,
-        {
-            openEditor: false,
-            translateMode: true,
-            onIframeLoaded: (iframe) => {
-                websiteServiceInTranslateMode.pageDocument = iframe.contentDocument;
-            },
-        }
-    );
-    await openBuilderSidebar();
-    return { getEditor, getEditableContent };
 }

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -435,6 +435,55 @@ export async function setupWebsiteBuilderWithSnippet(snippetName, options = {}) 
         hasToCreateWebsite: false,
     });
 }
+export const websiteServiceInTranslateMode = {
+    currentWebsite: {
+        metadata: {
+            lang: "fr_BE",
+            langName: " Français (BE)",
+            translatable: true,
+            defaultLangName: "English (US)",
+        },
+        default_lang_id: {
+            code: "en_US",
+        },
+    },
+    // Minimal context to avoid crashes.
+    context: {},
+    websites: [
+        {
+            id: 1,
+            metadata: {},
+        },
+    ],
+};
+
+export async function setupSidebarBuilderForTranslation(options) {
+    const { websiteContent } = options;
+    // Hack: configure the snippets menu as in translate mode when clicking
+    // on the "Edit" button of the systray. The goal of this hack is to avoid
+    // the handling of an extra reload of the action to arrive in translate
+    // mode.
+    patchWithCleanup(Builder.prototype, {
+        setup() {
+            super.setup();
+            this.env.services.website = websiteServiceInTranslateMode;
+            this.websiteService = websiteServiceInTranslateMode;
+            this.websiteContext = this.websiteService.context;
+        },
+    });
+    const { getEditor, getEditableContent, openBuilderSidebar } = await setupWebsiteBuilder(
+        websiteContent,
+        {
+            openEditor: false,
+            translateMode: true,
+            onIframeLoaded: (iframe) => {
+                websiteServiceInTranslateMode.pageDocument = iframe.contentDocument;
+            },
+        }
+    );
+    await openBuilderSidebar();
+    return { getEditor, getEditableContent };
+}
 
 export async function getStructureSnippet(snippetName) {
     const html = await getWebsiteSnippets();

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -37,6 +37,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
             'website_mass_mailing/static/tests/tours/**/*',
         ],
         'web.assets_unit_tests': [
+            'website_mass_mailing/static/tests/builder/**/*',
             'website_mass_mailing/static/tests/interactions/**/*',
         ],
         'web.assets_unit_tests_setup': [

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_translation_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_translation_option_plugin.js
@@ -1,0 +1,47 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { Plugin } from "@html_editor/plugin";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { ToggleThanksMessageAction } from "./mailing_list_subscribe_option_plugin";
+
+const selector = ".s_newsletter_list";
+const exclude = [
+    ".s_newsletter_block .s_newsletter_list",
+    ".o_newsletter_popup .s_newsletter_list",
+    ".s_newsletter_box .s_newsletter_list",
+    ".s_newsletter_centered .s_newsletter_list",
+    ".s_newsletter_grid .s_newsletter_list",
+].join(", ");
+
+export class ToggleThanksMessageBlockOption extends BaseOptionComponent {
+    static template = "website_mass_mailing.ToggleThanksMessageTranslationOption";
+    static selector = selector;
+    static exclude = exclude;
+    static hideOverlay = false;
+    static editableOnly = false;
+    static title = _t("Newsletter block");
+}
+
+export class ToggleThanksMessagePopupOption extends ToggleThanksMessageBlockOption {
+    static selector = ".o_newsletter_popup";
+    static exclude = "";
+    static applyTo = ".o_newsletter_popup .s_newsletter_list";
+    static title = _t("Newsletter popup");
+}
+
+export class MailingListSubscribeTranslationOptionPlugin extends Plugin {
+    static id = "newsletterSubscribeCommonOptionTranslation";
+    resources = {
+        builder_options: [ToggleThanksMessageBlockOption, ToggleThanksMessagePopupOption],
+        builder_actions: {
+            ToggleThanksMessageAction,
+        },
+    };
+}
+
+registry
+    .category("translation-plugins")
+    .add(
+        MailingListSubscribeTranslationOptionPlugin.id,
+        MailingListSubscribeTranslationOptionPlugin
+    );

--- a/addons/website_mass_mailing/static/src/website_builder/toggle_thanks_message_traslation_option.xml
+++ b/addons/website_mass_mailing/static/src/website_builder/toggle_thanks_message_traslation_option.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website_mass_mailing.ToggleThanksMessageTranslationOption">
+    <BuilderRow label.translate="Display Thanks Message">
+        <BuilderCheckbox action="'toggleThanksMessage'"/>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/website_mass_mailing/static/tests/builder/mailing_list_subscribe_translation_option_plugin.test.js
+++ b/addons/website_mass_mailing/static/tests/builder/mailing_list_subscribe_translation_option_plugin.test.js
@@ -1,0 +1,29 @@
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    getStructureSnippet,
+    setupSidebarBuilderForTranslation,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("'Display Thanks message' option should be visible in the translate mode", async () => {
+    const snippet = await getStructureSnippet("s_newsletter_block");
+    await setupSidebarBuilderForTranslation({
+        websiteContent: snippet.outerHTML,
+    });
+
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    await contains(":iframe .s_newsletter_block").click();
+
+    expect(".hb-row [data-action-id='toggleThanksMessage']").toHaveCount(1);
+    // thanks message shouldn't be displayed
+    expect(":iframe .js_subscribed_wrap").not.toHaveClass("o_enable_preview");
+    expect(":iframe .js_subscribe_wrap").not.toHaveClass("o_disable_preview");
+
+    await contains("[data-action-id='toggleThanksMessage'] input[type='checkbox']").click();
+    // thanks message should be displayed
+    expect(":iframe .js_subscribed_wrap").toHaveClass("o_enable_preview");
+    expect(":iframe .js_subscribe_wrap").toHaveClass("o_disable_preview");
+});


### PR DESCRIPTION
In translation mode we couldn't display, and, therefore, translate the
thanks message of the subscription field. This commit adds such an
option.
Steps to see the issue:
1. Open Website and start editing
2. Drop a `s_newsletter_block` snippet
3. Switch to another language
4. Start translating

=> There's no way to translate the thanks message.
Also, this commit moves `setupSidebarBuilderForTranslation` function
to the website test helpers in order for it to be used in other places
too.

task-5163109