### PR TITLE
[FIX] mail: fix hook on scheduled_message creation

### DIFF
--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -197,7 +197,7 @@ class MailScheduledMessage(models.Model):
                     subtype_xmlid='mail.mt_note' if scheduled_message.is_note else 'mail.mt_comment',
                     **{k: v for k, v in json.loads(scheduled_message.notification_parameters or '{}').items() if k in notification_parameters_whitelist},
                 )
-                self._message_created_hook(message)
+                scheduled_message._message_created_hook(message)
                 if auto_commit:
                     self.env.cr.commit()
             except Exception:


### PR DESCRIPTION
This commit fixes an issue introduced by [1] with the introduction of the
_message_created_hook on the `mail.scheduled.message` model.

This hook requires to be called in a single record scenario. But this wasn't the
case, as its call was done on potentially multiple newly created records. To fix
this, the call to the hook is now done on a single record instead of a potential
recordset.

[1]: https://github.com/odoo-dev/odoo/commit/3a3bf6361dcabd8319811ac9090ace6052f79fdb

task-5350130

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
