### PR TITLE
[FIX] hr: allow portal user to be linked to employee

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -294,8 +294,8 @@
                             <page name="hr_settings" string="Settings" groups="hr.group_hr_user">
                                 <group name="settings_group">
                                     <group string="User" name="user">
-                                        <field name="user_id" string="User" placeholder="Create User"
-                                        domain="[('company_ids', 'in', company_id), ('share', '=', False)]"
+                                        <field name="user_id" string="User" placeholder="No user linked"
+                                        domain="[('company_ids', 'in', company_id)]"
                                         context="{
                                             'default_create_employee_id': id,
                                             'default_name': name,
@@ -303,6 +303,7 @@
                                             'default_mobile': mobile_phone,
                                             'default_login': work_email,
                                             'default_partner_id': work_contact_id,
+                                            'search_default_filter_no_share': 1,
                                         }"
                                         widget="many2one_avatar_user"/>
                                     </group>


### PR DESCRIPTION
- Display all portal users in the user field.
- Set the default filter in the search view to show internal users.
- Change the placeholder text for the `user_id`.

task-5176046
