### PR TITLE
[FIX] im_livechat: ensure looking for help chat is unpinned once done

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -15,17 +15,16 @@ patch(Thread.prototype, {
         this.country_id = fields.One("res.country");
         this.livechat_channel_id = fields.One("im_livechat.channel", { inverse: "threads" });
         this.livechat_expertise_ids = fields.Many("im_livechat.expertise");
-        let wasLookingForHelp = false;
         /** @type {"in_progress"|"waiting"|"need_help"|undefined} */
         this.livechat_status = fields.Attr(undefined, {
             onUpdate() {
                 if (this.livechat_status === "need_help") {
-                    wasLookingForHelp = true;
+                    this.wasLookingForHelp = true;
                     this.unpinOnThreadSwitch = false;
                     return;
                 }
-                if (wasLookingForHelp) {
-                    wasLookingForHelp = false;
+                if (this.wasLookingForHelp) {
+                    this.wasLookingForHelp = false;
                     // Still the active thread; keep it pinned after leaving "need help" status.
                     // The agent may interact with the thread, keeping it pinned, or it will be
                     // unpinned on the next thread switch to avoid bloating the sidebar.


### PR DESCRIPTION
Before this commit, chats looking for help were sometimes kept in the sidebar even after help was provided.

This occurs because when a chat is currently shown to the user, we wait for the user to be done before unpinning it (next thread switch).

However, we use a flag to do so, which is used in the `livechat_status` on update method.

Since `onUpdate` methods are shared accross class instances, they share the same scope. So the `wasLookingForHelp` flag cannot be scoped to the setup function.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
