### PR TITLE
[IMP] web, *: use rounded-pill for badge consistency

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -683,7 +683,7 @@
                                 <field name="partner_id" class="fw-bolder fs-5 me-2" invisible="not partner_id" readonly="state != 'draft'"/>
                                 <field name="journal_id" class="fw-bolder fs-5 me-2" invisible="partner_id"/>
                                 <div invisible="review_state not in ('todo', 'anomaly') or state != 'posted'" groups="account.group_account_user">
-                                    <span class="badge text-bg-info">
+                                    <span class="badge rounded-pill text-bg-info">
                                         To Review
                                     </span>
                                 </div>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -102,7 +102,7 @@
                     <t t-name="card">
                         <div class="d-flex justify-content-between align-items-center">
                             <field name="vehicle_id" class="fw-bold" widget="res_partner_many2one"/>
-                            <field class="badge text-bg-secondary" name="state"/>
+                            <field class="badge rounded-pill text-bg-secondary" name="state"/>
                         </div>
                         <t t-if="luxon.DateTime.fromISO(record.expiration_date.raw_value) &lt; luxon.DateTime.local()" t-set="expiration_class" t-value="'text-danger fw-bold'"/>
                         <span t-att-class="expiration_class"><field name="start_date"/> - <field name="expiration_date"/></span>
@@ -275,7 +275,7 @@
                             <field name="vehicle_id" widget="image" options="{'preview_image': 'image_128'}" class="float-start col-2 pe-2"/>
                             <div class="col-10 pe-2 text-truncate">
                                 <field class="fw-bolder" name="vehicle_id"/>
-                                <span t-attf-class="float-end badge #{['todo', 'running'].indexOf(record.state.raw_value) > -1 ? 'text-bg-secondary' : ['cancelled'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : 'text-bg-success'}">
+                                <span t-attf-class="float-end badge rounded-pill #{['todo', 'running'].indexOf(record.state.raw_value) > -1 ? 'text-bg-secondary' : ['cancelled'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : 'text-bg-success'}">
                                     <field name="state"/>
                                 </span>
                                 <div class="text-truncate">

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -231,7 +231,7 @@
                             <field name="image_128" widget="image"/>
                         </aside>
                         <main>
-                            <button class="badge text-bg-primary ms-auto" type="action"
+                            <button class="badge rounded-pill text-bg-primary ms-auto" type="action"
                                 name="%(lunch.lunch_product_action_statbutton)d"
                                 context="{'search_default_category_id': id,'default_category_id': id}"
                                 invisible="product_count == 0">

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -472,7 +472,7 @@
                         </div>
                         <field t-if="record.serial_no.raw_value" name="serial_no"/>
                         <footer>
-                            <div class="badge text-bg-danger" t-if="record.maintenance_open_count.raw_value">
+                            <div class="badge rounded-pill text-bg-danger" t-if="record.maintenance_open_count.raw_value">
                                 <field name="maintenance_open_count" /> Request
                             </div>
                             <div class="d-flex ms-auto align-items-center">

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -362,7 +362,7 @@
                                 <field t-if="!record.date_start.raw_value" name="production_date"/>
                             </div>
                             <div class="h2 ms-2">
-                                <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'blocked'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
+                                <span t-attf-class="badge rounded-pill #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'blocked'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
                                     <field name="state"/>
                                 </span>
                             </div>

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -165,11 +165,11 @@
                                     <t t-if="!is_disabled">
                                         <div>
                                             <span t-if="is_published"
-                                                class="badge text-bg-success ms-1">
+                                                class="badge rounded-pill text-bg-success ms-1">
                                                 Published
                                             </span>
                                             <span t-else=""
-                                                class="badge text-bg-info ms-1">
+                                                class="badge rounded-pill text-bg-info ms-1">
                                                 Unpublished
                                             </span>
                                         </div>

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -99,10 +99,10 @@
                     <t t-name="card">
                         <div name="card_title" class="mb-4 ms-2">
                             <field name="name" class="fw-bold fs-4 d-block"/>
-                            <div t-if="!record.current_session_id.raw_value &amp;&amp; record.pos_session_username.value" class="badge text-bg-info d-inline-block">Opened by <field name="pos_session_username"/></div>
-                            <div t-if="record.pos_session_state.raw_value == 'opening_control'" class="badge text-bg-info d-inline-block">Opening Control</div>
-                            <div t-if="record.pos_session_state.raw_value == 'closing_control'" class="badge text-bg-info d-inline-block">Closing Control</div>
-                            <div t-if="record.pos_session_state.raw_value == 'opened' and record.pos_session_duration.raw_value > 1" t-attf-class="badge bg-#{record.pos_session_duration.raw_value > 3 and 'danger' or 'warning'} d-inline-block"
+                            <div t-if="!record.current_session_id.raw_value &amp;&amp; record.pos_session_username.value" class="badge rounded-pill text-bg-info d-inline-block">Opened by <field name="pos_session_username"/></div>
+                            <div t-if="record.pos_session_state.raw_value == 'opening_control'" class="badge rounded-pill text-bg-info d-inline-block">Opening Control</div>
+                            <div t-if="record.pos_session_state.raw_value == 'closing_control'" class="badge rounded-pill text-bg-info d-inline-block">Closing Control</div>
+                            <div t-if="record.pos_session_state.raw_value == 'opened' and record.pos_session_duration.raw_value > 1" t-attf-class="badge rounded-pill bg-#{record.pos_session_duration.raw_value > 3 and 'danger' or 'warning'} d-inline-block"
                                     title="The session has been opened for an unusually long period. Please consider closing.">
                                     To Close
                             </div>
@@ -158,7 +158,7 @@
                                         <field name="last_session_closing_cash" widget="monetary" class="col-6"/>
                                     </div>
                                 </t>
-                                
+
                                 <a t-if="record.number_of_rescue_session.value &gt; 0" class="col-12" name="open_opened_rescue_session_form" type="object">
                                     <field name="number_of_rescue_session" /> outstanding rescue session
                                 </a>

--- a/addons/web/static/src/views/fields/label_selection/label_selection_field.xml
+++ b/addons/web/static/src/views/fields/label_selection/label_selection_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.LabelSelectionField">
-        <span t-attf-class="badge text-bg-{{className}} " t-esc="string" t-att-raw-value="props.record.data[props.name]"/>
+        <span t-attf-class="badge rounded-pill text-bg-{{className}} " t-esc="string" t-att-raw-value="props.record.data[props.name]"/>
     </t>
 
 </templates>


### PR DESCRIPTION
*: account, fleet, lunch, maintenance, mrp, payment, point_of_sale

The badge_field used in list views already uses rounded-pill styling, but label_selection (used in kanban views) did not. This creates visual inconsistency when switching between list and kanban views for the same records.

This commit adds rounded-pill to the label_selection widget, and also aligns various hardcoded badges in some backend kanban views.

task-5357523

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
