### PR TITLE
[REM] stock: remove old `_find_delivery_ids_by_lot`

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -151,13 +151,13 @@ class StockLot(models.Model):
             prod_lot.display_complete = prod_lot.id or self.env.context.get('display_complete')
 
     def _compute_delivery_ids(self):
-        delivery_ids_by_lot = self._find_delivery_ids_by_lot_iterative()
+        delivery_ids_by_lot = self._find_delivery_ids_by_lot()
         for lot in self:
             lot.delivery_ids = delivery_ids_by_lot.get(lot.id, [])
             lot.delivery_count = len(lot.delivery_ids)
 
     def _compute_partner_ids(self):
-        delivery_ids_by_lot = self._find_delivery_ids_by_lot_iterative()
+        delivery_ids_by_lot = self._find_delivery_ids_by_lot()
         for lot in self:
             if delivery_ids_by_lot.get(lot.id, []):
                 lot.partner_ids = self.env['stock.picking'].browse(delivery_ids_by_lot[lot.id]).sorted(key='date_done', reverse=True).partner_id
@@ -304,49 +304,7 @@ class StockLot(models.Model):
             ('produce_line_ids', '!=', False),
         ]
 
-    def _find_delivery_ids_by_lot(self, lot_path=None, delivery_by_lot=None):
-        if lot_path is None:
-            lot_path = set()
-        domain = Domain([
-            ('lot_id', 'in', self.ids),
-            ('state', '=', 'done'),
-        ]) & Domain(self._get_outgoing_domain())
-        move_lines = self.env['stock.move.line'].search(domain)
-        moves_by_lot = {
-            lot_id: {'producing_lines': set(), 'barren_lines': set()}
-            for lot_id in move_lines.lot_id.ids
-        }
-        for line in move_lines:
-            if line.produce_line_ids:
-                moves_by_lot[line.lot_id.id]['producing_lines'].add(line.id)
-            else:
-                moves_by_lot[line.lot_id.id]['barren_lines'].add(line.id)
-        if delivery_by_lot is None:
-            delivery_by_lot = dict()
-        for lot in self:
-            delivery_ids = set()
-
-            if moves_by_lot.get(lot.id):
-                producing_move_lines = self.env['stock.move.line'].browse(moves_by_lot[lot.id]['producing_lines'])
-                barren_move_lines = self.env['stock.move.line'].browse(moves_by_lot[lot.id]['barren_lines'])
-
-                if producing_move_lines:
-                    lot_path.add(lot.id)
-                    next_lots = producing_move_lines.produce_line_ids.lot_id.filtered(lambda l: l.id not in lot_path)
-                    next_lots_ids = set(next_lots.ids)
-                    # If some producing lots are in lot_path, it means that they have been previously processed.
-                    # Their results are therefore already in delivery_by_lot and we add them to delivery_ids directly.
-                    delivery_ids.update(*(delivery_by_lot.get(lot_id, []) for lot_id in (producing_move_lines.produce_line_ids.lot_id - next_lots).ids))
-
-                    for lot_id, delivery_ids_set in next_lots._find_delivery_ids_by_lot(lot_path=lot_path, delivery_by_lot=delivery_by_lot).items():
-                        if lot_id in next_lots_ids:
-                            delivery_ids.update(delivery_ids_set)
-                delivery_ids.update(barren_move_lines.picking_id.ids)
-
-            delivery_by_lot[lot.id] = list(delivery_ids)
-        return delivery_by_lot
-
-    def _find_delivery_ids_by_lot_iterative(self):
+    def _find_delivery_ids_by_lot(self):
         """ Retrieve all delivery IDs (outgoing picking) linked to the lots
             in self and all the lots found when parcouring the produce lines.
             :return: A dictionary where keys are the IDs of the original 'stock.lot'

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -90,7 +90,7 @@ class StockLot(models.Model):
     def _compute_partner_ids(self):
         delivery_ids_by_lot = self._find_delivery_ids_by_lot()
         for lot in self:
-            if delivery_ids_by_lot[lot.id]:
+            if delivery_ids_by_lot.get(lot.id):
                 picking_ids = self.env['stock.picking'].browse(delivery_ids_by_lot[lot.id]).sorted(key='date_done', reverse=True)
                 lot.partner_ids = list(p.sale_id.partner_shipping_id.id if p.is_dropship else p.partner_id.id for p in picking_ids)
             else:


### PR DESCRIPTION
This PR: #233478, introduced a new method
`_find_delivery_ids_by_lot_iterative` as a performance optimization. The old method was not removed in stable to avoid breaking customizations, however, it's not needed anymore in current master (19.1).
