### PR TITLE
[FIX] website: correct editor behavior on nested cards

### DIFF
--- a/addons/website/static/src/builder/plugins/options/card_image_alignment_option.js
+++ b/addons/website/static/src/builder/plugins/options/card_image_alignment_option.js
@@ -14,14 +14,22 @@ export class CardImageAlignmentOption extends BaseOptionComponent {
         super.setup();
         this.state = useDomState(async (editingElement) => {
             await this.waitForAllImageloaded(this.env.getEditingElements());
-            const imageToWrapperRatio = this.getImageToWrapperRatio(editingElement);
-            const hasCoverImage = !!editingElement.querySelector(".o_card_img_wrapper");
+            // Filter to exclude cover images coming from nested cards
+            const coverImageWrapper = [
+                ...editingElement.querySelectorAll(".o_card_img_wrapper"),
+            ].filter((node) => node.closest(".s_card") === editingElement)[0];
+            const hasCoverImage = !!coverImageWrapper;
+            const imageToWrapperRatio = hasCoverImage
+                ? this.getImageToWrapperRatio(coverImageWrapper)
+                : null;
+            const hasShape = hasCoverImage
+                ? !!coverImageWrapper.querySelector(".o_card_img[data-shape]")
+                : false;
             // Sometimes the imageToWrapperRatio is very close to but not
             // exactly 1. In this case, the image alignment slider would have no
             // visible effect on the actual alignment. To avoid the slider to
             // spawn in this case, we use a loose comparison.
             const hasSquareRatio = Math.abs(imageToWrapperRatio - 1) < 0.001;
-            const hasShape = !!editingElement.querySelector(".o_card_img[data-shape]");
             return {
                 imageToWrapperRatio,
                 show: hasCoverImage && !(hasSquareRatio || hasShape),
@@ -38,12 +46,8 @@ export class CardImageAlignmentOption extends BaseOptionComponent {
      *                   - <1: img is more portrait (taller) than wrapper
      *                   - >1: img is more landscape (wider) than wrapper
      */
-    getImageToWrapperRatio(editingElement) {
-        const imageEl = editingElement.querySelector(".o_card_img");
-        const imageWrapperEl = editingElement.querySelector(".o_card_img_wrapper");
-        if (!imageEl || !imageWrapperEl) {
-            return null;
-        }
+    getImageToWrapperRatio(imageWrapperEl) {
+        const imageEl = imageWrapperEl.querySelector(".o_card_img");
         const imgRatio = imageEl.naturalWidth / imageEl.naturalHeight;
         const wrapperRatio = imageWrapperEl.offsetWidth / imageWrapperEl.offsetHeight;
         return imgRatio / wrapperRatio;

--- a/addons/website/static/src/builder/plugins/options/card_image_option.js
+++ b/addons/website/static/src/builder/plugins/options/card_image_option.js
@@ -7,8 +7,14 @@ export class CardImageOption extends BaseOptionComponent {
 
     setup() {
         super.setup();
-        this.state = useDomState((editingElement) => ({
-            hasCoverImage: !!editingElement.querySelector(".o_card_img_wrapper"),
-        }));
+        this.state = useDomState((editingElement) => {
+            // Filter to exclude cover images coming from nested cards
+            const coverImage = [...editingElement.querySelectorAll(".o_card_img_wrapper")].filter(
+                (node) => node.closest(".s_card") === editingElement
+            );
+            return {
+                hasCoverImage: !!coverImage.length,
+            };
+        });
     }
 }

--- a/addons/website/static/src/builder/plugins/options/card_image_option.xml
+++ b/addons/website/static/src/builder/plugins/options/card_image_option.xml
@@ -46,7 +46,7 @@
     <t t-if="state.hasCoverImage">
         <!-- Ratio  -->
         <BuilderRow label.translate="Ratio" level="1">
-            <BuilderSelect applyTo="'.o_card_img_wrapper'">
+            <BuilderSelect applyTo="':scope > .o_card_img_wrapper'">
                 <BuilderSelectItem id="'card_img_default_ratio_option'" classAction="''">Image default</BuilderSelectItem>
                 <BuilderSelectItem classAction="'ratio ratio-1x1'">Square</BuilderSelectItem>
                 <t t-if="isActiveItem('card_img_top_opt')">

--- a/addons/website/static/src/snippets/s_card/000.scss
+++ b/addons/website/static/src/snippets/s_card/000.scss
@@ -47,13 +47,13 @@
 
     // Options
     &.o_card_img_top {
-        .o_card_img_ratio_custom {
+        >.o_card_img_ratio_custom {
             --aspect-ratio: var(--card-img-aspect-ratio);
         }
     }
 
     &.o_card_img_horizontal {
-        .o_card_img_wrapper {
+        >.o_card_img_wrapper {
             flex-shrink: 0;
 
             @include media-breakpoint-up(lg) {


### PR DESCRIPTION
This commit fixes three issues occurring when editing nested s_card snippets.

**Problem 1 - Incorrect cover image detection**

Issue: An `s_card` without a cover image displayed the cover-image option if it contained a child `s_card` with a cover image.
Cause: `CardImageOption` and `CardImageAlignmentOption` relied on `querySelector`, which could detect images inside child snippets.
Fix: The cover image detection now checks that the closest `s_card` element corresponds to the snippet being edited.

**Problem 2 - Ratio settings applied to all child cards**

Issue: Changing the cover image ratio on an `s_card` applied the setting to all nested `s_card` elements.
Cause: The `BuilderSelect` in `CardImageOption` targeted `.o_card_img_wrapper`, causing `classAction` to apply to all descendants.
Fix: The selector is now `:scope > .o_card_img_wrapper`, ensuring the option acts only on the current snippet.

**Problem 3 - Parent image positioning leaking to children**

Issue: Adjusting the cover image position on a parent `s_card` affected the rendering of all child card images.
Cause: CSS rules for `.o_card_img_horizontal` applied to all descendant elements mathcing `.o_card_img_wrapper`.
Fix: The rules now apply only to direct children of `.o_card_img_horizontal`. The same correction was applied to `.o_card_img_ratio_custom`.

task-5349540