### PR TITLE
[FIX] l10n_id: load taxes only for parent companies

### DIFF
--- a/addons/l10n_id/migrations/1.3/end-migrate_update_taxes.py
+++ b/addons/l10n_id/migrations/1.3/end-migrate_update_taxes.py
@@ -6,7 +6,7 @@ def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {"lang": "en_US"})
 
     ChartTemplate = env["account.chart.template"]
-    companies = env["res.company"].search([("chart_template", "=", "id")], order="parent_path")
+    companies = env["res.company"].search([("chart_template", "=", "id"), ("parent_id", "=", False)])
 
     new_tax_groups = ["l10n_id_tax_group_stlg", "l10n_id_tax_group_non_luxury_goods", "l10n_id_tax_group_luxury_goods", "l10n_id_tax_group_0"]
     new_taxes = [


### PR DESCRIPTION
When searching companies with `("chart_template", "=", "id")` we were iterating them in `order=parent_path`. This meant the parent company was processed first, and then its child. During the child iteration, `_load_data` attempted to create the same tax records again, triggering the Python constraint `_constrains_name` due to duplicate tax names under the same root company.

To avoid this, only parent companies are selected for the tax loading.

opw-5266906
upg-3407920
tbg-2297

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
