### PR TITLE
[FIX] point_of_sale: allow access to non-administrator users

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -5,17 +5,17 @@ class IrModuleModule(models.Model):
     _inherit = 'ir.module.module'
 
     @api.model
-    def _load_pos_data_fields(self):
+    def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'state']
 
     @api.model
-    def _load_pos_data_domain(self):
+    def _load_pos_data_domain(self, data):
         return [('name', '=', 'pos_settle_due')]
 
     def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain()
-        fields = self._load_pos_data_fields()
+        domain = self._load_pos_data_domain(data)
+        fields = self._load_pos_data_fields(data)
         return {
             'data': self.search_read(domain, fields, load=False),
-            'fields': self._load_pos_data_fields(),
+            'fields': self._load_pos_data_fields(data),
         }

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -1128,7 +1128,7 @@ class PosConfig(models.Model):
         return {
             "has_pos_config": has_pos_config,
             "has_chart_template": has_chart_template,
-            "is_restaurant_installed": bool(self.env['ir.module.module'].search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
+            "is_restaurant_installed": bool(self.env['ir.module.module'].sudo().search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
             "is_main_company": main_company and self.env.company.id == main_company.id or False
         }
 

--- a/doc/cla/individual/quirino95.md
+++ b/doc/cla/individual/quirino95.md
@@ -1,0 +1,11 @@
+Italy, 2025-11-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Quirino Leone quirino.leone@pytech.it https://github.com/quirino95


### PR DESCRIPTION
Steps to reproduce bug:
- Uninstall `base_install_request` module;
- Login as "Demo";
- Try to open POS application;

Description of the issue/feature this PR addresses:
Non-administrator users cannot access the POS

Current behavior before PR:
Starting from a fresh-restored DB, login as Demo user and try to access pos application. Following message is faced:
<img width="1134" height="291" alt="immagine" src="https://github.com/user-attachments/assets/4e2b93d9-cb57-452f-a57b-b74a30df3274" />


Desired behavior after PR is merged:
Also non-administrator users can access to POS application.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
