### PR TITLE
[FIX] web: remove horizontal border ungrouped kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -30,7 +30,9 @@
 
     &:not(.o_kanban_ghost) {
         padding: var(--KanbanRecord-padding-v) var(--KanbanRecord-padding-h);
-        border: $border-width solid $border-color;
+        border-width: var(--KanbanRecord-border-width, #{$border-width});
+        border-style: solid;
+        border-color: $border-color;
         background-color: $o-view-background-color;
 
         @include media-only(print) {
@@ -207,5 +209,8 @@
         &:not(:last-of-type) {
             border-bottom: $border-width solid $border-color;
         }
+    }
+    .o_kanban_ungrouped .o_kanban_record {
+        --KanbanRecord-border-width: #{$border-width} 0;
     }
 }


### PR DESCRIPTION
On mobile the ungrouped kanban have horizontal borders which creates a weird effect with the sides of the device.

task-5357601


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
