### PR TITLE
[FIX] stock_account: allow Inventory User to validate AVCO pickings

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -290,7 +290,7 @@ class ProductProduct(models.Model):
         if at_date:
             product_value_domain &= Domain([('date', '<=', at_date)])
 
-        product_values = self.env['product.value'].search(product_value_domain, order="date, id")
+        product_values = self.env['product.value'].sudo().search(product_value_domain, order="date, id")
         avco_value = 0
         avco_total_value = 0
         moves = moves_in | moves_out
@@ -451,7 +451,7 @@ class ProductProduct(models.Model):
                 continue
             new_standard_price = product._run_avco()[0]
             if new_standard_price:
-                product.with_context(disable_auto_revaluation=True).standard_price = new_standard_price
+                product.with_context(disable_auto_revaluation=True).sudo().standard_price = new_standard_price
 
 
 class ProductCategory(models.Model):

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2908,3 +2908,20 @@ class TestStockValuation(TestStockValuationCommon):
                 {'account_id': self.account_expense.id, 'credit': 0.0, 'debit': 600.0},
             ]
         )
+
+    def test_inventory_user_can_validate_avco_picking(self):
+        """Ensure that an inventory user can validate a receipt picking
+        containing an AVCO-costed product without triggering an access error.
+        """
+        move = self.env['stock.move'].create({
+            'product_id': self.product_avco_auto.id,
+            'product_uom_qty': 1,
+            'product_uom': self.product_avco_auto.uom_id.id,
+            'location_id': self.customer_location.id,
+            'location_dest_id': self.stock_location.id,
+        })
+        move._action_confirm()
+        move.quantity = 1.0
+        move.picked = True
+        move.with_user(self.inventory_user)._action_done()
+        self.assertEqual(move.state, 'done')


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product “P1” with:
    - Product Category: - Costing Method: AVCO
- Log in as Mark Demo (Inventory User only)
- Create a picking containing:
    - 1 unit of P1
- Try to validate it

Issue:
An access error is raised:
“You are not allowed to access 'Product Value' (product.value) records. This operation is allowed for the following groups:
    - Inventory/Administrator”

During the picking validation, the `_run_avco` method performs a search on the `product.value` model, but this model is only accessible to Inventory Managers, causing the failure.

https://github.com/odoo/odoo/blob/08b62a4bbcc6f9a391b2cc00a621ef4c76100229/addons/stock_account/security/ir.model.access.csv#L4

opw-5254884
opw-5236047