### PR TITLE
[IMP] iot_drivers: allow longpolling direct response

### DIFF
--- a/addons/iot_drivers/controllers/driver.py
+++ b/addons/iot_drivers/controllers/driver.py
@@ -35,15 +35,9 @@ class DriverController(http.Controller):
 
         message_type = data.get('action', 'test_protocol') if device_identifier == IOT_IDENTIFIER else 'iot_action'
 
-        result = communication.handle_message(
+        return communication.handle_message(
             message_type, session_id=session_id, device_identifier=device_identifier, **data
         )
-        if result:
-            if result.get('status') == 'disconnected':
-                return False
-            event_manager.events.append(result)
-
-        return True
 
     @helpers.toggleable
     @route.iot_route(['/iot_drivers/event', '/hw_drivers/event'], type='jsonrpc', cors='*', csrf=False)

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -62,7 +62,7 @@ class EventManager:
         }
         send_to_controller({
             **event,
-            'session_id': data.get('action_args', {}).get('session_id', ''),
+            'session_id': data.get('owner', ''),
             'iot_box_identifier': IOT_IDENTIFIER,
             **data,
         })

--- a/addons/iot_drivers/tools/communication.py
+++ b/addons/iot_drivers/tools/communication.py
@@ -36,8 +36,9 @@ def handle_message(message_type: str, **kwargs: dict) -> dict:
                 return {**base_response, 'status': 'disconnected'}
             start_operation_time = time.perf_counter()
             _logger.info("device '%s' action started", device_identifier)
-            main.iot_devices[device_identifier].action(kwargs)
+            res = main.iot_devices[device_identifier].action(kwargs)
             _logger.info("device '%s' action finished - %.*f", device_identifier, 3, time.perf_counter() - start_operation_time)
+            return {**base_response, **res}
         case 'server_clear':
             helpers.disconnect_from_server()
             if server_logger:


### PR DESCRIPTION
To reduce the amount of network request and simplify the driver's response handling IoT Box side, we now provide the response directly to the action controller.

see odoo/enterprise#100629
Task: 5048746
