### PR TITLE
[FIX] website: correct editor behavior on nested cards

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -289,6 +289,14 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
             }
         });
 
+        // TODO remove in master: fixes the selector for the "Ratio" setting in
+        // cards, preventing the setting of a parent to leak onto children when
+        // cards are nested.
+        const cardRatioOptionEl = html.querySelector('[data-js="CardImageOptions"] we-select[string="Ratio"]');
+        if (cardRatioOptionEl) {
+            cardRatioOptionEl.dataset.applyTo = ">.o_card_img_wrapper";
+        }
+
         return super._computeSnippetTemplates(html);
     }
     /**

--- a/addons/website/static/src/snippets/s_card/000.scss
+++ b/addons/website/static/src/snippets/s_card/000.scss
@@ -46,13 +46,13 @@
 
     // Options
     &.o_card_img_top {
-        .o_card_img_ratio_custom {
+        >.o_card_img_ratio_custom {
             --aspect-ratio: var(--card-img-aspect-ratio);
         }
     }
 
     &.o_card_img_horizontal {
-        .o_card_img_wrapper {
+        >.o_card_img_wrapper {
             flex-shrink: 0;
 
             @include media-breakpoint-up(lg) {

--- a/addons/website/static/src/snippets/s_card/options.js
+++ b/addons/website/static/src/snippets/s_card/options.js
@@ -124,7 +124,7 @@ options.registry.CardImageOptions = options.Class.extend({
      * @override
      */
     _computeWidgetVisibility(widgetName, params) {
-        const hasCoverImage = !!this.$target[0].querySelector(".o_card_img_wrapper");
+        const hasCoverImage = !!this.$target[0].querySelector(":scope > .o_card_img_wrapper");
         const useRatio = !!this.$target[0].querySelector(".o_card_img_wrapper.ratio");
         const hasNonSquareRatio = this._getImageToWrapperRatio() !== 1;
         const hasShape = !!this.$target[0].querySelector(".o_card_img[data-shape]");


### PR DESCRIPTION
This commit fixes three issues occurring when editing nested `s_card` snippets.

**Problem 1 - Incorrect cover image detection**

Issue: An `s_card` without a cover image displayed the cover image option if it contained a child `s_card` with a cover image.
Cause: The `querySelector` in `CardImageOption` could detect images inside child snippets.
Fix: Now the `querySelector` only searches among direct children of the snippet root element.

**Problem 2 - Ratio settings applied to all child cards**

Issue: Changing the cover image ratio on an `s_card` applied the setting to all nested cards.
Cause: The `we-select` in `s_card` options targeted `.o_card_img_wrapper`, causing the class to apply to all descendants.
Fix: The selector is now `>.o_card_img_wrapper`, so the option acts only on the current snippet.

**Problem 3 - Parent image positioning leaking to children**

Issue: Adjusting the cover image position on a parent `s_card` affected the rendering of all child card images.
Cause: CSS rules for `.o_card_img_horizontal` applied to all descendant elements matching `.o_card_img_wrapper`.
Fix: The rules now apply only to direct children of `.o_card_img_horizontal`. The same correction was applied to `.o_card_img_ratio_custom`.

task-5349540