### PR TITLE
[FIX] google_calendar: odoobot event insertion

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -384,4 +384,7 @@ class Meeting(models.Model):
     def _is_google_insertion_blocked(self, sender_user):
         self.ensure_one()
         has_different_owner = self.user_id and self.user_id != sender_user
-        return has_different_owner
+        is_odoobot_user = sender_user == self.env.ref('base.user_root')
+        # Since Odoobot has no token, we must bypass this check for creating events.
+        # The function `_get_event_user` will always get the organizer as it can have a valid sync token.
+        return has_different_owner and not is_odoobot_user

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -244,4 +244,7 @@ class RecurrenceRule(models.Model):
         self.ensure_one()
         has_base_event = self.base_event_id
         has_different_owner = self.base_event_id.user_id and self.base_event_id.user_id != sender_user
-        return has_base_event and has_different_owner
+        is_odoobot_user = sender_user == self.env.ref('base.user_root')
+        # Since Odoobot has no token, we must bypass this check for creating events.
+        # The function `_get_event_user` will always get the organizer as it can have a valid sync token.
+        return has_base_event and has_different_owner and not is_odoobot_user

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -1047,28 +1047,28 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             self.assertGoogleEventSendUpdates('none')
 
     @patch_api
-    def test_odoobot_event_creation_for_synchronized_user(self):
+    @patch.object(GoogleCalendarService, 'get_events')
+    def test_odoobot_event_creation_for_synchronized_user(self, mock_get_events):
         """ Test that odoobot can create events for a synchronized user without blocking Google insertion. """
         with self.mock_datetime_and_now("2020-01-14"):
             # Setup: Create a synchronized user with Google token and get the odoobot user.
+            CalendarEvent = self.env['calendar.event']
             partner = self.env['res.partner'].create({'name': 'Synchronized User', 'email': 'o@opoo.com'})
             synced_user = self.env['res.users'].create({'name': 'Synced User', 'login': 'o@opoo.com', 'partner_id': partner.id})
             synced_user.google_calendar_token = 'valid-token'
             odoobot_user = self.env.ref('base.user_root')
 
-            # Create event as odoobot user for the synchronized user.
-            event = self.env['calendar.event'].with_user(odoobot_user).create({
+            # Create event as odoobot user for the synchronized user, mock the events return.
+            CalendarEvent.search([('partner_ids', 'in', odoobot_user.partner_id.id)]).google_id = 'demo'
+            event = CalendarEvent.with_user(odoobot_user).create({
                 'name': "Odoobot Event",
                 'start': datetime(2020, 1, 15, 8, 0),
                 'stop': datetime(2020, 1, 15, 18, 0),
                 'user_id': synced_user.id,
-                'need_sync': False,
+                'need_sync': True,
             })
-            event.with_user(synced_user)._sync_odoo2google(self.google_service)
-
-            # Assert that the event was inserted in Google Calendar.
-            self.assertGoogleEventInserted({
-                'id': False,
+            gevent = {
+                'id': 'odoobot_event',
                 'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
                 'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
                 'summary': 'Odoobot Event',
@@ -1080,7 +1080,13 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'attendees': [{'email': 'o@opoo.com', 'responseStatus': 'accepted'}],
                 'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
                 'transparency': 'opaque',
-            })
+                'updated': '2020-01-15T08:00:00Z',
+            }
+            mock_get_events.return_value = (GoogleEvent([gevent]), None, [{'method': 'popup', 'minutes': 30}])
+
+            # Synchronize the event as odoobot user and ensure it got inserted.
+            synced_user.sudo()._sync_google_calendar(self.google_service)
+            self.assertGoogleEventInserted(gevent)
 
     def test_recurrence_not_over_send_updates(self):
         """Test that recurrences that are not over send updates to attendees."""


### PR DESCRIPTION
After odoo/odoo#218856 got merged for targetting regular users, it had a side-effect that public users (like Odoobot) had their insertion blocked in Google Calendar when scheduling events for other users during cron calls.

This commit fixes the issue by checking if the current user is a public user, bypassing the check for the insertion blocking.

task-5361135