### PR TITLE
[FIX] sale_stock: replace date with create_date field

### DIFF
--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -67,7 +67,7 @@
                     </t>
                 </div>
             </div>
-            <t t-set="returns" t-value="delivery_orders.return_ids.sorted('date', reverse=True)"/>
+            <t t-set="returns" t-value="delivery_orders.return_ids.sorted('create_date', reverse=True)"/>
             <div t-if="returns" class="col-12 col-lg-6 mb-4">
                 <h4 class="mb-1">Returns</h4>
                 <hr class="mt-1 mb-2"/>


### PR DESCRIPTION
This commit replace date field with create_date field which was removed in [the PR] and causing traceback because that field does not existing in that model now.

[the PR]: https://github.com/odoo/odoo/pull/213949
