### PR TITLE
[FIX] website: industry select capital letters and synonyms

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -262,7 +262,7 @@ export class DescriptionScreen extends Component {
         } else {
             let synonymMatches = this.state.industries.filter((val, index) => {
                 // To match, every term should be contained in the synonym
-                for (const candidate of [...(val.synonyms || "").split(this.splitRegex)]) {
+                for (const candidate of [...(val.synonyms || "").split(/[|,]/)]) {
                     // Check if industry label has already matched
                     if (
                         terms.every((term) => candidate.toLowerCase().includes(term)) &&
@@ -316,7 +316,7 @@ export class DescriptionScreen extends Component {
             let bitIndex = 0;
             while (bitIndex < matchTermOrder.labelBits.length) {
                 const currentBit = matchTermOrder.labelBits[bitIndex];
-                const splitBits = currentBit.split(new RegExp(`(${escapeRegExp(term)})`));
+                const splitBits = currentBit.split(new RegExp(`(${escapeRegExp(term)})`, "i"));
                 matchTermOrder.labelBits.splice(bitIndex, 1, ...splitBits);
                 bitIndex += splitBits.length;
             }


### PR DESCRIPTION
The industry highlighting to indicate what the user wrote match with
the proposed industries was case sensitive, so the capital letters were
not indicated as matching with lowercase letters.
Fix:
Added the flage "i" at the end of the regex to make it case-insensitive

Also, in the case of the synonyms, the regex used was spliting on
",", "|" and space. The space spliting made matching a synonym sentence
much more complicated.
Fix:
Deleted the space in the regex

task-5066428