### PR TITLE
[FIX] website_crm_partner_assign: fix lead data update from portal for partners

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -274,7 +274,9 @@ class CrmLead(models.Model):
                         'summary': values['activity_summary'],
                         'date_deadline': values['activity_date_deadline'],
                     })
-            lead.write(lead_values)
+
+            # access checked with '_assert_portal_write_access' at method beginning
+            lead.sudo().write(lead_values)
 
     def update_contact_details_from_portal(self, values):
         self._assert_portal_write_access()

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -249,6 +249,18 @@ class TestPartnerLeadPortal(TestCrmCommon):
             'partner_id': test_partner.id,
         })
 
+        update_values = {
+            'expected_revenue': 9999.0,
+            'probability': 50.0,
+            'priority': '2',
+            'date_deadline': False,
+            'activity_date_deadline': False,
+            'activity_type_id': False,
+            'activity_summary': False,
+        }
+        opportunity.with_user(self.user_portal).update_lead_portal(update_values)
+        self.assertEqual(opportunity.expected_revenue, 9999.0, "Portal user should be able to update revenue or other details via portal method")
+
         email_2 = 'test_partner_updated@test.com'
         opportunity.with_user(self.user_portal).update_contact_details_from_portal({
             'email_from': email_2,


### PR DESCRIPTION
##  Steps to reproduce:

- Install 'website_crm_partner_assign' module.
- Create a partner X with a partner level.
- Save and go to "Opportunities".
- Create an new opportunity.
- Edit it and set the partner X as the assigned partner
- Grant the partner x portal access and change his password.
- Logout then login with the partner X credentials.
- Go to "My account" page and click on "Opportunities"
- Select the opportunity Y and edit the revenue or another field.
- Traceback on save. (Or no reaction, popup traceback from notification)

### Issue:
Since the commit ed94e84, we've removed the write access for portal partner users to the leads to avoid unexpected behaviors. However, this is provoking `update_lead_portal` to not be able to update the lead anymore, since we will not have direct access to modify the lead.

### Solution:
To fix this, we will follow same approach as in `update_contact_details_from_portal` and use `sudo()` to update the lead from the portal. We are already checking the portal access at the beginning of the method as `self._assert_portal_write_access()`, so we are sure that only authorized users will be able to update the lead.

opw-2764563


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
