### PR TITLE
[IMP] account: restore manual 'Reviewed' toggle on moves

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1513,6 +1513,7 @@
                                         <field name="auto_post_until"
                                                invisible="auto_post in ('no', 'at_date')"
                                                readonly="state != 'draft'"/>
+                                        <field name="checked"/>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
This commit restores the visibility of the `Reviewed` boolean on account.move (Other Info) so users can manually uncheck it and mark moves as 'to review'. Applies only to 19.0.

task-5361487
