### PR TITLE
[FIX] mail: can join subchannel of a group channel

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -514,7 +514,10 @@ class DiscussChannel(models.Model):
                 'guest_id': guest.id,
                 'channel_id': channel.id,
             } for guest in guests - existing_members.guest_id]
-            new_members = self.env['discuss.channel.member'].create(members_to_create)
+            if channel.parent_channel_id and channel.parent_channel_id.has_access("write"):
+                new_members = self.env["discuss.channel.member"].sudo().create(members_to_create)
+            else:
+                new_members = self.env["discuss.channel.member"].create(members_to_create)
             all_new_members += new_members
             for member in new_members:
                 payload = {

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -157,6 +157,13 @@ class TestDiscussChannelMember(MailCommon):
         with self.assertRaises(AccessError):
             channel_members.with_user(self.user_portal).unlink()
 
+    def test_group_subchannel_join(self):
+        """Test join subchannel."""
+        self.group.add_members((self.user_1 | self.user_2).partner_id.ids)
+        group_subchannel = self.group.with_user(self.user_1)._create_sub_channel()
+        group_subchannel.with_user(self.user_2).add_members(self.user_2.partner_id.id)
+        self.assertEqual(group_subchannel.channel_member_ids.partner_id, (self.user_1 | self.user_2).partner_id)
+
     # ------------------------------------------------------------
     # GROUP BASED CHANNELS
     # ------------------------------------------------------------


### PR DESCRIPTION
Before this commit, typing in a subchannel of a group DM of which you are not member of would result in an access error.

Steps to reproduce:
1. Log in as user A
2. Create group chat with user B
3. Create a subchannel in said group
4. Log in as user B
5. Open the subchannel in the group chat
6. Write in the composer -> access error

This is caused by incomplete access rules for the `discuss.channel.member` model.
Specifically the issue stems from the fact that a subchannel of a group channel is considered a group, and as such it's only possible to join it via invitation.
Since typing in a channel attempts to join it, an access error is raised.

This commit fixes the issue by executing the creation of a channel member for subchannels as superuser, on the condition of having write access to the parent channel.

task-5357621