### PR TITLE
[FIX] stock_account, sale_stock: avoid recomputing delivery date

### DIFF
--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -171,3 +171,8 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
                 invoice.delivery_date, custom_delivery_date,
                 "Custom invoice delivery shouldn't change posting invoice",
             )
+            invoice.button_draft()
+            self.assertEqual(
+                invoice.delivery_date, custom_delivery_date,
+                "Custom invoice delivery shouldn't change resetting to draft invoice",
+            )

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -57,7 +57,8 @@ class AccountMove(models.Model):
         res = super(AccountMove, self).button_draft()
 
         # Unlink the COGS lines generated during the 'post' method.
-        self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs').unlink()
+        with self.env.protecting(self.env['account.move']._get_protected_vals({}, self)):
+            self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs').unlink()
         return res
 
     def button_cancel(self):


### PR DESCRIPTION
**PROBLEM**
Resetting to draft an invoice can sometimes recompute the delivery date, overwritting any value the user may have enter.

**STEP TO REPRODUCE**
1. Enable anglo-saxon accounting
2. have a product category with automated AVCO
3. assign category to a deliverable product
4. set product to invoice on delivery
5. add product to a sales order
6. confirm order & delivery
7. create invoice
8. change the delivery on the invoice
9. confirm the invoice.
10. reset the invoice to draft.

**CAUSE**
button_draft() unlinks some account.move.lines, triggering the compute on delivery_date.

see for more info : https://github.com/odoo/odoo/pull/231186
opw-5347939