### PR TITLE
[IMP] mail: enhance call menu UI

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -33,7 +33,8 @@ export function registerCallAction(id, definition) {
 }
 
 export const muteAction = {
-    badge: ({ store }) => store.rtc.microphonePermission !== "granted",
+    badge: ({ owner, store }) =>
+        !owner.env.inCallMenu && store.rtc.microphonePermission !== "granted",
     badgeIcon: "fa fa-exclamation",
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
@@ -64,7 +65,8 @@ export const muteAction = {
 };
 registerCallAction("mute", muteAction);
 export const quickActionSettings = {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ owner, store, thread }) =>
+        !owner.env.inCallMenu && thread?.eq(store.rtc?.channel),
     dropdown: true,
     dropdownComponent: QuickVoiceSettings,
     dropdownMenuClass: "p-2",
@@ -76,7 +78,7 @@ export const quickActionSettings = {
 };
 registerCallAction("quick-voice-settings", quickActionSettings);
 registerCallAction("deafen", {
-    condition: false,
+    condition: ({ owner }) => owner.env.inCallMenu,
     name: ({ store }) => (store.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
     isActive: ({ store }) => store.rtc.selfSession?.is_deaf,
     isTracked: true,
@@ -88,7 +90,7 @@ registerCallAction("deafen", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
 export const cameraOnAction = {
-    badge: ({ store }) => store.rtc.cameraPermission !== "granted",
+    badge: ({ owner, store }) => !owner.env.inCallMenu && store.rtc.cameraPermission !== "granted",
     badgeIcon: "fa fa-exclamation",
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     disabledCondition: ({ store }) => store.rtc?.isRemote,
@@ -117,7 +119,8 @@ export const cameraOnAction = {
 };
 registerCallAction("camera-on", cameraOnAction);
 export const quickVideoSettings = {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ owner, store, thread }) =>
+        !owner.env.inCallMenu && thread?.eq(store.rtc?.channel),
     dropdown: true,
     dropdownComponent: QuickVideoSettings,
     dropdownMenuClass: "p-2",
@@ -167,7 +170,8 @@ registerCallAction("share-screen", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.SUCCESS : undefined),
 });
 registerCallAction("auto-focus", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ owner, store, thread }) =>
+        !owner.env.inCallMenu && thread?.eq(store.rtc?.channel),
     name: ({ store }) =>
         store.settings.useCallAutoFocus ? _t("Disable speaker autofocus") : _t("Autofocus speaker"),
     isActive: ({ store }) => store.settings?.useCallAutoFocus,
@@ -209,7 +213,8 @@ registerCallAction("fullscreen", {
     tags: ACTION_TAGS.CALL_LAYOUT,
 });
 registerCallAction("picture-in-picture", {
-    condition: ({ store, thread }) =>
+    condition: ({ owner, store, thread }) =>
+        !owner.env.inCallMenu &&
         thread?.eq(store.rtc?.channel) &&
         store.env.services["discuss.pip_service"] &&
         !store.env?.isSmall,

--- a/addons/mail/static/src/discuss/call/common/call_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_menu.js
@@ -1,18 +1,22 @@
-import { Component } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 
+import { ActionList } from "@mail/core/common/action_list";
 import { useCallActions } from "@mail/discuss/call/common/call_actions";
 
+import { Dropdown } from "@web/core/dropdown/dropdown";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
 export class CallMenu extends Component {
     static props = [];
     static template = "discuss.CallMenu";
+    static components = { ActionList, Dropdown };
     setup() {
         super.setup();
         this.rtc = useService("discuss.rtc");
-        this.callActions = useCallActions({ thread: () => this.thread });
+        this.callActions = useCallActions({ thread: () => this.rtc.channel });
         this.isEnterprise = odoo.info && odoo.info.isEnterprise;
+        useSubEnv({ inCallMenu: true });
     }
 
     get icon() {

--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -22,3 +22,9 @@
         transform: translateY(10px);
     }
 }
+
+.o-discuss-CallMenu-dropdownMore, .o-discuss-CallMenu-channelInfo {
+    &:hover {
+        background-color: mix($gray-200, $gray-300) !important;
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -4,14 +4,24 @@
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
             <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
-                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
-                    <span class="position-relative small bg-transparent">
-                        <i class="me-2 fa fa-fw" t-att-class="icon" />
-                        <small class="d-flex position-absolute top-0 end-0 smaller bg-inherit">
-                            <i class="o-discuss-CallMenu-animation fa fa-volume-up o-discuss-inCallIconColor bg-inherit" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>
-                        </small>
-                    </span>
-                    <span class="text-truncate fw-bold pe-1" t-esc="rtc.channel.displayName"/>
+                <div class="o-discuss-CallMenu-buttonContent d-flex btn-group rounded-2 opacity-75 opacity-100-hover" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
+                    <div class="o-discuss-CallMenu-channelInfo text-truncate btn btn-group-item border-0 m-0 p-0 d-flex align-items-center o-gap-0_5 ps-1" role="button">
+                        <span class="position-relative small bg-transparent">
+                            <i class="me-2 fa fa-fw" t-att-class="icon" />
+                            <small class="d-flex position-absolute top-0 end-0 smaller bg-inherit">
+                                <i class="o-discuss-CallMenu-animation fa fa-volume-up o-discuss-inCallIconColor bg-inherit" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>
+                            </small>
+                        </span>
+                        <span class="text-truncate fw-bold pe-1" t-esc="rtc.channel.displayName"/>
+                    </div>
+                    <Dropdown>
+                        <button class="o-discuss-CallMenu-dropdownMore btn btn-group-item m-0 pe-1 o-ps-0_5">
+                            <i class="oi oi-chevron-down o-xsmaller"/>
+                        </button>
+                        <t t-set-slot="content">
+                            <ActionList actions="callActions.actions" dropdown="true"/>
+                        </t>
+                    </Dropdown>
                 </div>
             </button>
         </div>


### PR DESCRIPTION
Currently, there is no way that we can deafen or mute in call menu directly. This commit adds mute and deafen button in call menu for better user experience. Also, adjust the call menu UI for better visual effect.

task-5262772

before:
<img width="260" height="51" alt="image" src="https://github.com/user-attachments/assets/206b3b3d-cafa-492f-95ed-db8075f16298" />

after:
![Dec-02-2025 15-15-55](https://github.com/user-attachments/assets/a7d1579e-7a30-4376-ba95-ceb387542616)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
