### PR TITLE
[IMP] hr: contract end date loading

### DIFF
--- a/addons/hr/static/src/js/DynamicMinDateTimeField.js
+++ b/addons/hr/static/src/js/DynamicMinDateTimeField.js
@@ -1,0 +1,80 @@
+/** @odoo-module **/
+
+import { DateTimeField, dateField } from "@web/views/fields/datetime/datetime_field";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+/**
+ * This extention introduces a new prop "minDateField" that works like "minDate" but allows the user to specify a field for a dynamic min value rather than a static value from a string
+ *
+ * @extends DateTimeField
+ */
+export class DynamicMinDateTimeField extends DateTimeField {
+    static props = {
+        ...DateTimeField.props,
+        minDateField: { type: String, optional: true },
+    };
+
+    /**
+     * @override
+     * Extends the picker props to support a dynamically computed minimum date.
+     *
+     * Unlike the standard static `minDate` option (which accepts a literal string),
+     * this enhancement allows the picker to derive its minimum date from another
+     * date field via the `minDateField` prop. This makes it possible to enforce
+     * contextual constraints.
+     *  For example: ensuring that an end date cannot precede a start date, with the end_date DateTime picker automatically using the start_date as its minimum allowed value.
+     * @returns {DateTimePickerProps} The picker configuration with the computed minDate.
+     */
+
+    getPickerProps() {
+        const originalGetPickerProps = super.getPickerProps();
+        if (this.props.minDateField) {
+            const dynamicMinDateValue = this.props.record.data[this.props.minDateField];
+            if (dynamicMinDateValue) {
+                originalGetPickerProps.minDate = dynamicMinDateValue;
+            }
+        }
+        return originalGetPickerProps;
+    }
+}
+
+export const dynamicMinDateField = {
+    ...dateField,
+    component: DynamicMinDateTimeField,
+    displayName: _t("Date with Dynamic Minimum Value"),
+    supportedTypes: ["date", "datetime"],
+
+    supportedOptions: [
+        ...dateField.supportedOptions,
+        {
+            label: _t("Minimum Date Field"),
+            name: "min_date_field",
+            type: "field",
+            availableTypes: ["date", "datetime"],
+            help: _t("Reference another date/datetime field to use as minimum date"),
+        },
+    ],
+
+    fieldDependencies: (args) => {
+        const deps = dateField.fieldDependencies(args);
+        if (args.options.min_date_field) {
+            deps.push({
+                name: args.options.min_date_field,
+                type: "datetime",
+                readonly: false,
+            });
+        }
+        return deps;
+    },
+
+    extractProps: (fieldInfo, dynamicInfo) => {
+        const baseProps = dateField.extractProps(fieldInfo, dynamicInfo);
+
+        return {
+            ...baseProps,
+            minDateField: fieldInfo.options.min_date_field,
+        };
+    },
+};
+
+registry.category("fields").add("date_dynamic_min", dynamicMinDateField);

--- a/addons/hr/static/tests/date_dynamic_min_widget.test.js
+++ b/addons/hr/static/tests/date_dynamic_min_widget.test.js
@@ -1,0 +1,86 @@
+/** @odoo-module **/
+
+import {
+    contains,
+    defineModels,
+    fields,
+    makeMockServer,
+    models,
+    mountView,
+} from "@web/../tests/web_test_helpers";
+import { describe, expect, test } from "@odoo/hoot";
+import { queryAll } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { defineHrModels } from "@hr/../tests/hr_test_helpers";
+
+defineHrModels();
+class Partner extends models.Model {
+    _name = "partner";
+
+    name = fields.Char({ string: "Name" });
+    start_date = fields.Date({ string: "Start Date" });
+    end_date = fields.Date({ string: "End Date" });
+    event_date = fields.Date({ string: "Event Date" });
+}
+
+defineModels([Partner]);
+describe.current.tags("desktop");
+
+test("date_dynamic_min field renders with minDateField option", async function () {
+    const { env } = await makeMockServer();
+    const partnerId = env["partner"].create({
+        name: "Test Partner",
+        start_date: "2024-01-15",
+        end_date: "2024-02-20",
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: partnerId,
+        arch: `
+            <form>
+                <field name="start_date"/>
+                <field name="end_date" widget="date_dynamic_min" 
+                       options="{'min_date_field': 'start_date'}"/>
+            </form>`,
+    });
+
+    expect("div[name='end_date']").toHaveCount(1);
+    expect("div[name='start_date']").toHaveCount(1);
+});
+
+test("minDateField is applied from referenced field value", async function () {
+    const { env } = await makeMockServer();
+    const partnerId = env["partner"].create({
+        name: "Test Partner",
+        start_date: "2024-01-02 10:00:00",
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: partnerId,
+        arch: `
+            <form>
+                <field name="start_date"/>
+                <field name="end_date" widget="date_dynamic_min" 
+                       options="{'min_date_field': 'start_date'}"/>
+            </form>`,
+    });
+
+    // Click on end_date to open datepicker
+    await contains("input[id='end_date_0']").click();
+    await animationFrame();
+
+    // Datepicker should be visible
+    const allCells = queryAll(".o_datetime_picker .o_date_item_cell");
+    // The first day should be disabled because it's before the minDate'
+    const dayBefore = allCells.find((el) => el.textContent.trim() === "1");
+    expect(dayBefore).toHaveAttribute("disabled");
+    expect(dayBefore).toHaveClass("opacity-50");
+    // the day after should be enabled
+    const dayAfter = allCells.find((el) => el.textContent.trim() === "3");
+    expect(dayAfter).not.toHaveAttribute("disabled");
+    expect(dayAfter).not.toHaveClass("opacity-50");
+});

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -375,7 +375,7 @@
                                         <div class="o_row" name="contract_dates">
                                             <field name="contract_date_start" string="Start Date" placeholder="Not Employed" class="o_hr_narrow_field me-3"/>
                                             <span invisible="not contract_date_start">to</span>
-                                            <field name="contract_date_end" string="End Date" placeholder="Indefinite"
+                                            <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
                                             <widget name="button_new_contract"/>
                                         </div>

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -106,63 +106,7 @@ export class DateTimeField extends Component {
     //-------------------------------------------------------------------------
 
     setup() {
-        const getPickerProps = () => {
-            const value = this.getRecordValue();
-            /** @type {DateTimePickerProps} */
-            const pickerProps = {
-                value,
-                type: this.field.type,
-                range: this.isRange(value),
-                showRangeToggler:
-                    this.relatedField &&
-                    !this.isRequired(this.relatedField) &&
-                    !this.props.alwaysRange,
-                onToggleRange,
-            };
-            if (this.props.maxDate) {
-                pickerProps.maxDate = this.parseLimitDate(this.props.maxDate);
-            }
-            if (this.props.minDate) {
-                pickerProps.minDate = this.parseLimitDate(this.props.minDate);
-            }
-            if (!isNaN(this.props.rounding)) {
-                pickerProps.rounding = this.props.rounding;
-            } else if (this.props.showSeconds) {
-                pickerProps.rounding = 0;
-            }
-            if (this.props.maxPrecision) {
-                pickerProps.maxPrecision = this.props.maxPrecision;
-            }
-            if (this.props.minPrecision) {
-                pickerProps.minPrecision = this.props.minPrecision;
-            }
-            return pickerProps;
-        };
-
-        const onToggleRange = () => {
-            this.state.range = !this.state.range;
-
-            if (this.state.range) {
-                let values = this.values;
-                const optionalFieldIndex = values[0] ? 1 : 0;
-
-                if (!values[0] && !values[1]) {
-                    values = [DateTime.local(), DateTime.local()];
-                }
-                values[optionalFieldIndex] = optionalFieldIndex
-                    ? values[0].plus({ hours: 1 })
-                    : values[1].minus({ hours: 1 });
-
-                this.state.focusedDateIndex = 0;
-                this.state.value = values;
-            } else {
-                const mainFieldIndex = this.props.name === this.startDateField ? 0 : 1;
-
-                this.state.focusedDateIndex = mainFieldIndex;
-                this.state.value[mainFieldIndex ? 0 : 1] = false;
-            }
-        };
-
+        const getPickerProps = () => this.getPickerProps();
         const dateTimePicker = useDateTimePicker({
             target: "root",
             showSeconds: this.props.showSeconds,
@@ -240,6 +184,63 @@ export class DateTimeField extends Component {
     //-------------------------------------------------------------------------
     // Methods
     //-------------------------------------------------------------------------
+
+    getPickerProps() {
+        const value = this.getRecordValue();
+        /** @type {DateTimePickerProps} */
+        const pickerProps = {
+            value,
+            type: this.field.type,
+            range: this.isRange(value),
+            showRangeToggler:
+                this.relatedField &&
+                !this.isRequired(this.relatedField) &&
+                !this.props.alwaysRange,
+            onToggleRange: this.onToggleRange.bind(this),
+        };
+        if (this.props.maxDate) {
+            pickerProps.maxDate = this.parseLimitDate(this.props.maxDate);
+        }
+        if (this.props.minDate) {
+            pickerProps.minDate = this.parseLimitDate(this.props.minDate);
+        }
+        if (!isNaN(this.props.rounding)) {
+            pickerProps.rounding = this.props.rounding;
+        } else if (this.props.showSeconds) {
+            pickerProps.rounding = 0;
+        }
+        if (this.props.maxPrecision) {
+            pickerProps.maxPrecision = this.props.maxPrecision;
+        }
+        if (this.props.minPrecision) {
+            pickerProps.minPrecision = this.props.minPrecision;
+        }
+        return pickerProps;
+    }
+
+    onToggleRange() {
+        this.state.range = !this.state.range;
+
+        if (this.state.range) {
+            let values = this.values;
+            const optionalFieldIndex = values[0] ? 1 : 0;
+
+            if (!values[0] && !values[1]) {
+                values = [DateTime.local(), DateTime.local()];
+            }
+            values[optionalFieldIndex] = optionalFieldIndex
+                ? values[0].plus({ hours: 1 })
+                : values[1].minus({ hours: 1 });
+
+            this.state.focusedDateIndex = 0;
+            this.state.value = values;
+        } else {
+            const mainFieldIndex = this.props.name === this.startDateField ? 0 : 1;
+
+            this.state.focusedDateIndex = mainFieldIndex;
+            this.state.value[mainFieldIndex ? 0 : 1] = false;
+        }
+    }
 
     /**
      * @param {number} valueIndex


### PR DESCRIPTION
This commit makes the contract_end_date field focus on the contract_start_date instead of today's date when the start date is in the future. This improves overall usability.

task - 5076457
