### PR TITLE
[IMP] crm,*: harmonize form and encourage partner_id creation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6983,7 +6983,7 @@ class AccountMove(models.Model):
         if not self.is_invoice(include_receipts=True):
             return super()._creation_message()
         return {
-            'out_invoice': _('Invoice Created'),
+            'out_invoice': '',
             'out_refund': _('Credit Note Created'),
             'in_invoice': _('Vendor Bill Created'),
             'in_refund': _('Refund Created'),

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -58,6 +58,7 @@
         'views/crm_team_views.xml',
         'views/crm_menu_views.xml',
         'views/crm_helper_templates.xml',
+        'views/crm_lead_templates.xml',
     ],
     'demo': [
         'data/crm_team_demo.xml',

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -415,93 +415,88 @@ class TestCRMLead(TestCrmCommon):
         phone and email fields. Phone especially has some corner cases due to
         automatic formatting (notably with onchange in form view). """
         lead, partner = self.lead_1.with_user(self.env.user), self.contact_2
-        # This is a type == 'lead', not a type == 'opportunity'
-        # {'invisible': ['|', ('type', '=', 'opportunity'), ('is_partner_visible', '=', False)]}
-        # lead.is_partner_visible = bool(lead.type == 'opportunity' or lead.partner_id or is_debug_mode)
-        # Hence, debug mode required for `partner_id` to be visible
-        with self.debug_mode():
-            lead_form = Form(lead)
+        lead_form = Form(lead)
 
-            # reset partner phone to a local number and prepare formatted / sanitized values
-            partner_phone = self.test_phone_data[2]
-            partner_phone_formatted = phone_format(partner_phone, 'US', '1', force_format='INTERNATIONAL')
-            partner_phone_sanitized = phone_format(partner_phone, 'US', '1', force_format='E164')
-            partner_email, partner_email_normalized = self.test_email_data[2], self.test_email_data_normalized[2]
-            self.assertEqual(partner_phone_formatted, '+1 202-555-0888')
-            self.assertEqual(partner_phone_sanitized, self.test_phone_data_sanitized[2])
-            # ensure initial data
-            self.assertEqual(partner.phone, partner_phone)
-            self.assertEqual(partner.email, partner_email)
+        # reset partner phone to a local number and prepare formatted / sanitized values
+        partner_phone = self.test_phone_data[2]
+        partner_phone_formatted = phone_format(partner_phone, 'US', '1', force_format='INTERNATIONAL')
+        partner_phone_sanitized = phone_format(partner_phone, 'US', '1', force_format='E164')
+        partner_email, partner_email_normalized = self.test_email_data[2], self.test_email_data_normalized[2]
+        self.assertEqual(partner_phone_formatted, '+1 202-555-0888')
+        self.assertEqual(partner_phone_sanitized, self.test_phone_data_sanitized[2])
+        # ensure initial data
+        self.assertEqual(partner.phone, partner_phone)
+        self.assertEqual(partner.email, partner_email)
 
-            # LEAD/PARTNER SYNC: email and phone are propagated to lead
-            # as well as mobile (who does not trigger the reverse sync)
-            lead_form.partner_id = partner
-            self.assertEqual(lead_form.email_from, partner_email)
-            self.assertEqual(lead_form.phone, partner_phone_formatted,
-                            'Lead: form automatically formats numbers')
-            self.assertFalse(lead_form.partner_email_update)
-            self.assertFalse(lead_form.partner_phone_update)
+        # LEAD/PARTNER SYNC: email and phone are propagated to lead
+        # as well as mobile (who does not trigger the reverse sync)
+        lead_form.partner_id = partner
+        self.assertEqual(lead_form.email_from, partner_email)
+        self.assertEqual(lead_form.phone, partner_phone_formatted,
+                        'Lead: form automatically formats numbers')
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
 
-            lead_form.save()
-            self.assertEqual(partner.phone, partner_phone,
-                            'Lead / Partner: partner values sent to lead')
-            self.assertEqual(lead.email_from, partner_email,
-                            'Lead / Partner: partner values sent to lead')
-            self.assertEqual(lead.email_normalized, partner_email_normalized,
-                            'Lead / Partner: equal emails should lead to equal normalized emails')
-            self.assertEqual(lead.phone, partner_phone_formatted,
-                            'Lead / Partner: partner values (formatted) sent to lead')
-            self.assertEqual(lead.phone_sanitized, partner_phone_sanitized,
-                            'Lead: phone_sanitized computed field on mobile')
+        lead_form.save()
+        self.assertEqual(partner.phone, partner_phone,
+                        'Lead / Partner: partner values sent to lead')
+        self.assertEqual(lead.email_from, partner_email,
+                        'Lead / Partner: partner values sent to lead')
+        self.assertEqual(lead.email_normalized, partner_email_normalized,
+                        'Lead / Partner: equal emails should lead to equal normalized emails')
+        self.assertEqual(lead.phone, partner_phone_formatted,
+                        'Lead / Partner: partner values (formatted) sent to lead')
+        self.assertEqual(lead.phone_sanitized, partner_phone_sanitized,
+                        'Lead: phone_sanitized computed field on mobile')
 
-            # for email_from, if only formatting differs, warning should not appear and
-            # email on partner should not be updated
-            lead_form.email_from = '"Hermes Conrad" <%s>' % partner_email_normalized
-            self.assertFalse(lead_form.partner_email_update)
-            lead_form.save()
-            self.assertEqual(partner.email, partner_email)
+        # for email_from, if only formatting differs, warning should not appear and
+        # email on partner should not be updated
+        lead_form.email_from = '"Hermes Conrad" <%s>' % partner_email_normalized
+        self.assertFalse(lead_form.partner_email_update)
+        lead_form.save()
+        self.assertEqual(partner.email, partner_email)
 
-            # for phone, if only formatting differs, warning should not appear and
-            # phone on partner should not be updated
-            lead_form.phone = partner_phone_sanitized
-            self.assertFalse(lead_form.partner_phone_update)
-            lead_form.save()
-            self.assertEqual(partner.phone, partner_phone)
+        # for phone, if only formatting differs, warning should not appear and
+        # phone on partner should not be updated
+        lead_form.phone = partner_phone_sanitized
+        self.assertFalse(lead_form.partner_phone_update)
+        lead_form.save()
+        self.assertEqual(partner.phone, partner_phone)
 
-            # LEAD/PARTNER SYNC: lead updates partner
-            new_email = '"John Zoidberg" <john.zoidberg@test.example.com>'
-            new_email_normalized = 'john.zoidberg@test.example.com'
-            lead_form.email_from = new_email
-            self.assertTrue(lead_form.partner_email_update)
-            new_phone = '+1 202 555 7799'
-            new_phone_formatted = phone_format(new_phone, 'US', '1', force_format="INTERNATIONAL")
-            new_phone_sanitized = phone_format(new_phone, 'US', '1', force_format="E164")
-            lead_form.phone = new_phone
-            self.assertEqual(lead_form.phone, new_phone_formatted)
-            self.assertTrue(lead_form.partner_email_update)
-            self.assertTrue(lead_form.partner_phone_update)
+        # LEAD/PARTNER SYNC: lead updates partner
+        new_email = '"John Zoidberg" <john.zoidberg@test.example.com>'
+        new_email_normalized = 'john.zoidberg@test.example.com'
+        lead_form.email_from = new_email
+        self.assertTrue(lead_form.partner_email_update)
+        new_phone = '+1 202 555 7799'
+        new_phone_formatted = phone_format(new_phone, 'US', '1', force_format="INTERNATIONAL")
+        new_phone_sanitized = phone_format(new_phone, 'US', '1', force_format="E164")
+        lead_form.phone = new_phone
+        self.assertEqual(lead_form.phone, new_phone_formatted)
+        self.assertTrue(lead_form.partner_email_update)
+        self.assertTrue(lead_form.partner_phone_update)
 
-            lead_form.save()
-            self.assertEqual(partner.email, new_email)
-            self.assertEqual(partner.email_normalized, new_email_normalized)
-            self.assertEqual(partner.phone, new_phone_formatted)
+        lead_form.save()
+        self.assertEqual(partner.email, new_email)
+        self.assertEqual(partner.email_normalized, new_email_normalized)
+        self.assertEqual(partner.phone, new_phone_formatted)
 
-            # LEAD/PARTNER SYNC: resetting lead values should not reset partner
-            # # voiding lead info (because of some reasons) should not prevent
-            # # from using the contact in other records
-            lead_form.email_from, lead_form.phone = False, False
-            self.assertFalse(lead_form.partner_email_update)
-            self.assertFalse(lead_form.partner_phone_update)
-            lead_form.save()
-            self.assertEqual(partner.email, new_email)
-            self.assertEqual(partner.email_normalized, new_email_normalized)
-            self.assertEqual(partner.phone, new_phone_formatted)
-            self.assertFalse(lead.phone)
-            self.assertFalse(lead.phone_sanitized)
-            # if SMS is uninstalled, phone_sanitized is not available on partner
-            if 'phone_sanitized' in partner:
-                self.assertEqual(partner.phone_sanitized, new_phone_sanitized,
-                                'Partner sanitized should be computed on mobile')
+        # LEAD/PARTNER SYNC: resetting lead values should not reset partner
+        # # voiding lead info (because of some reasons) should not prevent
+        # # from using the contact in other records
+        lead_form.email_from, lead_form.phone = False, False
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
+        lead_form.save()
+        self.assertEqual(partner.email, new_email)
+        self.assertEqual(partner.email_normalized, new_email_normalized)
+        self.assertEqual(partner.phone, new_phone_formatted)
+        self.assertFalse(lead.phone)
+        self.assertFalse(lead.phone_sanitized)
+        # if SMS is uninstalled, phone_sanitized is not available on partner
+        if 'phone_sanitized' in partner:
+            self.assertEqual(partner.phone_sanitized, new_phone_sanitized,
+                            'Partner sanitized should be computed on mobile')
 
     @users('user_sales_manager')
     def test_crm_lead_partner_sync_email_phone_corner_cases(self):
@@ -516,74 +511,69 @@ class TestCRMLead(TestCrmCommon):
             'email': '',
         })
 
-        # This is a type == 'lead', not a type == 'opportunity'
-        # {'invisible': ['|', ('type', '=', 'opportunity'), ('is_partner_visible', '=', False)]}
-        # lead.is_partner_visible = bool(lead.type == 'opportunity' or lead.partner_id or is_debug_mode)
-        # Hence, debug mode required for `partner_id` to be visible
-        with self.debug_mode():
-            lead_form = Form(lead)
-            self.assertEqual(lead_form.email_from, test_email)
-            self.assertFalse(lead_form.partner_email_update)
-            self.assertFalse(lead_form.partner_phone_update)
+        lead_form = Form(lead)
+        self.assertEqual(lead_form.email_from, test_email)
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
 
-            # email: False versus empty string
-            lead_form.partner_id = contact
-            self.assertTrue(lead_form.partner_email_update)
-            self.assertFalse(lead_form.partner_phone_update)
-            lead_form.email_from = ''
-            self.assertFalse(lead_form.partner_email_update)
-            lead_form.email_from = False
-            self.assertFalse(lead_form.partner_email_update)
+        # email: False versus empty string
+        lead_form.partner_id = contact
+        self.assertTrue(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
+        lead_form.email_from = ''
+        self.assertFalse(lead_form.partner_email_update)
+        lead_form.email_from = False
+        self.assertFalse(lead_form.partner_email_update)
 
-            # phone: False versus empty string
-            lead_form.phone = '+1 202-555-0888'
-            self.assertFalse(lead_form.partner_email_update)
-            self.assertTrue(lead_form.partner_phone_update)
-            lead_form.phone = ''
-            self.assertFalse(lead_form.partner_phone_update)
-            lead_form.phone = False
-            self.assertFalse(lead_form.partner_phone_update)
+        # phone: False versus empty string
+        lead_form.phone = '+1 202-555-0888'
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertTrue(lead_form.partner_phone_update)
+        lead_form.phone = ''
+        self.assertFalse(lead_form.partner_phone_update)
+        lead_form.phone = False
+        self.assertFalse(lead_form.partner_phone_update)
 
-            # email/phone: formatting should not trigger ribbon
-            lead.write({
-                'email_from': '"My Name" <%s>' % test_email,
-                'phone': '+1 202-555-0888',
-            })
-            contact.write({
-                'email': '"My Name" <%s>' % test_email,
-                'phone': '+1 202-555-0888',
-            })
+        # email/phone: formatting should not trigger ribbon
+        lead.write({
+            'email_from': '"My Name" <%s>' % test_email,
+            'phone': '+1 202-555-0888',
+        })
+        contact.write({
+            'email': '"My Name" <%s>' % test_email,
+            'phone': '+1 202-555-0888',
+        })
 
-            lead_form = Form(lead)
-            self.assertFalse(lead_form.partner_email_update)
-            self.assertFalse(lead_form.partner_phone_update)
-            lead_form.partner_id = contact
-            self.assertFalse(lead_form.partner_email_update)
-            self.assertFalse(lead_form.partner_phone_update)
-            lead_form.email_from = '"Another Name" <%s>' % test_email  # same email normalized
-            self.assertFalse(lead_form.partner_email_update, 'Formatting-only change should not trigger write')
-            self.assertFalse(lead_form.partner_phone_update, 'Formatting-only change should not trigger write')
-            lead_form.phone = '2025550888'  # same number but another format
-            self.assertFalse(lead_form.partner_email_update, 'Formatting-only change should not trigger write')
-            self.assertFalse(lead_form.partner_phone_update, 'Formatting-only change should not trigger write')
+        lead_form = Form(lead)
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
+        lead_form.partner_id = contact
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
+        lead_form.email_from = '"Another Name" <%s>' % test_email  # same email normalized
+        self.assertFalse(lead_form.partner_email_update, 'Formatting-only change should not trigger write')
+        self.assertFalse(lead_form.partner_phone_update, 'Formatting-only change should not trigger write')
+        lead_form.phone = '2025550888'  # same number but another format
+        self.assertFalse(lead_form.partner_email_update, 'Formatting-only change should not trigger write')
+        self.assertFalse(lead_form.partner_phone_update, 'Formatting-only change should not trigger write')
 
-            # wrong value are also propagated
-            lead_form.phone = '666 789456789456789456'
-            self.assertTrue(lead_form.partner_phone_update)
+        # wrong value are also propagated
+        lead_form.phone = '666 789456789456789456'
+        self.assertTrue(lead_form.partner_phone_update)
 
-            # test country propagation allowing to correctly compute sanitized numbers
-            # by adding missing relevant information from contact
-            be_country = self.env.ref('base.be')
-            contact.write({
-                'country_id': be_country.id,
-                'phone': '+32456001122',
-            })
-            lead.write({'country_id': False})
-            lead_form = Form(lead)
-            lead_form.partner_id = contact
-            lead_form.phone = '0456 00 11 22'
-            self.assertFalse(lead_form.partner_phone_update)
-            self.assertEqual(lead_form.country_id, be_country)
+        # test country propagation allowing to correctly compute sanitized numbers
+        # by adding missing relevant information from contact
+        be_country = self.env.ref('base.be')
+        contact.write({
+            'country_id': be_country.id,
+            'phone': '+32456001122',
+        })
+        lead.write({'country_id': False})
+        lead_form = Form(lead)
+        lead_form.partner_id = contact
+        lead_form.phone = '0456 00 11 22'
+        self.assertFalse(lead_form.partner_phone_update)
+        self.assertEqual(lead_form.country_id, be_country)
 
 
     @users('user_sales_manager')

--- a/addons/crm/views/crm_lead_templates.xml
+++ b/addons/crm/views/crm_lead_templates.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="crm_lead_creation_message" name="crm lead creation message">
+        <t t-set="has_address_line" t-value="False"/>
+        <t t-if="env.context.get('import_file')">
+            Lead/Opportunity created<br/>
+        </t>
+        <t t-if="lead.partner_name or lead.contact_name">
+            <i class="fa fa-user fa-fw me-1"/>
+            <span>
+                <b t-if="lead.partner_name" t-out="lead.partner_name"/><t t-if="lead.contact_name and lead.partner_name">,</t>
+                <t t-if="lead.contact_name" t-out="lead.contact_name"/>
+            </span><br/>
+        </t>
+        <t t-if="lead.function">
+            <i class="fa fa-briefcase fa-fw me-1"/>
+            <span t-out="lead.function"/><br/>
+        </t>
+        <t t-if="lead.street or lead.street2">
+            <t t-set="has_address_line" t-value="True"/>
+            <i class="fa fa-map-marker fa-fw me-1"/>
+            <span t-out="', '.join(s_bit for s_bit in [lead.street, lead.street2] if s_bit)"/><br/>
+        </t>
+        <t t-if="lead.city or lead.zip or lead.state_id or lead.country_id">
+            <i t-if="has_address_line" class="fa fa-fw me-1"/>
+            <i t-else="" class="fa fa-map-marker fa-fw me-1"/>
+            <span t-out="', '.join(s_bit for s_bit in [lead.city, lead.zip, lead.state_id.display_name, lead.country_id.display_name] if s_bit)"/><br/>
+        </t>
+        <t t-if="lead.website">
+            <i class="fa fa-globe fa-fw me-1"/>
+            <span>
+                <a t-att-href="lead.website" t-out="lead.website" target='_blank'/>
+            </span><br/>
+        </t>
+    </template>
+</odoo>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -117,11 +117,9 @@
                                 <field name="partner_is_blacklisted" invisible="1"/>
                                 <field name="date_conversion" invisible="1"/>
                                 <field name="user_company_ids" invisible="1"/>
-                                <!-- lead -->
-                                <field name="is_partner_visible" invisible='1'/>
 
                                 <field name="partner_id" widget="res_partner_many2one"
-                                    invisible="not is_partner_visible or type == 'opportunity'"
+                                    invisible="type == 'opportunity'"
                                     placeholder="Select or create a contact..."
                                     context="{
                                         'default_parent_id': commercial_partner_id,
@@ -211,7 +209,7 @@
                             </page>
                             <page name="extra" string="Extra Info">
                                 <group>
-                                    <group string="Company Information">
+                                    <group string="Company Information" groups="base.group_no_one">
                                         <field name="partner_name"/>
                                         <label for="street" string="Address"/>
                                         <div class="o_address_format">
@@ -226,7 +224,7 @@
                                         <field name="lang_id" invisible="lang_active_count &lt;= 1"
                                             options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
                                     </group>
-                                    <group string="Contact Information">
+                                    <group string="Contact Information" groups="base.group_no_one">
                                         <label for="contact_name"/>
                                         <div class="o_row">
                                             <field name="contact_name" id="contact_name"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -26,6 +26,7 @@
                         <field name="company_id" invisible="1"/>
                         <field name="is_rotting" invisible="1"/>
                         <field name="rotting_days" invisible="1"/>
+                        <field name="lang_code" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
                             <button name="action_schedule_meeting" type="object"
                                 class="oe_stat_button" icon="fa-calendar"
@@ -54,6 +55,11 @@
                                 <h1 class="flex-grow-1">
                                     <field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/>
                                 </h1>
+                                <div class="align-self-start mt-2 ms-2"
+                                    title="Convert into an Opportunity to see it in your Pipeline"
+                                    invisible="type == 'opportunity'">
+                                    <field name="type" widget="badge"/>
+                                </div>
                             </div>
                             <h2 class="row g-0 pb-3 pb-sm-4">
                                 <div class="col-auto pb-2 pb-md-0 w-100 w-sm-auto" invisible="type == 'lead'">
@@ -98,10 +104,25 @@
                             </h2>
                         </div>
                         <group>
-                            <group name="lead_partner" invisible="type == 'opportunity'">
+                            <group name="lead_partner">
                                 <!-- Preload all the partner's information -->
+                                <!-- common -->
+                                <field name="is_blacklisted" invisible="1"/>
+                                <field name="phone_blacklisted" invisible="1"/>
+                                <field name="email_state" invisible="1"/>
+                                <field name="phone_state" invisible="1"/>
+                                <field name="partner_email_update" invisible="1"/>
+                                <field name="partner_phone_update" invisible="1"/>
+                                <!-- opportunity -->
+                                <field name="partner_is_blacklisted" invisible="1"/>
+                                <field name="date_conversion" invisible="1"/>
+                                <field name="user_company_ids" invisible="1"/>
+                                <!-- lead -->
                                 <field name="is_partner_visible" invisible='1'/>
+
                                 <field name="partner_id" widget="res_partner_many2one"
+                                    invisible="not is_partner_visible or type == 'opportunity'"
+                                    placeholder="Select or create a contact..."
                                     context="{
                                         'default_parent_id': commercial_partner_id,
                                         'default_name': contact_name,
@@ -118,28 +139,14 @@
                                         'default_team_id': team_id,
                                         'default_website': website,
                                         'default_lang': lang_code,
-                                    }" invisible="not is_partner_visible"/>
-                                <field name="partner_name"/>
-                                <label for="street" string="Address"/>
-                                <div class="o_address_format">
-                                    <field name="street" placeholder="Street..." class="o_address_street"/>
-                                    <field name="street2" placeholder="Street 2..." class="o_address_street"/>
-                                    <field name="city" placeholder="City" class="o_address_city"/>
-                                    <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
-                                    <field name="zip" placeholder="ZIP" class="o_address_zip"/>
-                                    <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
-                                </div>
-                                <field name="website" widget="url" placeholder="e.g. https://www.odoo.com"/>
-                                <field name="lang_active_count" invisible="1"/>
-                                <field name="lang_code" invisible="1"/>
-                                <field name="lang_id" invisible="lang_active_count &lt;= 1"
-                                    options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
-                            </group>
-
-                            <group name="opportunity_partner" invisible="type == 'lead'">
+                                    }"
+                                />
                                 <field name="partner_id"
                                     widget="res_partner_many2one"
-                                    context="{'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
+                                    invisible="type == 'lead'"
+                                    placeholder="Select or create a contact..."
+                                    context="{
+                                        'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
                                         'default_name': contact_name or partner_name,
                                         'default_street': street,
                                         'default_is_company': type == 'opportunity' and contact_name == False,
@@ -159,20 +166,13 @@
                                         'show_vat': True,
                                     }"
                                 />
-                                <field name="is_blacklisted" invisible="1"/>
-                                <field name="partner_is_blacklisted" invisible="1"/>
-                                <field name="phone_blacklisted" invisible="1"/>
-                                <field name="email_state" invisible="1"/>
-                                <field name="phone_state" invisible="1"/>
-                                <field name="partner_email_update" invisible="1"/>
-                                <field name="partner_phone_update" invisible="1"/>
                                 <label for="email_from" class="oe_inline"/>
                                 <div class="o_row o_row_readonly">
                                     <button name="mail_action_blacklist_remove" class="fa fa-ban text-danger"
                                         title="This email is blacklisted for mass mailings. Click to unblacklist."
                                         type="object" context="{'default_email': email_from}" groups="base.group_user"
                                         invisible="not is_blacklisted"/>
-                                    <field name="email_from" string="Email" widget="email"/>
+                                    <field name="email_from" string="Email" widget="email" placeholder="e.g. john.doe@email.com"/>
                                     <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
                                         title="By saving this change, the customer email will also be updated."
                                         invisible="not partner_email_update"/>
@@ -183,70 +183,22 @@
                                         title="This phone number is blacklisted for SMS Marketing. Click to unblacklist."
                                         type="object" context="{'default_phone': phone}" groups="base.group_user"
                                         invisible="not phone_blacklisted"/>
-                                    <field name="phone" widget="phone"/>
+                                    <field name="phone" widget="phone" placeholder="e.g. (555) 555-0199"/>
                                     <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
                                         title="By saving this change, the customer phone number will also be updated."
                                         invisible="not partner_phone_update"/>
                                 </div>
-                                <field name="lost_reason_id" invisible="won_status != 'lost'"
-                                    placeholder="Not specified"/>
-                                <field name="date_conversion" invisible="1"/>
-                                <field name="user_company_ids" invisible="1"/>
+                                <field name="lost_reason_id" invisible="type == 'lead' or won_status != 'lost'" placeholder="Not specified"/>
                             </group>
-                            <group name="lead_info" invisible="type == 'opportunity'">
-                                <label for="contact_name"/>
-                                <div class="o_row">
-                                    <field name="contact_name"/>
-                                </div>
-                                <field name="is_blacklisted" invisible="1"/>
-                                <field name="phone_blacklisted" invisible="1"/>
-                                <field name="email_state" invisible="1"/>
-                                <field name="phone_state" invisible="1"/>
-                                <field name="partner_email_update" invisible="1"/>
-                                <field name="partner_phone_update" invisible="1"/>
-                                <label for="email_from_group_lead_info" class="oe_inline"/>
-                                <div class="o_row o_row_readonly">
-                                    <button name="mail_action_blacklist_remove" class="fa fa-ban text-danger"
-                                        title="This email is blacklisted for mass mailings. Click to unblacklist."
-                                        type="object" context="{'default_email': email_from}" groups="base.group_user"
-                                        invisible="not is_blacklisted"/>
-                                    <field name="email_from" id="email_from_group_lead_info" string="Email" widget="email"/>
-                                    <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
-                                        title="By saving this change, the customer email will also be updated."
-                                        invisible="not partner_email_update"/>
-                                </div>
-                                <field name="email_cc" groups="base.group_no_one"/>
-                                <field name="function"/>
-                                <label for="phone_group_lead_info" class="oe_inline"/>
-                                <div class="o_row o_row_readonly">
-                                    <button name="phone_action_blacklist_remove" class="fa fa-ban text-danger"
-                                        title="This phone number is blacklisted for SMS Marketing. Click to unblacklist."
-                                        type="object" context="{'default_phone': phone}" groups="base.group_user"
-                                        invisible="not phone_blacklisted"/>
-                                    <field name="phone" id="phone_group_lead_info" widget="phone"/>
-                                    <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
-                                        title="By saving this change, the customer phone number will also be updated."
-                                        invisible="not partner_phone_update"/>
-                                </div>
-                            </group>
-                            <field name="type" invisible="1"/>
-                            <group invisible="type == 'lead'">
+                            <group>
                                 <field name="user_id" context="{'default_sales_team_id': team_id}"
                                     widget="many2one_avatar_leader_user" teamField="team_id"/>
-                                <label for="date_deadline">Expected Closing</label>
-                                <div class="d-flex gap-3 align-items-center">
+                                <label for="date_deadline" invisible="type == 'lead'">Expected Closing</label>
+                                <div class="d-flex gap-3 align-items-center" invisible="type == 'lead'">
                                     <field name="date_deadline" nolabel="1" class="oe_inline" placeholder="No closing estimate"/>
                                     <field name="priority" widget="priority" nolabel="1" class="oe_inline align-top"/>
                                 </div>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
-                            </group>
-                            <group invisible="type == 'opportunity'">
-                                <field name="user_id" context="{'default_sales_team_id': team_id}"
-                                    widget="many2one_avatar_leader_user" teamField="team_id"/>
-                                <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
-                            </group>
-                            <group name="lead_priority" invisible="type == 'opportunity'">
-                                <field name="priority" widget="priority"/>
+                                <field name="priority" widget="priority" invisible="type == 'opportunity'"/>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
                             </group>
                         </group>
@@ -257,34 +209,13 @@
                             <page string="Notes" name="internal_notes">
                                 <field name="description" placeholder="Add a description..." options="{'collaborative': true}" />
                             </page>
-                            <page name="extra" string="Extra Info" invisible="type == 'opportunity'">
-                                <group>
-                                    <group string="Email" groups="base.group_no_one">
-                                        <field name="message_bounce" readonly="1"/>
-                                    </group>
-                                    <group string="Marketing" name="categorization">
-                                        <field name="company_id"
-                                            groups="base.group_multi_company"
-                                            options="{'no_create': True}"
-                                            placeholder="Visible to all"/>
-                                        <field name="campaign_id" options="{'create_name_field': 'title'}"/>
-                                        <field name="medium_id"/>
-                                        <field name="source_id"/>
-                                        <field name="referred"/>
-                                    </group>
-                                    <group string="Analysis">
-                                        <field name="date_open"/>
-                                        <field name="date_closed"/>
-                                    </group>
-                                </group>
-                            </page>
-                            <page name="lead" string="Contacts" invisible="type == 'lead'">
+                            <page name="extra" string="Extra Info">
                                 <group>
                                     <group string="Company Information">
                                         <field name="partner_name"/>
-                                        <label for="street_page_lead" string="Address"/>
+                                        <label for="street" string="Address"/>
                                         <div class="o_address_format">
-                                            <field name="street" id="street_page_lead" placeholder="Street..." class="o_address_street"/>
+                                            <field name="street" placeholder="Street..." class="o_address_street"/>
                                             <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                             <field name="city" placeholder="City" class="o_address_city"/>
                                             <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
@@ -296,17 +227,17 @@
                                             options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
                                     </group>
                                     <group string="Contact Information">
-                                        <label for="contact_name_page_lead"/>
+                                        <label for="contact_name"/>
                                         <div class="o_row">
-                                            <field name="contact_name" id="contact_name_page_lead"/>
+                                            <field name="contact_name" id="contact_name"/>
                                         </div>
                                         <field name="function"/>
                                         <field name="website" widget="url" placeholder="e.g. https://www.odoo.com"/>
                                     </group>
-                                    <group string="Marketing">
+                                    <group string="Marketing" name="categorization">
                                         <field name="campaign_id" options="{'create_name_field': 'title'}"/>
-                                        <field name="medium_id" />
-                                        <field name="source_id" />
+                                        <field name="medium_id"/>
+                                        <field name="source_id"/>
                                         <field name="referred"/>
                                     </group>
                                     <group string="Ownership" name="Misc">

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -367,8 +367,7 @@ class MailThread(models.AbstractModel):
                 # if we have a subtype, post message to notify users from _message_auto_subscribe
                 thread.sudo().message_post(
                     subtype_id=subtype.id, author_id=self.env.user.partner_id.id,
-                    # summary="o_mail_notification" is used to hide the message body in the front-end
-                    body=Markup('<div summary="o_mail_notification"><p>%s</p></div>') % thread._creation_message()
+                    body=Markup('<div><p>%s</p></div>') % thread._creation_message()
                 )
             if threads_no_subtype:
                 bodies = dict(

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1575,9 +1575,9 @@ class ProjectTask(models.Model):
     def _creation_message(self):
         self.ensure_one()
         if self.project_id:
-            return _('A new task has been created in the "%(project_name)s" project.',
+            return _('This new task has been created in the "%(project_name)s" project.',
                      project_name=self.project_id.display_name)
-        return _('A new task has been created and is not part of any project.')
+        return _('This new task is not part of any project.')
 
     def _track_subtype(self, init_values):
         self.ensure_one()

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -91,12 +91,9 @@ class TestCrmPerformance(CrmPerformanceCase):
         """ Test a single lead creation using Form with a partner """
         with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=144):  # tcf 141 / com 143
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
-            with self.debug_mode():
-                # {'invisible': ['|', ('type', '=', 'opportunity'), ('is_partner_visible', '=', False)]}
-                # lead.is_partner_visible = bool(lead.type == 'opportunity' or lead.partner_id or is_debug_mode)
-                with Form(self.env['crm.lead']) as lead_form:
-                    lead_form.partner_id = self.partners[0]
-                    lead_form.name = 'Test Lead'
+            with Form(self.env['crm.lead']) as lead_form:
+                lead_form.partner_id = self.partners[0]
+                lead_form.name = 'Test Lead'
 
             _lead = lead_form.save()
 

--- a/addons/website_crm_iap_reveal/views/crm_lead_views.xml
+++ b/addons/website_crm_iap_reveal/views/crm_lead_views.xml
@@ -6,13 +6,6 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='lead']/group" position="inside">
-                <group string="Lead Generation Information" invisible="not reveal_ip" groups="base.group_no_one">
-                    <field name="reveal_ip"/>
-                    <field name="reveal_iap_credits"/>
-                    <field name="reveal_rule_id"/>
-                </group>
-            </xpath>
             <xpath expr="//page[@name='extra']/group" position="inside">
                 <group string="Lead Generation Information" invisible="not reveal_ip" groups="base.group_no_one">
                     <field name="reveal_ip"/>


### PR DESCRIPTION
*: crm_iap_mine, mail, test_crm_full, website_crm_iap_mine

SUMMARY
---------------
1. Uniformize form view for lead and opportunity.
2. Show creation_message even if there is a creation_subtype. (mail.thread)
3. Always show partner_id field on the crm.lead form and move company/contact info groups in debug mode. Track those hidden fields, and at creation log a formatted creation_message in the chatter with that information.

UPG PR : odoo/upgrade#8993

Task-5357597
