### PR TITLE
[FIX] html_builder, website, website_crm: fix bugs with property fields in website form

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -120,10 +120,9 @@ export class BuilderList extends Component {
         if (!ev.currentTarget.dataset.id) {
             items.push(this.makeDefaultItem());
         } else {
-            const elementToAdd = this.allRecords.find(
-                (el) => el.id === Number(ev.currentTarget.dataset.id)
-            );
-            if (!items.some((item) => item.id === Number(ev.currentTarget.dataset.id))) {
+            const matchId = (el) => el.id.toString() === ev.currentTarget.dataset.id.toString();
+            const elementToAdd = this.allRecords.find(matchId);
+            if (!items.some(matchId)) {
                 items.push(elementToAdd);
             }
             this.dropdown.close();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -343,3 +343,42 @@ test("do not lose id when adjusting 'selected'", async () => {
         ])
     );
 });
+
+test("can add item with string and integer ids", async () => {
+    class Test extends BaseOptionComponent {
+        static template = xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                addItemTitle="'Add'"
+                itemShape="{ display_name: 'text', selected: 'boolean' }"
+                default="{ display_name: 'Extra', selected: false }"
+                records="availableRecords" />`;
+        static components = { BuilderList };
+        static props = ["*"];
+        setup() {
+            this.availableRecords = JSON.stringify([
+                {
+                    id: "57cb74cc2f17a163",
+                    display_name: "v1",
+                },
+                {
+                    id: 42,
+                    display_name: "v2",
+                },
+            ]);
+        }
+    }
+    addBuilderOption(
+        class extends Test {
+            static selector = ".test-options-target";
+        }
+    );
+    await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+
+    for (let i = 0; i < 2; i++) {
+        await contains(".we-bg-options-container .bl-dropdown-toggle").click();
+        await contains(".o_popover .o-hb-select-dropdown-item").click();
+    }
+    expect(".we-bg-options-container .bl-dropdown-toggle").toHaveProperty("disabled");
+});

--- a/addons/website/static/src/builder/plugins/form/form_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_option.js
@@ -10,18 +10,23 @@ export class FormOption extends BaseOptionComponent {
     static selector = ".s_website_form";
     static applyTo = "form";
     static components = { FormActionFieldsOption };
-    static cleanForSave(el, { services }) {
+    static async cleanForSave(el, { dependencies, services }) {
         for (const sigEl of el.querySelectorAll("input[name=website_form_signature]")) {
             sigEl.remove();
         }
 
         for (const formEl of selectElements(el, ".s_website_form form[data-model_name]")) {
             const model = formEl.dataset.model_name;
+            const authorizedFields = await dependencies.websiteFormOption.fetchAuthorizedFields(
+                formEl
+            );
             const fields = [
                 ...formEl.querySelectorAll(
                     ".s_website_form_field:not(.s_website_form_custom) .s_website_form_input"
                 ),
-            ].map((el) => el.name);
+            ]
+                .map((el) => el.name)
+                .filter((name) => !authorizedFields[name]?._property);
             if (fields.length) {
                 services.orm.call("ir.model.fields", "formbuilder_whitelist", [
                     model,

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -4,31 +4,45 @@ import {
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
-registerWebsitePreviewTour('website_crm_pre_tour', {
-    url: '/contactus',
-    edition: true,
-}, () => [{
-    content: "Select contact form",
-    trigger: ":iframe #wrap.o_editable section.s_website_form",
-    run: "click",
-},
-{
-    trigger: ".o-snippets-menu .o-snippets-tabs [data-name='customize'].active",
-},
-{
-    content: "Open action select",
-    trigger: ".o-snippets-menu [data-container-title='Block'] [data-label='Action'] .dropdown-toggle",
-    run: "click",
-}, {
-    content: "Select 'Create an Opportunity' as form action",
-    trigger: ".o_popover [data-action-id='selectAction']:contains('Create an Opportunity')",
-    run: "click",
-},
-...clickOnSave(),
-{
-    content: "Ensure form model has changed and page reload is done after save",
-    trigger: ":iframe section.s_website_form form[data-model_name='crm.lead']",
-}]);
+function setFormActionToCreateOpportunity() {
+    return [
+        {
+            content: "Select contact form",
+            trigger: ":iframe #wrap.o_editable section.s_website_form",
+            run: "click",
+        },
+        {
+            trigger: ".o-snippets-menu .o-snippets-tabs [data-name='customize'].active",
+        },
+        {
+            content: "Open action select",
+            trigger:
+                ".o-snippets-menu [data-container-title='Block'] [data-label='Action'] .dropdown-toggle",
+            run: "click",
+        },
+        {
+            content: "Select 'Create an Opportunity' as form action",
+            trigger: ".o_popover [data-action-id='selectAction']:contains('Create an Opportunity')",
+            run: "click",
+        },
+    ];
+}
+
+registerWebsitePreviewTour(
+    "website_crm_pre_tour",
+    {
+        url: "/contactus",
+        edition: true,
+    },
+    () => [
+        ...setFormActionToCreateOpportunity(),
+        ...clickOnSave(),
+        {
+            content: "Ensure form model has changed and page reload is done after save",
+            trigger: ":iframe section.s_website_form form[data-model_name='crm.lead']",
+        },
+    ]
+);
 
 registry.category("web_tour.tours").add('website_crm_tour', {
     url: '/contactus',
@@ -90,3 +104,51 @@ registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_t
     content: "Check we were redirected to the success page",
     trigger: "#wrap:has(h1:contains('Thank You!'))",
 }]});
+
+
+registerWebsitePreviewTour(
+    "website_crm_form_properties",
+    {
+        url: "/contactus",
+        edition: true,
+    },
+    () => [
+        ...setFormActionToCreateOpportunity(),
+        {
+            content: "Open Sales Team select",
+            trigger:
+                ".o-snippets-menu [data-container-title='Block'] [data-label='Sales Team'] .dropdown-toggle",
+            run: "click",
+        },
+        {
+            content: "Select 'Sales' as Sales Team",
+            trigger: ".o_popover [data-action-id='addActionField']:contains(Test Sales Team)",
+            run: "click",
+        },
+        {
+            content: "Wait the form is patched with values before continue to edit it",
+            trigger: ":iframe form#contactus_form input[name=team_id]:not(:visible)",
+        },
+        {
+            content: "Add a new field to the form",
+            trigger: "button:contains(+ Field)",
+            run: "click",
+        },
+        {
+            content: "Open field Type selector",
+            trigger: "[data-container-title=Field] button#type_opt",
+            run: "click",
+        },
+        {
+            content: "Select a property field",
+            trigger: ".o_popover [data-action-id=existingField]:contains(test property)",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Check that there is no traceback",
+            trigger: "body:not(:has(.o_error_dialog))",
+            run: "click",
+        },
+    ]
+);

--- a/addons/website_crm/tests/test_website_crm.py
+++ b/addons/website_crm/tests/test_website_crm.py
@@ -2,10 +2,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo.addons.crm.tests.common import TestCrmCommon
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestWebsiteCrm(odoo.tests.HttpCase):
+class TestWebsiteCrm(odoo.tests.HttpCase, TestCrmCommon):
 
     def test_tour(self):
         all_utm_campaign = self.env['utm.campaign'].search([])
@@ -54,3 +55,12 @@ class TestWebsiteCrm(odoo.tests.HttpCase):
         # check partner has not been changed
         self.assertEqual(user_partner.email, partner_email)
         self.assertEqual(user_partner.phone, partner_phone)
+
+    def test_form_properties(self):
+        self.lead_1.lead_properties = [{
+            'definition_changed': True,
+            'name': 'test',
+            'string': 'test property',
+            'type': 'char',
+        }]
+        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_crm_form_properties', login='admin')


### PR DESCRIPTION
[FIX] website, website_crm: fix crash on save if property field in form
---

__Before commit:__
1. Go to CRM app
2. Open a lead
3. Add a new property field by clicking on the cogwheel at the top left
and then *Edit Properties*
4. Open the website builder
5. Drag a new form
    - Set *Action* to *Create an Opportunity*
    - Set *Sales Team* to *Sales*
6. Add a new field and set *Type* to the newly created property field
7. Save
=> Traceback:
`ValueError: Unable to whitelist field(s) ['xxxx'] for model 'crm.lead'`

__Cause:__
We are trying to whitelist a property field which is not an actual field
to the `crm.lead` model but rather a property of one of the `crm.team`.

__Fix:__
Filter the property fields to whitelist.

---

[FIX] html_builder: make builder_list work with non-integer ids
---
__Before commit:__
1. Go to CRM app
2. Open a lead
3. Click on the cogwheel at the top left and then on *Edit Properties*
    - Set *Field Type* to *Selection*
    - Add two values
4. Open the website builder
5. Drag a new form
    - Set *Action* to *Create an Opportunity*
    - Set *Sales Team* to *Sales*
6. Add a new field and set *Type* as the newly created property field
7. Click on *Add New Radio*
=> There are still items to add although there are already all included.
8. Click on an item
=> Two tracebacks appear:
- `TypeError: Cannot use 'in' operator to search for '_id' in null`
- `TypeError: Cannot read properties of null (reading 'id')`

__Cause:__
When adding item to the selection, the id is casted to `Number` although
it can be a string if the field type is a property.

__Fix:__
When comparing two ids, cast both side of the comparison to strings to
make sure a match can always be found.

task-5248526