### PR TITLE
[FIX] sale_stock_margin: compute correct margin in SOL when uom

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -23,8 +23,9 @@ class SaleOrderLine(models.Model):
                 else:
                     qty_from_std_price = max(line.product_uom_qty - qty_from_delivery, 0)
                     purch_price = (qty_from_delivery * price_unit_from_delivery + qty_from_std_price * product.standard_price) / (qty_from_delivery + qty_from_std_price)
+                purch_price_uom = line.product_id.uom_id._compute_price(purch_price, line.product_uom_id)
                 line.purchase_price = line._convert_to_sol_currency(
-                    purch_price,
+                    purch_price_uom,
                     product.cost_currency_id,
                 )
             elif not line.product_uom_qty and line.qty_delivered:

--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -464,6 +464,24 @@ class TestSaleStockMargin(TestStockValuationCommon):
         self.assertEqual(first_delivery.state, 'done')
         self.assertEqual(sale_order_line.purchase_price, 10)
 
+    def test_avco_different_uom(self):
+        pack_of_6 = self.ref('uom.product_uom_pack_6')
+        self.product_avco.write({
+                'standard_price': 1,
+                'list_price': 3,
+                'uom_ids': [pack_of_6],
+            })
+        sale_order = self._create_sale_order()
+        sale_order_line = self.env['sale.order.line'].create({
+            'name': 'Sale order',
+            'order_id': sale_order.id,
+            'product_id': self.product_avco.id,
+            'product_uom_qty': 1,
+            'product_uom_id': pack_of_6,
+        })
+        sale_order.action_confirm()
+        self.assertEqual(sale_order_line.margin, 12.0)
+
     def test_avco_calc(self):
         """ test purchase_price and margin correct calculation for avco product"""
         # need to freezetime due to test being too fast resulting in inconsistent AVCO calculation for in/out moves having the same exact validation date


### PR DESCRIPTION
**Problem:**
Sale order margin not computed correctly after confirm

**Steps to reproduce:**
- enable the margins setting
- create a new storable product with avco category
- set Sale Price to 3 and cost to 1 (remove taxes)
- In the Sales Tab, in packagings add pack of 6
- create a sale order for 1 pack of 6
- unhide the margin% column
- see how it is rightly computed (66%)
- confirm the sale order 

**Current behavior:**
The margin is now 94%

**Expected behavior:**
It should not have changed when confirming

**Cause of the issue:**
Because we confirmed the sale order line, it now 
has valued move, so the pruchase_price will be computed 
inside the sale_stock_margin override of 
_compute_purchase_price().
https://github.com/odoo/odoo/blob/38cffd1d1580693c56f0d897b8c8e60b938a8e85/addons/sale_stock_margin/models/sale_order_line.py#L15
There is currently no mechanism to take the UoM into 
account inside this override.

opw-5344915