### PR TITLE
[FIX] stock_account: preserve fractional remaining qty/value on stock move

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -394,7 +394,7 @@ class ProductProduct(models.Model):
         if lot:
             fifo_stack_size = lot.product_qty
         else:
-            fifo_stack_size = int(self._with_valuation_context().with_context(to_date=at_date).qty_available)
+            fifo_stack_size = self._with_valuation_context().with_context(to_date=at_date).qty_available
         if fifo_stack_size <= 0:
             return fifo_stack, 0
 
@@ -414,7 +414,7 @@ class ProductProduct(models.Model):
             moves_domain &= Domain([('is_in', '=', True)])
 
         # Base limit to 100 to avoid issue with other UoM than Unit
-        initial_limit = fifo_stack_size * 10
+        initial_limit = int(fifo_stack_size * 10)
         unit_uom = self.env.ref('uom.product_uom_unit', raise_if_not_found=False)
         if unit_uom and self.uom_id != unit_uom:
             initial_limit = max(initial_limit, 100)

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -280,6 +280,16 @@ class TestStockValuation(TestStockValuationCommon):
         self.assertEqual(move8.remaining_qty, 0.0)  # unused in internal moves
         self.assertEqual(move9.remaining_qty, 0.0)  # unused in out moves
 
+    def test_fifo_perpetual_3(self):
+        """ Ensure correct fifo valuation for non-integer quantities
+        """
+        product = self.product_fifo
+
+        move1 = self._make_in_move(product, 1.9, 10)
+
+        self.assertAlmostEqual(move1.remaining_qty, 1.9)
+        self.assertAlmostEqual(move1.remaining_value, 19)
+
     def test_fifo_negative_1(self):
         """ Send products that you do not have. Value the first outgoing move to the standard
         price, receive in multiple times the delivered quantity and run _fifo_vacuum to compensate.


### PR DESCRIPTION
Problem:
When valued products are moved in fractional quantities, the "Valuation" report under Inventory > Reporting > Stock > Total Value will show the wrong computed value for both the Remaining Quantity and Remaining Value (`remaining_qty` and `remaining_value` on stock.move). This is due to an `int` cast while computing remaining quantity, which then affects the remaining value calculated on this report.

Solution:
Move the `int` cast to a more appropriate location in the `_run_fifo_get_stack` logic so that the remaining quantity is preserved.

Steps to reproduce (Runbot 19.0)
- Product with:
	- Inventory tracked by quantity
	- Non-zero standard price (e.g. $1)
1. Add a fractional quantity on hand with an inventory adjustment (e.g. 1.9)
2. Navigate to Inventory > Reporting > Stock, click the number for Total Value on the product (will be $1.90)

On this menu with the example data, Remaining Quantity will be 1.00, and remaining value will be $1.00.

opw-5230435
