### PR TITLE
18.0 fix website add social fields slg

### DIFF
--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -42,6 +42,17 @@
                                 <label for="custom_code_footer"/>
                                 <field name="custom_code_footer" widget="code" options="{'mode': 'xml'}"/>
                             </page>
+                            <page string="Social Media" name="page_social_media" groups="base.group_no_one">
+                                <group>
+                                    <field name="social_twitter"/>
+                                    <field name="social_facebook"/>
+                                    <field name="social_github"/>
+                                    <field name="social_linkedin"/>
+                                    <field name="social_youtube"/>
+                                    <field name="social_instagram"/>
+                                    <field name="social_tiktok"/>
+                                </group>
+                            </page>
                         </notebook>
                     </sheet>
                 </form>


### PR DESCRIPTION
Trivial PR.

**Description**

[FIX] website: Add social fields on website form view.

**rational**

website model have all social fields. (The Same fields are introduced by social_media module on 'res.company' model).

When creating a website, the default website fields are initialized by the comapny values.
However, if a value change, or is initialized after the creation of the website, there is no way to put the correct value on the 'website' model.


**Description of the issue/feature this PR addresses:**

- Install website module
- go to company form and change twitter / facebook url
- Go back on website and click on twitter / ... url

**Current behavior before PR:**
- The old URL is used

**Desired behavior after PR is merged:**
- The new URL should be used.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
