### PR TITLE
[FIX] website_sale_stock: fixes the no margin bottom issue

### DIFF
--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -7,7 +7,7 @@
             id="product_stock_availability"
         >
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} d-flex flex-column gap-2">
-                <div id="out_of_stock_message">
+                <div id="out_of_stock_message" class="mb-3">
                     <t t-if="has_out_of_stock_message">
                         <div class="d-inline-flex align-items-center badge text-bg-danger text-wrap">
                             <i class="fa fa-circle text-danger me-2"/>


### PR DESCRIPTION
The out_of_stock_message div doesn't have a margin bottom, 
and it looks like something is off in the product page.

Steps To Reproduce:
1.Go to a product with no inventory.
2.Add a out-of-stock message in the sale tab.
3.Go to the product page on the website.
We can see that the message div has no margin bottom.

To fix this we just add a margin bottom, as it was before.

The PR that affected the margin bottom:
https://github.com/odoo/odoo/pull/220506

opw-5259994