### PR TITLE
[FIX] l10n_sa_pos: prevent error when creating consolidated POS invoices

### DIFF
--- a/addons/l10n_sa_pos/models/pos_order.py
+++ b/addons/l10n_sa_pos/models/pos_order.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import fields, models
 
 
 class PosOrder(models.Model):
@@ -10,5 +10,6 @@ class PosOrder(models.Model):
     def _prepare_invoice_vals(self):
         vals = super()._prepare_invoice_vals()
         if self.company_id.country_id.code == 'SA':
-            vals.update({'l10n_sa_confirmation_datetime': self.date_order})
+            confirmation_datetime = self.date_order if len(self) == 1 else fields.Datetime.now()
+            vals['l10n_sa_confirmation_datetime'] = confirmation_datetime
         return vals

--- a/addons/l10n_sa_pos/tests/test_sa_pos.py
+++ b/addons/l10n_sa_pos/tests/test_sa_pos.py
@@ -1,4 +1,5 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
 from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
 from odoo.tests import tagged
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
@@ -64,3 +65,36 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.skipTest("The needed configuration for e-invoices is not available")
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_sa_qr_is_shown', login="pos_admin")
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestSaPosInvoice(TestPoSCommon, TestPointOfSaleHttpCommon):
+
+    def test_consolidate_invoices_for_same_customer(self):
+        """
+        Test that consolidated invoicing for multiple POS orders of the same customer
+        succeeds and sets the confirmation datetime for a Saudi Arabia company.
+        """
+        self.config = self.basic_config
+        self.env.company.country_id = self.env.ref('base.sa')
+
+        self.open_new_session()
+        pos_orders = sum(self._create_orders([
+            {
+                'pos_order_lines_ui_args': [(self.product_a, 1)],
+                'customer': self.customer,
+                'is_invoiced': False,
+            }
+            for _ in range(2)
+        ]).values(), self.env['pos.order'])
+
+        self.env['pos.make.invoice'].create({"consolidated_billing": True}).with_context({
+            "active_ids": pos_orders.ids
+        }).action_create_invoices()
+        invoice = pos_orders.account_move
+
+        self.assertTrue(invoice, "A consolidated invoice should have been created")
+        self.assertTrue(
+            invoice.l10n_sa_confirmation_datetime,
+            "The consolidated invoice should have l10n_sa_confirmation_datetime set"
+        )


### PR DESCRIPTION
Currently, an error occurs when trying to create a consolidated invoice for 
multiple POS orders associated with the same customer.

**Steps to reproduce:**

- Install the `l10n_sa_pos` module and switch to the `SA company`.
- Create two POS orders for the `same customer` without invoicing at checkout.
- Close the POS session and go to `Point of Sale` > `Orders`.
- Select both orders > click `Create Invoice` > `confirm` the action. (Make sure `Consolidated Billing` is enabled)

**Error:**
`ValueError: Expected singleton: pos.order(8, 7)`

**Root cause:**
At [1], the code accesses `self.date_order`, but when `consolidated billing` is 
enabled, self contains multiple POS orders, causing an `error`.

**Fix:**
This commit prevents the error by ensuring that the `current datetime` 
is assigned when creating a `consolidated invoice`, same as [2].

[1]:
https://github.com/odoo/odoo/blob/583bacdc8ad2b87b99b11d1e12dacf6e42edf22b/addons/l10n_sa_pos/models/pos_order.py#L13

[2]:
https://github.com/odoo/odoo/blob/583bacdc8ad2b87b99b11d1e12dacf6e42edf22b/addons/point_of_sale/models/pos_order.py#L828-L832

opw-5266908