### PR TITLE
[FIX] html_editor, website: close link popover on snippet remove

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -228,7 +228,7 @@ export class LinkPopover extends Component {
         useExternalListener(this.props.document, "pointerdown", onPointerDown);
         if (this.props.document !== document) {
             // Listen to pointerdown outside the iframe
-            useExternalListener(document, "pointerdown", onPointerDown);
+            useExternalListener(document, "pointerdown", onPointerDown, { capture: true });
         }
     }
 

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -1,8 +1,8 @@
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
-import { setContent } from "@html_editor/../tests/_helpers/selection";
+import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
 import { expect, test } from "@odoo/hoot";
-import { Deferred, tick } from "@odoo/hoot-dom";
+import { Deferred, queryOne, tick, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
@@ -151,6 +151,38 @@ test("Use the 'remove' overlay buttons: removing a grid item", async () => {
     expect(":iframe .row.o_grid_mode").toHaveAttribute("data-row-count", "4");
     expect(".overlay .oe_snippet_remove").toHaveCount(1);
     expect(".oe_overlay.oe_active").toHaveRect(":iframe .o_grid_item");
+});
+
+test("Use the 'remove' overlay buttons: closes the link popover if it is open during snippet removal", async () => {
+    await setupWebsiteBuilder(`
+        <section>
+            <div class="container">
+                <div class="row o_grid_mode" data-row-count="14">
+                    <div class="o_grid_item g-height-4 g-col-lg-7 col-lg-7" style="grid-area: 1 / 1 / 5 / 8; z-index: 1;">
+                        <p>TEST</p>
+                    </div>
+                    <div class="o_grid_item g-height-14 g-col-lg-5 col-lg-5" style="grid-area: 1 / 8 / 15 / 13; z-index: 2;">
+                        <p>TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    `);
+
+    await contains(":iframe .g-height-14").click();
+    const p = queryOne(":iframe .g-height-14 p");
+    setSelection({ anchorNode: p, anchorOffset: 0, focusNode: p, focusOffset: 1 });
+    await waitFor(".o-we-toolbar");
+    await contains('.o-we-toolbar button[name="link"]').click();
+    expect(".o-we-linkpopover").toHaveCount(1);
+    expect(".overlay .o_overlay_options").toHaveCount(1);
+    expect(".overlay .oe_snippet_remove").toHaveCount(1);
+
+    // Check that the link popover is closed and the element has been removed.
+    await contains(".overlay .oe_snippet_remove").click();
+    expect(".o-we-linkpopover").toHaveCount(0);
+    expect(":iframe .g-height-14").toHaveCount(0);
+    expect(".overlay .oe_snippet_remove").toHaveCount(1);
 });
 
 test("Use the 'remove' overlay buttons: removing the last element will remove the parent", async () => {


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- When removing, duplicating, or moving a snippet, the link popover stayed open because its `pointerdown` handler didn’t trigger, leaving the popover visible even after its selected content element was removed.

#### Desired behavior after PR is merged:

- Use { capture: true } on the link popover’s pointerdown listener so it always receives the event before overlay actions.
- This ensures the popover closes when clicking anywhere on the document, including overlay options.

task-5359000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
