### PR TITLE
[IMP] account:  Improve usability of "Exclude from Follow-up"

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1194,11 +1194,11 @@ class AccountMoveLine(models.Model):
             aml.no_followup = aml.move_id.is_entry() and not aml.move_id.origin_payment_id
 
     def _inverse_no_followup(self):
-        # If one line of an invoice gets excluded from or included in the follow up report, we want all
-        # payable/receivable lines of that invoice to do the same.
+        # If one line of an entry gets excluded from or included in the follow up report, we want all
+        # payable/receivable lines of that entry to do the same.
         for aml in self:
             move = aml.move_id
-            if move.is_invoice():
+            if not move.is_receipt():
                 move.no_followup = aml.no_followup
 
     def _search_payment_date(self, operator, value):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1015,6 +1015,7 @@
                                        invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')" />
                                 <field name="ref" default_focus="1" nolabel="1" invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')"/>
                                 <field name="ref" default_focus="1" invisible="move_type != 'entry'"/>
+                                <field name="no_followup" widget="boolean_toggle" invisible="not display_no_followup" readonly="state != 'draft'"/>
                                 <field name="tax_cash_basis_origin_move_id" invisible="not tax_cash_basis_origin_move_id"/>
                                 <label name="invoice_vendor_bill_id_label" for="invoice_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
                                        invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"/>


### PR DESCRIPTION
This commit implements multiple improvements around the `no_followup`
functionality to ensure misc entries and invoice-related moves behave
consistently across Follow-up Report, Client Portal, and PoS.

Main changes:
-Removed default journal filters from the Follow-up Report for a cleaner view.
-Display the “No Follow-up” field on miscellaneous entries whenever at least
 one line impacts a receivable account.
-Client Portal only shows invoices that are meant for follow-up.
-PoS balance includes entries that should be followed up.
-“Settle Invoices” lists only invoices that require follow-up.

Impact:
-Avoids showing invoices that should not appear in follow-up flows.
-Makes the experience more consistent across Follow-up report, Client Portal,
 and PoS.

Related enterprise PR: https://github.com/odoo/enterprise/pull/100685

task-5149502