### PR TITLE
[IMP] point_of_sale: adjust QR image and modal size

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_facing_qr.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_facing_qr.xml
@@ -2,13 +2,15 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.CustomerFacingQR">
         <Dialog
+            size="'md'"
             footer="false"
             header="false"
             bodyClass="'w-100 h-100 d-flex flex-column justify-content-center align-items-center'"
         >
             <div class="text-center">
                 <p t-out="title"/>
-                <img class="pos-customer_payment_qr_code my-1" t-att-src="props.qrCode" alt="QR Code"/>
+                <img class="pos-customer_payment_qr_code my-1" t-att-src="props.qrCode" alt="QR Code"
+                    style="width: 200px; height: 200px;"/>
             </div>
             <div class="text-center">
                 <div>


### PR DESCRIPTION
QR code generated for customer display in Odoo POS is considered too small, therefore need size adjustment for enhanced visibility and user experience. Sizing is adjusted to be more uniformed with the backend popup.

task-[5262218](https://www.odoo.com/odoo/project.task/5262218)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
