### PR TITLE
[FIX] website_sale: Fixed error for bool object attribute

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -48,8 +48,8 @@ class Website(models.Model):
         template_id = self.env['ir.config_parameter'].sudo().get_param(
             'sale.default_confirmation_template'
         )
-        default_template = template_id and self.env['mail.template'].browse(int(template_id))
-        if default_template.exists():
+        default_template = template_id and self.env['mail.template'].browse(int(template_id)).exists()
+        if default_template:
             return default_template
         return self.env.ref('sale.mail_template_sale_confirmation', raise_if_not_found=False)
 


### PR DESCRIPTION
When there is no default confirmation template,
An error is raised:
AttributeError: 'bool' object has no attribute 'exists'. This happens because default_template is False,
So calling default_template.exists() results in the error. The issue occurs during the upgrade process.

```
File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3142, in _init_column
    value = field.default(self)
  File "/home/odoo/src/odoo/19.0/addons/website_sale/models/website.py", line 52, in _default_confirmation_email_template
    if default_template.exists():
AttributeError: 'bool' object has no attribute 'exists'
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
