### PR TITLE
[FIX] project: remove duplicate 'Comment' field in customer rating form

### DIFF
--- a/addons/project/views/rating_rating_views.xml
+++ b/addons/project/views/rating_rating_views.xml
@@ -51,6 +51,12 @@
             <field name="feedback" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>
+            <xpath expr="//label[@for='publisher_comment']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='publisher_comment']/parent::div" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <field name="rated_on" position="after">
                 <field name="partner_id" position="move"/>
             </field>


### PR DESCRIPTION
**Steps to reproduce:**
- Enable the customer rating from project's setting.
- Go to project > Reporting > Customer Ratings.
- Open any rating record.
- Observe that the 'Comment' field is displayed twice.

**Issue:**
- The form view contains a two different field with same string i.e feedback and publisher_comment

**Fix:**
- Made the publisher_comment field invisible in project's customer rating

**Task-id: 5359052**