### PR TITLE
[FIX] l10n_it_edi: fix storing errors sent from Italian e-invoicing

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -122,7 +122,7 @@ class AccountMoveSend(models.AbstractModel):
                 attachment['raw'] = signed_data.encode()
                 # Show that those moves couldn't be sent
             if 'error_message' in attachment_data:
-                moves_data[move]['error'] = attachment_data['error_message']
+                moves_data[move]['error'] = {'error_title': attachment_data['error_message']}
 
     def _link_invoice_documents(self, invoices_data):
         # EXTENDS 'account'


### PR DESCRIPTION
If an invoice sent through the Italian EDI gets rejected, a traceback appears: 

```
`errors = '\n- '.join(error.get('errors', ''))
^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'`
```
`moves_data[move]['error']` shouldn't be a string, as `_hook_if_errors()` expects a dictionary from  this PR odoo/odoo#224267 on.
We restore the functionality by changing the error type.

Ticket [link](https://www.odoo.com/odoo/project.task/5271525)
opw-5271525