### PR TITLE
[FIX] html_editor: fix tripleclick on checkbox

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -243,9 +243,13 @@ export class SelectionPlugin extends Plugin {
         this.activeSelection = this.makeActiveSelection();
     }
 
-    onTripleClick() {
+    onTripleClick(ev) {
         const selectionData = this.getSelectionData();
         if (selectionData.documentSelectionIsInEditable) {
+            if (this.delegateTo("triple_click_overrides", ev)) {
+                // If the override is handled, we don't do anything.
+                return;
+            }
             const { documentSelection } = selectionData;
             const block = closestBlock(documentSelection.anchorNode);
             const [anchorNode, anchorOffset] = getDeepestPosition(block, 0);

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -126,6 +126,7 @@ export class ListPlugin extends Plugin {
         tab_overrides: this.handleTab.bind(this),
         shift_tab_overrides: this.handleShiftTab.bind(this),
         split_element_block_overrides: this.handleSplitBlock.bind(this),
+        triple_click_overrides: this.handleTripleClick.bind(this),
         node_to_insert_processors: this.processNodeToInsert.bind(this),
         before_insert_within_pre_processors: this.insertListWithinPre.bind(this),
     };
@@ -935,5 +936,15 @@ export class ListPlugin extends Plugin {
             pointerOffsetY >= checkboxPosition.top &&
             pointerOffsetY <= checkboxPosition.bottom
         );
+    }
+
+    handleTripleClick(ev) {
+        const node = ev.target;
+        const isChecklistItem =
+            node.tagName === "LI" && this.getListMode(node.parentElement) === "CL";
+        if (isChecklistItem && this.isPointerInsideCheckbox(node, ev.offsetX, ev.offsetY)) {
+            // If pointer is inside checkbox, prevent tripleclick selection.
+            return true;
+        }
     }
 }

--- a/addons/html_editor/static/tests/list/checklist.test.js
+++ b/addons/html_editor/static/tests/list/checklist.test.js
@@ -2,7 +2,7 @@ import { test } from "@odoo/hoot";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { clickCheckbox, pasteHtml } from "../_helpers/user_actions";
-import { click } from "@odoo/hoot-dom";
+import { click, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
 
 test("should do nothing if do not click on the checkbox", async () => {
     await testEditor({
@@ -86,6 +86,38 @@ test("should uncheck an empty item", async () => {
         contentAfter: unformat(`
             <ul class="o_checklist">
                 <li class="o_checked">[]<br></li>
+            </ul>`),
+    });
+});
+
+test("tripleclick on checkbox should not select the list content", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+            <ul class="o_checklist">
+                <li>test</li>
+            </ul>`),
+        stepFunction: async (editor) => {
+            const li = editor.editable.querySelector("li");
+            const { top, left } = li.getBoundingClientRect();
+            await manuallyDispatchProgrammaticEvent(li, "mousedown", {
+                detail: 3,
+                clientX: left - 10,
+                clientY: top + 10,
+            });
+            await manuallyDispatchProgrammaticEvent(li, "mouseup", {
+                detail: 3,
+                clientX: left - 10,
+                clientY: top + 10,
+            });
+            await manuallyDispatchProgrammaticEvent(li, "click", {
+                detail: 3,
+                clientX: left - 10,
+                clientY: top + 10,
+            });
+        },
+        contentAfter: unformat(`
+            <ul class="o_checklist">
+                <li class="o_checked">[]test</li>
             </ul>`),
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**

Currently, triple clicking on a checkbox in a checklist item ends up selecting the list content. This happens because in `selection_plugin` `onTripleClick` handler selects the whole list item.

**Desired behavior after PR is merged:**

This PR ensures that `onTripleClick` in `selection_plugin` does nothing if tripleclick is triggered when checking a box.

task-5361579





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
