### PR TITLE
[FIX] pos_*: remove duplicate customer details from receipt

### DIFF
--- a/addons/l10n_in_pos/static/src/app/components/receipt/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/app/components/receipt/pos_receipt.xml
@@ -3,7 +3,7 @@
     <t t-name="l10n_in_pos.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
             <t t-if="order.partner_id and order.company?.country_id?.code == 'IN'">
-                <div class="pos-receipt-center-align">
+                <div class="receipt-customer-contact pos-receipt-center-align">
                     <div t-if="order.preset_id?.identification != 'address'" t-out="order.partner_id.name"/>
                     <t t-if="order.partner_id.phone">
                         <div>
@@ -11,7 +11,6 @@
                             <t t-out="order.partner_id.phone" />
                         </div>
                     </t>
-                    <br />
                 </div>
             </t>
         </xpath>

--- a/addons/pos_loyalty/static/src/app/components/receipt/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/components/receipt/order_receipt/order_receipt.xml
@@ -27,12 +27,6 @@
                     </div>
                 </t>
             </t>
-            <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
-                <div class="d-flex pt-3" style="font-size: 75%;">
-                    <span>Customer</span>
-                    <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
-                </div>
-            </t>
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
                 <div class="pos-coupon-rewards pt-3">
                     <t t-foreach="order.new_coupon_info" t-as="coupon_info" t-key="coupon_info.code">


### PR DESCRIPTION
pos_*: pos_loyalty, l10n_in_pos
### Before this commit:
- The `pos_loyalty` module added an extra customer information block.
- Since the POS receipt already displays customer details in the receipt header, this resulted in the same information appearing twice.

### After this commit:
- The additional customer info block is removed from the `pos_loyalty` receipt.
- The receipt header now shows customer details only once, avoiding duplication for receipts.

Task - 5353203

Related PR:
- Enterprise: https://github.com/odoo/enterprise/pull/100698