### PR TITLE
[FIX] project:  Correct shortcut conflict between New and Share buttons

### DIFF
--- a/addons/project/static/src/views/components/project_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_template_dropdown.js
@@ -22,7 +22,7 @@ export class ProjectTemplateDropdown extends Component {
         },
     };
     static defaultProps = {
-        hotkey: "r",
+        hotkey: "c",
         isDisabled: false,
     };
 


### PR DESCRIPTION
Steps to Reproduce:
-

 - Go to Project → open any project.
 - Press Alt key to display shortcut hints.
 - Both New and Share buttons show the same shortcut.

Issue:
-

 The New button and the Share Project button use the same shortcut, leading to a conflict.

Cause:
-

 The New button and the Share Project button share the same shortcut (Alt+R) causing the wrong action to trigger.

Solution:
-

 Changed the shortcut for the New button from Alt+R to Alt+C to avoid conflict and ensure correct behavior.

task-5270075