### PR TITLE
[IMP] html_builder, mass_mailing, website: add slider to resize media

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.js
@@ -3,6 +3,7 @@ import { ImageShapeOption } from "@html_builder/plugins/image/image_shape_option
 import { ImageFilterOption } from "@html_builder/plugins/image/image_filter_option";
 import { ImageFormatOption } from "@html_builder/plugins/image/image_format_option";
 import { ImageTransformOption } from "./image_transform_option";
+import { MediaSizeOption } from "./media_size_option";
 
 export class ImageToolOption extends BaseOptionComponent {
     static template = "html_builder.ImageToolOption";
@@ -11,6 +12,7 @@ export class ImageToolOption extends BaseOptionComponent {
         ImageFilterOption,
         ImageFormatOption,
         ImageTransformOption,
+        MediaSizeOption,
     };
     static selector = "img";
     static exclude = "[data-oe-type='image'] > img";

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -24,18 +24,7 @@
         <ImageTransformOption t-if="!state.isImageAnimated" />
     </BuilderRow>
     <ImageFilterOption />
-    <t t-if="!state.isGridMode">
-        <BuilderRow label.translate="Size">
-            <BuilderSelect styleAction="'width'">
-                <BuilderSelectItem styleActionValue="''" title.translate="Resize Default">Default</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'100%'" title.translate="Resize Full">100%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'75%'" title.translate="Resize 75%">75%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'50%'" title.translate="Resize Half">50%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'25%'" title.translate="Resize Quarter">25%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'10%'" title.translate="Resize 10%">10%</BuilderSelectItem>
-            </BuilderSelect>
-        </BuilderRow>
-    </t>
+    <MediaSizeOption/>
     <ImageFormatOption />
 </t>
 

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -2,6 +2,7 @@ import { cropperDataFieldsWithAspectRatio, loadImage } from "@html_editor/utils/
 import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { ImageToolOption } from "./image_tool_option";
+import { VideoSizeOption } from "./video_size_option";
 import { isImageCorsProtected } from "@html_editor/utils/image";
 import { withSequence } from "@html_editor/utils/resource";
 import {
@@ -40,6 +41,7 @@ class ImageToolOptionPlugin extends Plugin {
         builder_options: [
             withSequence(REPLACE_MEDIA, ReplaceMediaOption),
             withSequence(IMAGE_TOOL, ImageToolOption),
+            withSequence(IMAGE_TOOL, VideoSizeOption),
             withSequence(ALIGNMENT_STYLE_PADDING, ImageAndFaOption),
         ],
         builder_actions: {

--- a/addons/html_builder/static/src/plugins/image/media_size_option.js
+++ b/addons/html_builder/static/src/plugins/image/media_size_option.js
@@ -1,0 +1,5 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+
+export class MediaSizeOption extends BaseOptionComponent {
+    static template = "html_builder.MediaSizeOption";
+}

--- a/addons/html_builder/static/src/plugins/image/media_size_option.xml
+++ b/addons/html_builder/static/src/plugins/image/media_size_option.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.MediaSizeOption">
+    <BuilderRow label.translate="Size">
+        <div style="width: 50%;">
+            <BuilderRange
+                action="'mediaSizeSlider'"
+                min="10"
+                max="100"
+                step="1" />
+        </div>
+        <div style="width: 35%;">
+            <BuilderTextInput
+                action="'mediaSizeText'" 
+                placeholder="'auto'"
+            />
+        </div>
+        <BuilderButton
+            title.translate="Auto"
+            action="'setMediaSizeAuto'">
+            <i class="fa fa-fw fa-expand" />
+        </BuilderButton>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/plugins/image/media_size_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/media_size_option_plugin.js
@@ -1,0 +1,75 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+class MediaSizeOptionPlugin extends Plugin {
+    static id = "MediaSizeOptionPlugin";
+    resources = {
+        builder_actions: {
+            MediaSizeSliderAction,
+            MediaSizeTextAction,
+            SetMediaSizeAutoAction,
+        },
+    };
+}
+
+function setWidth(getAction, editingElement, value) {
+    getAction("styleAction").apply({
+        editingElement,
+        params: {
+            mainParam: "width",
+        },
+        value: value,
+    });
+}
+
+export class MediaSizeSliderAction extends BuilderAction {
+    static id = "mediaSizeSlider";
+    static dependencies = ["builderActions"];
+    getValue({ editingElement }) {
+        return parseInt(editingElement.style.width) || 100;
+    }
+    apply({ editingElement, value }) {
+        setWidth(this.dependencies.builderActions.getAction, editingElement, value + "%");
+    }
+}
+
+export class MediaSizeTextAction extends BuilderAction {
+    static id = "mediaSizeText";
+    static dependencies = ["builderActions"];
+    getValue({ editingElement }) {
+        // If width is set to "auto", we return an empty string to display the
+        // text input placeholder.
+        const width = editingElement.style.width;
+        return width === "auto" ? "" : width;
+    }
+    apply({ editingElement, value }) {
+        if (value === "") {
+            setWidth(this.dependencies.builderActions.getAction, editingElement, "auto");
+            return;
+        }
+        if (value.endsWith("%")) {
+            value = value.slice(0, -1);
+        }
+        if (isNaN(value) || value == 0) {
+            setWidth(this.dependencies.builderActions.getAction, editingElement, "auto");
+            return;
+        }
+        value = Math.min(Math.max(value, 10), 100);
+        setWidth(this.dependencies.builderActions.getAction, editingElement, value + "%");
+    }
+}
+
+export class SetMediaSizeAutoAction extends BuilderAction {
+    static id = "setMediaSizeAuto";
+    static dependencies = ["builderActions"];
+    isApplied({ editingElement }) {
+        // The "Auto" button is active when width is auto or not set
+        return editingElement.style.width === "auto" || editingElement.style.width === "";
+    }
+    apply({ editingElement }) {
+        setWidth(this.dependencies.builderActions.getAction, editingElement, "auto");
+    }
+}
+
+registry.category("builder-plugins").add(MediaSizeOptionPlugin.id, MediaSizeOptionPlugin);

--- a/addons/html_builder/static/src/plugins/image/video_size_option.js
+++ b/addons/html_builder/static/src/plugins/image/video_size_option.js
@@ -1,0 +1,7 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+
+export class VideoSizeOption extends BaseOptionComponent {
+    static template = "html_builder.MediaSizeOption";
+    static selector = ".media_iframe_video";
+    static name = "videoSizeOption";
+}

--- a/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
@@ -16,7 +16,7 @@
             <attribute name="withAnimatedShapes">false</attribute>
         </xpath>
         <xpath expr="//ImageTransformOption" position="replace"/>
-        <xpath expr="//BuilderRow[@label.translate=&quot;Size&quot;]" position="attributes">
+        <xpath expr="//MediaSizeOption" position="attributes">
             <attribute name="t-if">massMailingState.isImgFluid</attribute>
         </xpath>
     </t>

--- a/addons/website/static/src/builder/plugins/image/image_tool_option.xml
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option.xml
@@ -1,7 +1,7 @@
 <templates>
     <t t-inherit="html_builder.ImageToolOption" t-inherit-mode="extension">
         <!-- Hide the image "Size" option when card cover width control is available -->
-        <xpath expr="//BuilderRow[@label.translate='Size']" position="attributes">
+        <xpath expr="//MediaSizeOption" position="attributes">
             <attribute name="t-if">!this.env.getEditingElement().closest('.o_card_img_wrapper')</attribute>
         </xpath>
     </t>

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { waitFor } from "@odoo/hoot-dom";
+import { animationFrame, clear, fill, press, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { testImg, testImgSrc, testGifImg, testGifImgSrc } from "./image_test_helpers";
@@ -59,4 +59,350 @@ test("the GIF background image should NOT show its size", async () => {
     await contains(":iframe .test-options-target section").click();
     await waitSidebarUpdated();
     expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+});
+
+test("images can be resized by slider, text input and button", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testImg}
+        </div>
+    `);
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-action-id='mediaSizeSlider'] input").toHaveValue(99);
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("9");
+    await animationFrame();
+    //min width is clipped to 10%
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "10% !important" },
+        { inline: true }
+    );
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("110");
+    await animationFrame();
+    //max width is clipped to 100%
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "100% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("50");
+    await animationFrame();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "50% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
+    await animationFrame();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeSlider'] input").click();
+    await clear();
+    await fill("65");
+    await waitSidebarUpdated();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "65% !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("65%");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").not.toHaveClass(
+        "active"
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await press("Enter");
+    await waitSidebarUpdated();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+});
+
+test("videos can be resized by slider, text input and button", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <figure class="figure">
+            <div data-oe-expression="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0" class="figure-img media_iframe_video">
+                <iframe src="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0"></iframe>
+            </div>
+        </figure>
+    `);
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-action-id='mediaSizeSlider'] input").toHaveValue(99);
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("9");
+    await animationFrame();
+    //min width is clipped to 10%
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "10% !important" },
+        { inline: true }
+    );
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("110");
+    await animationFrame();
+    //max width is clipped to 100%
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "100% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("50");
+    await animationFrame();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "50% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
+    await animationFrame();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeSlider'] input").click();
+    await clear();
+    await fill("65");
+    await waitSidebarUpdated();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "65% !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("65%");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").not.toHaveClass(
+        "active"
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await press("Enter");
+    await waitSidebarUpdated();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+});
+
+test("images can be resized by slider, text input and button (grid mode)", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="8" style="gap: 16px;">
+                <div class="test-options-target o_grid_item o_grid_item_image g-height-8 g-col-lg-5 col-lg-5 text-center rounded-4 o_colored_level o_draggable" data-name="Block" style="z-index: 1; grid-area: 1 / 5 / 9 / 10;">
+                    <img src="/web/image/website.s_masonry_block_default_image_1" class="img img-fluid mx-auto" alt="" loading="lazy" data-mimetype="image/webp">
+                </div>
+            </div>
+        </div>
+    `);
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-action-id='mediaSizeSlider'] input").toHaveValue(99);
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("9");
+    await animationFrame();
+    //min width is clipped to 10%
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "10% !important" },
+        { inline: true }
+    );
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("110");
+    await animationFrame();
+    //max width is clipped to 100%
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "100% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("50");
+    await animationFrame();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "50% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
+    await animationFrame();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeSlider'] input").click();
+    await clear();
+    await fill("65");
+    await waitSidebarUpdated();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "65% !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("65%");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").not.toHaveClass(
+        "active"
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await press("Enter");
+    await waitSidebarUpdated();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+});
+
+test("videos can be resized by slider, text input and button (grid mode)", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="8" style="gap: 16px;">
+                <div class="o_grid_item o_grid_item_image g-height-8 text-center rounded-4 o_colored_level g-col-lg-12 col-lg-12" data-name="Block" style="z-index: 1; grid-area: 1 / 1 / 9 / 13;">
+                    <div data-oe-expression="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0" class="mx-auto media_iframe_video">
+                        <div class="css_editable_mode_display"></div>
+                        <div class="media_iframe_video_size"></div>
+                        <iframe loading="lazy" frameborder="0" allowfullscreen="allowfullscreen" src="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0"></iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `);
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-action-id='mediaSizeSlider'] input").toHaveValue(99);
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("9");
+    await animationFrame();
+    //min width is clipped to 10%
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "10% !important" },
+        { inline: true }
+    );
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("110");
+    await animationFrame();
+    //max width is clipped to 100%
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "100% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await fill("50");
+    await animationFrame();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "50% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
+    await animationFrame();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeSlider'] input").click();
+    await clear();
+    await fill("65");
+    await waitSidebarUpdated();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "65% !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("65%");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").not.toHaveClass(
+        "active"
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await press("Enter");
+    await waitSidebarUpdated();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("auto");
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
 });


### PR DESCRIPTION
Previously, users could resize images only by selecting from a fixed set of options, and videos were not resizable.

This commit introduces `MediaSizeOption`, which provides a more flexible way to resize both images and videos. Users can now:
- Adjust size using a slider,
- Enter a custom width percentage manually,
- Set the size to "auto" by clicking a button.

task-4600541

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
