### PR TITLE
[FIX] website_sale: make sure category logo comes properly

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -248,6 +248,7 @@
             --o-wsale-filmstrip-item-span-width: 100%;
             --o-wsale-filmstrip-item-span-overflow: hidden;
             --o-wsale-filmstrip-item-span-text-overflow: ellipsis;
+            --o-wsale-filmstrip-item-span-white-space: nowrap;
         }
 
         &.o_wsale_filmstrip_grid {
@@ -283,6 +284,7 @@
             --o-wsale-filmstrip-item-span-width: 100%;
             --o-wsale-filmstrip-item-span-overflow: hidden;
             --o-wsale-filmstrip-item-span-text-overflow: ellipsis;
+            --o-wsale-filmstrip-item-span-white-space: nowrap;
 
             @include media-breakpoint-down(xl) {
                 --o-wsale-filmstrip-item-width: 14rem;
@@ -335,6 +337,7 @@
             --o-wsale-filmstrip-item-span-width: 100%;
             --o-wsale-filmstrip-item-span-overflow: hidden;
             --o-wsale-filmstrip-item-span-text-overflow: ellipsis;
+            --o-wsale-filmstrip-item-span-white-space: nowrap;
 
             @include media-breakpoint-down(xl) {
                 --o-wsale-filmstrip-item-width: 12rem;
@@ -461,6 +464,7 @@
                         height: var(--o-wsale-filmstrip-item-span-height);
                         overflow: var(--o-wsale-filmstrip-item-span-overflow);
                         text-overflow: var(--o-wsale-filmstrip-item-span-text-overflow);
+                        white-space: var(--o-wsale-filmstrip-item-span-white-space);
                     }
 
                     &:has(.o_wsale_filmstrip_placeholder) {


### PR DESCRIPTION
**Steps to produce:**
- Install `website_sale` module.
- Website > Shop > open editor > click on category of shop page.
- In editor set: - content width: Full - In Categories, set style as grid.
- Now write the category name continuously with a space until 3 lines come in the category.
- Save the changes, and set the browser window to 80% or 90%.

**Issue:**
- The image does not come up properly.

**Root cause:**
- Because our text contains spaces, and `white-space: nowrap;` is not applied It wraps the text at each space.

**Solution:**
- We forced the text to stay on one line using `white-space: nowrap;`.

Before:
<img width="159" height="116" alt="before" src="https://github.com/user-attachments/assets/a8506355-d84f-475a-be28-35e46ebe18b7" />

After:
<img width="253" height="189" alt="after" src="https://github.com/user-attachments/assets/28d42d87-f128-4c7d-98ab-b76608b83989" />



**opw-5262851**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
