### PR TITLE
[IMP] account, account_payment: Add transaction_uuid

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -69,6 +69,14 @@ class AccountPayment(models.Model):
         help="When an internal transfer is posted, a paired payment is created. "
         "They are cross referenced through this field", copy=False)
 
+    transaction_uuid = fields.Char(
+        string='Transaction ID',
+        compute='_compute_transaction_uuid',
+        store=True,
+        index=True,
+        help='Unique transaction identifier assigned by the initiating party',
+    )
+
     # == Payment methods fields ==
     payment_method_line_id = fields.Many2one('account.payment.method.line', string='Payment Method',
         readonly=False, store=True, copy=False,
@@ -440,6 +448,10 @@ class AccountPayment(models.Model):
 
                 reconcile_lines = (counterpart_lines + writeoff_lines).filtered(lambda line: line.account_id.reconcile)
                 pay.is_reconciled = pay.currency_id.is_zero(sum(reconcile_lines.mapped(residual_field)))
+
+    def _compute_transaction_uuid(self):
+        # TO BE OVERRIDDEN
+        pass
 
     @api.model
     def _get_method_codes_using_bank_account(self):

--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -103,6 +103,13 @@ class AccountPayment(models.Model):
         for payment in self:
             payment.refunds_count = data.get(payment.id, 0)
 
+    @api.depends('payment_transaction_id')
+    def _compute_transaction_uuid(self):
+        super()._compute_transaction_uuid()
+        for payment in self:
+            if payment.payment_transaction_id:
+                payment.transaction_uuid = payment.payment_transaction_id.provider_reference
+
     #=== ONCHANGE METHODS ===#
 
     @api.onchange('partner_id', 'payment_method_line_id', 'journal_id')

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -143,8 +143,6 @@ class PaymentTransaction(models.Model):
         """
         self.ensure_one()
 
-        reference = f'{self.reference} - {self.provider_reference or ""}'
-
         payment_method_line = self.provider_id.journal_id.inbound_payment_method_line_ids\
             .filtered(lambda l: l.payment_provider_id == self.provider_id)
         payment_values = {
@@ -158,7 +156,7 @@ class PaymentTransaction(models.Model):
             'payment_method_line_id': payment_method_line.id,
             'payment_token_id': self.token_id.id,
             'payment_transaction_id': self.id,
-            'memo': reference,
+            'memo': self.reference,
             'write_off_line_vals': [],
             'invoice_ids': self.invoice_ids,
             **extra_create_values,


### PR DESCRIPTION
When we create a payment transaction, we receive a reference from the provider.
Currently the match is done through string comparison. 
But we could isolate these to do a fast match.
It was done for end_to_end_uuid that we generalize.

task-5059766





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
