### PR TITLE
[FIX] web: display the caps lock alert properly

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -22,12 +22,14 @@
             </div>
 
             <div class="mb-3 field-confirm_password">
-                <label for="confirm_password" class="form-label">Confirm Password</label>
-                <div class="input-group mb-1">
-                    <input type="password" name="confirm_password" id="confirm_password" class="form-control" required="required" placeholder="••••••••••"/>
-                    <button type="button" class="btn btn-sm border border-start-0 o_show_password">
-                        <i class="fa fa-eye"/>
-                    </button>
+                <div class="mb-3 field-password pt-2 o_caps_lock_warning">
+                    <label for="confirm_password" class="form-label">Confirm Password</label>
+                    <div class="input-group mb-1">
+                        <input type="password" name="confirm_password" id="confirm_password" class="form-control" required="required" placeholder="••••••••••"/>
+                        <button type="button" class="btn btn-sm border border-start-0 o_show_password">
+                            <i class="fa fa-eye"/>
+                        </button>
+                    </div>
                 </div>
             </div>
         </template>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -449,7 +449,7 @@
                 <form action="/my/security" method="post" class="oe_reset_password_form">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <input type="hidden" name="op" value="password"/>
-                    <div class="mb-4">
+                    <div class="mb-4 o_caps_lock_warning">
                         <label for="current">Password:</label>
                         <div class="input-group input-group-sm">
                             <input type="password" t-attf-class="form-control {{ 'is-invalid' if get_error(errors, 'password.old') else '' }}"
@@ -478,7 +478,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="mb-3">
+                    <div class="mb-3 o_caps_lock_warning">
                         <label for="new2">Verify New Password:</label>
                         <div class="input-group input-group-sm">
                             <input type="password" t-attf-class="form-control {{ 'is-invalid' if get_error(errors, 'password.new2') else '' }}"

--- a/addons/web/static/src/public/caps_lock_warning.xml
+++ b/addons/web/static/src/public/caps_lock_warning.xml
@@ -2,9 +2,11 @@
 <templates xml:space="preserve">
 
 <t t-name="web.caps_lock_warning">
-    <span class="o_caps_lock_warning_text text-danger">
-        Caps Lock is on!
-    </span>
+    <div role="alert">
+        <span class="o_caps_lock_warning_text text-danger">
+            Caps Lock is on!
+        </span>
+    </div>
 </t>
 
 </templates>

--- a/addons/web/static/tests/interactions/caps_lock_warning.test.js
+++ b/addons/web/static/tests/interactions/caps_lock_warning.test.js
@@ -1,8 +1,8 @@
-import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
-import { describe, expect, test } from "@odoo/hoot";
-import { keyDown, queryOne, pointerDown } from "@odoo/hoot-dom";
+import { click, describe, edit, expect, test } from "@odoo/hoot";
+import { keyUp, pointerDown, queryOne } from "@odoo/hoot-dom";
+import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
-setupInteractionWhiteList("web.caps_lock_warning");
+setupInteractionWhiteList(["web.caps_lock_warning", "web.show_password"]);
 
 describe.current.tags("interaction_dev");
 
@@ -23,6 +23,48 @@ test("caps_lock_warning is started when there is a presence of password input fi
 test("caps lock alert is displayed when CapsLock is turned on", async () => {
     await startInteractions(template);
     await pointerDown(queryOne("#password"));
-    await keyDown("CapsLock");
+    await keyUp("a");
+    await keyUp("CapsLock");
+    expect(".o_caps_lock_warning_text").toBeVisible();
+});
+
+test("caps lock alert is displayed even when CapsLock has been pressed while not focused on the password field", async () => {
+    const loginField = `
+        <div class="mb-3 field-login">
+            <label for="login" class="form-label">Email</label>
+            <div class="input-group mb-1">
+                <input type="text" name="login" id="login"
+                class="form-control"/>
+            </div>
+        </div>`;
+    await startInteractions(loginField + template);
+    await pointerDown(queryOne("#login"));
+    await keyUp("a");
+    await keyUp("CapsLock");
+    await pointerDown(queryOne("#password"));
+    expect(".o_caps_lock_warning_text").toBeVisible();
+    await keyUp("CapsLock");
+    expect(".o_caps_lock_warning_text").not.toBeVisible();
+});
+
+test("show the password, type something, and then hide the password back, caps lock alert should be available", async () => {
+    const templateWithEye = `
+        <div class="mb-3 field-password pt-2 o_caps_lock_warning">
+            <label for="password" class="form-label">Password</label>
+            <div class="input-group mb-1">
+                <input type="password" name="password" id="password"
+                class="form-control"/>
+                <button type="button" class="btn btn-sm border o_show_password">
+                    <i class="fa fa-eye"></i>
+                </button>
+            </div>
+        </div>`;
+    await startInteractions(templateWithEye);
+    await click("button.o_show_password");
+    await click("#password");
+    await edit("secureinfo");
+    await click("button.o_show_password");
+    await click("#password");
+    await keyUp("CapsLock");
     expect(".o_caps_lock_warning_text").toBeVisible();
 });


### PR DESCRIPTION
After this feature was added here [1], the behavior of the caps lock
alert has been buggy.

For example, on Windows systems the behaviour of the alert is such:
- Go to /web/login and focus the password input
- Enable Caps Lock → alert is NOT shown
- Disable Caps Lock → alert IS shown (incorrect)
- Enable Caps Lock again → alert is NOT shown
- Type some text with Caps Lock enabled → alert IS shown
- Disable Caps Lock → alert IS shown (incorrect)
- Type some text → alert is NOT shown

This happens because of the incorrect use of `getModifierState`.
Actually, `event.getModifierState("CapsLock") is supposed to return
`true` when the CapsLock is on.

Also, if you clicked on the eye to show the password, and then pressed
pressed Caps Lock, it would display the alert, but after that pressing
Caps Lock again wouldn't hide it, even if you toggled the eye
off.

[1]: https://github.com/odoo/odoo/commit/c6cc2fca1dde2c1e50cf5632a73966afe495a3fc#diff-ce1ee753fc12d14e1602032d48e4a0464492c83e58c634a62e158000ba7d1e86

task-4954053
