### PR TITLE
[FIX] hr_work_entry_holidays: Fix work entry splitting when processing leave conflicts

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -43,7 +43,10 @@ class HrLeave(models.Model):
             for contract in contracts:
                 # Generate only if it has aleady been generated
                 if leave.date_to >= contract.date_generated_from and leave.date_from <= contract.date_generated_to:
-                    work_entries_vals_list += contracts._get_work_entries_values(leave.date_from, leave.date_to)
+                    work_entries_vals_list += contracts._get_work_entries_values(
+                        datetime.combine(leave.date_from, time.min),
+                        datetime.combine(leave.date_to, time.max),
+                    )
 
         work_entries_vals_list = self.env['hr.version']._generate_work_entries_postprocess(work_entries_vals_list)
         new_leave_work_entries = self.env['hr.work.entry'].create(work_entries_vals_list)


### PR DESCRIPTION
In this commit, we modified _get_work_entries_values calls to use full day boundaries. This regenerates attendance work entries with the proper remaining duration after leave deduction. Old entries are archived and replaced with correctly split ones.

task-5360919

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
