### PR TITLE
[IMP] account_accountant: adding a yearly periodicity to deferred entries

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1470,17 +1470,6 @@
                                                     ('country_id', '=', False),
                                                 ]"/>
 
-                                        <!-- Buttons -->
-                                        <button name="action_automatic_entry"
-                                                type="object"
-                                                icon="fa-calendar"
-                                                string="Cut-Off"
-                                                aria-label="Change Period"
-                                                class="float-end"
-                                                column_invisible="parent.move_type == 'entry' or parent.state != 'posted'"
-                                                invisible="account_internal_group not in ('income', 'expense')"
-                                                context="{'default_action': 'change_period'}"/>
-
                                         <!-- Others fields -->
                                         <field name="tax_line_id" column_invisible="True"/>
                                         <field name="company_currency_id" column_invisible="True"/>


### PR DESCRIPTION
For the deferred expenses and revenues, when the generate method is 'on bill validation', adding a periodicity, so entries can be posted either each month or each year. Changing the name of 'Based on' to 'Computation' for the amount computation method, and changing the names. Deleting the button 'Cut-Off' from the invoice and bill form view of Journal Items.

task-5207488


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
