### PR TITLE
[FIX] web,mail: fix concurrency in relational model

### DIFF
--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
@@ -43,9 +43,7 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
             this.quickCreate = this.quickCreateRecipient.bind(this);
         }
 
-        this.recipientCheckerBus = useRecipientChecker(() =>
-            this.tags.map((tag) => ({ id: tag.id, email: tag.props.email }))
-        );
+        this.recipientCheckerBus = useRecipientChecker(() => this.tags.map((tag) => ({ id: tag.id, email: tag.props.email })));
 
         const update = this.update;
         this.update = async (object) => {

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -1523,16 +1523,14 @@ test("set a required many2many_tags and save directly", async () => {
     def = new Deferred();
     await clickFieldDropdown("timmy");
     await clickFieldDropdownItem("timmy", "gold");
-    expect(".o_tag").toHaveCount(1);
-    expect(".o_tag").toHaveText("", {
-        message: "The tag is displayed, but the web read is not finished yet",
-    });
+    expect(".o_tag").toHaveCount(0);
 
     await clickSave();
     expect("[name='timmy']").not.toHaveClass("o_field_invalid");
 
     def.resolve();
     await animationFrame();
+    expect(".o_tag").toHaveCount(1);
     expect(".o_tag").toHaveText("gold");
 });
 


### PR DESCRIPTION
Before this commit, applying commands on x2m in relational model set
data on the model before the end of the operation. That caused the
reactivity to trigger and components to render.
The issue was visible with the many2many_tags_email field which opens
a popover on render (when some condition is met). The popover opened
and closed multiple times and opened even when it should not.

This commit fixes the relational model. It now set data on the model
only when the operation is finished which triggers the reactivity just
once.