### PR TITLE
[IMP] website: disable slide reorder & navgation in single slide

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
@@ -15,7 +15,7 @@ export class CarouselItemHeaderMiddleButtons extends Component {
         this.state = useDomState((editingElement) => {
             const carouselItemsNumber = editingElement.parentElement.children.length;
             return {
-                disableRemove: carouselItemsNumber === 1,
+                hasMultiItems: carouselItemsNumber > 1,
             };
         });
     }

--- a/addons/website/static/src/builder/plugins/carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_option.xml
@@ -69,12 +69,14 @@
     <button class="btn btn-primary ms-0 py-0 px-1 me-1"
             title="Move Backward"
             aria-label="Move Backward"
+            t-att-class="{ disabled: !state.hasMultiItems }"
             t-on-click="() => this.slide('prev')">
         <span class="fa fa-fw fa-angle-left"/>
     </button>
     <button class="btn btn-primary py-0 px-1 me-2"
             title="Move Forward"
             aria-label="Move Forward"
+            t-att-class="{ disabled: !state.hasMultiItems }"
             t-on-click="() => this.slide('next')">
         <span class="fa fa-fw fa-angle-right"/>
     </button>
@@ -85,8 +87,7 @@
         <span class="oi fa-fw oi-plus"/>
     </button>
     <button class="btn btn-danger py-0 px-1"
-            t-att-class="{ disabled: state.disableRemove }"
-            t-att-disabled="state.disableRemove"
+            t-att-class="{ disabled: !state.hasMultiItems }"
             title="Remove Slide"
             aria-label="Remove Slide"
             t-on-click="removeSlide">

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option.xml
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
 
 <t t-name="website.GalleryElementOption">
-    <BuilderRow label.translate="Re-order">
+    <BuilderRow label.translate="Re-order" disabled="!state.hasMultiItems">
         <BuilderButtonGroup preview="false" action="'setGalleryElementPosition'">
-            <BuilderButton icon="'fa-angle-double-left'" title.translate="Move to first"  actionValue="'first'"/>
-            <BuilderButton icon="'fa-angle-left'" title.translate="Move to previous" actionValue="'prev'"/>
-            <BuilderButton icon="'fa-angle-right'" title.translate="Move to next" actionValue="'next'"/>
-            <BuilderButton icon="'fa-angle-double-right'" title.translate="Move to last" actionValue="'last'"/>
+            <BuilderButton icon="'fa-angle-double-left'" title.translate="Move to first"  actionValue="'first'" className="!state.hasMultiItems || state.isFirstItem ? 'disabled': ''"/>
+            <BuilderButton icon="'fa-angle-left'" title.translate="Move to previous" actionValue="'prev'" className="!state.hasMultiItems ? 'disabled': ''"/>
+            <BuilderButton icon="'fa-angle-right'" title.translate="Move to next" actionValue="'next'" className="!state.hasMultiItems ? 'disabled': ''"/>
+            <BuilderButton icon="'fa-angle-double-right'" title.translate="Move to last" actionValue="'last'" className="!state.hasMultiItems || state.isLastItem ? 'disabled': ''"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
@@ -3,7 +3,7 @@ import { registry } from "@web/core/registry";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC } from "@html_builder/utils/option_sequence";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 
 /**
  * @typedef {((
@@ -21,6 +21,28 @@ export class GalleryElementOption extends BaseOptionComponent {
     static template = "website.GalleryElementOption";
     static selector =
         ".s_image_gallery img, .s_carousel .carousel-item, .s_quotes_carousel .carousel-item, .s_carousel_intro .carousel-item, .s_carousel_cards .carousel-item";
+    setup() {
+        this.state = useDomState((editingElement) => {
+            const isImageWall = editingElement.closest('[data-snippet="s_images_wall"]');
+            if (isImageWall) {
+                // Prevented disable reordering buttons for image wall.
+                return {
+                    hasMultiItems: true,
+                    isFirstItem: false,
+                    isLastItem: false,
+                };
+            }
+            const carouselEl = editingElement.closest(".carousel");
+            const carouselItemEls = carouselEl.querySelectorAll(".carousel-item");
+            const carouselItemCount = carouselItemEls.length;
+            const currentItemEl = editingElement.closest(".carousel-item");
+            return {
+                hasMultiItems: carouselItemCount > 1,
+                isFirstItem: currentItemEl === carouselItemEls[0],
+                isLastItem: currentItemEl === carouselItemEls[carouselItemCount - 1],
+            };
+        });
+    }
 }
 
 export class GalleryElementOptionPlugin extends Plugin {

--- a/addons/website/static/tests/builder/website_builder/carousel_item.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel_item.test.js
@@ -55,3 +55,32 @@ test("Remove slide", async () => {
     expect(":iframe .carousel-indicators > *").toHaveCount(2);
     expect(":iframe .carousel-indicators > .active").toHaveCount(1);
 });
+
+test("Should disable reordering and navigation buttons when carousel has a single slide", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilderWithSnippet("s_carousel");
+    expect(":iframe .carousel-item").toHaveCount(3);
+    await contains(":iframe .carousel-item").click();
+    expect("[data-action-value='first']").toHaveClass("disabled");
+
+    await contains("button[title='Move Backward']").click();
+    await waitSidebarUpdated();
+    expect("[data-container-title='Slide (3/3)']").toHaveCount(1);
+    expect("[data-action-value='last']").toHaveClass("disabled");
+
+    await contains("button[title='Remove Slide']").click();
+    await waitSidebarUpdated();
+    expect("[data-container-title='Slide (2/2)']").toHaveCount(1);
+
+    await contains("button[title='Remove Slide']").click();
+    await waitSidebarUpdated();
+    expect("[data-container-title='Slide (1/1)']").toHaveCount(1);
+
+    const reorderingButtons = ["first", "prev", "next", "last"];
+    for (const button of reorderingButtons) {
+        expect(`[data-action-value='${button}']`).toHaveClass("disabled");
+    }
+
+    expect('[data-label="Re-order"]').toHaveAttribute("data-disabled");
+    expect("button[title='Move Backward']").toHaveClass("disabled");
+    expect("button[title='Move Forward']").toHaveClass("disabled");
+});


### PR DESCRIPTION
1. The slide reordering and navigation buttons should be disabled when only a single slide is present. This prevents unnecessary actions, avoids confusing UI behavior and protects history from polluting with the unnecessary mutations. The disabling logic is handled by conditionally adding the "disabled" class based on the current slide count.

2. When the active slide is first then "**Move to first**" reordering button should be disabled. Similarly, when the active slide is last then "**Move to last**" reordering button should be disabled.

task-5363601


1. 
| Before | After |
|-----------------------------|---------------------------------|
| <img width="292" height="283" alt="image" src="https://github.com/user-attachments/assets/b89a810f-f5fe-4db4-a98b-036d6b1a6568" /> | <img width="284" height="273" alt="image" src="https://github.com/user-attachments/assets/c4ce2e7d-1fef-4186-bea0-ad00834a8680" /> |


2.
| Before | After |
|-----------------------------|---------------------------------|
| <img width="285" height="179" alt="image" src="https://github.com/user-attachments/assets/d0b6833f-a66f-4f80-8e18-c7ea2245fce1" /> | <img width="289" height="208" alt="image" src="https://github.com/user-attachments/assets/e0ef23fb-83ca-45c2-929b-2e86133c0789" /> |