### PR TITLE
[FIX] l10n_es_edi_verifactu_{pos}: support F3 invoice types

### DIFF
--- a/addons/l10n_es_edi_verifactu/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu/models/verifactu_document.py
@@ -588,7 +588,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
         rectified_document = vals['refunded_document'] or vals['substituted_document']
         if vals['verifactu_move_type'] == 'invoice':
             tipo_rectificativa = None
-            tipo_factura = 'F2' if vals['is_simplified'] else 'F1'
+            tipo_factura = 'F2' if vals['is_simplified'] else 'F3' if vals.get('was_simplified_invoice') else 'F1'
             delivery_date = self._format_date_type(vals['delivery_date'])
             fecha_operacion = delivery_date if delivery_date and delivery_date != invoice_date else None
         elif vals['verifactu_move_type'] == 'reversal_for_substitution':

--- a/addons/l10n_es_edi_verifactu_pos/models/account_move.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/account_move.py
@@ -11,4 +11,6 @@ class AccountMove(models.Model):
         refunded_order = None if self.reversed_entry_id else self.pos_order_ids.refunded_order_id
         if refunded_order:
             vals['refunded_document'] = refunded_order.l10n_es_edi_verifactu_document_ids._get_last('submission')
+        if self.pos_order_ids:
+            vals['was_simplified_invoice'] = self.pos_order_ids[0].l10n_es_edi_is_originally_simplified
         return vals


### PR DESCRIPTION
To reproduce
-------------
1. Install `l10n_es_edi_verifactu_pos`, and select the ES company
2. Make an order in PoS with a price less than 400, and don't invoice it.
3. Close the PoS session, then go to PoS > Orders, and select the previously made order
4. It will have a Verifactu generated document with invoice type as 'F2', which is correct since it's a simplified order.
5. Click invoice to invoice the order; the invoice is no longer simplified.

Notice now that the new Verifactu document has an invoice type of 'F1', which corresponds to a normal non simplified invoice. However, since the new invoice is replacing an old simplified one, it should be of type 'F3' instead.

The fix
-------
We add a new field on the `pos.order` model to retain if that order was previously invoiced with a simplified invoice, in that case, we set its type to 'F3' instead of 'F1' when fully invoicing it.

Sources:
--------
Difference between 'F1', 'F2', and 'F3' invoice types: https://sede.agenciatributaria.gob.es/Sede/iva/sistemas-informaticos-facturacion-verifactu/preguntas-frecuentes/procedimientos-facturacion.html?faqId=bdbd20022fe06910VgnVCM100000dc381e0aRCRD

opw-5343973
