### PR TITLE
[FIX] im_livechat: do not overwrite expertises when agent joins

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -43,7 +43,6 @@ class DiscussChannel(models.Model):
         "discuss_channel_im_livechat_expertise_rel",
         "discuss_channel_id",
         "im_livechat_expertise_id",
-        related="livechat_agent_history_ids.agent_expertise_ids",
         store=True,
     )
     livechat_agent_history_ids = fields.One2many(
@@ -895,8 +894,9 @@ class DiscussChannel(models.Model):
 
             # next, add the human_operator to the channel and post a "Operator invited to the channel" notification
             create_member_params = {'livechat_member_type': 'agent'}
-            if chatbot_script_step:
+            if chatbot_script_step.operator_expertise_ids:
                 create_member_params['agent_expertise_ids'] = chatbot_script_step.operator_expertise_ids.ids
+                channel_sudo.livechat_expertise_ids |= chatbot_script_step.operator_expertise_ids
             channel_sudo._add_new_members_to_channel(
                 create_member_params=create_member_params,
                 inviting_partner=bot_partner_id,


### PR DESCRIPTION
Before this commit, expertises manually added to a live chat would
be disappear when an agent joined the chat. This occurs because
this field is a related field so values are overwritten when the
dependencies change.

This field should actually not depend on the agent. Expertises
shouldn't depend on agent but be assigned when the chat bot
forwards the conversation or when an agent adds/remove expertises.