### PR TITLE
[FIX] account: show taxes matching the current type_tax_use on mobile

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1250,7 +1250,11 @@
                                             </group>
                                             <group>
                                                 <field name="account_id" domain="[('deprecated', '=', False), ('company_ids', 'parent_of', company_id)]" options="{'no_create': True}" context="{'partner_id': partner_id, 'move_type': parent.move_type}"/>
-                                                <field name="tax_ids" widget="many2many_tags"/>
+                                                <field name="tax_ids" widget="many2many_tags"
+                                                    domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
+                                                    context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain, 'active_test': True}"
+                                                    options="{'no_create': True}"
+                                                />
                                                 <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting"/>
                                             </group>
                                             <group>


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile viewport
- Create an new invoice
- Add an invoice line
- Click on the Taxes field => Both purchase and sales taxes are available

Solution
========

Copy the domain from the desktop list view

https://github.com/odoo/odoo/blob/fcc677e900c2fccb9fa0bd88ef01c559cadfa08a/addons/account/views/account_move_views.xml#L1051-L1055

We also add the corresponding context and options

opw-5124536