### PR TITLE
[IMP] point_of_sale: split tours to ease debugging

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/acceptance_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/acceptance_tour.js
@@ -1,5 +1,6 @@
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { registry } from "@web/core/registry";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { inLeftSide, waitForLoading } from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
@@ -11,6 +12,7 @@ registry.category("web_tour.tours").add("pos_basic_order_02_decimal_order_quanti
         [
             waitForLoading(),
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1"),
             inLeftSide([
                 { ...ProductScreen.clickLine("Desk Organizer")[0], isActive: ["mobile"] },
@@ -32,6 +34,7 @@ registry.category("web_tour.tours").add("pos_basic_order_03_tax_position", {
         [
             waitForLoading(),
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Letter Tray", true, "1"),
             inLeftSide(...Order.hasTotal("5.28")),
             ProductScreen.clickFiscalPosition("FP-POS-2M", true),

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -13,6 +13,7 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
     steps: () =>
         [
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             OfflineUtil.setOfflineMode(),
             ProductScreen.addOrderline("Letter Tray", "10"),
             ProductScreen.clickPayButton(),

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -27,6 +27,7 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
             // Go by default to home category
 
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             OfflineUtil.setOfflineMode(),
             ProductScreen.firstProductIsFavorite("Whiteboard Pen"),
             // Make sure we don't have any scroll bar on the product list
@@ -184,6 +185,7 @@ registry.category("web_tour.tours").add("FloatingOrderTour", {
     steps: () =>
         [
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             ProductScreen.orderIsEmpty(),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0", "5.10"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.0", "10.20"),

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -18,6 +18,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
         [
             // press close button in receipt screen
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             OfflineUtil.setOfflineMode(),
             ProductScreen.addOrderline("Letter Tray", "10", "5"),
             ProductScreen.clickPartnerButton(),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -621,6 +621,27 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 @tagged('post_install', '-at_install')
 class TestUi(TestPointOfSaleHttpCommon):
     def test_01_pos_basic_order(self):
+        self.start_pos_tour('pos_pricelist')
+
+    def test_pos_basic_order_02_decimal_order_quantity(self):
+        self.start_pos_tour('pos_basic_order_02_decimal_order_quantity')
+
+    def test_pos_basic_order_03_tax_position(self):
+        self.start_pos_tour('pos_basic_order_03_tax_position')
+
+    def test_floating_order_tour(self):
+        self.start_pos_tour('FloatingOrderTour')
+
+    def test_product_screen_tour(self):
+        self.whiteboard_pen.write({
+            'is_favorite': True
+        })
+        self.start_pos_tour('ProductScreenTour')
+
+    def test_payment_screen_tour(self):
+        self.start_pos_tour('PaymentScreenTour')
+
+    def test_receipt_screen_tour(self):
         self.tip.write({
             'taxes_id': False
         })
@@ -629,29 +650,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'tip_product_id': self.tip.id,
             'ship_later': True
         })
-
-        # Mark a product as favorite to check if it is displayed in first position
-        self.whiteboard_pen.write({
-            'is_favorite': True
-        })
-
-        # open a session, the /pos/ui controller will redirect to it
-        self.main_pos_config.with_user(self.pos_user).open_ui()
-
-        # needed because tests are run before the module is marked as
-        # installed. In js web will only load qweb coming from modules
-        # that are returned by the backend in module_boot. Without
-        # this you end up with js, css but no qweb.
-        self.env['ir.module.module'].search([('name', '=', 'point_of_sale')], limit=1).state = 'installed'
-
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_pricelist', login="pos_user")
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_basic_order_02_decimal_order_quantity', login="pos_user")
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_basic_order_03_tax_position', login="pos_user")
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FloatingOrderTour', login="pos_user")
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ProductScreenTour', login="pos_user")
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenTour', login="pos_user")
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="pos_user")
-
+        self.start_pos_tour('ReceiptScreenTour')
         for order in self.env['pos.order'].search([]):
             self.assertEqual(order.state, 'paid', "Validated order has payment of " + str(order.amount_paid) + " and total of " + str(order.amount_total))
 


### PR DESCRIPTION
Following this commit:
====
- Initially `test_01_pos_basic_order` now runs multiple tours in parallel.
- Now each tour has been split into its own independent method.
- This separation improves readability and significantly simplifies debugging.

task-5349813
