### PR TITLE
[FIX] website: fix option leaking in nested snippets

### DIFF
--- a/addons/website/static/src/snippets/s_accordion/000.scss
+++ b/addons/website/static/src/snippets/s_accordion/000.scss
@@ -21,13 +21,13 @@
     }
 
     .s_accordion_highlight {
-        .accordion-item {
+        >.accordion-item {
             border: 0;
             border-radius: var(--#{$prefix}accordion-border-radius);
             overflow: hidden;
 
             // This removes the bg color when the item isn't displayed.
-            &:has(.collapsed) {
+            &:has(>.collapsed) {
                 background: transparent !important;
                 color: inherit;
             }
@@ -37,7 +37,7 @@
             // replaced by a color preset or a custom color.
             // This avoids color conflicts and preserves the colors
             // selected by the user when changing the accordion template.
-            &:not(:has(.collapsed))::before {
+            &:not(:has(>.collapsed))::before {
                 position: absolute;
                 inset: 0;
                 display: block;

--- a/addons/website/static/src/snippets/s_blockquote/001.scss
+++ b/addons/website/static/src/snippets/s_blockquote/001.scss
@@ -14,7 +14,7 @@
         width: map-get($spacers, 1);
     }
 
-    &:not(.s_blockquote_with_line) .s_blockquote_line_elt, &:not(.s_blockquote_with_icon) .s_blockquote_wrap_icon {
+    &:not(.s_blockquote_with_line) >.s_blockquote_line_elt, &:not(.s_blockquote_with_icon) >.s_blockquote_wrap_icon {
         display: none;
     }
 }

--- a/addons/website/views/snippets/s_accordion.xml
+++ b/addons/website/views/snippets/s_accordion.xml
@@ -46,9 +46,9 @@
                 data-css-property="--accordion-border-radius"
                 data-unit="px"
                 data-select-style="0"
-                data-apply-to=".accordion-item"
+                data-apply-to=">.accordion-item"
                 />
-            <we-button-group string="Icon Position" data-apply-to=".accordion-header">
+            <we-button-group string="Icon Position" data-apply-to=">.accordion-item>.accordion-header">
                 <we-button title="Left" data-select-class="justify-content-end flex-row-reverse"
                     data-img="/website/static/src/img/snippets_options/pos_left.svg"/>
                 <we-button title="Right" data-select-class="justify-content-between"

--- a/addons/website/views/snippets/s_blockquote.xml
+++ b/addons/website/views/snippets/s_blockquote.xml
@@ -56,7 +56,7 @@
             </we-row>
         </div>
 
-        <div data-selector=".s_blockquote" data-target=".s_blockquote_infos">
+        <div data-selector=".s_blockquote" data-target=">.s_blockquote_infos">
             <we-select string="Author Alignment">
                 <we-button data-select-class="flex-row align-items-start justify-content-start text-start">Left</we-button>
                 <we-button data-select-class="flex-column align-items-center text-center">Center</we-button>


### PR DESCRIPTION
This commit fixes some issues that occur when editing nested instances of `s_accordion` and `s_blockquote` snippets. In all cases, changes applied to a parent unintentionally propagate to nested snippets.

**Accordion issues**
How to reproduce: drop two nested `s_accordion` snippets. Then:
1. Change the outer "Style" from "boxed" to "highlight active" -> both accordion change,
2. Change the outer "Round Corner" -> both accordion change,
3. Change the outer "Icon Position" ->  both accordion change.

**Blockquote issues**
How to reproduce: drop two nested `s_blockquote` snippets. Then:
1. Change the outer "Decoration" -> both blockquotes change,
2. Set the inner "Decoration" to "Icon" -> works only if the outer snippet has icon too,
3. Change the outer "Author Alignment" -> only the inner blockquote changes.

**Cause**
The above issues occur because certain `data-apply-to` and certain CSS selectors match all nested elements rather than restricting the scope only to the snippet being edited.

**Fix**
The relevant `data-apply-to` and CSS rules now use the child combinator `>` when needed.

task-5362171
