### PR TITLE
[REF] html_editor: getFonts in applyColor

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -788,7 +788,7 @@ pre {
         color: transparent;
         caret-color: black;
     }
-    * {
+    *:not([style*="background-image"]) {
         background-size: 0px;
         background-image: inherit !important;
     }

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -12,9 +12,7 @@ test("should apply a color to a slice of text in a span in a font", async () => 
         contentBefore: '<p>a<font class="a">b<span class="b">c[def]g</span>h</font>i</p>',
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter:
-            '<p>a<font class="a">b<span class="b">c</span></font>' +
-            '<font class="a" style="color: rgb(255, 0, 0);"><span class="b">[def]</span></font>' +
-            '<font class="a"><span class="b">g</span>h</font>i</p>',
+            '<p>a<font class="a">b<span class="b">c<font style="color: rgb(255, 0, 0);">[def]</font>g</span>h</font>i</p>',
     });
 });
 
@@ -39,9 +37,7 @@ test("should apply a background color to a slice of text in a span in a font", a
         contentBefore: '<p>a<font class="a">b<span class="b">c[def]g</span>h</font>i</p>',
         stepFunction: setColor("rgb(255, 0, 0)", "backgroundColor"),
         contentAfter:
-            '<p>a<font class="a">b<span class="b">c</span></font>' +
-            '<font class="a" style="background-color: rgb(255, 0, 0);"><span class="b">[def]</span></font>' +
-            '<font class="a"><span class="b">g</span>h</font>i</p>',
+            '<p>a<font class="a">b<span class="b">c<font style="background-color: rgb(255, 0, 0);">[def]</font>g</span>h</font>i</p>',
     });
 });
 
@@ -199,12 +195,12 @@ test("should not apply font tag to t nodes (protects if else nodes separation)",
             <p>
                 <t t-if="object.partner_id.parent_id">
                     <t t-out="object.partner_id.parent_id.name or ''" style="color: red;">
-                        <font style="color: red;">Azure Interior</font>
+                        Azure Interior
                     </t>
                 </t>
                 <t t-else="">
                     <t t-out="object.partner_id.name or ''" style="color: red;">
-                        <font style="color: red;">Brandon Freeman</font>
+                        Brandon Freeman
                     </t>
                 </t>
             </p>
@@ -452,30 +448,6 @@ test("should break gradient color on selected text", async () => {
             '<font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">bc</font></p>',
     });
 });
-test("should update the gradient color and remove the nested background color to make the gradient visible", async () => {
-    await testEditor({
-        contentBefore:
-            '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><font style="background-color: rgb(255, 0, 0);">[abc]</font></font></p>',
-        stepFunction: setColor(
-            "linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%)",
-            "backgroundColor"
-        ),
-        contentAfter:
-            '<p><font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[abc]</font></p>',
-    });
-});
-test("should update the gradient text color and remove the nested text color to make the gradient visible", async () => {
-    await testEditor({
-        contentBefore:
-            '<p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><font style="-webkit-text-fill-color: rgb(255, 0, 0); color: rgb(255, 0, 0);">[abc]</font></font></p>',
-        stepFunction: setColor(
-            "linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%)",
-            "color"
-        ),
-        contentAfter:
-            '<p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[abc]</font></p>',
-    });
-});
 test("should apply gradient color when a when background color is applied on span", async () => {
     await testEditor({
         contentBefore: '<p><span style="background-color: rgb(255, 0, 0)">ab[ca]bc</span></p>',
@@ -507,7 +479,7 @@ test("should applied background color to slice of text in a span without interru
             '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><span class="a">ab<font style="background-color: rgb(255, 0, 0);">[ca]</font>bc</span></font></p>',
     });
 });
-test("should break a gradient and apply gradient background color to a slice of text within a span", async () => {
+test("should not break a gradient and apply gradient background color to a slice of text within a span", async () => {
     await testEditor({
         contentBefore:
             '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><span class="a">ab<font style="background-color: rgb(255, 0, 0);">[ca]</font>bc</span></font></p>',
@@ -516,9 +488,7 @@ test("should break a gradient and apply gradient background color to a slice of 
             "color"
         ),
         contentAfter:
-            '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><span class="a">ab</span></font>' +
-            '<font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);" class="text-gradient"><span class="a"><font style="background-color: rgb(255, 0, 0);">[ca]</font></span></font>' +
-            '<font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><span class="a">bc</span></font></p>',
+            '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><span class="a">ab<font style="background-color: rgb(255, 0, 0);"><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[ca]</font></font>bc</span></font></p>',
     });
 });
 test("should apply gradient color on selected text", async () => {
@@ -920,9 +890,9 @@ test("should be able to change color of an icon", async () => {
             '<p><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</font></p>',
         stepFunction: setColor("rgb(255, 255, 0)", "color"),
         contentAfterEdit:
-            '<p><font style="color: rgb(255, 255, 0);">\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</font></p>',
+            '<p>[<font style="color: rgb(255, 255, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font>]</p>',
         contentAfter:
-            '<p><font style="color: rgb(255, 255, 0);">[<span class="fa fa-glass"></span>]</font></p>',
+            '<p>[<font style="color: rgb(255, 255, 0);"><span class="fa fa-glass"></span></font>]</p>',
     });
 });
 
@@ -932,7 +902,7 @@ test("should be able to remove color of an icon", async () => {
             '<p><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</font></p>',
         stepFunction: setColor("", "color"),
         contentAfterEdit:
-            '<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>',
+            '<p>[\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff]</p>',
         contentAfter: '<p>[<span class="fa fa-glass"></span>]</p>',
     });
 });
@@ -1045,4 +1015,12 @@ test("Should properly apply color when selection on feff", async () => {
     // Ensure the link inherited the font color.
     const a = el.querySelector("a");
     expect(getComputedStyle(a).color).toBe("rgb(255, 0, 0)");
+});
+
+test("should change text color for text with color and background gradient", async () => {
+    await testEditor({
+        contentBefore: `<p><font style="color: rgb(255, 0, 0);">this <font style="background-image: ${redToBlueGradient};">is a [tes]t</font> line</font></p>`,
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter: `<p><font style="color: rgb(255, 0, 0);">this <font style="background-image: ${redToBlueGradient};">is a <font style="color: rgb(0, 0, 255);">[tes]</font>t</font> line</font></p>`,
+    });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR refactors the logic of getFonts in applyColor.

A new font node is created when:
i. Applying a color with a different mode.
ii. The existing font has a text/background gradient color.

For the below cases the current font is split:
i. Applying a new color with the same mode.
ii. Applying a background gradient to text already having a text gradient.

task-5164526

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
