### PR TITLE
[18.0] [FIX] web: save kanban record before executing action

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -297,12 +297,15 @@ export class KanbanRecord extends Component {
     /**
      * @param {MouseEvent} ev
      */
-    onGlobalClick(ev) {
+    async onGlobalClick(ev) {
         if (ev.target.closest(CANCEL_GLOBAL_CLICK)) {
             return;
         }
         const { archInfo, forceGlobalClick, openRecord, record } = this.props;
         if (!forceGlobalClick && archInfo.openAction) {
+            if (this.props.record.isDirty()) {
+                await this.props.record.save();
+            }
             this.action.doActionButton({
                 name: archInfo.openAction.action,
                 type: archInfo.openAction.type,


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
We must save the kanban record before calling an action, otherwise it will certainly fail.
This is similar to the list controller: https://github.com/odoo/odoo/blob/b22ce2245c88bfd5798be902798618018f48c144/addons/web/static/src/views/list/list_controller.js#L292-L308


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
