### PR TITLE
[IMP] point_of_sale, pos_restaurant: feedback & combo pricing UX

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/chose_combo_popup/chose_combo_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/chose_combo_popup/chose_combo_popup.js
@@ -24,7 +24,7 @@ export class ChoseComboPopup extends Component {
             const comboProduct = this.pos.models["product.combo"].get(comboId);
             const maxQty = comboProduct.qty_max;
             const totalChosenQty = Object.values(comboChoice).reduce(
-                (sum, line) => (line === true ? sum : sum + line.qty),
+                (sum, line) => (line === true || typeof line === "number" ? sum : sum + line.qty),
                 0
             );
             for (const line of Object.values(comboChoice)) {

--- a/addons/point_of_sale/static/src/app/components/popups/chose_combo_popup/chose_combo_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/chose_combo_popup/chose_combo_popup.xml
@@ -10,16 +10,28 @@
                 <div class="d-flex justify-content-between p-3 combo-item" t-att-class="{'border-top': combo_index > 0}" t-foreach="this.allCombos" t-as="combo" t-key="combo_index">
                     <div>
                         <span class="fs-3" t-esc="combo.productTmpl.display_name"/>
+                        <span class="fw-bolder ms-2 fs-3" t-esc="env.utils.formatCurrency(combo.totalComboPrice)"/>
                         <ul class="mb-0 ps-3">
                             <li t-foreach="combo.lines" t-as="line" t-key="line_index" t-att-class="{'text-info': line.upsell}">
                                 - <t t-if="!line.upsell"><span t-esc="line.quantity"/> x </t><span t-esc="line.name"/><t t-if="line.upsell"> (up to <span t-esc="line.quantity"/> more)</t>
                             </li>
                         </ul>
                     </div>
-                    <button class="apply-combo-btn button btn btn-primary btn-lg align-self-start" t-on-click="() => this.confirm(combo)">
-                        <t t-if="combo.upsell">Choose</t>
-                        <t t-else="">Apply</t>
-                    </button>
+                    <div class="d-flex flex-column align-items-end">
+                        <button class="apply-combo-btn button btn btn-primary btn-lg" t-on-click="() => this.confirm(combo)">
+                            <t t-if="combo.upsell">Choose</t>
+                            <t t-else="">Apply</t>
+                        </button>
+                        <span class="mt-2">
+                            <t t-set="price_diff" t-value="combo.totalSplitedComboLinePrice - combo.totalComboPrice"/>
+                            <t t-if="price_diff > 0">
+                                Save <t t-esc="env.utils.formatCurrency(price_diff)"/>
+                            </t>
+                            <t t-else="">
+                                Add <t t-esc="env.utils.formatCurrency(Math.abs(price_diff))"/>
+                            </t>
+                        </span>
+                    </div>
                 </div>
             </div>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/components/price_formatter/price_formatter.js
+++ b/addons/point_of_sale/static/src/app/components/price_formatter/price_formatter.js
@@ -19,8 +19,8 @@ export class PriceFormatter extends Component {
         }
         const numericPart = trimmedPrice.replace(currencySymbol, "").trim();
         const amountParts = numericPart.split(localization.decimalPoint);
-        const decimal = amountParts[1] || "";
-        const amountStr = amountParts[0] + (decimal ? localization.decimalPoint : ""); // ex. "1000."
+        const decimal = amountParts?.[1] ? localization.decimalPoint + amountParts[1] : ""; // ex. ".00"
+        const amountStr = amountParts[0]; // ex. "1000"
         return {
             amountStr,
             decimal,

--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.scss
@@ -38,7 +38,7 @@
         background-color: rgba(255,255,255,0.1);
         border: 1px solid rgba(255,255,255,0.1);
         transform: translateX(0);
-        animation: wipe-away 5s linear forwards;
+        animation: wipe-away 1s linear forwards;
         z-index: 3;
         pointer-events: none;
     }

--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.xml
@@ -2,16 +2,16 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.FeedbackScreen">
         <div t-ref="feedback-screen" class="feedback-screen bg-100 fixed-top w-100 h-100 d-flex flex-column align-items-center justify-content-center" t-on-click="() => this.onClick()">
-            <div class="amount-paid fw-bolder">Amount Paid</div>
+            <div class="amount-paid">Amount Paid</div>
             <div class="amount-container">
                 <div t-ref="amount" class="amount lh-sm">
                     <PriceFormatter price="this.env.utils.formatCurrency(this.currentOrder.totalDue, false)"/>
                 </div>
             </div>
             <div t-if="!ui.isSmall" class="desktop-format w-75 d-flex gap-3 flex-row align-items-center justify-content-around p-2">
+                <button t-if="pos.canEditPayment(currentOrder)" t-att-disabled="state.loading" class="button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3 edit-order-payment" t-on-click.stop="() => this.clickEditPayment()">Back</button>
                 <button t-if="canPrintReceipt" t-att-disabled="state.loading || currentOrder.state == 'draft'" class="print-ticket-button button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.clickPrint()"><i class="fa fa-print" role="img" aria-label="Print" title="Print"></i> Print</button>
                 <button t-if="canSendReceipt" t-att-disabled="state.loading || currentOrder.state == 'draft'" class="send-receipt button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.clickSend()"><i class="fa fa-paper-plane" role="img" aria-label="Send" title="Send"></i> Send Receipt</button>
-                <button t-if="pos.canEditPayment(currentOrder)" t-att-disabled="state.loading" class="button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3 edit-order-payment" t-on-click.stop="() => this.clickEditPayment()"><i class="fa fa-pencil-square-o" role="img" aria-label="Edit" title="Edit"></i> Edit</button>
                 <button t-att-disabled="state.loading" class="validation button btn btn-primary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.onClick(true)">
                     Continue
                     <div t-if="this.state.timeout" class="wipe-overlay"/>
@@ -19,11 +19,11 @@
             </div>
             <div t-else="" class="mobile-format position-absolute bottom-0 w-100 d-flex flex-column gap-1 p-1">
                 <div class="d-flex w-100 gap-1">
-                    <button t-if="canSendReceipt" t-att-disabled="state.loading || currentOrder.state == 'draft'" class="send-receipt btn btn-secondary btn-lg lh-lg text-truncate flex-basis-50" t-on-click.stop="() => this.clickSend()">Send Receipt</button>
-                    <button t-att-disabled="state.loading || currentOrder.state == 'draft'" class="print-ticket-button btn btn-secondary btn-lg lh-lg text-truncate flex-grow-1" t-on-click.stop="() => this.clickPrint()">Print</button>
+                    <button t-if="pos.canEditPayment(currentOrder)" t-att-disabled="state.loading" class="back-button btn btn-secondary btn-lg lh-lg text-truncate flex-grow-1 edit-order-payment" t-on-click.stop="() => this.clickEditPayment()">Back</button>
+                    <button t-if="canSendReceipt" t-att-disabled="state.loading || currentOrder.state == 'draft'" class="send-receipt btn btn-secondary btn-lg lh-lg text-truncate flex-grow-1" t-on-click.stop="() => this.clickSend()">Send Receipt</button>
                 </div>
                 <div class="d-flex w-100 gap-1">
-                    <button t-if="pos.canEditPayment(currentOrder)" t-att-disabled="state.loading" class="back-button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-50 edit-order-payment" t-on-click.stop="() => this.clickEditPayment()">Edit</button>
+                    <button t-att-disabled="state.loading || currentOrder.state == 'draft'" class="print-ticket-button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-50" t-on-click.stop="() => this.clickPrint()">Print</button>
                     <button t-att-disabled="state.loading" class="validation button btn btn-primary btn-lg btn-lg lg-lh flex-grow-1" t-on-click.stop="() => this.onClick(true)">
                         Continue
                         <div t-if="this.state.timeout" class="wipe-overlay"/>

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -312,6 +312,10 @@ registry.category("web_tour.tours").add("test_convert_orderlines_to_combo", {
                     attributeLine: "Blue",
                 }),
             ]),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            FeedbackScreen.isShown(),
         ].flat(),
 });
 
@@ -337,6 +341,57 @@ registry.category("web_tour.tours").add("test_combo_item_image_not_display", {
             combo.checkImgAndSelect("Combo Product 4", false),
             combo.checkImgAndSelect("Combo Product 6", false),
             Dialog.confirm(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_convert_orderlines_to_combo_with_upsell", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+
+            // Add products that can be part of a first combo
+            ProductScreen.clickDisplayedProduct("Combo Product 2"),
+            ProductScreen.clickDisplayedProduct("Combo Product 4"),
+            ProductScreen.clickDisplayedProduct("Combo Product 6"),
+
+            // Add products that can be part of a second combo
+            ProductScreen.clickDisplayedProduct("Second Product 2"),
+            ProductScreen.clickDisplayedProduct("Second Product 4"),
+            ProductScreen.clickDisplayedProduct("Second Product 6"),
+
+            inLeftSide([
+                {
+                    content: "Click apply combo button",
+                    trigger: ".combo-proposition button.btn",
+                    run: "click",
+                },
+                Dialog.is(),
+                {
+                    content: "Check 'Second Combo Product' price",
+                    trigger: ".modal-body .combo-item:eq(0) .fw-bolder:contains('50.00')",
+                },
+                {
+                    content: "Check 'Second Combo Product' save price",
+                    trigger: ".modal-body .combo-item:eq(0) span:contains('11.00')",
+                },
+                {
+                    content: "Check 'Office Combo' price",
+                    trigger: ".modal-body .combo-item:eq(1) .fw-bolder:contains('47.33')",
+                },
+                {
+                    content: "Check 'Office Combo' save price",
+                    trigger: ".modal-body .combo-item:eq(1) span:contains('24.67')",
+                },
+                {
+                    content: "Check 'Third Combo Product' price",
+                    trigger: ".modal-body .combo-item:eq(2) span:contains('80.00')",
+                },
+                {
+                    content: "Check 'Third Combo Product' add price",
+                    trigger: ".modal-body .combo-item:eq(2) span:contains('19.00')",
+                },
+                Dialog.cancel(),
+            ]),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/feedback_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/feedback_screen_util.js
@@ -438,7 +438,7 @@ function clickPrintButton() {
 export function clickEditPayment() {
     return [
         {
-            trigger: ".feedback-screen .edit-order-payment:contains(Edit)",
+            trigger: ".feedback-screen .edit-order-payment:contains(Back)",
             run: "click",
         },
     ];

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3612,6 +3612,32 @@ class TestUi(TestPointOfSaleHttpCommon):
             }
         )
 
+        third_combo_with_upsell = self.env["product.combo"].create(
+            {
+                "name": "Third Combo",
+                "is_upsell": True,
+                "qty_free": 0,
+                "combo_item_ids": [
+                    Command.create({
+                        "product_id": combo_product_6.id,
+                        "extra_price": 0,
+                    }),
+                    Command.create({
+                        "product_id": combo_product_7.id,
+                        "extra_price": 0,
+                    }),
+                    Command.create({
+                        "product_id": combo_product_8.id,
+                        "extra_price": 5,
+                    }),
+                    Command.create({
+                        "product_id": combo_product_9.id,
+                        "extra_price": 0,
+                    }),
+                ],
+            }
+        )
+
         # Create Office Combo
         self.office_combo = self.env["product.product"].create(
             {
@@ -3627,8 +3653,23 @@ class TestUi(TestPointOfSaleHttpCommon):
             }
         )
 
+        self.third_combo_product = self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 50,
+                "name": "Third Combo Product",
+                "type": "combo",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "combo_ids": [
+                    (6, 0, [first_combo.id, second_combo.id, third_combo_with_upsell.id])
+                ],
+                "pos_categ_ids": [(6, 0, pos_category_ids)],
+            }
+        )
+
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_convert_orderlines_to_combo', login="pos_user")
+        self.start_pos_tour('test_convert_orderlines_to_combo_with_upsell', login="pos_user")
 
     def test_sync_from_ui_one_by_one(self):
         """

--- a/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
+++ b/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
@@ -19,7 +19,7 @@
                         />
                     </div>
                 </ListContainer>
-                <textarea t-att-rows="props.rows" class="h-100 flex-grow-1 form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
+                <textarea t-att-rows="props.rows" class="h-100 flex-grow-1 form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" style="resize: none;"/>
             </div>
         </xpath>
         <xpath expr="//button[hasclass('btn-primary')]" position="attributes">

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -32,7 +32,7 @@
                     <i class="oi oi-arrow-down me-1" />Transfer course
                 </button>
                 <button t-if="!pos.getOrder()?.table_id" t-att-class="buttonClass" t-on-click="() => this.pos.editFloatingOrderName(this.pos.getOrder())">
-                    <i class="fa fa-pencil-square-o me-1" />Edit Order Name
+                    <i class="fa fa-pencil-square-o me-1" />Set Order Name
                 </button>
             </t>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -108,7 +108,7 @@ patch(PosStore.prototype, {
     },
     async sendOrderInPreparation(order, opts = {}) {
         let categoryCount = [];
-        if (!opts.cancelled) {
+        if (!opts.cancelled && opts?.showNotification) {
             categoryCount = this.getCategoryCount(order);
         }
         const result = await super.sendOrderInPreparation(order, opts);
@@ -564,7 +564,9 @@ patch(PosStore.prototype, {
             try {
                 await this.ensureGuestCustomerCount(order);
                 this.env.services.ui.block();
-                await this.sendOrderInPreparationUpdateLastChange(order);
+                await this.sendOrderInPreparationUpdateLastChange(order, {
+                    showNotification: true,
+                });
             } finally {
                 this.env.services.ui.unblock();
             }
@@ -619,9 +621,10 @@ patch(PosStore.prototype, {
     },
     async editFloatingOrderName(order) {
         const payload = await makeAwaitable(this.dialog, EditOrderNamePopup, {
-            title: _t("Edit Order Name"),
+            title: _t("Set Order Name"),
             placeholder: _t("e.g. John"),
-            startingValue: order.floating_order_name || "",
+            startingValue: order.floatingOrderName,
+            size: "sm",
         });
         if (payload) {
             if (order.isSynced) {


### PR DESCRIPTION
In this commit:
---
- Feedback screen:
  - Move the Back button to the first position on both layouts.
  - Reduce the auto-skip delay and wipe animation from 5s to 1s for a faster flow when automatic receipting is enabled.
  - Adjust desktop layout width for better alignment.
- Combo selection:
  - Display combo price, “Save …” and “Add …” amounts in the combo chooser popup.
- Restaurant order name:
  - Rename “Edit Order Name” to “Set Order Name” in the product screen and popup.
  - Prefill the order name with a device-based sequence when empty and make the textarea non-resizable.
- Kitchen notifications:
  - Only show the preparation notification if the validate button triggers the sending.

task-5347023

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
