### PR TITLE
[FIX] sale_edi_ubl: exclude discounts

### DIFF
--- a/addons/sale_edi_ubl/models/sale_edi_common.py
+++ b/addons/sale_edi_ubl/models/sale_edi_common.py
@@ -72,6 +72,8 @@ class SaleEdiCommon(models.AbstractModel):
             lines_values += self._retrieve_line_charges(order, line_values, line_values['tax_id'])
             if not line_values['product_uom']:
                 line_values.pop('product_uom')  # if no uom, pop it so it's inferred from the product_id
+            if line_values.get('discount'):  # Exclude discounts
+                line_values.pop('discount')
             lines_values.append(line_values)
 
         return lines_values, logs

--- a/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
+++ b/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
@@ -58,12 +58,14 @@ class TestOrderEdiUbl(TestAccountEdiUblCii):
                 'product_uom': self.uom_units.id,
                 'product_qty': 10.0,
                 'taxes_id': self.purchase_tax.ids,
+                'discount': 10.0,
             }, {
                 'product_id': self.displace_prdct.id,
                 'price_unit': 30.0,
                 'product_uom': self.uom_units.id,
                 'product_qty': 50.0,
                 'taxes_id': self.purchase_tax.ids,
+                'discount': 0.0,
             },
         ]
         xml_attachment = self.get_xml_attachment_of_po(line_vals)
@@ -83,6 +85,7 @@ class TestOrderEdiUbl(TestAccountEdiUblCii):
         for line in line_vals:
             line_product = self.env['product.product'].browse(line['product_id'])
             line['product_uom_qty'] = line['product_qty']
+            line['discount'] = 0.0
             # Set sales tax related to similer to purchase tax
             line['tax_id'] = related_sales_tax.ids
             line['price_unit'] = line_product.list_price


### PR DESCRIPTION
Discounts are always sent by `_retrieve_line_vals` in `account_edi_ubl_cii`

In Sale orders, discounts aren't expected to be automatically imported
from the purchase order, it should always be 0.

`test_so_import_product_from_po` didn't use to fail because discount
wasn't checked until the recent refactor https://github.com/odoo/odoo/pull/190310

Check was added in 18.0 to avoid this error in the future.

Steps to reproduce:
- Disable discount in sale app
- Create a PO with a discount on any POL
- Enable discounts
- Import SO from PO

Issue:
Discount is added to the Sale order lines.

Runbot: 232724

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
