### PR TITLE
[FIX] hr_expense: approval date hours not computed correctly

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1414,7 +1414,7 @@ class HrExpense(models.Model):
             expense.write({
                 'approval_state': 'approved',
                 'manager_id': self.env.user.id,
-                'approval_date': fields.Date.context_today(expense),
+                'approval_date': fields.Datetime().now(),
             })
         self.update_activities_and_mails()
 


### PR DESCRIPTION
When approving an expense, we compute the approval date. We used fields.Date.context_today(expense) that only the the date but the hours are set to 1 AM. By using field.Datetime.now() the hours are computed correctly.

task-5262954




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
