### PR TITLE
[FIX] account: avoid warning on CoA reload

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -305,6 +305,10 @@ class AccountChartTemplate(models.AbstractModel):
         if account_group_count:
             data.pop('account.group', None)
 
+            for vals in data.get('account.account', {}).values():
+                if vals.get('group_id'):
+                    vals.pop('group_id', None)
+
         current_taxes = self.env['account.tax'].with_context(active_test=False).search([
             *self.env['account.tax']._check_company_domain(company),
         ])


### PR DESCRIPTION
When reloading a chart template, `_pre_reload_data` intentionally removes `account.group` entries so that groups are not recreated on reload.

However, the test chart template still provides `group_id = 'test_account_group_1'` on some accounts: https://github.com/odoo-dev/odoo/blob/d5bc2b12939861fbfda7182ff67b1f483124e783/addons/account/tests/test_chart_template.py#L83 . Since the group is skipped during reload, the loader tries to resolve the XML ID and logs the warning:
```
Failed when trying to recover test_account_group_1 for field=account.account.group_id
```
To avoid unnecessary warnings, this commit removes `group_id` from the template account values when groups are not being reloaded. This keeps reload behavior unchanged while preventing noisy log output.

[RB-230695](https://runbot.odoo.com/odoo/error/230695)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
