### PR TITLE
[FIX] mail: remove allowsEdition for owners

### DIFF
--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -52,15 +52,6 @@ const messagePatch = {
         });
         this.threadAsFirstUnread = fields.One("mail.thread", { inverse: "firstUnreadMessage" });
     },
-    /**
-     * @override
-     */
-    get allowsEdition() {
-        return (
-            super.allowsEdition ||
-            ["owner", "admin"].includes(this.channel_id?.self_member_id?.channel_role)
-        );
-    },
     /** @returns {import("models").ChannelMember[]} */
     get channelMemberHaveSeen() {
         return this.channel_id.membersThatCanSeen.filter(


### PR DESCRIPTION
Currently, the message model overrides the allowsEdition method to permit channel owners and admins to edit any message in the channel. This behavior is not desired, as only message authors and db admin should be able to edit the messages.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
