### PR TITLE
[FIX] hr_*_skills: Skill table display bugs

### DIFF
--- a/addons/hr_recruitment_skills/static/src/scss/skills_one2many_recruitment.scss
+++ b/addons/hr_recruitment_skills/static/src/scss/skills_one2many_recruitment.scss
@@ -1,0 +1,5 @@
+.o_applicant_skills .skills_header {
+    /* Margin and padding classes are added to .skills_header to work in both HR and Recruitment contexts. */
+    /* However, the combined spacing is too much for either scenario, so one is removed depending on context. */
+    margin: 0 !important;
+}

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -14,6 +14,7 @@
                                 <field mode="list" nolabel="1" name="current_applicant_skill_ids" widget="skills_one2many"
                                         context="{'default_applicant_id': id, 'no_timeline': True}" >
                                     <list
+                                        class="o_applicant_skills"
                                         decoration-muted="valid_to and valid_to &lt; context_today().strftime('%Y-%m-%d')"
                                         decoration-danger="valid_to and valid_to &lt;= (context_today() + relativedelta(days=7)).strftime('%Y-%m-%d') and valid_to &gt; context_today().strftime('%Y-%m-%d')"
                                         decoration-warning="valid_to and valid_to &lt;= (context_today() + relativedelta(months=1)).strftime('%Y-%m-%d') and valid_to &gt; (context_today() + relativedelta(days=7)).strftime('%Y-%m-%d')">

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.scss
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.scss
@@ -27,12 +27,32 @@ table.o_skill_table {
 }
 
 .skills_header {
-    padding-left: var(--ListRenderer-table-padding-x);
+    padding-inline: var(--ListRenderer-table-padding-x);
 }
 
+.o_skill_table thead {
+    /* This is to remove the top row with the column names from most displays of the skill table */
+    visibility: collapse;
+}
+
+.o_skill_table:not(.o_group_resume .o_skill_table) > thead {
+    /* This is needed because the border is rendered on chrome by default but not firefox but we also */
+    /* don't want to render any extra borders for the resume display */
+    border-width: 1px;
+}
+
+.o_employee_skills .skills_header {
+    /* Margin and padding classes are added to .skills_header to work in both HR and Recruitment contexts. */
+    /* However, the combined spacing is too much for either scenario, so one is removed depending on context. */
+    padding-block: 0 !important;
+}
+
+.o_employee_skills .o_list_renderer {
+    margin-top: 0 !important;
+}
 .skills_helper {
     display: flex;
     flex-direction: column;
     width: fit-content;
-    padding-left: var(--ListRenderer-table-padding-x);
+    padding-inline: var(--ListRenderer-table-padding-x);
 }

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
@@ -4,11 +4,8 @@
         <xpath expr="//table" position="attributes">
             <attribute name="t-attf-class" add="mb-1 {{ !isEditable ? 'cursor-default' : '' }} {{ !showTable ? 'd-none' : ''}} o_skill_table overflow-hidden" separator=" "/>
         </xpath>
-        <xpath expr="//thead" position="attributes">
-            <attribute name="style">visibility: collapse;</attribute>
-        </xpath>
         <xpath expr="//table" position="before">
-            <div name="skills_header" class="skills_header text-uppercase fw-bolder py-2" t-attf-style="{{!showTable ? 'box-shadow: 0 1px 0 #e6e6e6' : ''}}">
+            <div name="skills_header" class="skills_header text-uppercase small fw-bolder py-2 mt-4" t-att-class="{'o_horizontal_separator': !showTable }">
                 Skills &amp; Certifications
                 <a t-if="!isEmpty &amp;&amp; showTimeline" t-on-click="openSkillsReport" class="float-end cursor-pointer">
                     <span class="fa fa-line-chart me-1"/>

--- a/addons/hr_skills/static/src/scss/hr_employee.scss
+++ b/addons/hr_skills/static/src/scss/hr_employee.scss
@@ -1,7 +1,3 @@
-#o_work_information_right.o_hr_skills_group .o_list_renderer {
-    overflow-x: hidden !important;
-}
-
 .o_hr_skill_type_form {
     th[data-name="level_progress"] div span {
         text-align: left !important;
@@ -32,14 +28,6 @@
     .o_progressbar_value .o_input {
         width: 0 !important;
     }
-    .flex-row-reverse {
-        flex-direction: inherit !important;
-    }
-}
-
-#o_work_information_right .o_list_renderer {
-    --ListRenderer-margin-x: 0;
-    --ListRenderer-table-padding-x: 0;
 }
 
 .o_resume_html .note-editable {

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -123,8 +123,9 @@
             </div>
             <div id="o_work_information_right" position="inside">
                 <field mode="list" nolabel="1" name="current_employee_skill_ids" widget="skills_one2many"
-                    context="{'no_timeline': not employee_skill_ids}" class="mt-2">
+                    context="{'no_timeline': not employee_skill_ids}">
                     <list
+                        class="o_employee_skills"
                         decoration-muted="valid_to and valid_to &lt; context_today().strftime('%Y-%m-%d')"
                         decoration-danger="valid_to and valid_to &lt;= (context_today() + relativedelta(days=7)).strftime('%Y-%m-%d') and valid_to &gt; context_today().strftime('%Y-%m-%d')"
                         decoration-warning="valid_to and valid_to &lt;= (context_today() + relativedelta(months=3)).strftime('%Y-%m-%d') and valid_to &gt; (context_today() + relativedelta(days=7)).strftime('%Y-%m-%d')">
@@ -362,7 +363,7 @@
         <field name="arch" type="xml">
             <list string="Skill Levels" class="o_skill_level_tree" editable="bottom" default_order="level_progress desc">
                 <field name="name"/>
-                <field name="level_progress" widget="progressbar" options="{'editable': true}"/>
+                <field name="level_progress" widget="progressbar" options="{'editable': true}" width="250"/>
                 <field name="default_level" widget="boolean_toggle_load"/>
                 <field name="technical_is_new_default" column_invisible="1"/> <!-- needs to be here to be accessible for the front-end -->
             </list>


### PR DESCRIPTION
This PR fixes various issues with how the skill table is displayed in hr, hr_recruitment, and hr_appraisal. Additionally, all code related to displaying sample data for the appraisal skills is removed in this PR, as the skills page has been hidden (rather than showing sample data) since at least v18.

Issues:
1. The skills table on the employee form view is cropped on the sidees when viewing in Firefox.
2. The skills table header and the resume header on the employee form view is not aligned and styled the same way.
3. The skills table header on the employee form view is missing the separator below it when viewing in Chrome.
4. The skills table header on the applicant form view is missing the separator below it when viewing in Firefox. 
5. The skills table on the appraisal form view is missing a separator when
	viewing on Firefox.

Task-5033427
