### PR TITLE
[FIX] html_editor: link popover reposition issues

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -7,7 +7,6 @@ import {
     makeContentsInline,
     removeClass,
     removeStyle,
-    splitTextNode,
     unwrapContents,
     wrapInlinesInBlocks,
 } from "../utils/dom";
@@ -39,7 +38,7 @@ import {
     lastLeaf,
 } from "../utils/dom_traversal";
 import { FONT_SIZE_CLASSES, TEXT_STYLE_CLASSES } from "../utils/formatting";
-import { DIRECTIONS, childNodeIndex, nodeSize, rightPos } from "../utils/position";
+import { childNodeIndex, nodeSize, rightPos } from "../utils/position";
 import { normalizeCursorPosition } from "@html_editor/utils/selection";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -166,7 +165,12 @@ export class DomPlugin extends Plugin {
         let insertBefore = false;
         if (selection.startContainer.nodeType === Node.TEXT_NODE) {
             insertBefore = !selection.startOffset;
-            splitTextNode(selection.startContainer, selection.startOffset, DIRECTIONS.LEFT);
+            if (
+                selection.startOffset !== 0 &&
+                selection.startOffset !== selection.startContainer.length
+            ) {
+                selection.startContainer.splitText(selection.startOffset);
+            }
             startNode = selection.startContainer;
         }
 

--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -26,7 +26,7 @@ export class EditorOverlay extends Component {
         editable: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
         bus: Object,
         getContainer: Function,
-        history: Object,
+        shared: Object,
         close: Function,
         isOverlayOpen: Function,
 
@@ -109,10 +109,11 @@ export class EditorOverlay extends Component {
     getSelectionTarget() {
         const doc = this.props.editable.ownerDocument;
         const selection = doc.getSelection();
+        const selectionData = this.props.shared.getSelectionData();
         if (!selection || !selection.rangeCount || !this.props.isOverlayOpen()) {
             return null;
         }
-        const inEditable = this.props.editable.contains(selection.anchorNode);
+        const inEditable = selectionData.currentSelectionIsInEditable;
         let range;
         if (inEditable) {
             range = selection.getRangeAt(0);
@@ -128,7 +129,7 @@ export class EditorOverlay extends Component {
             // Attention, ignoring DOM mutations is always dangerous (when we add or remove nodes)
             // because if another mutation uses the target that is not observed, that mutation can never be applied
             // again (when undo/redo and in collaboration).
-            this.props.history.ignoreDOMMutations(() => {
+            this.props.shared.ignoreDOMMutations(() => {
                 const clonedRange = range.cloneRange();
                 const shadowCaret = doc.createTextNode("|");
                 clonedRange.insertNode(shadowCaret);

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -15,7 +15,7 @@ import { closestScrollableY } from "@web/core/utils/scrolling";
  */
 export class OverlayPlugin extends Plugin {
     static id = "overlay";
-    static dependencies = ["history"];
+    static dependencies = ["history", "selection"];
     static shared = ["createOverlay"];
     resources = {
         step_added_handlers: this.getScrollContainer.bind(this),
@@ -108,8 +108,9 @@ export class Overlay {
                     getContainer: this.getContainer,
                     close: this.close.bind(this),
                     isOverlayOpen: this.isOverlayOpen.bind(this),
-                    history: {
+                    shared: {
                         ignoreDOMMutations: this.plugin.dependencies.history.ignoreDOMMutations,
+                        getSelectionData: this.plugin.dependencies.selection.getSelectionData,
                     },
                 }),
                 {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -132,6 +132,29 @@ describe("popover should not reposition when editing", () => {
             '<p>H<a href="https://test.com">ell[]</a>o</p>'
         );
     });
+    test("In iframe, when editing the link url, the popover should not reposition", async () => {
+        const { el } = await setupEditor("<p>H[ell]o</p>", { props: { iframe: true } });
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await animationFrame();
+        await waitFor(".o-we-linkpopover");
+        const popoverEl = queryOne(".o-we-linkpopover").parentElement;
+        const initialPopoverBox = popoverEl.getBoundingClientRect();
+
+        queryOne(".o-we-linkpopover input.o_we_href_input_link").focus();
+        await fill("test.com");
+        await animationFrame();
+        const newPopoverBox = popoverEl.getBoundingClientRect();
+
+        expect(Math.floor(newPopoverBox.top)).toBe(Math.floor(initialPopoverBox.top));
+        expect(Math.floor(newPopoverBox.left)).toBe(Math.floor(initialPopoverBox.left));
+
+        await waitFor(".o_we_apply_link:not([disabled])");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>H<a href="https://test.com">ell[]</a>o</p>'
+        );
+    });
 });
 
 describe("popover should switch UI depending on editing state", () => {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -108,6 +108,32 @@ describe("should open a popover", () => {
     });
 });
 
+describe("popover should not reposition when editing", () => {
+    test("when editing the link url, the popover should not reposition", async () => {
+        const { el } = await setupEditor("<p>H[ell]o</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await animationFrame();
+        await waitFor(".o-we-linkpopover");
+        const popoverEl = queryOne(".o-we-linkpopover").parentElement;
+        const initialPopoverBox = popoverEl.getBoundingClientRect();
+
+        queryOne(".o-we-linkpopover input.o_we_href_input_link").focus();
+        await fill("test.com");
+        await animationFrame();
+        const newPopoverBox = popoverEl.getBoundingClientRect();
+
+        expect(Math.floor(newPopoverBox.top)).toBe(Math.floor(initialPopoverBox.top));
+        expect(Math.floor(newPopoverBox.left)).toBe(Math.floor(initialPopoverBox.left));
+
+        await waitFor(".o_we_apply_link:not([disabled])");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>H<a href="https://test.com">ell[]</a>o</p>'
+        );
+    });
+});
+
 describe("popover should switch UI depending on editing state", () => {
     test("after clicking on edit button, the popover should switch to editing mode", async () => {
         await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');


### PR DESCRIPTION
Two related overlay reposition issues are solved separately out of iframe and in the iframe.

**Commit 1:**
[FIX] html_editor: avoid wrong range after insert and popover reposition

Before this commit: The link popover is repositioned at the beginning of the
text when editing url. When insert, we first delete the non-collapsed selection,
then we split the text node by splitTextNode at the collapsed selection. However,
splitTextNode resets the text node's value by its substring, which breaks the
range of the collapsed selection. This range is stored and used to reposition
the overlay when the selection is not in the editable.

Reproduction:
1. selection some text, create a link
2. go the the url field and type something
3. the popover is replaced to the beginning of the text.

After this commit: we use dom function splitText to split the text only when we
need to, e.g. when the currently selection's offset isn't at the beginning or
the end of the text node. The dom function keeps the range properly maintained
after splitting.

However, there is a limitation case from how we create the link on selection,
how the browser manages the selection's range and how the overlay reacts to it.

The limitation case is when the selection is inside one text node and selecting
the whole text node of the range's startContainer (which is the same with
endContainer). When the link is created, we do extractContent on the selection's
range, put it in the link and insert the link at the collapsed selection. During
this process, the browser loses the range's start/end container which leads to
invalid start/end container.

For this range isn't valid case, it triggers the overlay plugin's special
handler which inserts one shadow caret (which is after the inserted link) and
uses it to calculate the position. Because the shadow caret is inserted by the
cloned collapsed range, we can't really have enough context from the range
(about where to re-place the caret) to manipulate the position.


**Commit2:**
[FIX] html_editor: pass selection data to overlay to avoid reposition in iframe

Before this commit: the overlay plugin uses the editable's document's selection
to check if the current selection is in the editable. It works when there's no
iframe, as the overlays are part of the document. However in an iframe's
editable zone, e.g. the website editing zone, the overlays are not under the
iframe document but under the outer window's document. When checking iframe
document's selection, it cannot detect the selection in the overlay, which gives
a wrong "inEditable" value.

After this commit: we pass the getSelectionData to the overlay so it can use the
existing currentSelectionIsInEditable

task-5184799


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
