### PR TITLE
[FIX] mail: bigger composer on small UI for improved accessibility

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -39,6 +39,10 @@
         margin-top: map-get($spacers, 1) / 2;
     }
 
+    &.o-isUiSmall:not(.o-editing) .o-mail-Composer-mainActions {
+        margin-top: map-get($spacers, 1) * 6 / 4;
+    }
+
     &:not(.o-focused) {
         .o-mail-Composer-input::placeholder {
             opacity: 50%;
@@ -128,6 +132,11 @@
     .o-mail-Composer.o-isUiSmall & {
         padding-top: 7px;
         padding-bottom: 7px;
+    }
+
+    .o-mail-Composer.o-isUiSmall:not(.o-editing) & {
+        padding-top: 12px;
+        padding-bottom: 12px;
     }
 }
 


### PR DESCRIPTION
When using small UI, the composer of Discuss is quite low. This is a problem especially with iPhones that have heavily rounded courners for which some content is cut and thus make it hard to use.

One solution is to add some bottom margin, but it needs to be removed when composer is focused otherwise it's too high with soft keyboard. That was the strategy we used, but it has been reverted [1] because this makes clicking on the "Send" button unreliable, due to the jump of send button when moving vertically, which made OWL not register the click on the button.

This commit makes the composer bigger on small UI, so that although the bottom might be cut like on iPhones, at least the bigger size of the composer makes it less of a problem.

Also the bigger size is welcome: with touch devices, the input is now vertically sized for touch interaction, of about 44px, which is close to recommended 48px.

[1]: https://github.com/odoo/odoo/pull/226546

Before / After
<img width="284" height="616" alt="Screenshot 2025-11-27 at 15 23 33" src="https://github.com/user-attachments/assets/ff9a3b42-078b-4e4f-a1c5-4d5828f7bb56" /> <img width="284" height="616" alt="Screenshot 2025-11-27 at 15 22 32" src="https://github.com/user-attachments/assets/f9fcb6c7-08f0-4cff-a578-648cf7866050" />

