### PR TITLE
[IMP] account: Hide inactive currencies in search more

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -984,8 +984,7 @@
                                            groups="base.group_multi_currency"
                                            invisible="move_type == 'entry'"
                                            readonly="state != 'draft'"
-                                           options="{'no_create': True}"
-                                           context="{'search_default_active': 1, 'search_default_inactive': 1}"/>
+                                           options="{'no_create': True}"/>
                                 </div>
 
                                 <field name="currency_id"

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -103,7 +103,6 @@
                     <field name="name"/>
                     <field name="symbol"/>
                     <field name="full_name"/>
-                    <field name="active"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="oe_kanban_global_click">
@@ -115,7 +114,7 @@
                                         <span class="badge rounded-pill"><t t-esc="record.symbol.value"/></span>
                                     </div>
                                     <div class="col-5 text-end">
-                                        <t t-if="! record.active.raw_value"><span class="badge rounded-pill bg-light border">inactive</span></t>
+                                        <field name="active" widget="boolean_toggle"/>
                                     </div>
                                 </div>
                                 <div class="row">


### PR DESCRIPTION
This commit does 2 things:
1. In account.move form view, when the user click on search more of the currency, they would only see active ones they can then show inactive currencies using filters
2. The kanban view of the currency now shows a toggle which can toggle between active and inactive states for the currency so that the users on the mobile view can easily toggle through kanbans without having to go to form view

task-5354516





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
