### PR TITLE
[FIX] sale*: disable editing docs on locked SO

### DIFF
--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.js
@@ -20,12 +20,14 @@ export class CustomContentKanbanLikeWidget extends Component {
             headers: {},
             lines: {},
             footers: {},
+            is_so_locked: true,
+            is_sol_locked: true,
         });
 
         // Initialize the state and update available documents when updating the quotation template.
         useEffect((saleOrderTemplate) => {
             this.updateState();
-        }, () => [this.props.record.data.sale_order_template_id]);
+        }, () => [this.props.record.data.sale_order_template_id, this.props.record.data.locked]);
     }
 
     async updateState() {
@@ -37,6 +39,8 @@ export class CustomContentKanbanLikeWidget extends Component {
             this.state.headers = headers;
             this.state.lines = lines;
             this.state.footers = footers;
+            this.state.is_so_locked = this.props.record.data.locked;
+            this.state.is_sol_locked = this.props.record._isReadonly('order_line');
         }
     }
 

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_content_kanban_like_widget.xml
@@ -4,6 +4,7 @@
         <t t-if="state.headers.files?.length">
             <t t-call="sale_pdf_quote_builder.section">
                 <t t-set="section" t-value="state.headers"/>
+                <t t-set="locked" t-value="state.is_so_locked"/>
                 <t
                     t-set="save"
                     t-value="(lineId, docId, isSelected) => {
@@ -15,6 +16,7 @@
         <t t-if="state.lines?.length">
             <t t-foreach="state.lines" t-as="section" t-key="section.id">
                 <t t-call="sale_pdf_quote_builder.section">
+                    <t t-set="locked" t-value="state.is_sol_locked"/>
                     <t
                         t-set="save"
                         t-value="(lineId, docId, isSelected) => {
@@ -27,6 +29,7 @@
         <t t-if="state.footers.files?.length">
             <t t-call="sale_pdf_quote_builder.section">
                 <t t-set="section" t-value="state.footers"/>
+                <t t-set="locked" t-value="state.is_so_locked"/>
                 <t
                     t-set="save"
                     t-value="(lineId, docId, isSelected) => {
@@ -51,6 +54,7 @@
                         class="btn-check"
                         t-att-id="id+'-'+doc.id"
                         t-att-checked="doc.is_selected"
+                        t-att-disabled="locked"
                         t-on-click="() => {
                             doc.is_selected = !doc.is_selected;
                             save(id, doc.id, doc.is_selected);
@@ -81,6 +85,7 @@
                         <CustomFieldCard
                             name="formField.name"
                             value="formField.value"
+                            disabled="locked"
                             onChange="(value) => { formField.value = value; this.updateJson(); }"
                         />
                     </t>

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.js
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.js
@@ -10,6 +10,7 @@ export class CustomFieldCard extends Component {
         name: String,
         value: String,
         onChange: Function,
+        disabled: { type: Boolean, default: false },
     };
 
     setup() {

--- a/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/custom_content_kanban_like_widget/custom_field_card/custom_field_card.xml
@@ -11,6 +11,7 @@
                         t-model.lazy="this.props.value"
                         t-on-change="(ev) => { this.props.onChange(this.props.value) }"
                         t-att-placeholder="this.placeholder"
+                        t-att-disabled="this.props.disabled"
                         class="customFieldCardTextArea form-control overflow-y-hidden"
                     />
                 </span>


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable the `Lock Confirmed Sales` option from settings
2. Create a new quotation and add a customer
3. Add a product that includes a document that has its visibility set to `Inside quote pdf`
4. Modify which documents (header, product document, etc) are attached to the quotation and their custom fields from the `Quote Builder` tab
5. Confirm the quotation and notice that the sale order is now locked

Issue
-----
Although the sale order is locked, you are still able to add/remove the documents, and you can also modify the custom fields. Adding/removing the headers and footers work as expected, however if you try to add or remove a product document it will look like your modification has been successful, but if you refresh the page you will discover it hasn't actually been saved. Even though you can't add or remove a product document, you still can modify the custom fields for these product documents.

Cause
-----
You are allowed to edit the headers, footers, and custom fields because there are no checks to stop you from doing so if the sale order is locked. The reason that adding or removing product documents doesn't work is that these are saved on the sale order line, which becomes read only when the sale order is locked.

Solution
--------
When the sale order is locked, disable adding/removing documents or modifying custom fields. It is only disabled from the frontend similarly to other fields in the locked sale order.

opw-5182258
