### PR TITLE
[FIX] html_builder: correct scrolling in shape selector

### DIFF
--- a/addons/html_builder/static/src/plugins/shape/shape_selector.js
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.js
@@ -35,9 +35,11 @@ export class ShapeSelector extends BaseOptionComponent {
         return `o_${shapePath.replaceAll("/", "_")}`;
     }
     scrollToShapes(id) {
-        this.rootRef.el
-            ?.querySelector(`[data-shape-group-id="${id}"]`)
-            ?.scrollIntoView({ behavior: "smooth" });
+        const container = this.rootRef.el;
+        const selectedElement = container?.querySelector(`[data-shape-group-id="${id}"]`);
+        if (container && selectedElement) {
+            container.scrollTop = selectedElement.offsetTop - container.offsetTop;
+        }
     }
 
     _onScroll() {


### PR DESCRIPTION
**Description of the problem**
If the browser window has a limited height, clicking on a shape category in the shape selector scrolls both the shape selector pager (wanted) and the full viewport (not wanted), leading to white bands appearing at the bottom of the viewport.

**How to reproduce**
1. Drop `s_picture` snippet
2. Open the background shape selector
3. Reduce the window height until only ~4 rows of shapes are visible
4. Click on "Linear" or "Creative" category
5. BUG: the viewport scrolled

**Why the problem happens**
When a shape category in the shape selector is clicked, the function `scrollIntoView` is used to bring the first shape of that category into view. By default, `scrollIntoView` scrolls all ancestor scroll-containers (and possibly the viewport) until the desired element is visible. This means that in specific situations the viewport could scroll too.

**Fix**
The function `scrollIntoView` should support the option `container: "nearest"`, which would force only the first scroll-container to scroll, avoiding scrolling the viewport. However, at the moment this option is not widely supported across browsers [1]. Thus `scrollIntoView` has been removed and its behaviour has been replicated by changing the `scrollTop` property of the `ShapeSelector` scroll-container.

[1]: https://caniuse.com/mdn-api_element_scrollintoview_options_parameter_container_option

task-5262945
