### PR TITLE
[FIX] project_timesheet_holidays: correct timesheets for new employee

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -49,7 +49,7 @@ class Employee(models.Model):
         today = fields.Datetime.today()
         global_leaves_wo_calendar = defaultdict(lambda: self.env["resource.calendar.leaves"])
         global_leaves_wo_calendar.update(dict(self.env['resource.calendar.leaves']._read_group(
-            [('calendar_id', '=', False), ('date_from', '>=', today)],
+            [('calendar_id', '=', False), ('resource_id', '=', False), ('date_from', '>=', today)],
             groupby=['company_id'],
             aggregates=['id:recordset'],
         )))


### PR DESCRIPTION
**Steps to reproduce**
1. Have a future `resource.calendar.leaves` without a `calendar_id` but with a `resource_id`. To achieve this, you can for example install Payroll and Attendance, create a contract with the work entry source being attendances and with no working schedule. Then, create a time off in hours for that employee and validate it. In that case, the `hr.leave` has no `resource_calendar_id` as computed in `_compute_resource_calendar_id`. This leads to a `resource.calendar.leaves` record without a `calendar_id` once the time off is validated.
2. Create a new employee. A timesheet corresponding to the previously created time off is created.

**Change**
Make sure only global time offs are considered.

opw-5248992