### PR TITLE
[FIX] web: colibri restore t-outs on destroy

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -420,6 +420,19 @@ export class Colibri {
             }
         }
 
+        for (const tOut of this.tOuts) {
+            const { sel, initialValue } = tOut;
+            if (!initialValue) {
+                continue;
+            }
+            for (const node of this.dynamicNodes.get(sel) || []) {
+                if (initialValue.has(node)) {
+                    const value = initialValue.get(node);
+                    this.applyTOut(node, INITIAL_VALUE, value);
+                }
+            }
+        }
+
         this.listeners.clear();
         this.dynamicNodes.clear();
         this.destroyInteraction();


### PR DESCRIPTION
When the Interaction framework was introduced in [1], fields that used t-outs weren't restored to the initial values, although initial values were saved. This commit restores it on `destroy`.

[1]: https://github.com/odoo/odoo/commit/dd13994674d4ef4683f5a4d46a1f604650cfb92b
