### PR TITLE
[FIX] mail: fix standalone messages badges in MessagingMenu

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -14,9 +14,9 @@
             <t t-foreach="visibleStandaloneMessages" name="standaloneInboxMessages" t-as="message" t-key="message.id">
                 <NotificationItem
                     isActive="state.activeIndex === itemIndex"
-                    counter="1"
                     datetime="message?.datetime"
                     iconSrc="store.DEFAULT_AVATAR"
+                    important="true"
                     hasMarkAsReadButton="1"
                     muted="0"
                     onClick="(isMarkAsRead) => this.onClickInboxMsg(isMarkAsRead, message)"

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1379,8 +1379,7 @@ test("ensure messaging menu shows standalone inbox messages", async () => {
 
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem .badge", { text: "1" });
+    await contains(".o-mail-NotificationItem .badge");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-Message-author", { text: "Partner1" });
     await contains(".o-mail-Message-textContent", { text: "Message with needaction" });


### PR DESCRIPTION
**Fix:**
Show red pill with no counter on standalone messages

related: https://github.com/odoo/odoo/commit/920fbf05b2d9108d538ee03298a542871ef4503a

opw-4969005