### PR TITLE
[FIX] website_profile: website profile edition check from portal

### DIFF
--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -12,6 +12,7 @@ from dateutil.relativedelta import relativedelta
 from operator import itemgetter
 
 from odoo import _, fields, http, tools
+from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.osv import expression
 
@@ -148,6 +149,8 @@ class WebsiteProfile(http.Controller):
             user = request.env.user
         values = self._profile_edition_preprocess_values(user, **kwargs)
         whitelisted_values = {key: values[key] for key in user.SELF_WRITEABLE_FIELDS if key in values}
+        if not user.partner_id.can_edit_vat() and whitelisted_values.get('country_id') != user.partner_id.country_id.id:
+            raise UserError(_("Changing the country is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."))
         user.write(whitelisted_values)
         if kwargs.get('url_param'):
             return request.redirect("/profile/user/%d?%s" % (user.id, kwargs['url_param']))


### PR DESCRIPTION
Steps to reproduce:

1. Install website_forum, website_sale.
2. Confirm a Sale Order for a portal user.
3. Log in as the portal user, go to My Account -> Edit Information.
4. Country is in readonly.
5. Go to Forum -> Profile -> Edit
6. Edit the country
7. Nothing stops the user from doing so.

---

Description of the issue this commit addresses:

If there is already an invoice or a sale order for a partner, we restrict the edition of some of its values to system administrators. This is already enforced on the edition of the profile via /my/home route but not via the /profile/user.

---

Desired behavior after the commit is merged:

When an invoice or a sale order is set for a partner with portal access, he can't edit his country via the /profile/user route anymore.

---

task-5331916

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr