### PR TITLE
[FIX] pos_hr_{restaurant}: respect default screen config after login

### DIFF
--- a/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
@@ -132,18 +132,15 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
 
         const currentScreen = pos.mainScreen.component.name;
         if (currentScreen === "LoginScreen" && login && employee) {
-            const isRestaurant = pos.config.module_pos_restaurant;
             let selectedScreen =
                 pos.previousScreen && pos.previousScreen !== "LoginScreen"
                     ? pos.previousScreen
-                    : isRestaurant
-                    ? "FloorScreen"
-                    : "ProductScreen";
+                    : pos.defaultScreen;
 
             const props = {};
             if (selectedScreen === "PaymentScreen") {
                 if (!pos.selectedOrderUuid) {
-                    selectedScreen = isRestaurant ? "FloorScreen" : "ProductScreen";
+                    selectedScreen = pos.defaultScreen;
                 } else {
                     props.orderUuid = pos.selectedOrderUuid;
                 }

--- a/addons/pos_hr_restaurant/__manifest__.py
+++ b/addons/pos_hr_restaurant/__manifest__.py
@@ -16,6 +16,9 @@ This module adapts the behavior of the PoS when the pos_hr and pos_restaurant ar
         'point_of_sale._assets_pos': [
             'pos_hr_restaurant/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'pos_hr_restaurant/static/tests/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/pos_hr_restaurant/static/tests/tours/pos_hr_restaurant_tour.js
+++ b/addons/pos_hr_restaurant/static/tests/tours/pos_hr_restaurant_tour.js
@@ -1,0 +1,33 @@
+import * as PosHr from "@pos_hr/../tests/tours/utils/pos_hr_helpers";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
+import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_post_login_default_screen_is_tables", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            FloorScreen.isShown(),
+            Chrome.clickMenuOption("Close Register"),
+            Dialog.confirm("Close Register"),
+            Chrome.clickBtn("Backend"),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_post_login_default_screen_is_register", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_hr_restaurant/tests/__init__.py
+++ b/addons/pos_hr_restaurant/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_frontend

--- a/addons/pos_hr_restaurant/tests/test_frontend.py
+++ b/addons/pos_hr_restaurant/tests/test_frontend.py
@@ -1,0 +1,15 @@
+from odoo.tests import tagged
+from odoo.addons.pos_hr.tests.test_frontend import TestPosHrHttpCommon
+from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontendCommon
+
+
+@tagged("post_install", "-at_install")
+class TestUi(TestPosHrHttpCommon, TestFrontendCommon):
+    def test_post_login_default_screen(self):
+        self.main_pos_config.default_screen = "tables"
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour("test_post_login_default_screen_is_tables", login="pos_admin")
+
+        self.main_pos_config.default_screen = "register"
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour("test_post_login_default_screen_is_register", login="pos_admin")


### PR DESCRIPTION
Steps to reproduce
------------------
1. For a restaurant, set the default page as "register", i.e. the
   products page
2. Enable
3. Now login with an employee, and notice that the page after the login
   page is the floor page, not the products page as set in the
   configuration of (step 1).

Why the issue
-------------
After successfully logging in, we were redirecting the user either to
the products page, always if it's not a restaurant, or to the floor
page, always if it's a restaurant. That means we were not taking into
consideration, for the restauarnt case, whether the default page is the
floor page or the products page.

The fix
-------
Now we redirect users after logging using the `defaultPage` getter,
which takes into consideration the `default_page` cofiguration for a
restaurant PoS.

opw-5359514