### PR TITLE
[FIX] website: Cookie consent button unresponsive after size change

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -504,7 +504,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @param ev
      */
     _onAcceptClick(ev) {
-        const isFullConsent = ev.target.id === "cookies-consent-all";
+        const isFullConsent = ev.currentTarget.id === "cookies-consent-all";
         this.cookieValue = `{"required": true, "optional": ${isFullConsent}, "ts": ${Date.now()}}`;
         if (isFullConsent) {
             document.dispatchEvent(new Event("optionalCookiesAccepted"));


### PR DESCRIPTION
The "I agree" button in the cookie bar would stop working if its font size was changed.

Steps to reproduce:
===================
- Enable the cookie bar in website settings.
- Go to the website and enter Edit mode.
- Click on the cookie bar.
- Select the "I agree" button's text and change its font size.
- Save and visit the page as a guest (e.g., in a private window).
- Click on the "I agree" button text. 
-> The maps doesn't show and the Cookie bar disappear.

Cause:
======
Applying a font size to the button's text wraps that text within a `<span>` element.

The event listener for accepting cookies is attached to the elements with IDs `#cookies-consent-essential` and `#cookies-consent-all`. in that case it ID `cookies-consent-essential` exist in the parent element. However, the code was checking the ID of `event.target`. When a user clicks directly on the newly created
`<span>`, `event.target` refers to the `<span>` itself, not the element who owns the event.

Since the `<span>` does not have the required ID ('cookies-consent-all'), the condition to accept the cookies was false.

Solution:
=========
Use `event.currentTarget` instead of `event.target`.

Unlike `event.target`, `event.currentTarget` always refers to the element to which the event handler was attached—in.
check: 
https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget

opw-5004645

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
