### PR TITLE
[FIX] website: preserve COW views in _theme_cleanup

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -292,12 +292,21 @@ class IrModuleModule(models.Model):
             return model
         # use active_test to also unlink archived models
         # and use MODULE_UNINSTALL_FLAG to also unlink inherited models
-        orphans = model.with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search([
+        orphan_candidates = model.with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search([
             ('key', '=like', self.name + '.%'),
             ('website_id', '=', website.id),
             ('theme_template_id', '=', False),
         ])
-        orphans.unlink()
+        # Only delete true orphans: website-specific views whose generic parent
+        # no longer exists. COW views (created when users edit generic views)
+        # have the same key as their generic parent and should NOT be deleted.
+        true_orphans = orphan_candidates.filtered(
+            lambda v: not model.search_count([
+                ('key', '=', v.key),
+                ('website_id', '=', False),
+            ])
+        )
+        true_orphans.unlink()
 
     def _theme_get_upstream(self):
         """


### PR DESCRIPTION
**Description**  
This PR fixes an issue where COW views created by users were being deleted during `_theme_cleanup`.

**Issue:** [odoo/odoo#233723](https://github.com/odoo/odoo/issues/233723)

### Explanation  
The `_theme_cleanup` method deleted all views with `theme_template_id=False`.  
COW views created when users edited generic views also had `theme_template_id=False` because the field has `copy=False`.  
As a result, the method couldn’t distinguish between true orphans and user customizations.

### Solution  
Before deleting, the cleanup process now checks if a generic parent view exists.  
Only views without generic parents (true orphans) are deleted.

task-5248173
