### PR TITLE
[FIX] stock_account: handle float quantities in fifo

### DIFF
--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -280,6 +280,16 @@ class TestStockValuation(TestStockValuationCommon):
         self.assertEqual(move8.remaining_qty, 0.0)  # unused in internal moves
         self.assertEqual(move9.remaining_qty, 0.0)  # unused in out moves
 
+    def test_fifo_perpetual_3(self):
+        """ Make sure that the fifo valuation is correct for non-integer quantities.
+        """
+        product = self.product_fifo
+
+        move1 = self._make_in_move(product, 1.9, 10)
+
+        self.assertAlmostEqual(move1.remaining_qty, 1.9)
+        self.assertAlmostEqual(move1.remaining_value, 19)
+
     def test_fifo_negative_1(self):
         """ Send products that you do not have. Value the first outgoing move to the standard
         price, receive in multiple times the delivered quantity and run _fifo_vacuum to compensate.


### PR DESCRIPTION
Steps to reproduce:
- Storable product with fifo valuation & standard price of $1
- Do an inventory adjustment with 1.9 qty
- Go to Inventory > Reporting > Stock and click on the total value

Issue:
Remaning quantity is 1 and remaining value is $1.00

A cast to int() on the `qty_available` was done so it would be used as a `limit` for a search. However, this meant that the decimal part of the quantity would be dropped.

After further analysis, we changed the over-engineered limit to always be 100, as by nature that value is completely arbitrary anyway.

opw-5230435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
