### PR TITLE
[FIX] pos_loyalty: set customer as gift card's partner

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -96,7 +96,7 @@ class PosOrder(models.Model):
                 coupon["code"] = coupon.get("gift_code")
         coupon_create_vals = [{
             'program_id': p['program_id'],
-            'partner_id': get_partner_id(p.get('partner_id', False)),
+            'partner_id': get_partner_id(p.get('partner_id', self.partner_id.id)),
             'code': p.get('code') or p.get('barcode') or self.env['loyalty.card']._generate_code(),
             'points': 0,
             'expiration_date': p.get('date_to', False),


### PR DESCRIPTION
When buying a gift card from a POS, the gift card is created without a partner. This is an issue for users who want to see who bought a specific gift card.

In [`pos_loyalty/models/pos_order.py`](https://github.com/odoo/odoo/blob/0bf53e6b2ab8c4c1705ebbb776102d493ac7445c/addons/pos_loyalty/models/pos_order.py), the `coupon_data` passed to the `confirm_coupon_programs` method does not contain the `partner_id`. This happens because the *Gift Card* program is not considered "nominative", failing the following condition from `pos_loyalty/static/src/overrides/models/pos_store.js`:

https://github.com/odoo/odoo/blob/0bf53e6b2ab8c4c1705ebbb776102d493ac7445c/addons/pos_loyalty/static/src/overrides/models/pos_store.js#L795-L801

In fact, the conditions for nominative programs are defined in the `loyalty` module:

https://github.com/odoo/odoo/blob/0bf53e6b2ab8c4c1705ebbb776102d493ac7445c/addons/loyalty/models/loyalty_program.py#L196-L200

This fix uses the customer's id when there's no `partner_id` in the `coupon_data` coming from the Javascript side. If there's no customer selected when buying the gift card from the POS, `self.partner_id.id` evaluates to `False`, leading to the original behavior: a gift card with no partner.

### Steps to reproduce:
1. Install Point of Sale (`point_of_sale`)
2. In Settings > Point of Sale, toggle *Promotions, Coupons, Gift Card & Loyalty Program*
3. In the POS, open a register
4. On the product screen, select the *"Gift Card"* product and click *Payment*
5. On the payment screen, set the Customer to any customer, pay, and click *Validate*
6. In the POS backend, go to Products > Gift cards & eWallet, click the *Gift Cards* program, and click the *Gift Cards (1)* smart button
7. The gift card we just sold in the POS appears in the list, but there's no Partner assigned to it.

opw-5261991