### PR TITLE
[ADD] update requirements.txt with markdown2 for AI

### DIFF
--- a/doc/cla/individual/hostomani.md
+++ b/doc/cla/individual/hostomani.md
@@ -1,0 +1,9 @@
+Egypt, 2020-02-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Hosam Hasam hostomani@gmail.com https://github.com/hostomani

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,10 @@ lxml==4.8.0 ; python_version <= '3.10'
 lxml==4.9.3 ; python_version > '3.10' and python_version < '3.12' # min 4.9.2, pinning 4.9.3 because of missing wheels for darwin in 4.9.3
 lxml==5.2.1; python_version >= '3.12' # (Noble - removed html clean)
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
+markdown2==2.4.1 ; python_version <= '3.10'
+markdown2==2.4.2 ; python_version == '3.11'
+markdown2==2.4.10 ; python_version >= '3.12' and python_version < '3.13'
+markdown2==2.5.0 ; python_version >= '3.13'
 MarkupSafe==2.0.1 ; python_version <= '3.10'
 MarkupSafe==2.1.2 ; python_version > '3.10' and python_version < '3.12'
 MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
PR adds missing markdown2 python library to requirements.txt

Current behavior before PR:
AI responses are not formatted due to lack of markdown2 library

Desired behavior after PR is merged:
Ai responses are formatted due to addition of markdown2 library in requirements.txt



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
