### PR TITLE
[17.0][FIX] jsonb extraction on translate field

### DIFF
--- a/doc/cla/individual/adasatorres.md
+++ b/doc/cla/individual/adasatorres.md
@@ -1,0 +1,11 @@
+Spain, 2025-11-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Adasat Torres de León adasat.torres.dev@gmail.com https://github.com/adasatorres

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1283,8 +1283,8 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner_title"."id"
             FROM "res_partner_title"
-            WHERE (COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s) like %s)
-            ORDER BY COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s)
+            WHERE (COALESCE(("res_partner_title"."name"->>%s), ("res_partner_title"."name"->>%s)) like %s)
+            ORDER BY COALESCE(("res_partner_title"."name"->>%s), ("res_partner_title"."name"->>%s))
         ''']):
             Model.search([('name', 'like', 'foo')])
 
@@ -1328,10 +1328,10 @@ class TestQueries(TransactionCase):
         self.assertEqual(Model._rec_names_search, ['name', 'model'])
 
         with self.assertQueries(['''
-            SELECT "ir_model"."id", "ir_model"."name"->>%s
+            SELECT "ir_model"."id", ("ir_model"."name"->>%s)
             FROM "ir_model"
             WHERE (
-                ("ir_model"."name"->>%s ILIKE %s)
+                (("ir_model"."name"->>%s) ILIKE %s)
                 OR ("ir_model"."model"::text ILIKE %s)
             )
             ORDER BY "ir_model"."model"
@@ -1340,10 +1340,10 @@ class TestQueries(TransactionCase):
             Model.name_search('foo')
 
         with self.assertQueries(['''
-            SELECT "ir_model"."id", "ir_model"."name"->>%s
+            SELECT "ir_model"."id", ("ir_model"."name"->>%s)
             FROM "ir_model"
             WHERE (
-                ("ir_model"."name" is NULL OR "ir_model"."name"->>%s not ilike %s)
+                ("ir_model"."name" is NULL OR ("ir_model"."name"->>%s) not ilike %s)
                 AND (("ir_model"."model"::text NOT ILIKE %s) OR "ir_model"."model" IS NULL)
             )
             ORDER BY "ir_model"."model"

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -46,19 +46,19 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE (jsonb_path_query_array("test_new_api_indexed_translation"."name", '$.*')::text ILIKE %s
-            AND "test_new_api_indexed_translation"."name"->>%s ILIKE %s)
+            AND ("test_new_api_indexed_translation"."name"->>%s) ILIKE %s)
             ORDER BY "test_new_api_indexed_translation"."id"
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE (jsonb_path_query_array("test_new_api_indexed_translation"."name", '$.*')::text ILIKE %s
-            AND COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>%s) ILIKE %s)
+            AND COALESCE(("test_new_api_indexed_translation"."name"->>%s), ("test_new_api_indexed_translation"."name"->>%s)) ILIKE %s)
             ORDER BY "test_new_api_indexed_translation"."id"
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE ("test_new_api_indexed_translation"."name" IS NULL
-            OR COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>%s) ILIKE %s)
+            OR COALESCE(("test_new_api_indexed_translation"."name"->>%s), ("test_new_api_indexed_translation"."name"->>%s)) ILIKE %s)
             ORDER BY "test_new_api_indexed_translation"."id"
         """]):
             record_en.search([('name', 'ilike', 'foo')])

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2962,9 +2962,9 @@ class TestFields(TransactionCaseWithUserDemo):
 
         with self.assertQueries(["""
             SELECT "test_new_api_prefetch"."id",
-                   "test_new_api_prefetch"."name"->>%s,
-                   "test_new_api_prefetch"."description"->>%s,
-                   "test_new_api_prefetch"."html_description"->>%s,
+                   ("test_new_api_prefetch"."name"->>%s),
+                   ("test_new_api_prefetch"."description"->>%s),
+                   ("test_new_api_prefetch"."html_description"->>%s),
                    "test_new_api_prefetch"."create_uid",
                    "test_new_api_prefetch"."create_date",
                    "test_new_api_prefetch"."write_uid",

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -279,7 +279,7 @@ class PropertiesCase(TestPropertiesMixin):
                        "test_new_api_message"."author",
                        "test_new_api_message"."name",
                        "test_new_api_message"."important",
-                       "test_new_api_message"."label"->>%s,
+                       ("test_new_api_message"."label"->>%s),
                        "test_new_api_message"."priority",
                        "test_new_api_message"."active",
                        "test_new_api_message"."create_uid",

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2879,7 +2879,7 @@ class BaseModel(metaclass=MetaModel):
         elif field.translate and not self.env.context.get('prefetch_langs'):
             sql_field = SQL.identifier(alias, fname)
             langs = field.get_translation_fallback_langs(self.env)
-            sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
+            sql_field_langs = [SQL("(%s->>%s)", sql_field, lang) for lang in langs]
             if len(sql_field_langs) == 1:
                 return sql_field_langs[0]
             return SQL("COALESCE(%s)", SQL(", ").join(sql_field_langs))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When adding a module that uses fuzzy search through the ORM, translatable fields fail when only one language is available. This happens because the WHERE clause is generated as field->>'en_US' % 'example'. PostgreSQL first evaluates the expression 'en_US' % 'example' as literals, producing a boolean value. It then attempts to apply field->>boolean, which is invalid and causes an error.

Current behavior before PR:

The extraction of translatable fields (jsonb->>'key') is not forced to be parenthesized, which causes PostgreSQL to evaluate the query differently with certain operators.

Desired behavior after PR is merged:

The extraction of translatable fields (jsonb->>'key') is forced to be parenthesized, which causes PostgreSQL to first evaluate the JSONB value extraction and then the result of that operation, thus avoiding issues with certain operators.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
