### PR TITLE
[FIX] hr_holidays: correct timezone for time off calendar event

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1148,9 +1148,14 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 meeting_name = _("%s on Time Off : %.2f day(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_days)
                 allday_value = not holiday.request_unit_half
 
-            leave_tz = timezone(holiday.tz) if holiday.tz else UTC
-            start_value = UTC.localize(holiday.date_from).astimezone(leave_tz).replace(tzinfo=None)
-            stop_value = UTC.localize(holiday.date_to).astimezone(leave_tz).replace(tzinfo=None)
+            if allday_value:
+                # `start` and `stop` are not in UTC for allday events
+                leave_tz = timezone(holiday.tz) if holiday.tz else UTC
+                start_value = UTC.localize(holiday.date_from).astimezone(leave_tz).replace(tzinfo=None)
+                stop_value = UTC.localize(holiday.date_to).astimezone(leave_tz).replace(tzinfo=None)
+            else:
+                start_value = holiday.date_from
+                stop_value = holiday.date_to
 
             meeting_values = {
                 'name': meeting_name,

--- a/addons/hr_holidays/tests/test_holidays_calendar.py
+++ b/addons/hr_holidays/tests/test_holidays_calendar.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date, datetime, time, timedelta
+from datetime import date, timedelta
 
 from odoo.addons.base.tests.common import HttpCase
 from odoo.tests.common import tagged
@@ -69,12 +68,11 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
 
         leave.action_validate()
 
-        expected_fd_start = datetime.combine(test_date, time(8, 0))
-        expected_fd_stop = datetime.combine(test_date, time(17, 0))
-        self.assertEqual(leave.meeting_id.start, expected_fd_start,
-                        f"Meeting start date should be {expected_fd_start}")
-        self.assertEqual(leave.meeting_id.stop, expected_fd_stop,
-                        f"Meeting end date should be {expected_fd_stop}")
+        self.assertEqual(leave.meeting_id.allday, True)
+        self.assertEqual(leave.meeting_id.start_date, test_date,
+                        f"Meeting start date should be {test_date}")
+        self.assertEqual(leave.meeting_id.stop_date, test_date,
+                        f"Meeting end date should be {test_date}")
 
         # case 2: half day in Los/Angeles tz
 
@@ -92,10 +90,6 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
 
         leave_half.action_validate()
 
-        expected_hd_start = datetime.combine(test_date_half, time(13, 0))
-        expected_hd_stop = datetime.combine(test_date_half, time(17, 0))
-
-        self.assertEqual(leave_half.meeting_id.start, expected_hd_start,
-                        f"Half-day meeting start date should be {expected_hd_start}")
-        self.assertEqual(leave_half.meeting_id.stop, expected_hd_stop,
-                        f"Half-day meeting end date should be {expected_hd_stop}")
+        self.assertEqual(leave_half.meeting_id.allday, False)
+        self.assertEqual(leave_half.meeting_id.start, leave_half.date_from)
+        self.assertEqual(leave_half.meeting_id.stop, leave_half.date_to)


### PR DESCRIPTION
**Steps to reproduce**
- Have all timezones (browser, employee, working schedule...) aligned on an diffrent timezone than UTC (normal flow).
- Take a time off for a half day, or in custom hours and validate it. Issue: the associated calendar event created doesn't match the time off start/end.

**Cause**
Commit 8c8c38b1d57971aa5ef220f720d4aeea86b6de98 converts the times from the time off (in UTC) to the leave's timezone, this is an issue because `start` and `stop` of `calendar.event` should be in UTC.

**Change**
The conversion makes sense for allday events, as the `start`/`stop` are
not in UTC (see `_inverse_dates` in `calendar_event.py`,  they represent
a date used for the display of the event, but for non-allday events we
have to make sure the `start`/`stop` are the actual times of the leave.

opw-5225375