### PR TITLE
[FIX] website_sale: prevent horizontal scroll in dynamic products

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -92,3 +92,14 @@ img.o_img_product_square {
         }
     }
 }
+.s_dynamic_snippet_products .container-fluid .s_dynamic_snippet_content {
+    @include media-breakpoint-up(md) {
+        // Prevented horizontal overflow of control buttons.
+        .carousel-control-prev {
+            transform: translateX(50%); 
+        }
+        .carousel-control-next {
+            transform: translateX(-50%); 
+        }
+    }
+}


### PR DESCRIPTION
Steps to reproduce:
1. Drag and drop the dynamic products snippet.
2. Select it and change the content width to **max**.

Issue:
When the content width is set to **max**, an unnecessary horizontal scroll appears.

Reason:
The issue occurs because the `previous` and `next` navigation buttons were not properly positioned.

Fix:
For devices larger than "mobile", the `previous` and `next` buttons are re-positioned, horizontally inward by "**50%**" of their own width with the help of `transform` property. This keeps the controls within the visible area and prevents horizontal scrolling.

task-5090468


Before:
<img width="1915" height="966" alt="image" src="https://github.com/user-attachments/assets/0c20d0b6-32cc-477b-8403-55bb0d372d8d" />

After:
<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/4194b0f1-f3ad-4818-aa6f-2fda4561d2c7" />
