### PR TITLE
[FIX] pos_restaurant: remove many guest count, default numpad to last value

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
@@ -3,6 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { Component, useState } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { Numpad, buttonsType } from "@point_of_sale/app/components/numpad/numpad";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 
 export class NumberPopup extends Component {
     static template = "point_of_sale.NumberPopup";
@@ -31,10 +32,10 @@ export class NumberPopup extends Component {
     setup() {
         this.numberBuffer = useService("number_buffer");
         this.numberBuffer.use({
-            triggerAtEnter: () => this.confirm(),
-            triggerAtEscape: () => this.cancel(),
             triggerAtInput: ({ buffer }) => (this.state.buffer = buffer),
         });
+        useHotkey("enter", () => this.confirm());
+        useHotkey("escape", () => this.cancel());
         this.state = useState({
             buffer: this.props.startingValue,
         });

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -20,7 +20,7 @@ patch(PosOrder.prototype, {
         return this.customer_count;
     },
     setCustomerCount(count) {
-        this.customer_count = Math.max(count, 0);
+        this.customer_count = Math.max(count, 1);
     },
     getTable() {
         return this.table_id;

--- a/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.xml
@@ -29,11 +29,6 @@
                     <span class="text-black fs-4 fw-bolder" t-esc="currentOrder?.getCustomerCount() || 0"/>
                 </button>
             </div>
-            <div class="fs-2 text-center">
-            2: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(2))" /> <span class="me-4">/ Guest</span>
-            3: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(3))" /> <span class="me-4">/ Guest</span>
-            4: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(4))" /> <span class="me-4">/ Guest</span>
-            </div>
         </xpath>
     </t>
 

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -85,6 +85,7 @@ patch(PosStore.prototype, {
     async setCustomerCount(o = false) {
         const currentOrder = o || this.getOrder();
         const count = await makeAwaitable(this.dialog, NumberPopup, {
+            startingValue: currentOrder.customer_count,
             feedback: (buffer) => {
                 const value = this.env.utils.formatCurrency(
                     currentOrder?.amountPerGuest(parseInt(buffer, 10) || 0) || 0
@@ -92,7 +93,7 @@ patch(PosStore.prototype, {
                 return value ? `${value} / ${_t("Guest")}` : "";
             },
         });
-        const guestCount = parseInt(count, 10) || 0;
+        const guestCount = parseInt(count, 10) || currentOrder.customer_count;
         if (guestCount == 0 && currentOrder.lines.length === 0) {
             this.removeOrder(currentOrder);
             this.navigate("FloorScreen");


### PR DESCRIPTION
after this commit:
- The payment screen no longer shows extra guest count.
- The numpad will display the last guest count.
- Discarding will keep the last guest count unchanged.
- Use hotkey handling so Enter confirms input only, ignoring any numpad button currently in focus.

task: 5364073

