### PR TITLE
[FIX] mail: scrollable message content inside the message bubble

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -78,7 +78,7 @@
         }
     }
 
-    & > p:last-child {
+    & > p:last-child, .o-mail-Message-richBody > p:last-child {
         margin-bottom: 0 !important;
     }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -93,7 +93,7 @@
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="message.showTranslation" t-out="message.translationValue"/>
-                                                        <t t-elif="message.body and !message.linkPreviewSquash" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
+                                                        <div class="o-mail-Message-richBody overflow-x-auto" t-elif="message.body and !message.linkPreviewSquash" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
                                                         <p class="fst-italic text-muted small" t-if="message.showTranslation">
                                                             <t t-if="message.translationSource" t-esc="translatedFromText"/>
                                                         </p>


### PR DESCRIPTION
Current behavior before PR:

When the email template (message_type = `comment`) has content that is longer (in width), the content tends to overflow out of the bubble which breaks the UI.

Desired behavior after PR is merged:

This commit fixes the issue by making the content scrollable inside the bubble.

Task-5363388

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
