### PR TITLE
[FIX] loyalty: correct format of coupon information email template

### DIFF
--- a/addons/loyalty/data/mail_template_data.xml
+++ b/addons/loyalty/data/mail_template_data.xml
@@ -69,7 +69,7 @@
     <td valign="top" style="text-align: center; font-size: 14px;">
         Use this promo code
         <t t-if="object.expiration_date">
-            before <t t-out="object.expiration_date or ''">2021-06-16</t>
+            before <t t-out="format_date(object.expiration_date) or ''">2021-06-16</t>
         </t>
         <p style="margin-top: 16px;">
             <strong style="padding: 16px 8px 16px 8px; border-radius: 3px; background-color: #F1F1F1;" t-out="object.code or ''">15637502648479132902</strong>

--- a/addons/loyalty/report/loyalty_report_templates.xml
+++ b/addons/loyalty/report/loyalty_report_templates.xml
@@ -28,7 +28,7 @@
                                 <br/>
                                 <h4 t-if="o.expiration_date">
                                     Use this promo code before
-                                    <span t-field="o.expiration_date" t-options='{"format": "yyyy-MM-d"}'>2023-08-20</span>
+                                    <span t-field="o.expiration_date">2023-08-20</span>
                                 </h4>
                                 <h2 class="mt-4">
                                     <strong class="bg-light"><span t-out="o.code">DEMO_CODE</span></strong>


### PR DESCRIPTION
Steps to reproduce:
1. Install `loyalty` and `sale_management`
2. Activate another language with another date format, eg. English (AU)
3. Set that language on a contact
4. Sales > Product > Discount & loyalty
5. Create a record with program type coupons
6. Generate a coupon for that AU contact with an expiration date

Issue:
The coupon email received by the customer shows the expiration date using the yyyy-MM-dd format, and the attachment shows the same technical format instead of the customer’s localized date format.

Cause:
We are not using a formatted date according to the customer

before: Customer with English AU language
<img width="601" height="563" alt="image" src="https://github.com/user-attachments/assets/faea2840-aca6-4850-bfc9-b0d24da65a3b" />

<img width="1510" height="883" alt="image" src="https://github.com/user-attachments/assets/b0ebc0cc-6243-450d-ad12-cecda4858e26" />


After:
<img width="603" height="543" alt="image" src="https://github.com/user-attachments/assets/5be2332b-3237-4ce5-8122-0766cd274650" />

<img width="1482" height="886" alt="image" src="https://github.com/user-attachments/assets/99d31b4c-33fa-4f92-9970-56720181911e" />


opw-5247621