### PR TITLE
[FIX] account: move test case to enterprise

### DIFF
--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -427,30 +427,6 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
         self.assertRecordValues(invoice, [{'payment_state': 'not_paid'}])
         self.assertRecordValues(payment.move_id.line_ids, [{'reconciled': True}] * 2)
 
-    def test_bill_state_change_on_payment_state(self):
-        """Test that bill payment state changes correctly when payment state transitions occur.
-        • Draft payment case: Bill state reverts to 'not_paid' when payment is drafted
-        • Payment unlink case: Bill state reverts to 'not_paid' when payment is deleted
-        """
-        bill = self.init_invoice('in_invoice', post=True, partner=self.partner_a, products=self.product_a)
-
-        # We have to test it without any Outstanding Payment account set in Journal
-        self.bank_journal_1.outbound_payment_method_line_ids.payment_account_id = False
-
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=bill.ids)\
-            .create({})\
-            ._create_payments()
-        self.assertEqual(bill.payment_state, self.env['account.move']._get_invoice_in_payment_state())
-
-        payment.action_draft()
-        self.assertEqual(payment.state, 'draft')
-        self.assertEqual(payment.invoice_ids.payment_state, 'not_paid')
-
-        payment.action_post()
-        payment.unlink()
-        self.assertEqual(bill.payment_state, 'not_paid')
-
     def test_payment_without_default_company_account(self):
         """ The purpose of this test is to check the specific behavior when duplicating an inbound payment, then change
         the copy to an outbound payment when we set the outstanding accounts (payments and receipts) on a journal but


### PR DESCRIPTION
Community build was failing with:
```
test_bill_state_change_on_payment_state
self.assertEqual(payment.invoice_ids.payment_state, 'not_paid')
AssertionError: 'paid' != 'not_paid'
- paid
+ not_paid
```
[Commit](https://github.com/odoo/odoo/pull/234725/commits/5dc43a2156e5b176e3236583b45b4838a987ee7d)

In community there is no any `in_payment` state for account move records. As on
changing payment state to draft It stayed in the `paid` only. `in_payment` state
introduced in the enterprise module. So the test case is failing for the
community version.

To fix this I've moved the test case to the enterprise to retain the expected
behaviour.

runbot error: 234453