### PR TITLE
[FIX] l10n_hk: Salaries & Wages Payable

### DIFF
--- a/addons/l10n_hk/data/template/account.account-hk.csv
+++ b/addons/l10n_hk/data/template/account.account-hk.csv
@@ -26,6 +26,7 @@
 "l10n_hk_2214","Provision for Taxation","2214","liability_current","","False"
 "l10n_hk_2215","Proposed Dividend","2215","liability_current","","False"
 "l10n_hk_2216","Other Payable","2216","liability_payable","","True"
+"l10n_hk_2217","Salaries & Wages Payable","2217","liability_current","","True"
 "l10n_hk_31","Paid Capital","31","liability_current","","False"
 "l10n_hk_32","Accumulated Profit & Loss","32","liability_current","","False"
 "l10n_hk_33","Profit & Loss Account","33","liability_current","","False"


### PR DESCRIPTION
Adds a new Salaries & Wages Payable account of type current liabilities in order to use it in payroll for the NET rules and solve a misconfiguration in the default data.

task-5042786

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
