### PR TITLE
[FIX] base: fix TestRequestRemainingAfterFirstCheck

### DIFF
--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -221,9 +221,10 @@ class TestRequestRemainingAfterFirstCheck(TestRequestRemainingCommon):
             s.get(self.base_url() + "/web/concurrent", timeout=10)
 
         type(self).thread_a = threading.Thread(target=late_request_thread)
+        main_lock = self.main_lock
         self.thread_a.start()
         # we need to ensure that the first check is made and that we are aquiring the lock
-        self.main_lock.acquire()
+        main_lock.acquire()
 
     def assertCanOpenTestCursor(self):
         super().assertCanOpenTestCursor()


### PR DESCRIPTION
In some rare cases the late_request_thread could execute so fast without
releasing the GIL that assertCanOpenTestCursor was executed before the
main_lock.acquire(), causing the lock to be None.
In this case, acquiring the lock is pointless since the
late_request_thread has already finished, defeating the purpose of this
quire, but we can workaround this keeping a reference to the main_lock
before starting the thread. This way, even if the late_request_thread is
already finished, we can still acquire the lock even if it is already
released.

Normal flow:

- main_thread acquires main_lock
- main_thread span request_thread
- main_thread tries to acquire main_lock and again and blocks
- request_thread runs and releases main_lock
- main_thread acquires main_lock and continues

When it fails
- main_thread acquires main_lock
- main_thread span request_thread
- request_thread runs and releases main_lock
- main_thread tries to acquire main_lock witch is None and fails

Fixed
- main_thread acquires main_lock
- main_thread span request_thread
- request_thread runs and releases main_lock
- main_thread tries to acquire main_lock but it is already released
- main_thread acquires main_lock and continues


Runbot error [229827](https://runbot.odoo.com/odoo/runbot.build.error/229827) 