### PR TITLE
[FIX] hr_attendance: overtime recordset access error

### DIFF
--- a/addons/hr_attendance/security/ir.model.access.csv
+++ b/addons/hr_attendance/security/ir.model.access.csv
@@ -6,5 +6,6 @@ access_hr_attendance_own_reader,hr.attendance.own.reader,model_hr_attendance,gro
 access_hr_attendance_overtime_rule_admin,hr.attendance.admin.overtime.rule,model_hr_attendance_overtime_rule,group_hr_attendance_manager,1,1,1,1
 access_hr_attendance_overtime_ruleset_admin,hr.attendance.admin.overtime.ruleset,model_hr_attendance_overtime_ruleset,group_hr_attendance_manager,1,1,1,1
 access_hr_attendance_overtime_rule_user,hr.attendance.admin.overtime.rule,model_hr_attendance_overtime_rule,hr.group_hr_manager,1,0,0,0
+access_hr_attendance_overtime_rule_officer,hr.attendance.officer.overtime.rule,model_hr_attendance_overtime_rule,group_hr_attendance_officer,1,0,0,0
 access_hr_attendance_overtime_line_officer,hr.attendance.officer.overtime.line,model_hr_attendance_overtime_line,group_hr_attendance_officer,1,1,1,1
 access_hr_attendance_overtime_ruleset_hr_manager,hr.attendance.admin.overtime.ruleset,model_hr_attendance_overtime_ruleset,hr.group_hr_manager,1,0,0,0

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1110,3 +1110,13 @@ class TestHrAttendanceOvertime(HttpCase):
 
             self.assertAlmostEqual(attendance_company_be.overtime_hours, 8, 2, "Employee from Company 1 should have overtime for working on a public holiday.")
             self.assertAlmostEqual(attendance_company_de.overtime_hours, 0, 2, "Employee from Company 2 should not have overtime for working on a non-holiday day.")
+
+    def test_officer_access_on_overtime_records(self):
+        user1 = new_test_user(self.env, login='user1', groups='hr_attendance.group_hr_attendance_officer', company_id=self.company.id).with_company(self.company)
+        self.other_employee.attendance_manager_id = user1.id
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.other_employee.id,
+            'check_in': datetime(2021, 1, 4, 8, 0),
+            'check_out': datetime(2021, 1, 4, 20, 0)
+        })
+        self.assertTrue(attendance.with_user(user1).linked_overtime_ids.rule_ids.has_access("read"))


### PR DESCRIPTION
## Issue
- Getting access error when the user having no special access rights tries to access the attendance record.
## Steps to reproduce
1. Log in as user (a user with no special access rights)
2. Open the Attendances app, and click on a record with overtime attendance
3. You get an Access error wizard, upon closing will show the attendance wizard of that record, without extra hours captured on it. 
## Solution
- Fixed security rights to access attendance records when you do not have any special access rights.

task-5366484
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
