### PR TITLE
[FIX] web_editor: removing icon makes paragraph unreachable

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3552,7 +3552,23 @@ export class OdooEditor extends EventTarget {
                 this._compositionStep();
                 this.historyRollback();
                 ev.preventDefault();
-                getDeepRange(this.editable, { select: true, correctTripleClick: true });
+                const deepRange = getDeepRange(this.editable, { correctTripleClick: true });
+                const startEl = deepRange && closestElement(deepRange.startContainer);
+                const endEl = deepRange && closestElement(deepRange.endContainer);
+                if (startEl && endEl && startEl.isContentEditable && endEl.isContentEditable) {
+                    const { startContainer, startOffset, endContainer, endOffset } = deepRange;
+                    const direction = getCursorDirection(
+                        newSelection.anchorNode,
+                        newSelection.anchorOffset,
+                        newSelection.focusNode,
+                        newSelection.focusOffset
+                    );
+                    if (direction === DIRECTIONS.RIGHT) {
+                        setSelection(startContainer, startOffset, endContainer, endOffset);
+                    } else {
+                        setSelection(endContainer, endOffset, startContainer, startOffset);
+                    }
+                }
                 // To remove only the anchor cell's content when multiple table cells are selected on Enter,
                 // we need to change the selection to focus only on the anchor cell. This can't be done in `oEnter`
                 // because `deleteRange` responsible for removing content, execute before `oEnter` in `_applyRawCommand`.

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteBackward.js
@@ -63,7 +63,9 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false, 
         if (
             isDeletable(leftNode)
         ) {
+            const parentEl = leftNode.parentElement;
             leftNode.remove();
+            fillEmpty(parentEl);
             return;
         }
         if (!isBlock(leftNode) || isVisibleEmpty(leftNode)) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteForward.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteForward.js
@@ -146,12 +146,14 @@ HTMLElement.prototype.oDeleteForward = function (offset) {
     if (firstLeafNode && (isFontAwesome(firstLeafNode) || isNotEditableNode(firstLeafNode))) {
         const nextSibling = firstLeafNode.nextSibling;
         const nextSiblingText = nextSibling ? nextSibling.textContent : '';
+        const parentEl = firstLeafNode.parentElement;
         firstLeafNode.remove();
         if (isEditorTab(firstLeafNode) && nextSiblingText[0] === '\u200B') {
             // When deleting an editor tab, we need to ensure it's related ZWS
             // il deleted as well.
             nextSibling.textContent = nextSiblingText.replace('\u200B', '');
         }
+        fillEmpty(parentEl);
         return;
     }
     if (

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -1151,6 +1151,13 @@ X[]
                         contentAfter: unformat(`<div>a[]d</div>`),
                     });
                 });
+                it('should fill empty block with a <br>', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>[]<i class="fa fa-bug" contenteditable="false"></i></p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                });
             });
         });
         describe('Selection not collapsed', () => {
@@ -2788,6 +2795,11 @@ X[]
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><img>[]</p>',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><i class="fa fa-bug" contenteditable="false"></i>[]</p>',
                         stepFunction: deleteBackward,
                         contentAfter: '<p>[]<br></p>',
                     });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -3698,6 +3698,15 @@ X[]
                         contentAfter: '<p>abc</p><p>[]<br></p>',
                     });
                 });
+                it('inserts an empty paragraph when Enter is pressed before a non-editable element', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>[]<i class="fa fa-bug" contenteditable="false"></i></p>',
+                        stepFunction: async editor => {
+                            await triggerEvent(editor.editable, 'input', { data: 'Enter', inputType: 'insertParagraph' });
+                        },
+                        contentAfter: '<p><br></p><p>[]<i class="fa fa-bug" contenteditable="false"></i></p>',
+                    });
+                });
             });
             describe('Pre', () => {
                 it('should insert a line break within the pre', async () => {
@@ -4352,6 +4361,15 @@ X[]
                         // The second <br> is needed to make the first
                         // one visible.
                         contentAfter: '<p>abc<br>[]<br></p>',
+                    });
+                });
+                it('inserts a <br> when a line break is inserted before a non-editable element', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>[]<i class="fa fa-bug" contenteditable="false"></i></p>',
+                        stepFunction: async editor => {
+                            await triggerEvent(editor.editable, 'input', { data: 'Enter', inputType: 'insertLineBreak' });
+                        },
+                        contentAfter: '<p><br>[]<i class="fa fa-bug" contenteditable="false"></i></p>',
                     });
                 });
             });


### PR DESCRIPTION
**Issue 1:**

Steps to reproduce:
- Insert a icon in an empty paragraph.
- Remove the inserted icon.
- The paragraph becomes unreachable.

Cause:
- When a paragraph contains only an icon, removing that icon during the delete process does not trigger `fillEmpty`. As a result, the paragraph ends up with no content, leaving it empty and unreachable.

Solution:
- During the delete process, after the icon is removed, call the `fillEmpty` method. This ensures that if the block becomes empty, a `<br>` is inserted inside the paragraph, keeping it accessible.


**Issue 2:**

Steps to reproduce

- Insert an icon in an empty paragraph.
- Place the cursor before the icon.
- Press Enter.
- Nothing happens.

Cause
- When the cursor is placed before a `contenteditable=false` element, `getDeepRange` sets the selection deep inside the non-editable element as a result, when Enter is pressed, the action is ignored because the selection is not in an editable context.

Solution

- Instead of setting the selection inside `getDeepRange`, set the selection after calling `getDeepRange` only if the returned range is not within a `contenteditable=false` element.

task-3540454
