### PR TITLE
[FIX] account_{peppol, edi_proxy_client}: error when sending invoice by peppol

### DIFF
--- a/addons/account_edi_proxy_client/models/res_company.py
+++ b/addons/account_edi_proxy_client/models/res_company.py
@@ -6,4 +6,4 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    account_edi_proxy_client_ids = fields.One2many('account_edi_proxy_client.user', inverse_name='company_id', context={'active_test': True})
+    account_edi_proxy_client_ids = fields.One2many('account_edi_proxy_client.user', inverse_name='company_id')

--- a/addons/account_edi_proxy_client/views/account_edi_proxy_user_views.xml
+++ b/addons/account_edi_proxy_client/views/account_edi_proxy_user_views.xml
@@ -5,7 +5,7 @@
             <field name="name">EDI Proxy User</field>
             <field name="model">account_edi_proxy_client.user</field>
             <field name="arch" type="xml">
-                <form string="Account Journal">
+                <form string="Account Journal" create="false" delete="false" edit="false">
                     <sheet>
                         <group>
                             <group>

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -193,8 +193,10 @@ class AccountMoveSend(models.AbstractModel):
         if not params['documents']:
             return
 
-        edi_user = next(iter(invoices_data)).company_id.account_edi_proxy_client_ids.filtered(
+        edi_user = next(iter(invoices_data)).company_id.with_context(active_test=False).account_edi_proxy_client_ids.filtered(
             lambda u: u.proxy_type == 'peppol')
+        active_user = edi_user.filtered(lambda u: u.active)[:1]
+        edi_user = active_user or edi_user.filtered(lambda u: not u.active)[:1]
 
         try:
             response = edi_user._call_peppol_proxy(

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -276,5 +276,7 @@ class ResCompany(models.Model):
         config_param = self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
         # by design, we can only have zero or one proxy user per company with type Peppol
         peppol_user = self.sudo().account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')
+        active_peppol_user = peppol_user.filtered(lambda u: u.active)[:1]
+        peppol_user = active_peppol_user or peppol_user.filtered(lambda u: not u.active)[:1]
         demo_if_demo_identifier = 'demo' if self.peppol_eas == 'odemo' else False
         return demo_if_demo_identifier or peppol_user.edi_mode or config_param or 'prod'


### PR DESCRIPTION
An error occurs when a user sends an invoice by Peppol
while the company’s EDI Proxy User is archived or deleted.

Steps to reproduce the error:

- Install ``accountant`` and ``l10n_be`` module with demo data
- Switch to BE company COA company
- Go to Settings and Enable PEPPOL > save > go back again > Activate electronic invoicing > Activate Peppol
- Go to Accounting > configuration > EDI Proxy Users > archive the user
- Create an invoice > customer: BE company COA > add a product > confirm > send >
  select by peppol > send

Traceback:
```py
ValueError: Expected singleton: account_edi_proxy_client.user()
```

https://github.com/odoo/odoo/blob/4a65bec64e02fd7c3b55e455b1cbab9e977fda10/addons/account_peppol/models/account_move_send.py#L194-L197
The method ``_call_peppol_proxy`` is invoked when sending an invoice by Peppol.
However, if the EDI Proxy User linked to the company is archived or deleted,
``ensure_one()`` raises an above exception from [1].

[1]: https://github.com/odoo/odoo/blob/4a65bec64e02fd7c3b55e455b1cbab9e977fda10/addons/account_peppol/models/account_edi_proxy_user.py#L34-L35

sentry-7048840557

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
