### PR TITLE
[FIX] web: catch Failed to fetch error on firefox

### DIFF
--- a/addons/web/static/src/service_worker.js
+++ b/addons/web/static/src/service_worker.js
@@ -69,6 +69,12 @@ const readDataOnCache = async (url) => {
     });
 };
 
+const fetchErrorMessages = [
+    "Failed to fetch", // Chromium
+    "Load failed", // WebKit
+    "NetworkError when attempting to fetch resource.", // Firefox
+];
+
 const navigateOrDisplayOfflinePage = async (request) => {
     const isDebugAssets = new URL(request.url).searchParams.get("debug")?.includes("assets");
     try {
@@ -80,7 +86,8 @@ const navigateOrDisplayOfflinePage = async (request) => {
     } catch (requestError) {
         if (
             request.method === "GET" &&
-            ["Failed to fetch", "Load failed"].includes(requestError.message)
+            requestError instanceof TypeError &&
+            fetchErrorMessages.includes(requestError.message)
         ) {
             if (sessionInfo?.length && !isDebugAssets) {
                 const cachedResponse = await readDataOnCache(request.url);

--- a/addons/web/static/src/webclient/errors/offline_fail_to_fetch_error_handler.js
+++ b/addons/web/static/src/webclient/errors/offline_fail_to_fetch_error_handler.js
@@ -3,6 +3,12 @@ import { registry } from "@web/core/registry";
 
 const errorHandlerRegistry = registry.category("error_handlers");
 
+const fetchErrorMessages = [
+    "Failed to fetch", // Chromium
+    "Load failed", // WebKit
+    "NetworkError when attempting to fetch resource.", // Firefox
+];
+
 /**
  * @param {OdooEnv} env
  * @param {UncaughError} error
@@ -10,7 +16,7 @@ const errorHandlerRegistry = registry.category("error_handlers");
  * @returns {boolean}
  */
 export function offlineFailToFetchErrorHandler(env, error, originalError) {
-    if (["Failed to fetch", "Load failed"].includes(originalError.message)) {
+    if (originalError instanceof TypeError && fetchErrorMessages.includes(originalError.message)) {
         Promise.resolve().then(() => {
             throw new ConnectionLostError();
         });


### PR DESCRIPTION
Before this commit, reloading the webclient on firefox while being offline resulted in a traceback. Now that we introduced a (partial) support of offline mode in the webclient, we have an error handler to catch errors thrown by window.fetch when there're connection problems. The thrown error is a TypeError (which is quite generic) with various messages depending on the browser. This commit adds the message of the TypeError for firefox.

We applied the same diff in the service worker, in the handler responsible of displaying the offline page, which was never shown on firefox.

Task~5364336

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
