### PR TITLE
[FIX] website_sale: correct tax-included price in cart notification

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -460,6 +460,7 @@ class Cart(PaymentPortal):
         if not lines:
             return {}
 
+        show_tax = order.website_id.show_line_subtotals_tax_selection == 'tax_included'
         return {
             'currency_id': order.currency_id.id,
             'lines': [
@@ -470,7 +471,10 @@ class Cart(PaymentPortal):
                     'name': line._get_line_header(),
                     'combination_name': line._get_combination_name(),
                     'description': line._get_sale_order_line_multiline_description_variants(),
-                    'price_total': line.price_unit * added_qty_per_line[line.id],
+                    'price_total': (
+                        line.price_reduce_taxinc
+                        if show_tax else line.price_reduce_taxexcl
+                    ) * added_qty_per_line[line.id],
                     **self._get_additional_cart_notification_information(line),
                 } for line in lines
             ],

--- a/addons/website_sale/tests/test_website_sale_cart_notification.py
+++ b/addons/website_sale/tests/test_website_sale_cart_notification.py
@@ -4,6 +4,7 @@ from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.product.tests.common import ProductVariantsCommon
+from odoo.addons.website_sale.controllers.cart import Cart
 
 
 @tagged('post_install', '-at_install')
@@ -12,6 +13,7 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.WebsiteSaleCartController = Cart()
         cls.size_attribute.create_variant = 'no_variant'
         cls.env['product.template'].create({
             'name': 'website_sale_cart_notification_product_1',
@@ -44,3 +46,29 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
 
         self.env.ref('website_sale.product_search').active = True
         self.start_tour("/", 'website_sale_cart_notification_qty_and_total')
+
+    def test_website_sale_cart_notification_product_price(self):
+        """Check that the cart notification displays the correct total price included/excluded taxes
+        depending on the website settings.
+        """
+        website = self.env['website'].get_current_website()
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+            'website_id': website.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product.id,
+                }),
+            ]
+        })
+        added_qty_per_line = {sale_order.order_line.id: 1.0}
+        website.show_line_subtotals_tax_selection = 'tax_included'
+        price_tax_included = self.WebsiteSaleCartController._get_cart_notification_information(
+            sale_order, added_qty_per_line
+        )['lines'][0]['price_total']
+        self.assertEqual(price_tax_included, 23)
+        website.show_line_subtotals_tax_selection = 'tax_excluded'
+        price_tax_excluded = self.WebsiteSaleCartController._get_cart_notification_information(
+            sale_order, added_qty_per_line
+        )['lines'][0]['price_total']
+        self.assertEqual(price_tax_excluded, 20)


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **website_sale** module with demo data.
* Go to *Website → Settings → eCommerce* and select **Tax Included**.
* Create a product with specific **tax_ids** and publish it on the website.
* Navigate to *Website → Shop*, open the created product page.
* Click **Add to Cart** to trigger the cart notification popup.
* Observe the price displayed in the top-corner notification.

**Observed behavior:**
* The notification displays the **list price without tax**, even though 
*Tax Included* pricing is enabled.

**Cause:**
* The notification computes the price as *list_price × quantity* without
checking whether taxes should be included or excluded.

* Issue occur from this [commit](https://github.com/odoo/odoo/pull/184320/commits/04b7dc893039087e0f764e242c21076ce249bebf)

**Fix:**
* Add logic to detect whether prices should be shown tax-included or tax-excluded
and assign the correct computed amount accordingly.

---

opw-5350375

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
