### PR TITLE
[FIX] web: restore t-Out when an interaction stops in colibri

### DIFF
--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1740,6 +1740,41 @@ describe("t-att and t-out", () => {
         await startInteraction(Test, TemplateTest);
         expect("span").toHaveText("colibri");
     });
+
+    test("t-out-... resets at stop", async () => {
+        class Test extends Interaction {
+            static selector = "span";
+            dynamicContent = {
+                _root: { "t-out": () => "colibri" },
+            };
+        }
+        const { core } = await startInteraction(Test, TemplateTest);
+        expect("span").toHaveText("colibri");
+        core.stopInteractions();
+        expect("span").toHaveText("coucou");
+    });
+
+    test("t-out-... restores all values on stop", async () => {
+        class Test extends Interaction {
+            static selector = "div";
+            dynamicContent = {
+                span: { "t-out": () => "colibri" },
+            };
+        }
+        const { core } = await startInteraction(
+            Test,
+            `
+            <div>
+                <span>penguin</span>
+                <span>ostrich</span>
+            </div>
+        `
+        );
+        expect("span").toHaveText("colibri");
+        core.stopInteractions();
+        expect("span:first").toHaveText("penguin");
+        expect("span:last").toHaveText("ostrich");
+    });
 });
 
 describe("components", () => {


### PR DESCRIPTION
When the Interaction framework was introduced in [1], fields that were modified by t-outs weren't restored to the initial values. This commit restores it on `destroy`.

[1]: https://github.com/odoo/odoo/commit/dd13994674d4ef4683f5a4d46a1f604650cfb92b