### PR TITLE
[IMP] web: list: make optional field dropdown available offline

### DIFF
--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -6,7 +6,7 @@ import { useService } from "@web/core/utils/hooks";
 
 const SELECTORS_TO_DISABLE = [
     "button:not([data-available-offline]):not([disabled])",
-    "input[type='checkbox']:not([disabled])",
+    "input[type='checkbox']:not([data-available-offline]):not([disabled])",
 ];
 
 function offlineUI() {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -7,7 +7,7 @@ import { localization } from "@web/core/l10n/localization";
 import { Pager } from "@web/core/pager/pager";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
-import { useAutofocus, useBus, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useBus, useChildRef, useService } from "@web/core/utils/hooks";
 import { useSortable } from "@web/core/utils/sortable_owl";
 import { getTabableElements } from "@web/core/utils/ui";
 import { AGGREGATABLE_FIELD_TYPES, combineModifiers } from "@web/model/relational_model/utils";
@@ -147,6 +147,7 @@ export class ListRenderer extends Component {
         this.groupByButtons = this.props.archInfo.groupBy.buttons;
         useExternalListener(window, "click", this.onGlobalClick.bind(this), { capture: true });
         this.tableRef = useRef("table");
+        this.optionalColumnsDropdownRef = useChildRef();
         this.odoomark = odoomark;
 
         this.longTouchTimer = null;
@@ -2317,5 +2318,13 @@ export class ListRenderer extends Component {
             ev.preventDefault();
             this.toggleRecordSelection(record);
         }
+    }
+
+    onOptionalColumnsDropdownOpened() {
+        this.optionalColumnsDropdownRef.el
+            .querySelectorAll(".o-dropdown-item input[type='checkbox']")
+            .forEach((checkbox) => {
+                checkbox.setAttribute("data-available-offline", "");
+            });
     }
 }

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -47,8 +47,8 @@
                         <th t-if="hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view w-print-0 p-print-0"/>
                         <th t-if="hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0">
                             <div t-if="displayOptionalFields or hasOptionalOpenFormViewColumn" class="o_optional_columns_dropdown d-print-none text-center border-top-0">
-                                <Dropdown position="'bottom-end'">
-                                    <button class="btn p-0" tabindex="-1">
+                                <Dropdown position="'bottom-end'" menuRef="optionalColumnsDropdownRef" onOpened.bind="onOptionalColumnsDropdownOpened">
+                                    <button class="btn p-0" tabindex="-1" data-available-offline="">
                                         <i class="o_optional_columns_dropdown_toggle oi oi-fw oi-settings-adjust"/>
                                     </button>
 


### PR DESCRIPTION
Before this commit, it wasn't possible to open the optional field dropdown when being offline, because the toggler was automatically disabled. This commit makes it available offline, and ensures that checkboxes inside the dropdown are enabled as well.

Task~5359151

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
