### PR TITLE
[FIX] point_of_sale: show correct price on ProductConfiguratorPopup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -241,7 +241,13 @@ export class ProductConfiguratorPopup extends Component {
     }
 
     get title() {
-        const info = this.props.productTemplate.getProductPriceInfo(this.product, this.pos.company);
+        const order = this.pos.getOrder();
+        const pricelist = order.pricelist_id || this.pos.config.pricelist_id;
+        const info = this.props.productTemplate.getProductPriceInfo(
+            this.product,
+            this.pos.company,
+            pricelist
+        );
         const name = this.props.productTemplate.display_name;
         const total = this.env.utils.formatCurrency(info?.raw_total_included_currency || 0.0);
         const taxName = info?.taxes_data[0]?.name || "";

--- a/addons/point_of_sale/static/src/app/models/pos_config.js
+++ b/addons/point_of_sale/static/src/app/models/pos_config.js
@@ -55,7 +55,9 @@ export class PosConfig extends Base {
             return [];
         }
         const available_pricelists = new Set(this.available_pricelist_ids);
-        available_pricelists.add(this.pricelist_id);
+        if (this.pricelist_id) {
+            available_pricelists.add(this.pricelist_id);
+        }
         return Array.from(available_pricelists);
     }
 }

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -118,7 +118,7 @@ registry.category("web_tour.tours").add("PosProductWithDynamicAttributes", {
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("test_attribute_order", {
+registry.category("web_tour.tours").add("test_attribute_order_with_pricelist", {
     steps: () =>
         [
             Chrome.startPoS(),
@@ -127,11 +127,12 @@ registry.category("web_tour.tours").add("test_attribute_order", {
             ProductConfigurator.pickRadio("Value 1"),
             ProductConfigurator.pickRadio("Value 2"),
             ProductConfigurator.pickRadio("Value 3"),
+            ProductConfigurator.checkTitle("Product Test | $ 58.00 | VAT: Tax 16% (= $ 8.00)"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
                 "Product Test",
                 "1",
-                "10",
+                "58",
                 "Value 1, Value 2, Value 3"
             ),
         ].flat(),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
@@ -26,6 +26,14 @@ export function pickMulti(name) {
         },
     ];
 }
+export function checkTitle(name) {
+    return [
+        {
+            content: `check title is properly created`,
+            trigger: `.modal-header h4:contains('${name}')`,
+        },
+    ];
+}
 export function selectedMulti(name) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2524,12 +2524,15 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_quantity_package_of_non_basic_unit', login="pos_user")
 
-    def test_attribute_order(self):
+    def test_attribute_order_with_pricelist(self):
         product = self.env['product.template'].create({
             'name': 'Product Test',
             'available_in_pos': True,
             'list_price': 10,
-            'taxes_id': False,
+            'taxes_id': [Command.create({
+                'name': 'Tax 16%',
+                'amount': 16,
+            })],
         })
 
         attribute_3 = self.env['product.attribute'].create({
@@ -2578,9 +2581,14 @@ class TestUi(TestPointOfSaleHttpCommon):
             'value_ids': [(6, 0, attribute_1.value_ids.ids)],
             'sequence': 1,
         })
+        self.main_pos_config.pricelist_id.item_ids = [Command.create({
+            'compute_price': 'fixed',
+            'fixed_price': 50,
+            'product_id': product.product_variant_ids[0].id,
+        })]
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_attribute_order', login="pos_user")
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_attribute_order_with_pricelist', login="pos_user")
 
     def test_preset_timing_retail(self):
         """


### PR DESCRIPTION
Steps to reproduce:
- Configure POS → enable Allow Flexible Pricelist and assign the Default pricelist.
- Create product A with variants.
- Add product A to the Default pricelist.
- Set a fixed price for product A in that pricelist.
- Open POS session.
- Select product A in POS.

Observation:
- In ProductConfiguratorPopup dialog, pricelist price is not considered

Cause:
- After this [commit](https://github.com/odoo/odoo/commit/5e77c14912324bf967a55a1a40bb01071eca5c8b) the text appears from `get title()` method, which do not consider pricelist

Fix:
- we now consider pricelist for displaying title.

**Before**
<table>
<tr>
<td>
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/6faac3e4-a579-41db-a2ad-fdc9c24e422f" />
</td>
<td>
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/14035707-aa23-4fb3-97d7-d0ce2f6e6b46" />
</td>
</tr>
</table>

**After**
<img width="340" height="225" alt="image" src="https://github.com/user-attachments/assets/3beeaf76-fc1a-42a5-9f3c-dabc43389d36" />


opw-5270319

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
