### PR TITLE
[IMP] web: cache user groups on disk

### DIFF
--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -119,12 +119,19 @@ export function _makeUser(session) {
         if (!userId) {
             return Promise.resolve(false);
         }
-        return rpc("/web/dataset/call_kw/res.users/has_group", {
+        const params = {
             model: "res.users",
             method: "has_group",
             args: [userId, group],
             kwargs: { context },
-        });
+        };
+        const cache = {
+            type: "disk",
+            callback: (updatedValue) => {
+                groupCache.cache[group] = Promise.resolve(updatedValue);
+            },
+        };
+        return rpc("/web/dataset/call_kw/res.users/has_group", params, { cache });
     };
     const getGroupCacheKey = (group) => group;
     const groupCache = new Cache(getGroupCacheValue, getGroupCacheKey);


### PR DESCRIPTION
Without this, views that need to check the user access rights could not be accessed offline. This was for instance the case of the crm pipeline.

Task~4893295

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
