### PR TITLE
[IMP] pos_{,self_order}: hide certain settings for kiosk mode

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -38,7 +38,7 @@
 
                     <!-- HIDE this div in create_mode (when '+ New Shop' is clicked in the general settings.) -->
                     <div class="row mt16 o_settings_container" invisible="context.get('pos_config_create_mode', False)">
-                        <setting
+                        <setting id = "multiple_employee_session"
                                 title="Employees can scan their badge or enter a PIN to log in to a PoS session. These credentials are configurable in the *HR Settings* tab of the employee form."
                                 string="Log in with Employees"
                                 help="Allow to log and switch between selected Employees">

--- a/addons/pos_self_order/views/pos_config_view.xml
+++ b/addons/pos_self_order/views/pos_config_view.xml
@@ -10,4 +10,15 @@
             </xpath>
         </field>
     </record>
+
+    <record id="pos_config_view_form_inherit_pos_self_order" model="ir.ui.view">
+        <field name="name">pos.config.form.inherited.pos.self.order</field>
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.pos_config_view_form"/>
+        <field name="arch" type="xml">
+            <setting id="multiple_employee_session" position="attributes">
+                <attribute name="invisible">self_ordering_mode == 'kiosk'</attribute>
+            </setting>
+        </field>
+    </record>
 </odoo>

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -142,6 +142,10 @@
             <setting id="iface_printbill" position="attributes">
                 <attribute name="invisible">use_kiosk_mode</attribute>
             </setting>
+
+            <setting id="iface_tipproduct" position="attributes">
+                <attribute name="invisible">use_kiosk_mode</attribute>
+            </setting>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
In this commit:
===============
- We hide the `module_pos_hr` setting in the `pos_config_view` and `tips`
setting in the `res_config_view` when the PoS is in kiosk mode.
- These settings are not relevant for the kiosk mode.

Task: 5365500
