### PR TITLE
[FIX] pos_loyalty,pos_restaurant_loyalty: keep multi‑device rewards visible

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -809,6 +809,9 @@ patch(PosStore.prototype, {
             return agg;
         }, {});
         for (const line of rewardLines) {
+            if (!line.coupon_id) {
+                continue;
+            }
             const reward = line.reward_id;
             const couponId = line.coupon_id.id;
             if (!couponData[couponId]) {

--- a/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_store.js
@@ -5,7 +5,7 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 
 patch(PosStore.prototype, {
     async setTable(table, orderUid = null) {
-        await super.setTable(...arguments);
         this.updateRewards();
+        await super.setTable(...arguments);
     },
 });

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
@@ -20,3 +20,25 @@ registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
             PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_loyalty_multi_device_deviceA", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.addOrderline("Coca-Cola", "3"),
+            PosLoyalty.hasRewardLine("Free Product - Coca-Cola", "-2.20", "1"),
+            Chrome.clickPlanButton(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_loyalty_multi_device_deviceB", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            FloorScreen.clickTable("5"),
+            PosLoyalty.hasRewardLine("Free Product - Coca-Cola", "-2.20", "1"),
+            ProductScreen.orderLineHas("Coca-Cola", "3.0"),
+        ].flat(),
+});


### PR DESCRIPTION
When two users were connected to the same POS Restaurant, if one of them created an order on a table with a ‘Buy X, Get Y’ promotion, that promotion was not visible on the first opening of that table by the other user.

Steps to reproduce:
-------------------
* Configure a “buy X get Y” program
* Open two pos-session on the same bar/restaurant
In the first session:
* Create on order that triggers the program
* Go back to floor screen
In the second session:
* Open the table with the order

> Observation:
Only the products are in the order without the promo

Why the fix:
------------
pos_restaurant_loyalty: Move updateRewards() back before super.setTable(...). Calling it afterward could remove rewards because the synced order wasn't fully loaded yet.
pos_loyalty: Prevent _postProcessLoyalty from crashing when a synced reward line still lacks a coupon. We simply skip those lines until the coupon is available.

opw-5185559
