### PR TITLE
[FIX] mail: show pulse effect for fullscreen mode in chat window

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.scss
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.scss
@@ -1,3 +1,15 @@
 .o-discuss-CallActionList-pulse {
-    animation: pulse 1s 10;
+    --pulse-spread-radius: 1.5rem;
+    animation: pulseFullScreen 1s cubic-bezier(0.4, 1, 0.6, 1) 10;
+}
+
+@keyframes pulseFullScreen {
+    from {
+        box-shadow: 0 0 0 0 var(--pulse-color-from, #{$primary});
+        border-radius: 50%;
+    }
+    to {
+        box-shadow: 0 0 7px var(--pulse-spread-radius, 2em) var(--pulse-color-to, #{rgba($primary, 0.2)});
+        border-radius: 50%;
+    }
 }

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -71,7 +71,7 @@ const ThreadPatch = {
                     return;
                 }
                 this.promoteFullscreen =
-                    this.videoCountNotSelf > 0 && this.chat_window?.isOpen
+                    this.videoCountNotSelf > 0 && this.channel?.chatWindow?.isOpen
                         ? CALL_PROMOTE_FULLSCREEN.ACTIVE
                         : CALL_PROMOTE_FULLSCREEN.INACTIVE;
             },


### PR DESCRIPTION
**Description of the issue this PR addresses:**
The pulse effect for the fullscreen mode was not visible in chat window
even when another participant’s video camera was on.

**Steps to Reproduce:**
- Log in with Admin and Demo user
- From the Demo side, open the chat window and call Mitchell Admin
- Join the call from the Admin side and enable the video camera
- Look at the fullscreen option on the Demo side. The pulse effect is not visible.

**Current behavior before PR:**

Since this https://github.com/odoo/odoo/pull/232493, the thread model no longer had a direct `chat_window` reference, 
causing a pulse effect issue.

**Desired behavior after PR is merged:**

This commit ensures that the pulse effect should now be visible on 
fullscreen mode, when another participant's camera is on.

task-[5364914](https://www.odoo.com/odoo/project/1519/tasks/5364914)

Before:
<img width="336" height="56" alt="image" src="https://github.com/user-attachments/assets/c3b76f15-d07f-4673-b013-68b7a580b3b2" />


After:
![final_pulse](https://github.com/user-attachments/assets/2aba4c92-b1e9-4c35-b81c-f68832867a75)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
