### PR TITLE
[ADD] mail: add mail activities to KPI provider

### DIFF
--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -66,6 +66,7 @@ from . import ir_ui_menu
 from . import ir_ui_view
 from . import ir_qweb
 from . import ir_websocket
+from . import kpi_provider
 from . import res_company
 from . import res_config_settings
 from . import res_role

--- a/addons/mail/models/kpi_provider.py
+++ b/addons/mail/models/kpi_provider.py
@@ -1,0 +1,43 @@
+import re
+
+from odoo import api, models
+
+
+class KpiProvider(models.AbstractModel):
+    _inherit = 'kpi.provider'
+
+    @api.model
+    def get_mail_activities_kpi_summary(self):
+        domain = [
+            '|', ('activity_type_id.kpi_provider_visibility', '=', 'all'),
+                 '&', ('activity_type_id.kpi_provider_visibility', '=', 'own'),
+                      ('user_id', '=', self.env.uid),
+        ]
+        count_by_activity_type = self.env['mail.activity'].sudo()._read_group(
+            domain=domain,
+            groupby=['activity_type_id'],
+            aggregates=['__count'],
+        )
+        activity_types = self.env['mail.activity.type'].browse([pair[0].id for pair in count_by_activity_type])
+        activity_types_external_ids = activity_types._get_external_ids()
+        identifier_by_activity_type_id = {}
+        for act_type in activity_types:
+            if xmlids := activity_types_external_ids[act_type.id]:
+                identifier = xmlids[0]
+            else:
+                identifier = act_type.name
+            normalized_identifier = re.sub(r'[^a-z0-9]', '_', identifier.lower())
+            identifier_by_activity_type_id[act_type.id] = 'mail_activity_type.' + normalized_identifier
+
+        return [{
+            'id': identifier_by_activity_type_id[act_type.id],
+            'name': act_type.name,
+            'type': 'integer',
+            'value': count,
+        } for act_type, count in count_by_activity_type]
+
+    @api.model
+    def get_kpi_summary(self):
+        result = super().get_kpi_summary()
+        result.extend(self.get_mail_activities_kpi_summary())
+        return result

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -74,6 +74,15 @@ class MailActivityType(models.Model):
     mail_template_ids = fields.Many2many('mail.template', string='Email templates')
     default_user_id = fields.Many2one("res.users", string="Default User")
     default_note = fields.Html(string="Default Note", translate=True)
+    kpi_provider_visibility = fields.Selection([
+            ('none', 'None'),
+            ('own', 'Own Activities'),
+            ('all', 'All Activities'),
+        ], string='KPI Provider Visibility', default='own',
+        help="Whether this type of activity should be displayed in the KPI Provider API.\n"
+             "None: never display this type of activity\n"
+             "Own Activities: the synchronization user will only count their own activities of this type\n"
+             "All Activities: the synchronization user will count the all the activities of this type, whatever their owner")
 
     #Fields for display purpose only
     initial_res_model = fields.Selection(selection=_get_model_selection, string='Initial model', compute="_compute_initial_res_model", store=False,

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_font_to_img
 from . import test_ir_mail_server
 from . import test_ir_ui_menu
 from . import test_ir_websocket
+from . import test_kpi_provider
 from . import test_link_preview
 from . import test_mail_activity
 from . import test_mail_composer

--- a/addons/mail/tests/test_kpi_provider.py
+++ b/addons/mail/tests/test_kpi_provider.py
@@ -1,0 +1,53 @@
+from odoo.tests import new_test_user, tagged, TransactionCase, users
+
+
+@tagged('post_install', '-at_install')
+class TestKpiProvider(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_someemployee = new_test_user(cls.env, name='Some Employee', login='someemployee')
+        cls.user_anotheremployee = new_test_user(cls.env, name='AnotherEmployee', login='anotheremployee')
+
+        cls.env['mail.activity'].create([{
+            'activity_type_id': cls.env.ref('mail.mail_activity_data_todo').id,
+            'user_id': cls.user_someemployee.id,
+        }, {
+            'activity_type_id': cls.env.ref('mail.mail_activity_data_meeting').id,
+            'user_id': cls.user_someemployee.id,
+        }, {
+            'activity_type_id': cls.env.ref('mail.mail_activity_data_meeting').id,
+            'user_id': cls.user_anotheremployee.id,
+        }])
+
+    @users('someemployee')
+    def test_kpi_summary(self):
+        """ Ensure that a user will see their own mail activities if their visibility is 'own' """
+
+        self.assertCountEqual(self.env['kpi.provider'].get_mail_activities_kpi_summary(), [
+            {'id': 'mail_activity_type.mail_mail_activity_data_todo', 'name': 'To-Do', 'type': 'integer', 'value': 1},
+            {'id': 'mail_activity_type.mail_mail_activity_data_meeting', 'name': 'Meeting', 'type': 'integer', 'value': 1},
+        ])
+
+    @users('someemployee')
+    def test_kpi_summary_visibility_all(self):
+        """ Ensure that a user will see two meetings if the visibility is 'all' """
+
+        self.env.ref('mail.mail_activity_data_meeting').sudo().kpi_provider_visibility = 'all'
+
+        self.assertCountEqual(self.env['kpi.provider'].get_mail_activities_kpi_summary(), [
+            {'id': 'mail_activity_type.mail_mail_activity_data_todo', 'name': 'To-Do', 'type': 'integer', 'value': 1},
+            {'id': 'mail_activity_type.mail_mail_activity_data_meeting', 'name': 'Meeting', 'type': 'integer', 'value': 2},
+        ])
+
+    @users('someemployee')
+    def test_kpi_summary_visibility_none(self):
+        """ Ensure that a user won't see any meetings if the visibility is 'none' """
+
+        self.env.ref('mail.mail_activity_data_meeting').sudo().kpi_provider_visibility = 'none'
+
+        self.assertCountEqual(self.env['kpi.provider'].get_mail_activities_kpi_summary(), [
+            {'id': 'mail_activity_type.mail_mail_activity_data_todo', 'name': 'To-Do', 'type': 'integer', 'value': 1},
+        ])


### PR DESCRIPTION
Since 19.0, Odoo provides an RPC interface to retrieve KPIs from a database, mainly intended for the enterprise `databases` module.

With this commit, we add a count of activities by type to the list of KPIs, in order to be able to easily configure new KPIs that will be made available to an external service.

To prevent all activity types to be exported to the interface, this commit also adds a new field `databases_visibility` on the model `mail.activity.type`, that accepts three values:
- none: the count of activities for this type will never be exported.
- own: the user making the RPC call will see the count of the activities owned by his user only.
- all: the RPC call will contain the count of all the activities of this type, whatever the owner.

The default value is `own`.

Task-id: [5167740](https://www.odoo.com/odoo/project.task/5167740)