### PR TITLE
[FIX] web: prevent checkbox animation from affecting form switches 

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -284,7 +284,6 @@ $-o-bg-colors-custom: null;
 }
 
 .form-check-input[type="checkbox"]:checked {
-    background-size: 100% 100%;
     animation: check-grow 300ms ease-in-out;
 }
 
@@ -299,6 +298,7 @@ $-o-bg-colors-custom: null;
     .form-check-input:checked {
         background-color: $o-success;
         border-color: $o-success;
+        animation: none;
     }
 
     .form-check-input:focus {


### PR DESCRIPTION
Before this commit, the recent checkbox changes from commit [1] applied background-size: 100% 100% to all checked checkboxes, including form switches (toggles). This caused switches to render incorrectly with the toggle bullet appearing in the middle instead of the right side.

This commit removes the unnecessary `background-size` override and disables the check-grow animation for form switches.

task-5367051

[1]: https://github.com/odoo/odoo/commit/0c4c8022c71c269683ac6df093b7495c44fa7907

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
