### PR TITLE
[FIX] pos_self_order: prevent choosing past time slots

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_preset.js
+++ b/addons/point_of_sale/static/src/app/models/pos_preset.js
@@ -89,13 +89,14 @@ export class PosPreset extends Base {
     }
 
     generateSlots() {
+        const now = DateTime.now();
         const usage = this.slotsUsage;
         const interval = this.interval_time;
         const slots = {};
 
         // Compute slots for next 7 days
         for (const i of [...Array(7).keys()]) {
-            const dateNow = DateTime.now().plus({ days: i });
+            const dateNow = now.plus({ days: i });
             const getDateTime = (hour) =>
                 DateTime.fromObject({
                     year: dateNow.year,
@@ -105,7 +106,7 @@ export class PosPreset extends Base {
                     minute: Math.round((hour % 1) * 60),
                 });
             const dayOfWeek = (dateNow.weekday - 1).toString();
-            const date = DateTime.now().plus({ days: i }).toFormat("yyyy-MM-dd");
+            const date = dateNow.toFormat("yyyy-MM-dd");
             const attToday = this.attendance_ids.filter((a) => a.dayofweek === dayOfWeek);
             slots[date] = [];
 
@@ -115,18 +116,19 @@ export class PosPreset extends Base {
 
                 let start = dateOpening;
                 while (start >= dateOpening && start <= dateClosing && interval > 0) {
-                    const sqlDatetime = start.toFormat("yyyy-MM-dd HH:mm:ss");
+                    if (start >= now) {
+                        const sqlDatetime = start.toFormat("yyyy-MM-dd HH:mm:ss");
 
-                    if (slots[date][sqlDatetime]) {
-                        slots[date][sqlDatetime].order_ids.add(...(usage[sqlDatetime] || []));
-                    } else {
-                        slots[date][sqlDatetime] = {
-                            periode: attendance.day_period,
-                            datetime: start,
-                            order_ids: new Set(usage[sqlDatetime] || []),
-                        };
+                        if (slots[date][sqlDatetime]) {
+                            slots[date][sqlDatetime].order_ids.add(...(usage[sqlDatetime] || []));
+                        } else {
+                            slots[date][sqlDatetime] = {
+                                periode: attendance.day_period,
+                                datetime: start,
+                                order_ids: new Set(usage[sqlDatetime] || []),
+                            };
+                        }
                     }
-
                     start = start.plus({ minutes: interval });
                 }
             }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -983,21 +983,23 @@ registry.category("web_tour.tours").add("test_remove_archived_product_from_cache
 registry.category("web_tour.tours").add("test_preset_timing_retail", {
     steps: () =>
         [
+            Chrome.freezeDateTime(1764583200000), // 1 dec 2025 - 10:00
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.selectPreset("Eat in", "Delivery"),
             PartnerList.clickPartner("A simple PoS man!"),
             Chrome.clickPresetTimingSlot(),
+            Chrome.presetTimingSlotHourNotExists("09:00"),
             Chrome.selectPresetTimingSlotHour("15:00"),
             Chrome.presetTimingSlotIs("15:00"),
             Chrome.createFloatingOrder(),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             Chrome.clickOrders(),
-            TicketScreen.nthRowContains(1, "A simple PoS man!"),
-            TicketScreen.nthRowContains(1, "Delivery", false),
-            TicketScreen.nthRowContains(2, "002"),
-            TicketScreen.nthRowContains(2, "Eat in", false),
+            TicketScreen.nthRowContains(1, "002"),
+            TicketScreen.nthRowContains(1, "Eat in", false),
+            TicketScreen.nthRowContains(2, "A simple PoS man!"),
+            TicketScreen.nthRowContains(2, "Delivery", false),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -165,6 +165,12 @@ export function presetTimingSlotIs(hour) {
 export function selectPresetTimingSlotHour(hour) {
     return { trigger: `.modal button:contains('${hour}')`, run: "click" };
 }
+export function presetTimingSlotHourNotExists(hour) {
+    return { trigger: negate(`.modal button:visible:contains('${hour}')`) };
+}
+export function presetTimingSlotHourExists(hour) {
+    return { trigger: `.modal button:contains('${hour}')` };
+}
 export function clickRegister() {
     return { trigger: ".pos-leftheader .register-label", run: "click" };
 }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -528,6 +528,7 @@ registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
 registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
     steps: () =>
         [
+            Chrome.freezeDateTime(1764583200000), // 1 dec 2025 - 10:00
             Chrome.startPoS(),
             FloorScreen.clickTable("5"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
@@ -541,6 +542,7 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
             Dialog.confirm(),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             Chrome.clickPresetTimingSlot(),
+            Chrome.presetTimingSlotHourNotExists("09:00"),
             Chrome.selectPresetTimingSlotHour("15:00"),
             Chrome.presetTimingSlotIs("15:00"),
             Chrome.clickPlanButton(),


### PR DESCRIPTION
Task: [#5365003](https://www.odoo.com/odoo/project/1737/tasks/5365003)

---

before this commit selecting a time slot in self-order, the customer can still pick time slots that are already in the past. For example, if the current time is 14:05, the system still allows selecting 12:00, 12:20, 13:00, etc.

This should not be possible.
When choosing a pickup time for today, all time slots earlier than the current time should not be generated