### PR TITLE
[IMP] website: allow user to choose multiple dependency values

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -38,6 +38,7 @@ export class BuilderList extends Component {
         defaultNewValue: { type: Object, optional: true },
         columnWidth: { optional: true },
         forbidLastItemRemoval: { type: Boolean, optional: true },
+        isEditable: { type: Boolean, optional: true },
     };
     static defaultProps = {
         addItemTitle: _t("Add"),
@@ -49,6 +50,7 @@ export class BuilderList extends Component {
         defaultNewValue: {},
         columnWidth: {},
         forbidLastItemRemoval: false,
+        isEditable: true,
     };
     static components = { BuilderComponent, SelectMenu };
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -43,7 +43,6 @@ export class BuilderList extends Component {
     static defaultProps = {
         addItemTitle: _t("Add"),
         itemShape: { value: "text" },
-        default: { value: _t("Item") },
         sortable: true,
         hiddenProperties: [],
         mode: "button",
@@ -55,7 +54,9 @@ export class BuilderList extends Component {
     static components = { BuilderComponent, SelectMenu };
 
     setup() {
-        this.validateProps();
+        if (this.props.default) {
+            this.validateProps();
+        }
         this.dialog = useService("dialog");
         useBuilderComponent();
         const { state, commit, preview } = useInputBuilderComponent({

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -35,7 +35,7 @@
                                                     t-att-name="entry[0]"
                                                     t-att-value="item[entry[0]]"
                                                     t-att-data-id="item._id"
-                                                    t-att-disabled="isMany2X"
+                                                    t-att-disabled="isMany2X || !props.isEditable"
                                                     t-on-input="onInput"
                                                     t-on-change="onChange"
                                             />
@@ -44,7 +44,7 @@
                                 </t>
                                 <td>
                                     <button type="button" class="btn text-danger builder_list_remove_item"
-                                            t-if="!(this.props.forbidLastItemRemoval and (items.length === 1))"
+                                            t-if="props.isEditable and !(this.props.forbidLastItemRemoval and (items.length === 1))"
                                             t-on-click="() => this.deleteItem(item._id)">
                                         <i class="fa fa-fw fa-minus" aria-hidden="true"/>
                                         <span class="visually-hidden">Delete item</span>
@@ -78,7 +78,8 @@
             </div>
             <t t-else="">
                 <div class="text-end mt-1">
-                    <button type="button" class="builder_list_add_item o-hb-btn btn btn-success px-3"
+                    <button t-if="props.isEditable" type="button"
+                            class="builder_list_add_item o-hb-btn btn btn-success px-3"
                             t-on-click="() => this.addItem()">
                         <t t-out="props.addItemTitle"/>
                     </button>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -204,15 +204,6 @@ test("throws error on wrong properties default value", async () => {
     `);
 });
 
-test("throws error on missing default value with a custom itemShape", async () => {
-    await testBuilderListFaultyProps(`
-        <BuilderList
-            dataAttributeAction="'list'"
-            itemShape="{ a: 'number', b: 'text' }"
-        />
-    `);
-});
-
 test("throws error if itemShape contains reserved key '_id'", async () => {
     await testBuilderListFaultyProps(`
         <BuilderList

--- a/addons/website/static/src/builder/plugins/form/form_field_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_field_option.js
@@ -58,6 +58,7 @@ export class FormFieldOption extends BaseOptionComponent {
                     isFormDate: false,
                     isFormDateTime: false,
                     hasDateTimePicker: false,
+                    isMultipleInputs: false,
                 };
             }
 
@@ -69,6 +70,7 @@ export class FormFieldOption extends BaseOptionComponent {
                 isFormDate: !!dependencyEl.closest(".s_website_form_date"),
                 isFormDateTime: !!dependencyEl.closest(".s_website_form_datetime"),
                 hasDateTimePicker: dependencyEl.classList.contains("datetimepicker-input"),
+                isMultipleInputs: !!dependencyEl.closest(".s_website_form_multiple"),
             };
         });
 
@@ -211,6 +213,15 @@ export class FormFieldOption extends BaseOptionComponent {
         return (
             fieldEl.classList.contains("s_website_form_custom") ||
             ["one2many", "many2many"].includes(fieldEl.dataset.type)
+        );
+    }
+    get isMultiSelectVisible() {
+        const el = this.env.getEditingElement();
+        const dependencyEl = getDependencyEl(el);
+        return (
+            (["checkbox", "radio"].includes(dependencyEl.type) ||
+                dependencyEl.nodeName === "SELECT") &&
+            ["contains", "!contains"].includes(el.dataset.visibilityComparator)
         );
     }
 }

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -325,7 +325,7 @@
                     t-out="input.textContent"
                 />
             </BuilderSelect>
-            <BuilderSelect t-if="domStateDependency.type === 'checkbox' || domStateDependency.type === 'radio' || domStateDependency.nodeName === 'SELECT'"
+            <BuilderSelect t-if="domStateDependency.isMultipleInputs || domStateDependency.nodeName === 'SELECT'"
                 id="'hidden_condition_no_text_opt'" preview="false" dataAttributeAction="'visibilityComparator'"
             >
                 <BuilderSelectItem dataAttributeActionValue="'selected'">Is equal to</BuilderSelectItem>
@@ -381,7 +381,8 @@
                 <BuilderSelectItem dataAttributeActionValue="'fileSet'">Is set</BuilderSelectItem>
                 <BuilderSelectItem dataAttributeActionValue="'!fileSet'">Is not set</BuilderSelectItem>
             </BuilderSelect>
-            <BuilderSelect t-if="domStateDependency.isRecordField"
+            <BuilderSelect t-if="domStateDependency.isRecordField ||
+                (!domStateDependency.isMultipleInputs and domStateDependency.type === 'checkbox')"
                 id="'hidden_condition_record_opt'" dataAttributeAction="'visibilityComparator'" preview="false"
             >
                 <BuilderSelectItem dataAttributeActionValue="'selected'">Is equal to</BuilderSelectItem>
@@ -389,7 +390,7 @@
             </BuilderSelect>
         </div>
         <div class="d-flex position-relative p-1 px-2 ps-3 hb-row" data-name="hidden_condition_additional_text">
-            <BuilderSelect t-if="state.conditionValueList and (domStateDependency.type === 'checkbox' || domStateDependency.type === 'radio' || domStateDependency.nodeName === 'SELECT')"
+            <BuilderSelect t-if="!isMultiSelectVisible"
                 id="'hidden_condition_no_text_opt'" preview="false" dataAttributeAction="'visibilityCondition'"
             >
                 <!-- checkbox, select, radio possible values -->
@@ -398,6 +399,10 @@
                     t-out="record.textContent"
                 />
             </BuilderSelect>
+            <BuilderList t-if="isMultiSelectVisible" action="'setDependencyValueList'"
+                sortable="false"
+                isEditable="false"
+                itemShape="{ display_name: 'text', selected: 'boolean' }"/>
             <BuilderSelect t-if="state.conditionValueList and domStateDependency.isRecordField"
                 id="'hidden_condition_record_opt'" preview="false" dataAttributeAction="'visibilityCondition'"
             >

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -550,6 +550,67 @@ test("Label falls back to default value (data-translated-name) when removed", as
     );
 });
 
+test("multiple conditional visiblity value for 'contains'", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(
+        `<section class="s_website_form">
+            <form data-model_name="mail.mail">
+                <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="one2many">
+                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                        <label class="col-sm-auto s_website_form_label" style="width: 200px" for="ofwe8fyqws37">
+                            <span class="s_website_form_label_content">Custom Text</span>
+                        </label>
+                        <div class="col-sm">
+                            <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" data-name="Custom Text" data-display="horizontal">
+                                <div class="checkbox col-12 col-lg-4 col-md-6">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws370" name="Custom Text" value="Option 1" data-fill-with="undefined">
+                                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws370">Option 1</label>
+                                    </div>
+                                </div>
+                                <div class="checkbox col-12 col-lg-4 col-md-6">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws371" name="Custom Text" value="Option 2">
+                                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws371">Option 2</label>
+                                    </div>
+                                </div>
+                                <div class="checkbox col-12 col-lg-4 col-md-6">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws372" name="Custom Text" value="Option 3">
+                                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws372">Option 3</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom d-none" data-type="char">
+                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                        <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="second">
+                            <span class="s_website_form_label_content">b</span>
+                        </label>
+                        <div class="col-sm">
+                            <input class="form-control s_website_form_input" type="text" name="b" id="second"/>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </section>`
+    );
+
+    const fieldB = ":iframe .s_website_form_field:has(input[name=b])";
+    await contains(fieldB).click();
+    // Change visibility condition to "contains".
+    await contains("[data-label='Visibility Rule'] button").click();
+    await contains("[data-action-value='conditional']").click();
+    await contains("button[id='hidden_condition_no_text_opt']").click();
+    await contains(".o_popover .dropdown-item:contains(Contains)").click();
+    expect(fieldB).toHaveAttribute("data-visibility-condition", "Option 1");
+
+    await contains(".form-switch input[data-id='1']").click();
+    expect(fieldB).toHaveAttribute("data-visibility-condition", '["Option 1","Option 2"]');
+});
+
 describe("Many2one Field", () => {
     const addRecordButtonSelector =
         ".we-bg-options-container .o_select_menu button.o-hb-selectMany2X-toggle";

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -430,6 +430,155 @@ test("form submit result cleaned but not removed on stop", async () => {
     expect(queryOne("#s_website_form_result").children.length).toEqual(0);
 });
 
+function formWithVisibilityRulesOnCheckbox(condition) {
+    return `
+        <section class="s_website_form">
+            <form data-model_name="mail.mail">
+                <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="one2many">
+                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                        <label class="col-sm-auto s_website_form_label" style="width: 200px" for="ofwe8fyqws37">
+                            <span class="s_website_form_label_content">Custom Text</span>
+                        </label>
+                        <div class="col-sm">
+                            <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" data-name="Custom Text" data-display="horizontal">
+                                <div class="checkbox col-12 col-lg-4 col-md-6">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws370" name="Custom Text" value="Option 1" data-fill-with="undefined">
+                                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws370">Option 1</label>
+                                    </div>
+                                </div>
+                                <div class="checkbox col-12 col-lg-4 col-md-6">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws371" name="Custom Text" value="Option 2">
+                                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws371">Option 2</label>
+                                    </div>
+                                </div>
+                                <div class="checkbox col-12 col-lg-4 col-md-6">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws372" name="Custom Text" value="Option 3">
+                                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws372">Option 3</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom s_website_form_field_hidden_if d-none" data-type="char" data-visibility-dependency="Custom Text" data-visibility-condition='["Option 1","Option 2"]' data-visibility-comparator="${condition}">
+                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                        <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="second">
+                            <span class="s_website_form_label_content">b</span>
+                        </label>
+                        <div class="col-sm">
+                            <input class="form-control s_website_form_input" type="text" name="b" id="second"/>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </section>
+    `;
+}
+
+test("contains conditional visibility(multiple checkbox)", async () => {
+    const { core } = await startInteractions(formWithVisibilityRulesOnCheckbox("contains"));
+    const fieldB = ".s_website_form_field:has(input[name=b])";
+    expect(core.interactions).toHaveLength(1);
+    expect(fieldB).not.toBeVisible();
+
+    await contains("input[value='Option 3']").click();
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).not.toBeVisible();
+
+    await contains("input[value='Option 2']").click();
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).toBeVisible();
+
+    await contains("input[value='Option 1']").click();
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).toBeVisible();
+});
+
+test("does't contains conditional visibility(multiple checkbox)", async () => {
+    const { core } = await startInteractions(formWithVisibilityRulesOnCheckbox("!contains"));
+    const fieldB = ".s_website_form_field:has(input[name=b])";
+    expect(core.interactions).toHaveLength(1);
+    expect(fieldB).toBeVisible();
+
+    await contains("input[value='Option 3']").click();
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).toBeVisible();
+
+    await contains("input[value='Option 2']").click();
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).not.toBeVisible();
+
+    await contains("input[value='Option 1']").click();
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).not.toBeVisible();
+});
+
+function formWithVisibilityRulesOnText(condition) {
+    return `
+        <section class="s_website_form">
+            <form data-model_name="mail.mail">
+                <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="char">
+                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                        <label class="col-sm-auto s_website_form_label" style="width: 200px" for="ofwe8fyqws37">
+                            <span class="s_website_form_label_content">a</span>
+                        </label>
+                        <div class="col-sm">
+                            <input class="form-control s_website_form_input" type="text" name="a" required="1" id="obij2aulqyau"/>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom s_website_form_field_hidden_if d-none" data-type="char" data-visibility-dependency="a" data-visibility-condition='test' data-visibility-comparator="${condition}">
+                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                        <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="second">
+                            <span class="s_website_form_label_content">b</span>
+                        </label>
+                        <div class="col-sm">
+                            <input class="form-control s_website_form_input" type="text" name="b" id="second"/>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </section>
+    `;
+}
+
+test("contains conditional visibility(text input)", async () => {
+    const { core } = await startInteractions(formWithVisibilityRulesOnText("contains"));
+    const fieldB = ".s_website_form_field:has(input[name=b])";
+    expect(core.interactions).toHaveLength(1);
+    expect(fieldB).not.toBeVisible();
+
+    await contains("input[name=a]").click();
+    await fill("something");
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).not.toBeVisible();
+
+    await contains("input[name=a]").click();
+    await fill("test string");
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).toBeVisible();
+});
+
+test("doesn't contains conditional visibility(text input)", async () => {
+    const { core } = await startInteractions(formWithVisibilityRulesOnText("!contains"));
+    const fieldB = ".s_website_form_field:has(input[name=b])";
+    expect(core.interactions).toHaveLength(1);
+    expect(fieldB).toBeVisible();
+
+    await contains("input[name=a]").click();
+    await fill("something");
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).toBeVisible();
+
+    await contains("input[name=a]").click();
+    await fill("test string");
+    await advanceTime(400); // Debounce delay.
+    expect(fieldB).not.toBeVisible();
+});
+
 test("form prefilled conditional", async () => {
     onRpc("res.users", "read", ({ parent }) => {
         const result = parent();

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1014,7 +1014,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Open condition comparator select",
-            trigger: "[data-container-title='Field'] #hidden_condition_no_text_opt",
+            trigger: "[data-container-title='Field'] #hidden_condition_record_opt",
             run: "click",
         },
         {


### PR DESCRIPTION
Steps to reproduce:
1. Go to Website -> Edit Mode.
2. Drag and drop a "Contact Us" form.
3. Add two fields:
   - selection field (e.g. "Author")
   - text field.
4. Edit the text field's visibility and select comparator
   "Contains" or "Doesn't Contain".
5. Try selecting multiple values (e.g. "Mitchell Admin" and
   "Marc Demo").
6. Only one value can be selected, behaving like equality checks.

Before this commit, visibility rules using the "Contains" or
"Doesn't Contain" comparator behaved like equality checks. Users
were unable to select multiple values when configuring visibility
conditions, even when the dependency field supported multi-value
logic (select, checkbox, radio).

This commit adds support for choosing multiple values when the
comparator is "Contains" or "Doesn't Contain". Visibility now
evaluates correctly for dependency fields of type select, checkbox
or radio.

task-4203938