### PR TITLE
[IMP] base: add tooltip on kanban contact types

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -371,7 +371,7 @@
                                     <p class="mb-0">
                                         <field name="name" invisible="not name" class="fw-bold"/>
                                         <field name="type" invisible="name" class="fw-bold"/>
-                                        <i t-if="record.type.raw_value != 'contact'" t-att-title="record.type.value" class="fa ms-2 text-muted" t-att-class="{'invoice': 'fa-file','delivery': 'fa-truck', 'other': 'fa-cube'}[record.type.raw_value]" role="img"/>
+                                        <i t-if="record.type.raw_value != 'contact'" t-att-data-tooltip="record.type.value" class="fa ms-2 text-muted" t-att-class="{'invoice': 'fa-file','delivery': 'fa-truck', 'other': 'fa-cube'}[record.type.raw_value]" role="img"/>
                                     </p>
                                     <field invisible="not parent_id" name="parent_id" class="text-muted"/>
                                 </div>


### PR DESCRIPTION
This commit enhances UX by providing clearer context when hovering the contact type icons in the kanban view using tooltip.

task-5347758

<img width="384" height="154" alt="Capture d’écran 2025-11-28 à 13 21 00" src="https://github.com/user-attachments/assets/ee160232-bdf4-4daf-8ff4-8d9dd3332698" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
