### PR TITLE
[FIX] website: add a route to check if a link is valid

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -408,6 +408,10 @@ class Website(Home):
             ]
         }
 
+    @http.route('/website/check_existing_link', type='jsonrpc', auth="user", website=True, readonly=True)
+    def check_existing_link(self, link):
+        return request.website.check_existing_page(link)
+
     @http.route('/website/save_session_layout_mode', type='jsonrpc', auth='public', website=True, readonly=True)
     def save_session_layout_mode(self, layout_mode, view_id):
         assert layout_mode in ('grid', 'list'), "Invalid layout mode"

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -11,6 +11,7 @@ import re
 import requests
 import threading
 import types
+import werkzeug.routing
 
 from collections import defaultdict
 from lxml import etree, html
@@ -22,7 +23,7 @@ from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website.tools import similarity_score, text_from_html, get_base_domain
 from odoo.addons.portal.controllers.portal import pager
 from odoo.addons.iap.tools import iap_tools
-from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.modules.module import get_manifest
@@ -1715,6 +1716,53 @@ class Website(models.Model):
             if len(res) == limit:
                 break
         return res
+
+    def check_existing_page(self, page):
+        """
+            Returns a boolean, whether the page is considered to exist for the
+            current website. This is a heuristic and is not perfectly reliable.
+        """
+        # The page exists if there is a 'website.page' record with this url
+        if len(self._get_website_pages(domain=[('url', '=', page), ('view_id', '!=', False)], limit=1)) > 0:
+            return True
+
+        # The page is considered to exist if there is a 'website.rewrite' record
+        # that does a redirect 301 or 302, for simplicity we do not check
+        # further whether the redirection points to an existing url.
+        redirects_domain = self.get_current_website().website_domain() & Domain(
+            [('url_from', '=', page), ('redirect_type', 'in', ('301', '302'))]
+        )
+        if len(self.env['website.rewrite'].search(redirects_domain, limit=1)) > 0:
+            return True
+
+        router = request.env['ir.http'].routing_map().bind_to_environ(request.httprequest.environ)
+        # If there is no rules matching this page, it does not exists
+        if not router.test(path_info=page, method='GET'):
+            return False
+
+        try:
+            rule, args = router.match(page, method='GET', return_rule=True)
+        except werkzeug.routing.RequestRedirect:
+            # The page is considered to exist if it redirects (this happens if
+            # there is a 'website.rewrite' 308), for simplicity we do not check
+            # further whether the redirection points to an existing url.
+            return True
+
+        try:
+            # The rule may have restriction for some records that appear in its
+            # url, these are checked by `rule.build`.
+            for arg in args:
+                if isinstance(args[arg], models.BaseModel):
+                    # Models from `router.match` are missing users in their env
+                    args[arg] = args[arg].with_user(self.env.uid)
+                    # For record that may be related to a website, we skip them
+                    # if they are for a different website than the current one
+                    if hasattr(args[arg], 'website_id') and args[arg].website_id and args[arg].website_id != self:
+                        return False
+            rule.build(args, append_unknown=False)
+        except MissingError:
+            return False
+        return True
 
     def get_suggested_controllers(self):
         """


### PR DESCRIPTION
When the user edits the menu of a website with the "Edit menu" tool, there is the suggestion to create a page or an icon to tell the link does not point to an existing page. This was implemented by fetching all the existing routes on the server, which resulted in terrible performances on large databases with a lot of generated pages; and then checking if the links of the menu were in that list.

This commit adds a new rpc endpoint to tell if links exist. Thus only the links of the menu are checked. It also uses a cache to avoid fetching information about the same link several times.

task-5367548
