### PR TITLE
[FIX] mail: adjust spacing between attachments and reactions in Chatter

### DIFF
--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -6,7 +6,8 @@
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.isDiscussion),
             'o-emojiPickerOpen': emojiPicker.isOpen,
-            'mt-n1': props.message.message_type === 'comment',
+            'mt-n1': props.message.message_type === 'comment' and !props.message.attachment_ids.length,
+            'o-mt-0_5': props.message.attachment_ids.length,
         }">
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
In version 19, when a message in the Chatter includes an attachment and an emoji
reaction is added, both elements appear visually too close to each other.
This overlap creates a cluttered look and reduces readability in the message view.

**Current behavior before PR:**
----------------------------------------------
- Emoji reactions and attachment previews are rendered too close together.
- Negative or insufficient top margin on the reactions container causes overlap.
- Visual inconsistency between text-only messages and messages with attachments.

**Desired behavior after PR is merged:**
----------------------------------------------
- Proper spacing between attachments and emoji reactions in the Chatter.
- Consistent, clean layout across all message types.
- Improved readability without affecting compactness for text-only messages.

Task-5259482

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr