### PR TITLE
[FIX] {sale,purchase,sale_purchase}_stock: prevent crash when confirming grouped RFQ

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -21,7 +21,7 @@ class ResPartner(models.Model):
     group_rfq = fields.Selection(
         [('default', 'On Order'), ('day', 'Daily'), ('week', 'Weekly'), ('all', 'Always')],
         string='Group RFQ', required=True, default='default', help="Define if RFQ should be grouped \
-        together based on expected arrival.\n \
+        together based on expected arrival, except for dropship operations.\n \
         On Order: Replenishment needs will be grouped together except for MTO.\n \
         Daily: Replenishment needs will be grouped if the expected arrival is the same day\n \
         Weekly: Replenishment needs will be grouped if the expected arrival is the same week or week day\n \

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -367,7 +367,7 @@ class StockRule(models.Model):
             ('user_id', '=', partner.buyer_id.id),
             ('currency_id', '=', currency.id),
         )
-        if partner.group_rfq == 'default':
+        if partner.group_rfq == 'default' or self.picking_type_id.code == 'dropship':
             if values.get('reference_ids'):
                 domain += (('reference_ids', 'in', tuple(values['reference_ids'].ids)),)
         date_planned = fields.Datetime.from_string(values['date_planned'])

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -186,7 +186,8 @@ class StockPicking(models.Model):
         for picking in self:
             # picking and move should have a link to the SO to see the picking on the stat button.
             # This will filter the move chain to the delivery moves only.
-            picking.sale_id = picking.move_ids.sale_line_id.order_id
+            sales_order = picking.move_ids.sale_line_id.order_id
+            picking.sale_id = sales_order[0] if sales_order else False
 
     @api.depends('move_ids.sale_line_id')
     def _compute_move_type(self):


### PR DESCRIPTION
An error occurs when confirming a purchase order linked to multiple sales orders.

Steps to reproduce:
1) Install sale_stock & sale_management and enable dropshipping. 
2) Create a vendor with group_rfq 'always'.
3) Create a product with dropship route and add that vendor.
4) Create a Quotation with that product, confirm it, duplicate and confirm.
5) From the magic button go to Purchase Orders and confirm the PO.

Reference video for steps : https://drive.google.com/file/d/1xglkuZAWNxcz0WSj_49Hemjkxx4KjSqv/view?usp=sharing

Error:
`ValueError: Wrong value for stock.picking.sale_id: sale.order(26, 27)`

Root Cause:
The computed field `sale_id` receives multiple `sale.order` records from `move_ids.sale_line_id.order_id` (see [1]). Since `sale_id` is a Many2one field, it can only accept one record or False. Assigning multiple records causes the error.

Fix:
* Create only one sale order per purchase order for drop-shipping picking types.
  For existing databases, set the value to the first available sale_id, or False
  if none exists.

[1]- https://github.com/odoo/odoo/blob/38cffd1d1580693c56f0d897b8c8e60b938a8e85/addons/sale_stock/models/stock.py#L175-L179

opw-5344535
