### PR TITLE
[FIX] html_editor, website: toolbar not reopening after link popover close

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -1037,14 +1037,22 @@ export class SelectionPlugin extends Plugin {
             return;
         }
 
-        const closestNonEditable = (node) => closestElement(node, (el) => !el.isContentEditable);
-        // If selection includes a non-editable element, focusing editor will move cursor to different position.
-        if (
-            !closestNonEditable(editableSelection.anchorNode) &&
-            !closestNonEditable(editableSelection.focusNode)
-        ) {
-            // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
-            this.editable.focus({ preventScroll: true });
+        // Focusing the closest editable element is required since, in the website
+        // 'this.editable' itself is contenteditable="false`.
+        const closestEditable = closestElement(
+            editableSelection.commonAncestorContainer,
+            (el) => el.getAttribute("contenteditable") === "true"
+        );
+        closestEditable?.focus({ preventScroll: true });
+
+        // If selection is inside a non-editable element, focusing editor might
+        // move cursor to different position. so reapply the last selection.
+        const closestNonEditable = closestElement(
+            editableSelection.commonAncestorContainer,
+            (el) => !el.isContentEditable
+        );
+        if (closestNonEditable) {
+            this.setSelection(editableSelection, { normalize: false });
         }
 
         if (!currentSelectionIsInEditable) {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -257,6 +257,7 @@ export class SelectionPlugin extends Plugin {
         if (this.document !== document) {
             const focusEditable = () => {
                 this.focusEditableDocument = true;
+                this.dispatchTo("selection_enter_handlers");
             };
             const unFocusEditable = (ev) => {
                 if (this.focusEditableDocument) {

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -147,6 +147,7 @@ export class ToolbarPlugin extends Plugin {
     resources = {
         selectionchange_handlers: this.handleSelectionChange.bind(this),
         selection_leave_handlers: () => this.closeToolbar(),
+        selection_enter_handlers: () => this.updateToolbar(),
         step_added_handlers: () => this.updateToolbar(),
         user_commands: {
             id: "expandToolbar",

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -194,6 +194,23 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
     );
 });
 
+test.tags("focus required");
+test("should focus the nearest editable ancestor when selection is inside a non-editable", async () => {
+    const { editor } = await setupEditor(
+        `<div contenteditable="false"><p contenteditable="true">[test]</p></div>`
+    );
+    const p = queryOne('p[contenteditable="true"]');
+    expect(p).toBeFocused();
+
+    // Moved focus outside of the editable
+    p.blur();
+    expect(document.body).toBeFocused();
+
+    editor.shared.selection.focusEditable();
+    // Focus should be on the closest editable element of the selection
+    expect(p).toBeFocused();
+});
+
 test("restore a selection when you are not in the editable shouldn't move the focus", async () => {
     class TestInput extends Component {
         static template = xml`<input t-ref="input" t-att-value="'eee'" class="test"/>`;


### PR DESCRIPTION
#### Description of the issue this PR addresses:

`focusEditable`:
- The previous focusEditable logic failed in the website because `this.editable` is `contenteditable="false"` and there is often a non-editable ancestor near the selection.
- As a result, the editor did not receive focus, and focusing the wrong element caused the cursor to collapse or move unexpectedly.

`Toolbar not remains open`:
- The toolbar closed when focus leaves iframe but not getting reopen when focus returns.

### Desired behavior after PR is merged:
- The focusEditable focuses the nearest element with `contenteditable="true"` and then restores the cursor when the selection lies inside a non-editable region.
- We dispatch `selection_enter_handlers` when focus returns to the iframe document.
- This reopens the toolbar when the selection is not collapsed.

task-5261404

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
