### PR TITLE
[FIX] hr: show document fields in employee form

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -256,6 +256,10 @@
                                         <field name="certificate"/>
                                         <field name="study_field"/>
                                     </group>
+                                    <group string="Documents" name="hr_document_group">
+                                        <field name="id_card"/>
+                                        <field name="driving_license"/>
+                                    </group>
                                 </group>
                             </page>
                             <page name="payroll_information" string="Payroll" groups="hr.group_hr_manager">


### PR DESCRIPTION
- These fields were not available in the employee form view.
- create a new section named 'Documents' under the Personal Tab in employee
form view
- added the fields in the employee form view

task-5366982
