### PR TITLE
[FIX] account: Send & Print alerts not computed in some edge case

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1109,7 +1109,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         expected_results = {
             'sending_methods': {'email'},
             'invoice_edi_format': False,
-            'extra_edis': {},
+            'extra_edis': set(),
             'pdf_report': self.env.ref('account.account_invoices'),
             'author_user_id': self.env.user.id,
             'author_partner_id': self.env.user.partner_id.id,

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -104,9 +104,9 @@ class AccountMoveSendWizard(models.TransientModel):
         for wizard in self:
             move_data = {
                 wizard.move_id: {
-                    'sending_methods': set(wizard.sending_methods or []) or {},
+                    'sending_methods': set(wizard.sending_methods or []),
                     'invoice_edi_format': wizard.invoice_edi_format,
-                    'extra_edis': set(wizard.extra_edis or []) or {},
+                    'extra_edis': set(wizard.extra_edis or []),
                 }
             }
             wizard.alerts = self._get_alerts(wizard.move_id, move_data)
@@ -130,7 +130,7 @@ class AccountMoveSendWizard(models.TransientModel):
         methods = self.env['ir.model.fields'].get_field_selection('res.partner', 'invoice_sending_method')
         for wizard in self:
             preferred_method = self._get_default_sending_method(wizard.move_id)
-            need_fallback = not self._is_applicable_to_move(preferred_method, wizard.move_id, **self._get_sending_settings())
+            need_fallback = not self._is_applicable_to_move(preferred_method, wizard.move_id, **self._get_default_sending_settings(wizard.move_id))
             fallback_method = need_fallback and 'email'
             wizard.sending_method_checkboxes = {
                 method_key: {
@@ -158,10 +158,10 @@ class AccountMoveSendWizard(models.TransientModel):
                 for edi_key in self._get_default_extra_edis(wizard.move_id)
             }
 
-    @api.depends('move_id', 'sending_methods')
+    @api.depends('sending_methods')
     def _compute_invoice_edi_format(self):
         for wizard in self:
-            wizard.invoice_edi_format = self._get_default_invoice_edi_format(wizard.move_id, sending_methods=set(wizard.sending_methods or []) or {})
+            wizard.invoice_edi_format = self._get_default_invoice_edi_format(wizard.move_id, sending_methods=set(wizard.sending_methods or []))
 
     @api.depends('move_id')
     def _compute_pdf_report_id(self):
@@ -210,7 +210,7 @@ class AccountMoveSendWizard(models.TransientModel):
                     wizard.move_id,
                     wizard.mail_template_id,
                     invoice_edi_format=wizard.invoice_edi_format,
-                    extra_edis=set(wizard.extra_edis or []) or {},
+                    extra_edis=set(wizard.extra_edis or []),
                     pdf_report=wizard.pdf_report_id,
                 )
                 + manual_attachments_data
@@ -242,9 +242,9 @@ class AccountMoveSendWizard(models.TransientModel):
     def _get_sending_settings(self):
         self.ensure_one()
         send_settings = {
-            'sending_methods': set(self.sending_methods or []) or {},
+            'sending_methods': set(self.sending_methods or []),
             'invoice_edi_format': self.invoice_edi_format,
-            'extra_edis': set(self.extra_edis or []) or {},
+            'extra_edis': set(self.extra_edis or []),
             'pdf_report': self.pdf_report_id,
             'author_user_id': self.env.user.id,
             'author_partner_id': self.env.user.partner_id.id,


### PR DESCRIPTION
Due to a wrong computation chain/dependencies in some cases the alerts were not correctly computed.
Indeed, when the wizard opens, the `sending_method_checkboxes` are the first computed, this compute should not be re-triggered afterwards since it only depends on `move_id`. That method was using `_get_sending_settings` which gives the setup of the **current** wizard instance.

It made no sense to do that since at this point in the computation it should be mostly empty, and it was therefore triggering the compute of most attributes, that themselves depends on the sending method and ended up into a loop of computation with inconsistent state.

This commit also clean up a bit useless depends & "or" fallback.

task-none (found while testing)
