### PR TITLE
[FIX] account: Don't save sending method on first Send & Print

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -263,12 +263,6 @@ class AccountMoveSendWizard(models.TransientModel):
     def _update_preferred_settings(self):
         """If the partner's settings are not set, we use them as partner's default."""
         self.ensure_one()
-        if (
-            self.sending_methods
-            and len(self.sending_methods) == 1
-            and not self.move_id.partner_id.with_company(self.company_id).invoice_sending_method
-        ):
-            self.move_id.partner_id.with_company(self.company_id).sudo().invoice_sending_method = self.sending_methods[0]
         if not self.move_id.partner_id.invoice_template_pdf_report_id and self.pdf_report_id != self._get_default_pdf_report_id(self.move_id):
             self.move_id.partner_id.sudo().invoice_template_pdf_report_id = self.pdf_report_id
 


### PR DESCRIPTION
Before this commit, we were setting the preferred invoice sending method on the Contact depending on what was in the first Send & Print to this specific partner.

It's a bad idea because user don't know about this setting and when they want to switch the default method (example email -> peppol) the wizard will keep propose them to send it by email only and they don't know why since they never knowingly set it to "email".

task-none (feedback from AVW)
