### PR TITLE
[FIX] base_vat: avoid VIES revalidation when creating company from contact

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -826,3 +826,10 @@ class ResPartner(models.Model):
         if self.env.context.get('import_file'):
             self.env.remove_to_compute(self._fields['vies_valid'], self)
         return res
+
+    def _create_contact_parent_company(self):
+        new_company = super()._create_contact_parent_company()
+        if new_company and self.vies_valid:
+            new_company.env.remove_to_compute(self._fields['vies_valid'], new_company)
+            new_company.vies_valid = self.vies_valid
+        return new_company

--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -13,7 +13,7 @@ from zeep.wsdl import Document
 class TestStructure(TransactionCase):
     @classmethod
     def setUpClass(cls):
-        def check_vies(vat_number):
+        def check_vies(vat_number, timeout=10):
             return {'valid': vat_number == 'BE0477472701'}
 
         super().setUpClass()
@@ -75,6 +75,7 @@ class TestStructure(TransactionCase):
             with self.assertRaises(ValidationError):
                 company.vat = "BE0987654321"  # VIES refused, don't fallback on other check
             company.vat = "BE0477472701"
+            self.assertEqual(company.vies_valid, True)
 
     def test_vat_syntactic_validation(self):
         """ Tests VAT validation (both successes and failures), with the different country
@@ -131,6 +132,25 @@ class TestStructure(TransactionCase):
                 patch.object(Client, 'service', return_value=None):
             doc = Document(location=None, transport=Transport())
             new_get_soap_client(doc, 30)
+
+    def test_no_vies_revalidation_when_creating_company_from_contact(self):
+        # Test that we don't revalidate the VAT when create a company from a contact where it's already validated
+        self.env.user.company_id.vat_check_vies = True
+        with patch('odoo.addons.base_vat.models.res_partner.check_vies', type(self)._vies_check_func):
+            partner = self.env["res.partner"].create({
+                'name': 'Dummy Partner',
+                'company_name': 'My Company',
+                'vat': 'BE0477472701',
+                'country_id': self.env.ref("base.be").id,
+            })
+            self.assertEqual(partner.vies_valid, True)
+
+        with patch('odoo.addons.base_vat.models.res_partner.check_vies',
+                   side_effect=Exception('should not call check_vies()')):
+            partner.create_company()
+            self.assertEqual(partner.vies_valid, True)
+            self.assertEqual(partner.parent_id.name, 'My Company')
+            self.assertEqual(partner.parent_id.vies_valid, True)
 
     def test_rut_uy(self):
         test_partner = self.env["res.partner"].create({"name": "UY Company", "country_id": self.env.ref("base.uy").id})

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -983,17 +983,22 @@ class ResPartner(models.Model):
 
     def create_company(self):
         self.ensure_one()
-        if self.company_name:
-            # Create parent company
-            values = dict(name=self.company_name, is_company=True, vat=self.vat)
-            values.update(self._convert_fields_to_values(self._address_fields()))
-            new_company = self.create(values)
+        if (new_company := self._create_contact_parent_company()):
             # Set new company as my parent
             self.write({
                 'parent_id': new_company.id,
                 'child_ids': [Command.update(partner_id, dict(parent_id=new_company.id)) for partner_id in self.child_ids.ids]
             })
         return True
+
+    def _create_contact_parent_company(self):
+        self.ensure_one()
+        if self.company_name:
+            # Create parent company
+            values = dict(name=self.company_name, is_company=True, vat=self.vat)
+            values.update(self._convert_fields_to_values(self._address_fields()))
+            return self.create(values)
+        return self.browse()
 
     def open_commercial_entity(self):
         """ Utility method used to add an "Open Company" button in partner views """


### PR DESCRIPTION
Use case:
- prerequisite: enable "vies" validation on the company

- a customer create from an account from the website
- from /my/account he edit his information, filling in:
  * the company name
  * the vat number

The VIES validation succeed and for future orders/invoices the B2B fiscal position will be correctly applied.

- then later, a backend user go the user's contact form and click on the `create company` button.

Here when creating the new "company" partner and then linking the contact to it, we will trigger the recomputation of the `vies_valid` field on the new "company" partner.

At that time, if the new VIES validation performed fail because of an network error or because the service is overloaded (`MS_MAX_CONCURRENT_REQ`) the `vies_valid` will be reset to `False`; and on future orders/invoices a wrong fiscal position (B2C) will be applied.

This commit ensure we keep the previously performed VIES validation when creating the company of a contact.

opw-5365258

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
