### PR TITLE
Unwrap blocks when inserting in editable span

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -73,7 +73,7 @@ function getConnectedParents(nodes) {
 /**
  * @typedef {((insertedNodes: Node[]) => void)[]} after_insert_handlers
  *
- * @typedef {((insertedNode: Node) => insertedNode)[]} before_insert_processors
+ * @typedef {((container: Element, block: Element) => container)[]} before_insert_processors
  * @typedef {((arg: { nodeToInsert: Node, container: HTMLElement }) => nodeToInsert)[]} node_to_insert_processors
  *
  * @typedef {string[]} system_attributes
@@ -160,6 +160,9 @@ export class DomPlugin extends Plugin {
         for (const cb of this.getResource("before_insert_processors")) {
             container = cb(container, block);
         }
+        if (!container.hasChildNodes()) {
+            return [];
+        }
         selection = this.dependencies.selection.getEditableSelection();
 
         let startNode;
@@ -195,6 +198,7 @@ export class DomPlugin extends Plugin {
             (isParagraphRelatedElement(node) || isListItemElement(node)) &&
             !isEmptyBlock(block) &&
             !isEmptyBlock(node) &&
+            isContentEditable(block) &&
             (isContentEditable(node) ||
                 (!node.isConnected && !closestElement(node, "[contenteditable]"))) &&
             !this.dependencies.split.isUnsplittable(node) &&
@@ -326,7 +330,7 @@ export class DomPlugin extends Plugin {
                 // Split blocks at the edges if inserting new blocks (preventing
                 // <p><p>text</p></p> or <li><li>text</li></li> scenarios).
                 while (
-                    !this.isEditionBoundary(currentNode.parentElement) &&
+                    !this.isEditionBoundary(currentNode) &&
                     (!allowsParagraphRelatedElements(currentNode.parentElement) ||
                         (isListItemElement(currentNode.parentElement) &&
                             !this.dependencies.split.isUnsplittable(nodeToInsert)))
@@ -335,6 +339,9 @@ export class DomPlugin extends Plugin {
                         // If we have to insert an unsplittable element, we cannot afford to
                         // unwrap it we need to search for a more suitable spot to put it
                         if (this.dependencies.split.isUnsplittable(nodeToInsert)) {
+                            if (this.isEditionBoundary(currentNode.parentElement)) {
+                                break;
+                            }
                             currentNode = currentNode.parentElement;
                             doesCurrentNodeAllowsP = allowsParagraphRelatedElements(currentNode);
                             continue;

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -12,27 +12,24 @@ import {
 /** @typedef {import("@html_editor/core/selection_plugin").Cursors} Cursors */
 
 /**
- * Take a node and unwrap all of its block contents recursively. All blocks
- * (except for firstChilds) are preceded by a <br> in order to preserve the line
- * breaks.
+ * Take a node and unwrap all of its block contents recursively. Paragraph
+ * related elements (except the first child) are preceded by a <br> in order to
+ * preserve the line breaks.
  *
  * @param {Node} node
  */
 export function makeContentsInline(node) {
     const document = node.ownerDocument;
-    let childIndex = 0;
-    for (const child of node.childNodes) {
-        if (isBlock(child)) {
-            if (childIndex && isParagraphRelatedElement(child)) {
-                child.before(document.createElement("br"));
+    let currentNode = node.firstChild;
+    while (currentNode) {
+        if (isBlock(currentNode)) {
+            if (currentNode.previousSibling && isParagraphRelatedElement(currentNode)) {
+                currentNode.before(document.createElement("br"));
             }
-            for (const grandChild of child.childNodes) {
-                child.before(grandChild);
-                makeContentsInline(grandChild);
-            }
-            child.remove();
+            currentNode = unwrapContents(currentNode)[0];
+        } else {
+            currentNode = currentNode.nextSibling;
         }
-        childIndex += 1;
     }
 }
 

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3620,6 +3620,42 @@ describe("editable in iframe", () => {
     });
 });
 
+describe("paste in contenteditable span", () => {
+    test("should unwrap block when pasting inside a contenteditable span", async () => {
+        const { el, editor } = await setupEditor(
+            `<p contenteditable="false"><span contenteditable="true">[]</span></p>`
+        );
+        pasteOdooEditorHtml(editor, `<h1>text<b>bold text</b>more text</h1>`);
+        expect(getContent(el)).toBe(
+            `<p contenteditable="false"><span contenteditable="true">text<b>bold text</b>more text[]</span></p>`
+        );
+    });
+    test("should unwrap block with br between them when pasting inside a contenteditable span", async () => {
+        const { el, editor } = await setupEditor(
+            `<p contenteditable="false"><span contenteditable="true">[]</span></p>`
+        );
+        pasteOdooEditorHtml(
+            editor,
+            `<p>a paragraph</p><h1>text<b>bold text</b>more text</h1><p>another</p>`
+        );
+        expect(getContent(el)).toBe(
+            `<p contenteditable="false"><span contenteditable="true">a paragraph<br>text<b>bold text</b>more text<br>another[]</span></p>`
+        );
+    });
+    test("should unwrap block with br between them when pasting in text inside a contenteditable span", async () => {
+        const { el, editor } = await setupEditor(
+            `<p contenteditable="false"><span contenteditable="true">ab[]cd</span></p>`
+        );
+        pasteOdooEditorHtml(
+            editor,
+            `<p>a paragraph</p><h1>text<b>bold text</b>more text</h1><p>another</p>`
+        );
+        expect(getContent(el)).toBe(
+            `<p contenteditable="false"><span contenteditable="true">aba paragraph<br>text<b>bold text</b>more text<br>another[]cd</span></p>`
+        );
+    });
+});
+
 describe("Paste HTML tables", () => {
     // The tests below are very sensitive to whitespaces as they do represent actual
     // whitespace text nodes in the DOM. The tests will fail if those are removed.

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -3,6 +3,7 @@ import { setupEditor } from "../_helpers/editor";
 import {
     cleanTextNode,
     fillEmpty,
+    makeContentsInline,
     splitTextNode,
     wrapInlinesInBlocks,
 } from "@html_editor/utils/dom";
@@ -205,6 +206,58 @@ describe("cleanTextNode", () => {
         cleanTextNode(el.querySelector("p").firstChild, "\uFEFF", cursors);
         cursors.restore();
         expect(getContent(el)).toBe("<p>te[]xt</p>");
+    });
+});
+
+describe("makeContentsInline", () => {
+    test("should unwrap P", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<p>text</p>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("text");
+    });
+    test("should unwrap DIV", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<div>text</div>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("text");
+    });
+    test("should unwrap P in DIV", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<div><p>text</p></div>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("text");
+    });
+    test("should not unwrap inline", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<strong>text</strong>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("<strong>text</strong>");
+    });
+    test("should unwrap multiple Ps and insert BR between", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<p>text1</p><p>text2</p>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("text1<br>text2");
+    });
+    test("should unwrap multiple Ps in multiple DIVs and insert BR between", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML =
+            "<div><p>text1</p><p>text2</p><div><div><p>text3</p><p>text4</p><div>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("text1<br>text2<br>text3<br>text4");
+    });
+    test("should preserve inline elements when unwrapping P", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<p><strong>text1</strong><u>text2</u></p>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("<strong>text1</strong><u>text2</u>");
+    });
+    test("should preserve inline elements when unwrapping P in DIV", async () => {
+        const container = document.createElement("fake-container");
+        container.innerHTML = "<div><p><strong>text1</strong><u>text2</u></p><div>";
+        makeContentsInline(container);
+        expect(container.innerHTML).toBe("<strong>text1</strong><u>text2</u>");
     });
 });
 

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -35,6 +35,7 @@ from odoo.addons.web.controllers.binary import Binary
 from odoo.addons.web.controllers.session import Session
 from odoo.addons.website.tools import get_base_domain
 from odoo.tools.json import scriptsafe as json
+from odoo.tools.translate import TRANSLATED_ELEMENTS
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +207,10 @@ class Website(Home):
     @http.route('/website/get_languages', type='jsonrpc', auth="user", website=True, readonly=True)
     def website_languages(self, **kwargs):
         return [(py_to_js_locale(lg.code), lg.url_code, lg.name) for lg in request.website.language_ids]
+
+    @http.route('/website/get_translated_elements', type='jsonrpc', auth="user", readonly=True)
+    def translated_elements(self, **kwargs):
+        return list(TRANSLATED_ELEMENTS)
 
     @http.route('/website/lang/<lang>', type='http', auth="public", website=True, multilang=False)
     def change_lang(self, lang, r='/', **kwargs):

--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -6,6 +6,12 @@ export class TranslateLinkInlinePlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         create_link_handlers: (linkEl) => linkEl.classList.add("o_translate_inline"),
+        before_insert_processors: (container) => {
+            for (const linkEl of container.querySelectorAll("a")) {
+                linkEl.classList.add("o_translate_inline");
+            }
+            return container;
+        },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -8,6 +8,7 @@ import {
     TranslatorInfoDialog,
 } from "../translation_components/translatorInfoDialog";
 import { withSequence } from "@html_editor/utils/resource";
+import { makeContentsInline, unwrapContents } from "@html_editor/utils/dom";
 
 export const translationAttributeSelector =
     '[placeholder*="data-oe-translation-source-sha="], ' +
@@ -79,12 +80,21 @@ export class TranslationPlugin extends Plugin {
             this.prepareTranslation();
         }),
         system_classes: ["o_editable_attribute"],
+        before_insert_processors: withSequence(20, (container) => {
+            makeContentsInline(container);
+            for (const el of container.querySelectorAll(this.nonTranslatedSelector)) {
+                unwrapContents(el);
+            }
+            return container;
+        }),
     };
 
     setup() {
         this.websiteService = this.services.website;
         this.notificationService = this.services.notification;
         this.dialogService = this.services.dialog;
+        this.nonTranslatedSelector =
+            `:not(${this.config.translatedElements.join(", ")})` + `:not(.o_translate_inline)`;
     }
 
     prepareTranslation() {

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -9,7 +9,7 @@ import { TranslateSetupEditorPlugin } from "./plugins/translate_setup_editor_plu
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
 import { removePlugins } from "@html_builder/utils/utils";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { Component } from "@odoo/owl";
+import { Component, onWillStart } from "@odoo/owl";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -34,6 +34,7 @@ import { BuilderContentEditablePlugin } from "@html_builder/core/builder_content
 import { ImageFieldPlugin } from "@html_builder/plugins/image_field_plugin";
 import { MonetaryFieldPlugin } from "@html_builder/plugins/monetary_field_plugin";
 import { Many2OneOptionPlugin } from "@html_builder/plugins/many2one_option_plugin";
+import { rpc } from "@web/core/network/rpc";
 
 const TRANSLATION_PLUGINS = [
     BuilderOptionsTranslationPlugin,
@@ -77,6 +78,11 @@ export class WebsiteBuilder extends Component {
         useSetupAction({
             beforeUnload: (ev) => this.onBeforeUnload(ev),
             beforeLeave: () => this.onBeforeLeave(),
+        });
+        onWillStart(async () => {
+            this.translatedElements = this.props.translation
+                ? await rpc("/website/get_translated_elements")
+                : [];
         });
     }
 
@@ -183,6 +189,7 @@ export class WebsiteBuilder extends Component {
                 type: editableEl.dataset["oeType"],
             };
         };
+        builderProps.config.translatedElements = this.translatedElements;
         builderProps.getThemeTab = () => this.websiteService.isDesigner && ThemeTab;
         const installSnippetModule = builderProps.installSnippetModule;
         builderProps.installSnippetModule = (snippet) =>

--- a/addons/website/static/tests/builder/translated_elements_getter.hoot.js
+++ b/addons/website/static/tests/builder/translated_elements_getter.hoot.js
@@ -1,0 +1,21 @@
+import { globals } from "@odoo/hoot";
+
+let translatedElements;
+export const getTranslatedElements = async () => {
+    if (!translatedElements) {
+        translatedElements = globals
+            .fetch("/website/get_translated_elements", {
+                body: JSON.stringify({}),
+                headers: { "Content-Type": "application/json" },
+                method: "POST",
+            })
+            .then(async (response) => {
+                const { error, result } = await response.json();
+                if (error) {
+                    throw error;
+                }
+                return result;
+            });
+    }
+    return translatedElements;
+};

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -1,7 +1,7 @@
 import { Builder } from "@html_builder/builder";
 import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
-import { insertText, pasteText } from "@html_editor/../tests/_helpers/user_actions";
+import { insertText, pasteHtml, pasteText } from "@html_editor/../tests/_helpers/user_actions";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import {
     animationFrame,
@@ -18,6 +18,7 @@ import {
 } from "./website_helpers";
 import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 import { TranslationPlugin } from "@website/builder/plugins/translation_plugin";
+import { dummyBase64Img } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
@@ -284,6 +285,36 @@ test("translate select", async () => {
     expect(queryAllTexts(":iframe [data-initial-translation-value='Option 1']")).toEqual([
         "Option fr",
     ]);
+});
+
+describe("paste in translate", () => {
+    test("paste html in a translated span should not add blocks", async () => {
+        const { getEditor } = await setupSidebarBuilderForTranslation({
+            websiteContent: getTranslateEditable({ inWrap: "a<b>c</b>a" }),
+        });
+        setSelection({ anchorNode: queryOne(":iframe b") });
+        pasteHtml(getEditor(), `<h1><u>hello</u></h1>`);
+        expect(":iframe b u").toHaveText("hello");
+        expect(":iframe h1").toHaveCount(0);
+    });
+
+    test("paste html in translate mode should not add img", async () => {
+        const { getEditor } = await setupSidebarBuilderForTranslation({
+            websiteContent: getTranslateEditable({ inWrap: "a<b>c</b>a" }),
+        });
+        setSelection({ anchorNode: queryOne(":iframe b") });
+        pasteHtml(getEditor(), `<img src="${dummyBase64Img}"/>`);
+        expect(":iframe img").toHaveCount(0);
+    });
+
+    test("paste html in translate mode should add o_translate_inline on `a` element", async () => {
+        const { getEditor } = await setupSidebarBuilderForTranslation({
+            websiteContent: getTranslateEditable({ inWrap: "a<b>c</b>a" }),
+        });
+        setSelection({ anchorNode: queryOne(":iframe b") });
+        pasteHtml(getEditor(), `<a href="/">link</a>`);
+        expect(":iframe b a").toHaveClass("o_translate_inline");
+    });
 });
 
 test("test that powerbox should not open in translate mode", async () => {

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -38,6 +38,7 @@ import { getWebsiteSnippets } from "./snippets_getter.hoot";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
 import { WebsiteBuilder } from "@website/builder/website_builder";
+import { getTranslatedElements } from "./translated_elements_getter.hoot";
 
 class Website extends models.Model {
     _name = "website";
@@ -142,6 +143,8 @@ export async function setupWebsiteBuilder(
     const editAssetsLoaded = new Promise((resolve) => {
         resolveEditAssetsLoaded = () => resolve();
     });
+
+    onRpc("/website/get_translated_elements", () => getTranslatedElements());
 
     patchWithCleanup(WebsiteBuilderClientAction.prototype, {
         setIframeLoaded() {


### PR DESCRIPTION
### [FIX] html_editor: unwrap blocks when inserting in editable span

When the ancestors of the selection are not elements supposed to contain
blocks when pasting, nothing was done to remove those blocks. This could
lead to `span` elements containing `p` elements for example.

This commit unwraps the blocks in the pasted content if the block
containing the selection is outside of the `contenteditable`
element that contains the selection. It also fixes the function
`makeContentsInline` that was not robust to containing some nodes
structures.

Steps to reproduce:
- Open `example.com`, and copy "Example" from the first block
- Open website builder in translate mode
- Paste
- Bug: The appearance is weird because the pasted title is not styled
  as translation
- Save
- Bug: The span of translation where the text was pasted has been reset

####
- Open `example.com`, and copy the whole content
- Open website builder
- Move cursor to the bottom of the footer, with the company name
- Paste
- Bug: it inserted a `p` element in the `span`

(non deterministic, depends on the mood of the AI)
- Open website builder in translate mode
- Select some text (more likely to trigger the bug if it includes a line
  break, for example the description in the footer)
- Use the "Translate with AI" tool from the toolbar
- Bug: The appearance is weird because the inserted translation is not
  styled as translation
- Save
- Bug: The span of translation where the text was changed has been reset

opw-5053872
opw-5109137
opw-5136337
task-5222402

### [FIX] website: restrict inserted content in translate mode to whitelist

The translate mode of the website builder should only ever insert
nodes with a tag in the `TRANSLATED_ELEMENTS` whitelist or with
`o_translate_inline` class inside a translation span. Doing otherwise
makes the translation span "invalid" according to the server, which
discards the translation.

Blocks are already unwrapped when inserting in translations (by the
previous commit), but some other nodes are not in the whitelist, for
example `img`.

This commit adds the class `o_translate_inline` on `a` elements when
inserted and unwraps nodes that are not in the whitelist and do not have
that class.

Steps to reproduce:
- Open `example.com`, and copy the link "Learn More"
- Open website builder in translate mode
- Paste
- Save
- Bug: The span of translation where the link was pasted has been reset

####
- Copy an image (or a piece of html containing an image)
- Open website builder in translate mode
- Paste
- Save
- Bug: The span of translation where the image was pasted has been reset

opw-5053872
opw-5109137
opw-5136337
task-5222402