### PR TITLE
[FIX] mail: fix error when deleting subthread

### DIFF
--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -78,7 +78,7 @@ export function makeStore(env, { localRegistry } = {}) {
                             record._.gettingField = true;
                             const val = recordFullProxy[name];
                             record._.gettingField = false;
-                            if (isRelation(Model, name)) {
+                            if (isRelation(Model, name) && val !== undefined) {
                                 const recordListFullProxy = val._proxy;
                                 if (isMany(Model, name)) {
                                     return recordListFullProxy;

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -1,4 +1,5 @@
 import { Record } from "./record";
+import { RecordList } from "./record_list";
 import { STORE_SYM, modelRegistry } from "./misc";
 import { reactive, toRaw } from "@odoo/owl";
 
@@ -161,6 +162,11 @@ export class Store extends Record {
                                 for (let c = 0; c < count; c++) {
                                     usingRecord2[name2].delete(record);
                                 }
+                            } else if (
+                                usingRecord2.Model._.fieldsOne.get(name2) &&
+                                usingRecord2[name2] instanceof RecordList
+                            ) {
+                                usingRecord2[name2].clear();
                             } else {
                                 usingRecord2[name2] = undefined;
                             }


### PR DESCRIPTION
Before this commit, in some cases deleting the subthread would result in an error. The `correspondent` field on the thread model would be set to undefined. The deletion would react due to owl and request the `correspondent` value which fails since undefined at that time.

Steps to reproduce:
- install mail and im_livechat modules
- create a group chat (3 users minimum)
- create a subthread
- delete the subthread

This commit aims to clear the recordlist instead of forcing undefined (if possible) therefore making calls to get the value while deleting still possible.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
