### PR TITLE
[FIX] mail: fields.Attr() of objects should be reactive

### DIFF
--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -17,6 +17,7 @@ declare module "models" {
         activity_counter_bus_id: number;
         activityCounter: number;
         activityGroups: Object[];
+        sortedActivityGroups: Object[];
         computeGlobalCounter: () => number;
         globalCounter: number;
         history: Thread;

--- a/addons/mail/static/src/core/web/activity_menu.xml
+++ b/addons/mail/static/src/core/web/activity_menu.xml
@@ -9,11 +9,11 @@
         </button>
         <t t-set-slot="content">
             <div t-att-class="`${discussSystray.contentClass} o-mail-ActivityMenu`">
-                <div t-if="store.activityGroups.length === 0" class="o-mail-ActivityMenu-empty align-items-center text-muted p-2 opacity-50 d-flex justify-content-center">
+                <div t-if="store.sortedActivityGroups.length === 0" class="o-mail-ActivityMenu-empty align-items-center text-muted p-2 opacity-50 d-flex justify-content-center">
                     <span>Congratulations, you're done with your activities.</span>
                 </div>
                 <div class="d-flex flex-column list-group list-group-flush" name="activityGroups">
-                    <t t-foreach="store.activityGroups" t-as="group" t-key="group_index" name="activityGroupLoop">
+                    <t t-foreach="store.sortedActivityGroups" t-as="group" t-key="group_index" name="activityGroupLoop">
                         <div class="o-mail-ActivityGroup list-group-item list-group-item-action d-flex p-2 cursor-pointer"
                              t-att-data-model_name="group.model" t-custom-click="(ev, isMiddleClick) => this.openActivityGroup(group, undefined, isMiddleClick)">
                             <img alt="Activity" t-att-src="group.icon"/>

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -23,14 +23,20 @@ const StorePatch = {
             onUpdate() {
                 this.onUpdateActivityGroups();
             },
-            sort(g1, g2) {
-                /**
-                 * Sort by model ID ASC but always place the activity group for "mail.activity" model at
-                 * the end (other activities).
-                 */
-                const getSortId = (activityGroup) =>
-                    activityGroup.model === "mail.activity" ? Number.MAX_VALUE : activityGroup.id;
-                return getSortId(g1) - getSortId(g2);
+        });
+        this.sortedActivityGroups = fields.Attr([], {
+            compute() {
+                return this.activityGroups.slice().sort((g1, g2) => {
+                    /**
+                     * Sort by model ID ASC but always place the activity group for "mail.activity" model at
+                     * the end (other activities).
+                     */
+                    const getSortId = (activityGroup) =>
+                        activityGroup.model === "mail.activity"
+                            ? Number.MAX_VALUE
+                            : activityGroup.id;
+                    return getSortId(g1) - getSortId(g2);
+                });
             },
         });
         this.globalCounter = fields.Attr(0, {

--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -141,7 +141,11 @@ export function makeStore(env, { localRegistry } = {}) {
                             }
                             // ensure each field write goes through the updatingAttrs method exactly once
                             if (record._.updatingAttrs.has(name)) {
-                                record[name] = val;
+                                if (record._.updatingReactives.has(name)) {
+                                    record[name] = val.value;
+                                } else {
+                                    record[name] = val;
+                                }
                                 return true;
                             }
                             return store.MAKE_UPDATE(function recordSet() {

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -67,6 +67,7 @@ export class RecordInternal {
     fieldsDefault = new Map();
     uses = new RecordUses();
     updatingAttrs = new Map();
+    updatingReactives = new Map();
     proxyUsed = new Map();
     /** @type {string} */
     localId;


### PR DESCRIPTION
Before this commit, fields.Attr() of Object were sometimes not reactive on write. This is a problem because a write on them doesn't follow reactively, thus can lead to bugs like component not rendering when value inside object changes.

This happens because JS models fields.Attr() assumed primitive values and was simply writing on raw record field. Note that write on raw record is preferred when possible, as this is more performant. Therefore primitive values should still ideally write on raw record.

This commit fixes the problem by writing a reactive on supported objects. That way object is reactive.