### PR TITLE
[FIX] l10n_ae: use commercial contact to decide simplified or tax invoice

### DIFF
--- a/addons/l10n_ae/models/account_move.py
+++ b/addons/l10n_ae/models/account_move.py
@@ -25,4 +25,4 @@ class AccountMove(models.Model):
     def _l10n_ae_is_simplified(self):
         """Returns True if the customer is an individual, i.e: The invoice is B2C"""
         self.ensure_one()
-        return not self.partner_id.is_company
+        return not self.commercial_partner_id.is_company


### PR DESCRIPTION
Before this commit:
- If an invoice is issued to a related contact of a company contact, it is labeled as a 'Simplified Tax' invoice. This is incorrect since the invoice is being issued to the related company on behalf of the company, so it should be a 'Tax' invoice.

After this commit:
- The commercial_partner field is now used to decide whether an invoice is a 'Tax' or 'Simplified Tax' invoice.

task-5366608