### PR TITLE
[FIX] stock: html_sanitize to error messages

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -686,10 +686,10 @@ class StockWarehouseOrderpoint(models.Model):
 
                 # Log an activity on product template for failed orderpoints.
                 for orderpoint, error_msg in all_orderpoints_exceptions:
-                    existing_activity = self.env['mail.activity'].search([
+                    existing_activity = self.env['mail.activity'].search_count([
                         ('res_id', '=', orderpoint.product_id.product_tmpl_id.id),
                         ('res_model_id', '=', self.env.ref('product.model_product_template').id),
-                        ('note', '=', error_msg)])
+                        ('note', 'like', error_msg)], limit=1)
                     if not existing_activity:
                         orderpoint.product_id.product_tmpl_id.sudo().activity_schedule(
                             'mail.mail_activity_data_warning',


### PR DESCRIPTION
From saas-18.2 and later, html fields has been changed the old behaviour.

Ex.

```python
model.create({'note': 'test'}) -> <p>test</p>
```

Old behaviour:
```python
model.search_count([('note', '=', 'test')]) -> 1
```

New behaviour:
```python
model.search_count([('note', '=', 'test')]) -> 0
```

To follow the new behaviour and not generate infinite activities, we need to add html elements to the error message.

Additional, we improved the performance (better to count and limit vs see all the whole table).

OPW-5266061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
