### PR TITLE
[FIX] website_livechat: operators can receive lc session

### DIFF
--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -157,8 +157,8 @@ class WebsiteVisitor(models.Model):
                 "last_track_ids",
                 [Store.One("page_id", ["name"]), "visit_datetime"],
                 value=lambda visitor: self.env["website.track"]
+                .sudo()
                 .browse(results.get(visitor.id))
                 .with_prefetch(all_track_ids),
-                sudo=True,
             ),
         ]

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import datetime
 import random
 
 from odoo import fields
@@ -51,6 +52,41 @@ class TestLivechatCommon(MailCommon, TransactionCaseWithUserDemo):
             for _ in range(self.max_sessions_per_operator)
         ])
         self.visitor_demo, self.visitor = self.visitors[0], self.visitors[1]
+        self.page_1, self.page_2 = self.env["website.page"].create(
+            [
+                {
+                    "name": "Test Page 1",
+                    "type": "qweb",
+                    "url": "/page_1",
+                    "website_id": self.env.ref("website.default_website").id,
+                },
+                {
+                    "name": "Test Page 2",
+                    "type": "qweb",
+                    "url": "/page_2",
+                    "website_id": self.env.ref("website.default_website").id,
+                },
+            ],
+        )
+        self.track_ids = self.env["website.track"].create(
+            [
+                {
+                    "page_id": self.page_1.id,
+                    "visitor_id": self.visitor.id,
+                    "visit_datetime": self.base_datetime - datetime.timedelta(minutes=20),
+                },
+                {
+                    "page_id": self.page_2.id,
+                    "visitor_id": self.visitor.id,
+                    "visit_datetime": self.base_datetime - datetime.timedelta(minutes=10),
+                },
+                {
+                    "page_id": self.page_1.id,
+                    "visitor_id": self.visitor.id,
+                    "visit_datetime": self.base_datetime,
+                },
+            ],
+        )
 
         self.livechat_base_url = self.livechat_channel.get_base_url()
 

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import datetime
 from freezegun import freeze_time
 
 from odoo import fields, _
@@ -163,41 +162,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         guest = self.env["mail.guest"].search([], order="id desc", limit=1)
         operator_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
-        page_1, page_2 = self.env["website.page"].create(
-            [
-                {
-                    "name": "Test Page 1",
-                    "type": "qweb",
-                    "url": "/page_1",
-                    "website_id": self.env.ref("website.default_website").id,
-                },
-                {
-                    "name": "Test Page 2",
-                    "type": "qweb",
-                    "url": "/page_2",
-                    "website_id": self.env.ref("website.default_website").id,
-                },
-            ]
-        )
-        track_ids = self.env["website.track"].create(
-            [
-                {
-                    "page_id": page_1.id,
-                    "visitor_id": self.visitor.id,
-                    "visit_datetime": self.base_datetime - datetime.timedelta(minutes=20),
-                },
-                {
-                    "page_id": page_2.id,
-                    "visitor_id": self.visitor.id,
-                    "visit_datetime": self.base_datetime - datetime.timedelta(minutes=10),
-                },
-                {
-                    "page_id": page_1.id,
-                    "visitor_id": self.visitor.id,
-                    "visit_datetime": self.base_datetime,
-                },
-            ]
-        )
         self.assertEqual(
             Store().add(channel).get_result(),
             {
@@ -312,24 +276,24 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     {"id": self.env.ref("website.default_website").id, "name": "My Website"}
                 ],
                 "website.page": [
-                    {"id": page_1.id, "name": "Test Page 1"},
-                    {"id": page_2.id, "name": "Test Page 2"},
+                    {"id": self.page_1.id, "name": "Test Page 1"},
+                    {"id": self.page_2.id, "name": "Test Page 2"},
                 ],
                 "website.track": [
                     {
-                        "id": track_ids[2].id,
-                        "page_id": page_1.id,
-                        "visit_datetime": fields.Datetime.to_string(track_ids[2].visit_datetime),
+                        "id": self.track_ids[2].id,
+                        "page_id": self.page_1.id,
+                        "visit_datetime": fields.Datetime.to_string(self.track_ids[2].visit_datetime),
                     },
                     {
-                        "id": track_ids[1].id,
-                        "page_id": page_2.id,
-                        "visit_datetime": fields.Datetime.to_string(track_ids[1].visit_datetime),
+                        "id": self.track_ids[1].id,
+                        "page_id": self.page_2.id,
+                        "visit_datetime": fields.Datetime.to_string(self.track_ids[1].visit_datetime),
                     },
                     {
-                        "id": track_ids[0].id,
-                        "page_id": page_1.id,
-                        "visit_datetime": fields.Datetime.to_string(track_ids[0].visit_datetime),
+                        "id": self.track_ids[0].id,
+                        "page_id": self.page_1.id,
+                        "visit_datetime": fields.Datetime.to_string(self.track_ids[0].visit_datetime),
                     },
                 ],
                 "website.visitor": [
@@ -338,7 +302,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "display_name": f"Website Visitor #{self.visitor.id}",
                         "id": self.visitor.id,
                         "lang_id": self.env.ref("base.lang_en").id,
-                        "last_track_ids": track_ids.ids[::-1],
+                        "last_track_ids": self.track_ids.ids[::-1],
                         "partner_id": False,
                         "website_id": self.env.ref("website.default_website").id,
                     }


### PR DESCRIPTION
Before this commit, live chat operators without the "Website/Editor and Designer" group could not receive sessions initiated by visitors.

This was caused by an access error on `website.page` when the operator attempted to fetch the visitor's browsing history (website.track). The issue was introduced in [1], which refactored how visitor tracks are retrieved.

Steps to reproduce:
1. Have an operator not in group "Website/Editor and Designer"
2. As a visitor, try to start a live chat (make sure the above operator is the only one available)
3. Access error and chat does not open operator side

In that change, the tracks were fetched using Store.Many with a lambda function. However, the sudo argument in Store helpers only applies to direct field access, not to computed values. Consequently, the tracks were being read with the operator's limited user privileges.

This commit fixes the issue by applying .sudo() inside the lambda function used to compute last_track_ids.

[1] https://github.com/odoo/odoo/pull/228693

task-5367538