### PR TITLE
[FIX] payment_razorpay: fix unwanted background error dialog

### DIFF
--- a/addons/payment_razorpay/static/src/js/payment_form.js
+++ b/addons/payment_razorpay/static/src/js/payment_form.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 /* global Razorpay */
 
-import { _t } from "@web/core/l10n/translation";
 import { loadJS } from "@web/core/assets";
 import paymentForm from '@payment/js/payment_form';
 
@@ -46,9 +45,6 @@ paymentForm.include({
         await loadJS('https://checkout.razorpay.com/v1/checkout.js');
         const RazorpayJS = Razorpay(razorpayOptions);
         RazorpayJS.open();
-        RazorpayJS.on('payment.failed', response => {
-            this._displayErrorDialog(_t("Payment processing failed"), response.error.description);
-        });
     },
 
     /**


### PR DESCRIPTION
Steps:
- Install and setup razorpay provider.
- Create a SO and try to pay SO with UPI PM.
- Cancel payment in between.

Issue:
- Error dialog in background appear even Razorpay form is still open.

Cause:
- We were opening Error dialog on `payment.failed` notification.

Fix:
- Remove Error dialog related code on `payment.failed` notification as it is already handled in `_initiatePaymentFlow` method.