### PR TITLE
[FIX] web: cache rejected promises

### DIFF
--- a/addons/web/static/src/core/utils/persistent_cache.js
+++ b/addons/web/static/src/core/utils/persistent_cache.js
@@ -50,9 +50,10 @@ export class PersistentCache {
                 def.resolve(result);
             }
         });
-        const prom = fallback()
+        fallback()
             .then((result) => {
                 this.indexedDB.write(table, key, result);
+                this.ramCache.write(table, key, Promise.resolve(result));
                 def.resolve(result);
                 return result;
             })
@@ -60,7 +61,7 @@ export class PersistentCache {
                 this.ramCache.delete(table, key);
                 def.reject(error);
             });
-        this.ramCache.write(table, key, prom);
+        this.ramCache.write(table, key, def);
         return def;
     }
 

--- a/addons/web/static/tests/core/utils/persistent_cache.test.js
+++ b/addons/web/static/tests/core/utils/persistent_cache.test.js
@@ -94,3 +94,14 @@ test("PersistentCache: can cache a simple call", async () => {
         value: { test: 456 },
     });
 });
+
+test("rejected promise is rejected for all reads", async () => {
+    const persistentCache = new PersistentCache("mockRpc", 1);
+    const fail = async () => {
+        throw new Error("fetch failed");
+    }
+    const promA = persistentCache.read("table", "key", fail);
+    const promB = persistentCache.read("table", "key", fail);
+    await expect(promA).rejects.toThrow("fetch failed");
+    await expect(promB).rejects.toThrow("fetch failed");
+});


### PR DESCRIPTION
Let's say we trigger two times a RPC that fails.

The first time, the cache is empty and we make the RPC. The ram cache is filled with `prom`.

The second time, we get `prom` from the ram cache.

When the RPC actually finishes, we end up in
```js
.catch((error) => {
    this.ramCache.delete(table, key);
    def.reject(error);
});
```

=> the RPC failure is catched, which means `prom` itself is not rejected. Instead, it resolves with the result of `.catch(...)`, which is `undefined`

Here is a simplified toy example:

```js
const prom = Promise.resolve(
    Promise.reject(new Error("fetch failed")).catch(() => {})
);
```
In this example, `prom` is successful and the result is `undefined`

"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
