### PR TITLE
[FIX] portal: make phone to be shown optional in service product checkout

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -446,6 +446,7 @@ class CustomerPortal(Controller):
             ),
             'vat_label': request.env._("VAT"),
             'discard_url': callback or '/my/addresses',
+            'needs_address': True,
         }
 
     def _is_used_as_billing(self, address_type, **kwargs):

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -158,7 +158,7 @@
             />
         </div>
         <div id="div_phone" class="col-lg-6 mb-2">
-            <label class="col-form-label" for="o_phone">Phone</label>
+            <label t-attf-class="col-form-label #{'' if needs_address else 'label-optional'}" for="o_phone">Phone</label>
             <input
                 id="o_phone"
                 type="tel"
@@ -226,7 +226,7 @@
             </t>
         </t>
         <div id="div_street" class="col-lg-12 mb-2">
-            <label class="col-form-label" for="o_street">
+            <label t-attf-class="col-form-label #{'' if needs_address else 'label-optional'}" for="o_street">
                 Street and Number
             </label>
             <input
@@ -252,7 +252,7 @@
         <div class="w-100"/>
         <t t-if="zip_before_city">
             <div id="div_zip" class="col-md-4 mb-2">
-                <label class="col-form-label" for="o_zip">
+                <label t-attf-class="col-form-label #{'' if needs_address else 'label-optional'}" for="o_zip">
                     Zip Code
                 </label>
                 <input
@@ -265,7 +265,7 @@
             </div>
         </t>
         <div id="div_city" class="col-md-8 mb-2">
-            <label class="col-form-label" for="o_city">City</label>
+            <label t-attf-class="col-form-label #{'' if needs_address else 'label-optional'}" for="o_city">City</label>
             <input
                 id="o_city"
                 type="text"
@@ -276,7 +276,7 @@
         </div>
         <t t-if="not zip_before_city">
             <div id="div_zip" class="col-md-4 mb-2">
-                <label class="col-form-label" for="o_zip">
+                <label t-attf-class="col-form-label #{'' if needs_address else 'label-optional'}" for="o_zip">
                     Zip Code
                 </label>
                 <input
@@ -290,7 +290,7 @@
         </t>
         <div class="w-100"/>
         <div id="div_country" class="col-lg-6 mb-2">
-            <label class="col-form-label" for="o_country_id">
+            <label t-attf-class="col-form-label #{'' if needs_address else 'label-optional'}" for="o_country_id">
                 Country
             </label>
             <select

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1074,6 +1074,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'website_sale_order': order_sudo,
             'only_services': order_sudo.only_services,
             'discard_url': callback or (is_anonymous_cart and '/shop/cart') or '/shop/checkout',
+            'needs_address': self._needs_address(),
         }
 
     def _get_default_country(self, order_sudo=False, **kwargs):


### PR DESCRIPTION
### Issue
Due to this issue, when the product is service, the phone field is not required, even though there is * marking it as required.

#### To reproduce
1- Add a service product to cart
2- Click checkout and fill the address
3- Leave the phone blank
4- Click on confirm

As you see, it is allowed to confirm without setting the address while shown as required.

### Cause
This is due to https://github.com/odoo/odoo/pull/198731, making phone number not required in quick checkout case.

However, this change should also make not required fields to be displayed as optional.

opw-5348695
