### PR TITLE
[IMP] payment_adyen: allow testing without URL prefix

### DIFF
--- a/addons/payment_adyen/views/payment_provider_views.xml
+++ b/addons/payment_adyen/views/payment_provider_views.xml
@@ -12,7 +12,7 @@
                     <field name="adyen_api_key" required="code == 'adyen' and state != 'disabled'" password="True"/>
                     <field name="adyen_client_key" required="code == 'adyen' and state != 'disabled'"/>
                     <field name="adyen_hmac_key" required="code == 'adyen' and state != 'disabled'" password="True"/>
-                    <field name="adyen_api_url_prefix" required="code == 'adyen' and state != 'disabled'"/>
+                    <field name="adyen_api_url_prefix" required="code == 'adyen' and state == 'enabled'"/>
                 </group>
             </group>
             <group name="provider_config" position='before'>


### PR DESCRIPTION
This commit simplifies onboarding with Adyen by removing the requirement on the API URL Prefix field for test payments. Its value is the same for everyone, so it's now hard-coded.

task-5368019
