### PR TITLE
[FIX] website: hide child menus when their parent menu is hidden

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -189,21 +189,19 @@ class WebsiteMenu(models.Model):
 
     def _compute_visible(self):
         for menu in self:
-            visible = True
-            if menu.page_id and not menu.env.user._is_internal():
+            visible = True if not menu.parent_id else menu.parent_id.is_visible
+            if visible and menu.page_id and not menu.env.user._is_internal():
                 page_sudo = menu.page_id.sudo()
                 if (not page_sudo.is_visible
                     or (not page_sudo.view_id._handle_visibility(do_raise=False)
                         and page_sudo.view_id._get_cached_visibility() != "password")):
                     visible = False
-
-            if menu.controller_page_id and not menu.env.user._is_internal():
+            if visible and menu.controller_page_id and not menu.env.user._is_internal():
                 controller_page_sudo = menu.controller_page_id.sudo()
                 if (not controller_page_sudo.is_published
                     or (not controller_page_sudo.view_id._handle_visibility(do_raise=False)
                         and controller_page_sudo.view_id._get_cached_visibility() != "password")):
                     visible = False
-
             menu.is_visible = visible
 
     def _clean_url(self):

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -178,7 +178,7 @@ class WebsiteMenu(models.Model):
             raise UserError(_("You cannot delete this website menu as this serves as the default parent menu for new websites (e.g., /shop, /event, ...)."))
 
     def _compute_visible(self):
-        for menu in self:
+        for menu in self.sorted('parent_path'):
             visible = True
             if menu.page_id and not menu.env.user._is_internal():
                 page_sudo = menu.page_id.sudo()
@@ -193,7 +193,8 @@ class WebsiteMenu(models.Model):
                     or (not controller_page_sudo.view_id._handle_visibility(do_raise=False)
                         and controller_page_sudo.view_id._get_cached_visibility() != "password")):
                     visible = False
-
+            if menu.parent_id and not menu.parent_id.is_visible:
+                visible = False
             menu.is_visible = visible
 
     def _clean_url(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

A website menu can both point to a page and act as a dropdown parent for other menus. When such a parent menu has its page/controller unpublished (or its view visibility restricted), the parent's own link is correctly hidden, but its children were computed independently and stayed visible.

Because the navbar renders a dropdown based on whether it has any visible child (show_dropdown) — not on the parent's own visibility — the whole dropdown and its children kept showing even though the parent was meant to be hidden. As a result, sub-pages of a deliberately hidden section were still exposed in the menu.

This PR propagates the parent menu's visibility to its children, so the entire branch is hidden consistently.

Steps to reproduce:

  1. Create a page /services and add it to the top menu ("Services").
  2. Add /services/a and /services/b as children of "Services".
  3. Unpublish /services (or restrict its view visibility to e.g. "Logged in" / "Restricted Group").
  4. As a public user, the "Services" link is hidden, but the "Services" dropdown still shows A and B.
  
**Current behavior before PR:** the dropdown and its children remain visible.

**Desired behavior after PR is merged:** the "Services" dropdown and its children are hidden.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr