### PR TITLE
[FIX] stock_account: avoid division by zero in FIFO price computation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -227,7 +227,10 @@ class ProductProduct(models.Model):
             return self.standard_price
         if (product_value and last_in and product_value.date > last_in.date) or not last_in:
             return product_value.value
-        return last_in._get_value(at_date=date) / last_in._get_valued_qty()
+        valued_qty = last_in._get_valued_qty()
+        if not valued_qty:
+            return self.standard_price
+        return last_in._get_value(at_date=date) / valued_qty
 
     def _get_value_from_lots(self):
         lots = self.env['stock.lot'].search([


### PR DESCRIPTION
When you try to open inventory valuation and a FIFO move is marked as
done but ends up with a valued quantity of zero, the standard price
computation crashes due to a division by zero.

We now guard against this situation by falling back to the product's
standard price when the last incoming move has no valued quantity.

opw-5229244