### PR TITLE
[FIX] account_update_tax_tags: add company field

### DIFF
--- a/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.xml
+++ b/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.xml
@@ -5,6 +5,7 @@
         <field name="model">account.update.tax.tags.wizard</field>
         <field name="arch" type="xml">
             <form>
+                <field name="company_id" invisible="1"/> <!-- Required to ensure company_id is loaded in the view so that date_from is properly computed before display_lock_date_warning. -->
                 <div class="alert alert-warning" role="alert">
                     Updating tax tags on existing Journal Entries is an <b>irreversible</b> action that will impact
                     your reports.<br/>


### PR DESCRIPTION
Opening the `Update Tax Tags` wizard in v18 crashes when the company has a tax lock date configured, raising:

```
TypeError: '<' not supported between instances of 'bool' and 'datetime.date'
```

The error happens because `_compute_display_lock_date_warning` is evaluated while date_from is still False, so the comparison `wizard.date_from < tax_lock_date` ends up comparing a boolean with a date. In v17 the wizard form view included an invisible company_id field, which ensured the company was properly loaded in the cache and allowed `_compute_date_from` to run with the correct company_id and tax_lock_date before the warning compute was triggered.

This change reintroduces the invisible company_id field in the wizard form view to restore the v17 behavior. The wizard now loads the company correctly, computes `date_from` based on the tax lock date, and then computes `display_lock_date_warning` without triggering the TypeError.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
