### PR TITLE
[FIX] stock_account: display correct total value stock avco report

### DIFF
--- a/addons/stock_account/report/stock_avco_audit_report.py
+++ b/addons/stock_account/report/stock_avco_audit_report.py
@@ -94,8 +94,8 @@ WHERE
             avco = 0.0
             for record in records:
                 if record.res_model_name == 'stock.move':
-                    added_value = record.value
-                    total_value += record.value
+                    added_value = record.value if self.product_id.cost_method != 'average' or record.value >= 0 or not avco else avco * record.quantity
+                    total_value += added_value
                     total_quantity += record.quantity
                 elif record.res_model_name == 'product.value':
                     added_value = (record.value * total_quantity) - total_value

--- a/addons/stock_account/tests/__init__.py
+++ b/addons/stock_account/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_anglo_saxon_valuation_reconciliation_common
 from . import test_lot_valuation
 from . import test_stockvaluation
 from . import test_stockvaluationlayer
+from . import test_stock_avco_report

--- a/addons/stock_account/tests/test_stock_avco_report.py
+++ b/addons/stock_account/tests/test_stock_avco_report.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.common import TestStockValuationCommon
+
+
+class TestStockValuation(TestStockValuationCommon):
+    def test_avco_report_in_move_new_value(self):
+        """Check that the top line of the stock.avco.report's avco value
+        matches the standard_price when the value of an in_move
+        has been changed after the following out move
+        """
+        product = self.product_avco_auto
+        move_in = self._make_in_move(product, 2, 10)
+        self._make_out_move(product, 2)
+        move_in.value = 24
+        self._make_in_move(product, 1, 10)
+        report_lines = self.env['stock.avco.report'].search([('product_id', '=', product.id)])
+        report_lines._compute_cumulative_fields()
+        self.assertEqual(report_lines[0].avco_value, 10)
+        self.assertEqual(product.standard_price, 10)


### PR DESCRIPTION
**Steps to reproduce:**
- avco product perpetual
- PO for 1 @ 10 (validate move)
- SO for 1 (validate move)
- create a bill at 12 for the PO
- new PO for 1 @ 10
- Open the unit cost history of this product (click on the unit cost on the stock report)

**Current behavior:**
The standard price is 10 which is correct because, in run_avco() :
- the value of the first in move is now at 12 (after update from the bill)
- the second move is (rightfully) valued at 12 which is the avco_value when the quantity of this
out move is valued in the for loop iterating through the moves sorted by date
(and not at 10 which is its value).
https://github.com/odoo/odoo/blob/2ba9bbb3712271dd9aeacc7a6a08f657187672af/addons/stock_account/models/product.py#L337
- the second in move is valued at 10

However in the unit cost history of the product,
you can see that the top stock.avco.report line
has an avco value of 12.
This does not affect the standard_price or the
next moves and is only the value of the the report but 
it's a wrong value and can be confusing for the client.

**Expected behavior:**
This value should reflect the current standard_price of 10

**fix**
Inside _run_avco() for the outgoing moves
we do not use their value but the current
avco value when it's their turn in the
for loop (with moves sorted by date)
to value the move.
https://github.com/odoo/odoo/blob/2ba9bbb3712271dd9aeacc7a6a08f657187672af/addons/stock_account/models/product.py#L337
This is why in our case, the standard_price
of 10 is correctly computed.
Using the same mechanism in the avco report
fixes the issue.

opw-5261825