### PR TITLE
[FIX] html_builder: align overlay on zoom

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
@@ -80,13 +80,21 @@ export class BuilderOverlay {
         const iframeRect = this.iframe.getBoundingClientRect();
         const overlayContainerRect = this.overlayContainer.getBoundingClientRect();
         const targetRect = overlayTarget.getBoundingClientRect();
+        const isMobile = isMobileView(overlayTarget);
+        const iframeScaleX = isMobile ? iframeRect.width / this.iframe.offsetWidth : 1;
+        const iframeScaleY = isMobile ? iframeRect.height / this.iframe.offsetHeight : 1;
+
         Object.assign(this.overlayElement.style, {
-            width: `${targetRect.width}px`,
-            height: `${targetRect.height}px`,
-            top: `${iframeRect.y + targetRect.y - overlayContainerRect.y + window.scrollY}px`,
-            left: `${iframeRect.x + targetRect.x - overlayContainerRect.x + window.scrollX}px`,
+            width: `${targetRect.width * iframeScaleX}px`,
+            height: `${targetRect.height * iframeScaleY}px`,
+            top: `${
+                iframeRect.y - overlayContainerRect.y + window.scrollY + targetRect.y * iframeScaleY
+            }px`,
+            left: `${
+                iframeRect.x - overlayContainerRect.x + window.scrollX + targetRect.x * iframeScaleX
+            }px`,
         });
-        this.handlesWrapperEl.style.height = `${targetRect.height}px`;
+        this.handlesWrapperEl.style.height = `${targetRect.height * iframeScaleY}px`;
     }
 
     refreshHandles() {


### PR DESCRIPTION
Steps to reproduce:
===================
1- Go to the Website editor.
2- Go to mobile view
3- Zoom in (e.g., set it to 120%).
4- Click on any snippet inside the website iframe. 
-> The highlight overlay is in the wrong position.

When the website builder iframe is zoomed (scaled), the overlay elements (blue selection borders) become misaligned and incorrectly sized.

Cause:
======
This occurs because `targetRect` returns coordinates in the iframe's internal coordinate system (unscaled), while `iframeRect` is in the window's coordinate system (scaled).
So when we try to draw the Overlay (in Main Window) using targetRect (from Iframe), we must scale the `targetRect` values to match the Main Window's reality.

See [1] for more informations on how `getBoundingClientRect` works

Solution
=========
Scale targetRect to match the main windows's reality.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect 
opw-5345154

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
