### PR TITLE
[FIX] stock_account: compute correct avco standard_price

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -295,6 +295,7 @@ class ProductProduct(models.Model):
         avco_total_value = 0
         moves = moves_in | moves_out
         moves = moves.sorted('date, id')
+        moves_in = moves_in.sorted('date, id')
 
         # If the last value was defined by the user just return it
         if product_values and not moves_in:


### PR DESCRIPTION
PR supplémentaire commit msg et envoyer à adrien

**steps to reproduce:**
- product stored avco perpetual
- set manually the standard_price at 10
- 1 PO @10 (validate move)
- 1 PO @8 (validate move)
- set manually the standard_price at 15
- 1 PO at 25 (validate move)

**current behavior**
the standard_price is still at 15

**cause of the issue**
dans le fonctionnement tout les moves
avant l'udpate de price on les prends
a la valeur du standard price mis
manuellemnet
le problème c'est qu'on sort pas les in move
donc c'est pas dans le bon ordre
et on compare la date du dernier move ici
et on déduit à tord (vu que les move sont pas trié) que tous les move sont avant l'udpate de price
et donc on met 15 comme value