### PR TITLE
[FIX] l10n_latam_invoice_document: header and footer on printed pdf AR electronic invoices

### DIFF
--- a/addons/l10n_ar/models/res_company.py
+++ b/addons/l10n_ar/models/res_company.py
@@ -33,7 +33,7 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Argentinean localization use documents """
         self.ensure_one()
-        return self.chart_template in {'ar_base', 'ar_ex', 'ar_ri'} or super()._localization_use_documents()
+        return self.chart_template in {'ar_base', 'ar_ex', 'ar_ri'} or self.account_fiscal_country_id.code == "AR" or super()._localization_use_documents()
 
     def write(self, vals):
         if 'l10n_ar_afip_responsibility_type_id' in vals:

--- a/addons/l10n_br/models/res_company.py
+++ b/addons/l10n_br/models/res_company.py
@@ -15,4 +15,4 @@ class ResCompany(models.Model):
 
     def _localization_use_documents(self):
         self.ensure_one()
-        return self.chart_template == 'br' or super()._localization_use_documents()
+        return self.chart_template == 'br' or self.account_fiscal_country_id.code == "BR" or super()._localization_use_documents()

--- a/addons/l10n_cl/models/res_company.py
+++ b/addons/l10n_cl/models/res_company.py
@@ -12,4 +12,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Chilean localization use documents """
         self.ensure_one()
-        return self.chart_template == 'cl' or super()._localization_use_documents()
+        return self.chart_template == 'cl' or self.account_fiscal_country_id.code == "CL" or super()._localization_use_documents()

--- a/addons/l10n_ec/models/res_company.py
+++ b/addons/l10n_ec/models/res_company.py
@@ -7,4 +7,4 @@ class ResCompany(models.Model):
 
     def _localization_use_documents(self):
         self.ensure_one()
-        return self.chart_template == 'ec' or super()._localization_use_documents()
+        return self.chart_template == 'ec' or self.account_fiscal_country_id.code == "EC" or super()._localization_use_documents()

--- a/addons/l10n_pe/models/res_company.py
+++ b/addons/l10n_pe/models/res_company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         # OVERRIDE
         self.ensure_one()
-        return self.chart_template == 'pe' or super()._localization_use_documents()
+        return self.chart_template == 'pe' or self.account_fiscal_country_id.code == "PE" or super()._localization_use_documents()

--- a/addons/l10n_uy/models/res_company.py
+++ b/addons/l10n_uy/models/res_company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Uruguayan localization use documents """
         self.ensure_one()
-        return self.chart_template == 'uy' or super()._localization_use_documents()
+        return self.chart_template == 'uy' or self.account_fiscal_country_id.code == "UY" or super()._localization_use_documents()


### PR DESCRIPTION
This commit fixes a bug introduced here https://github.com/odoo/odoo/commit/3f7d79731fd5e5a751f7f1aeae63379c6211de5c because some old databases do not have set the chart template so it is needed to render the header and footer of the report template layouts taking in consideration the account fiscal country code instead of the chart template. Replicate printing the pdf of a customer electronic invoice on an argentinen company without chart template.
Ticket Adhoc side: 105739
Task latam: 1373

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
