### PR TITLE
[FIX] mail: Handle None response in IMAP unread message check

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -32,7 +32,7 @@ class OdooIMAP4(IMAP4):
     def check_unread_messages(self):
         self.select()
         _result, data = self.search(None, '(UNSEEN)')
-        self._unread_messages = data[0].split()
+        self._unread_messages = data[0].split() if data and data[0] else []
         self._unread_messages.reverse()
         return len(self._unread_messages)
 

--- a/doc/cla/individual/gnephilim.md
+++ b/doc/cla/individual/gnephilim.md
@@ -1,0 +1,10 @@
+USA, 2025-11-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+Joseph VanHorn JBVanHorn@live.com https://github.com/GNephilim


### PR DESCRIPTION
When checking for unread messages on an IMAP server, the search() method can return None for data[0] if there are no unseen messages or in certain server response conditions. Attempting to call .split() on None causes an AttributeError.

This fix adds a null check to handle the None case gracefully by returning an empty list of unread messages, allowing the mail fetch process to continue without errors.

Fixes #236771

Description of the issue/feature this PR addresses:

The IMAP server's search() method can return None for data[0] in certain conditions, particularly when there are no unseen messages. Attempting to call .split() on None causes an AttributeError, preventing the mail fetch process from continuing.

Current behavior before PR:

When checking for unread messages on certain IMAP servers with no unseen messages, the system crashes with: `AttributeError: 'NoneType' object has no attribute 'split'`

Desired behavior after PR is merged:

The mail fetch process should gracefully handle the None case by returning an empty list of unread messages, allowing the process to continue without errors.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr