### PR TITLE
[FIX] website_blog: test_course_publisher_elearning_manager

### DIFF
--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -62,6 +62,11 @@ registerWebsitePreviewTour(
             {
                 trigger: "body:not(:has(.modal))",
             },
+            {
+                content: "wait for the page to be loaded",
+                trigger:
+                    ".o_website_preview :iframe [data-view-xmlid='website_slides.course_main']",
+            },
             ...clickOnEditAndWaitEditMode(),
             {
                 content: "eLearning: double click image to edit it",


### PR DESCRIPTION
In this commit, we fix a non deterministic behavior by ensuring the iframe is loaded before it try to open editor.

runbot-232846
