### PR TITLE
[FIX] project: avoid falsy task_id and assertion failures in sharing wizard

### DIFF
--- a/addons/project/wizard/project_task_share_wizard.py
+++ b/addons/project/wizard/project_task_share_wizard.py
@@ -6,5 +6,5 @@ class TaskShareWizard(models.TransientModel):
     _inherit = ['portal.share']
     _description = 'Task Sharing'
 
-    task_id = fields.Many2one('project.task', default=lambda self: self.res_id)
+    task_id = fields.Many2one('project.task', default=lambda self: self.env.context.get('active_id'))
     project_privacy_visibility = fields.Selection(related='task_id.project_privacy_visibility')


### PR DESCRIPTION
Steps to reproduce:
- Go to a task form view.
- Share the task to a portal user.
- Click on the "Send" button after filling the wizard. → A traceback occurs due to a falsy ID.

Issue:
The wizard assigned a falsy task_id (0), causing related fields to trigger an "Invalid falsy real id" assertion.

Solution:
Ensure task_id is correctly computed from context and never assigned a falsy value.

this is the [PR](https://github.com/odoo/odoo/pull/227477) which prevents the falsy id 

task-5363416

