### PR TITLE
[FIX] point_of_sale: tax not applied on so but present in product

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
@@ -41,7 +41,7 @@ export class NumberPopup extends Component {
     }
 
     get confirmButtonLabel() {
-        return this.props.confirmButtonLabel || _t("Ok");
+        return this.props.confirmButtonLabel || _t("Confirm");
     }
 
     confirm() {

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -17,7 +17,7 @@
                         class="btn btn-primary btn-lg lh-lg o-default-button me-2 flex-fill"
                         tabindex="1"
                         t-on-click="confirm">
-                        Confirm
+                        <t t-esc="confirmButtonLabel"/>
                     </button>
                     <button class="btn btn-secondary btn-lg lh-lg o-default-button flex-fill"
                         tabindex="1"

--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -156,9 +156,7 @@ export class PosOrderlineAccounting extends Base {
         };
         if (order?.fiscal_position_id && product !== this.config.discount_product_id) {
             // Recompute taxes based on product and fiscal position.
-            values.tax_ids = order.fiscal_position_id.getTaxesAfterFiscalPosition(
-                values.product_id.taxes_id
-            );
+            values.tax_ids = order.fiscal_position_id.getTaxesAfterFiscalPosition(values.tax_ids);
         }
         return values;
     }

--- a/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@odoo/hoot";
+import { test, expect, describe } from "@odoo/hoot";
 import { setupPosEnv, getFilledOrder } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
 
@@ -198,13 +198,48 @@ test("[canBeMergedWith]: Base test", async () => {
     expect(line1.qty).toBe(5);
 });
 
-test("Test taxes after fiscal position", async () => {
-    const store = await setupPosEnv();
-    const models = store.models;
-    const dataDict = getAllPricesData();
-    dataDict["pos.order"][0]["fiscal_position_id"] = 2;
-    const data = models.loadConnectedData(dataDict);
-    const orderLine = data["pos.order.line"][0];
-    const lineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
-    expect(lineValues.tax_ids.length).toBe(0);
+describe("Test taxes after fiscal position", () => {
+    test("Orderline containing a taxed product", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const dataDict = getAllPricesData();
+        dataDict["pos.order"][0]["fiscal_position_id"] = 2;
+        const data = models.loadConnectedData(dataDict);
+        const orderLine = data["pos.order.line"][0];
+        const lineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
+        expect(lineValues.tax_ids.length).toBe(0);
+    });
+    test("Taxed Orderline orderline after fiscal position", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const dataDict = getAllPricesData();
+        dataDict["pos.order"][0]["fiscal_position_id"] = 1;
+        const data = models.loadConnectedData(dataDict);
+        // Taxed order line
+        const orderLine = data["pos.order.line"][0];
+        // Taxed Product
+        const taxedProductLineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
+        expect(taxedProductLineValues.tax_ids.length).toBe(1);
+        // Non Taxed Product
+        orderLine.product_id.taxes_id = [];
+        const nonTaxedProductlineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
+        expect(nonTaxedProductlineValues.tax_ids.length).toBe(1);
+    });
+    test("Non-taxed orderline after fiscal position", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const dataDict = getAllPricesData();
+        dataDict["pos.order"][0]["fiscal_position_id"] = 1;
+        const data = models.loadConnectedData(dataDict);
+        const orderLine = data["pos.order.line"][0];
+        // Non taxed order line
+        orderLine.tax_ids = [];
+        // Taxed product
+        const taxedProductLineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
+        expect(taxedProductLineValues.tax_ids.length).toBe(0);
+        orderLine.product_id.taxes_id = [];
+        // Non Taxed product
+        const nonTaxedProductlineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
+        expect(nonTaxedProductlineValues.tax_ids.length).toBe(0);
+    });
 });

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -4,7 +4,7 @@ import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_p
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { ask, makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
-import { enhancedButtons } from "@point_of_sale/app/components/numpad/numpad";
+import { enhancedButtons, DECIMAL } from "@point_of_sale/app/components/numpad/numpad";
 import { patch } from "@web/core/utils/patch";
 import { PosStore } from "@point_of_sale/app/services/pos_store";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
@@ -43,7 +43,11 @@ patch(PosStore.prototype, {
 
         //Add a down payment for transactions that were already done online
         if (sale_order.amount_paid > 0) {
-            this.addDownPaymentProductOrderlineToOrder(sale_order, -sale_order.amount_paid, false);
+            await this.addDownPaymentProductOrderlineToOrder(
+                sale_order,
+                -sale_order.amount_paid,
+                false
+            );
         }
         const selectedOption = await makeAwaitable(this.dialog, SelectionPopup, {
             title: _t("What do you want to do?"),
@@ -245,10 +249,23 @@ patch(PosStore.prototype, {
     },
 
     async downPaymentSO(saleOrder, isPercentage) {
+        const colorClassMap = {
+            [DECIMAL.value]: "o_colorlist_item_numpad_color_6",
+            Backspace: "o_colorlist_item_numpad_color_1",
+            "+10": "o_colorlist_item_numpad_color_10",
+            "+20": "o_colorlist_item_numpad_color_10",
+            "+50": "o_colorlist_item_numpad_color_10",
+            "-": "o_colorlist_item_numpad_color_3",
+        };
+
         const payload = await makeAwaitable(this.dialog, NumberPopup, {
             title: _t("Down Payment"),
             subtitle: _t("Due balance: %s", this.env.utils.formatCurrency(saleOrder.amount_unpaid)),
-            buttons: enhancedButtons(),
+            buttons: enhancedButtons().map((button) => ({
+                ...button,
+                class: `${colorClassMap[button.value] || ""}`,
+            })),
+            confirmButtonLabel: _t("Apply"),
             formatDisplayedValue: (x) => (isPercentage ? `% ${x}` : x),
             feedback: (buffer) =>
                 isPercentage && buffer
@@ -262,7 +279,7 @@ patch(PosStore.prototype, {
         }
 
         const amount = parseFloat(payload);
-        this.addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage);
+        await this.addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage);
     },
     async loadDownPaymentProduct() {
         if (!this.config.down_payment_product_id && this.config.raw.down_payment_product_id) {
@@ -275,11 +292,15 @@ patch(PosStore.prototype, {
                     "It seems that you didn't configure a down payment product in your point of sale. You can go to your point of sale configuration to choose one."
                 ),
             });
+            return false;
+        }
+        return true;
+    },
+    async addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage) {
+        const result = await this.loadDownPaymentProduct();
+        if (!result) {
             return;
         }
-    },
-    addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage) {
-        this.loadDownPaymentProduct();
         const saleOrderLines = saleOrder.order_line.filter((soLine) => !soLine.display_type);
         const baseLines = [];
         for (const saleOrderLine of saleOrderLines) {

--- a/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
+++ b/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
@@ -40,8 +40,8 @@ export function addDownPayment(percentage, soNth, downPaymentType) {
         steps.push(clickDownPaymentNumpad(num));
     }
     steps.push({
-        content: "Select 'Confirm'",
-        trigger: ".modal-dialog button.btn-primary:contains('Confirm')",
+        content: "Select 'Apply'",
+        trigger: ".modal-dialog button.btn-primary:contains('Apply')",
         run: "click",
     });
     return steps;

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -63,7 +63,7 @@ export function downPaymentFirstOrder(amount) {
             run: "click",
         },
         Numpad.click(amount),
-        Dialog.confirm("Confirm"),
+        Dialog.confirm("Apply"),
     ];
 }
 

--- a/addons/pos_sale/static/tests/unit/services/pos_store.test.js
+++ b/addons/pos_sale/static/tests/unit/services/pos_store.test.js
@@ -83,7 +83,7 @@ describe("onClickSaleOrder", () => {
         await waitFor(".modal-title:contains('Down Payment')");
         await click(".modal-body .numpad .numpad-button[value='+50']");
         await new Promise((resolve) => setTimeout(resolve, 50));
-        await click(".modal-footer .btn:contains('Confirm')");
+        await click(".modal-footer .btn:contains('Apply')");
         await promiseResult;
 
         const currentOrder = store.getOrder();
@@ -137,7 +137,7 @@ describe("onClickSaleOrder", () => {
         await waitFor(".modal-title:contains('Down Payment')");
         await click(".modal-body .numpad .numpad-button[value='+50']");
         await new Promise((resolve) => setTimeout(resolve, 50));
-        await click(".modal-footer .btn:contains('Confirm')");
+        await click(".modal-footer .btn:contains('Apply')");
         await promiseResult;
 
         const currentOrder = store.getOrder();


### PR DESCRIPTION
Before this commit:
-------------------
- If a tax was set on the Sale Order line, it was not applied on the down payment created from the POS.
- If no tax was set on the Sale Order line, the POS settlement incorrectly applied the product’s default tax when settling the order.

After this commit:
---------------------
- The tax defined on the Sale Order line is now consistently applied to both down payments (partial settlements) and full settlements from the POS.
- If the Sale Order line has no tax, then no tax is applied on either partial or full settlements and if have tax the tax will be applied.
- Added consistent color styling to all buttons.

task: 5269354

