### PR TITLE
[FIX] web: prevent property value from disappearing after making changes

### DIFF
--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -84,8 +84,15 @@ export class PropertyValue extends Component {
                     return;
                 }
                 // maybe the record display name has changed
-                await record.load();
-                const recordData = m2oTupleFromData(record.data);
+                const records = await this.orm.read(
+                    record.resModel,
+                    [record.resId],
+                    ["display_name"],
+                    {
+                        context: this.context,
+                    }
+                );
+                const recordData = m2oTupleFromData(records[0]);
                 await this.onValueChange([{ id: recordData[0], name: recordData[1] }]);
             },
             fieldString: this.props.string,

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -1051,7 +1051,7 @@ test("properties: many2many", async () => {
  * modal should correspond to the selected model and should be updated dynamically.
  */
 test.tags("desktop");
-test("properties: many2one 'Search more...'", async () => {
+test("properties: many2one 'Search more...' +  internal link save keeps data", async () => {
     onRpc(({ method, model }) => {
         if (["has_access", "has_group"].includes(method)) {
             return true;
@@ -1065,6 +1065,8 @@ test("properties: many2one 'Search more...'", async () => {
                 { model: "partner", display_name: "Partner" },
                 { model: "res.users", display_name: "User" },
             ];
+        } else if (method === "get_formview_id") {
+            return false;
         }
     });
 
@@ -1092,6 +1094,14 @@ test("properties: many2one 'Search more...'", async () => {
             <field name="id"/>
             <field name="display_name"/>
         </list>`;
+    User._views[["form", false]] = /* xml */ `
+        <form>
+            <sheet>
+                <group>
+                    <field name="display_name"/>
+                </group>
+            </sheet>
+        </form>`;
     User._views[["list", false]] = /* xml */ `
         <list>
             <field name="id"/>
@@ -1161,6 +1171,21 @@ test("properties: many2one 'Search more...'", async () => {
     await animationFrame();
     // Checking the model loaded
     expect.verifySteps(["res.users"]);
+
+    // Select the first value
+    await click(".o_list_table tbody tr:first-child td[name='display_name']");
+    await animationFrame();
+
+    // Click on external button
+    await click(".o_properties_external_button");
+    await animationFrame();
+
+    // Click on Save & close button
+    await click(".modal .o_form_button_save");
+    await animationFrame();
+
+    // Check that value does not disappear
+    expect(".o_field_property_definition_value input").toHaveValue("Alice");
 });
 
 test("properties: date(time) property manipulations", async () => {


### PR DESCRIPTION
**Steps to produce:**
- Install project module.
- Go to project > Open any project > Open any task > Click on gear icon.
- Click on Add properies > Set Field type as `Many2one` and Model as `Contact`.
- Now assign value to Property 1 > Click on `External button` > Click on `Save & Close`.

**Issue:**
- The assigned value disappears after saving.

**Root cause:**
- At [1], since `id` is not an active field (see [2]), it is not present in
  record.data, which is expected. However, record.data is then passed to
  m2oTupleFromData, which assumes that the data includes an id because it is
  normally used on data coming directly from the ORM.
- Additionally, since display_name is also not present, m2oTupleFromData falls
  back to record.data.name, which is not proper.

**Solution:**
- Use an ORM read to retrieve the proper display_name of the record before
  constructing the Many2one tuple.

[1]: https://github.com/odoo-dev/odoo/blob/24ccc3faf14ade70b21bf253af16a534df726fc8/addons/web/static/src/views/fields/properties/property_value.js#L87-L89
[2]: https://github.com/odoo/odoo/blob/369ca1e5a154235e80b9ea6af7b3f10442c0939f/addons/web/static/src/model/relational_model/record.js#L793-L795


Before:
<img width="589" height="68" alt="bef" src="https://github.com/user-attachments/assets/b2aeba0c-1c52-4663-9f94-5c7808a882db" />

After:
<img width="613" height="81" alt="after1" src="https://github.com/user-attachments/assets/a3b3d733-929d-4a24-9e17-c73d9569e9b7" />


**opw-5257819**



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
