### PR TITLE
[FIX] website: prevent race condition when opening the editor

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -269,6 +269,9 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     async onEditPage() {
+        if (!this.websiteContext) {
+            await this.iframeLoaded;
+        }
         this.websiteContext.showResourceEditor = false;
         this.blockIframe();
 


### PR DESCRIPTION
In this commit, we fix a non deterministic behavior by ensuring the iframe is loaded before it try to open editor.

runbot-232846

