### PR TITLE
[FIX] point_of_sale: correct shipping address is used when invoicing POS orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -671,6 +671,7 @@ class PosOrder(models.Model):
             'move_type': 'out_invoice' if self.amount_total >= 0 else 'out_refund',
             'ref': self.name,
             'partner_id': self.partner_id.address_get(['invoice'])['invoice'],
+            'partner_shipping_id': self.partner_id.address_get(['delivery'])['delivery'],
             'partner_bank_id': self._get_partner_bank_id(),
             'currency_id': self.currency_id.id,
             'invoice_user_id': self.user_id.id,

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -823,6 +823,52 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         # I close the session to generate the journal entries
         current_session.action_pos_session_closing_control()
 
+    def test_order_to_invoice_uses_correct_shipping_address(self):
+        """
+        Test that invoice created from POS uses the correct shipping address
+        same as selected in the POS order.
+        """
+        _, delivery2 = self.env["res.partner"].create([{
+                'name': f"Delivery Address {i + 1}",
+                'type': 'delivery',
+                'parent_id': self.partner1.id,
+            } for i in range(2)]
+        )
+
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        untax, tax = self.compute_tax(self.product3, 100, 1)
+
+        pos_order = self.PosOrder.create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': delivery2.id,
+            'pricelist_id': self.partner1.property_product_pricelist.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.product3.id,
+                'price_unit': 100,
+                'qty': 1.0,
+                'tax_ids': [(6, 0, self.product3.taxes_id.ids)],
+                'price_subtotal': untax,
+                'price_subtotal_incl': untax + tax,
+            })],
+            'amount_tax': tax,
+            'amount_total': untax + tax,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+            'last_order_preparation_change': '{}'
+        })
+
+        pos_order.action_pos_order_invoice()
+        invoice = pos_order.account_move
+
+        self.assertEqual(
+            invoice.partner_shipping_id.id,
+            delivery2.id,
+            "The shipping address should be 'Delivery Address 2' as selected in the POS order."
+        )
+
     def test_create_from_ui(self):
         """
         Simulation of sales coming from the interface, even after closing the session


### PR DESCRIPTION
Currently, an incorrect shipping address is assigned to invoices generated from 
POS orders when the customer has multiple delivery addresses.

**Steps to reproduce:**

- Install the `point_of_sale` and `contacts` modules.
- Enable `Customer Addresses` from the settings.
- Create a contact with `two` delivery addresses.
- Open POS and create an order using the `second delivery address` as the customer.
- Confirm the order with the `invoice`.
- Observe the `shipping address` on the invoice.

**Observation:**
The invoice incorrectly shows the first delivery address instead of the 
second delivery address.

**Cause:**
At invoice creation in POS, only `partner_id` is set and `partner_shipping_id` 
is missing at [1]. As a result, the invoice defaults to the customer's first 
delivery address instead of the delivery address selected in POS.

**Fix:**
This commit adds `partner_shipping_id` to the invoice values to ensure the 
POS invoice uses the exact delivery address selected during order creation. 
same as the `sale` module behaviour.

[1]:
https://github.com/odoo/odoo/blob/1d1cd8648ed1c3f13febbde8d48e28928e18583f/addons/point_of_sale/models/pos_order.py#L667-L684

opw-5350137