### PR TITLE
[FIX] mail_group: traceback on mail group filter

### DIFF
--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -110,7 +110,7 @@ class PortalMailGroup(http.Controller):
             domain &= Domain('group_message_parent_id', '=', False)
 
         if date_begin and date_end:
-            domain &= Domain('create_date', '>', date_begin) & ('create_date', '<=', date_end)
+            domain &= Domain('create_date', '>', date_begin) & Domain('create_date', '<=', date_end)
 
         # SUDO after the search to apply access rules but be able to read attachments
         messages_sudo = GroupMessage.search(

--- a/addons/mail_group/tests/test_mail_group_mailing.py
+++ b/addons/mail_group/tests/test_mail_group_mailing.py
@@ -33,3 +33,13 @@ class TestMailGroupMailing(TestMailListCommon, HttpCase):
 
         self.assertEqual(test_group.member_ids, self.test_group_member_4_emp,
                          "Mail Group: people should have been unsubscribed")
+
+    def test_group_view_messages_date_filter(self):
+        """Test that date filtering works correctly in group_view_messages controller"""
+        url = f'/groups/{self.test_group.id}'
+        response = self.url_open(url, params={
+            'date_begin': '2025-11-01',
+            'date_end': '2025-12-01'
+        })
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Steps to reprodude:
-------------------------
1. Install `mail_group` module.
2. Go to groups from the portal side
3. Click on any group
4. From Archives section, click on any month in By Date groupby

Observation:
-------------------------
Taceback occurs:
```
TypeError: unsupported operand type(s) for &: 'DomainCondition' and 'tuple'
```

Issue:
-------------------------
In the following code:
https://github.com/odoo/odoo/blob/0c19399518029b85650b6204279e1e20d8d2e85c/addons/mail_group/controllers/portal.py#L112-L113 Only one tuple is converted to Domain object and it was trying to combine a Domain object with a plain tuple using the `&` operator, which generates the `TypeError`

Solution:
-------------------------
Converted the other domain tuple to the Domain object.