### PR TITLE
[FIX] l10n_cl: correct unit price rendering without decimals in invoice pdf

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -159,7 +159,7 @@
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
             <attribute name="t-field"></attribute>
             <attribute name="t-out">line_amounts['price_item_document']</attribute>
-            <attribute name="t-options">{"widget": "float", "precision": 2}</attribute>
+            <attribute name="t-options">{"widget": "float", "precision": line_amounts['main_currency'].decimal_places}</attribute>
         </xpath>
 
         <xpath expr="//th[@name='th_discount']" position="after">


### PR DESCRIPTION
**Steps to reproduce:**
* Install the *l10n_cl* module with demo data.
* Switch the environment to the **CL** company.
* Create a customer invoice containing at least one invoice line.
  Enter a **price_unit with decimals** (e.g., *99.56*).
* Confirm the invoice.
* Download and open the generated PDF from the invoice form.

**Observed behavior:**
* The **unit price** rendered in the PDF is displayed as a rounded
  decimal value (e.g., *100.00*), even though *Chilean* localization
  does **not** use decimal representation for unit prices.

**Cause:**
* The QWeb template uses `t-options` to format float values with
  **two-decimal precision**, forcing decimals to appear in the PDF.

**Fix:**
* Reduce the formatting precision in the PDF template so that **no
  decimal points** are displayed, matching Chilean localization rules.
  
 
**Before Fix**
<img width="783" height="319" alt="image" src="https://github.com/user-attachments/assets/e5ea5a38-a77a-4d64-9aae-672940734ea4" />


 **After Fix**
<img width="794" height="316" alt="image" src="https://github.com/user-attachments/assets/c47d2f0a-b4ea-428e-bf57-23584c34bf5c" />

---

opw-5234563
