### PR TITLE
[IMP] web, bus: refine OdooEnv typing for service inference

### DIFF
--- a/addons/bus/static/src/debug/bus_logs_service.js
+++ b/addons/bus/static/src/debug/bus_logs_service.js
@@ -7,7 +7,7 @@ export const busLogsService = {
     dependencies: ["bus_service", "worker_service"],
     /**
      * @param {import("@web/env").OdooEnv}
-     * @param {Partial<import("services").Services>} services
+     * @param {Partial<import("services").ServiceFactories>} services
      */
     start(env, { bus_service, worker_service }) {
         const state = reactive({

--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -10,7 +10,7 @@ export class OutdatedPageWatcherService {
 
     /**
      * @param {import("@web/env").OdooEnv}
-     * @param {Partial<import("services").Services>} services
+     * @param {Partial<import("services").ServiceFactories>} services
      */
     setup(env, { bus_service, multi_tab, notification }) {
         this.notification = notification;

--- a/addons/bus/static/src/services/bus_monitoring_service.js
+++ b/addons/bus/static/src/services/bus_monitoring_service.js
@@ -18,7 +18,7 @@ export class BusMonitoringService {
 
     /**
      * @param {import("@web/env").OdooEnv} env
-     * @param {Partial<import("services").Services>} services
+     * @param {Partial<import("services").ServiceFactories>} services
      */
     setup(env, { bus_service }) {
         bus_service.addEventListener("BUS:WORKER_STATE_UPDATED", ({ detail }) =>

--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -12,7 +12,7 @@ import { isMacOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} OdooEnv
- * @property {import("services").Services} services
+ * @property {import("services").ServiceFactories} services
  * @property {EventBus} bus
  * @property {string} debug
  * @property {boolean} [isSmall]

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -33,7 +33,7 @@ import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog
  * @property {boolean} [write]
  * @property {Function | null} onDelete
  *
- * @typedef {import("services").Services} Services
+ * @typedef {import("services").ServiceFactories} Services
  */
 
 import {


### PR DESCRIPTION
The OdooEnv.services type previously referenced Services, which did not 
accurately reflect the structure needed for proper type inference. This commit 
updates it to ServiceFactories, allowing IDEs and TypeScript tooling to 
correctly infer service types and improve developer experience.

Before / After:
<img width="755" height="367" alt="image" src="https://github.com/user-attachments/assets/5fb7a288-b323-442a-9dbb-98872574c21d" />
<img width="772" height="356" alt="image" src="https://github.com/user-attachments/assets/20d5fb8e-a83b-4507-8f00-b8b4776cf6c2" />
