### PR TITLE
[FIX] event{,_booth}_sale: prevent traceback when close the select event option

### DIFF
--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -48,7 +48,7 @@ patch(SaleOrderLineProductField.prototype, {
             {
                 additionalContext: actionContext,
                 onClose: async (closeInfo) => {
-                    if (!closeInfo || closeInfo.special) {
+                    if (!closeInfo?.eventBoothConfiguration || closeInfo.special || closeInfo.dismiss) {
                         // wizard popup closed or 'Cancel' button triggered
                         if (!this.props.record.data.event_ticket_id) {
                             // remove product if event configuration was cancelled.

--- a/addons/event_sale/static/src/js/sale_product_field.js
+++ b/addons/event_sale/static/src/js/sale_product_field.js
@@ -37,7 +37,7 @@ patch(SaleOrderLineProductField.prototype, {
             {
                 additionalContext: actionContext,
                 onClose: async (closeInfo) => {
-                    if (!closeInfo || closeInfo.special) {
+                    if (!closeInfo?.eventConfiguration || closeInfo.special || closeInfo.dismiss) {
                         // wizard popup closed or 'Cancel' button triggered
                         if (!this.props.record.data.event_ticket_id) {
                             // remove product if event configuration was cancelled.


### PR DESCRIPTION
**Steps to produce:**
- Install `Events and Sales` modules.
- Go to `sale > sale order > Open any SO > Add product > Event registration`.
- When the wizard opens, dismiss it by either clicking the X button in the
  top-right corner of the modal or by pressing the `Escape` key.

**Traceback:**
`TypeError: Cannot convert undefined or null to object.`

**Root cause:**
- In this [commit], the `{ dismiss: true }` option was added to the `dismiss` call.
- At [1], when `onClose` is triggered, we only check `!closeInfo || closeInfo.special`.
 Since `{ dismiss: true }` does not satisfy either condition, the code falls into the `else` branch,
 where `update` is called with an `undefined` value.

**Solution:**
- Now, we also check the condition `closeInfo.dismiss`.
- So, now that we have closed the selection of the event, our product is also removed from the SO line.

[commit]: https://github.com/odoo/odoo/commit/31c00161fd3a77c9fbd260754cb8c142fcb0d652
[1]https://github.com/odoo/odoo/blob/01a896557ec2bada04db60195926c6fa61375b10/addons/event_sale/static/src/js/sale_product_field.js#L40

**opw-5349732**


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr