### PR TITLE
[FIX] html_editor: add title keyword in heading commands

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -223,14 +223,17 @@ export class FontPlugin extends Plugin {
             {
                 categoryId: "format",
                 commandId: "setTagHeading1",
+                keywords: [_t("title")],
             },
             {
                 categoryId: "format",
                 commandId: "setTagHeading2",
+                keywords: [_t("title")],
             },
             {
                 categoryId: "format",
                 commandId: "setTagHeading3",
+                keywords: [_t("title")],
             },
             {
                 categoryId: "format",

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -95,6 +95,19 @@ describe("search", () => {
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
     });
 
+    test("should filter heading commands with term 'title'", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "/");
+        await animationFrame();
+        expect(commandNames(el).length).toBe(25);
+        await insertText(editor, "title");
+        await animationFrame();
+        const commands = commandNames(el);
+        expect(["Heading 1", "Heading 2", "Heading 3"].every((h) => commands.includes(h))).toBe(
+            true
+        );
+    });
+
     test("should hide categories when you have a search term", async () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");


### PR DESCRIPTION
#### Desired behavior after PR is merged:

- `title` is added to the list of keywords in `powerbox_items`, allowing `/title` to display the `heading (H1–H3)` commands in the powerbox.

task-5367576

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
