### PR TITLE
[FIX] hr_holidays: correct duration display for flexible schedule type

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -606,7 +606,7 @@ Versions:
                     else:
                         hours = (leave.date_to - leave.date_from).total_seconds() / 3600
                     if not leave.request_unit_hours and not public_holidays:
-                        days = 1 if not leave.request_unit_half else 0.5
+                        days = 0.5 if leave.request_unit_half and leave.request_date_from_period == leave.request_date_to_period else 1
                     else:
                         days = hours / 24
                 elif leave.leave_type_request_unit == 'day' and check_leave_type:

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -2115,3 +2115,26 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_req_form.employee_id = self.employee_responsible
 
         self.assertFalse(leave_req_form.can_approve)
+
+    def test_duration_display_with_flexible_and_half_day_timeoff_type(self):
+        """
+        Verify that a one-day leave on a flexible calendar displays a duration
+        of 1 day, even when using a half-day time off type.
+        """
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Flexible 40h/week',
+            'hours_per_day': 8.0,
+            'full_time_required_hours': 40,
+            'flexible_hours': True,
+        })
+        self.employee_emp.resource_calendar_id = calendar
+        leave_full_day = self.env['hr.leave'].create({
+            'name': 'Test full day',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_half.id,
+            'request_date_from': '2025-11-28',
+            'request_date_to': '2025-11-28',
+            'request_date_from_period': 'am',
+            'request_date_to_period': 'pm',
+        })
+        self.assertEqual(leave_full_day.duration_display, '1 days')


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install hr_holidays with demo data.
2. Create a Time Off type configured as a "half-day".
(Disable "Requires allocation" to skip allocations)
4. Set an employee’s working hours to a "Flexible" Schedule.
5. Create a one-day Time Off using that half-day type.
6. Check the displayed duration.

Issue:
--------
The duration is displayed as 0.5 day instead of 1 day, even though the leave spans a full day.

Cause:
----------
https://github.com/odoo/odoo/blob/f7020ea954c8e69ce6f1096fd4fcce607613d636/addons/hr_holidays/models/hr_leave.py#L608-L609 The logic fails to correctly determine whether the leave should be treated
as half-day or full-day when using a half-day time off type on a flexible schedule.

Solution:
------------
This commit ensures the compute duration_display correctly.

opw-5265120



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
