### PR TITLE
[FIX] web: prevent name from having trailing spaces from UI

### DIFF
--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -44,6 +44,7 @@ export class TextField extends Component {
         useInputField({
             getValue: () => this.props.record.data[this.props.name] || "",
             refName: "textarea",
+            parse: (v) => this.parse(v),
             preventLineBreaks: !this.props.lineBreaks,
         });
         useSpellCheck({ refName: "textarea" });
@@ -51,6 +52,17 @@ export class TextField extends Component {
         useAutoresize(this.textareaRef, { minimumHeight: this.minimumHeight });
 
         this.selectionStart = this.props.record.data[this.props.name]?.length || 0;
+    }
+
+    get shouldTrim() {
+        return this.props.record.fields[this.props.name].trim;
+    }
+
+    parse(value) {
+        if (this.shouldTrim) {
+            return value.trim();
+        }
+        return value;
     }
 
     async onBlur() {

--- a/addons/web/static/tests/views/fields/text_field.test.js
+++ b/addons/web/static/tests/views/fields/text_field.test.js
@@ -61,6 +61,17 @@ test("basic rendering char field", async () => {
     expect(".o_field_text textarea").toHaveValue("Description\nas\ntext");
 });
 
+test("char field with widget='text' trims trailing spaces", async () => {
+    Product._fields.name = fields.Char({ trim: true });
+    await mountView({
+        type: "form",
+        resModel: "product",
+        arch: '<form><field name="name" widget="text"/></form>',
+    });
+    await fieldTextArea("name").edit("test  ");
+    expect(".o_field_text textarea").toHaveValue("test");
+});
+
 test("render following an onchange", async () => {
     Product._fields.name = fields.Char({
         onChange: (record) => {


### PR DESCRIPTION
**Steps to reproduce:**
1. Create a product with a trailing space at the end of its name.
2. Create a quotation and confirm it.
3. Open the delivery through stat button.

**Observation:**
- The picking description displays the product name twice when the product name ends with trailing spaces.

**Cause:**
 The duplication occurs due to a combination of two issues:

1. **In sale_stock** 
https://github.com/odoo/odoo/blob/ac6d4f0211e7680b5f5b41537b1e2eb2c9efb239/addons/sale_stock/models/stock.py#L32
products without attributes, `_get_sale_order_line_multiline_description_variants()`  returns an `empty` string, yet the code still prepends a newline before the existing picking description. When the product name contains trailing spaces, this newline `+` trailing-space combination causes Odoo to interpret the description as multiple lines, resulting in the product name being duplicated on the picking.

2. **In web,**
the char field with `widget="text"` did not trim trailing spaces when saving the value.
This allowed product names such as `"Test  "` to be stored.

**Fix:**
- Trim the value entered in `char` fields using `widget="text"` when the field has `trim=True`, preventing trailing spaces from being saved and ensuring consistent description generation.

**opw-5351356**
