### PR TITLE
[FIX] html_editor: allow selection placeholders inside table cells

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -146,6 +146,8 @@ export class TablePlugin extends Plugin {
         selection_placeholder_container_predicates: (container) => {
             if (container.nodeName === "TABLE") {
                 return false;
+            } else if (["TD", "TH"].includes(container.nodeName)) {
+                return true;
             }
         },
         normalize_handlers: this.distributeTableColorsToAllCells.bind(this),

--- a/addons/html_editor/static/tests/selection_placeholder.test.js
+++ b/addons/html_editor/static/tests/selection_placeholder.test.js
@@ -82,6 +82,58 @@ test("a selection placeholder is inserted between two tables, and removed on cle
     });
 });
 
+test("a selection placeholder is inserted inside a <td> before and after a contenteditable=false element, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<table class="table o_table table-bordered">
+                <tbody><tr><td><div contenteditable="false">X</div></td></tr></tbody>
+            </table>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table o_table table-bordered">
+                <tbody><tr><td>
+                    <p data-selection-placeholder=""><br></p>
+                    <div contenteditable="false">X</div>
+                    <p data-selection-placeholder=""><br></p>
+                </td></tr></tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        ),
+        contentAfter: unformat(
+            `<table class="table o_table table-bordered">
+                <tbody><tr><td><div contenteditable="false">X</div></td></tr></tbody>
+            </table>`
+        ),
+    });
+});
+
+test("a selection placeholder is inserted inside a <th> before and after a contenteditable=false element, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<table class="table o_table table-bordered">
+                <tbody><tr><th><div contenteditable="false">X</div></th></tr></tbody>
+            </table>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table o_table table-bordered">
+                <tbody><tr><th>
+                    <p data-selection-placeholder=""><br></p>
+                    <div contenteditable="false">X</div>
+                    <p data-selection-placeholder=""><br></p>
+                </th></tr></tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        ),
+        contentAfter: unformat(
+            `<table class="table o_table table-bordered">
+                <tbody><tr><th><div contenteditable="false">X</div></th></tr></tbody>
+            </table>`
+        ),
+    });
+});
+
 test.tags("focus required");
 test("can navigate in and out of selection placeholders", async () => {
     await testEditor({

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -332,6 +332,7 @@ test("should not navigate table cells when table picker is open", async () => {
                     </tr>
                     <tr>
                         <td>
+                            <p data-selection-placeholder=""><br></p>
                             <table class="table table-bordered o_table">
                                 <tbody>
                                     <tr>
@@ -341,6 +342,7 @@ test("should not navigate table cells when table picker is open", async () => {
                                     </tr>
                                 </tbody>
                             </table>
+                            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
### Steps to reproduce:

- Create a table inside the Todo.
- Insert a banner into any table cell.
- Place the cursor inside the banner and press Backspace.
- Banner cannot be deleted and no selection placeholders are inserted.

### Description of the issue/feature this PR addresses:

- Selection placeholders were not inserted inside table cells. when they contained contenteditable=false nodes.

### Desired behavior after PR is merged:

-  Table cells are allowed as valid selection placeholder containers.
- When a non-editable element exists inside a table cell, placeholders are inserted before and after it.

task-5357197

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
