### PR TITLE
[FIX] mail_group: fix traceback in date filter

### DIFF
--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -110,7 +110,7 @@ class PortalMailGroup(http.Controller):
             domain &= Domain('group_message_parent_id', '=', False)
 
         if date_begin and date_end:
-            domain &= Domain('create_date', '>', date_begin) & ('create_date', '<=', date_end)
+            domain &= Domain('create_date', '>', date_begin) & Domain('create_date', '<=', date_end)
 
         # SUDO after the search to apply access rules but be able to read attachments
         messages_sudo = GroupMessage.search(


### PR DESCRIPTION
Steps to reproduce
===================
1. Open any mail group on the website side.
2. Try to access the date filter.

Here https://github.com/odoo/odoo/pull/206575/commits/99ece288df1bbb98fd538479b07da14f3abf0d03, we missed wrapping the tuple in the `Domain` class.

Task-5369008