### PR TITLE
[FIX] hr: fix presence state test

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -669,6 +669,7 @@ class TestHrEmployee(TestHrCommon):
         self.assertNotEqual(partner.email, second_employee.work_email)
         self.assertNotEqual(partner.email, first_employee.work_email)
 
+    @freeze_time('2025-12-01 09-00-00')
     def test_presence_state_groupby(self):
         present_user_a, present_user_b, absent_user = self.env['res.users'].create([
             {


### PR DESCRIPTION
The test introduces with https://github.com/odoo/odoo/pull/235438 is failing if run outside of working hours. This commit fixes the test by using freeze_time.

Related Runbot issue: https://runbot.odoo.com/odoo/runbot.build.error/234532

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
