### PR TITLE
[FIX] html_editor: navigation behavior for same-page links

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -170,7 +170,13 @@
                         </span>
                         <div class="ms-1 w-100">
                             <div class="d-flex">
-                                <a href="#" target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
+                                <a
+                                    href="#"
+                                    t-att-target="linkPreviewTarget"
+                                    t-attf-href="{{ state.url }}"
+                                    class="o_we_url_link fw-bold flex-grow-1 text-truncate"
+                                    t-attf-title="{{ state.urlTitle }}"
+                                >
                                     <t t-esc="state.urlTitle"/>
                                 </a>
                                 <div class="flex-grow-1 d-flex justify-content-end gap-2">

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1380,6 +1380,20 @@ describe("link preview", () => {
         expect("a.o_we_replace_title_btn").toHaveCount(1);
         expect("button.o_we_replace_title_btn").toHaveCount(0);
     });
+    test("should open same-page links with anchor in current tab", async () => {
+        onRpc("/html_editor/link_preview_internal", () => ({}));
+        onRpc("/", () => ({}));
+        await setupEditor(`<p>This is a <a href="${window.origin}/#section">li[]nk</a></p>`);
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover .o_we_url_link").toHaveAttribute("target", "_self");
+    });
+    test("should open same-page links without anchor in new tab", async () => {
+        onRpc("/html_editor/link_preview_internal", () => ({}));
+        onRpc("/section", () => ({}));
+        await setupEditor(`<p>This is a <a href="${window.origin}/section">li[]nk</a></p>`);
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover .o_we_url_link").toHaveAttribute("target", "_blank");
+    });
 });
 
 describe("link in templates", () => {


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The link preview button (`o_we_url_link`) always used `target="_blank"`, causing every link — including links pointing to the same document — to open in a new tab.

### Desired behavior after PR is merged:

- When a link points to the same page and contains a meaningful anchor, `o_we_url_link` now uses `target="_self"` so navigation happens in the current tab.
- Links without a meaningful anchor (e.g., identical URLs without fragment) continue to open in a new tab.

task-5345735

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
