### PR TITLE
[IMP] product: Stock without Stock module 

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+from collections import defaultdict
 
 from collections import defaultdict
 
@@ -73,7 +74,15 @@ class ProductProduct(models.Model):
     volume = fields.Float('Volume', digits='Volume')
     weight = fields.Float('Weight', digits='Stock Weight')
     qty_available = fields.Float('Quantity On Hand', company_dependent=True, digits='Product Unit')
-
+    virtual_available = fields.Float(
+        'Forecasted Quantity', compute='_compute_quantities', compute_sudo=False, search='_search_virtual_available',
+        digits='Product Unit', help="Forecasted quantity if all confirmed sales and purchase orders were delivered.")
+    incoming_qty = fields.Float(
+        'Incoming', compute='_compute_quantities', compute_sudo=False, search='_search_incoming_qty', digits='Product Unit',
+        help="Quantity of planned incoming quantities from all confirmed purchase orders not received.")
+    outgoing_qty = fields.Float(
+        'Outgoing', compute='_compute_quantities', compute_sudo=False, search='_search_outgoing_qty', digits='Product Unit',
+        help="Quantity of planned outgoing quantities from all confirmed sale orders not delivered.")
     pricelist_rule_ids = fields.One2many(
         string="Pricelist Rules",
         comodel_name='product.pricelist.item',
@@ -364,6 +373,46 @@ class ProductProduct(models.Model):
                     break
             else:
                 product.partner_ref = product.display_name
+
+    @api.depends_context('to_date')
+    def _compute_quantities(self):
+        """ Simple per company compute overriden by Stock._compute_quantities """
+        self.virtual_available = 0
+        self.incoming_qty = 0
+        self.outgoing_qty = 0
+
+        products = self.filtered(lambda p: p.type != 'service' and p.is_storable)
+        forecasted = products._compute_forecasted_without_stock()
+        for product in products:
+            vals = forecasted.get(product.id)
+            if not vals:
+                continue
+            product.virtual_available = vals['virtual_available']
+            product.incoming_qty = vals['incoming_qty']
+            product.outgoing_qty = vals['outgoing_qty']
+
+    def _compute_forecasted_without_stock(self):
+        """ Forecast = qty_available + qty purchased not received - qty sold not delivered"""
+        forecast = defaultdict(dict)
+        for product in self:
+            forecast[product.id]['virtual_available'] = product.qty_available
+            forecast[product.id]['incoming_qty'] = 0
+            forecast[product.id]['outgoing_qty'] = 0
+        return forecast
+
+    def _search_virtual_available(self, operator, value):
+        return self._search_product_quantity(operator, value, 'virtual_available')
+
+    def _search_incoming_qty(self, operator, value):
+        return self._search_product_quantity(operator, value, 'incoming_qty')
+
+    def _search_outgoing_qty(self, operator, value):
+        return self._search_product_quantity(operator, value, 'outgoing_qty')
+
+    def _search_product_quantity(self, operator, value, field):
+        # Order the search on `id` to prevent the default order on the product name which slows down the search.
+        ids = self.with_context(prefetch_fields=False).search_fetch([], [field], order='id').filtered_domain([(field, operator, value)]).ids
+        return [('id', 'in', ids)]
 
     def _compute_product_document_count(self):
         for product in self:

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -72,6 +72,7 @@ class ProductProduct(models.Model):
         Used to compute margins on sale orders.""")
     volume = fields.Float('Volume', digits='Volume')
     weight = fields.Float('Weight', digits='Stock Weight')
+    qty_available = fields.Float('Quantity On Hand', company_dependent=True, digits='Product Unit')
 
     pricelist_rule_ids = fields.One2many(
         string="Pricelist Rules",

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -3,8 +3,6 @@
 import re
 from collections import defaultdict
 
-from collections import defaultdict
-
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.fields import Domain

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -104,6 +104,13 @@ class ProductTemplate(models.Model):
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
         Used to compute margins on sale orders.""")
 
+    is_storable = fields.Boolean(
+        'Track Inventory', store=True, compute='compute_is_storable', readonly=False,
+        default=False, precompute=True, tracking=True,
+        help='A storable product is a product for which you manage stock.')
+    qty_available = fields.Float(
+        'Quantity On Hand', compute='_compute_quantities', search='_search_qty_available',
+        inverse='_set_qty_available', compute_sudo=False, digits='Product Unit')
     volume = fields.Float(
         'Volume', compute='_compute_volume', inverse='_set_volume', digits='Volume', store=True)
     volume_uom_name = fields.Char(string='Volume unit of measure label', compute='_compute_volume_uom_name')
@@ -318,6 +325,42 @@ class ProductTemplate(models.Model):
 
     def _search_standard_price(self, operator, value):
         return [('product_variant_ids.standard_price', operator, value)]
+
+    @api.depends('type')
+    def compute_is_storable(self):
+        self.filtered(lambda t: t.type != 'consu' and t.is_storable).is_storable = False
+
+    def _compute_quantities(self):
+        res = self._compute_quantities_dict()
+        fields = self._compute_quantities_fields()
+        for template in self:
+            for field in fields:
+                template[field] = res[template.id][field]
+
+    def _compute_quantities_dict(self):
+        quantities_fields = self._compute_quantities_fields()
+        variants_available = {
+            p['id']: p for p in self.product_variant_ids._origin.read(quantities_fields)
+        }
+        prod_available = {}
+        for template in self:
+            prod_available[template.id] = {field: 0 for field in quantities_fields}
+            for p in template.product_variant_ids._origin:
+                for field in quantities_fields:
+                    prod_available[template.id][field] += variants_available[p.id][field]
+        return prod_available
+
+    def _compute_quantities_fields(self):
+        return ['qty_available']
+
+    def _search_qty_available(self, operator, value):
+        return [('product_variant_ids.qty_available', operator, value)]
+
+    def _set_qty_available(self):
+        for template in self:
+            if len(template.product_variant_ids) != 1:
+                continue
+            template.product_variant_ids.qty_available = template.qty_available
 
     @api.depends('product_variant_ids.volume')
     def _compute_volume(self):

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -163,6 +163,8 @@ class ProductTemplate(models.Model):
     product_variant_count = fields.Integer(
         '# Product Variants', compute='_compute_product_variant_count')
 
+    show_qty_update_button = fields.Boolean(compute='_compute_show_qty_update_button')
+
     # related to display product product information if is_product_variant
     barcode = fields.Char('Barcode', compute='_compute_barcode', inverse='_set_barcode', search='_search_barcode')
     default_code = fields.Char(
@@ -338,6 +340,11 @@ class ProductTemplate(models.Model):
     @api.depends('type')
     def _compute_is_storable(self):
         self.filtered(lambda t: t.type != 'consu' and t.is_storable).is_storable = False
+
+    @api.depends('product_variant_count', 'is_storable')
+    def _compute_show_qty_update_button(self):
+        for product in self:
+            product.show_qty_update_button = product.product_variant_count > 1
 
     def _compute_quantities(self):
         res = self._compute_quantities_dict()

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -105,12 +105,21 @@ class ProductTemplate(models.Model):
         Used to compute margins on sale orders.""")
 
     is_storable = fields.Boolean(
-        'Track Inventory', store=True, compute='compute_is_storable', readonly=False,
+        'Track Inventory', store=True, compute='_compute_is_storable', readonly=False,
         default=False, precompute=True, tracking=True,
         help='A storable product is a product for which you manage stock.')
     qty_available = fields.Float(
         'Quantity On Hand', compute='_compute_quantities', search='_search_qty_available',
         inverse='_set_qty_available', compute_sudo=False, digits='Product Unit')
+    virtual_available = fields.Float(
+        'Forecasted Quantity', compute='_compute_quantities', search='_search_virtual_available',
+        compute_sudo=False, digits='Product Unit')
+    incoming_qty = fields.Float(
+        'Incoming', compute='_compute_quantities', search='_search_incoming_qty',
+        compute_sudo=False, digits='Product Unit')
+    outgoing_qty = fields.Float(
+        'Outgoing', compute='_compute_quantities', search='_search_outgoing_qty',
+        compute_sudo=False, digits='Product Unit')
     volume = fields.Float(
         'Volume', compute='_compute_volume', inverse='_set_volume', digits='Volume', store=True)
     volume_uom_name = fields.Char(string='Volume unit of measure label', compute='_compute_volume_uom_name')
@@ -327,18 +336,18 @@ class ProductTemplate(models.Model):
         return [('product_variant_ids.standard_price', operator, value)]
 
     @api.depends('type')
-    def compute_is_storable(self):
+    def _compute_is_storable(self):
         self.filtered(lambda t: t.type != 'consu' and t.is_storable).is_storable = False
 
     def _compute_quantities(self):
         res = self._compute_quantities_dict()
-        fields = self._compute_quantities_fields()
+        fields = ['qty_available', 'virtual_available', 'incoming_qty', 'outgoing_qty']
         for template in self:
             for field in fields:
                 template[field] = res[template.id][field]
 
     def _compute_quantities_dict(self):
-        quantities_fields = self._compute_quantities_fields()
+        quantities_fields = ['qty_available', 'virtual_available', 'incoming_qty', 'outgoing_qty']
         variants_available = {
             p['id']: p for p in self.product_variant_ids._origin.read(quantities_fields)
         }
@@ -350,9 +359,6 @@ class ProductTemplate(models.Model):
                     prod_available[template.id][field] += variants_available[p.id][field]
         return prod_available
 
-    def _compute_quantities_fields(self):
-        return ['qty_available']
-
     def _search_qty_available(self, operator, value):
         return [('product_variant_ids.qty_available', operator, value)]
 
@@ -361,6 +367,17 @@ class ProductTemplate(models.Model):
             if len(template.product_variant_ids) != 1:
                 continue
             template.product_variant_ids.qty_available = template.qty_available
+
+    def _search_incoming_qty(self, operator, value):
+        return self._search_product_quantity(operator, value, 'incoming_qty')
+
+    def _search_outgoing_qty(self, operator, value):
+        return self._search_product_quantity(operator, value, 'outgoing_qty')
+
+    def _search_virtual_available(self, operator, value):
+        domain = [('virtual_available', operator, value)]
+        product_variant_query = self.env['product.product']._search(domain)
+        return [('product_variant_ids', 'in', product_variant_query)]
 
     @api.depends('product_variant_ids.volume')
     def _compute_volume(self):

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -19,6 +19,8 @@
                     groups="base.group_multi_company" optional="hide"/>
                 <field name="list_price" string="Sales Price" widget='monetary' options="{'currency_field': 'currency_id'}" optional="show" decoration-muted="not sale_ok"/>
                 <field name="standard_price" widget='monetary' options="{'currency_field': 'cost_currency_id'}" optional="show" readonly="1"/>
+                <field name="qty_available" string="On Hand" decoration-danger="qty_available &lt; 0" optional="show" sum="Total On Hand" readonly="1"/>
+                <field name="virtual_available" string="Forecasted" decoration-danger="virtual_available &lt; 0" optional="show" decoration-bf="1" sum="Total Forecasted" readonly="1"/>
                 <field name="categ_id" optional="hide"/>
                 <field name="type" optional="hide" readonly="1"/>
                 <field name="uom_id" readonly="1" optional="show" groups="uom.group_uom"/>
@@ -133,6 +135,7 @@
                 <field name="currency_id"/>
                 <field name="activity_state"/>
                 <field name="categ_id"/>
+                <field name="is_storable" invisible="1"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="card" class="flex-row">
@@ -153,6 +156,9 @@
                                 Price: <field name="list_price" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                             </span>
                             <field name="product_properties" widget="properties"/>
+                            <span name="on_hand_qty_kanban" t-if="record.is_storable.raw_value">
+                                On hand: <field name="qty_available"/> <field name="uom_id" groups="uom.group_uom"/>
+                            </span>
                         </main>
                         <aside>
                             <field

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -72,6 +72,14 @@
                                         string=""
                                         invisible="not product_tooltip"
                                     />
+                                    <label for="is_storable" class="oe_inline" invisible="type != 'consu'"/>
+                                    <div class="o_row w-100 o_is_storable" invisible="type != 'consu'">
+                                        <field name="is_storable"/>
+                                        <field name="qty_available" style="max-width: fit-content;" invisible="not is_storable"/>
+                                        <span invisible="not is_storable">
+                                            <field name="uom_name" class="oe_inline"/>
+                                        </span>
+                                    </div>
                                 </group>
                                 <group name="group_standard_price">
                                     <label for="list_price"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="product_view_list_qty" model="ir.ui.view">
+        <field name="name">product.product.view.list.qty</field>
+        <field name="model">product.product</field>
+        <field name="arch" type="xml">
+            <list string="Update Quantities" editable="bottom" create="false">
+                <field name="display_name" readonly="1"/>
+                <field name="product_template_variant_value_ids" widget="many2many_tags" groups="product.group_product_variant" readonly="1"/>
+                <field name="qty_available" string="On Hand" decoration-danger="qty_available &lt; 0" sum="Total On Hand"/>
+                <field name="virtual_available" string="Forecasted" decoration-danger="virtual_available &lt; 0" decoration-bf="1" sum="Total Forecasted"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="product_variant_edit_qty_action" model="ir.actions.act_window">
+        <field name="name">Update Variant Quantities</field>
+        <field name="res_model">product.product</field>
+        <field name="view_mode">list</field>
+        <field name="domain">[('product_tmpl_id', '=', active_id)]</field>
+        <field name="context">{'default_product_tmpl_id': active_id, 'create': False}</field>
+        <field name="view_ids"
+                eval="[(5, 0, 0),
+                       (0, 0, {'view_mode': 'list', 'view_id': ref('product_view_list_qty')})]"/>
+    </record>
+
     <!-- base structure of product.template, common with product.product -->
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.common.form</field>
@@ -73,12 +97,20 @@
                                         invisible="not product_tooltip"
                                     />
                                     <label for="is_storable" class="oe_inline" invisible="type != 'consu'"/>
-                                    <div class="o_row w-100 o_is_storable" invisible="type != 'consu'">
+                                    <field name="show_qty_update_button" invisible="1"/>
+                                    <div name="tracking_and_qty_no_stock" class="o_row w-100" invisible="type != 'consu'">
                                         <field name="is_storable"/>
-                                        <field name="qty_available" style="max-width: fit-content;" invisible="not is_storable"/>
-                                        <span invisible="not is_storable">
-                                            <field name="uom_name" class="oe_inline"/>
-                                        </span>
+                                        <div name="product_template_qty_field" class="d-flex" invisible="is_product_variant or not is_storable">
+                                            <a type="action" name="%(product_variant_edit_qty_action)d" invisible="not show_qty_update_button">
+                                                <field name="qty_available" readonly="True"/>
+                                            </a>
+                                            <field name="qty_available" invisible="show_qty_update_button" style="max-width: fit-content;"/>
+                                            <field name="uom_name" class="ms-2 oe_inline" groups="uom.group_uom"/>
+                                        </div>
+                                        <div name="product_product_qty_field" class="d-flex" invisible="not is_product_variant or not is_storable">
+                                            <field name="qty_available" style="max-width: fit-content;"/>
+                                            <field name="uom_name" class="ms-2 oe_inline" groups="uom.group_uom"/>
+                                        </div>
                                     </div>
                                 </group>
                                 <group name="group_standard_price">
@@ -379,6 +411,13 @@
                         </group>
                         <group>
                             <group name="weight" string="Logistics" invisible="type != 'consu'">
+                                <label for="qty_available"  invisible="not is_storable"/>
+                                <div class="d-flex" name="no_stock_variant_qty_edit" invisible="not is_storable">
+                                    <div class="d-flex">
+                                        <field name="qty_available" class="oe_inline"/>
+                                        <field name="uom_name" groups="uom.group_uom"/>
+                                    </div>
+                                </div>
                                 <label for="volume"/>
                                 <div class="d-flex">
                                     <field name="volume" class="oe_inline"/>
@@ -447,6 +486,13 @@
                     <field name="product_tag_ids" widget="many2many_tags" readonly="1" optional="hide"/>
                     <field name="additional_product_tag_ids" widget="many2many_tags" optional="hide"/>
                     <field name="type" optional="hide" readonly="1"/>
+                    <field name="qty_available" invisible="not is_storable" string="On Hand" readonly="1" optional="show"
+                           decoration-danger="virtual_available &lt; 0" decoration-warning="virtual_available == 0" decoration-bf="1"
+                           sum="Total On Hand"
+                    />
+                    <field name="virtual_available" invisible="not is_storable" string="Forecasted" readonly="1" optional="show"
+                           decoration-danger="virtual_available &lt; 0" decoration-warning="virtual_available == 0" sum="Total Forecasted"
+                    />
                     <field name="uom_id" groups="uom.group_uom" optional="show" readonly="1"/>
                     <field name="product_tmpl_id" readonly="1" column_invisible="True"/>
                     <field name="active" column_invisible="True"/>

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -81,6 +81,19 @@ class ProductProduct(models.Model):
                 continue
             product.purchased_product_qty = product.uom_id.round(purchased_data.get(product.id, 0))
 
+    def _compute_forecasted_without_stock(self):
+        """ Adds orders not receives to forecasted stock tally, """
+        res = super()._compute_forecasted_without_stock()
+        domain = [
+            ('order_id.state', '=', 'purchase'),
+            ('product_id', 'in', self.ids),
+        ]
+        order_lines = self.env['purchase.order.line']._read_group(domain, ['product_id'], ['product_uom_qty:sum', 'qty_received:sum'])
+        for product, qty_ordered, qty_received in order_lines:
+            res[product.id]['incoming_qty'] = (qty_ordered - qty_received)
+            res[product.id]['virtual_available'] = res[product.id]['virtual_available'] + (qty_ordered - qty_received)
+        return res
+
     @api.depends_context('order_id')
     def _compute_is_in_purchase_order(self):
         order_id = self.env.context.get('order_id')

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -83,7 +83,7 @@ class ProductProduct(models.Model):
 
     @api.depends_context("to_date")
     def _compute_forecasted_without_stock(self):
-        """ Adds orders not receives to forecasted stock tally, """
+        """ Adds orders not received to forecasted stock tally, """
         res = super()._compute_forecasted_without_stock()
         domain = Domain.AND([
             Domain('order_id.state', '=', 'purchase'),

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -105,14 +105,34 @@
             <field name="arch" type="xml">
                 <button name="action_open_documents" position="after">
                     <button class="oe_stat_button" name="action_view_po"
-                        groups="purchase.group_purchase_user"
-                        type="object" icon="fa-credit-card" invisible="not purchase_ok" help="Purchased in the last 365 days">
-                        <div class="o_field_widget o_stat_info">
+                            groups="purchase.group_purchase_user"
+                            type="object" icon="fa-credit-card" invisible="not purchase_ok"
+                            help="Purchased in the last 365 days. Incoming represents confirmed purchase orders not received or partially received">
+                        <div class="o_field_widget o_stat_info" invisible="is_storable == True">
                             <span class="o_stat_value d-flex gap-1">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
-                                <field name="uom_name"  class="oe_inline" groups="uom.group_uom"/>
+                                <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Purchased</span>
+                        </div>
+                        <div class="d-flex flex-row gap-1 ms-1" invisible="is_storable == False">
+                            <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
+                                <span class="o_stat_value d-flex gap-1">
+                                    <field name="purchased_product_qty" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                                </span>
+                                <span class="o_stat_value text-info d-flex gap-1">
+                                    <field name="incoming_qty" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                                </span>
+                            </div>
+                            <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
+                                <span class="o_stat_value">
+                                    <field name="uom_name" widget="statinfo" nolabel="1" groups="uom.group_uom"/>
+                                    <span groups="!uom.group_uom">Purchased</span>
+                                </span>
+                                <span class="o_stat_value text-muted">
+                                    Incoming
+                                </span>
+                            </div>
                         </div>
                     </button>
                 </button>
@@ -126,14 +146,34 @@
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
-                        groups="purchase.group_purchase_user"
-                        type="object" icon="fa-credit-card" invisible="not purchase_ok" help="Purchased in the last 365 days">
-                        <div class="o_field_widget o_stat_info">
+                            groups="purchase.group_purchase_user"
+                            type="object" icon="fa-credit-card" invisible="not purchase_ok"
+                            help="Purchased in the last 365 days. Incoming represents confirmed sales order not received, or partially received">
+                        <div class="o_field_widget o_stat_info" invisible="is_storable == True">
                             <span class="o_stat_value d-flex gap-1">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
-                                <field name="uom_name"  class="oe_inline" groups="uom.group_uom"/>
+                                <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Purchased</span>
+                        </div>
+                        <div class="d-flex flex-row gap-1 ms-1" invisible="is_storable == False">
+                            <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
+                                <span class="o_stat_value d-flex gap-1">
+                                    <field name="purchased_product_qty" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                                </span>
+                                <span class="o_stat_value d-flex gap-1">
+                                    <field name="incoming_qty" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                                </span>
+                            </div>
+                            <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
+                                <span class="o_stat_value">
+                                    <field name="uom_name" widget="statinfo" nolabel="1" groups="uom.group_uom"/>
+                                    <span groups="!uom.group_uom">Purchased</span>
+                                </span>
+                                <span class="o_stat_value text-muted">
+                                    Incoming
+                                </span>
+                            </div>
                         </div>
                     </button>
                 </div>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -136,6 +136,7 @@
                     <button name="button_approve" type="object" invisible="state != 'to approve'" string="Approve Order" class="oe_highlight" groups="purchase.group_purchase_manager" data-hotkey="z"/>
                     <button name="action_rfq_send" invisible="state != 'sent'" string="Send RFQ" type="object" context="{'send_rfq':True}" data-hotkey="g"/>
                     <button name="button_confirm" type="object" invisible="state != 'draft'" context="{'validate_analytic': True}" string="Confirm Order" id="draft_confirm" data-hotkey="q"/>
+                    <button name="action_receive" class="btn-primary" type="object" string="Receive" data-hotkey="e" invisible="not show_receive_button"/>
                     <widget name="purchase_file_uploader" invisible="state != 'purchase'"/>
                     <button name="action_rfq_send" invisible="state != 'purchase'" string="Send PO" type="object" context="{'send_rfq':False}" data-hotkey="g"/>
                     <button name="action_acknowledge" string="Acknowledge" type="object" invisible="acknowledged or state != 'purchase'"/>
@@ -231,6 +232,16 @@
                                     <widget name='toaster_button' button_name="send_reminder_preview" title="Preview the reminder email by sending it to yourself." invisible="not id"/>
                                 </div>
                             </div>
+                            <label for="receipt_status" invisible="state !='purchase'"/>
+                                <div class="d-flex align-items-center" invisible="state !='purchase'">
+                                    <div name="receipt_status_on_form" class="me-3">
+                                        <field name="receipt_status" widget="badge" invisible="state != 'purchase'"
+                                            decoration-success="receipt_status == 'full'"
+                                            decoration-info="receipt_status == 'partial'"
+                                            decoration-danger="receipt_status == 'pending' and date_planned and date_planned &lt; context_today().strftime('%Y-%m-%d')"
+                                            decoration-muted="receipt_status == 'pending' and date_planned and date_planned &gt;= context_today().strftime('%Y-%m-%d')"/>
+                                    </div>
+                                </div>
                         </group>
                     </group>
                     <notebook>
@@ -403,6 +414,7 @@
                                 </group>
                                 <group name="tracking_info" string="tracking">
                                     <field name="origin"/>
+                                    <field name="receipt_status" invisible="state != 'purchase'"/>
                                 </group>
                             </group>
                         </page>
@@ -592,7 +604,7 @@
                 multi_edit="1"
                 class="o_purchase_order" js_class="purchase_dashboard_list" sample="1">
                     <header>
-                        <button name="button_cancel" type="object" string="Cancel"
+                        <button name="button_cancel" type="object" string="Cancel" data-hotkey="x"
                             confirm="Are you sure you want to cancel the selected RFQs/Orders?"/>
                     </header>
                     <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
@@ -635,7 +647,8 @@
                     sample="1">
                     <header>
                         <button name="action_create_invoice" type="object" string="Create Bills"/>
-                        <button name="button_cancel" type="object" string="Cancel"
+                        <button name="action_receive" type="object" string="Receive" data-hotkey="e"/>
+                        <button name="button_cancel" type="object" string="Cancel" data-hotkey="x"
                             confirm="Are you sure you want to cancel the selected RFQs/Orders?"/>
                     </header>
                     <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
@@ -655,6 +668,11 @@
                     <field name="state" column_invisible="True"/>
                     <field name="amount_total_cc" sum="Total amount" widget="monetary" optional="hide"/>
                     <field name="company_currency_id" column_invisible="True"/>
+                    <field name="receipt_status" optional="hide" widget="badge"
+                        decoration-success="receipt_status=='full'"
+                        decoration-info="receipt_status == 'partial'"
+                        decoration-danger="receipt_status == 'pending' and date_planned and date_planned &lt; context_today().strftime('%Y-%m-%d')"
+                        decoration-muted="receipt_status == 'pending' and date_planned and date_planned &gt;= context_today().strftime('%Y-%m-%d')"/>
                     <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to invoice'" optional="show"/>
                     <field name="date_planned" column_invisible="context.get('quotation_only', False)" optional="show" readonly="1"/>
                 </list>

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -32,11 +32,6 @@ class PurchaseOrder(models.Model):
     effective_date = fields.Datetime("Arrival", compute='_compute_effective_date', store=True, copy=False,
         help="Completion date of the last receipt order.")
     on_time_rate = fields.Float(related='partner_id.on_time_rate', compute_sudo=False)
-    receipt_status = fields.Selection([
-        ('pending', 'Not Received'),
-        ('partial', 'Partially Received'),
-        ('full', 'Fully Received'),
-    ], string='Receipt Status', compute='_compute_receipt_status', store=True)
     date_promised = fields.Datetime('Promised Date', index=True, copy=False, compute="_compute_date_promised", store=True, readonly=False,
         help="Date promised by the vendor for at least 1 or more products to be delivered by.")
 
@@ -75,6 +70,9 @@ class PurchaseOrder(models.Model):
                 order.receipt_status = 'partial'
             else:
                 order.receipt_status = 'pending'
+
+    def _compute_show_receive_button(self):
+        self.show_receive_button = False  # Revert to the stock Delivery smart button logic
 
     @api.depends('picking_type_id')
     def _compute_dest_address_id(self):

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -51,9 +51,6 @@
             <xpath expr="//field[@name='order_line']/form//field[@name='invoice_lines']" position="after">
                 <field name="move_ids"/>
             </xpath>
-            <field name="origin" position="after">
-                <field name="receipt_status" invisible="state != 'purchase'"/>
-            </field>
             <xpath expr="//field[@name='order_line']/form//field[@name='analytic_distribution']" position="before">
                 <field name="propagate_cancel" groups="base.group_no_one"/>
             </xpath>
@@ -75,19 +72,11 @@
             <xpath expr="//div[@name='reminder']" position="after">
                 <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
                 <field name="dest_address_id" invisible="default_location_dest_id_usage != 'customer'" readonly="locked" required="default_location_dest_id_usage == 'customer'"/>
-                <label for="receipt_status" invisible="state !='purchase'"/>
-                <div class="d-flex align-items-center"  invisible="state !='purchase'">
-                    <div class="me-3">
-                        <field name="receipt_status" widget="badge" invisible="state != 'purchase'"
-                               decoration-success="receipt_status == 'full'"
-                               decoration-info="receipt_status == 'partial'"
-                               decoration-danger="receipt_status == 'pending' and date_planned and date_planned &lt; context_today().strftime('%Y-%m-%d')"
-                               decoration-muted="receipt_status == 'pending' and date_planned and date_planned &gt;= context_today().strftime('%Y-%m-%d')"/>
-                    </div>
-                    <span class="text-muted" invisible="not effective_date">
-                        On <field name="effective_date" nolabel="1" class="text-muted oe_inline"/>
-                    </span>
-                </div>
+            </xpath>
+            <xpath expr="//div[@name='receipt_status_on_form']" position="after">
+                <span class="text-muted" invisible="not effective_date">
+                    On <field name="effective_date" nolabel="1" class="text-muted oe_inline"/>
+                </span>
             </xpath>
         </field>
     </record>
@@ -109,14 +98,9 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_view_tree"/>
         <field name="arch" type="xml">
-            <field name="invoice_status" position="before">
-                <field name="effective_date" column_invisible="True"/>
-                <field name="receipt_status" optional="hide" widget="badge"
-                decoration-success="receipt_status=='full'"
-                decoration-info="receipt_status == 'partial'"
-                decoration-danger="receipt_status == 'pending' and date_planned and date_planned &lt; context_today().strftime('%Y-%m-%d')"
-                decoration-muted="receipt_status == 'pending' and date_planned and date_planned &gt;= context_today().strftime('%Y-%m-%d')"/>
-            </field>
+            <xpath expr="//button[@name='action_receive']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <xpath expr="//field[@name='date_planned']" position="attributes">
                 <attribute name="decoration-danger">date_planned and (date_planned &lt; effective_date or date_planned &lt; datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full' and effective_date &lt;= date_planned)</attribute>
             </xpath>

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -72,6 +72,7 @@ This module contains all the common features of Sales Management and eCommerce.
             'sale/static/src/js/product_configurator_dialog/*',
             'sale/static/src/js/product_list/*',
             'sale/static/src/js/product_template_attribute_line/*',
+            'sale/static/src/js/quantity_availability/*',
             'sale/static/src/js/quantity_buttons/*',
             'sale/static/src/js/sale_order_line_field/*',
             'sale/static/src/js/sale_progressbar_field.js',

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 from odoo.tools import float_round
 
 
@@ -41,17 +42,24 @@ class ProductProduct(models.Model):
             product.sales_count = product.uom_id.round(r.get(product.id, 0))
         return r
 
+    @api.depends_context("to_date")
     def _compute_forecasted_without_stock(self):
         """ Substract sales lines not delivered from forecasted tally """
         res = super()._compute_forecasted_without_stock()
-        domain = [
-            ('order_id.state', '=', 'sale'),
-            ('product_id', 'in', self.ids),
-        ]
-        order_lines = self.env['sale.order.line']._read_group(domain, ['product_id'], ['product_uom_qty:sum', 'qty_delivered:sum'])
-        for product, qty_sold, qty_delivered in order_lines:
-            res[product.id]['outgoing_qty'] = (qty_sold - qty_delivered)
-            res[product.id]['virtual_available'] = res[product.id]['virtual_available'] - (qty_sold - qty_delivered)
+        domain = Domain.AND([
+            Domain('order_id.state', '=', 'sale'),
+            Domain('product_id', 'in', self.ids),
+        ])
+        if self.env.context.get("to_date"):
+            domain = Domain.AND([
+                domain,
+                [('order_id.commitment_date', '<=', self.env.context.get("to_date").date())]
+            ])
+        order_lines = self.env['sale.order.line']._read_group(domain, ['product_id', 'product_uom_id'], ['product_uom_qty:sum', 'qty_delivered:sum'])
+        for product, line_uom, qty_sold, qty_delivered in order_lines:
+            to_deliver = (qty_sold - qty_delivered) * line_uom.factor / product.uom_id.factor
+            res[product.id]['outgoing_qty'] += to_deliver
+            res[product.id]['virtual_available'] -= to_deliver
         return res
 
     @api.onchange('type')

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -136,6 +136,11 @@ class SaleOrderLine(models.Model):
         domain='[("id", "in", allowed_uom_ids)]',
         store=True, readonly=False, precompute=True, ondelete='restrict')
     allowed_uom_ids = fields.Many2many('uom.uom', compute='_compute_allowed_uom_ids')
+    qty_available_today = fields.Float(compute='_compute_qty_at_date')
+    virtual_available_at_date = fields.Float(compute='_compute_qty_at_date', digits='Product Unit')
+    display_qty_widget = fields.Boolean(compute='_compute_display_qty_widget')
+    is_storable = fields.Boolean(related='product_id.is_storable')
+    scheduled_date = fields.Datetime(string='Delivery Date', compute='_compute_qty_at_date')
     linked_line_id = fields.Many2one(
         string="Linked Order Line",
         comodel_name='sale.order.line',
@@ -622,6 +627,30 @@ class SaleOrderLine(models.Model):
                 line.technical_price_unit = 0.0
             else:
                 line._reset_price_unit()
+
+    @api.depends('is_storable', 'product_uom_qty', 'qty_delivered', 'state', 'product_uom_id')
+    def _compute_display_qty_widget(self):
+        """Compute the visibility of the inventory widget."""
+        for line in self:
+            qty_to_deliver = line.product_uom_qty - line.qty_delivered
+            if line.state in ('draft', 'sent', 'sale') and line.is_storable and qty_to_deliver > 0:
+                line.display_qty_widget = True
+            else:
+                line.display_qty_widget = False
+
+    @api.depends('product_id', 'order_id.commitment_date', 'display_qty_widget')
+    def _compute_qty_at_date(self):
+        """ Compute the quantity forecasted of product at delivery date"""
+        self.scheduled_date = fields.Date.today()
+        self.virtual_available_at_date = 0
+        self.qty_available_today = 0
+        for line in self:
+            if not line.display_qty_widget:
+                continue
+            schedule_date = line.order_id.commitment_date or line._expected_date()
+            line.scheduled_date = schedule_date
+            line.virtual_available_at_date = line.product_id.with_context(to_date=schedule_date).virtual_available
+            line.qty_available_today = line.product_id.qty_available
 
     def _reset_price_unit(self):
         self.ensure_one()
@@ -1318,7 +1347,7 @@ class SaleOrderLine(models.Model):
             return lines
 
         for line in lines:
-            if line.qty_delivered_method == 'manual' and line.product_id.is_storable:
+            if line.qty_delivered_method == 'manual' and line.is_storable:
                 qty_delivered = line.product_uom_id._compute_quantity(line.qty_delivered, line.product_id.uom_id)
                 line.product_id.with_context(skip_qty_available_update=True).qty_available -= qty_delivered
             if line.product_id and line.state == 'sale':
@@ -1362,7 +1391,7 @@ class SaleOrderLine(models.Model):
 
         if 'qty_delivered' in values:
             for line in self:
-                if line.qty_delivered_method != 'manual' or not line.product_id.is_storable:
+                if line.qty_delivered_method != 'manual' or not line.is_storable:
                     continue
                 delta_qty_delivered = values['qty_delivered'] - line.qty_delivered
                 delta_qty_delivered = line.product_uom_id._compute_quantity(delta_qty_delivered, line.product_id.uom_id)

--- a/addons/sale/static/src/js/quantity_availability/qty_at_date_widget.js
+++ b/addons/sale/static/src/js/quantity_availability/qty_at_date_widget.js
@@ -1,0 +1,85 @@
+import { formatDateTime } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { Component, onWillRender } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { _t } from "@web/core/l10n/translation";
+
+export class QtyAtDatePopover extends Component {
+    static template = "sale.QtyAtDatePopover";
+    static props = {
+        record: Object,
+        calcData: Object,
+        close: Function,
+    };
+    setup() {
+        this.actionService = useService("action");
+    }
+
+    get forecastedLabel() {
+        return _t("Forecasted Stock");
+    }
+
+    get availableLabel() {
+        return _t("Available");
+    }
+}
+
+export class QtyAtDateWidget extends Component {
+    static components = { Popover: QtyAtDatePopover };
+    static template = "sale.QtyAtDate";
+    static props = { ...standardWidgetProps };
+    setup() {
+        this.popover = usePopover(this.constructor.components.Popover, { position: "top" });
+        this.orm = useService("orm");
+        this.calcData = {};
+        onWillRender(() => {
+            this.initCalcData();
+        });
+    }
+
+    async initCalcData() {
+        // Computes the color of the chart icon representing the widget
+        const { data } = this.props.record;
+        const leftToDeliver = data.product_uom_qty - data.qty_delivered;
+
+        this.calcData.forecasted_issue = "";
+        if (data.qty_available_today < leftToDeliver) {
+            this.calcData.forecasted_issue = "text-danger";
+        } else if (data.virtual_available_at_date < 0) {
+            this.calcData.forecasted_issue = "text-warning"; // Enough on hand NOW to fullfill not at delivery date
+        }
+    }
+
+    updateCalcData() {
+        // popup specific data
+        const { data } = this.props.record;
+        if (data.scheduled_date) {
+            this.calcData.delivery_date = formatDateTime(data.scheduled_date, {
+                format: localization.dateFormat,
+            });
+        }
+    }
+
+    async showPopup(ev) {
+        const target = ev.currentTarget;
+        this.updateCalcData();
+        this.popover.open(target, {
+            record: this.props.record,
+            calcData: this.calcData,
+        });
+    }
+}
+
+export const qtyAtDateWidget = {
+    component: QtyAtDateWidget,
+    fieldDependencies: [
+        { name: "display_qty_widget", type: "boolean" },
+        { name: "qty_available_today", type: "float" },
+        { name: "scheduled_date", type: "datetime" },
+        { name: "virtual_available_at_date", type: "float" },
+    ],
+};
+registry.category("view_widgets").add("simple_qty_at_date_widget", qtyAtDateWidget);

--- a/addons/sale/static/src/js/quantity_availability/qty_at_date_widget.xml
+++ b/addons/sale/static/src/js/quantity_availability/qty_at_date_widget.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template id="template" xml:space="preserve">
+
+    <t t-name="sale.QtyAtDate">
+        <a t-att-tabindex="props.record.data.display_qty_widget ? '0' : '-1'"
+            t-on-click="showPopup"
+            t-att-class="!props.record.data.display_qty_widget ? 'invisible' : ''"
+            t-attf-class="fa fa-area-chart cursor-pointer {{ calcData.forecasted_issue }}"
+        />
+    </t>
+
+    <t t-name="sale.QtyAtDatePopover">
+        <div class="p-2">
+            <h6>Availability</h6>
+            <table class="table table-borderless table-sm">
+                <tbody>
+                    <tr>
+                        <td>
+                            <strong t-out="availableLabel"/>
+                            <br/>
+                        </td>
+                        <td class="text-end">
+                            <b t-out='props.record.data.qty_available_today'
+                             t-att-class="props.record.data.qty_available_today &lt; props.calcData.leftToDeliver ? 'text-danger': ''"/>
+                            <t t-out='props.record.data.product_uom_id[1]'/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><strong t-out="forecastedLabel"/><br/><small>On <span t-out="props.calcData.delivery_date"/></small></td>
+                        <td class="text-end">
+                            <b t-out='props.record.data.virtual_available_at_date'
+                            t-att-class="props.record.data.qty_available_today &lt; props.calcData.leftToDeliver ? 'text-danger': ''"/>
+                            <t t-out='props.record.data.product_uom_id[1]'/>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </t>
+</template>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -49,16 +49,35 @@
                     name="action_view_sales"
                     type="object"
                     icon="fa-signal"
-                    help="Sold in the last 365 days"
+                    help="Sold in the last 365 days. Outgoing represents confirmed sales orders not delivered, or partially delivered"
                     groups="sales_team.group_sale_salesman"
                     invisible="not sale_ok">
-                    <div class="o_field_widget o_stat_info">
+                    <div class="o_field_widget o_stat_info" invisible="is_storable == True">
                         <span class="o_stat_value d-flex gap-1">
                             <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
                             <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                         </span>
                         <span class="o_stat_text">Sold</span>
                     </div>
+                    <div class="d-flex flex-row gap-1 ms-1" invisible="is_storable == False">
+                        <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
+                            <span class="o_stat_value d-flex gap-1">
+                                <field name="sales_count" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                            </span>
+                            <span class="o_stat_value d-flex gap-1">
+                                <field name="outgoing_qty" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                            </span>
+                        </div>
+                        <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
+                            <span class="o_stat_value">
+                                <field name="uom_name" widget="statinfo" nolabel="1" groups="uom.group_uom"/>
+                                <span groups="!uom.group_uom">Sold</span>
+                            </span>
+                            <span class="o_stat_value text-muted">
+                                Outgoing
+                            </span>
+                        </div>
+                     </div>
                 </button>
             </div>
         </field>
@@ -73,16 +92,35 @@
                 <button class="oe_stat_button"
                     name="action_view_sales"
                     type="object" icon="fa-signal"
-                    help="Sold in the last 365 days"
+                    help="Sold in the last 365 days. Outgoing represents confirmed sales orders not delivered, or partially delivered"
                     groups="sales_team.group_sale_salesman"
                     invisible="not sale_ok">
-                    <div class="o_field_widget o_stat_info">
+                    <div class="o_field_widget o_stat_info" invisible="is_storable == True">
                         <span class="o_stat_value d-flex gap-1">
                             <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline" options="{'hide_trailing_zeros': true}"/>
                             <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                         </span>
                         <span class="o_stat_text">Sold</span>
                     </div>
+                    <div class="d-flex flex-row gap-1 ms-1" invisible="is_storable == False">
+                        <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
+                            <span class="o_stat_value d-flex gap-1">
+                                <field name="sales_count" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                            </span>
+                            <span class="o_stat_value d-flex gap-1">
+                                <field name="outgoing_qty" widget="statinfo" nolabel="1" options="{'hide_trailing_zeros': true}"/>
+                            </span>
+                        </div>
+                        <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
+                            <span class="o_stat_value">
+                                <field name="uom_name" widget="statinfo" nolabel="1" groups="uom.group_uom"/>
+                                <span groups="!uom.group_uom">Sold</span>
+                            </span>
+                            <span class="o_stat_value text-muted">
+                                Outgoing
+                            </span>
+                        </div>
+                     </div>
                 </button>
             </button>
         </field>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -597,6 +597,7 @@
                                                 widget="many2one_uom"
                                                 readonly="product_uom_readonly"
                                                 required="not display_type and not is_downpayment"/>
+                                            <widget name="simple_qty_at_date_widget"/>
                                         </div>
                                         <label for="qty_delivered" string="Delivered" invisible="parent.state != 'sale'"/>
                                         <div name="delivered_qty" invisible="parent.state != 'sale'">
@@ -741,6 +742,7 @@
                                     decoration-info="(not display_type and invoice_status == 'to invoice')"
                                     decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     readonly="is_downpayment"/>
+                                <widget name="simple_qty_at_date_widget" width="20px"/>
                                 <field
                                     name="qty_delivered"
                                     string="Delivered"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -188,10 +188,22 @@
         <field name="mode">primary</field>
         <field name="priority">2</field>
         <field name="arch" type="xml">
-            <!-- Dummy view content since empty views are not supported atm -->
-            <list position="attributes">
-                <attribute name="string">Sales Orders</attribute>
-            </list>
+            <xpath expr="//header/button[@name='%(sale.action_view_sale_advance_payment_inv)d']" position="before">
+                <button
+                    string="Deliver"
+                    name="deliver_sold_quantity"
+                    type="object"
+                    class="btn-secondary"/>
+            </xpath>
+            <field name="invoice_status" position="before">
+                <field
+                    name="delivery_status"
+                    decoration-success="delivery_status == 'full'"
+                    decoration-warning="delivery_status == 'partial'"
+                    decoration-info="delivery_status in ['pending', 'started']"
+                    widget="badge"
+                    optional="hide"/>
+            </field>
         </field>
     </record>
 
@@ -311,6 +323,13 @@
                     context="{'default_advance_payment_method': 'percentage'}"
                     data-hotkey="q"
                     invisible="invoice_status != 'no' or state != 'sale'"/>
+                <button
+                    string="Deliver"
+                    id="deliver_quantities"
+                    name="deliver_sold_quantity"
+                    type="object"
+                    invisible="not show_deliver_button"
+                    data-hotkey="d"/>
                 <button
                     string="Send"
                     id="quotation_send_primary"
@@ -939,6 +958,7 @@
                                 <div name="commitment_date_div" class="o_row">
                                     <field name="commitment_date" readonly="state == 'cancel' or locked"/>
                                 </div>
+                                <field name="delivery_status" invisible="state != 'sale'"/>
                             </group>
                             <group name="sale_reporting" string="Tracking">
                                 <field name="origin"/>

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -24,15 +24,6 @@ class SaleOrder(models.Model):
         check_company=True)
     picking_ids = fields.One2many('stock.picking', 'sale_id', string='Transfers')
     delivery_count = fields.Integer(string='Delivery Orders', compute='_compute_picking_ids')
-    delivery_status = fields.Selection([
-        ('pending', 'Not Delivered'),
-        ('started', 'Started'),
-        ('partial', 'Partially Delivered'),
-        ('full', 'Fully Delivered'),
-    ], string='Delivery Status', compute='_compute_delivery_status', store=True,
-       help="Blue: Not Delivered/Started\n\
-            Orange: Partially Delivered\n\
-            Green: Fully Delivered")
     late_availability = fields.Boolean(
         string="Late Availability",
         compute='_compute_late_availability',
@@ -209,6 +200,10 @@ class SaleOrder(models.Model):
                 ]
             })
             order.show_json_popover = bool(late_stock_picking)
+
+    @api.depends('order_line.qty_delivered')
+    def _compute_show_deliver_button(self):
+        self.show_deliver_button = False  # Revert to Delivery smart button for stock module
 
     def _action_confirm(self):
         self.order_line._action_launch_stock_rule()

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -15,16 +15,12 @@ class SaleOrderLine(models.Model):
     qty_delivered_method = fields.Selection(selection_add=[('stock_move', 'Stock Moves')])
     route_ids = fields.Many2many('stock.route', string='Routes', domain=[('sale_selectable', '=', True)], ondelete='restrict')
     move_ids = fields.One2many('stock.move', 'sale_line_id', string='Stock Moves')
-    virtual_available_at_date = fields.Float(compute='_compute_qty_at_date', digits='Product Unit')
-    scheduled_date = fields.Datetime(compute='_compute_qty_at_date')
     forecast_expected_date = fields.Datetime(compute='_compute_qty_at_date')
     free_qty_today = fields.Float(compute='_compute_qty_at_date', digits='Product Unit')
-    qty_available_today = fields.Float(compute='_compute_qty_at_date')
     warehouse_id = fields.Many2one('stock.warehouse', compute='_compute_warehouse_id', store=True)
     qty_to_deliver = fields.Float(compute='_compute_qty_to_deliver', digits='Product Unit')
     is_mto = fields.Boolean(compute='_compute_is_mto')
     display_qty_widget = fields.Boolean(compute='_compute_qty_to_deliver')
-    is_storable = fields.Boolean(related='product_id.is_storable')
     customer_lead = fields.Float(
         compute='_compute_customer_lead', store=True, readonly=False, precompute=True,
         inverse='_inverse_customer_lead')

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -40,6 +40,7 @@ export class QtyAtDatePopover extends Component {
     }
 }
 
+// TODO inherit from simple_qty_at_date_widget
 export class QtyAtDateWidget extends Component {
     static components = { Popover: QtyAtDatePopover };
     static template = "sale_stock.QtyAtDate";

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -47,7 +47,7 @@
             <xpath expr="//field[@name='order_line']//form//field[@name='analytic_distribution']" position="before">
                 <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
             </xpath>
-            <xpath expr="//field[@name='order_line']//form//field[@name='product_uom_id']" position="after">
+            <xpath expr="//widget[@name='simple_qty_at_date_widget']" position="replace">
                 <widget name="qty_at_date_widget"/>
             </xpath>
             <xpath expr="//field[@name='order_line']//list//field[@name='analytic_distribution']" position="after">
@@ -58,7 +58,7 @@
                     options="{'no_create': True}"
                     optional="hide"/>
             </xpath>
-            <xpath expr="//field[@name='order_line']//list//field[@name='qty_delivered']" position="after">
+            <xpath expr="//widget[@name='simple_qty_at_date_widget']" position="replace">
                 <widget name="qty_at_date_widget" width="20px"/>
             </xpath>
         </field>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -86,6 +86,9 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_tree"/>
         <field name="arch" type="xml">
+            <xpath expr="//list/header/button[@name='deliver_sold_quantity']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <field name="delivery_date" position="attributes">
                 <attribute name="decoration-danger">
                     (
@@ -102,15 +105,6 @@
                         or delivery_status == 'partial'
                     )
                 </attribute>
-            </field>
-            <field name="invoice_status" position="before">
-                <field
-                    name="delivery_status"
-                    decoration-success="delivery_status == 'full'"
-                    decoration-warning="delivery_status == 'partial'"
-                    decoration-info="delivery_status in ['pending', 'started']"
-                    widget="badge"
-                    optional="hide"/>
             </field>
         </field>
     </record>

--- a/addons/stock/__init__.py
+++ b/addons/stock/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from . import controllers
 from . import models
 from . import report
@@ -14,6 +16,17 @@ def pre_init_hook(env):
         ('module', '=', 'stock')
     ]).unlink()
 
+
+def post_init_hook(env):
+    _assign_default_mail_template_picking_id(env)
+    _create_inventory_adjustment(env)
+
+
+def uninstall_hook(env):
+    picking_type_ids = env["stock.picking.type"].with_context({"active_test": False}).search([])
+    picking_type_ids.sequence_id.unlink()
+
+
 def _assign_default_mail_template_picking_id(env):
     company_ids_without_default_mail_template_id = env['res.company'].search([
         ('stock_mail_confirmation_template_id', '=', False)
@@ -24,6 +37,25 @@ def _assign_default_mail_template_picking_id(env):
             'stock_mail_confirmation_template_id': default_mail_template_id.id,
         })
 
-def uninstall_hook(env):
-    picking_type_ids = env["stock.picking.type"].with_context({"active_test": False}).search([])
-    picking_type_ids.sequence_id.unlink()
+
+def _create_inventory_adjustment(env):
+    env.cr.execute("""SELECT id, qty_available FROM product_product WHERE qty_available IS NOT NULL;""")
+    products = env.cr.fetchall()
+    qty_available_by_company = defaultdict(lambda: defaultdict(float))
+    for product_id, qty_available in products:
+        for company_id, quantity in qty_available.items():
+            qty_available_by_company[int(company_id)][product_id] = quantity
+
+    for company_id, qty_available in qty_available_by_company.items():
+        inventory_quant_vals = []
+        location = env['stock.warehouse'].search([('company_id', '=', company_id)], limit=1).lot_stock_id
+        # Maybe we should automatically create a warehouse for them?
+        if not location:
+            continue
+        for product, quantity in qty_available.items():
+            inventory_quant_vals.append({
+                'product_id': product,
+                'inventory_quantity': quantity,
+                'location_id': location.id,
+            })
+        env['stock.quant'].create(inventory_quant_vals)._apply_inventory()

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -91,7 +91,7 @@
     ],
     'application': True,
     'pre_init_hook': 'pre_init_hook',
-    'post_init_hook': '_assign_default_mail_template_picking_id',
+    'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'assets': {
         'web.report_assets_common': [

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -810,7 +810,6 @@ class ProductTemplate(models.Model):
         string="Category Routes", related='categ_id.total_route_ids', related_sudo=False)
     show_on_hand_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
     show_forecasted_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
-    show_qty_update_button = fields.Boolean(compute='_compute_show_qty_update_button')
 
     @api.depends('lot_sequence_id', 'lot_sequence_id.prefix')
     def _compute_serial_prefix_format(self):

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -62,8 +62,6 @@ class ProductProduct(models.Model):
              "Otherwise, this includes goods stored in any Stock Location "
              "with 'internal' type.")
     virtual_available = fields.Float(
-        'Forecasted Quantity', compute='_compute_quantities', search='_search_virtual_available',
-        digits='Product Unit', compute_sudo=False,
         help="Forecast quantity (computed as Quantity On Hand "
              "- Outgoing + Incoming)\n"
              "In a context with a single Stock Location, this includes "
@@ -86,8 +84,6 @@ class ProductProduct(models.Model):
              "Otherwise, this includes goods stored in any Stock Location "
              "with 'internal' type.")
     incoming_qty = fields.Float(
-        'Incoming', compute='_compute_quantities', search='_search_incoming_qty',
-        digits='Product Unit', compute_sudo=False,
         help="Quantity of planned incoming products.\n"
              "In a context with a single Stock Location, this includes "
              "goods arriving to this Location, or any of its children.\n"
@@ -97,8 +93,6 @@ class ProductProduct(models.Model):
              "Otherwise, this includes goods arriving to any Stock "
              "Location with 'internal' type.")
     outgoing_qty = fields.Float(
-        'Outgoing', compute='_compute_quantities', search='_search_outgoing_qty',
-        digits='Product Unit', compute_sudo=False,
         help="Quantity of planned outgoing products.\n"
              "In a context with a single Stock Location, this includes "
              "goods leaving this Location, or any of its children.\n"
@@ -428,26 +422,8 @@ class ProductProduct(models.Model):
             return [('id', 'in', product_ids)]
         return self._search_product_quantity(operator, value, 'qty_available')
 
-    def _search_virtual_available(self, operator, value):
-        # TDE FIXME: should probably clean the search methods
-        return self._search_product_quantity(operator, value, 'virtual_available')
-
-    def _search_incoming_qty(self, operator, value):
-        # TDE FIXME: should probably clean the search methods
-        return self._search_product_quantity(operator, value, 'incoming_qty')
-
-    def _search_outgoing_qty(self, operator, value):
-        # TDE FIXME: should probably clean the search methods
-        return self._search_product_quantity(operator, value, 'outgoing_qty')
-
     def _search_free_qty(self, operator, value):
         return self._search_product_quantity(operator, value, 'free_qty')
-
-    def _search_product_quantity(self, operator, value, field):
-        # Order the search on `id` to prevent the default order on the product name which slows
-        # down the search.
-        ids = self.with_context(prefetch_fields=False).search_fetch([], [field], order='id').filtered_domain([(field, operator, value)]).ids
-        return [('id', 'in', ids)]
 
     def _search_qty_available_new(self, operator, value, lot_id=False, owner_id=False, package_id=False):
         ''' Optimized method which doesn't search on stock.moves, only on stock.quants. '''
@@ -810,15 +786,6 @@ class ProductTemplate(models.Model):
     qty_available = fields.Float(
         'Quantity On Hand', compute='_compute_quantities', search='_search_qty_available',
         inverse='_inverse_qty_available', compute_sudo=False, digits='Product Unit')
-    virtual_available = fields.Float(
-        'Forecasted Quantity', compute='_compute_quantities', search='_search_virtual_available',
-        compute_sudo=False, digits='Product Unit')
-    incoming_qty = fields.Float(
-        'Incoming', compute='_compute_quantities', search='_search_incoming_qty',
-        compute_sudo=False, digits='Product Unit')
-    outgoing_qty = fields.Float(
-        'Outgoing', compute='_compute_quantities', search='_search_outgoing_qty',
-        compute_sudo=False, digits='Product Unit')
     # The goal of these fields is to be able to put some keys in context from search view in order
     # to influence computed field.
     location_id = fields.Many2one('stock.location', 'Location', store=False)
@@ -910,9 +877,6 @@ class ProductTemplate(models.Model):
     @api.depends_context('warehouse_id')
     def _compute_quantities(self):
         return super()._compute_quantities()
-
-    def _compute_quantities_fields(self):
-        return super()._compute_quantities_fields() + ['virtual_available', 'incoming_qty', 'outgoing_qty']
 
     def _compute_nbr_moves(self):
         res = defaultdict(lambda: {'moves_in': 0, 'moves_out': 0})

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -120,9 +120,15 @@
             <field name="arch" type="xml">
                 <field name="uom_id" position="before">
                     <field name="show_on_hand_qty_status_button" column_invisible="True" groups="stock.group_stock_user"/>
-                    <field name="qty_available" invisible="not show_on_hand_qty_status_button" string="On Hand" optional="show" decoration-danger="qty_available &lt; 0" groups="stock.group_stock_user" sum="Total On Hand"/>
-                    <field name="virtual_available" invisible="not show_on_hand_qty_status_button" string="Forecasted" optional="show" decoration-danger="virtual_available &lt; 0" decoration-bf="1" groups="stock.group_stock_user" sum="Total Forecasted"/>
                 </field>
+                <xpath expr="//field[@name='qty_available']" position="attributes">
+                    <attribute name="invisible">not show_on_hand_qty_status_button</attribute>
+                    <attribute name="groups">stock.group_stock_user</attribute>
+                </xpath>
+                <xpath expr="//field[@name='virtual_available']" position="attributes">
+                    <attribute name="invisible">not show_on_hand_qty_status_button</attribute>
+                    <attribute name="groups">stock.group_stock_user</attribute>
+                </xpath>
                 <field name="default_code" position="after">
                     <field name="responsible_id" widget="many2one_avatar_user" optional="hide" groups="stock.group_stock_user"/>
                 </field>
@@ -258,7 +264,7 @@
                 <xpath expr="//kanban" position="inside">
                     <field name="show_on_hand_qty_status_button" groups="stock.group_stock_user"/>
                 </xpath>
-                <xpath expr="//field[@name='product_properties']" position="before">
+                <xpath expr="//span[@name='on_hand_qty_kanban']" position="replace">
                     <div groups="stock.group_stock_user" t-if="record.show_on_hand_qty_status_button.raw_value">
                         On hand: <field name="qty_available"/> <field name="uom_id" groups="uom.group_uom"/>
                     </div>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -177,12 +177,15 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <field name="product_tooltip" position="after">
-                    <label for="is_storable" class="oe_inline" invisible="type != 'consu'"/>
-                    <div class="o_row w-100" invisible="type != 'consu'">
+                <xpath expr="//div[hasclass('o_is_storable')]" position="replace">
+                     <div class="o_row w-100 o_is_storable" invisible="type != 'consu'">
                         <field name="is_storable"/>
-                        <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
-                    </div>
+                     </div>
+                </xpath>
+                <field name="is_storable" position="after">
+                    <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
+                </field>
+                <xpath expr="//div[hasclass('o_is_storable')]" position="after">
                     <field name="show_qty_update_button" invisible="1"/>
                     <label for="qty_available" class="oe_inline" invisible="not is_storable" groups="stock.group_stock_user"/>
                     <div class="o_row" invisible="not is_storable" groups="stock.group_stock_user">
@@ -196,7 +199,7 @@
                             <field name="uom_name" class="oe_inline"/>
                         </span>
                     </div>
-                </field>
+                </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
                     <label for="sale_delay" invisible="not sale_ok"/>
                     <div invisible="not sale_ok">

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -87,29 +87,26 @@
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_product_tree_view"/>
             <field name="arch" type="xml">
-                <field name="type" position="after">
-                    <field
-                        name="qty_available"
-                        invisible="not is_storable"
-                        string="On Hand"
-                        optional="show"
-                        decoration-danger="virtual_available &lt; 0"
-                        decoration-warning="virtual_available == 0"
-                        decoration-bf="1"
-                        groups="stock.group_stock_user"
-                        sum="Total On Hand"
-                    />
-                    <field
-                        name="virtual_available"
-                        invisible="not is_storable"
-                        string="Forecasted"
-                        optional="show"
-                        decoration-danger="virtual_available &lt; 0"
-                        decoration-warning="virtual_available == 0"
-                        groups="stock.group_stock_user"
-                        sum="Total Forecasted"
-                    />
-                </field>
+                <xpath expr="//field[@name='qty_available']" position='attributes'>
+                    <attribute name="groups">stock.group_stock_user</attribute>
+                </xpath>
+                <xpath expr="//field[@name='virtual_available']" position='attributes'>
+                    <attribute name="groups">stock.group_stock_user</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <!-- Disable variant qty editing not using quants -->
+        <record id="product.product_view_list_qty" model="ir.ui.view">
+            <field name="active" eval="False"/>
+        </record>
+
+        <record id="stock_variant_easy_edit_view" model="ir.ui.view">
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_variant_easy_edit_view"></field>
+            <field name="arch" type="xml">
+                <xpath expr="//label[@for='qty_available']" position="replace"/>
+                <xpath expr="//div[@name='no_stock_variant_qty_edit']" position="replace"/>
             </field>
         </record>
 
@@ -183,18 +180,15 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('o_is_storable')]" position="replace">
-                     <div class="o_row w-100 o_is_storable" invisible="type != 'consu'">
+                <xpath expr="//div[@name='tracking_and_qty_no_stock']" position="replace">
+                    <!-- Replace the single line tacking + qty without stock with 2 individual lines with stock (tracking + tracking method // qty) -->
+                    <div name="tracking_with_stock" class="o_row w-100" invisible="type != 'consu'">
                         <field name="is_storable"/>
-                     </div>
-                </xpath>
-                <field name="is_storable" position="after">
+                    </div>
                     <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
-                </field>
-                <xpath expr="//div[hasclass('o_is_storable')]" position="after">
-                    <field name="show_qty_update_button" invisible="1"/>
+                    <!-- Qty line if storable -->
                     <label for="qty_available" class="oe_inline" invisible="not is_storable" groups="stock.group_stock_user"/>
-                    <div class="o_row" invisible="not is_storable" groups="stock.group_stock_user">
+                    <div name="qty_available_with_stock" class="o_row" invisible="not is_storable" groups="stock.group_stock_user">
                         <a type="object" name="action_open_quants"
                            invisible="not show_qty_update_button" groups="stock.group_stock_manager">
                             <field name="qty_available" readonly="True"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Adds minimal stock functionality to the Sale, and Purchase module without needing to install the stock module. 
A user can now track the quantity on hand of a product, which we deduct from when making a sale and we add to when making a purchase. This is done without pickings or deliveries, solely using the `qty_received` and `qty_delivered` fields on the order lines.

**WHY:**  You have to install stock module to handle your quantity on hand in Odoo. However the stock module enforce hard process with deliveries and receipts to fill and validate. A lot of business don't have the requirement of an advanced inventory management and they just want to increase/decrease the inventory with simple operations base on their sales/purchase/POS,...

**Current behavior before PR:**
Cannot track available quantities for product without installing stock.

**Desired behavior after PR is merged:**
A user should be able to:

 - Define product qty in stock
 - See product availability on SO line
 - Reduce the quantity by delivering product on SO line 
 - Increase the qty in stock be receiving product on PO line
 - See incoming / outgoing quantities per product 

Because the new feature relies heavily on keeping your delivered / received qty up to date, we also included some buttons to make it easier to keep up to date (Deliver/Receive buttons on the PO/SO form and list) and we display the incoming and outgoing qty on the product smart button as well. 

Upgrade PR: https://github.com/odoo/upgrade/pull/9081
task#5186344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
