### PR TITLE
[FIX] mrp: prevent error when marking multiple manufacturing orders as done

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -472,12 +472,13 @@ class MrpWorkorder(models.Model):
     def write(self, values):
         new_workcenter = False
         if 'qty_produced' in values:
-            if any(w.state in ['done', 'cancel'] for w in self):
-                raise UserError(_('You cannot change the quantity produced of a work order that is in done or cancel state.'))
-            elif float_compare(values['qty_produced'], 0, precision_rounding=self.product_uom_id.rounding) < 0:
-                raise UserError(_('The quantity produced must be positive.'))
-            elif values['qty_produced'] not in (0, 1) and any(wo.product_tracking == 'serial' for wo in self):
-                raise UserError(_('You cannot produce more than 1 unit of a serial product at a time.'))
+            for wo in self:
+                if wo.state in ['done', 'cancel']:
+                    raise UserError(_('You cannot change the quantity produced of a work order that is in done or cancel state.'))
+                elif float_compare(values['qty_produced'], 0, precision_rounding=wo.product_uom_id.rounding) < 0:
+                    raise UserError(_('The quantity produced must be positive.'))
+                elif values['qty_produced'] not in (0, 1) and wo.product_tracking == 'serial':
+                    raise UserError(_('You cannot produce more than 1 unit of a serial product at a time.'))
 
         if 'production_id' in values and any(values['production_id'] != w.production_id.id for w in self):
             raise UserError(_('You cannot link this work order to another manufacturing order.'))
@@ -518,10 +519,13 @@ class MrpWorkorder(models.Model):
                         })
 
         res = super().write(values)
-        if 'qty_produced' in values and float_compare(values.get('qty_produced', 0), 0, precision_rounding=self.production_id.product_uom_id.rounding) > 0:
-            for production in self.production_id:
+        productions = self.production_id.filtered(lambda p: float_compare(
+            values.get('qty_produced', 0), 0, precision_rounding=p.product_uom_id.rounding) > 0
+        )
+        if 'qty_produced' in values and productions:
+            for production in productions:
                 min_wo_qty = min(production.workorder_ids.mapped('qty_produced'))
-                if float_compare(min_wo_qty, 0, precision_rounding=self.production_id.product_uom_id.rounding) > 0:
+                if float_compare(min_wo_qty, 0, precision_rounding=production.product_uom_id.rounding) > 0:
                     production.workorder_ids.filtered(lambda w: w.state != 'done').qty_producing = min_wo_qty
             self._set_qty_producing()
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5348,6 +5348,37 @@ class TestMrpOrder(TestMrpCommon):
             with mo_form.workorder_ids.edit(1) as second_wo_line:
                 second_wo_line.duration = 12.0  # Edit the duration of the second workorder
 
+    def test_mark_done_multi_mo_with_different_uom(self):
+        """Test marking multiple productions as done with different product UoMs."""
+        mo1, mo2 = self.env['mrp.production'].create([
+            {'product_id': self.product_1.id},
+            {'product_id': self.product_3.id},
+        ])
+        wo1, wo2 = self.env['mrp.workorder'].create([
+            {
+                'name': 'Test order1',
+                'workcenter_id': self.workcenter_1.id,
+                'product_uom_id': self.product_1.uom_id.id,
+                'production_id': mo1.id,
+            },
+            {
+                'name': 'Test order2',
+                'workcenter_id': self.workcenter_1.id,
+                'product_uom_id': self.product_3.uom_id.id,
+                'production_id': mo2.id,
+            }
+        ])
+
+        mos = mo1 | mo2
+        mos.action_confirm()
+        mos.button_mark_done()
+
+        self.assertEqual(mo1.state, 'done')
+        self.assertEqual(mo2.state, 'done')
+        self.assertNotEqual(mo1.workorder_ids.product_uom_id, mo2.workorder_ids.product_uom_id)
+        self.assertEqual(mo1.product_qty, mo2.product_qty)
+        self.assertEqual(wo1.qty_produced, wo2.qty_produced)
+
 
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):


### PR DESCRIPTION
Currently, an error occurs when user marks multiple Manufacturing Orders as Done.

**Steps to Reproduce ([Video](https://drive.google.com/file/d/1XfkMB001rMiyulRGrP4dlJFDYByo_5Bv/view?usp=drive_link)):**
 - Install the `mrp` module.
 - Go to `Settings` and enable `Units of Measure & Packagings`.
 - Go to `Products and `create two products` with different `units of measure`.
 - Go to `Manufacturing Orders`, create a manufacturing order by `adding one of the products`, and then `create work order` in the Work Orders section and `confirm` it.
 - Create another `manufacturing order` with the `same quantity` for the second product and add a `Work Order` for it as well and `confirm` it.
 - Go to the `list view`, select `both orders`, and click `Mark as Done` from the `Actions` menu.

**Error:**
```
ValueError: ValueError('Expected singleton: uom.uom(4, 6)') while evaluating
"if records:\n                res = records.filtered(lambda mo: mo.state in {'confirmed', 'to_close', 'progress'}).button_mark_done()\n                if res is not True:\n                    action = res"
ValueError: Expected singleton: uom.uom(4, 6)
```

After [this commit], which improves the performance of button_finish, when a user marks multiple orders as done with the same quantity but different uom , it creates all_vals_dict based on the vals[1] data as the key and the work order as the value[2]. Then it  stores two or more work orders with different UoMs under the same vals key. When attempting to write multiple work orders[3], the precision rounding is calculated, which raises the error[4] due to multiple UoMs.

The commit ensures that when writing records, precision_rounding is calculated separately for each Work Order's UoM.

[this commit]: https://github.com/odoo/odoo/pull/223715/commits/b857d192085a38b612335223d04f8bdff91b898c

[1]- https://github.com/odoo/odoo/blob/186a9eb4a6c55c9c4c2178d4b2492a9a23a267fe/addons/mrp/models/mrp_workorder.py#L698-L703

[2]- https://github.com/odoo/odoo/blob/186a9eb4a6c55c9c4c2178d4b2492a9a23a267fe/addons/mrp/models/mrp_workorder.py#L706

[3]- https://github.com/odoo/odoo/blob/186a9eb4a6c55c9c4c2178d4b2492a9a23a267fe/addons/mrp/models/mrp_workorder.py#L708

[4]- https://github.com/odoo/odoo/blob/186a9eb4a6c55c9c4c2178d4b2492a9a23a267fe/addons/mrp/models/mrp_workorder.py#L477

sentry-7050854871

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
