### PR TITLE
[FIX] sale: prevent traceback when product has duplicate attribute lines

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -299,7 +299,12 @@ class SaleProductConfiguratorController(Controller):
         )
         product_or_template = product or product_template
         ptals = product_template.attribute_line_ids
-        attrs_map = dict(zip(ptals.ids, ptals.attribute_id.read(['id', 'name', 'display_type'])))
+        attrs = ptals.attribute_id.read(['id', 'name', 'display_type'])
+        attrs_by_id = {a['id']: a for a in attrs}
+        attrs_map = {
+            ptal.id: attrs_by_id.get(ptal.attribute_id.id)
+            for ptal in ptals
+        }
         ptavs = ptals.product_template_value_ids.filtered(lambda p: p.ptav_active or combination and p.id in combination.ids)
         ptavs_map = dict(zip(ptavs.ids, ptavs.read(['name', 'html_color', 'image', 'is_custom'])))
 


### PR DESCRIPTION
Issue before this commit:
=========================
When a product contains multiple attribute lines using the same attribute and 
also has optional products, attempting to add the product to the cart from the 
website resulted in a server error. The product configurator failed during 
attribute-line processing, causing the Add to Cart button to crash.

Steps to Reproduce:
=========================
1. Install website_sale and enable product variants.
2. Create a product containing:
    - Two or more attribute lines referencing the same attribute
    - At least one optional product.
3. Publish the product on the website.
4. Go to the product page and click Add to Cart button.

Cause of the Issue:
=========================
The website product configurator assumes a one-to-one mapping between attribute
lines and their attributes.
When multiple attribute lines share the same attribute_id, the current mapping 
logic builds an incomplete attribute map.
This causes a KeyError during configurator construction, leading to a error when
adding the product to the cart.
Related to this PR: https://github.com/odoo/odoo/pull/235170

With This Commit:
=========================
A safer attribute mapping mechanism is introduced, ensuring that each attribute
line even if sharing the same attribute always receives its own attribute data.
This prevents missing keys during configurator processing and allows products 
with duplicate attribute lines and optional products to be added to the cart 
without errors.

Steps To Reporduce: [Video Link](https://drive.google.com/file/d/1cKLNfJAOvp6IFTmoL4BtkGnZgIV7omta/view?usp=drive_link)

**opw-5361565**