### PR TITLE
[IMP] account: Hide inactive currencies in search more

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1102,8 +1102,7 @@
                                             <field name="currency_id"
                                                    readonly="state != 'draft'"
                                                    class="oe_inline"
-                                                   options="{'no_create': True}"
-                                                   context="{'search_default_active': 1, 'search_default_inactive': 1}"/>
+                                                   options="{'no_create': True}"/>
                                             <widget name="account_pick_currency_date" invisible="state != 'draft' or currency_id == company_currency_id"/>
                                         </div>
                                         <div name="currency_conversion_div"


### PR DESCRIPTION
In account.move form view, when the user clicks on search more of the currency, they should only see active ones they can then show inactive currencies using filters

task-5354516




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
