### PR TITLE
[FIX] website_sale: fix variant section being visible with no visible attribute

### DIFF
--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -2,8 +2,12 @@
 <odoo>
     <template id="variants">
         <t t-set="attribute_exclusions" t-value="product._get_attribute_exclusions(parent_combination)"/>
+        <t
+            t-set="has_configurable_attribute_line"
+            t-value="any(ptal._is_configurable() for ptal in product.attribute_line_ids)"
+        />
         <ul
-            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 pt-3 #{ul_class} #{'d-none' if not product.valid_product_template_attribute_line_ids else '' }"
+            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 pt-3 #{ul_class} #{'d-none' if not has_configurable_attribute_line else '' }"
             t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)"
         >
             <t t-foreach="product.valid_product_template_attribute_line_ids" t-as="ptal">


### PR DESCRIPTION

### Issue:
Variant section which only contains multi-value attributes is visible when none of the attributes are visible.

#### To reproduce:
1- Create a product with a single value attribute.
2- Navigate to product page on the website.
3- As seen there is an empty extra section under price.

<img width="626" height="296" alt="image" src="https://github.com/user-attachments/assets/cbf0e9e2-b17a-4b1b-94e0-f4b94780dab3" />


#### Cause:
This section is to show custom or multi-value attributes.
However, when product only contains attributes which have single and non-custom values, the attributes will not be visible.
In this cases the section is visible but empty.
This fix propose to hide variants when no visible line exists.

opw-5241432
