### PR TITLE
[IMP] html_editor: split text node upon separator insertion

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_blueprint.xml
@@ -3,7 +3,12 @@
         <div data-embedded="toggleBlock"
             data-oe-protected="true" contenteditable="false" t-att-data-embedded-props="embeddedProps">
             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
-                <t t-tag="baseContainerNodeName" t-att="baseContainerAttributes"><br/></t>
+                <t t-if="initialText">
+                    <t t-tag="baseContainerNodeName" t-att="baseContainerAttributes" t-out="initialText"/>
+                </t>
+                <t t-else="">
+                    <t t-tag="baseContainerNodeName" t-att="baseContainerAttributes"><br/></t>
+                </t>
             </div>
             <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
                 <t t-tag="baseContainerNodeName" t-att="baseContainerAttributes"><br/></t>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -54,7 +54,10 @@ export class ToggleBlockPlugin extends Plugin {
         move_node_blacklist_selectors: `${toggleSelector} ${titleSelector} *`,
         selection_blocker_predicates: (blocker) => {
             // Prevent the insertion of selection placeholders around toggle blocks.
-            if (blocker.nodeType === Node.ELEMENT_NODE && blocker.dataset.embedded === "toggleBlock") {
+            if (
+                blocker.nodeType === Node.ELEMENT_NODE &&
+                blocker.dataset.embedded === "toggleBlock"
+            ) {
                 return false;
             }
         },
@@ -523,7 +526,15 @@ export class ToggleBlockPlugin extends Plugin {
     }
 
     insertToggleBlock() {
-        const block = this.renderToggleBlock();
+        let initialText;
+        const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        if (selection.isCollapsed) {
+            const selectedBlock = closestBlock(selection.startContainer);
+            initialText = selectedBlock.textContent;
+            selectedBlock.remove();
+        }
+
+        const block = this.renderToggleBlock(initialText);
         const target = block.querySelector(`${titleSelector} > ${baseContainerGlobalSelector}`);
         this.dependencies.dom.insert(block);
         this.dependencies.selection.setCursorStart(target);
@@ -571,7 +582,7 @@ export class ToggleBlockPlugin extends Plugin {
         }
     }
 
-    renderToggleBlock() {
+    renderToggleBlock(initialText) {
         const baseContainer = this.dependencies.baseContainer.createBaseContainer();
         return parseHTML(
             this.document,
@@ -581,6 +592,7 @@ export class ToggleBlockPlugin extends Plugin {
                     class: baseContainer.className,
                 },
                 embeddedProps: JSON.stringify({ toggleBlockId: this.getUniqueIdentifier() }),
+                initialText,
             })
         );
     }

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -6,6 +6,7 @@ import {
     addStep,
     deleteBackward,
     deleteForward,
+    insertText,
     keydownShiftTab,
     keydownTab,
     splitBlock,
@@ -17,7 +18,7 @@ import {
     toggleBlockEmbedding,
 } from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
 import { onMounted } from "@odoo/owl";
-import { animationFrame, queryOne, tick } from "@odoo/hoot-dom";
+import { animationFrame, press, queryOne, tick } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 import { browser } from "@web/core/browser/browser";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
@@ -1063,5 +1064,18 @@ describe("Toggle block: Switch Direction", () => {
             `
             )
         );
+    });
+});
+
+describe("create with powerbox", () => {
+    test("current line text should be used when creating new toggle block", async () => {
+        const { editor } = await setupEditor(`<p>ab[]c</p>`, {
+            config: getConfig([toggleBlockEmbedding]),
+        });
+        await insertText(editor, "/toggle");
+        await press("Enter");
+        expect(
+            "[data-embedded='toggleBlock'] [data-embedded-editable='title']:contains('abc')"
+        ).toHaveCount(1);
     });
 });


### PR DESCRIPTION
When using the `/separator` command, the separator used to be added after the current block.

In this commit this is changed towards a more intuitive behavior that splits the block at the current cursor position.

task-5367766
