### PR TITLE
[FIX] website: fix tour `edit_menus`

### DIFF
--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -224,7 +224,6 @@ registerWebsitePreviewTour(
         },
         // Edit the menu item from the "edit menu" popover button
         ...clickOnEditAndWaitEditMode(),
-        clickOnExtraMenuItem({}, true),
         {
             content: "Wait for the builder sidebar to fully open",
             trigger: ":iframe .editor_enable",
@@ -241,6 +240,7 @@ registerWebsitePreviewTour(
                 await delay(200);
             },
         },
+        clickOnExtraMenuItem({}, true),
         ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Modnar')", "Modnar"),
         {
             content: "Click on the popover Edit Menu button",
@@ -503,13 +503,20 @@ registerWebsitePreviewTour(
         {
             content: "Nest 'new_nested_menu' under 'new_menu'",
             trigger: '.oe_menu_editor li:contains("new_nested_menu") .oi-draggable',
-            run: "drag_and_drop .oe_menu_editor li:contains('new_menu') .form-control",
+            run(helpers) {
+                return helpers.drag_and_drop(
+                    ".oe_menu_editor li:contains('new_menu') .form-control",
+                    {
+                        position: "bottom",
+                    }
+                );
+            },
         },
         {
             content: "Drag 'Modnar !!' below 'new_menu'",
             trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
-            async run(helpers) {
-                await helpers.drag_and_drop(
+            run(helpers) {
+                return helpers.drag_and_drop(
                     '.oe_menu_editor li:contains("new_menu") .oi-draggable',
                     {
                         position: "bottom",
@@ -520,19 +527,26 @@ registerWebsitePreviewTour(
         {
             content: "Nest 'Modnar !!' under 'new_menu'",
             trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
-            run: "drag_and_drop .oe_menu_editor li:contains('new_menu') .form-control",
+            run(helpers) {
+                return helpers.drag_and_drop(
+                    ".oe_menu_editor li:contains('new_menu') .form-control",
+                    {
+                        position: "bottom",
+                    }
+                );
+            },
         },
         {
-            content: "Check if 'nested_menu' and 'Modnar !!' is nested under 'new_menu'",
+            content: "Check if 'new_nested_menu' and 'Modnar !!' is nested under 'new_menu'",
             trigger:
-                '.oe_menu_editor li:contains("new_menu") > ul > li:contains("Modnar !!") + li:contains("nested_menu")',
+                '.oe_menu_editor li:contains("new_menu") > ul > li:contains("Modnar !!") + li:contains("new_nested_menu")',
         },
         {
             content: "Move 'Modnar !!' below 'new_nested_menu' inside the 'new_menu'",
             trigger:
                 '.oe_menu_editor  li:contains("new_menu") > ul > li:contains("Modnar !!") .oi-draggable',
-            async run(helpers) {
-                await helpers.drag_and_drop(
+            run(helpers) {
+                return helpers.drag_and_drop(
                     ".oe_menu_editor  li:contains('new_menu') > ul > li:contains('new_nested_menu') .oi-draggable",
                     {
                         position: "bottom",


### PR DESCRIPTION
The `test_17_website_edit_menus` test fails nondeterministically on runbot, with an observed failure rate of about 3% at the time of this commit. See [1].

The issue is related to the penultimate `drag_and_drop`, which sometimes fails to drop the target element in the correct location. This happens because `drag_and_drop` is called with no extra options, thus the arguments "position" and "relative" default to "top" and "true". This default setting seems to lead to the element to be sometimes dropped to the wrong place.

This commit explicitly sets the options for that call of `drag_and_drop`, removing the source of nondeterminism. The same fix is applied to a previous call to `drag_and_drop`, even if it does not seem to make the test fail. Additionally:
1. The fourth call to `clickOnExtraMenuItem` is moved after the wait for the sidebar to fully open. This is more reasonable because this button must be pressed after entering edit mode.
2. To maintain consistency along the tour, the unnecessary keywords "async" are removed from every call to `helpers.drag_and_drop`.
3. The text "nested_menu" is replaced with "new_nested_menu", which is the correct label of the menu entry.

[1]: https://runbot.odoo.com/odoo/runbot.build.error/233372