### PR TITLE
[FIX] point_of_sale: adapt _compute_margin for refund order

### DIFF
--- a/addons/pos_discount/tests/test_taxes_global_discount.py
+++ b/addons/pos_discount/tests/test_taxes_global_discount.py
@@ -105,6 +105,7 @@ class TestTaxesGlobalDiscountPOS(TestTaxCommonPOS, TestTaxesGlobalDiscount):
         ])
 
     def test_pos_global_discount_sell_and_refund(self):
+        self.desk_pad.standard_price = 1.0
         self.main_pos_config.open_ui()
         self.start_pos_tour('test_pos_global_discount_sell_and_refund')
         orders = self.main_pos_config.current_session_id.order_ids
@@ -114,8 +115,16 @@ class TestTaxesGlobalDiscountPOS(TestTaxCommonPOS, TestTaxesGlobalDiscount):
         self.assertEqual(len(refund_order.lines), 2)
         self.assertEqual(refund_order.lines[1].product_id.id, self.main_pos_config.discount_product_id.id)
         self.assertAlmostEqual(refund_order.lines[1].price_subtotal_incl, -0.15)
+        self.assertAlmostEqual(refund_order.lines[0].margin, -2.0)
+        self.assertAlmostEqual(refund_order.lines[0].margin_percent, 0.6667)
+        self.assertAlmostEqual(refund_order.margin, -1.85)
+        self.assertAlmostEqual(refund_order.margin_percent, 0.6491)
         pos_order = orders[1]
         self.assertAlmostEqual(pos_order.amount_total, 2.85)
         self.assertEqual(len(pos_order.lines), 2)
         self.assertEqual(pos_order.lines[1].product_id.id, self.main_pos_config.discount_product_id.id)
         self.assertAlmostEqual(pos_order.lines[1].price_subtotal_incl, -0.15)
+        self.assertAlmostEqual(pos_order.lines[0].margin, 2.0)
+        self.assertAlmostEqual(pos_order.lines[0].margin_percent, 0.6667)
+        self.assertAlmostEqual(pos_order.margin, 1.85)
+        self.assertAlmostEqual(pos_order.margin_percent, 0.6491)


### PR DESCRIPTION
**Step to reproduce:**
- configure pos for global discount from settings
- start pos
- select product A and add a discount line (product A must have a cost price)
- confirm it.
- refund the same order.
- go to backend and open refunded order from `orders` menu

**Observation:**
- the margin percentage is > 100

**Cause:**
- After  https://github.com/odoo/odoo/commit/9538698f13d5763b49b00f4c06a1a2afc0d6b39e it has been decided to keep order sign regardless if it is refund
or normal order

**Fix:**
- Adapt `_compute_margin` to include signs based on order is refund or not

**Before**
<img width="1151" height="228" alt="image" src="https://github.com/user-attachments/assets/2a1760ad-7ad8-4b64-9d22-cf7cff98c90d" />

<img width="1144" height="198" alt="image" src="https://github.com/user-attachments/assets/8d2d4aff-1293-4906-b79b-518ca22317db" />

After
<img width="1144" height="253" alt="image" src="https://github.com/user-attachments/assets/ec1d4add-d93b-4490-86ad-f5f5d24de9c2" />

<img width="1170" height="244" alt="image" src="https://github.com/user-attachments/assets/c3ce5b6e-a572-4f85-9bf2-f651574ce124" />


opw-5362912


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
