### PR TITLE
[FIX] website: fix the tour `edit_menus`

### DIFF
--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -155,7 +155,6 @@ registerWebsitePreviewTour('edit_menus', {
     },
     // Edit the menu item from the "edit menu" popover button
     ...clickOnEditAndWaitEditMode(),
-    clickOnExtraMenuItem({}, true),
     {
         content: "Wait for the builder sidebar to fully open",
         trigger: ":iframe .editor_enable",
@@ -172,6 +171,7 @@ registerWebsitePreviewTour('edit_menus', {
             await delay(200);
         },
     },
+    clickOnExtraMenuItem({}, true),
     ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Modnar')", "Modnar"),
     {
         content: "Click on the popover Edit Menu button",


### PR DESCRIPTION
Before this commit, when tested locally, `test_17_website_edit_menus` could fail at step 49/117 because the link element marked as "Modnar" could be invisible. The element could be invisible because it could be hidden under the "Extra" menu that is created when too many links are added to the navbar. In order to make the element appear, the "Extra" menu should be opened first. In the test, the call to `clickOnExtraMenuItem` happens at the wrong moment. This commit fixes the problem by calling `clickOnExtraMenuItem` before actually trying to interact with the element. Note that this problem doesn't seem to happen on runbot, but systematically fails on local, probably because of its dependance on screen resolution (determining whether the "Extra" menu is created or not).