### PR TITLE
[FIX] l10n_mr: explicitly define install_demo

### DIFF
--- a/addons/l10n_mr/demo/demo_company.xml
+++ b/addons/l10n_mr/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>mr</value>
         <value model="res.company" eval="obj().env.ref('l10n_mr.demo_company_mr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/c8f5e26ac28f0110d4f1c131d3393c0d4bf0a2f2 , try_loading of demo companies requires `install_demo` to be explicitly defined as True. Otherwise, we get the warning `Incorrect usage of try_loading without a fully loaded registry. This could lead to issues.`

Fix build error: https://runbot.odoo.com/odoo/runbot.build.error/234524



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
