### PR TITLE
[FIX] hr: autofill user email when selecting user in Employee form

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -807,7 +807,7 @@ class HrEmployee(models.Model):
     def _compute_work_contact_details(self):
         for employee in self:
             if employee.work_contact_id:
-                if len(employee.work_contact_id.employee_ids) == 1:
+                if len(employee.work_contact_id.employee_ids) <= 1:
                     employee.work_phone = employee.work_contact_id.phone
                     employee.work_email = employee.work_contact_id.email
 
@@ -817,7 +817,7 @@ class HrEmployee(models.Model):
             if not employee.work_contact_id:
                 employees_without_work_contact += employee
             else:
-                if len(employee.work_contact_id.employee_ids) == 1:
+                if len(employee.work_contact_id.employee_ids) <= 1:
                     employee.work_contact_id.sudo().write({
                         'email': employee.work_email,
                         'phone': employee.work_phone,

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -100,6 +100,18 @@ class TestHrEmployee(TestHrCommon):
         self.assertEqual(employee.work_email, self.res_users_hr_officer.email)
         self.assertEqual(employee.tz, self.res_users_hr_officer.tz)
 
+    def test_employee_computed_from_user(self):
+        self.res_users_hr_officer.name = 'Raoul Grosbedon'
+        self.res_users_hr_officer.email = 'raoul@example.com'
+        Employee = self.env['hr.employee']
+        employee_form = Form(Employee)
+        employee_form.user_id = self.res_users_hr_officer
+        self.assertEqual(employee_form.name, 'Raoul Grosbedon')
+        self.assertEqual(employee_form.work_email, 'raoul@example.com')
+        employee = employee_form.save()
+        self.assertEqual(employee.name, 'Raoul Grosbedon')
+        self.assertEqual(employee.work_email, 'raoul@example.com')
+
     def test_employee_from_manager_tz_no_reset(self):
         _tz = 'Pacific/Apia'
         self.res_users_hr_manager.tz = False


### PR DESCRIPTION
### Issue:
During the creation of a new employee, when we select a user to create the employee, its mail and phone are not inputted in the Form. And when saving the partner linked to the user have its email and phone removed.

### Steps to reproduce:
- Create a new User with an email
- Create a new employee
- In the "Settings" page, select the created user as "User"
- The mail in not automatically inputted in the form view
- Save
- The User no longer have an email

### Cause:
This [commit](https://github.com/odoo/odoo/commit/876bac817ccdc853661f33c53d40070d30c93124#diff-1c37517a76b393d1d30c2b03e96611643a747d12c13b086653989f4068c660b2) added a condition in the compute and inverse methods of the `work_email` field (the field displayed in the form view): `if len(employee.work_contact_id.employee_ids) == 1:`

This condition is meant to avoid linking email and phone when a partner is linked to multiple employees.

The issue is that, when in the form view `len(employee.work_contact_id.employee_ids)` is 0 (the employee is not created yet). So when selecting the user in the form view the compute is not run, so `work_email` is not updated and stays at `False`. When saving, we write `False` in `work_email`, the inverse method is triggered because now the employee is created, so the email of the partner (and user) is also set to `False`.

### Solution:
Instead of checking if the length is exactly 1, we should also consider the case 0, during the creation of the employee.

opw-5361079