### PR TITLE
[IMP] mail: show confirmation dialog with last message when leaving livechat

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[@name='thread content']" position="replace">
             <t>$0</t>
             <t t-if="props.chatWindow.livechatStep === CW_LIVECHAT_STEP.CONFIRM_CLOSE">
-                <CloseConfirmation onCloseConfirmationDialog.bind="onCloseConfirmationDialog" onClickLeaveConversation.bind="close"/>
+                <CloseConfirmation channelName="channel.displayName" onCloseConfirmationDialog.bind="onCloseConfirmationDialog" onClickLeaveConversation.bind="close"/>
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">

--- a/addons/im_livechat/static/src/core/common/close_confirmation.js
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.js
@@ -1,12 +1,23 @@
 import { Component } from "@odoo/owl";
 import { useAutofocus } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 
 export class CloseConfirmation extends Component {
     static template = "im_livechat.CloseConfirmation";
-    static props = ["onCloseConfirmationDialog", "onClickLeaveConversation"];
+    static props = ["onCloseConfirmationDialog", "onClickLeaveConversation", "channelName?"];
 
     setup() {
         useAutofocus({ refName: "confirm" });
+    }
+
+    get confirmationMessage() {
+        if (this.props.channelName) {
+            return _t(
+                "Leaving will end the live chat with %(channel_name)s. Are you sure you want to continue?",
+                { channel_name: this.props.channelName }
+            );
+        }
+        return _t("Leaving will end the live chat. Do you want to proceed?");
     }
 
     onKeydown(ev) {

--- a/addons/im_livechat/static/src/core/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.xml
@@ -7,7 +7,7 @@
                 <div class="position-absolute top-0 end-0 p-1 o-xsmaller">
                     <button class="o-livechat-CloseConfirmation-close btn-close" t-on-click.stop="() => this.props.onCloseConfirmationDialog()"/>
                 </div>
-                <span class="pt-2 pb-3">Leaving will end the live chat. Do you want to proceed?</span>
+                <span class="pt-2 pb-3" t-out="confirmationMessage"/>
                 <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
             </div>
         </div>

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -33,7 +33,7 @@ test("from the discuss app", async () => {
         name: "HR",
         user_ids: [serverState.userId],
     });
-    pyEnv["discuss.channel"].create([
+    const [channelId_1] = pyEnv["discuss.channel"].create([
         {
             channel_type: "livechat",
             channel_member_ids: [
@@ -63,6 +63,11 @@ test("from the discuss app", async () => {
             create_uid: serverState.publicUserId,
         },
     ]);
+    pyEnv["mail.message"].create({
+        body: "Last message from guest_1",
+        model: "discuss.channel",
+        res_id: channelId_1,
+    });
     await start();
     await openDiscuss();
     await contains(
@@ -85,6 +90,10 @@ test("from the discuss app", async () => {
         parent: [".o-mail-DiscussSidebarChannel", { text: "guest_1" }],
     });
     await click(".o-dropdown-item:contains('Leave Channel')");
+    await contains(
+        ".modal-header:has(:text('Leaving will end the live chat with guest_1. Are you sure you want to continue?'))"
+    );
+    await contains(".modal-body .o-mail-Message-body:has(:text('Last message from guest_1'))");
     await click("button:contains(Leave Conversation)");
     await contains(".o-mail-DiscussSidebarChannel", { text: "guest_1", count: 0 });
     await click("[title='Chat Actions']", {

--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -166,15 +166,15 @@ test("can close confirm livechat with keyboard", async () => {
     await triggerHotkey("Enter");
     await contains(".o-mail-Thread:not([data-transient])");
     await triggerHotkey("Escape");
-    await contains(".o-livechat-CloseConfirmation", {
-        text: "Leaving will end the live chat. Do you want to proceed?",
-    });
+    await contains(
+        ".o-livechat-CloseConfirmation:has(:text('Leaving will end the live chat with Mitchell Admin. Are you sure you want to continue?'))"
+    );
     await triggerHotkey("Escape");
     await contains(".o-livechat-CloseConfirmation", { count: 0 });
     await triggerHotkey("Escape");
-    await contains(".o-livechat-CloseConfirmation", {
-        text: "Leaving will end the live chat. Do you want to proceed?",
-    });
+    await contains(
+        ".o-livechat-CloseConfirmation:has(:text('Leaving will end the live chat with Mitchell Admin. Are you sure you want to continue?'))"
+    );
     await triggerHotkey("Enter");
     await expect.waitForSteps(["/im_livechat/visitor_leave_session"]);
     await contains(".o-mail-ChatWindow", { text: "Did we correctly answer your question?" });

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -279,7 +279,7 @@ test("Active category item should be visible even if the category is closed", as
 
 test("Clicking on leave button leaves the channel", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({
+    const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({
@@ -291,11 +291,20 @@ test("Clicking on leave button leaves the channel", async () => {
         livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
+    pyEnv["mail.message"].create({
+        body: "Last message from Visitor",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "Visitor 11" });
     await click("[title='Chat Actions']");
     await click(".o-dropdown-item:contains('Leave Channel')");
+    await contains(
+        ".modal-header:has(:text('Leaving will end the live chat with Visitor 11. Are you sure you want to continue?'))"
+    );
+    await contains(".modal-body .o-mail-Message-body:has(:text('Last message from Visitor'))");
     await click("button:contains(Leave Conversation)");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Visitor 11" });
 });


### PR DESCRIPTION
Previously, the confirmation dialog shown when leaving a livechat session was too generic and did not provide enough context to help agents ensure they were closing the correct conversation. As a result, agents could accidentally leave the wrong chat, especially when the livechat list is reordered due to new incoming messages.

This PR improves the dialog to make the action clearer and safer:
- Displays the visitor’s name in the confirmation title.
- Shows the most recent message from the conversation in the dialog body.
- Helps agents verify they are leaving the intended conversation.

task-5355106

Before this PR: 
<img width="593" height="138" alt="image" src="https://github.com/user-attachments/assets/363eeab9-0306-47cc-8f4f-4035862f7e29" />

After this PR:
<img width="1135" height="277" alt="image" src="https://github.com/user-attachments/assets/6a7b7aea-d3bf-4b52-be39-001448ba7afc" />

Before vs After (Chat Window)
<table> <tr> <td> <img width="256" height="422" src="https://github.com/user-attachments/assets/b895b831-e11d-4aee-8f35-cd79f5c77aaf" /> </td> <td> <img width="256" height="422" src="https://github.com/user-attachments/assets/d31c061d-6a6e-42cb-ae60-12a5329cd4d4" /> </td> </tr> </table>


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
