### PR TITLE
[FIX] mail: patch with cleanup window in discuss HOOT test

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -38,7 +38,6 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
-import { patch } from "@web/core/utils/patch";
 import { getOrigin, url } from "@web/core/utils/urls";
 
 const { DateTime } = luxon;
@@ -2211,7 +2210,7 @@ test("Prettify message links", async () => {
 });
 
 test("Clicking message link does not open a new tab", async () => {
-    patch(window, {
+    patchWithCleanup(window, {
         open() {
             expect.step("new_window");
             super.open();


### PR DESCRIPTION
Window is patched in test to intercept `window.open()` but was made without cleanup.