### PR TITLE
[FIX] website_sale: Maintain correct product image aspect ratio in grid

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -826,3 +826,7 @@ a.no-decoration {
 .accordion-button:not(.collapsed).bg-transparent::after {
     background-image: escape-svg($accordion-button-icon);
 }
+
+.object-fit-contain {
+    object-fit: contain !important;
+}

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -193,7 +193,7 @@
                 <a t-att-href="product_href" class="oe_product_image_link d-block h-100 position-relative" itemprop="url" contenteditable="false">
                     <t t-set="image_holder" t-value="product._get_image_holder()"/>
                     <span t-field="image_holder.image_1920"
-                        t-options="{'widget': 'image', 'preview_image': image_type, 'itemprop': 'image', 'class': 'h-100 w-100 position-absolute'}"
+                        t-options="{'widget': 'image', 'preview_image': image_type, 'itemprop': 'image', 'class': 'h-100 w-100 position-absolute object-fit-contain'}"
                         class="oe_product_image_img_wrapper d-flex h-100 justify-content-center align-items-center position-absolute"/>
 
                     <t t-set="bg_color" t-value="td_product['ribbon']['bg_color'] or ''"/>


### PR DESCRIPTION
Steps to reproduce:
===================
1- Add a product with a very large image width & publish product.
2. Go to the Shop page & type product name. -> The product image is blurred.

Cause:
======
The product images have `h-100 w-100` classes which force them to fill the container dimensions exactly, ignoring their intrinsic aspect ratio.

Solution:
=========
Add the `object-fit-contain`  class to the image. This ensures the image scales to fit within the container while preserving its aspect ratio.

Side note: `object-fit-contain` class will be added only in version 17.0 In the next versions the class already exists.

opw-5258658

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
