### PR TITLE
[IMP] point_of_sale: add reload data button on error dialogs

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.js
+++ b/addons/point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.js
@@ -1,7 +1,15 @@
 import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { patch } from "@web/core/utils/patch";
+import { logPosMessage } from "@point_of_sale/app/utils/pretty_console_log";
+import { SyncPopup } from "@point_of_sale/app/components/popups/sync_popup/sync_popup";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { _t } from "@web/core/l10n/translation";
 
 patch(ConfirmationDialog.prototype, {
+    setup() {
+        super.setup();
+        this.pos = usePos();
+    },
     async _cancel() {
         this.props.getPayload && this.props.getPayload(false);
         return this.execButton(this.props.cancel);
@@ -14,14 +22,40 @@ patch(ConfirmationDialog.prototype, {
         this.props.getPayload && this.props.getPayload(false);
         return this.execButton(this.props.dismiss || this.props.cancel);
     },
+    async _reloadData() {
+        this.props.close();
+        if (this.pos.config?.module_pos_restaurant) {
+            try {
+                await this.pos.syncAllOrders();
+            } catch (error) {
+                logPosMessage("Failed to sync orders:", error);
+            }
+        }
+        this.pos.dialog.add(SyncPopup, {
+            title: _t("Reload Data"),
+            confirm: (fullReload) => this.pos.reloadData(fullReload),
+        });
+    },
 });
 
 ConfirmationDialog.props = {
     ...ConfirmationDialog.props,
     getPayload: { type: Function, optional: true },
+    showReloadButton: { type: Boolean, optional: true },
+};
+
+ConfirmationDialog.defaultProps = {
+    ...ConfirmationDialog.defaultProps,
+    showReloadButton: false,
 };
 
 AlertDialog.props = {
     ...AlertDialog.props,
     getPayload: { type: Function, optional: true },
+    showReloadButton: { type: Boolean, optional: true },
+};
+
+AlertDialog.defaultProps = {
+    ...AlertDialog.defaultProps,
+    showReloadButton: false,
 };

--- a/addons/point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+  <t t-name="point_of_sale.ConfirmationDialog" t-inherit="web.ConfirmationDialog" t-inherit-mode="extension">
+    <xpath expr="//t[@t-set-slot='footer']" position="inside">
+      <button t-if="props.showReloadButton" class="btn btn-secondary" t-on-click="_reloadData">
+        Reload Data
+      </button>
+    </xpath>
+  </t>
+  <t t-name="point_of_sale.AlertDialog" t-inherit="web.AlertDialog" t-inherit-mode="extension">
+    <xpath expr="//t[@t-set-slot='footer']" position="inside">
+      <button t-if="props.showReloadButton" class="btn btn-secondary" t-on-click="_reloadData">
+        Reload Data
+      </button>
+    </xpath>
+  </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/components/popups/sync_popup/sync_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/sync_popup/sync_popup.xml
@@ -6,6 +6,7 @@
                 <h4 class="modal-title" t-esc="props.title" />
             </t>
             <div class="payment-methods-overview overflow-auto">
+                <h5 class="text-warning">Be aware that reloading data will delete unsaved orders.</h5>
                 <p>You can update it by selecting one of the following options:</p>
                 <ul>
                     <li><strong>Limited Synchronization:</strong> Quickly refresh essential data.</li>

--- a/addons/point_of_sale/static/src/app/hooks/hooks.js
+++ b/addons/point_of_sale/static/src/app/hooks/hooks.js
@@ -56,6 +56,7 @@ export function useErrorHandlers() {
             await dialog.add(AlertDialog, {
                 title: _t("Unknown Error"),
                 body: _t("The order could not be sent to the server due to an unknown error"),
+                showReloadButton: true,
             });
         }
     };

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -97,6 +97,7 @@ export class ReceiptScreen extends Component {
                 body: _t(
                     "This order is not yet synced to server. Make sure it is synced then try again."
                 ),
+                showReloadButton: true,
             });
             return Promise.reject();
         }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
@@ -50,6 +50,7 @@ export class InvoiceButton extends Component {
                 this.dialog.add(AlertDialog, {
                     title: _t("Network Error"),
                     body: _t("Unable to download invoice."),
+                    showReloadButton: true,
                 });
             }
         }

--- a/addons/point_of_sale/static/src/app/utils/error_handlers.js
+++ b/addons/point_of_sale/static/src/app/utils/error_handlers.js
@@ -58,6 +58,7 @@ function defaultErrorHandler(env, error, originalError) {
         env.services.dialog.add(AlertDialog, {
             title: _t("Unknown Error"),
             body: _t("Unable to show information about this error."),
+            showReloadButton: true,
         });
     }
     return true;

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -635,6 +635,7 @@ patch(PosStore.prototype, {
                         'The reward "%s" contain an error in its domain, your domain must be compatible with the PoS client',
                         this.models["loyalty.reward"].getAll()[index].description
                     ),
+                    showReloadButton: true,
                 });
 
                 reward.delete();

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -93,6 +93,7 @@ patch(PaymentScreen.prototype, {
                         body: _t(
                             "There is a problem with the server. The order online payment status cannot be retrieved."
                         ),
+                        showReloadButton: true,
                     });
                     return false;
                 }
@@ -200,6 +201,7 @@ patch(PaymentScreen.prototype, {
             this.dialog.add(AlertDialog, {
                 title: _t("Server error"),
                 body: _t("The saved order could not be retrieved."),
+                showReloadButton: true,
             });
             return;
         }
@@ -216,6 +218,7 @@ patch(PaymentScreen.prototype, {
             this.dialog.add(AlertDialog, {
                 title: _t("Order saving issue"),
                 body: _t("The order has not been saved correctly on the server."),
+                showReloadButton: true,
             });
             return;
         }
@@ -235,6 +238,7 @@ patch(PaymentScreen.prototype, {
                 this.dialog.add(AlertDialog, {
                     title: _t("Invoice could not be generated"),
                     body: _t("The invoice could not be generated."),
+                    showReloadButton: true,
                 });
             } else {
                 await this.invoiceService.downloadPdf(orderJSON[0].account_move);


### PR DESCRIPTION
Purpose:
------------
- On Error dialogs, users only had "Ok" or could close the dialog, with no
  guidance on what to do next.
- Many blocking issues are resolved simply by reloading POS data.

Before this commit:
-----------
- Error dialogs only had an "Ok" button.

After this commit:
------------------
- Added a "Reload Data" button for quick recovery of common blocking issues.
- Added a warning message in the reload data popup
- For POS Restaurant, orders will attempt to sync before reloading data, 
  reducing the risk of data loss.

Task-5353590
