### PR TITLE
[FIX] point_of_sale: prevent year sensitive runbot error

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2934,7 +2934,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_cross_exclusion_attribute_values')
 
-    @freeze_time("2025-08-28 04:15:00")
     def test_consistent_order_receipt_number_offline(self):
         """
         Tests that an order will have the same receipt number if it was done
@@ -2947,9 +2946,9 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         orders = self.env['pos.order'].search([], order="id desc", limit=2)
         # Online, with a 0
-        self.assertEqual(orders[1].pos_reference, f"2501-{orders[1].session_id.id:03d}-00001")
+        self.assertEqual(orders[1].pos_reference, f"{orders[1].pos_reference[:2]}01-{orders[1].session_id.id:03d}-00001")
         # Offline, with a 1 and no Order
-        self.assertEqual(orders[0].pos_reference, f"2501-{orders[0].session_id.id:03d}-10001")
+        self.assertEqual(orders[0].pos_reference, f"{orders[0].pos_reference[:2]}01-{orders[0].session_id.id:03d}-10001")
 
     def test_sync_from_ui_one_by_one(self):
         """


### PR DESCRIPTION
**Why the fix:**
The date was frozen in the backend but it did not work in the case where we are offline. This happens because when offline we get the date in the frontend by creating a *new Date()*, which is not affected by either the backend or the frontend freezeDate.

This means that when the year changes, this test would fail, as we check that the year is 2025 by hardcoding it.

To avoid this, we now use the pos_reference value to build this part back together.

runbot-233565