### PR TITLE
[19.0][FIX] Fix domain add operation

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -134,13 +134,15 @@ class EventEvent(models.Model):
         if self:
             base_domain = Domain('event_id', 'in', self.ids) & base_domain
 
-        visitor_domain = Domain.TRUE
+        visitor_domain = Domain.FALSE
         partner_id = self.env.user.partner_id
         if current_visitor:
             visitor_domain = Domain('visitor_id', '=', current_visitor.id)
             partner_id = current_visitor.partner_id
         if partner_id:
             visitor_domain |= Domain('partner_id', '=', partner_id.id)
+        if visitor_domain.is_false():
+            return self.env['event.event']
 
         registrations_events = self.env['event.registration'].sudo()._read_group(
             visitor_domain & base_domain,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When no current_visitor, the partner domain is not added
This behaviour was discovered within a unit test that did not create a visitor. This resulted in all event registrations being considered instead of just the one of the partner.

Current behavior before PR:
- when there is no current_visitor, the domain of the partner_id is not added
```
visitor_domain = [(1, '=', 1)]
visitor_domain |= Domain('partner_id', '=', partner_id.id)

--> visitor_domain == [(1, '=', 1)]
```

Desired behavior after PR is merged:
- partner_id domain is added
```
visitor_domain = [(1, '=', 1)]
visitor_domain &= Domain('partner_id', '=', partner_id.id)

--> visitor_domain == [(1, '=', 1), ('partner_id', '=', partner_id.id)]
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
