### PR TITLE
[FIX] account: discard data from non dependent modules

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1381,6 +1381,7 @@ class AccountChartTemplate(models.AbstractModel):
                 for model, fnames in spec.items()
             }
             ChartTemplate._pre_reload_data(company, {}, pre_defined_data, force_update=True)
+            ChartTemplate._pre_load_data(company.chart_template, company, {}, pre_defined_data)
             ChartTemplate._load_data(pre_defined_data)
 
     # --------------------------------------------------------------------------------

--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -78,6 +78,7 @@ class IrModuleModule(models.Model):
                         module_template_data.pop('template_data', None)
                         if module_template_data:
                             ChartTemplate._pre_reload_data(company, {}, module_template_data, force_update=True)
+                            ChartTemplate._pre_load_data(company.chart_template, company, {}, module_template_data)
                             ChartTemplate._load_data(module_template_data)
             if (
                 not self.env.company.chart_template


### PR DESCRIPTION
In order to avoid declaring an exponential number of bridge modules, we can define values for fields declared in modules that are not in the dependencies of the l10n.
In order to support that, `_pre_load_data` needs to be called before `_load_data` as it is the method discarding those fields.

Reproduce:
* Create a database with only `account` and the demo data
* Install a l10n with stock account defined, for instance `l10n_mx`

