### PR TITLE
[PERF] mail: faster click handler of message action "reply"

### DIFF
--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -112,7 +112,7 @@ export class Composer extends Record {
         },
     });
     autofocus = 0;
-    replyToMessage = fields.One("mail.message");
+    replyToMessage = fields.One("mail.message", { inverse: "composerAsReplyToMessage" });
     /** @type {"text" | "html" | undefined} */
     updateFrom = undefined;
 

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -264,7 +264,7 @@ export class Message extends Component {
             "pt-1": !this.props.asCard && !this.props.squashed,
             "o-pt-0_5": !this.props.asCard && this.props.squashed,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
-            "o-selected": this.props.thread?.composer.replyToMessage?.eq(this.props.message),
+            "o-selected": this.props.message.composerAsReplyToMessage?.thread.eq(this.props.thread),
             "o-squashed": this.props.squashed,
             "mt-1":
                 !this.props.squashed &&
@@ -272,7 +272,6 @@ export class Message extends Component {
                 !this.env.messageCard &&
                 !this.props.asCard,
             "px-1": this.props.isInChatWindow,
-            "opacity-50": this.props.thread?.composer.replyToMessage?.notEq(this.props.message),
             "o-actionMenuMobileOpen": this.ui.isSmall && this.optionsDropdown.isOpen,
             "o-editing": this.isEditing,
         };

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -60,6 +60,7 @@ export class Message extends Record {
         },
     });
     composer = fields.One("Composer", { inverse: "message", onDelete: (r) => r.delete() });
+    composerAsReplyToMessage = fields.One("Composer", { inverse: "replyToMessage" });
     date = fields.Datetime();
     /** @type {string} */
     default_subject;

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -1,5 +1,11 @@
-.o-mail-Thread:focus-visible {
-    outline: 0;
+.o-mail-Thread {
+    &:has(.o-mail-Message.o-selected) .o-mail-Message:not(.o-selected) {
+        opacity: 50% !important;
+    }
+
+    &:focus-visible {
+        outline: 0;
+    }
 }
 
 .o-mail-Thread-jumpPresent {

--- a/addons/mail/static/tests/discuss/core/discuss_performance.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss_performance.test.js
@@ -1,4 +1,5 @@
 import {
+    click,
     contains,
     defineMailModels,
     insertText,
@@ -14,6 +15,7 @@ import { Message } from "@mail/core/common/message";
 import { describe, expect, test } from "@odoo/hoot";
 import { onMounted, onPatched } from "@odoo/owl";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -67,4 +69,43 @@ test("posting new message should only render relevant part", async () => {
     const result2 = stopObserve2();
     expect(result2.get(Composer)).toBeLessThan(3); // 2: temp disabling + clear content
     expect(result2.get(Message)).toBeLessThan(4); // 3: new temp msg + new genuine msg + prev msg
+});
+
+test("replying to message should only render relevant part", async () => {
+    // For example, it should not render all messages when selecting message to reply
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const messageIds = range(0, 10).map((i) =>
+        pyEnv["mail.message"].create({ body: `${i}`, model: "discuss.channel", res_id: channelId })
+    );
+    messageIds.pop(); // remove last as this is the one to be replied to
+    let replying = false;
+    prepareObserveRenders();
+    patchWithCleanup(Message.prototype, {
+        setup() {
+            const cb = () => {
+                if (replying) {
+                    if (messageIds.includes(this.message.id)) {
+                        throw new Error(
+                            "Should not re-render other messages on replying to a message"
+                        );
+                    }
+                }
+            };
+            onMounted(cb);
+            onPatched(cb);
+            return super.setup();
+        },
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 10 });
+    const stopObserve = observeRenders();
+    replying = true;
+    await click(".o-mail-Message:last [title='Reply']");
+    await contains(".o-mail-Composer:has(:text('Replying to Mitchell Admin'))");
+    replying = false;
+    const result = stopObserve();
+    expect(result.get(Composer)).toBeLessThan(2);
+    expect(result.get(Message)).toBeLessThan(2);
 });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -646,8 +646,13 @@ test("Other messages are grayed out when replying to another one", async () => {
     await click(".o-mail-Message [title='Reply']", {
         parent: [".o-mail-Message", { text: "Hello world" }],
     });
-    await contains(".o-mail-Message.opacity-50", { text: "Goodbye world" });
-    await contains(".o-mail-Message:not(.opacity_50)", { text: "Hello world" });
+    await contains(".o-mail-Message.o-selected:has(:text('Hello world'))");
+    expect(
+        getComputedStyle(queryFirst(".o-mail-Message:has(:text('Goodbye world'))")).opacity
+    ).toBe("0.5");
+    expect(getComputedStyle(queryFirst(".o-mail-Message:has(:text('Hello world))")).opacity).toBe(
+        "1"
+    );
 });
 
 test("Parent message body is displayed on replies", async () => {


### PR DESCRIPTION
Before this commit, message action "reply" click handler could be slow. This happens because visually all messages but the one to reply is selected, and non-selected messages have their opacity reduced. The reduced opacity was triggered from re-rendering all the message, which all observe `thread.composer.replyToMessage` to compare with themselves.

This is quite inefficient, especially when lots of messages are loaded, just to reduce opacity of all but the selected message to reply.

This commit improves by rendering only the selected message, and adapt style of all other messages in CSS.

With about 125 messages loaded, click handler timing goes from about 320ms to 60ms.

Task-5262770