### PR TITLE
[REF] mail: refactor displayInSidebar

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.js
@@ -2,7 +2,7 @@ import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_app/s
 import { DiscussSidebarCategory } from "@mail/discuss/core/public_web/discuss_app/sidebar/category";
 import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel";
 
-import { Component, useSubEnv } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useService } from "@web/core/utils/hooks";
@@ -25,13 +25,6 @@ export class DiscussSidebarCategories extends Component {
         this.store = useService("mail.store");
         this.discusscorePublicWebService = useService("discuss.core.public.web");
         this.orm = useService("orm");
-        useSubEnv({
-            filteredThreads: (threads) => this.filteredThreads(threads),
-        });
-    }
-
-    filteredThreads(threads) {
-        return threads.filter((thread) => thread.displayInSidebar);
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.xml
@@ -11,7 +11,7 @@
     <t t-name="mail.DiscussSidebarCategories.category">
         <DiscussSidebarCategory category="category"/>
         <t t-if="category.is_open">
-            <DiscussSidebarChannel t-foreach="filteredThreads(category.threads)" t-as="thread" t-key="thread.localId" thread="thread"/>
+            <DiscussSidebarChannel t-foreach="category.threads.filter((thread) => thread.channel.isDisplayInSidebar)" t-as="thread" t-key="thread.localId" thread="thread"/>
         </t>
         <DiscussSidebarChannel t-elif="store.discuss.thread?.in(category.threads)" thread="store.discuss.thread"/>
         <DiscussSidebarChannel t-elif="store.discuss.thread?.parent_channel_id?.in(category.threads)" thread="store.discuss.thread.parent_channel_id" />

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -83,7 +83,7 @@ export class DiscussSidebarChannel extends Component {
     get bordered() {
         return (
             this.store.discuss.isSidebarCompact &&
-            Boolean(this.env.filteredThreads?.(this.thread.sub_channel_ids)?.length)
+            Boolean(this.thread.channel?.subChannelsInSidebar?.length)
         );
     }
 
@@ -112,7 +112,7 @@ export class DiscussSidebarChannel extends Component {
     }
 
     get subChannels() {
-        return this.env.filteredThreads?.(this.thread.sub_channel_ids) ?? [];
+        return this.thread.channel.subChannelsInSidebar;
     }
 
     showThread(sub) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
@@ -10,6 +10,20 @@ const discussChannelPatch = {
         this.discuss_category_id = fields.One("discuss.category", {
             inverse: "channel_ids",
         });
+        this.isDisplayInSidebar = fields.Attr(false, {
+            compute() {
+                return (
+                    this.displayToSelf ||
+                    this.isLocallyPinned ||
+                    this.sub_channel_ids.some((thread) => thread.channel?.isDisplayInSidebar)
+                );
+            },
+        });
+        this.subChannelsInSidebar = fields.Many("mail.thread", {
+            compute() {
+                return this.sub_channel_ids?.filter((thread) => thread.channel?.isDisplayInSidebar);
+            },
+        });
     },
     delete() {
         this.store.env.services.bus_service.deleteChannel(this.busChannel);

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -18,7 +18,7 @@ const threadPatch = {
         });
         this.categoryAsThreadWithCounter = fields.One("DiscussAppCategory", {
             compute() {
-                return this.displayInSidebar && this.importantCounter > 0
+                return this.channel?.isDisplayInSidebar && this.importantCounter > 0
                     ? this.discussAppCategory
                     : null;
             },
@@ -49,15 +49,6 @@ const threadPatch = {
             sort: (a, b) =>
                 compareDatetime(b.channel?.lastInterestDt, a.channel?.lastInterestDt) ||
                 b.id - a.id,
-        });
-        this.displayInSidebar = fields.Attr(false, {
-            compute() {
-                return (
-                    this.displayToSelf ||
-                    this.isLocallyPinned ||
-                    this.sub_channel_ids.some((t) => t.displayInSidebar)
-                );
-            },
         });
         this.loadSubChannelsDone = false;
         /** @type {import("models").Thread|null} */


### PR DESCRIPTION
This commit moves `displayInSidebar` to the channel and renames it
`isDisplayInSidebar` to be consistent with other boolean fields.
We also remove `filteredThreads` that can now be computed inside the models.