### PR TITLE
[REV] portal: revert revoke access from portal user to public

### DIFF
--- a/addons/portal/tests/test_portal_wizard.py
+++ b/addons/portal/tests/test_portal_wizard.py
@@ -108,8 +108,9 @@ class TestPortalWizard(MailCommon):
             portal_user.action_revoke_access()
 
         self.assertEqual(portal_user.user_id, self.public_user, 'Must keep the user even if it is archived')
+        self.assertEqual(group_public, portal_user.user_id.groups_id, 'Must add the group public after removing the portal group')
         self.assertFalse(portal_user.user_id.active, 'Must have archived the user')
-        self.assertTrue(portal_user.is_portal)
+        self.assertFalse(portal_user.is_portal)
         self.assertFalse(portal_user.is_internal)
         self.assertNotSentEmail()
 

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -163,14 +163,16 @@ class PortalWizardUser(models.TransientModel):
         return self.action_refresh_modal()
 
     def action_revoke_access(self):
-        """Archive the portal user of the partner.
+        """Remove the user of the partner from the portal group.
 
-        User is kept in `group_portal` as `group_public` should only be
-        used for automated tasks and guest interactions.
+        If the user was only in the portal group, we archive it.
         """
         self.ensure_one()
         if not self.is_portal:
             raise UserError(_('The partner "%s" has no portal access or is internal.', self.partner_id.name))
+
+        group_portal = self.env.ref('base.group_portal')
+        group_public = self.env.ref('base.group_public')
 
         self._update_partner_email()
 
@@ -179,8 +181,9 @@ class PortalWizardUser(models.TransientModel):
 
         user_sudo = self.user_id.sudo()
 
+        # remove the user from the portal group
         if user_sudo and user_sudo.has_group('base.group_portal'):
-            user_sudo.write({'active': False})
+            user_sudo.write({'groups_id': [(3, group_portal.id), (4, group_public.id)], 'active': False})
 
         return self.action_refresh_modal()
 


### PR DESCRIPTION
**Issue:**
Active check is needed when granting access to a previous portal user which was archived. But changing the template to fix this is not stable for previous versions.

**Fix:**
Reverted https://github.com/odoo/odoo/pull/233757 in 17.0
(Fixed with https://github.com/odoo/odoo/pull/236462 in 18.0+) -> reverted as well for now https://github.com/odoo/odoo/pull/239477

opw-4760550