### PR TITLE
[FIX] tests: fix traceback log retry

### DIFF
--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -33,6 +33,28 @@ class TestRetry(TestRetryCommon):
         self.assertEqual(tests_run_count, self.count)
 
 
+@tagged('test_retry', 'test_retry_success')
+class TestRetryTraceback(TestRetryCommon):
+    """ Check some tests behaviour when ODOO_TEST_FAILURE_RETRIES is set"""
+
+    def test_retry_traceback_success(self):
+        tests_run_count = self.get_tests_run_count()
+        self.update_count()
+        if tests_run_count != self.count:
+            _logger.error('Traceback (most recent call last):\n')
+        self.assertEqual(tests_run_count, self.count)
+
+
+@tagged('test_retry', 'test_retry_success')
+class TestRetryTracebackArg(TestRetryCommon):
+    def test_retry_traceback_args_success(self):
+        tests_run_count = self.get_tests_run_count()
+        self.update_count()
+        if tests_run_count != self.count:
+            _logger.error('%s', 'Traceback (most recent call last):\n')
+        self.assertEqual(tests_run_count, self.count)
+
+
 @tagged('-standard', 'test_retry', 'test_retry_failures')
 class TestRetryFailures(TestRetryCommon):
     def test_retry_failure_assert(self):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1389,7 +1389,7 @@ class ChromeBrowser:
             self._websocket_send(cmd, params={'requestId': params['requestId'], **response})
         except websocket.WebSocketConnectionClosedException:
             pass
-        except (BrokenPipeError, ConnectionResetError):
+        except (BrokenPipeError, ConnectionResetError, OSError):
             # this can happen if the browser is closed. Just ignore it.
             _logger.info("Websocket error while handling request %s", params['request']['url'])
 

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -856,6 +856,7 @@ class lower_logging(logging.Handler):
             record.levelname = f'_{record.levelname}'
             record.levelno = self.to_level
             self.had_error_log = True
+            record.msg = record.msg.replace('Traceback (most recent call last):', '_Traceback_ (most recent call last):')
             record.args = tuple(arg.replace('Traceback (most recent call last):', '_Traceback_ (most recent call last):') if isinstance(arg, str) else arg for arg in record.args)
 
         if logging.getLogger(record.name).isEnabledFor(record.levelno):


### PR DESCRIPTION
The auto-retry is supposed to catch error logs as well as tracebacks. In some cases a traceback is logged as a message, and not as a logger arg, bypassing the replace already in place.

This pr simply replaces the traceback string in the message as well.

Build error [234619](https://runbot.odoo.com/odoo/runbot.build.error/234619)


Also fixes OSError while handling request paused
Build error [229906](https://runbot.odoo.com/odoo/runbot.build.error/229906)