### PR TITLE
[FIX] point_of_sale,l10n_fr_pos_cert: fix displaying old price

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -15,7 +15,7 @@
                     Old unit price:
                     <span class="oldPrice">
                         <s>
-                            <t t-out="line.currencyDisplayPrice" /> / Units
+                            <t t-out="line.product_id.displayPriceUnit" /> / Units
                         </s>
                     </span>
                 </div>

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderSummary.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderSummary.xml
@@ -7,7 +7,7 @@
                     Old unit price:
                     <span class="oldPrice">
                         <s>
-                            <t t-esc="line.currencyDisplayPrice" /> / Units
+                            <t t-esc="line.product_id.displayPriceUnit" /> / Units
                         </s>
                     </span>
                 </li>

--- a/addons/l10n_fr_pos_cert/static/tests/tours/l10n_fr_pos_cert_tour.js
+++ b/addons/l10n_fr_pos_cert/static/tests/tours/l10n_fr_pos_cert_tour.js
@@ -3,6 +3,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("l10nFrPosCertSelfInvoicingTour", {
@@ -18,6 +19,32 @@ registry.category("web_tour.tours").add("l10nFrPosCertSelfInvoicingTour", {
             {
                 trigger: ".pos-receipt #posqrcode",
                 content: "QR code is visible on the receipt",
+            },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_correct_old_price_upon_price_change_fr", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            ProductScreen.selectedOrderlineHas("Desk Pad", "1", "1.98"),
+            Numpad.click("Price"),
+            Numpad.isActive("Price"),
+            Numpad.click("5"),
+            ProductScreen.selectedOrderlineHas("Desk Pad", "1", "5.00"),
+            {
+                content: "Old unit price is correctly shown",
+                trigger: ".order-container .orderline.selected:has(.oldPrice:contains(1.98))",
+            },
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            {
+                content: "Old unit price is correctly shown",
+                trigger: ".order-container .orderline:has(.oldPrice:contains(1.98))",
             },
         ].flat(),
 });

--- a/addons/l10n_fr_pos_cert/tests/test_frontend.py
+++ b/addons/l10n_fr_pos_cert/tests/test_frontend.py
@@ -21,3 +21,9 @@ class TestUi(Testl10nFrPosCert):
         self.assertEqual(company.country_id.code, "FR", "Company should be set to France (FR)")
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour("l10nFrPosCertSelfInvoicingTour", login="pos_user")
+
+    def test_correct_old_price_upon_price_change_fr(self):
+        company = self.main_pos_config.company_id
+        self.assertEqual(company.country_id.code, "FR", "Company should be set to France (FR)")
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_correct_old_price_upon_price_change_fr", login="pos_user")

--- a/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
@@ -2,6 +2,7 @@ import { roundPrecision } from "@web/core/utils/numbers";
 import { Base } from "../related_models";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { _t } from "@web/core/l10n/translation";
+import { formatCurrency } from "@web/core/currency";
 
 export class ProductTemplateAccounting extends Base {
     static pythonModel = "product.template";
@@ -157,5 +158,14 @@ export class ProductTemplateAccounting extends Base {
         accountTaxHelpers.add_tax_details_in_base_line(baseLine, config.company_id);
         accountTaxHelpers.round_base_lines_tax_details([baseLine], config.company_id);
         return baseLine.tax_details;
+    }
+
+    get displayPriceUnit() {
+        const config = this.models["pos.config"].getFirst();
+        const price =
+            config.iface_tax_included === "total"
+                ? this.getTaxDetails().total_included
+                : this.getTaxDetails().total_excluded;
+        return formatCurrency(price, config.currency_id.id);
     }
 }


### PR DESCRIPTION
Steps to reproduce
------------------
1. Insall `l10n_fr_pos_cert` and set the company to the french one
2. Open PoS, and select a product, it will have a price say X
3. Using the numpad, change the price of that product to Y

Observe that the line now says "Old price unit: Y * Qty / Unit", instead of it being "X / Unit".

Why it's happening:
-------------------
We were displaying the `currencyDisplayPrice`, which is the total amount
to be paid, instead.

The fix
-------
We add a getter on the product model `displayPriceUnit`, it shows the
original product unit price.

We therefore introduce a new getter that compute the unit price using the original lst price.

opw-5365735
opw-5378158