### PR TITLE
[FIX] mail,*: no formatting paste in HTML composer

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -236,6 +236,9 @@ export class ClipboardPlugin extends Plugin {
         if (odooEditorHtml) {
             const fragment = parseHTML(this.document, odooEditorHtml);
             this.dependencies.sanitize.sanitize(fragment);
+            if (this.delegateTo("handle_paste_html_override", fragment)) {
+                return true;
+            }
             if (fragment.hasChildNodes()) {
                 this.dependencies.dom.insert(fragment);
             }
@@ -254,6 +257,11 @@ export class ClipboardPlugin extends Plugin {
         const textContent = clipboardData.getData("text/plain");
         if (ONLY_LINK_REGEX.test(textContent)) {
             return false;
+        }
+        const fragment = parseHTML(this.document, clipboardHtml);
+        this.dependencies.sanitize.sanitize(fragment);
+        if (this.delegateTo("handle_paste_html_override", fragment)) {
+            return true;
         }
         if (files.length || clipboardHtml) {
             const clipboardElem = this.prepareClipboardData(clipboardHtml);

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -4,13 +4,31 @@ import { isEmptyBlock } from "@html_editor/utils/dom_info";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
+const ALLOWED_TAGS = [
+    "A",
+    "B",
+    "DIV",
+    "EM",
+    "I",
+    "LI",
+    "OL",
+    "P",
+    "S",
+    "SPAN",
+    "STRONG",
+    "U",
+    "UL",
+];
+
+const PRESERVED_CLASSNAMES = new Set(["o_mail_redirect", "o_channel_redirect", "o-discuss-mention"]);
+
 /**
  * This plugin works with the composer used in Discuss, ChatWindow and Chatter.
  * For the full composer, it is using HtmlComposerMessageField.
  */
 export class MailComposerPlugin extends Plugin {
     static id = "mail_composer";
-    static dependencies = ["clipboard", "hint", "input", "selection"];
+    static dependencies = ["clipboard", "dom", "hint", "history", "input", "selection"];
     resources = {
         before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
         bypass_paste_image_files: () => true,
@@ -21,6 +39,7 @@ export class MailComposerPlugin extends Plugin {
                 text: this.config.placeholder,
             }),
         ],
+        handle_paste_html_override: this.handlePasteHtmlOverride.bind(this),
         hint_targets_providers: (selectionData, editable) => {
             const el = editable.firstChild;
             if (
@@ -53,5 +72,39 @@ export class MailComposerPlugin extends Plugin {
             "focusout",
             this.config.composerPluginDependencies.onFocusout
         );
+    }
+    handlePasteHtmlOverride(sanitizedFragment) {
+        if (sanitizedFragment.childNodes.length === 0) {
+            return false;
+        }
+        const removeStyle = (node) => {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                const tagName = node.nodeName.toUpperCase();
+                if (tagName === "BR") {
+                    return;
+                }
+                if (!ALLOWED_TAGS.includes(tagName)) {
+                    node.replaceWith(document.createTextNode(node.textContent));
+                    return;
+                }
+                node.removeAttribute("style");
+                if (node.hasAttribute("class")) {
+                    const preservedClasses = [...node.classList].filter((className) =>
+                        PRESERVED_CLASSNAMES.has(className)
+                    );
+                    if (preservedClasses.length) {
+                        node.className = preservedClasses.join(" ");
+                    } else {
+                        node.removeAttribute("class");
+                    }
+                }
+                // Recursively sanitize child nodes
+                [...node.childNodes].forEach(removeStyle);
+            }
+        };
+        [...sanitizedFragment.childNodes].forEach(removeStyle);
+        this.dependencies.dom.insert(sanitizedFragment);
+        this.dependencies.history.addStep();
+        return true;
     }
 }


### PR DESCRIPTION
When pasting content into the HTML editor composer, we want to
ensure that no formatting is retained from the source in Discuss.

This is achieved by intercepting the paste event in the clipboard
plugin and removing the style and remove tags that we do not want to
allow in the HTML editor composer in Discuss.
This prevents any unwanted styles or HTML elements from being introduced into
the composer in Discuss.

task-5364799




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
