### PR TITLE
[FIX] 16.0: Peppol sending fails due to missing access rights on `account.edi.document.attachment_id

### DIFF
--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -127,7 +127,7 @@ class AccountInvoiceSend(models.TransientModel):
                 invoice_data['error'] = _('Please verify partner configuration in partner settings.')
                 continue
 
-            attachment = invoice._get_peppol_document().attachment_id
+            attachment = invoice._get_peppol_document().sudo().attachment_id
             if not attachment:
                 invoice.peppol_move_state = 'error'
                 invoice_data['error'] = _('Please check that a Peppol document has been generated.')


### PR DESCRIPTION
#### Problem

When sending a Peppol invoice through the *Send & Print* wizard, accounting users receive:

```
Access Denied by ACLs for operation: read,
uid: <user_id>, model: account.edi.document, fields: attachment_id
```

This happens because `account.edi.document.attachment_id` is restricted to `base.group_system`, yet the wizard tries to read it here:

```python
attachment = invoice._get_peppol_document().attachment_id
```

As a result, non-admin users cannot send Peppol invoices even when all other permissions are correct.

#### Root cause

The send flow legitimately needs to fetch the generated Peppol XML/PDF, but this field is protected and the wizard is executed under the accounting user’s rights. Since the wizard does not modify anything on the attachment, only needs to *read* it, the restriction breaks the normal Peppol workflow.

#### Fix

Use `sudo()` when accessing the Peppol EDI document’s attachment:

```python
attachment = invoice._get_peppol_document().sudo().attachment_id
```

This is safe, as the wizard only retrieves the file produced earlier by the system and does not expose wider attachment access.

#### Why this matters

Without this patch, any accounting user without system privileges is unable to send Peppol invoices — a blocking issue in production setups.
