### PR TITLE
[IMP] hr_recruitment, website_hr_recruitment: refine recruitment design

### DIFF
--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -12,14 +12,22 @@
                 --Ribbon-wrapper-width: 5rem;
                 --Ribbon-height: 1.9;
 
-                @include media-breakpoint-up(md) {
-                    min-width: 768px;
+                @include media-breakpoint-between(md, xxl) {
+                    min-width: calc(100vw - (#{$btn-font-size-sm} + #{$btn-padding-x-sm * 2} + #{map-get($spacers, 1) * 4})); // cscreen size reduced by the size of the closed search panel
                 }
 
                 &:not(.o_kanban_ghost) {
                     border: none;
                     border-bottom: $border-width solid $border-color;
                     justify-content: center;
+                }
+
+                .o_hr_recruitment_no-activity {
+                    visibility: var(--KanbanRecord-visibility, hidden);
+                }
+
+                &:hover .o_hr_recruitment_no-activity {
+                    --KanbanRecord-visibility: visible;
                 }
             }
 
@@ -43,21 +51,34 @@
         }
 
         .o_kanban_card_header {
-            --o-kanban-card-header-title-favorite-width: 1.4rem;
-
             margin-bottom: 1px;
 
-            .o_favorite {
-                width: var(--o-kanban-card-header-title-favorite-width);
+            .o_favorite a {
+                display: flex;
+                justify-content: center;
+                margin-right: map-get($spacers, 1);
+                width: var(--Avatar-size);
+
+                i {
+                    --Favorite-font-size: #{$h3-font-size};
+
+                    margin: 0 !important;
+                }
             }
 
-            & > div:where(:not(:first-child)) {
-                margin-left: var(--o-kanban-card-header-title-favorite-width);
+            .fa-envelope {
+                width: var(--Avatar-size);
+            }
+        }
+
+        @include media-breakpoint-down(xxl) {
+            .o_hr_recruitment_activity-col {
+                width: map-get($spacers, 3) *  3.5;
             }
         }
 
         .o_field_many2one_avatar_user .o_avatar{
-            column-gap: 0.375rem;
+            column-gap: map-get($spacers, 1);
         }
         
         .o_hr_recruitment_kanban_card_mobile_screen {
@@ -67,6 +88,12 @@
         &.o_kanban_grouped {
             .o_hr_recruitment_kanban_card_large_screen {
                 display: none;    
+            }
+        }
+
+        .o_dropdown_kanban {
+            @include media-breakpoint-down(xl) {
+                visibility: visible;
             }
         }
     }
@@ -89,15 +116,15 @@
 }
 
 .o_hr_recruitment_kanban {
-    .o_m2o_avatar {
-        --Avatar-size: 1.5em;
+    --Avatar-size: 1.5em;
 
+    .o_m2o_avatar {
         margin-right: 0px !important;
     }
 
     .number {
-        font-size: 1.8rem !important;
-        margin: 0 map-get($spacers, 2) 0 0;
+        font-size: 1.75rem !important;
+        margin: 0 map-get($spacers, 2) * .75 0 0;
         align-content: center;
         font-variant-numeric: tabular-nums;
     }
@@ -126,4 +153,12 @@
 
 .hr_recruitment_is_favorite_job .o_favorite a {
     display: flex;
+}
+
+[name="kanban_job_more_options"] .o_boolean_toggle {
+    margin-bottom: 0 !important;
+
+    label {
+        @include o-position-absolute(0, 0, 0, 0);
+    }
 }

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -61,7 +61,7 @@
                                 <div class="col-6" role="menuitem" aria-haspopup="true">
                                     <field name="color" widget="kanban_color_picker"/>
                                 </div>
-                                <div class="col-6" role="menuitem">
+                                <div class="col-6" role="menuitem" name="kanban_job_more_options">
                                     <a class="dropdown-item" t-if="widget.editable" name="edit_job" type="open">Configuration</a>
                                     <a class="dropdown-item" t-if="record.active.raw_value" type="archive" >Archive</a>
                                     <a class="dropdown-item" t-if="!record.active.raw_value" name="action_unarchive" type="object">Unarchive</a>
@@ -72,23 +72,15 @@
                     <t t-name="card">
                         <div class="o_hr_recruitment_kanban_card_large_screen">
                             <main>
-                                <div class="d-flex flex-row align-content-center ms-2 py-1">
-                                    <div class="col-3 col-xl-4 d-flex flex-column align-self-center o_kanban_card_header">
-                                        <div class="d-flex flex-row justify-content-between">
-                                            <div class="o_kanban_card_header_title d-flex fw-bold fs-4">
-                                                <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
-                                                <field class="fs-4" name="name"/>
-                                            </div>
-                                            <div t-if="record.alias_email.value" class="d-flex flex-wrap">
-                                                <field name="alias_id"
-                                                    groups="hr_recruitment.group_hr_recruitment_interviewer"/>
-                                            </div>
+                                <div class="d-flex ms-3 py-1">
+                                    <div class="o_kanban_card_header col-4 col-lg-3 d-flex flex-column pt-2 pt-lg-0">
+                                        <div class="o_kanban_card_header_title d-flex align-items-baseline fw-bold">
+                                            <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+                                            <field class="fs-4" name="name"/>
                                         </div>
-                                        <div class="d-flex flex-row"
-                                            groups="hr_recruitment.group_hr_recruitment_interviewer,hr.group_hr_user">
-                                            <div class="col">
-                                                <div groups="!base.group_multi_company">
-                                                    <field name="user_id" widget="many2one_avatar_user"
+                                        <div groups="hr_recruitment.group_hr_recruitment_interviewer,hr.group_hr_user">
+                                            <div groups="!base.group_multi_company">
+                                                    <field name="user_id" widget="many2one_avatar_user" class="text-muted"
                                                         options="{'display_avatar_name': True}"/>
                                                 </div>
                                                 <div groups="base.group_multi_company">
@@ -96,15 +88,19 @@
                                                         <div class="d-flex flex-row">
                                                             <field name="user_id" widget="many2one_avatar_user"
                                                                 options="{'display_avatar_name': False}"/>
-                                                            <field class="ms-1" name="company_id"/>
+                                                            <field class="ms-1 text-muted" name="company_id" />
                                                         </div>
                                                     </t>
                                                     <t t-else="">
-                                                        <field name="user_id" widget="many2one_avatar_user"
+                                                        <field name="user_id" widget="many2one_avatar_user" class="text-muted"
                                                             options="{'display_avatar_name': True}"/>
                                                     </t>
                                                 </div>
-                                            </div>
+                                        </div>
+                                        <div t-if="record.alias_email.value" class="d-flex align-items-baseline mt-1 small text-muted">
+                                            <i class="fa fa-envelope flex-shrink-0 me-1 text-center" title="Email"></i>
+                                            <field name="alias_id" class="d-flex flex-wrap"
+                                                groups="hr_recruitment.group_hr_recruitment_interviewer"/>
                                         </div>
                                     </div>
                                     <div class="col align-content-center px-1">
@@ -112,35 +108,35 @@
                                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="flex-shrink-0 flex-basis-100"/>
                                         </div>
                                     </div>
-                                    <div class="col align-content-center px-1">
-                                        <div t-attf-class="d-flex justify-content-center #{record.no_of_recruitment.raw_value == 0  ? 'text-muted opacity-75' : ''}">
-                                            <field name="no_of_recruitment" class="number flex-shrink-0 flex-basis-50 fw-semibold text-end"/>
-                                            <div class="number_description flex-shrink-0 flex-basis-50 fs-6 lh-1 text-muted">
-                                                to<br/><span class="text-nowrap">recruit</span>
-                                            </div>
-                                        </div>
-                                    </div>
                                     <div class="col align-content-center px-1"
                                         groups="hr_recruitment.group_hr_recruitment_interviewer">
                                         <div t-attf-class="d-flex justify-content-center px-1 #{record.new_application_count.raw_value == 0  ? 'text-muted opacity-75' : ''}">
-                                            <field name="new_application_count" class="number flex-shrink-0 flex-basis-50 fw-semibold text-end"/>
+                                            <field name="new_application_count" class="number flex-shrink-0 flex-basis-lg-50 fw-semibold text-lg-end"/>
                                             <div class="number_description flex-shrink-0 flex-basis-50 fs-6 lh-1 text-muted">
                                                 new<br/><span class="text-nowrap">applications</span>
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col align-content-center px-1"
+                                    <div class="col d-none d-lg-block align-content-center px-1"
                                         groups="hr_recruitment.group_hr_recruitment_interviewer">
                                         <div t-attf-class="d-flex justify-content-center #{record.open_application_count.raw_value == 0  ? 'text-muted opacity-75' : ''}">
-                                            <field name="open_application_count" class="number flex-shrink-0 flex-basis-50 fw-semibold text-end"/>
+                                            <field name="open_application_count" class="number flex-shrink-0 flex-basis-50 fw-semibold text-lg-end"/>
                                             <div class=" number_description flex-shrink-0 flex-basis-50 fs-6 lh-1 text-muted">
                                                 in<br/><span class="text-nowrap">progress</span>
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col align-content-center px-1"
+                                    <div class="col d-none d-lg-block align-content-center px-1">
+                                        <div t-attf-class="d-flex justify-content-center #{record.no_of_recruitment.raw_value == 0  ? 'text-muted opacity-75' : ''}">
+                                            <field name="no_of_recruitment" class="number flex-shrink-0 flex-basis-50 fw-semibold text-lg-end"/>
+                                            <div class="number_description flex-shrink-0 flex-basis-50 fs-6 lh-1 text-muted">
+                                                to<br/><span class="text-nowrap">recruit</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="o_hr_recruitment_activity-col flex-shrink-0 align-content-center ps-xxl-1 pe-xxl-5" t-attf-class="#{record.activity_count.raw_value == 0 ? 'o_hr_recruitment_no-activity' : ''}"
                                         groups="hr_recruitment.group_hr_recruitment_interviewer">
-                                        <div class="d-flex justify-content-sm-center justify-content-xl-start mt-1">
+                                        <div class="d-flex justify-content-sm-start justify-content-xl-start mt-1">
                                             <div class="position-relative">
                                                 <button name="action_open_activities" type="object" class="px-2 pt-2 pb-1">
                                                     <i class="fa fa-2x fa-clock-o" role="img" aria-label="Activities"></i>
@@ -152,8 +148,8 @@
                                         </div>
                                     </div>
                                     <div class="align-content-center me-5">
-                                        <div class="d-flex justify-content-center">
-                                            <div name="large_screen_job_page_div" class="me-2" invisible="1">
+                                        <div class="d-flex flex-column flex-xl-row justify-content-center gap-2">
+                                            <div name="large_screen_job_page_div" invisible="1">
                                                 <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
                                                     Job Page
                                                 </button>

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -22,6 +22,13 @@
             <xpath expr="//div[@name='large_screen_job_page_div']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>
+
+            <xpath expr="//div[@name='kanban_job_more_options']" position="inside">
+                <a class="dropdown-item d-flex position-relative">
+                    <field string="Published" name="website_published" widget="boolean_toggle"></field>
+                    Published
+                </a>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This PR refines the recruitment design by:
- adding a publish/unpublish action in the dropdown,
- improving alignment,
- improving tablet version
- moving alias email address
- showing activity button on hover when no activities

task-5375908

| Before | After |
|--------|--------|
| <img width="820" height="694" alt="recruitment-master-tablet-before" src="https://github.com/user-attachments/assets/9aebd827-98a6-436b-93ff-921b03032c36" /> | <img width="820" height="701" alt="Job-Positions-12-01-2025_04_39_PM" src="https://github.com/user-attachments/assets/f0780b94-6e5d-490e-bbf0-614259be4139" /> |
| <img width="1609" height="1035" alt="recruitment-master-desktop-before" src="https://github.com/user-attachments/assets/79c052fa-673e-4caa-bc13-17c8c330db07" /> | <img width="1609" height="1035" alt="recruitment-master-desktop-after" src="https://github.com/user-attachments/assets/a35fd9fa-134b-445e-b91d-bdb1ca867cc9" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
