### PR TITLE
[16.0][FIX] account_edi_ubl_cii: allow BIS 3 customers invoices without customer VAT

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -435,10 +435,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             'peppol_en16931_ubl_seller_endpoint': self._check_required_fields(
                 vals['supplier'], 'vat'
             ),
-            # PEPPOL-EN16931-R010: Buyer electronic address MUST be provided
-            'peppol_en16931_ubl_buyer_endpoint': self._check_required_fields(
-                vals['customer'], 'vat'
-            ),
             # PEPPOL-EN16931-R003: A buyer reference or purchase order reference MUST be provided.
             'peppol_en16931_ubl_buyer_ref_po_ref':
                 "A buyer reference or purchase order reference must be provided." if self._check_required_fields(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Allow sending peppol invoices to customers without VAT number.

It is allowed to send peppol invoices to customers without VAT number (e.g. public sector). Tested with the ecosio validator (BIS Billing 3.0.19)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
