### PR TITLE
[FIX] web, *: Display of the stat buttons on the bottom sheet 

### DIFF
--- a/addons/sale_project/__manifest__.py
+++ b/addons/sale_project/__manifest__.py
@@ -32,6 +32,7 @@ This module allows to generate a project/task from sales orders.
     'assets': {
         'web.assets_backend': [
             'sale_project/static/src/components/**/*',
+            'sale_project/static/src/core/**/*',
             'sale_project/static/src/views/**/*',
         ],
         'web.assets_tests': [

--- a/addons/sale_project/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/sale_project/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -1,0 +1,16 @@
+.o_bottom_sheet .o_bottom_sheet_sheet {
+    .o-dropdown-item {
+        .oe_stat_button[name="action_view_project_ids"] {
+            > .o_stat_info {
+                flex-direction: column;
+
+                > .o_row {
+                    display: flex;
+                    gap: inherit;
+                    padding-block: map-get($spacers, 1);
+                    align-items: baseline;
+                }
+            }
+        }
+    }
+}

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -277,6 +277,10 @@
         text-align: start !important;
     }
 
+    .dropdown-item .o_stat_value {
+        display: flex;
+    }
+
     .o_bottom_sheet_body:not(.o_custom_bottom_sheet) {
         // Dropdown
         .dropdown-item {


### PR DESCRIPTION
when a stat button is displayed inside a bottom sheet, it can appear
broken (e.g., in sale_project, sale_timesheet).

task-5359751


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
