### PR TITLE
[FIX] payment: fix processing of transaction issue

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -745,8 +745,9 @@ class PaymentTransaction(models.Model):
         tx = self or self._search_by_reference(provider_code, payment_data)
         if tx:
             tx.ensure_one()
+            previous_state = tx.state
             tx._validate_amount(payment_data)
-            if tx.state == 'error':
+            if tx.state == 'error' and tx.state != previous_state:
                 return tx
             tx._apply_updates(payment_data)
             if tx.tokenize and tx.state in {'authorized', 'done'}:

--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -261,6 +261,18 @@ class TestPaymentTransaction(PaymentCommon):
             tx._validate_amount({})
         self.assertNotEqual(tx.state, 'error')
 
+    def test_processing_applies_updates_to_error_txs_with_valid_amount_data(self):
+        tx = self._create_transaction('redirect', state='error')
+        with patch(
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
+            '._validate_amount'
+        ), patch(
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
+            '._apply_updates'
+        ) as apply_updates_mock:
+            tx._process('test', {})
+        self.assertEqual(apply_updates_mock.call_count, 1)
+
     def test_processing_does_not_apply_updates_when_amount_data_is_invalid(self):
         tx = self._create_transaction('redirect', state='draft', amount=100)
         with patch(


### PR DESCRIPTION
Steps:
- Install razorpay provider.
- Set up provider and try to make payment with UPI PM.
- Cancel processing payment in Razorpay form while processing keep form open.
- Now complete that same tx in same Razorpay form.

Issue:
- Transaction stays in `error` state.

Cause:
- _process method skips calling _apply_changes for `error` stage transactions even though
it should allowed.

Fix:
- Improve condition to only skip `_apply_changes` only if `_validate_amount` fails.

issued PR: https://github.com/odoo/odoo/pull/224627

Note: This is just temporary fix for the stable in master we will make `_validate_amount` method
return boolean value depending on that we will decide whether to apply changes or not.