### PR TITLE
[FIX] account: keep unit price after FPOS change on SO invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4076,7 +4076,8 @@ class AccountMove(models.Model):
         }
 
     def action_update_fpos_values(self):
-        self.invoice_line_ids._compute_price_unit()
+        if not('sale_line_ids' in self.invoice_line_ids._fields and self.invoice_line_ids.sale_line_ids):
+            self.invoice_line_ids._compute_price_unit()
         self.invoice_line_ids._compute_tax_ids()
         self.line_ids._compute_account_id()
 


### PR DESCRIPTION
Commit 8df3d0424b30289d81e15a483dcc779bfe3964ba fixed an inconsistent behavior on invoices, but introduced a side effect: when the unit price comes from a sale order where the price was changed (via a pricelist or manually), recomputing the unit price after changing the fiscal position may result in an unintended price.
At that point, the invoice no longer has the necessary information to restore the original SO price.

To avoid this, we no longer recompute the unit price for invoice lines originating from sale orders.

task-5373733
