### PR TITLE
[IMP] html_editor: preserve button's size and shape on type change

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -596,17 +596,15 @@ export class LinkPopover extends Component {
             .join(" ");
 
         let stylePrefix = "";
-        if (this.state.type === "custom") {
-            if (this.state.buttonSize) {
-                classes += ` btn-${this.state.buttonSize}`;
+        if (this.state.buttonSize) {
+            classes += ` btn-${this.state.buttonSize}`;
+        }
+        if (this.state.buttonShape) {
+            const buttonShape = this.state.buttonShape.split(" ");
+            if (["outline", "fill"].includes(buttonShape[0])) {
+                stylePrefix = `${buttonShape[0]}-`;
             }
-            if (this.state.buttonShape) {
-                const buttonShape = this.state.buttonShape.split(" ");
-                if (["outline", "fill"].includes(buttonShape[0])) {
-                    stylePrefix = `${buttonShape[0]}-`;
-                }
-                classes += ` ${buttonShape.slice(stylePrefix ? 1 : 0).join(" ")}`;
-            }
+            classes += ` ${buttonShape.slice(stylePrefix ? 1 : 0).join(" ")}`;
         }
         if (this.state.type) {
             classes += ` btn btn-${stylePrefix}${this.state.type}`;

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -380,6 +380,36 @@ describe("button edit", () => {
             '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">X[]</a></p>'
         );
     });
+
+    test("changing button type to secondary doesn't change button's size and shape", async () => {
+        await setupEditor(
+            `<p><a href="https://test.com/" class="btn btn-lg btn-outline-custom" style="border-width: 1px; border-color: black; border-style: dashed;">link[]Label</a></p>`,
+            allowCustomOpt
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        await click('select[name="link_type"]');
+        await select("secondary");
+        await animationFrame();
+
+        expect("a").toHaveClass("btn btn-lg btn-outline-secondary");
+    });
+
+    test("changing button type to primary doesn't change button's size and shape", async () => {
+        await setupEditor(
+            `<p><a href="https://test.com/" class="btn btn-sm btn-custom flat">link[]Label</a></p>`,
+            allowCustomOpt
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        await click('select[name="link_type"]');
+        await select("primary");
+        await animationFrame();
+
+        expect("a").toHaveClass("btn btn-primary btn-sm flat");
+    });
 });
 
 test("button should never contain selection placeholder", async () => {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -873,7 +873,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"');
         await select("primary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-primary">link2</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-fill-primary">link2</a></p>'
         );
     });
     test("after changing the link format, the link should be updated (2)", async () => {
@@ -905,7 +905,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"');
         await select("primary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="random-css-class text-muted btn btn-primary">link2</a></p>'
+            '<p><a href="http://test.com/" class="random-css-class text-muted  btn btn-outline-primary">link2</a></p>'
         );
     });
     test("after applying the link format, the link's format should be updated", async () => {


### PR DESCRIPTION
These options have been reintroduced here [1], but they are used only when the button shape is custom, which is wrong as we'd like to keep button's size and shape when we change it's type.
Steps to see the issue:
- Open Website and start editing
- Drop any snippet with a button, or drop a button directly
- Click on the button
- Click on the pen to edit the 'link'
- Change button's type to custom and set size to something else than medium, and set shape to flat
- Change button's type to 'Button Primary' or 'Secondary'

=> Size and shape have been reset, but we'd like to keep them.

[1]: https://github.com/odoo/odoo/commit/1d22ee329e097f6ae164f2fccf6d2d82ae4afd70

task-5353659
