### PR TITLE
[FIX] stock_account: soften lock date constraint on pickings

### DIFF
--- a/addons/stock_account/models/stock_picking.py
+++ b/addons/stock_account/models/stock_picking.py
@@ -26,7 +26,7 @@ class StockPicking(models.Model):
 
     def _is_date_in_lock_period(self):
         self.ensure_one()
-        lock = self.company_id._get_lock_date_violations(self.scheduled_date.date(), fiscalyear=True)
+        lock = self.company_id._get_lock_date_violations(self.scheduled_date.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
         if self.date_done:
-            lock += self.company_id._get_lock_date_violations(self.date_done.date(), fiscalyear=True)
+            lock += self.company_id._get_lock_date_violations(self.date_done.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
         return bool(lock)


### PR DESCRIPTION
### Issue:

The `_check_backdate_allowed` constraint on `scheduled_date` and `date_done` of pickings:
https://github.com/odoo/odoo/blob/5375b865570efb714720096c34aeec2e833dd1f9/addons/stock_account/models/stock_picking.py#L13-L19 is suppose to check if these dates happen prior to the `fiscal_year` lock date and (of course) before the hard lock date. However, the `_get_lock_date_violations` set all its parameters to `True` by default: https://github.com/odoo/odoo/blob/5375b865570efb714720096c34aeec2e833dd1f9/addons/account/models/company.py#L664-L673 and only the fiscalyear variable is set in the constraint calls: https://github.com/odoo/odoo/blob/5375b865570efb714720096c34aeec2e833dd1f9/addons/stock_account/models/stock_picking.py#L27-L32

opw-5329858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
