### PR TITLE
[IMP] fleet: add Cars History Smart button to res.partner

### DIFF
--- a/addons/fleet/__manifest__.py
+++ b/addons/fleet/__manifest__.py
@@ -37,6 +37,7 @@ Main Features
         'views/mail_activity_views.xml',
         'views/res_config_settings_views.xml',
         'views/fleet_vehicle_odometer_report.xml',
+        'views/res_partner_views.xml',
         'data/fleet_cars_data.xml',
         'data/fleet_data.xml',
         'data/mail_message_subtype_data.xml',

--- a/addons/fleet/models/__init__.py
+++ b/addons/fleet/models/__init__.py
@@ -14,3 +14,4 @@ from . import fleet_vehicle_state
 from . import fleet_vehicle_tag
 from . import mail_activity_type
 from . import res_config_settings
+from . import res_partner

--- a/addons/fleet/models/res_partner.py
+++ b/addons/fleet/models/res_partner.py
@@ -1,0 +1,32 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    partner_cars_count = fields.Integer(
+        compute="_compute_partner_cars_count",
+        string="Cars Count"
+    )
+
+    def _compute_partner_cars_count(self):
+        rg = self.env['fleet.vehicle.assignation.log']._read_group([
+            ('driver_id', 'in', self.ids),
+        ], ['driver_id'], ['__count'])
+        cars_count = {driver.id: count for driver, count in rg}
+        for partner in self:
+            partner.partner_cars_count = cars_count.get(partner.id, 0)
+
+    def action_open_partner_cars(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "fleet.vehicle.assignation.log",
+            "views": [[self.env.ref("fleet.fleet_vehicle_assignation_log_view_list").id, "list"],
+                      [False, "form"]],
+            "domain": [("driver_id", "in", self.ids)],
+            "context": dict(self.env.context, default_driver_id=self.id),
+            "name": self.env._("Cars History"),
+        }

--- a/addons/fleet/views/res_partner_views.xml
+++ b/addons/fleet/views/res_partner_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.view.form.inherit.fleet</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="priority" eval="99" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button name="action_open_partner_cars" type="object"
+                        class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_manager"
+                        invisible="partner_cars_count == 0">
+                    <field name="partner_cars_count" widget="statinfo" string="Cars History" />
+                </button>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
With this commit we added the Car History Smart Button (same as the one already in employees) for contacts.

Task - 5368158

