### PR TITLE
[IMP] web: Add contact names and avatar in sample mode

### DIFF
--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -235,11 +235,16 @@ export class SampleServer {
     _generateFieldValue(modelName, fieldName, id) {
         const field = this.data[modelName].fields[fieldName];
         switch (field.type) {
+            case "binary":
+                if (["avatar_128", "image_128"].includes(fieldName)) {
+                    return getSampleFromId(id, SampleServer.SAMPLE_AVATARS);
+                }
+                return false;
             case "boolean":
                 return fieldName === "active" ? true : this._getRandomBool();
             case "char":
             case "text":
-                if (["display_name", "name"].includes(fieldName)) {
+                if (["complete_name", "display_name", "name"].includes(fieldName)) {
                     if (SampleServer.PEOPLE_MODELS.includes(modelName)) {
                         return getSampleFromId(id, SampleServer.SAMPLE_PEOPLE);
                     } else if (modelName === "res.country") {
@@ -841,6 +846,13 @@ SampleServer.PEOPLE_MODELS = [
     "hr.employee",
     "mail.followers",
     "mailing.contact",
+];
+SampleServer.SAMPLE_AVATARS = [
+    "PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0nVVRGLTgnID8+PHN2ZyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB4bWxuczp4bGluaz0naHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayc+PHJlY3QgZmlsbD0naHNsKDM0OSwgNDglLCA0NSUpJyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcvPjx0ZXh0IGZpbGw9JyNmZmZmZmYnIGZvbnQtc2l6ZT0nOTYnIHRleHQtYW5jaG9yPSdtaWRkbGUnIHg9JzkwJyB5PScxMjUnIGZvbnQtZmFtaWx5PSdzYW5zLXNlcmlmJz5BPC90ZXh0Pjwvc3ZnPg==",
+    "PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0nVVRGLTgnID8+PHN2ZyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB4bWxuczp4bGluaz0naHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayc+PHJlY3QgZmlsbD0naHNsKDIxNiwgNjklLCA0NSUpJyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcvPjx0ZXh0IGZpbGw9JyNmZmZmZmYnIGZvbnQtc2l6ZT0nOTYnIHRleHQtYW5jaG9yPSdtaWRkbGUnIHg9JzkwJyB5PScxMjUnIGZvbnQtZmFtaWx5PSdzYW5zLXNlcmlmJz5CPC90ZXh0Pjwvc3ZnPg==",
+    "PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0nVVRGLTgnID8+PHN2ZyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB4bWxuczp4bGluaz0naHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayc+PHJlY3QgZmlsbD0naHNsKDI3MiwgNDElLCA0NSUpJyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcvPjx0ZXh0IGZpbGw9JyNmZmZmZmYnIGZvbnQtc2l6ZT0nOTYnIHRleHQtYW5jaG9yPSdtaWRkbGUnIHg9JzkwJyB5PScxMjUnIGZvbnQtZmFtaWx5PSdzYW5zLXNlcmlmJz5DPC90ZXh0Pjwvc3ZnPg==",
+    "PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0nVVRGLTgnID8+PHN2ZyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB4bWxuczp4bGluaz0naHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayc+PHJlY3QgZmlsbD0naHNsKDEwNCwgNTclLCA0NSUpJyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcvPjx0ZXh0IGZpbGw9JyNmZmZmZmYnIGZvbnQtc2l6ZT0nOTYnIHRleHQtYW5jaG9yPSdtaWRkbGUnIHg9JzkwJyB5PScxMjUnIGZvbnQtZmFtaWx5PSdzYW5zLXNlcmlmJz5EPC90ZXh0Pjwvc3ZnPg==",
+    "PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0nVVRGLTgnID8+PHN2ZyBoZWlnaHQ9JzE4MCcgd2lkdGg9JzE4MCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB4bWxuczp4bGluaz0naHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayc+PHJlY3QgZmlsbD0naHNsKDYyLCA0NCUsIDQ1JSknIGhlaWdodD0nMTgwJyB3aWR0aD0nMTgwJy8+PHRleHQgZmlsbD0nI2ZmZmZmZicgZm9udC1zaXplPSc5NicgdGV4dC1hbmNob3I9J21pZGRsZScgeD0nOTAnIHk9JzEyNScgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnPkU8L3RleHQ+PC9zdmc+",
 ];
 
 SampleServer.UnimplementedRouteError = UnimplementedRouteError;


### PR DESCRIPTION
This commit:
- adds `complete_name` to the generated field in sample data.
- adds  sample avatars for `avatar_128` and `image_128` fields.

task-5258965