### PR TITLE
[IMP] web: update loading indicator design

### DIFF
--- a/addons/web/static/src/webclient/loading_indicator/loading_indicator.scss
+++ b/addons/web/static/src/webclient/loading_indicator/loading_indicator.scss
@@ -1,14 +1,23 @@
-.o_loading_indicator {
-  position: fixed;
-  bottom: 0;
-  right: 0;
-  z-index: $zindex-modal + 1;
-  background-color: $o-brand-odoo;
-  color: white;
-  padding: 4px;
+.o_loading_indicator_wrap {
+    left: auto;
+    z-index: $zindex-modal + 1;
 
-  transition: opacity 0.4s;
-  &.o-fade-leave, &.o-fade-enter {
-    opacity: 0;
-  }
+    .spinner-border {
+        --#{$prefix}spinner-height: 1em;
+        --#{$prefix}spinner-width: 1em;
+        --#{$prefix}spinner-border-width: #{$border-width * 2};
+        --#{$prefix}spinner-animation-speed: 1.25s;
+    }
+
+    .o_loading_indicator {
+        transition: all .2s ease;
+    }
+
+    &.o_translate-leave, &.o_translate-enter {
+        .o_loading_indicator {
+            transform: scale(.95);
+            opacity: 0;
+            transition-delay: .5s;
+        }
+    }
 }

--- a/addons/web/static/src/webclient/loading_indicator/loading_indicator.xml
+++ b/addons/web/static/src/webclient/loading_indicator/loading_indicator.xml
@@ -2,8 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="web.LoadingIndicator">
-        <Transition visible="state.show" name="'o-fade'" t-slot-scope="transition" leaveDuration="400">
-            <span class="o_loading_indicator" t-att-class="transition.className">Loading<t t-if="env.debug" t-esc="' (' + state.count + ')'" /></span>
+        <Transition visible="state.show" name="'o_translate'" t-slot-scope="transition" leaveDuration="700">
+        <div t-attf-class="{{transition.className}} o_loading_indicator_wrap fixed-bottom p-2 opacity-100 opacity-25-hover transition-base">
+            <span class="o_loading_indicator d-inline-flex align-items-center gap-1 rounded-pill border py-1 px-3 bg-view small shadow-lg">
+                <span class="spinner-border text-primary"/>
+                Loading…
+            </span>
+        </div>
         </Transition>
     </t>
 

--- a/addons/web/static/tests/webclient/loading_indicator.test.js
+++ b/addons/web/static/tests/webclient/loading_indicator.test.js
@@ -4,7 +4,6 @@ import {
     getService,
     mountWithCleanup,
     patchWithCleanup,
-    serverState,
 } from "@web/../tests/web_test_helpers";
 
 import { rpcBus } from "@web/core/network/rpc";
@@ -17,7 +16,7 @@ beforeEach(() => {
     patchWithCleanup(transitionConfig, { disabled: true });
 });
 
-test("displays the loading indicator in non debug mode", async () => {
+test("displays the loading indicator", async () => {
     await mountWithCleanup(LoadingIndicator, { noMainContainer: true });
     expect(".o_loading_indicator").toHaveCount(0, {
         message: "the loading indicator should not be displayed",
@@ -28,82 +27,10 @@ test("displays the loading indicator in non debug mode", async () => {
     expect(".o_loading_indicator").toHaveCount(1, {
         message: "the loading indicator should be displayed",
     });
-    expect(".o_loading_indicator").toHaveText("Loading", {
+    expect(".o_loading_indicator").toHaveText("Loading…", {
         message: "the loading indicator should display 'Loading'",
     });
     rpcBus.trigger("RPC:RESPONSE", payload(1));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveCount(0, {
-        message: "the loading indicator should not be displayed",
-    });
-});
-
-test("displays the loading indicator for one rpc in debug mode", async () => {
-    serverState.debug = "1";
-    await mountWithCleanup(LoadingIndicator, { noMainContainer: true });
-    expect(".o_loading_indicator").toHaveCount(0, {
-        message: "the loading indicator should not be displayed",
-    });
-    rpcBus.trigger("RPC:REQUEST", payload(1));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveCount(1, {
-        message: "the loading indicator should be displayed",
-    });
-    expect(".o_loading_indicator").toHaveText("Loading (1)", {
-        message: "the loading indicator should indicate 1 request in progress",
-    });
-    rpcBus.trigger("RPC:RESPONSE", payload(1));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveCount(0, {
-        message: "the loading indicator should not be displayed",
-    });
-});
-
-test("displays the loading indicator for multi rpc in debug mode", async () => {
-    serverState.debug = "1";
-    await mountWithCleanup(LoadingIndicator, { noMainContainer: true });
-    expect(".o_loading_indicator").toHaveCount(0, {
-        message: "the loading indicator should not be displayed",
-    });
-    rpcBus.trigger("RPC:REQUEST", payload(1));
-    rpcBus.trigger("RPC:REQUEST", payload(2));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveCount(1, {
-        message: "the loading indicator should be displayed",
-    });
-    expect(".o_loading_indicator").toHaveText("Loading (2)", {
-        message: "the loading indicator should indicate 2 requests in progress.",
-    });
-    rpcBus.trigger("RPC:REQUEST", payload(3));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveText("Loading (3)", {
-        message: "the loading indicator should indicate 3 requests in progress.",
-    });
-    rpcBus.trigger("RPC:RESPONSE", payload(1));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveText("Loading (2)", {
-        message: "the loading indicator should indicate 2 requests in progress.",
-    });
-    rpcBus.trigger("RPC:REQUEST", payload(4));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveText("Loading (3)", {
-        message: "the loading indicator should indicate 3 requests in progress.",
-    });
-    rpcBus.trigger("RPC:RESPONSE", payload(2));
-    rpcBus.trigger("RPC:RESPONSE", payload(3));
-    await runAllTimers();
-    await animationFrame();
-    expect(".o_loading_indicator").toHaveText("Loading (1)", {
-        message: "the loading indicator should indicate 1 request in progress.",
-    });
-    rpcBus.trigger("RPC:RESPONSE", payload(4));
     await runAllTimers();
     await animationFrame();
     expect(".o_loading_indicator").toHaveCount(0, {


### PR DESCRIPTION
This commit updates and modernizes the loading indicator design.

task-5365524

| Before | After |
|--------|--------|
| <img width="118" height="90" alt="image" src="https://github.com/user-attachments/assets/c22fb397-4fc1-4ae2-9383-1c154a96a864" /> | <img width="163" height="70" alt="Capture d’écran 2025-12-04 à 17 09 29" src="https://github.com/user-attachments/assets/eae76225-8e02-4aba-9e7b-896228947dce" /> |






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
