### PR TITLE
[FIX] pos_hr: fix Close Register visibility with navbar helper

### DIFF
--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
@@ -16,4 +16,12 @@ patch(Navbar.prototype, {
             (cashier && cashier.id === this.pos.session.user_id?.id)
         );
     },
+    get showCloseRegister() {
+        const cashier = this.pos.get_cashier_user_id();
+        return (
+            !this.pos.config.module_pos_hr ||
+            this.pos.employeeIsAdmin ||
+            (cashier && cashier.id === this.pos.session.user_id?.id)
+        );
+    },
 });

--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
@@ -6,9 +6,7 @@
             <attribute name="t-if">showBackend</attribute>
         </xpath>
         <xpath expr="//DropdownItem[contains(text(), 'Close Register')]" position="attributes">
-            <attribute name="t-if">
-                !pos.config.module_pos_hr or pos.employeeIsAdmin or pos.get_cashier_user_id() === pos.session.user_id?.id
-            </attribute>
+            <attribute name="t-if">showCloseRegister</attribute>
         </xpath>
         <xpath expr="//CashierName" position="after">
             <button t-if="pos.config.module_pos_hr and !ui.isSmall" class="lock-screen btn btn-light btn-lg" title="Lock" t-on-click="() => this.pos.showLoginScreen()">


### PR DESCRIPTION
The "Close Register" menu item visibility relied on an inline expression comparing pos.get_cashier_user_id() with pos.session.user_id?.id. However, get_cashier_user_id() can return a user object,
while session.user_id is typically an id or [id, name] pair, so the strict comparison would often fail and hide "Close Register" incorrectly.

Introduce a showCloseRegister getter on the POS Navbar to centralize and normalize this check, ensuring we compare compatible values and that only the current session user or an admin can see "Close Register". Update the navbar XML to use this helper instead of the fragile inline comparison.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
