### PR TITLE
[IMP] base, project: keep datas at the edge of ir.attachment

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import base64
 import json
 
 from collections import OrderedDict
@@ -572,7 +572,7 @@ class ProjectCustomerPortal(CustomerPortal):
 
         values = IrAttachment._check_contents({
             'name': name,
-            'datas': data,
+            'raw': base64.b64decode(data),
             'res_model': 'project.task',
             'res_id': res_id,
             'access_token': IrAttachment._generate_access_token(),


### PR DESCRIPTION
Currently every layer inside `ir.attachment` has to deal with the duality of `raw` and `datas` and `b64decode` repeatedly.

Start deprecating `datas` as an internal component by removing its support from internal utility functions (`_compute_mimetype`, `postprocess_contents`) by decoding and moving such content into `raw` at the outset.
