### PR TITLE
[FIX] mail: show link in message reply to preview

### DIFF
--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -14,7 +14,7 @@
                             <b class="o-mail-MessageInReply-author o-fw-600"><t t-out="props.message.parent_id.authorName"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">
                                 <t t-if="!props.message.parent_id.isBodyEmpty">
-                                    <t t-out="props.message.parent_id.inlineBody"/>
+                                    <t t-out="props.message.parent_id.linkifiedInlineBody"/>
                                     <em t-if="props.message.parent_id.edited" class="smaller fw-bold text-500"> (edited)</em>
                                 </t>
                                 <t t-elif="props.message.parent_id.attachment_ids.length > 0">

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -8,6 +8,7 @@ import {
     generateEmojisOnHtml,
     getNonEditableMentions,
     htmlToTextContentInline,
+    linkify,
 } from "@mail/utils/common/format";
 
 import { browser } from "@web/core/browser/browser";
@@ -403,6 +404,12 @@ export class Message extends Record {
                 return "";
             }
             return decorateEmojis(htmlToTextContentInline(this.body));
+        },
+    });
+
+    linkifiedInlineBody = fields.Html("", {
+        compute() {
+            return linkify(this.inlineBody);
         },
     });
 

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -117,7 +117,7 @@ function _parseAndTransform(nodes, transformFunction) {
  * @param {string} text
  * @return {ReturnType<markup>} linkified text
  */
-function linkify(text) {
+export function linkify(text) {
     let curIndex = 0;
     let result = "";
     let match;


### PR DESCRIPTION
Before this commit, when replying to a message with a link, the reply preview did not have link around the URL.

This happens from a fix on reply to message preview to show spaces around new lines [1], but made a regression of removing the links, due to use of `inlineBody` that uses `htmlToTextContentInline`, which doesn't linkify content. Previously this was using `richBody`.

While the content-inline part is desirable, some rich feature should be preserved in the inline presentation of message, such as links.

This commit fixes the issue by linkifying the `inlineBody` in the message preview, so that it has the desired property of presentation of previous fix [1] while linkifying content as desired.

[1]: https://github.com/odoo/odoo/pull/225886

Task-5263284

Before
<img width="1093" height="448" alt="Screenshot 2025-12-01 at 16 21 16" src="https://github.com/user-attachments/assets/1ac6d99a-5c98-4f89-af9a-35772bbc39f8" />


After
<img width="1082" height="439" alt="Screenshot 2025-12-01 at 16 21 22" src="https://github.com/user-attachments/assets/f765ff84-de47-4784-b56b-609dea1d52e4" />

