### PR TITLE
[FIX] account_peppol: fix neutralize script if no key

### DIFF
--- a/addons/account_peppol/data/neutralize.sql
+++ b/addons/account_peppol/data/neutralize.sql
@@ -1,3 +1,4 @@
-UPDATE ir_config_parameter
-SET value = 'test'
-WHERE key = 'account_peppol.edi.mode';
+INSERT INTO ir_config_parameter (key, value)
+     VALUES ('account_peppol.edi.mode', 'test')
+ON CONFLICT (key) DO UPDATE
+        SET VALUE = 'test';


### PR DESCRIPTION
There can be some siutations where you can not have the key account_peppol.edi.mode while having a connection. 
But the neutralize only updates and so, if the key is not present, it does nothing.
So change it to insert the key if no present




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
