### PR TITLE
[FIX] l10n_ar: fix demo data for python 3.10

### DIFF
--- a/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
@@ -116,19 +116,19 @@
             (0, 0, {'product_id': ref('product.product_product_25'), 'price_unit': 3245.0, 'quantity': 2}),
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 124.3, 'quantity': 3, 'name': 'Support Services 8',
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
-                ref(f'account.{ref('base.company_ri')}_ri_tax_percepcion_iibb_caba_sufrida')
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
+                ref('account.%s_ri_tax_percepcion_iibb_caba_sufrida' % ref('base.company_ri'))
             ])]
            }),
             (0, 0, {'product_id': ref('product.product_product_25'), 'price_unit': 1740.0, 'quantity': 1,
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
                 ref('account.%s_base_tax_impuestos_internos' % ref('base.company_ri'))
             ])]
            }),
             (0, 0, {'product_id': ref('product.product_product_25'), 'price_unit': 10000.0, 'quantity': 1,
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
                 ref('account.%s_base_tax_otros_tributos' % ref('base.company_ri'))
             ])]
            }),
@@ -167,14 +167,14 @@
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 124.3, 'quantity': 3, 'name': 'Support Services 8',
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
                 ref('account.%s_base_tax_otros_tributos' % ref('base.company_ri'))
             ])]
            }),
             (0, 0, {'product_id': ref('product.product_product_25'), 'price_unit': 1740.0, 'quantity': 1,
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
-                ref(f'account.{ref('base.company_ri')}_ri_tax_percepcion_iibb_caba_sufrida')
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
+                ref('account.%s_ri_tax_percepcion_iibb_caba_sufrida' % ref('base.company_ri'))
             ])]
            }),
         ]"/>
@@ -190,14 +190,14 @@
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 124.3, 'quantity': 3, 'name': 'Support Services 8',
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
                 ref('account.%s_base_tax_impuestos_internos' % ref('base.company_ri'))
             ])]
            }),
             (0, 0, {'product_id': ref('product.product_product_25'), 'price_unit': 1740.0, 'quantity': 1,
             'tax_ids': [(6, 0, [
-                ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras'),
-                ref(f'account.{ref('base.company_ri')}_ri_tax_percepcion_iibb_caba_sufrida')
+                ref('account.%s_ri_tax_vat_0_compras' % ref('base.company_ri')),
+                ref('account.%s_ri_tax_percepcion_iibb_caba_sufrida' % ref('base.company_ri'))
             ])]
            }),
         ]"/>


### PR DESCRIPTION
**Steps to reproduce:**
- Use Python 3.10
- Install l10n_ar

**Issue:**
The installation fails with a SyntaxError.

**Cause:**
Some demo data use the following format for the taxes definition:
`ref(f'account.{ref('base.company_ri')}_ri_tax_vat_0_compras')`
However, in python 3.10, a quote cannot be used inside f''.

opw-5376152



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
