### PR TITLE
[FIX] html_editor: avoid traceback when removing color from a block

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -390,6 +390,12 @@ export class ColorPlugin extends Plugin {
                                     font.style.removeProperty(style);
                                 }
                             }
+                            font.classList.forEach((className) => {
+                                if (TEXT_CLASSES_REGEX.test(className)) {
+                                    font.classList.remove(className);
+                                    newFont.classList.add(className);
+                                }
+                            });
                             newFont.append(...font.childNodes);
                             font.append(newFont);
                             font = newFont;

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -966,3 +966,11 @@ test("should be able to remove color applied by 'text-*' classes (2)", async () 
         contentAfter: '<p><a href="#">[a]</a></p>',
     });
 });
+
+test("should be able to remove color from block element", async () => {
+    await testEditor({
+        contentBefore: '<p><a href="#" class="nav-link text-muted">[a]</a></p>',
+        stepFunction: setColor("", "color"),
+        contentAfter: '<p><a href="#" class="nav-link">[a]</a></p>',
+    });
+});


### PR DESCRIPTION
Problem:
When removing a color from a block, a traceback occurs.

Cause:
After https://github.com/odoo/odoo/commit/bda6835293b2b222a003b9696fa052f31539a4ef
we copy only style attributes to the `newFont` but the color can be
applied through a class that applies text color so we should also copy
classes that changes text color.

Steps to reproduce:
- Open Website.
- Add a mega menu.
- Open the editor.
- On the mega menu, enable the “eCommerce Categories” option.
- Edit one of the navigation headers’ labels and save.
- Observe traceback.

opw-5357516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
