### PR TITLE
[FIX] mail: html composer supports list

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -122,12 +122,6 @@ export class Composer extends Component {
         this.store = useService("mail.store");
         this.composerActions = useComposerActions({ composer: () => this.props.composer });
         this.EDIT_CLICK_TYPE = EDIT_CLICK_TYPE;
-        this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
-            send_keybind: htmlJoin(
-                this.sendKeybinds.map((key) => markup`<samp>${key}</samp>`),
-                " + "
-            ),
-        });
         this.attachmentUploader = useAttachmentUploader(
             this.thread ?? this.props.composer.message.thread,
             { composer: this.props.composer }
@@ -408,8 +402,23 @@ export class Composer extends Component {
         return this.props.type === "note" ? _t("Log") : _t("Send");
     }
 
+    get OR_PRESS_SEND_KEYBIND() {
+        return _t("%(prefix)s press %(send_keybind)s %(suffix)s", {
+            prefix: this.shouldUseCtrlEnterToSend ? "" : _t("or"),
+            send_keybind: htmlJoin(
+                this.sendKeybinds.map((key) => markup`<samp>${key}</samp>`),
+                " + "
+            ),
+            suffix: this.shouldUseCtrlEnterToSend ? _t("to send") : "",
+        });
+    }
+
+    get shouldUseCtrlEnterToSend() {
+        return !this.props.composer.isSimpleContent;
+    }
+
     get sendKeybinds() {
-        return this.env.inChatter ? [_t("CTRL"), _t("Enter")] : [_t("Enter")];
+        return this.shouldUseCtrlEnterToSend ? [_t("CTRL"), _t("Enter")] : [_t("Enter")];
     }
 
     get showComposerAvatar() {
@@ -597,7 +606,9 @@ export class Composer extends Component {
                 if (this.isMobileOS || ev.isComposing) {
                     return;
                 }
-                const shouldPost = this.env.inChatter ? ev.ctrlKey : !ev.shiftKey;
+                const shouldPost = this.shouldUseCtrlEnterToSend
+                    ? ev.ctrlKey
+                    : !ev.shiftKey && !ev.ctrlKey;
                 if (!shouldPost) {
                     return;
                 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -118,13 +118,14 @@
                         }"/>
                     </div>
                     <div t-ref="picker-target"/>
+                    <span t-if="env.inDiscussApp and !isSendButtonDisabled and !isMobileOS and shouldUseCtrlEnterToSend" class="text-muted small ms-1" t-out="OR_PRESS_SEND_KEYBIND"/>
                 </div>
                 <div t-else="" class="d-flex align-items-center gap-1 w-100 pe-2">
                     <div class="pt-1" t-att-class="{ 'mt-2': !props.composer.message }">
                         <span t-if="props.composer.message and !ui.isSmall" class="text-muted px-1 small" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText" />
                         <t t-elif="!props.composer.message and !props.composer.restoredFromFullComposer">
                             <t t-call="mail.Composer.sendButton"/>
-                            <span t-if="!isSendButtonDisabled and !isMobileOS" class="text-muted small ms-1" t-out="OR_PRESS_SEND_KEYBIND"/>
+                            <span t-if="!isSendButtonDisabled and !isMobileOS and shouldUseCtrlEnterToSend" class="text-muted small ms-1" t-out="OR_PRESS_SEND_KEYBIND"/>
                         </t>
                     </div>
                     <span class="flex-grow-1"/>

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -5,7 +5,7 @@ import {
     prettifyMessageText,
 } from "@mail/utils/common/format";
 import { markup } from "@odoo/owl";
-import { isHtmlEmpty } from "@web/core/utils/html";
+import { createDocumentFragmentFromContent, isHtmlEmpty } from "@web/core/utils/html";
 
 export class Composer extends Record {
     static id = OR("thread", "message");
@@ -125,6 +125,29 @@ export class Composer extends Record {
 
     get syncHtmlWithMessage() {
         return this.message && !this.isDirty;
+    }
+
+    get isSimpleContent() {
+        if (isHtmlEmpty(this.composerHtml)) {
+            return true;
+        }
+        const body = createDocumentFragmentFromContent(this.composerHtml).body;
+        if (body.querySelector("ul, ol, li, br")) {
+            return false;
+        }
+        const meaningfulChildren = [...body.childNodes].filter((node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                return node.textContent.trim();
+            }
+            if (node.nodeType !== Node.ELEMENT_NODE) {
+                return false;
+            }
+            return node.textContent.trim();
+        });
+        const topLevelBlocks = meaningfulChildren.filter(
+            (node) => node.nodeType === Node.ELEMENT_NODE && ["DIV", "P"].includes(node.tagName)
+        );
+        return topLevelBlocks.length <= 1 && meaningfulChildren.length <= 1;
     }
 
     get targetThread() {

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -6,6 +6,7 @@ import { HintPlugin } from "@html_editor/main/hint_plugin";
 import { InlineCodePlugin } from "@html_editor/main/inline_code";
 import { LinkPastePlugin } from "@html_editor/main/link/link_paste_plugin";
 import { LinkPlugin } from "@html_editor/main/link/link_plugin";
+import { ListPlugin } from "@html_editor/main/list/list_plugin";
 import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
@@ -23,6 +24,7 @@ export const MAIL_CORE_PLUGINS = [
     InlineCodePlugin,
     LinkPastePlugin,
     LinkPlugin,
+    ListPlugin,
     MailComposerPlugin,
     MentionPlugin,
     ProtectedNodePlugin,


### PR DESCRIPTION
Before this commit, the html composer in mail module did not support list editing functionalities such as adding bullet points or numbered lists. In this case, users were unable to format/unformat the lists in their messages.

After this commit, the html composer in mail module now includes the ListPlugin, enabling users to create and manage lists within their messages.

task-6068651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
