### PR TITLE
[FIX] l10n_ar: display tax in company currency on invoice

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -114,9 +114,6 @@
         <!-- remove default document title -->
         <xpath expr="//t[@t-set='layout_document_title']" position="replace"/>
 
-        <!-- remove detail of taxes when currency != from company's currency -->
-        <t t-call="account.document_tax_totals_company_currency_template" position="replace"/>
-
         <!-- NCM column for fiscal bond -->
         <th name="th_description" position="after">
             <th t-if="fiscal_bond" name="th_ncm_code" class="text-start"><span>NCM</span></th>


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_ar
- Switch to a Argentinian company (e.g. (AR) Responsable Inscripto)
- In Accounting settings, enable "Taxes in company currency" option
- Activate another currency (e.g. USD)

- Create an invoice in USD
- Confirm the invoice
- Print the invoice

**Issue:**
The section showing the taxes in the company currency doesn't appear on the invoice despite the enabled option.

Cause:
An override of "report_invoice_document" from l10n_are is removing the section no matter what the configuration.

**Solution:**
Do not remove the section.
It was done originally in 17.0 where "Taxes in company currency" option didn't exist.

opw-5351010




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
