### PR TITLE
[FIX] hr_holidays: allow holiday responsible to unlink resource_calendar_leaves of related employees

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -902,6 +902,8 @@ Attempting to double-book your time off won't magically make your vacation 2x be
 
     def _remove_resource_leave(self):
         """ This method will create entry in resource calendar time off object at the time of holidays cancel/removed """
+        if self.has_access('write'):
+            return self.env['resource.calendar.leaves'].search([('holiday_id', 'in', self.ids)]).sudo().unlink()
         return self.env['resource.calendar.leaves'].search([('holiday_id', 'in', self.ids)]).unlink()
 
     def _validate_leave_request(self):

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -25,6 +25,9 @@ class TestHrHolidaysCommon(common.TransactionCase):
         cls.user_hrmanager_id = cls.user_hrmanager.id
         cls.user_hrmanager.tz = 'Europe/Brussels'
 
+        cls.user_hrresponsible = mail_new_test_user(cls.env, login='jeremy', groups='base.group_user,hr_holidays.group_hr_holidays_responsible')
+        cls.user_hrresponsible_id = cls.user_hrresponsible.id
+
         cls.user_employee = mail_new_test_user(cls.env, login='enguerran', password='enguerran', groups='base.group_user')
         cls.user_employee_id = cls.user_employee.id
 
@@ -51,6 +54,12 @@ class TestHrHolidaysCommon(common.TransactionCase):
             'department_id': cls.rd_dept.id,
         })
         cls.employee_hruser_id = cls.employee_hruser.id
+
+        cls.employee_hrresponsible = cls.env['hr.employee'].create({
+            'name': 'Jeremy HrResp',
+            'user_id': cls.user_hrresponsible_id,
+            'department_id': cls.rd_dept.id,
+        })
 
         cls.employee_hrmanager = cls.env['hr.employee'].create({
             'name': 'Bastien HrManager',

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -359,6 +359,28 @@ class TestAcessRightsStates(TestHrHolidaysAccessRightsCommon):
             leave._force_cancel("Cancel the leave")
             leave.with_user(self.user_hrmanager.id).action_reset_confirm()
 
+    def test_holiday_responsible_refuse_leave(self):
+        """
+            The holiday responsible should be able to accept and refuse correct type leaves of users they are responsible for
+        """
+        respo_user = self.user_hrresponsible
+        self.employee_emp.leave_manager_id = respo_user
+
+        for validatation_type in ['manager', 'both']:
+            self.leave_type.write({'leave_validation_type': validatation_type})
+            values = {
+                'name': 'Random Time Off',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'state': 'confirm',
+            }
+            leave = self.request_leave(self.user_employee, date.today(), 1, values)
+            leave.with_user(respo_user).action_refuse()
+            leave.with_user(self.user_hrmanager_id).action_reset_confirm()
+            leave.with_user(respo_user).action_approve()
+            leave.with_user(respo_user).action_refuse()
+
+
 @tests.tagged('access_rights', 'access_rights_create')
 class TestAccessRightsCreate(TestHrHolidaysAccessRightsCommon):
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')


### PR DESCRIPTION
****Behavior:****
When a user who is Time off Responsible but not Officer or Admin and is marked as responsible for an employee tries to refuse a fully accepted leave an access error occurs.
This occurs because approving a leave creates a resource.calendar.leave linked to the hr.leave, and when refusing it, the system will try to unlink it.
https://github.com/odoo/odoo/blob/72e8a29dd0edb0ca3d464142ce869f38f96c730a/addons/hr_holidays/models/hr_leave.py#L896-L901

According to access rules of r.calendar.leaves, Time-off Responsibles are not allowed any access for entries of other employees.
Approving them doesn't cause an error because the create operation uses sudo(), assuming that the user must have had valid rights to access the function. This is not the case for the unlink.

**Solution:**
This fix checks wether the user has write access to the related hr.leave record, then uses sudo().
The idea is that if they are allowed to modify the state of the leave, they can refuse the leave, and therefore should be able to go through the following operations.
This is in a similar fashion as the behavior for approving the leaves.

****Steps to Reproduce:****
- Create a Leave Type that requires validation from a manager, and assign one to an employee.
- Remove any access rights to Time-Off for the user, but leave Time off Responsible checked.
- Assign the user as time-off responsible for the employee
- Log in as the user and approve the leave
- When refusing the leave, you should get an access error.

opw-5178783