### PR TITLE
[FIX] l10n_it_stock_ddt: kit component value

### DIFF
--- a/addons/l10n_it_stock_ddt/models/stock_picking.py
+++ b/addons/l10n_it_stock_ddt/models/stock_picking.py
@@ -53,6 +53,11 @@ class StockPicking(models.Model):
         for picking in self.filtered(lambda p: p.picking_type_id.l10n_it_ddt_sequence_id):
             picking.l10n_it_ddt_number = picking.picking_type_id.l10n_it_ddt_sequence_id.next_by_id()
 
+    def action_report_ddt(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("l10n_it_stock_ddt.action_report_ddt")
+        action['context'] = {'mrp_installed': self.env["ir.module.module"]._installed()}
+        return action
+
 
 class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'

--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -113,7 +113,50 @@
                     </thead>
                     <tbody>
                         <t t-set="total_value" t-value="0"/>
-                        <t t-foreach="o.move_ids" t-as="move">
+                        <t t-set="moves" t-value="o.move_ids"/>
+                        <t t-if="o.env.context.get('mrp_installed')">
+                            <t t-set="kit_moves" t-value="o.move_ids.filtered(lambda m: m.bom_line_id.bom_id.type == 'phantom')"/>
+                            <t t-set="moves" t-value="moves - kit_moves"/>
+                            <t t-foreach="kit_moves.sale_line_id" t-as="kit_sale_line">
+                                <t t-if="kit_sale_line.product_uom_qty">
+                                    <tr>
+                                        <td>
+                                            <span t-field="kit_sale_line.product_id"/>
+                                        </td>
+                                        <td>
+                                            <span t-field="kit_sale_line.product_uom_qty"/>
+                                            <span t-field="kit_sale_line.product_uom" groups="uom.group_uom"/>
+                                        </td>
+                                        <td t-if="display_discount">
+                                            <span t-field="kit_sale_line.discount"/>
+                                        </td>
+                                        <td>
+                                            <!-- t-if-else kept for stable policy, to be removed in master -->
+                                            <t t-set="lst_price" t-value="kit_sale_line.price_total"/>
+                                            <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                            <t t-set="total_value" t-value="total_value + lst_price"/>
+                                        </td>
+                                    </tr>
+                                    <!-- components -->
+                                    <t t-foreach="kit_sale_line.move_ids" t-as="move">
+                                    <t t-if="move in o.move_ids">
+                                        <tr>
+                                            <td>
+                                                <span t-field="move.product_id"/>
+                                            </td>
+                                            <td>
+                                                <span t-field="move.quantity"/>
+                                                <span t-field="move.product_uom" groups="uom.group_uom"/>
+                                            </td>
+                                            <td t-if="display_discount"/>
+                                            <td/>
+                                        </tr>
+                                    </t>
+                                    </t>
+                                </t>
+                            </t>
+                        </t>
+                        <t t-foreach="moves" t-as="move">
                             <t t-if="move.quantity">
                                 <tr>
                                     <td>

--- a/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
+++ b/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//button[@name='do_print_picking']" position="after">
                 <field name="l10n_it_show_print_ddt_button" invisible="1"/>
-                <button name="%(l10n_it_stock_ddt.action_report_ddt)d" type="action" string="Print"
+                <button name="action_report_ddt" type="object" string="Print"
                         invisible="not l10n_it_show_print_ddt_button"
                         groups="base.group_user"/>
             </xpath>


### PR DESCRIPTION
Steps to reproduce:
- Have an IT company setup
- Create a product with a Sales Price and define a kit BOM with 2 components
- Create SO with product
- Confirm, go to delivery, validate
- Print

Issue:
In the delivery DDT, there is a summary of the delivery where each item has its own entry (product, quantity, value). However, in case of kit BOM, each component is reported with the full value of the sale operation.

Analysis:
This occurs because in the report code we don't consider the possibility of kit products, where multiple components are associated to the same sale line.

Ticket [link](https://www.odoo.com/odoo/project.task/5013606)
opw-5013606
