### PR TITLE
[FIX] account: remove redundant price unit computation in FPOS update

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4112,7 +4112,6 @@ class AccountMove(models.Model):
                     fiscal_position=line.move_id.fiscal_position_id,
                     product_taxes_after_fp=new_taxes,
                 )
-        lines_to_recompute._compute_price_unit()
         self.invoice_line_ids._compute_tax_ids()
         self.line_ids._compute_account_id()
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Performance Optimization when updating the Fiscal Position (FP) on documents (e.g., invoices).

This PR focuses on removing an unnecessary and redundant compute field that was executed on the model when modifying the Fiscal Position, aiming to reduce processing overhead and improve the performance of the write operation.

🚨 CRITICAL REGRESSION NOTE: This modification has generated a critical side effect: it breaks price consistency by forcing the re-evaluation of prices on the document lines (see details below).

Current behavior before PR:
When updating a document's Fiscal Position, a redundant compute field was executed, generating minor performance overhead.

Crucially, the system correctly maintained the originally calculated or recorded prices on the document lines, preserving price consistency, even when the Fiscal Position was updated.

Desired behavior after PR is merged:
Mainly: Improved performance and lower resource consumption when updating the Fiscal Position, due to the removal of the redundant compute.

Side Effect (Potential Regression): The new logic forces prices to always be recomputed when the Fiscal Position (FP) is changed or the "Update taxes and accounts" button is used. This causes a loss of consistency, as prices are updated to the latest rates (the current price at the moment of update) instead of retaining the original, historical prices associated with the document.

Error was introduce in https://github.com/odoo/odoo/pull/208780

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
