### PR TITLE
[FIX] web: close_on_report_download works when using a custom handler

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1295,6 +1295,12 @@ export function makeActionManager(env, router = _router) {
         for (const handler of handlers) {
             const result = await handler(action, options, env);
             if (result) {
+                const { onClose } = options;
+                if (action.close_on_report_download) {
+                    return doAction({ type: "ir.actions.act_window_close" }, { onClose });
+                } else if (onClose) {
+                    onClose();
+                }
                 return result;
             }
         }


### PR DESCRIPTION
Problem:
When an alternate ir.action.report handler is used (such as for IoT), the logic to close the wizard after the report is downloaded (printed) is skipped, so the wizard stays open.

Steps to Reproduce:
- Go to "Acoustic Bloc Screens" product and click "Print Labels"
- Select "ZPL labels" and confirm
- The report downloads and the wizard closes as expected
- Go to Settings > Technical > Reports and select "Product Label (ZPL)"
- Set an IoT device on the report
- "Print Labels" again, selecting a printer and the IoT toasts in the top right appear after the wizard closes
- Refresh the page, and try printing again
- The wizard stays open (wrong) and the IoT toasts appear

Solution:
When returning from the custom handler, check if close_on_report_download and close the wizard.

opw-5153139