### PR TITLE
[IMP] account:  Improve tax list view on Fiscal Position

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -293,7 +293,14 @@ class AccountFiscalPosition(models.Model):
         return all_auto_apply_fpos._get_first_matching_fpos(delivery)
 
     def action_open_related_taxes(self):
-        return self.tax_ids._get_records_action(name=_("%s taxes", self.display_name))
+        list_view = self.env.ref('account.account_tax_fiscal_position_view_tree', raise_if_not_found=False)
+        return {
+            'type': 'ir.actions.act_window',
+            'name': self.env._("%s taxes", self.display_name),
+            'res_model': 'account.tax',
+            'views': [(list_view.id if list_view else False, 'list'), (False, 'form')],
+            'domain': [('id', 'in', self.tax_ids.ids)],
+        }
 
     def action_create_foreign_taxes(self):
         self.ensure_one()

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -69,6 +69,22 @@
             </field>
         </record>
 
+        <record id="account_tax_fiscal_position_view_tree" model="ir.ui.view">
+            <field name="name">account.fiscal.position.tax.list</field>
+            <field name="model">account.tax</field>
+            <field name="inherit_id" ref="account.account_tax_view_tree"/>
+            <field name="mode">primary</field>
+            <field name="priority">20</field>
+            <field name="arch" type="xml">
+                <field name="display_name" position="before">
+                    <field name="type_tax_use"/>
+                </field>
+                <field name="display_name" position="after">
+                    <field name="original_tax_ids" widget="many2many_tax_tags"/>
+                </field>
+            </field>
+        </record>
+
         <record id="view_tax_kanban" model="ir.ui.view">
             <field name="name">account.tax.kanban</field>
             <field name="model">account.tax</field>


### PR DESCRIPTION
-Update the list view opened from the “Taxes” stat button to make tax
 replacement rules easier to inspect.

Impact:
-Users can review tax mappings directly without extra clicks.

task-5374524