### PR TITLE
[IMP] pos_event: autofill ticket info from selected customer

### DIFF
--- a/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.js
+++ b/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.js
@@ -45,6 +45,24 @@ export class EventRegistrationPopup extends Component {
             this.state.byOrder[question.id] = "";
         }
 
+        // Autofill first ticket with customer data if customer is selected
+        const customer = this.pos.getOrder()?.partner_id;
+        if (customer && this.state.byRegistration.length) {
+            const firstTicketQuestions = this.state.byRegistration[0].questions;
+            const fieldMap = {
+                name: customer.name,
+                email: customer.email,
+                phone: customer.phone,
+                company_name: customer.parent_name,
+            };
+
+            this.questionsByRegistration.forEach(
+                (q) =>
+                    fieldMap[q.question_type] &&
+                    (firstTicketQuestions[q.id] = fieldMap[q.question_type])
+            );
+        }
+
         if (this.props.event.question_ids.length === 0) {
             this.confirm();
         }

--- a/addons/pos_event/static/tests/unit/data/event_event.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_event.data.js
@@ -33,7 +33,7 @@ export class EventEvent extends models.ServerModel {
             registration_ids: [],
             seats_limited: true,
             write_date: "2019-03-10 11:00:00",
-            question_ids: [1, 2, 3, 4],
+            question_ids: [1, 2, 3, 4, 5],
             general_question_ids: [],
             specific_question_ids: [],
             badge_format: "A6",

--- a/addons/pos_event/static/tests/unit/data/event_question.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_question.data.js
@@ -59,6 +59,16 @@ export class EventQuestion extends models.ServerModel {
             is_mandatory_answer: false,
             answer_ids: [1, 2],
         },
+        {
+            id: 5,
+            title: "Company Name",
+            question_type: "company_name",
+            event_ids: [1],
+            sequence: 5,
+            once_per_order: false,
+            is_mandatory_answer: false,
+            answer_ids: [],
+        },
     ];
 }
 


### PR DESCRIPTION
Before this commit:
---------------
The event registration popup did not prefill customer details. Cashiers had to manually enter name, email, and phone for each ticket.

After this commit:
----------------
When a customer is selected on the POS order, the first ticket’s registration fields (name/email/phone) are automatically filled with the customer’s info.

Task-5217718

