### PR TITLE
[FIX] account,hr_expense: display analytic account linked to expenses correctly

### DIFF
--- a/addons/account/models/account_analytic_account.py
+++ b/addons/account/models/account_analytic_account.py
@@ -65,7 +65,7 @@ class AccountAnalyticAccount(models.Model):
     def action_view_vendor_bill(self):
         self.ensure_one()
         account_move_lines = self.env['account.move.line'].search_fetch([
-            ('move_id.move_type', 'in', self.env['account.move'].get_purchase_types()),
+            ('move_id.move_type', 'in', self.env['account.move'].get_purchase_types(include_receipts=True)),
             ('analytic_distribution', 'in', self.ids),
         ], ['move_id'])
         return {

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1021,3 +1021,22 @@ class TestExpenses(TestExpenseCommon):
         expense.action_approve()
         # Should not raise trust validation error despite missing recipient partner bank
         expense.action_post()
+
+    def test_expense_analytic_vendor_bill_count(self):
+        """
+        Verify that purchase receipts appear when opening a vendor bill via the smart button,
+        and that the vendor bill count matches the records shown.
+        """
+        expense = self.create_expenses([
+            {
+                'name': 'Employee PA 2*800 + 15%',
+                'analytic_distribution': {self.analytic_account_1.id: 100},
+            }])
+        expense.action_submit()
+        expense.action_approve()
+        self.post_expenses_with_wizard(expense)
+
+        self.assertEqual('in_receipt', expense.account_move_id.move_type)
+
+        vendor_bill_view = self.analytic_account_1.action_view_vendor_bill()
+        self.assertTrue(expense.account_move_id.id in vendor_bill_view['domain'][0][2])


### PR DESCRIPTION
Currently, when the user clicks the vendor bill smart button from analytic accounts, the list view shows no records even though the button count is greater than 0.

**Steps to replicate:**
* Install `accountant` and `hr_expense` with demo.
* Enable analytic accounting from settings.
* Expense > Approve and Post submitted expense
* Analytic Accounts > Nebula > Vendor Bills

**Observed Behaviour:**
* Even though the smart button shows a count of 1 there are no records displayed in the list view.

**Root cause:**
* After PR [1], vendor bills were changed to receipts. Since [2] counts receipts too, the button shows a different count than the list view, as [3] does not include receipts.

**Solution:**
* Show purchase receipts along with the vendor bills which correctly matches with the vendor bill count.

[1]:
https://github.com/odoo/odoo/pull/217758
[2]:
https://github.com/odoo/odoo/blob/569b2e27699a76f9bac210e61b47f8a5708c814b/addons/account/models/account_analytic_account.py#L36 
[3]:
https://github.com/odoo/odoo/blob/569b2e27699a76f9bac210e61b47f8a5708c814b/addons/account/models/account_analytic_account.py#L68

opw-5359320