### PR TITLE
[FIX] account: remove demo data from test

### DIFF
--- a/addons/account/static/tests/tours/invoice_line_keydown.js
+++ b/addons/account/static/tests/tours/invoice_line_keydown.js
@@ -12,11 +12,11 @@ registry.category('web_tour.tours').add('section_saved_on_tab_keydown_tour', {
         {
             content: "Add customer",
             trigger: 'div.o_field_widget.o_field_res_partner_many2one[name="partner_id"] div input',
-            run: 'edit Deco Addict',
+            run: 'edit Partner A',
         },
         {
             content: "Valid customer",
-            trigger: '.ui-menu-item a:contains("Deco Addict")',
+            trigger: '.ui-menu-item a:contains("Partner A")',
             run: 'click',
         },
         ...stepUtils.saveForm(),

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -89,6 +89,9 @@ class TestUi(AccountTestInvoicingHttpCommon):
         self.start_tour("/odoo", 'account_tax_group', login="admin")
 
     def test_section_saved_on_tab_keydown_tour(self):
+        self.env['res.partner'].create({
+            'name': 'Partner A',
+        })
         self.start_tour('/odoo/customer-invoices', 'section_saved_on_tab_keydown_tour', login='accountman')
         invoice = self.env['account.move'].search([('move_type', '=', 'out_invoice')])
         self.assertEqual(invoice.invoice_line_ids[0].name, 'Section content')


### PR DESCRIPTION
## Versions
18.0 to saas-18.2
Fixed from saas-18.3 in PR #237375

## Issue
The test relies on demo data presence and tries to create an SO with an existing partner instead of creating a new partner, always present in the testing environment

## Cause
PR #230644 added the test counting on Deco Addict's presence