### PR TITLE
[IMP/PERF] orm: check field access when getting the field cache

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -61,7 +61,7 @@ class ProductTemplate(models.Model):
             product_template.cost_method = (
                 product_template.categ_id.with_company(
                     product_template.company_id
-                ).property_cost_method
+                ).sudo().property_cost_method
                 or (product_template.company_id or self.env.company).cost_method
             )
 

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -788,11 +788,11 @@ class Cache:
 
     def _get_field_cache(self, model: BaseModel, field: Field) -> Mapping[IdType, typing.Any]:
         """ Return the field cache of the given field, but not for modifying it. """
-        return self._set_field_cache(model, field)
+        return field._get_cache(model.env)
 
     def _set_field_cache(self, model: BaseModel, field: Field) -> dict[IdType, typing.Any]:
         """ Return the field cache of the given field for modifying it. """
-        return field._get_cache(model.env)
+        return field._get_cache(model.env, fallback_to_sudo=True)
 
     def contains(self, record: BaseModel, field: Field) -> bool:
         """ Return whether ``record`` has a value for ``field``. """

--- a/odoo/orm/fields_reference.py
+++ b/odoo/orm/fields_reference.py
@@ -96,7 +96,7 @@ class Many2oneReference(Integer):
             records = records.filtered_domain(invf.get_comodel_domain(corecord))
             if not records:
                 continue
-            ids0 = invf._get_cache(corecord.env).get(corecord.id)
+            ids0 = invf._get_cache(corecord.env, fallback_to_sudo=True).get(corecord.id)
             # if the value for the corecord is not in cache, but this is a new
             # record, assign it anyway, as you won't be able to fetch it from
             # database (see `test_sale_order`)

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -286,7 +286,7 @@ class BaseString(Field[str | typing.Literal[False]]):
         records = self._filter_not_equal(records, cache_value)
         if not records:
             return
-        field_cache = self._get_cache(records.env)
+        field_cache = self._get_cache(records.env, fallback_to_sudo=True)
         dirty_ids = records.env._field_dirty.get(self, ())
 
         # flush dirty None values


### PR DESCRIPTION
Move the field access check on the cache of fields to perform it only once per environment.

```py
partner = env['res.partner'].with_user(5).search([], limit=1)

%timeit partner.name
# before vs after (no groups on field)
# 512 ns ± 5.17 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
# 459 ns ± 1.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

%timeit partner.opportunity_count
# before vs after (has groups on field)
# 4.08 μs ± 15.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# 359 ns ± 2.61 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
