### PR TITLE
[IMP] hr_work_entry_enterprise: show New/Last tags in employee header

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -570,6 +570,9 @@ class HrEmployee(models.Model):
             versions = remove_gap(versions)
         return min(versions.mapped('date_start')) if versions else False
 
+    def get_first_version_dates_by_employee(self):
+        return {employee.id: employee._get_first_version_date() for employee in self}
+
     @api.depends('name')
     def _compute_legal_name(self):
         for employee in self:

--- a/addons/hr_work_entry/static/tests/hr_work_entry_test_helpers.js
+++ b/addons/hr_work_entry/static/tests/hr_work_entry_test_helpers.js
@@ -1,6 +1,7 @@
 import { defineModels } from "@web/../tests/web_test_helpers";
 import { hrModels } from "@hr/../tests/hr_test_helpers";
 import { HrEmployee } from "@hr_work_entry/../tests/mock_server/mock_models/hr_employee";
+import { HrVersion } from "@hr_work_entry/../tests/mock_server/mock_models/hr_version";
 import { HrWorkEntryType } from "@hr_work_entry/../tests/mock_server/mock_models/hr_work_entry_type";
 import { HrWorkEntry } from "@hr_work_entry/../tests/mock_server/mock_models/hr_work_entry";
 
@@ -11,6 +12,7 @@ export function defineHrWorkEntryModels() {
 export const hrWorkEntryModels = {
     ...hrModels,
     HrEmployee,
+    HrVersion,
     HrWorkEntry,
     HrWorkEntryType,
 };

--- a/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_employee.js
+++ b/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_employee.js
@@ -4,6 +4,9 @@ export class HrEmployee extends models.ServerModel {
     _name = "hr.employee";
 
     _records = [
+        { id: 1, display_name: "Mario" },
+        { id: 2, display_name: "Luigi" },
+        { id: 3, display_name: "Yoshi" },
         { id: 100, name: "Richard" },
         { id: 200, name: "Alice" },
     ];

--- a/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_version.js
+++ b/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_version.js
@@ -1,0 +1,26 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class HrVersion extends models.Model {
+    _name = "hr.version";
+
+    _records = [
+        {
+            employee_id: 1,
+            contract_date_start: "2025-10-06", // triggers 'new' badge
+            contract_date_end: false,
+            departure_date: false,
+        },
+        {
+            employee_id: 2,
+            contract_date_start: "2025-09-07",
+            contract_date_end: "2025-11-07",
+            departure_date: "2025-11-07", // triggers 'last' badge
+        },
+        {
+            employee_id: 3,
+            contract_date_start: "2025-10-02", // shouldn't trigger 'new' badge
+            contract_date_end: false,
+            departure_date: false,
+        },
+    ];
+}


### PR DESCRIPTION
This commit contains an added model method on `hr.employee` to return a dictionary of the first ever contract starting date for each employee. It is complementary work to the below-mentioned Enterprise PR.

See https://github.com/odoo/enterprise/pull/92991

task-5026080