### PR TITLE
[REF] mail: remove obsolets fields

### DIFF
--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -36,7 +36,6 @@ declare module "models" {
         updateBusSubscription: (() => unknown) & { cancel: () => void };
     }
     export interface Thread {
-        allowCalls: Readonly<boolean>;
         allowedToLeaveChannelTypes: Readonly<string[]>;
         allowedToUnpinChannelTypes: Readonly<string[]>;
         avatar_cache_key: string;
@@ -67,7 +66,6 @@ declare module "models" {
         self_member_id: ChannelMember;
         showCorrespondentCountry: Readonly<boolean>;
         showUnreadBanner: Readonly<boolean>;
-        typesAllowingCalls: Readonly<string[]>;
     }
 
     export interface Models {

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -295,19 +295,6 @@ const threadPatch = {
             this.allowedToUnpinChannelTypes.includes(this.channel?.channel_type)
         );
     },
-    get allowDescription() {
-        return ["channel", "group"].includes(this.channel?.channel_type);
-    },
-    get typesAllowingCalls() {
-        return ["chat", "channel", "group"];
-    },
-    get allowCalls() {
-        return (
-            !this.isTransient &&
-            this.typesAllowingCalls.includes(this.channel?.channel_type) &&
-            !this.correspondent?.persona.eq(this.store.odoobot)
-        );
-    },
     get invitationLink() {
         if (!this.uuid || this.channel?.channel_type === "chat") {
             return undefined;


### PR DESCRIPTION
Following PRs https://github.com/odoo/odoo/pull/237516/ and https://github.com/odoo/odoo/pull/237749, the `allowDescription`, `typesAllowingCalls`, and `allowCalls` fields on `thread_model` are no longer used. This commit removes them.