### PR TITLE
FIX KeyError in product configurator

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -299,7 +299,10 @@ class SaleProductConfiguratorController(Controller):
         )
         product_or_template = product or product_template
         ptals = product_template.attribute_line_ids
-        attrs_map = dict(zip(ptals.ids, ptals.attribute_id.read(['id', 'name', 'display_type'])))
+        attrs_map = {
+            attr_data['id']: attr_data
+            for attr_data in ptals.attribute_id.read(['id', 'name', 'display_type'])
+        }
         ptavs = ptals.product_template_value_ids.filtered(lambda p: p.ptav_active or combination and p.id in combination.ids)
         ptavs_map = dict(zip(ptavs.ids, ptavs.read(['name', 'html_color', 'image', 'is_custom'])))
 
@@ -318,7 +321,7 @@ class SaleProductConfiguratorController(Controller):
             quantity=quantity,
             attribute_lines=[dict(
                 id=ptal.id,
-                attribute=dict(**attrs_map[ptal.id]),
+                attribute=dict(**attrs_map[ptal.attribute_id.id]),
                 attribute_values=[
                     dict(
                         **ptavs_map[ptav.id],

--- a/addons/sale/tests/test_product_configurator_data.py
+++ b/addons/sale/tests/test_product_configurator_data.py
@@ -321,6 +321,61 @@ class TestProductConfiguratorData(HttpCaseWithUserDemo, ProductVariantsCommon, S
         # Make sure that deleted value is not selected
         self.assertNotIn(archived_ptav.id, selected_values)
 
+    def test_multiple_attribute_lines_same_attribute(self):
+        """
+        Test that product configurator works correctly when multiple attribute
+        lines reference the same attribute. This ensures no KeyError is raised
+        when building the attrs_map in _get_product_information.
+        """
+        # Create a product template with two attribute lines referencing the same attribute
+        product_template = self.env['product.template'].create({
+            'name': 'Multi Size Shirt',
+            'categ_id': self.product_category.id,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.size_attribute.id,
+                    'value_ids': [
+                        Command.set([
+                            self.size_attribute_l.id,
+                        ]),
+                    ],
+                }),
+                Command.create({
+                    'attribute_id': self.color_attribute.id,
+                    'value_ids': [
+                        Command.set([
+                            self.color_attribute_red.id,
+                            self.color_attribute_blue.id,
+                        ])
+                    ],
+                }),
+                Command.create({
+                    'attribute_id': self.size_attribute.id,
+                    'value_ids': [
+                        Command.set([
+                            self.size_attribute_m.id,
+                        ]),
+                    ],
+                }),
+            ],
+        })
+
+        self.authenticate('demo', 'demo')
+        # This should not raise a KeyError
+        result = self.request_get_values(product_template)
+
+        # Verify we got the expected number of attribute lines
+        self.assertEqual(len(result['products'][0]['attribute_lines']), 3)
+        # Verify that each attribute line has its attribute info correctly mapped
+        attribute_names = [
+            line['attribute']['name']
+            for line in result['products'][0]['attribute_lines']
+        ]
+        self.assertIn('Size', attribute_names)
+        self.assertIn('Color', attribute_names)
+        # Count occurrences of 'Size' - should be 2 since we have two lines with the same attribute
+        self.assertEqual(attribute_names.count('Size'), 2)
+
 
 @tagged('post_install', '-at_install')
 class TestSaleProductVariants(ProductAttributesCommon, SaleCommon):

--- a/doc/cla/individual/ecino.md
+++ b/doc/cla/individual/ecino.md
@@ -1,0 +1,11 @@
+Switzerland, December 02 2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Emanuel Cino ecino@compassion.ch https://github.com/ecino


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When multiple `product.template.attribute.line` records reference the same `product.attribute`, the product configurator raises a `KeyError` at line 321.

Root cause: `ptals.attribute_id` returns a unique recordset (Odoo deduplicates), so `zip(ptals.ids, ptals.attribute_id.read(...))` produces fewer entries than expected when attributes are shared across lines.

```python
# Before: zip stops at shorter list, missing entries in attrs_map
attrs_map = dict(zip(ptals.ids, ptals.attribute_id.read(['id', 'name', 'display_type'])))

# After: preserve 1:1 mapping by iterating each ptal
attrs_map = {ptal.id: ptal.attribute_id.read(['id', 'name', 'display_type'])[0] for ptal in ptals}
```

Current behavior before PR:

`KeyError` raised when accessing `attrs_map[ptal.id]` for attribute lines whose ID was truncated by the `zip`.

Desired behavior after PR is merged:

Product configurator correctly maps all attribute lines regardless of whether they share the same underlying attribute.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr