### PR TITLE
[FIX] point_of_sale: prevent recompute of manually set prices while settling

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -936,7 +936,9 @@ export class PosStore extends Reactive {
                 line,
                 related_lines
             );
-            related_lines.forEach((line) => line.set_unit_price(price));
+            related_lines
+                .filter((line) => line.price_type !== "manual")
+                .forEach((line) => line.set_unit_price(price));
         }
         line.setOptions(options);
         this.selectOrderLine(order, line);

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -115,7 +115,7 @@ patch(PosStore.prototype, {
                 product_id: line.product_id,
                 qty: line.product_uom_qty,
                 price_unit: line.price_unit,
-                price_type: "automatic",
+                price_type: "manual",
                 tax_ids: taxes.map((tax) => ["link", tax]),
                 sale_order_origin_id: sale_order,
                 sale_order_line_id: line,

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -605,3 +605,18 @@ registry.category("web_tour.tours").add("test_settle_groupable_lot_total_amount"
             Order.hasTotal("12.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_settle_changed_price_with_lots", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.totalAmountIs("180.00"),
+            Order.doesNotHaveLine({
+                productName: "Settle Lots",
+                quantity: "1.0",
+                price: "100",
+            }),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -2246,6 +2246,36 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             pos_order = self.env['pos.order'].browse(res['pos.order'][0]['id'])
             self.assertEqual(pos_order.account_move.line_ids.tax_ids, tax_0_percent, "The downpayment line should have the fixed tax applied")
 
+    def test_settle_changed_price_with_lots(self):
+        """
+        Tests that when we change the price of a line in the quotation, it will not be reverted when
+        settling it through the PoS
+        """
+        partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        product_lot_tracked = self.env['product.product'].create({
+            'name': 'Settle Lots',
+            'available_in_pos': True,
+            'lst_price': 100.0,
+            'taxes_id': False,
+            'tracking': 'lot',
+        })
+        self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': product_lot_tracked.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 120.0,
+                }),
+                (0, 0, {
+                    'product_id': product_lot_tracked.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 60.0,
+                })
+            ]
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_settle_changed_price_with_lots', login="accountman")
+
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPosSaleAccount(TestPoSCommon):


### PR DESCRIPTION
**Steps to reproduce:**
- Create a product tracked by lot, set it's price to 1000
- Create a quotation add a line with the created product and change the price to 1200
- Add another line with the same product and change it's price to 600
- Go to PoS and settle this quotation
- The lines' prices will be 1000 and 600 instead of 1200 and 600

**Why the fix:**
In the event of a settle with a product tracked by lots, we are setting the price of all *related_lines* (lines with the same product in this case) to it's base price, not taking into account the fact that this price has been modified by the user when making the quotation.

This only happens for related lines, which explains why one line's price is still 600 while the other was reverted to the base price of 1000 instead of being 1200 as it was previously set.

To avoid this, we now set the price_unit back to the base one only if the price hasn't been changed manually.

opw-5223463