### PR TITLE
[IMP] pos_{, restaurant}: allow early receipt print in retails

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -203,6 +203,7 @@ class PosConfig(models.Model):
         'pos.payment.method', string='Fast Payment Methods', compute="_compute_fast_payment_method_ids", relation='pos_payment_method_config_fast_validation_relation',
         store=True, help="These payment methods will be available for fast payment", readonly=False)
     statistics_for_current_session = fields.Json(string="Session Statistics", compute="_compute_statistics_for_session")
+    iface_printbill = fields.Boolean(string='Bill Printing', help="Allows to print the Bill before payment.")
 
     pos_snooze_ids = fields.One2many('pos.product.template.snooze', 'pos_config_id', string='Snoozed Products')
 

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -118,6 +118,7 @@ class ResConfigSettings(models.TransientModel):
     group_pos_preset = fields.Boolean(string="Presets", implied_group="point_of_sale.group_pos_preset", help="Hide or show the Presets menu in the Point of Sale configuration.")
     pos_use_fast_payment = fields.Boolean(related='pos_config_id.use_fast_payment', readonly=False)
     pos_fast_payment_method_ids = fields.Many2many(related='pos_config_id.fast_payment_method_ids', readonly=False)
+    pos_iface_printbill = fields.Boolean(related='pos_config_id.iface_printbill', readonly=False)
 
     def open_payment_method_form(self):
         bank_journal = self.env['account.journal'].search([('type', '=', 'bank'), ('company_id', 'in', self.env.company.parent_ids.ids)], limit=1)

--- a/addons/point_of_sale/static/src/app/components/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/components/receipt/order_receipt.xml
@@ -4,6 +4,7 @@
         <div class="pos-receipt p-2">
             <t t-set="showTaxGroupLabels" t-value="doesAnyOrderlineHaveTaxLabel()"/>
             <ReceiptHeader order="order" />
+            <div t-if="!order.finalized" class="text-center fs-2 mb-1">Pro forma receipt</div>
             <div class="pt-3"/>
             <OrderDisplay order="order" t-slot-scope="scope" mode="'receipt'">
                 <t t-set="line" t-value="scope.line"/>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -10,6 +10,7 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { SelectPartnerButton } from "@point_of_sale/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button";
+import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 
 export class ControlButtons extends Component {
     static template = "point_of_sale.ControlButtons";
@@ -30,6 +31,13 @@ export class ControlButtons extends Component {
         this.ui = useService("ui");
         this.dialog = useService("dialog");
         this.notification = useService("notification");
+        this.clickPrintBill = useAsyncLockedMethod(this.clickPrintBill);
+    }
+    async clickPrintBill() {
+        // Need to await to have the result in case of automatic skip screen.
+        await this.pos.printReceipt({
+            printBillActionTriggered: true,
+        });
     }
     get partner() {
         return this.pos.getOrder()?.getPartner();

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -23,6 +23,11 @@
                     label.translate="Customer Note"
                     class="buttonClass"
                     icon="'fa fa-sticky-note'"/>
+                <button t-if="pos.config.iface_printbill" t-att-class="buttonClass"
+                    t-att-disabled="!pos.getOrder()?.getOrderlines()?.length"
+                    t-on-click="clickPrintBill">
+                    <i class="fa fa-print me-1"></i>Bill
+                </button>
                 <button t-if="this.pos.cashier._role != 'minimal'" class="o_pricelist_button" t-att-class="buttonClass" t-on-click="() => this.clickPricelist()">
                     <i class="fa fa-th-list me-2" role="img" aria-label="Price list" title="Price list" />
                     <t t-if="currentOrder?.pricelist_id" t-esc="currentOrder.pricelist_id.display_name" />

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -351,6 +351,9 @@
                                 <setting id="basic_receipt" help="Print basic ticket without prices. Can be used for gifts.">
                                     <field name="pos_basic_receipt"/>
                                 </setting>
+                                <setting string="Early Receipt Printing" help="Allow to print receipt before payment" id="iface_printbill">
+                                    <field name="pos_iface_printbill"/>
+                                </setting>
                             </block>
 
                             <block title="Payment Terminals" help="Those settings are common to all PoS." id="pos_payment_terminals_section">

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -8,7 +8,6 @@ class PosConfig(models.Model):
     _inherit = 'pos.config'
 
     iface_splitbill = fields.Boolean(string='Bill Splitting', help='Enables Bill Splitting in the Point of Sale.')
-    iface_printbill = fields.Boolean(string='Bill Printing', help='Allows to print the Bill before payment.')
     floor_ids = fields.Many2many('restaurant.floor', string='Restaurant Floors', help='The restaurant floors served by this point of sale.', copy=False)
     default_screen = fields.Selection([('tables', 'Tables'), ('register', 'Register')], string='Default Screen', default='tables')
     use_course_allocation = fields.Boolean(string="Enable Course Allocation")

--- a/addons/pos_restaurant/models/res_config_settings.py
+++ b/addons/pos_restaurant/models/res_config_settings.py
@@ -7,7 +7,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     pos_floor_ids = fields.Many2many(related='pos_config_id.floor_ids', readonly=False)
-    pos_iface_printbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
     pos_iface_splitbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
     pos_default_screen = fields.Selection(related="pos_config_id.default_screen", readonly=False)
     pos_use_course_allocation = fields.Boolean(related='pos_config_id.use_course_allocation', readonly=False)
@@ -17,11 +16,9 @@ class ResConfigSettings(models.TransientModel):
         for res_config in self:
             if not res_config.pos_module_pos_restaurant:
                 res_config.update({
-                    'pos_iface_printbill': False,
                     'pos_iface_splitbill': False,
                 })
             else:
                 res_config.update({
-                    'pos_iface_printbill': res_config.pos_config_id.iface_printbill,
                     'pos_iface_splitbill': res_config.pos_config_id.iface_splitbill,
                 })

--- a/addons/pos_restaurant/static/src/app/components/receipt/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/app/components/receipt/order_receipt/order_receipt.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_restaurant.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
-        <xpath expr="//ReceiptHeader" position="after">
-            <div t-if="!order.finalized" class="fs-2 mb-1">Pro forma receipt</div>
-        </xpath>
-    </t>
     <t t-name="pos_restaurant.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('cashier')]" position="after">
             <t t-if="order.table_id or order.self_ordering_table_id" t-esc="tableName"/>

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,7 +1,6 @@
 import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { SelectPartnerButton } from "@point_of_sale/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button";
 import { useService } from "@web/core/utils/hooks";
-import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 import { patch } from "@web/core/utils/patch";
 
 patch(ControlButtons.prototype, {
@@ -9,13 +8,6 @@ patch(ControlButtons.prototype, {
         super.setup(...arguments);
         this.alert = useService("alert");
         this.printer = useService("printer");
-        this.clickPrintBill = useAsyncLockedMethod(this.clickPrintBill);
-    },
-    async clickPrintBill() {
-        // Need to await to have the result in case of automatic skip screen.
-        await this.pos.printReceipt({
-            printBillActionTriggered: true,
-        });
     },
     clickTableGuests() {
         this.pos.setCustomerCount();

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -14,11 +14,6 @@
             position="before">
             <!-- All these buttons will only be displayed in a dialog -->
             <t t-if="pos.config.module_pos_restaurant">
-                <button t-if="pos.config.iface_printbill" t-att-class="buttonClass"
-                    t-att-disabled="!pos.getOrder()?.getOrderlines()?.length"
-                    t-on-click="clickPrintBill">
-                    <i class="fa fa-print me-1"></i>Bill
-                </button>
                 <button t-att-class="buttonClass" t-on-click="clickTableGuests">
                     <span t-esc="currentOrder?.getCustomerCount() || 0" t-attf-class="rounded-circle text-bg-dark fw-bolder small me-1 {{ui.isSmall ? 'px-1' : 'px-2 py-1'}}"/>
                     <span>Guests</span>

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -18,9 +18,6 @@
                         </div>
                     </div>
                 </setting>
-                <setting string="Early Receipt Printing" help="Allow to print receipt before payment" id="iface_printbill"  invisible="not pos_module_pos_restaurant or use_kiosk_mode">
-                    <field name="pos_iface_printbill"/>
-                </setting>
                 <setting help="Split total or order lines" id="iface_splitbill"  documentation="/applications/sales/point_of_sale/restaurant/bill_printing.html" invisible="not pos_module_pos_restaurant or use_kiosk_mode">
                     <field name="pos_iface_splitbill" string="Allow Bill Splitting"/>
                 </setting>

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -138,6 +138,10 @@
             <setting id="barcode_scanner" position="attributes">
                 <attribute name="invisible">use_kiosk_mode</attribute>
             </setting>
+
+            <setting id="iface_printbill" position="attributes">
+                <attribute name="invisible">use_kiosk_mode</attribute>
+            </setting>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
*: pos_self_order

Before this commit:
===========
- Early receipt printing was only available in restaurant POS configs.

After this commit:
===========
- Early receipt printing is now allowed in both retail and restaurant POS setups.

Related PR:
- Upgrade: https://github.com/odoo/upgrade/pull/8981

Task-5365571
