### PR TITLE
[FIX] website: fix dynamic snippets visibility

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -176,7 +176,11 @@ const DynamicSnippet = publicWidget.Widget.extend({
      */
     _render: function () {
         if (this.data.length > 0 || this.editableMode) {
-            this.$el.removeClass('o_dynamic_snippet_empty');
+            // Compatibility code: A dynamic snippet may end up with the
+            // `o_dynamic_empty` class or `o_dynamic_snippet_empty` or both.
+            // Remark: the `s_dynamic_empty` class was introduced by mistake
+            // and does not have any associated CSS.
+            this.$el.removeClass('o_dynamic_snippet_empty o_dynamic_empty');
             this._prepareContent();
         } else {
             this.$el.addClass('o_dynamic_snippet_empty');

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
@@ -1,6 +1,19 @@
 .s_dynamic {
-    &.o_dynamic_snippet_empty:not(.o_check_scroll_position) {
-        display: none !important;
+    #wrap &:not(.o_check_scroll_position) {
+        // Compatibility code: The `o_dynamic_empty` class was originally used to control
+        // the visibility of dynamic snippets. It was later renamed (starting from 18.0)
+        // to `s_dynamic_empty`, while another class `o_dynamic_snippet_empty` was added by
+        // the public widget before leaving edit mode (on destroy). As a result, a dynamic
+        // snippet may end up with:
+        // - `o_dynamic_empty` & `o_dynamic_snippet_empty` > for old but edited snippets.
+        // - `o_dynamic_empty` > for old snippets never updated in edit mode.
+        // - `s_dynamic_empty` and `o_dynamic_snippet_empty` > for new snippets.
+        &.o_dynamic_empty,
+        &.o_dynamic_snippet_empty {
+            body:not(.editor_enable) & {
+                display: none !important;
+            }
+        }
     }
     [data-url] {
         cursor: pointer;

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
@@ -1,0 +1,81 @@
+/** @odoo-module */
+
+import {
+    changeOption,
+    clickOnSave,
+    clickOnSnippet,
+    insertSnippet,
+    registerWebsitePreviewTour,
+    clickOnEditAndWaitEditMode,
+} from "@website/js/tours/tour_utils";
+
+const blogPostsOptionName = "dynamic_snippet_blog_posts";
+const blogPostsSnippet = {
+    id: "s_blog_posts",
+    name: "Blogs",
+    groupName: "Blogs",
+};
+
+const isSnippetVisible = () => [
+    {
+        content: "Check that a dynamic snippet with content is visible",
+        trigger:
+            ":iframe .s_dynamic_snippet_blog_posts:not(.o_dynamic_snippet_empty):not(.o_dynamic_empty) h5:contains('Post Test')",
+    },
+];
+
+registerWebsitePreviewTour(
+    "blog_posts_dynamic_snippet_edit",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet(blogPostsSnippet),
+        ...clickOnSnippet(blogPostsSnippet),
+        changeOption(
+            blogPostsOptionName,
+            `we-select[data-name="template_opt"] we-toggler`,
+            "template"
+        ),
+        changeOption(
+            blogPostsOptionName,
+            `we-button[data-select-data-attribute="website_blog.dynamic_filter_template_blog_post_card"]`
+        ),
+        {
+            content: "Check that a dynamic snippet is visible in edit mode",
+            trigger:
+                ":iframe .s_dynamic_snippet_blog_posts:not(.o_dynamic_snippet_empty):not(.o_dynamic_empty)",
+        },
+        ...clickOnSave(),
+        ...isSnippetVisible(),
+    ]
+);
+
+registerWebsitePreviewTour(
+    "blog_posts_dynamic_snippet_visible",
+    {
+        url: "/",
+    },
+    isSnippetVisible
+);
+
+registerWebsitePreviewTour(
+    "blog_posts_dynamic_snippet_empty",
+    {
+        url: "/",
+    },
+    () => [
+        {
+            content: "Check that a dynamic snippet with no content is hidden",
+            trigger:
+                ":iframe .o_dynamic_snippet_empty:not(:visible), :iframe .o_dynamic_empty:not(:visible)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Check that a dynamic snippet is visible in edit mode",
+            trigger:
+                ":iframe .s_dynamic_snippet_blog_posts:not(.o_dynamic_snippet_empty):not(.o_dynamic_empty)",
+        },
+    ]
+);

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -103,3 +103,26 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         blog_post_2.write({'tag_ids': [(4, blog_tag.id)]})
 
         self.start_tour("/blog", "blog_tags_with_date", login="admin")
+
+    def test_blog_posts_dynamic_snippet_visibility(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_edit', login='admin')
+        # Unpublish blog posts so the dynamic snippet can't show content.
+        blog_posts = self.env['blog.post'].search([])
+        blog_posts.write({'website_published': False})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_empty', login='admin')
+        # Compatibility with old snippets only with the `o_dynamic_empty` class.
+        homepage_view = self.env['ir.ui.view'].search([
+            ('website_id', '=', self.env.ref('website.default_website').id),
+            ('key', '=', 'website.homepage'),
+        ])
+        homepage_view_arch_old = homepage_view.arch_db.replace('s_dynamic_empty', 'o_dynamic_empty').replace('o_dynamic_snippet_empty', '')
+        homepage_view.write({'arch': homepage_view_arch_old})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_empty', login='admin')
+        blog_posts.write({'website_published': True})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_visible', login='admin')
+        # Compatibility with old but edited snippets (having `o_dynamic_empty` & `o_dynamic_snippet_empty` classes).
+        homepage_view_arch_old_edited = homepage_view.arch_db.replace('o_dynamic_empty', 'o_dynamic_empty o_dynamic_snippet_empty')
+        homepage_view.write({'arch': homepage_view_arch_old_edited})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_visible', login='admin')
+        blog_posts.write({'website_published': False})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_empty', login='admin')


### PR DESCRIPTION
Steps to reproduce [18.2+]:

1. Add a dynamic snippet to a website page (e.g., Events).

2. Unpublish all event records.

3. The snippet first appears with a visible header, which then
disappears.

[A]- Starting from [1], the `o_dynamic_empty` class was introduced to
handle the dynamic snippets visibility, and an upgrade script (see [3])
set this class by default on them.

Later in 18.0 (after [2]), the class was changed to `s_dynamic_empty` in
the XML template, while on the JS side, the class used to toggle snippet
visibility was `o_dynamic_snippet_empty`. This class was also added to
snippets on destroy (before saving).

[B]- As a result, a dynamic snippet may end up with:

- `o_dynamic_empty` & `o_dynamic_snippet_empty`: for old (before 18.0) but
edited snippets.
- `o_dynamic_empty`: for old snippets never updated in edit mode on 18.0.
- `s_dynamic_empty` & `o_dynamic_snippet_empty`: for new snippets created
in 18.0.

Remark: the `s_dynamic_empty` class was introduced by mistake and does
not have any associated CSS

Since only `o_dynamic_snippet_empty` has `display: none` in CSS, the
interaction flow became inconsistent (starting from 18.2): snippets were
initially visible, then hidden if no content was found... which caused
the flickering behavior described above.

And because of [B], old snippets with the `o_dynamic_empty` class
will be visible by default in 18.0.

This commit restores the intended (and original) behavior:

- A dynamic snippet should be invisible by default,

- Then the interaction decides (based on actual content) whether the
snippet should be displayed.

[1]: https://github.com/odoo/odoo/commit/63def9c87305dd7773e0592a28fe19d0b63c0878
[2]: https://github.com/odoo/odoo/commit/76cf201e1fc356ad00b27bcdec408c54949df33b
[3]: https://github.com/odoo/upgrade/commit/af5821d9aeb75d09653fc33f14e98fae5f5ba906

opw-5354523