### PR TITLE
[FIX] mass_mailing: fix mailing_domain for multi_company cron job

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1009,11 +1009,11 @@ class MassMailing(models.Model):
 
     def _get_recipients(self):
         mailing_domain = self._get_recipients_domain()
-        res_ids = self.env[self.mailing_model_real].search(mailing_domain).ids
+        res_ids = self.env[self.mailing_model_real].with_user(self.user_id).search(mailing_domain).ids
 
         # randomly choose a fragment
         if self.ab_testing_enabled and not self.ab_testing_is_winner_mailing:
-            contact_nbr = self.env[self.mailing_model_real].search_count(mailing_domain)
+            contact_nbr = self.env[self.mailing_model_real].with_user(self.user_id).search_count(mailing_domain)
             topick = 0
             if contact_nbr:
                 topick = max(int(contact_nbr / 100.0 * self.ab_testing_pc), 1)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Email Marketing app
- Create contacts in 2 different companies
- Give all of them the same tag
- Log in as a user who only has access to one company
- Create a new mailing campaign
- Set recipients to "Contacts"
- In the custome domain, filter by the shared tag
- Showed records are properly filtered
- Send the campaign
- The email is sent to all tagged contacts, even those in the other companies

**Issue:**
Cron job doesn't restrict the domain search to the original user when triggered.

**Fix:**
Used `with_user` before the `search` of the mailing_domain. Also added it for the `search_count`.

opw-5143925
