### PR TITLE
[18.0][FIX] website_blog: avoid unnecessary calls to the database when no blog is selected

### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -60,6 +60,8 @@ class Blog(models.Model):
 
     def all_tags(self, join=False, min_limit=1):
         BlogTag = self.env['blog.tag']
+        if join:
+            return BlogTag.search([])
         req = """
             SELECT
                 p.blog_id, count(*), r.blog_tag_id
@@ -83,9 +85,6 @@ class Blog(models.Model):
                     all_tags.add(tag_id)
                 else:
                     tag_by_blog[blog_id].append(tag_id)
-
-        if join:
-            return BlogTag.browse(all_tags)
 
         for blog_id in tag_by_blog:
             tag_by_blog[blog_id] = BlogTag.browse(tag_by_blog[blog_id])


### PR DESCRIPTION
Functional impact:

The main blog view (/blog) becomes very slow on databases with a high number of posts, tags and multiple blogs, when the sidebar option “Tags List” is enabled.
In large installations (thousands of posts and dozens of tags shared across several blogs), server response time can exceed 5–7 seconds, significantly affecting the user experience.

Steps to reproduce:

- Install website_blog.
- Create several blogs (3–4).
- Create a large number of posts per blog (1000+ total).
- Create many tags (40–60), shared between different blogs.
- Ensure many posts share multiple tags.
- Enable the “Tags List” option in the blog sidebar. -Access /blog without selecting a specific blog.

Current behavior:

The /blog page always calls: blogs.all_tags(join=True) when no blog is selected (blog=None). This triggers a heavy SQL aggregation query on: blog_post_blog_tag_rel and blog_post, even though when no blog is selected, the sidebar only needs the global list of tags, not per-blog aggregated information.
With large datasets, this query is expensive and may take several seconds. Because the sidebar requires all_tags, this query is executed on every request to /blog, even when no specific blog is chosen. The result is a TTFB of 5–7 seconds in real installations with high content volume.

Expected behavior:

When no blog is selected (blog=None), the /blog view should not execute heavy aggregation queries that depend on the size of the post–tag M2M relationship.
In this case, it is sufficient to load the global tags (blog.tag), because the sidebar widget does not require per-blog statistics. The main blog page should load almost instantly (<200 ms backend time), even on large databases.

Technical solution:

Adjust the logic so that when no blog is selected, the tag list is retrieved directly from blog.tag, avoiding the expensive SQL aggregation. Completely skip the heavy query when blog=None.
Preserve the original behavior when a specific blog is selected. The sidebar still works exactly the same and displays the same tags. No functional behavior changes and no data is lost.

Additional notes:

The slow TTFB (5–7 s) appears only in installations with:
- a large number of posts (thousands),
- tags shared across several blogs,
- the sidebar “Tags List” enabled. Small installations do not show the issue, which is why it can remain unnoticed, but it becomes critical in real production systems.

@Tecnativa TT59484


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
