### PR TITLE
[FIX] mail: fix traceback on mass mailing

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -26,7 +26,10 @@ export class MailComposerAttachmentSelector extends Component {
         if (this.props.record.resModel === "mail.scheduled.message") {
             resIds = [this.props.record.data.res_id.resId];
         } else {
-            resIds = JSON.parse(this.props.record.data.res_ids);
+            // composer does not store res_ids past a certain limit, assume active_ids is used
+            resIds = this.props.record.data.res_ids
+                ? JSON.parse(this.props.record.data.res_ids)
+                : this.props.record.context.active_ids;
         }
         const thread = await this.mailStore.Thread.insert({
             model: this.props.record.data.model,


### PR DESCRIPTION
Steps to reproduce:
1. Install 'contact'
2. Create 501+ contacts (e.g. by duplicating existing one)
3. Select all contacts in list view and click Send Email (from Action menu)
4. Try to add an attachment

Issue:
- A traceback is raised in the mail composer: `SyntaxError: Unexpected end of JSON input`

Cause:
`res_ids` is not set on the composer when more than 500 records are selected. This is expected, as the compute method `_compute_res_ids()` does not write `res_ids` when the number of active_ids exceeds 500 (to avoid storing large payloads on the field). Because of this, the code trying to JSON.parse(res_ids) fails. see: https://github.com/odoo/odoo/blob/abc8417413faf598fb83106de4328571d71888aa/addons/mail/wizard/mail_compose_message.py#L400

Solution:
- Fallback to context.active_ids when res_ids is not available

opw-5351374