### PR TITLE
[FIX] sale_management: make SO template demo data translatable

### DIFF
--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -156,7 +156,7 @@ class SaleOrderTemplate(models.Model):
                 'product_uom_qty': 8,
             }),
             Command.create({
-                'name': "Optional Products Section",
+                'name': self.env._("Optional Products Section"),
                 'display_type': 'line_section',
                 'is_optional': True,
                 'product_uom_qty': 0,


### PR DESCRIPTION
This commit fixes a little issue with the `sale.order.template` demo data, where the optional section title wasn't translatable.

Affected version-19.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
