### PR TITLE
[FIX] core: auto upgrade remaining

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -592,6 +592,16 @@ def load_modules(
             model._register_hook()
         env.flush_all()
 
+        if update_module:
+            cr.execute(
+                """
+                INSERT INTO ir_config_parameter(key, value)
+                SELECT 'base.partially_updated_database', '1'
+                WHERE EXISTS(SELECT FROM ir_module_module WHERE state IN ('to upgrade', 'to install', 'to remove'))
+                ON CONFLICT DO NOTHING
+                """
+            )
+
 
 def reset_modules_state(db_name: str) -> None:
     """

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1353,11 +1353,7 @@ def preload_registries(dbnames):
     for dbname in dbnames:
         try:
             threading.current_thread().dbname = dbname
-            update_from_config = update_module = config['init'] or config['update']
-            if not update_from_config:
-                with sql_db.db_connect(dbname).cursor() as cr:
-                    cr.execute("SELECT 1 FROM ir_module_module WHERE state IN ('to remove', 'to upgrade', 'to install') FETCH FIRST 1 ROW ONLY")
-                    update_module = bool(cr.rowcount)
+            update_module = config['init'] or config['update']
             registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
 
             # run post-install tests
@@ -1365,7 +1361,7 @@ def preload_registries(dbnames):
                 from odoo.tests import loader  # noqa: PLC0415
                 t0 = time.time()
                 t0_sql = sql_db.sql_counter
-                module_names = (registry.updated_modules if update_from_config else
+                module_names = (registry.updated_modules if update_module else
                                 sorted(registry._init_modules))
                 _logger.info("Starting post tests")
                 tests_before = registry._assertion_report.testsRun


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/216025, we force auto upgrade of
modules remaining in the database when `preload_registries` is called.
However, this strategy doesn't work if Odoo is not started with the `-d`
argument, because `preload_registries` is only called for databases
specified in the `-d` argument.

This commit fixes the issue by adding a special record in
`ir_config_parameter` with key `base.partially_updated_database` to
indicate that the next time `Registry.new` is called, it should force
auto upgrade of modules remaining in the database.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
