### PR TITLE
[FIX] sale_pdf_quote_builder: Fix no detect PDF form field with Hierarchy object

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -208,6 +208,9 @@ class IrActionsReport(models.Model):
                 # Modifying the annots that hold every information about the form fields
                 for j in range(len(page['/Annots'])):
                     reader_annot = page['/Annots'][j].getObject()
+                    # Check parent object for '/T' if missing.
+                    if '/T' not in reader_annot and '/Parent' in reader_annot:
+                        reader_annot = reader_annot['/Parent'].getObject()
                     if reader_annot.get('/T') in field_names:
                         # Prefix all form fields in the document with the document identifier.
                         # This is necessary to know which value needs to be taken when filling the forms.

--- a/doc/cla/individual/khaihoan123.md
+++ b/doc/cla/individual/khaihoan123.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-12-02
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Khai Hoan Hoang hoangkhaihoan190298@gmail.com https://github.com/khaihoan123


### PR DESCRIPTION
- For Hierarchy objects, we have to check '/T' in '/Parent' instead directly within '/Annot' like flat fields.

Desired behavior after PR is merged:

- Support form fields with Hierarchy objects.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
