### PR TITLE
[FIX] sale: fix included tax mapping

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1347,6 +1347,10 @@ class SaleOrder(models.Model):
 
     def _recompute_taxes(self):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
+
+        # We do not provide 'force_price_recomputation' here on purpose as we don't want
+        # manual prices to be reset on 'Update Taxes' button trigger
+        lines_to_recompute._compute_price_unit()
         lines_to_recompute._compute_tax_ids()
         self.show_update_fpos = False
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1348,10 +1348,9 @@ class SaleOrder(models.Model):
     def _recompute_taxes(self):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
 
-        # We do not provide 'force_price_recomputation' here on purpose as we don't want
-        # manual prices to be reset on 'Update Taxes' button trigger
-        lines_to_recompute._compute_price_unit()
-        lines_to_recompute._compute_tax_ids()
+        lines_to_recompute.with_context(
+            recompute_unit_price_on_tax_change=True
+        )._compute_tax_ids()
         self.show_update_fpos = False
 
     def action_update_prices(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -564,6 +564,13 @@ class SaleOrderLine(models.Model):
                 else:
                     result = fiscal_position.map_tax(taxes)
                     cached_taxes[cache_key] = result
+
+                if (
+                    line.env.context.get('recompute_unit_price_on_tax_change', False)
+                    and result != line.tax_ids
+                ):
+                    line.env.add_to_compute(self._fields['price_unit'], line)
+
                 # If company_id is set, always filter taxes by the company
                 line.tax_ids = result
 


### PR DESCRIPTION
### Issue:
Due to this issue, the line price is not calculated correctly after applying included tax mapping fiscal position.

#### To reproduce:
1- Create included taxes of 6% and 21%
2- Create a fiscal position that maps 21% to 6%
3- Create a product and apply 21% sale tax and 121 sale unit price
4- Create a SO and add the product to first line
5- From `Other info` tab, apply the created fiscal position
6- Click on `Update Taxes`
7- As you see unit price is 121 and subtotal price is 114.15
8- Add another line with the same product. The unit price is 106 and subtotal is 100 which differs from first line.

PO has confirmed the price from the 2nd line is the correct flow.

After checking the flow in accounting, the flow from 2nd line here is applied on both lines on invoices.
On accounting, the price is recomputed after fiscal position is applied before taxes being recomputed.
This is done to fix the same issue: #210451
We can apply the same logic here so flow matches with accounting.

opw-5361503
