### PR TITLE
[FIX] purchase: convert currency for vendor in catalog

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -911,8 +911,11 @@ class PurchaseOrder(models.Model):
             params=params
         )
         if seller:
+            price = seller.price_discounted
+            if seller.currency_id != self.currency_id:
+                price = seller.currency_id._convert(seller.price_discounted, self.currency_id)
             product_infos.update(
-                price=seller.price_discounted,
+                price=price,
                 min_qty=seller.min_qty,
             )
         # Check if the product uses some packaging.
@@ -1043,7 +1046,10 @@ class PurchaseOrder(models.Model):
                 uom_id=pol.product_uom)
             if seller:
                 # Fix the PO line's price on the seller's one.
-                pol.price_unit = seller.price
+                price = seller.price
+                if seller.currency_id != self.currency_id:
+                    price = seller.currency_id._convert(seller.price, self.currency_id)
+                pol.price_unit = price
                 pol.discount = seller.discount
         return pol.price_unit_discounted
 

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_access_rights
 from . import test_accrued_purchase_orders
 from . import test_purchase_tax_totals
 from . import test_purchase_dashboard
+from . import test_purchase_product_catalog

--- a/addons/purchase/tests/test_purchase_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_product_catalog.py
@@ -1,0 +1,143 @@
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import HttpCase, tagged
+
+import json
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
+
+    def test_catalog_price(self):
+        """
+        Products having a SupplierInfo record in a foreign currency should have their price
+        converted in the product catalog
+        When it's the same currency, the price shouldn't be changed
+        """
+        self.authenticate(self.env.user.login, self.env.user.login)
+        company_currency = self.env.company.currency_id
+
+        rates = [(fields.Date.today(), 0.5)]
+        other_currency = self.env['res.currency'].with_context(active_test=False).search([('name', '=', 'HRK')], limit=1)
+        other_currency.rate_ids.unlink()
+        other_currency.write({
+            'active': True,
+            'rate_ids': [Command.create(
+                {
+                    'name': rate_date,
+                    'rate': rate,
+                    'company_id': self.env.company.id,
+                }
+            ) for rate_date, rate in rates],
+        })
+
+        other_product_price = 100
+        company_product_price = 150
+        other_product_price_converted = other_product_price / 0.5
+
+        other_product = self.env['product.product'].create({
+            'name': 'Other Product',
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'min_qty': 1,
+                    'price': other_product_price,
+                    'currency_id': other_currency.id,
+                }),
+            ]
+        })
+        company_product = self.env['product.product'].create({
+            'name': 'Company Product',
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'min_qty': 1,
+                    'price': company_product_price,
+                    'currency_id': company_currency.id,
+                }),
+            ]
+        })
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': company_currency.id,
+        })
+        self.assertNotEqual(other_product.seller_ids[0].currency_id.id, purchase_order.currency_id.id)
+
+        resp = self.url_open(
+            url='/product/catalog/order_lines_info',
+            data=json.dumps({
+                'params': {
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_ids': other_product.ids + company_product.ids,
+                    'res_model': 'purchase.order'
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertEqual(resp.status_code, 200)
+        catalog_price_other_cur = resp.json()['result'][str(other_product.id)]['price']
+        self.assertEqual(catalog_price_other_cur, other_product_price_converted)
+        catalog_price_company_cur = resp.json()['result'][str(company_product.id)]['price']
+        self.assertEqual(catalog_price_company_cur, company_product_price)
+
+        # The prices are recalculated on product order line update
+        resp = self.url_open(
+            url='/product/catalog/update_order_line_info',
+            data=json.dumps({
+                'params': {
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_id': other_product.id,
+                    'quantity': 1,
+                    'res_model': 'purchase.order'
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], other_product_price_converted)
+
+        resp = self.url_open(
+            url='/product/catalog/update_order_line_info',
+            data=json.dumps({
+                'params': {
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_id': company_product.id,
+                    'quantity': 1,
+                    'res_model': 'purchase.order'
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], company_product_price)
+
+    def test_catalog_discount(self):
+        """
+        Verify that when picking a product from the catalog, if the seller has a discount,
+        we add to the purchase order line the full price and the discount
+        """
+        company_product = self.env['product.product'].create({
+            'name': 'Company Product',
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'min_qty': 1,
+                    'price': 100,
+                    'discount': 10,
+                }),
+            ]
+        })
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+
+        purchase_order._update_order_line_info(company_product.id, 1)
+
+        order_line = purchase_order.order_line.search([], limit=1)
+
+        self.assertEqual(order_line.price_unit, 100)
+        self.assertEqual(order_line.discount, 10)


### PR DESCRIPTION
When a product is sold by a vendor in a different currency from
the PO currency, the product catalog did not correctly convert the
currency when displaying the product or when adding it to the PO.
This was inconsistent with the backend form view, which does
convert the currency when the product is added.
This fix is a backport of:
 https://github.com/odoo/odoo/commit/aadb877f971c638bc39e91136bfe7f8dc2fce500

opw-5266131



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
