### PR TITLE
[FIX] l10n_it_edi: fix sending Italian edi attachments to Italian e-invoicing

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -102,7 +102,7 @@ class AccountMoveSend(models.AbstractModel):
         # Prepare attachment data
         for move, move_data in moves_data.items():
             if attachment := move.l10n_it_edi_attachment_file:
-                attachments_vals[move] = {'name': move.l10n_it_edi_attachment_name, 'raw': attachment}
+                attachments_vals[move] = {'name': move.l10n_it_edi_attachment_name, 'raw': base64.b64decode(attachment)}
                 moves |= move
             elif edi_values := move_data.get('l10n_it_edi_values'):
                 attachments_vals[move] = edi_values


### PR DESCRIPTION
Before this commit:
Steps
1) When clients try to send invoices to Italian e-invoicing 
2) And if `L10N It Edi Attachment File` is already set (Ex. already sent but using only the `by Post` option, the XML gets generated and set)

=> A Invalid Operation Error is raised with the message: `Error sending file from the Proxy Server to SdI: Start tag expected, '<' not found, line 1, column 1 (<string>, line 1)`,

This occurs because the `_l10n_it_edi_send()` method is called with invalid `attachments_vals` as `raw` key contains encoded file instead of the raw version. Then it's encoded again in that method, so there is a double encoding and the Italian e-invoicing fails to decode it.

After this commit:
If the client try to send the invoice to Italian e-invoicing after generating the `L10N It Edi Attachment File`, it works well.