### PR TITLE
[IMP] account: Add test ensuring peppol status updated automatically

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -726,9 +726,41 @@ class AccountTestInvoicingCommon(ProductCommon):
             ._create_payments()
         )
 
+    @contextmanager
+    def mocked_get_payment_method_information(self, code='none'):
+        self.ensure_installed('account_payment')
+
+        Method_get_payment_method_information = self.env['account.payment.method']._get_payment_method_information
+
+        def _get_payment_method_information(*args, **kwargs):
+            res = Method_get_payment_method_information()
+            res[code] = {'mode': 'electronic', 'type': ('bank',)}
+            return res
+
+        with patch.object(self.env.registry['account.payment.method'], '_get_payment_method_information', _get_payment_method_information):
+            yield
+
+    @classmethod
+    def _create_dummy_payment_method_for_provider(cls, provider, journal, **kwargs):
+        cls.ensure_installed('account_payment')
+
+        code = kwargs.get('code', 'none')
+
+        with cls.mocked_get_payment_method_information(cls, code):
+            payment_method = cls.env['account.payment.method'].sudo().create({
+                'name': 'Dummy method',
+                'code': code,
+                'payment_type': 'inbound',
+                **kwargs,
+            })
+            provider.journal_id = journal
+            return payment_method
+
     @classmethod
     def _create_sale_order(cls, confirm=True, **values):
         cls.ensure_installed('sale')
+
+        cls._prepare_record_kwargs('sale.order', values)
 
         sale_order = cls.env['sale.order'].create([{
             'partner_id': cls.partner_a.id,

--- a/addons/account_payment/tests/common.py
+++ b/addons/account_payment/tests/common.py
@@ -12,13 +12,10 @@ class AccountPaymentCommon(PaymentCommon, AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        with cls.mocked_get_payment_method_information(cls):
-            cls.dummy_provider_method = cls.env['account.payment.method'].sudo().create({
-                'name': 'Dummy method',
-                'code': 'none',
-                'payment_type': 'inbound'
-            })
-            cls.dummy_provider.journal_id = cls.company_data['default_journal_bank']
+        cls.dummy_provider_method = cls._create_dummy_payment_method_for_provider(
+            provider=cls.dummy_provider,
+            journal=cls.company_data['default_journal_bank'],
+        )
 
         cls.account = cls.outbound_payment_method_line.payment_account_id
         cls.invoice = cls.env['account.move'].create({
@@ -47,17 +44,3 @@ class AccountPaymentCommon(PaymentCommon, AccountTestInvoicingCommon):
     def setUp(self):
         self.enable_post_process_patcher = False
         super().setUp()
-
-    #=== Utils ===#
-
-    @contextmanager
-    def mocked_get_payment_method_information(self):
-        Method_get_payment_method_information = self.env['account.payment.method']._get_payment_method_information
-
-        def _get_payment_method_information(*args, **kwargs):
-            res = Method_get_payment_method_information()
-            res['none'] = {'mode': 'electronic', 'type': ('bank',)}
-            return res
-
-        with patch.object(self.env.registry['account.payment.method'], '_get_payment_method_information', _get_payment_method_information):
-            yield

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -6,6 +6,7 @@ from urllib import parse
 
 from requests import PreparedRequest, Response, Session
 
+from odoo import Command
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged, freeze_time
 from odoo.tools.misc import file_open
@@ -525,3 +526,52 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         partners._compute_available_peppol_eas()
         for partner in partners:
             self.assertFalse('odemo' in partner.available_peppol_eas)
+
+    def test_automatic_invoicing_auto_update_partner_peppol_status(self):
+        self.ensure_installed('sale')
+        tax = self.percent_tax(21.0)
+        product = self._create_product(lst_price=100.0, taxes_id=tax)
+        partner = self.env['res.partner'].create({
+            'name': 'partner_be',
+            'street': "Rue des Bourlottes 9",
+            'zip': "1367",
+            'city': "Ramillies",
+            'vat': 'BE0477472701',
+            'company_registry': '0477472701',
+            'invoice_sending_method': 'peppol',
+            'invoice_edi_format': 'ubl_bis3',
+            'company_id': self.env.company.id,
+            'country_id': self.env.ref('base.be').id,
+        })
+        self.env.user.groups_id |= self.env.ref('sales_team.group_sale_salesman')
+
+        self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', True)
+        so = self._create_sale_order_one_line(product_id=product, partner_id=partner)
+
+        payment_method = self.env.ref('payment.payment_method_unknown')
+
+        dummy_provider = self.env['payment.provider'].create({
+            'name': "Dummy Provider",
+            'code': 'none',
+            'state': 'test',
+            'is_published': True,
+            'payment_method_ids': [Command.set(payment_method.ids)],
+            'allow_tokenization': True,
+        })
+        self._create_dummy_payment_method_for_provider(
+            provider=dummy_provider,
+            journal=self.company_data['default_journal_bank'],
+        )
+        transaction = self.env['payment.transaction'].create({
+            'payment_method_id': payment_method.id,
+            'amount': so.amount_total,
+            'state': 'done',
+            'provider_id': dummy_provider.id,
+            'currency_id': so.currency_id.id,
+            'reference': so.name,
+            'partner_id': partner.id,
+            'sale_order_ids': [Command.set(so.ids)],
+        })
+        transaction.sudo()._post_process()
+
+        self.assertRecordValues(partner, [{'peppol_verification_state': 'valid'}])


### PR DESCRIPTION
When creating a SO on e-commerce leading to an automatic invoice, the invoice is automatically sent using Peppol upon the payment. This test ensures the peppol status of the partner is updated during the process.

task_id: 5025176

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
