### PR TITLE
[FIX] payment_stripe: add default to shipping address

### DIFF
--- a/addons/payment_stripe/utils.py
+++ b/addons/payment_stripe/utils.py
@@ -68,11 +68,11 @@ def format_shipping_address(shipping_partner):
     :rtype: dict
     """
     return {
-        'shipping[address][city]': shipping_partner.city,
-        'shipping[address][country]': shipping_partner.country_id.code,
-        'shipping[address][line1]': shipping_partner.street,
-        'shipping[address][line2]': shipping_partner.street2,
-        'shipping[address][postal_code]': shipping_partner.zip,
-        'shipping[address][state]': shipping_partner.state_id.name,
-        'shipping[name]': shipping_partner.name or shipping_partner.parent_id.name,
+        'shipping[address][city]': shipping_partner.city or '',
+        'shipping[address][country]': shipping_partner.country_id.code or '',
+        'shipping[address][line1]': shipping_partner.street or '',
+        'shipping[address][line2]': shipping_partner.street2 or '',
+        'shipping[address][postal_code]': shipping_partner.zip or '',
+        'shipping[address][state]': shipping_partner.state_id.name or '',
+        'shipping[name]': shipping_partner.name or shipping_partner.parent_id.name or '',
     }


### PR DESCRIPTION
Paypal was failing when the address fields were `False` 

**Solution:**
Add a fallback to missing fields in the shipping address

Fixes: https://github.com/odoo/odoo/issues/237360

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
