### PR TITLE
[IMP] website_sale: emphasise scroll in checkout summary

### DIFF
--- a/addons/website_sale/static/src/interactions/scrollable_table.js
+++ b/addons/website_sale/static/src/interactions/scrollable_table.js
@@ -1,0 +1,52 @@
+import { Interaction } from '@web/public/interaction';
+import { registry } from '@web/core/registry';
+import { SIZES, utils as uiUtils } from '@web/core/ui/ui_service';
+
+export class ScrollableTable extends Interaction {
+    static selector = '.o_wsale_scrollable_table';
+    dynamicContent = {
+        _root: {
+            't-on-scroll': this.throttled(this.onScroll, 100),
+        },
+        _window: {
+            't-on-resize': this.debounced(this.updateMobileBadgeVisibility, 250),
+        },
+    };
+
+    setup() {
+        // This class exists when there are more than 4 items in the cart.
+        this.badgeDesktopEl = this.el.querySelector('.o_wsale_scrollable_table_badge_desktop');
+        // On mobile the badge is in .offcanvas-footer, it's not a child of
+        // .o_wsale_scrollable_table (the scrollable element)
+        const offCanvasEl = this.el.closest('.offcanvas');
+        this.badgeMobileEl = offCanvasEl?.querySelector('.o_wsale_scrollable_table_badge_mobile');
+        this.updateMobileBadgeVisibility();
+    }
+
+    updateMobileBadgeVisibility() {
+        this.isMobile = uiUtils.getSize() < SIZES.LG;
+        const scrollAmount = this.el.scrollHeight - this.el.clientHeight;
+        const minScrollAmount = 24; // half image height at 1:1 ratio
+        if (this.badgeMobileEl && this.isMobile) {
+            this.badgeMobileEl.classList.toggle('d-none', scrollAmount < minScrollAmount);
+        }
+    }
+
+    onScroll() {
+        const isScrolled = this.el.scrollTop > 0;
+        const badgeEl = this.isMobile ? this.badgeMobileEl : this.badgeDesktopEl;
+        if (badgeEl) {
+            badgeEl.classList.toggle('o_scrollable_table_badge_hidden', isScrolled);
+        }
+    }
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale.scrollable_table', ScrollableTable);
+
+registry
+    .category('public.interactions.edit')
+    .add('website_sale.scrollable_table', {
+        Interaction: ScrollableTable,
+    });

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1803,17 +1803,44 @@ $-product-radius-map: (
         }
     }
 
-    .o_wsale_scrollable_table {
-        -ms-overflow-style: none;
-        scrollbar-width: none;
+    .o_wsale_scrollable_table_badge {
+        --badge-bg: #{rgba($body-color, 0.85)};
+        --badge-color: #{color-contrast($body-color)};
+        --badge-border-color: #{rgba($body-color, 0.9)};
 
-        &::-webkit-scrollbar {
-            display: none;
+        transition: $transition-base;
+        opacity: 1;
+
+        &.o_wsale_scrollable_table_badge_desktop {
+            bottom: 0;
+        }
+        &.o_wsale_scrollable_table_badge_mobile {
+            top: -1.5rem;
         }
 
-        @include media-breakpoint-up(lg) {
-            overflow-y: scroll;
-            height: 15rem;
+        &.o_scrollable_table_badge_hidden {
+            opacity: 0;
+
+            &.o_wsale_scrollable_table_badge_desktop {
+                bottom: -.75rem;
+            }
+            &.o_wsale_scrollable_table_badge_mobile {
+                top: 0;
+            }
+        }
+    }
+
+    .o_wsale_scrollable_table {
+        --o-wsale-checkout-cart-product-img-width: 48px;
+
+        &.o_wsale_scrollable_table_desktop {
+            @include media-breakpoint-up(lg) {
+                overflow-y: scroll;
+
+                // Calculate the height of 4.5 <tr> through the images height.
+                // (+ spacer 3 to compensate negative margin)
+                max-height: calc(calc(#{$border-width} * 4 + (#{$table-cell-padding-y} + #{map-get($spacers, 3)} + (var(--o-wsale-checkout-cart-product-img-width) / var(--o-wsale-shop-thumb-aspect-ratio, 1))) * 4.5) + #{map-get($spacers, 3)});
+            }
         }
     }
 
@@ -1895,7 +1922,7 @@ $-product-radius-map: (
 }
 
 .o_cart_product_image img {
-    max-width: 64px;
+    max-width: var(--o-wsale-checkout-cart-product-img-width, 64px);
     @extend %o-wsale-shop-thumb;
 }
 

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -225,7 +225,7 @@
                                         <t t-call="website_sale.total">
                                             <t
                                                 t-set="_cart_total_classes"
-                                                t-valuef="border-top pt-2"
+                                                t-valuef="pt-2"
                                             />
                                         </t>
                                     </div>
@@ -272,10 +272,16 @@
                             tabindex="-1"
                             aria-labelledby="o_cart_summary_offcanvas"
                         >
-                            <div class="offcanvas-body">
-                                <t t-call="website_sale.cart_summary_content"/>
+                            <div class="offcanvas-body o_wsale_scrollable_table">
+                                <t t-call="website_sale.cart_summary_content" is_offcanvas="True"/>
                             </div>
-                            <div class="offcanvas-footer p-3">
+                            <div class="offcanvas-footer p-3 position-relative">
+                                <span
+                                    class="o_wsale_scrollable_table_badge o_wsale_scrollable_table_badge_mobile d-none badge position-absolute start-50 z-1 translate-middle py-2 px-3 pe-none"
+                                >
+                                    <t t-out="str(website_sale_order.cart_quantity)"/> items - Scroll for more
+                                    <i class="oi oi-arrow-down ms-1" aria-hidden="true"/>
+                                </span>
                                 <a href="/shop/cart" class="btn btn-link w-100">
                                     Coupon, Gift card, Promo-code?
                                 </a>
@@ -326,6 +332,8 @@
 
     <!-- Called in `website_sale.checkout_layout` and `website_sale.confirmation`. -->
     <template id="website_sale.cart_summary_content">
+        <t t-set="is_scrollable" t-value="len(website_sale_order.website_order_line) &gt; 4"/>
+
         <div
             t-if="not website_sale_order or not website_sale_order.website_order_line"
             name="cart_summary_info"
@@ -333,12 +341,19 @@
         >
             Your cart is empty!
         </div>
-        <div>
-            <div t-att-class="len(website_sale_order.website_order_line) &gt; 3 and 'o_wsale_scrollable_table'">
+        <div class="position-relative">
+            <div t-attf-class="border-bottom {{(is_scrollable and not is_offcanvas) and 'o_wsale_scrollable_table o_wsale_scrollable_table_desktop mx-n4 mt-n3 px-4 pt-3'}}">
                 <table
                     t-if="website_sale_order and website_sale_order.website_order_line"
                     class="o_cart_products_table table mb-0"
                 >
+                    <span
+                        t-if="is_scrollable and not is_offcanvas"
+                        class="o_wsale_scrollable_table_badge o_wsale_scrollable_table_badge_desktop badge d-none d-lg-inline py-2 px-3 position-absolute start-50 z-1 translate-middle pe-none"
+                    >
+                        <t t-out="str(website_sale_order.cart_quantity)"/> items - Scroll for more
+                        <i class="oi oi-arrow-down ms-1" aria-hidden="true"/>
+                    </span>
                     <tbody>
                         <tr
                             t-foreach="website_sale_order.website_order_line"


### PR DESCRIPTION
Inside the checkout summary the `o_wsale_scrollable_table` is applied when there are more than 5 elements to create a scroll container, but it is not clear that this container is scrollable.

This introduces a badge to indicate scrollable content and also crops the container perfectly to 4.5 cart items regardless of their aspect ratio or content.

task-5366858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
