### PR TITLE
[IMP] uom, account{_edi_ubl_cii,}: add 2 UoM from UNECE Recommendation No.20

### DIFF
--- a/addons/account/models/uom_uom.py
+++ b/addons/account/models/uom_uom.py
@@ -24,6 +24,7 @@ class UoM(models.Model):
             'uom.product_uom_gram': 'GRM',
             'uom.product_uom_day': 'DAY',
             'uom.product_uom_hour': 'HUR',
+            'uom.product_uom_minute': 'MIN',
             'uom.product_uom_ton': 'TNE',
             'uom.product_uom_meter': 'MTR',
             'uom.product_uom_km': 'KMT',
@@ -44,6 +45,7 @@ class UoM(models.Model):
             'uom.uom_square_foot': 'FTK',
             'uom.product_uom_yard': 'YRD',
             'uom.product_uom_millimeter': 'MMT',
+            'uom.product_uom_kwh': 'KWH',
         }
         xml_ids = self._get_external_ids().get(self.id, [])
         matches = list(set(xml_ids) & set(mapping.keys()))

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -18,6 +18,7 @@ UOM_TO_UNECE_CODE = {
     'uom.product_uom_gram': 'GRM',
     'uom.product_uom_day': 'DAY',
     'uom.product_uom_hour': 'HUR',
+    'uom.product_uom_minute': 'MIN',
     'uom.product_uom_ton': 'TNE',
     'uom.product_uom_meter': 'MTR',
     'uom.product_uom_km': 'KMT',
@@ -38,6 +39,7 @@ UOM_TO_UNECE_CODE = {
     'uom.uom_square_foot': 'FTK',
     'uom.product_uom_yard': 'YRD',
     'uom.product_uom_millimeter': 'MMT',
+    'uom.product_uom_kwh': 'KWH',
 }
 
 # -------------------------------------------------------------------------

--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -20,6 +20,10 @@
     <record id="product_uom_categ_vol" model="uom.category">
         <field name="name">Volume</field>
     </record>
+    <record id="product_uom_categ_energy" model="uom.category">
+        <field name="name">Energy</field>
+    </record>
+
 
     <!-- UOM.UOM -->
     <!-- Units -->
@@ -50,6 +54,13 @@
         <field name="factor" eval="8.0"/>
         <field name="uom_type">smaller</field>
     </record>
+    <record id="product_uom_minute" model="uom.uom">
+        <field name="name">Minutes</field>
+        <field name="category_id" ref="uom_categ_wtime"/>
+        <field name="factor" eval="480.0"/>
+        <field name="uom_type">smaller</field>
+    </record>
+
 
     <!-- LENGTH -->
     <record id="product_uom_meter" model="uom.uom">
@@ -200,6 +211,14 @@
         <field name="category_id" ref="product_uom_categ_vol"/>
         <field name="factor_inv">28.3168</field>
         <field name="uom_type">bigger</field>
+    </record>
+
+    <!-- ENERGY -->
+    <record id="product_uom_kwh" model="uom.uom">
+        <field name="category_id" ref="product_uom_categ_energy"/>
+        <field name="name">KWH</field>
+        <field name="factor" eval="1.0"/>
+        <field name="uom_type">reference</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
**Issue:**
2 UoM that is in the UNECE Recommendation No.20 for Peppol don't exist in Odoo:
- MIN: Minute
- KWH: Kilowatt hour

Even if they are created manually, they are not used in the UBL/CII electronic invoices.
Instead, the default code (i.e. "C62" for "Units" is used).

Some localization modules create the "Kilowatt hour" UoM as they need it. (l10n_cl and l10n_tr_nilvera)
So it's better to have a "generic" one available for every module.

opw-5269119




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
