### PR TITLE
[IMP] website: add indentation to the table of content

### DIFF
--- a/addons/website/static/src/snippets/s_table_of_content/000.scss
+++ b/addons/website/static/src/snippets/s_table_of_content/000.scss
@@ -35,6 +35,20 @@
                 &:focus {
                     background: none;
                 }
+
+                &.table_of_content_link_depth_0 {
+                    padding-left: 3px;
+                    &.active {
+                        padding-left: 8px;
+                    }
+                }
+
+                @for $depth from 1 through 5 {
+                    &.table_of_content_link_depth_#{$depth} {
+                        padding-left: calc(3px + Min(15px, 5%) * #{$depth});
+                    }
+                }
+
                 &.active {
                     background: none;
                     padding-left: 8px;
@@ -54,7 +68,7 @@
 
             .s_table_of_content_navbar {
                 display: inline;
-    
+
                 > a {
                     &.list-group-item-action {
                         width: auto;
@@ -62,6 +76,12 @@
                     &.list-group-item {
                         display: inline-block;
                         margin-bottom: 2px;
+                    }
+                    @for $depth from 1 through 5 {
+                        /* display only top level headings */
+                        &.table_of_content_link_depth_#{$depth} {
+                            display: none;
+                        }
                     }
                 }
             }

--- a/addons/website/static/tests/builder/website_builder/table_of_content_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/table_of_content_option.test.js
@@ -1,7 +1,18 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
-import { insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
+import { deleteBackward, insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
-import { click, queryAll, queryOne, queryAllTexts, tick, waitFor } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    click,
+    manuallyDispatchProgrammaticEvent,
+    press,
+    queryAll,
+    queryAllTexts,
+    queryFirst,
+    queryOne,
+    tick,
+    waitFor,
+} from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -15,10 +26,9 @@ test("edit title in content with table of content", async () => {
     const { getEditor } = await setupWebsiteBuilderWithSnippet("s_table_of_content");
     const editor = getEditor();
     expect(":iframe .s_table_of_content").toHaveCount(1);
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
-        "Intuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Intuitive system", "Design features"]);
     expect(queryAllTexts(":iframe .s_table_of_content_main h2")).toEqual([
         "Intuitive system",
         "Design features",
@@ -27,20 +37,18 @@ test("edit title in content with table of content", async () => {
     const h2 = queryAll(":iframe .s_table_of_content_main h2:contains('Intuitive system')")[0];
     setSelection({ anchorNode: h2, anchorOffset: 0 });
     await insertText(editor, "New Title:");
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
-        "New Title:Intuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["New Title:Intuitive system", "Design features"]);
     expect(queryAllTexts(":iframe .s_table_of_content_main h2")).toEqual([
         "New Title:Intuitive system",
         "Design features",
     ]);
 
     undo(editor);
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
-        "New TitleIntuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["New TitleIntuitive system", "Design features"]);
     expect(queryAllTexts(":iframe .s_table_of_content_main h2")).toEqual([
         "New TitleIntuitive system",
         "Design features",
@@ -50,10 +58,9 @@ test("edit title in content with table of content", async () => {
 test("click on addItem option button", async () => {
     const { getEditor } = await setupWebsiteBuilderWithSnippet("s_table_of_content");
     const editor = getEditor();
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
-        "Intuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Intuitive system", "Design features"]);
     expect(queryAllTexts(":iframe .s_table_of_content_main h2")).toEqual([
         "Intuitive system",
         "Design features",
@@ -61,11 +68,9 @@ test("click on addItem option button", async () => {
 
     await contains(":iframe .s_table_of_content_main h2").click();
     await contains("[data-action-id='addItem']").click();
-    expect(queryAllTexts(":iframe .s_table_of_content_vertical_navbar a")).toEqual([
-        "Intuitive system",
-        "Design features",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_vertical_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Intuitive system", "Design features", "Design features"]);
     expect(queryAllTexts(":iframe .s_table_of_content_main h2")).toEqual([
         "Intuitive system",
         "Design features",
@@ -73,10 +78,9 @@ test("click on addItem option button", async () => {
     ]);
 
     undo(editor);
-    expect(queryAllTexts(":iframe .s_table_of_content_vertical_navbar a")).toEqual([
-        "Intuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_vertical_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Intuitive system", "Design features"]);
     expect(queryAllTexts(":iframe .s_table_of_content_main h2")).toEqual([
         "Intuitive system",
         "Design features",
@@ -87,10 +91,9 @@ test("hide title in content with table of content", async () => {
     const { getEditor } = await setupWebsiteBuilderWithSnippet("s_table_of_content");
     const editor = getEditor();
     expect(":iframe .s_table_of_content").toHaveCount(1);
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
-        "Intuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Intuitive system", "Design features"]);
 
     // Hide title
     await contains(":iframe .s_table_of_content_main h2").click();
@@ -99,13 +102,90 @@ test("hide title in content with table of content", async () => {
     expect(sectionOptionContainer.querySelector("div")).toHaveText("Section");
     await click(sectionOptionContainer.querySelector("[data-action-id='toggleDeviceVisibility']"));
     await tick();
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual(["Design features"]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Design features"]);
 
     undo(editor);
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
-        "Intuitive system",
-        "Design features",
-    ]);
+    expect(
+        queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
+    ).toEqual(["Intuitive system", "Design features"]);
+});
+
+test("properly sets the level of depth for a new heading", async () => {
+    const { getEditor } = await setupWebsiteBuilderWithSnippet("s_table_of_content");
+    const editor = getEditor();
+    expect(":iframe .s_table_of_content_navbar a").toHaveCount(6);
+
+    // we create a new heading h4 after h3
+    setSelection({
+        anchorNode: queryOne(":iframe #table_of_content_heading_1_4 + p"),
+        anchorOffset: 1,
+    });
+    await press("enter");
+    await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+        inputType: "insertParagraph",
+    });
+    await insertText(editor, "New Subheading");
+
+    const newSubheadingEl = queryOne(":iframe .s_table_of_content p:contains('New Subheading')");
+    setSelection({
+        anchorNode: newSubheadingEl.firstChild,
+        anchorOffset: 0,
+        focusOffset: newSubheadingEl.firstChild.length,
+    });
+    await waitFor(".o-we-toolbar");
+    await click(".o-we-toolbar .btn[name=font]");
+    await animationFrame();
+    await click(".o-dropdown-item[name='h4']");
+    expect(":iframe .s_table_of_content_navbar a").toHaveCount(7);
+    // it should have depth 2:
+    // h2
+    // |-h3
+    // |--h4 New Subheading
+    expect(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_2").toHaveCount(1);
+    expect(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_2").toHaveText(
+        "New Subheading"
+    );
+});
+
+test("updates depth after removing a heading", async () => {
+    const { getEditor } = await setupWebsiteBuilderWithSnippet("s_table_of_content");
+    const editor = getEditor();
+    expect(":iframe .s_table_of_content_navbar a").toHaveCount(6);
+    expect(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0").toHaveCount(2);
+    expect(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_1").toHaveCount(4);
+    // current structure:
+    // h2
+    // |-h3
+    // |-h3
+    // h2
+    // |-h3
+    // |-h3
+    const firstHeadingEl = queryFirst(":iframe .s_table_of_content h2");
+    // remove text from the heading
+    setSelection({
+        anchorNode: firstHeadingEl,
+        focusNode: firstHeadingEl,
+        focusOffset: 1,
+    });
+    deleteBackward(editor);
+
+    // remove the heading itself
+    setSelection({
+        anchorNode: firstHeadingEl,
+    });
+    deleteBackward(editor);
+
+    // updated structure:
+    // h3
+    // h3
+    // h2
+    // |-h3
+    // |-h3
+    expect(":iframe .s_table_of_content_navbar a").toHaveCount(5);
+    expect(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0").toHaveCount(3);
+    expect(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_1").toHaveCount(2);
 });
 
 test("remove main content with table of content", async () => {
@@ -114,12 +194,20 @@ test("remove main content with table of content", async () => {
     expect(":iframe .s_table_of_content").toHaveCount(1);
     expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
         "Intuitive system",
+        "What you see is what you get",
+        "Customization tool",
         "Design features",
+        "Building blocks system",
+        "Bootstrap-Based Templates",
     ]);
 
     await contains(":iframe .s_table_of_content_main h2").click();
     await contains(".overlay .oe_snippet_remove").click();
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual(["Design features"]);
+    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
+        "Design features",
+        "Building blocks system",
+        "Bootstrap-Based Templates",
+    ]);
 
     await contains(":iframe .s_table_of_content_main h2").click();
     await contains(".overlay .oe_snippet_remove").click();
@@ -127,8 +215,13 @@ test("remove main content with table of content", async () => {
     expect(":iframe .s_table_of_content_navbar a").toHaveCount(0);
 
     undo(editor);
-    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual(["Design features"]);
+    expect(queryAllTexts(":iframe .s_table_of_content_navbar a")).toEqual([
+        "Design features",
+        "Building blocks system",
+        "Bootstrap-Based Templates",
+    ]);
 });
+
 test("update second toc navbar", async () => {
     const { getEditor } = await setupWebsiteBuilderWithSnippet("s_table_of_content");
     const editor = getEditor();

--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -9,8 +9,12 @@
                     <div class="s_table_of_content_navbar list-group o_no_link_popover"
                         style="top: 76px; max-height: calc(100vh - 96px);"
                     >
-                        <a href="#table_of_content_heading_1_1" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 active">Intuitive system</a>
-                        <a href="#table_of_content_heading_1_2" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0">Design features</a>
+                        <a href="#table_of_content_heading_1_1" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 table_of_content_link_depth_0 active">Intuitive system</a>
+                        <a href="#table_of_content_heading_1_2" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 table_of_content_link_depth_1">What you see is what you get</a>
+                        <a href="#table_of_content_heading_1_3" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 table_of_content_link_depth_1">Customization tool</a>
+                        <a href="#table_of_content_heading_1_4" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 table_of_content_link_depth_0">Design features</a>
+                        <a href="#table_of_content_heading_1_5" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 table_of_content_link_depth_1">Building blocks system</a>
+                        <a href="#table_of_content_heading_1_6" class="table_of_content_link list-group-item list-group-item-action py-2 border-0 rounded-0 table_of_content_link_depth_1">Bootstrap-Based Templates</a>
                     </div>
                 </div>
                 <div class="col-lg-9 s_table_of_content_main oe_structure oe_empty" data-name="Content">


### PR DESCRIPTION
Before this commit, the ToC snippet didn't look fine: headings
looked the same, even if they didn't have the same semantics, the
indentation didn't work.
Also, this commit adds other headings (h3, h4,
h5, and h6) to be included in the navbar. We calculate the depth and
indent them respectively. If the position of the navbar is at the top,
and not on the left or right, we display only the top-level headings.

task-5354832