### PR TITLE
[FIX] hr: allow deletion of archived versions of employee

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -258,7 +258,7 @@ class HrVersion(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_last_version(self):
         for employee_id, versions in self.grouped('employee_id').items():
-            if employee_id.versions_count == len(versions):
+            if employee_id.version_ids == versions:
                 raise ValidationError(
                     self.env._('Employee %s must always have at least one active version.') % employee_id.name
                 )

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -689,3 +689,15 @@ class TestHrVersion(TransactionCase):
         # attempt to reassign all versions
         with self.assertRaises(ValidationError):
             employee.version_ids.write({"employee_id": another_employee.id})
+
+    def test_unlink_version_except_one(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'John Doe',
+            'date_version': '2020-01-01',
+        })
+        version = employee.create_version({
+            'date_version': '2021-01-01',
+        })
+        self.assertEqual(len(employee.version_ids), 2)
+        version.unlink()
+        self.assertEqual(len(employee.version_ids), 1)


### PR DESCRIPTION
Version – saas-18.4

Issue:
Deleting an archived version of an employee that has only a single version
raises a `ValidationError` stating:
`Employee %s must always have at least one active version.`

Steps to Reproduce:
- Make an archived version of an employee which have exactly one version.
- Try to delete that archived version
- Validation Error will occur which states that
 `Employee %s must always have at least one active version.`

Cause:
The validation logic prevents deletion when the number of versions being deleted
equals the total number of unarchived versions of the employee.

Fix:
Improved the ValidationError logic by ensuring that no error is raised when the
version being deleted is archived.

Impact:
Archived employee versions can now be deleted without raising unnecessary errors.

Task – 5347109





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
