### PR TITLE
[FIX] im_livechat: visitor can access agents partners for rating

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -650,7 +650,8 @@ class DiscussChannel(models.Model):
                 "is_internal": False,
                 "res_id": self.id,
                 "res_model_id": self.env["ir.model"]._get_id("discuss.channel"),
-                "rated_partner_id": self.livechat_agent_partner_ids[:1].id,
+                # sudo: res.partner - visitor can access the agent record to add a rating
+                "rated_partner_id": self.sudo().livechat_agent_partner_ids[:1].id,
                 "partner_id": user.partner_id.id,
             }
             rating_sudo = self.env["rating.rating"].sudo().create(rating_values)

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -12,6 +12,7 @@ from . import test_get_discuss_channel
 from . import test_get_operator
 from . import test_im_livechat_calls
 from . import test_im_livechat_channel
+from . import test_im_livechat_rating
 from . import test_im_livechat_report
 from . import test_im_livechat_support_page
 from . import test_js

--- a/addons/im_livechat/tests/test_im_livechat_rating.py
+++ b/addons/im_livechat/tests/test_im_livechat_rating.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
+
+
+class TestImLivechatFeedback(TestGetOperatorCommon):
+    def test_rating_is_associated_to_agent(self):
+        agent = self._create_operator()
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Test Livechat Channel", "user_ids": [agent.id]},
+        )
+        self.authenticate(None, None)
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {"channel_id": livechat_channel.id, "persisted": True},
+        )
+        chat = self.env["discuss.channel"].browse(data["channel_id"])
+        self.make_jsonrpc_request(
+            "/im_livechat/feedback",
+            {"channel_id": chat.id, "rate": 5, "reason": "Good service"},
+        )
+        self.assertEqual(chat.rating_ids.rated_partner_id, agent.partner_id)


### PR DESCRIPTION
Before this commit, ratings in live chat would not be associated a `rated_partner_id`.

This happens because, since the change in [1], the rated partner would be taken from the `livechat_agent_partner_ids` field, to which live chat visitors (public users) don't have access to.

This commit fixes the issue by adding a sudo to the field access.

[1] https://github.com/odoo/odoo/pull/214725