### PR TITLE
[FIX] hr_attendance: fix overtime on holidays from another company

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -184,7 +184,7 @@ class HrAttendanceOvertimeRule(models.Model):
 
         if self.timing_type in ['work_days', 'non_work_days']:
             company = self.company_id or employee.company_id
-            unusual_days = company.resource_calendar_id._get_unusual_days(start_dt, end_dt)
+            unusual_days = company.resource_calendar_id._get_unusual_days(start_dt, end_dt, company_id=company)
 
             attendance_intervals = []
             for date, day_attendances in attendances.filtered(

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1053,3 +1053,60 @@ class TestHrAttendanceOvertime(HttpCase):
         self.assertEqual(response.get('last_attendance_worked_hours'), 0)
         self.assertEqual(response.get('overtime_today'), 10)
         self.assertEqual(response.get('total_overtime'), 10)
+
+    def test_overtime_with_public_holidays(self):
+        """ Comapny 1 has a public holiday, while Company 2 does not.
+            Employee from Company 2 should not get overtime for working that day.
+        """
+        with freeze_time("2025-11-11 12:00:00"):
+            company_be = self.env['res.company'].create({'name': 'Odoo BE'})
+            company_de = self.env['res.company'].create({'name': 'Odoo DE'})
+
+            with Form(self.env['resource.calendar.leaves'].with_company(company_be)) as holiday_form:
+                holiday_form.name = 'Armistice Day'
+                holiday_form.date_from = datetime(2025, 11, 11, 0, 0)
+                holiday_form.save()
+
+            ruleset_be = self.env['hr.attendance.overtime.ruleset'].with_company(company_be).create({
+                'name': 'Ruleset schedule timing',
+                'rule_ids': [Command.create({
+                        'name': 'Rule schedule timing',
+                        'base_off': 'timing',
+                        'timing_type': 'non_work_days',
+                        'timing_start': 0,
+                        'timing_stop': 24,
+                    })],
+            })
+            ruleset_de = self.env['hr.attendance.overtime.ruleset'].with_company(company_de).create({
+                'name': 'Ruleset schedule timing',
+                'rule_ids': [Command.create({
+                        'name': 'Rule schedule timing',
+                        'base_off': 'timing',
+                        'timing_type': 'non_work_days',
+                        'timing_start': 0,
+                        'timing_stop': 24,
+                    })],
+            })
+
+            employee_be = self.env['hr.employee'].with_company(company_be).create({
+                'name': 'Hans Belgian',
+                'ruleset_id': ruleset_be.id,
+            })
+            employee_de = self.env['hr.employee'].with_company(company_de).create({
+                'name': 'Henry German',
+                'ruleset_id': ruleset_de.id,
+            })
+
+            attendance_company_be = self.env['hr.attendance'].create({
+                'employee_id': employee_be.id,
+                'check_in': datetime(2025, 11, 11, 8, 0),
+                'check_out': datetime(2025, 11, 11, 17, 0),
+            })
+            attendance_company_de = self.env['hr.attendance'].create({
+                'employee_id': employee_de.id,
+                'check_in': datetime(2025, 11, 11, 8, 0),
+                'check_out': datetime(2025, 11, 11, 17, 0),
+            })
+
+            self.assertAlmostEqual(attendance_company_be.overtime_hours, 8, 2, "Employee from Company 1 should have overtime for working on a public holiday.")
+            self.assertAlmostEqual(attendance_company_de.overtime_hours, 0, 2, "Employee from Company 2 should not have overtime for working on a non-holiday day.")


### PR DESCRIPTION
A bug was found that set attendances as overtime when done in the same day another company had a public holiday with no working schedule set. This fix adds the current company to the filter of _get_unusal_days to get only public holidays of the current company.

task-5347555

## To do
- [x] Add tests