### PR TITLE
[IMP] stock: ensure Done By shows the user who last updated

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -33,7 +33,7 @@
                        decoration-muted="state == 'draft'"
                        decoration-success="state == 'done'"
                        decoration-warning="state not in ('draft','cancel','done','assigned')"/>
-                <field name="create_uid" string="Done By" widget="many2one_avatar_user" optional="hide"/>
+                <field name="write_uid" string="Done By" widget="many2one_avatar_user" optional="hide"/>
             </list>
         </field>
     </record>
@@ -102,7 +102,7 @@
                             <field name="package_id" string="Source Package" groups="stock.group_tracking_lot"/>
                             <field name="result_package_id" string="Destination Package" groups="stock.group_tracking_lot"/>
                             <field name="owner_id" string="Owner" groups="stock.group_tracking_owner"/>
-                            <field name="create_uid" string="Done By" widget="many2one_avatar_user" optional="hide"/>
+                            <field name="write_uid" string="Done By" widget="many2one_avatar_user" optional="hide"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
The `Done By` column in the `Moves History Report` list view and move line form
view previously showed the create user of the move line instead of the user who
actually validated it.
This caused misleading information in multi-user workflows such as purchase,
manufacture and sales, where the person who creates the document is often not
the person validating the operation.

This incorrect display resulted in situations where a buyer who created a PO
appeared as the user who validated the picking, even when the action was
performed by a warehouse operator. This made traceability unclear and created
confusion during audits and day-to-day operations.

By ensuring the Done By column reflects the last user who validated (updated)
the move line, the system now provides accurate operational accountability and
improves clarity for all involved teams.

Task ID: 5190297