### PR TITLE
[FIX] website_sale: Display product tile image

### DIFF
--- a/addons/website_sale/views/product_tile_templates.xml
+++ b/addons/website_sale/views/product_tile_templates.xml
@@ -59,9 +59,9 @@
                 t-value="product_variant or product_variants[product]"
             />
             <t
-                t-if="variant and variant.with_context(bin_size=True).image_128"
+                t-if="product_variant and product_variant.with_context(bin_size=True).image_128"
                 t-set="all_images_list"
-                t-value="variant._get_images()"
+                t-value="product_variant._get_images()"
             />
             <t
                 t-else=""


### PR DESCRIPTION
Steps to reproduce:
===================
1- Add a product & product variants
2- Add different photos for product & product variants 3- visit website shop
-> observe that the product image is set to the image of the first product variant

Cause:
======
The `product_tile` template defined a variable `variant` that defaulted to the first available variant if no specific variant was selected. The condition
https://github.com/odoo/odoo/blob/bf83a4efefedae61e06a6b29ad82e647fd673ce2/addons/website_sale/views/product_tile_templates.xml#L62 subsequently used this default variant's image, bypassing the intended fallback to the product template's image.

Solution:
=========
Update the condition to check `product_variant` instead of `variant`. `product_variant` is only set when a specific variant is explicitly selected. This ensures the product template image is displayed by default, and the variant image is only shown when specifically requested.

opw-5362624
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
