### PR TITLE
[IMP] html_editor: preview local images in link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -83,8 +83,17 @@ async function fetchInternalMetaData(url) {
 
     const result = await keepLastPromise
         .add(fetch(urlParsed))
-        .then((response) => response.text())
-        .then(async (content) => {
+        .then((response) => ({
+            contentPromise: response.text(),
+            type: response.headers.get("content-type"),
+        }))
+        .then(async ({ contentPromise, type }) => {
+            if (type.startsWith("image/")) {
+                return {
+                    imgSrc: urlParsed,
+                };
+            }
+            const content = await contentPromise;
             const html_parser = new window.DOMParser();
             const doc = html_parser.parseFromString(content, "text/html");
             const internalUrlMetaData = await rpc("/html_editor/link_preview_internal", {

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -584,6 +584,14 @@ export class LinkPopover extends Component {
                     ? internalMetadata.ogTitle.getAttribute("content")
                     : internalMetadata.title.text.trim();
             }
+
+            if (internalMetadata.imgSrc) {
+                this.state.imgSrc = internalMetadata.imgSrc;
+                this.state.previewIcon = {
+                    type: "fa",
+                    value: "fa-picture-o",
+                };
+            }
         }
     }
 


### PR DESCRIPTION
When a link targets a local attachment image, no preview was displayed.

This commit uses the target linked image as preview and displays the `fa-picture-o` icon beside the URL.

task-5367699
