### PR TITLE
[IMP] hr_holidays_attendance: enable give back as time off on default overtime ruleset

### DIFF
--- a/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
+++ b/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
@@ -4,5 +4,11 @@
         <record id="hr_holidays.holiday_status_extra_hours" model="hr.leave.type">
             <field name="overtime_deductible" eval="True"/>
         </record>
+        <record id="hr_attendance.hr_attendance_overtime_employee_schedule_rule" model="hr.attendance.overtime.rule">
+            <field name="compensable_as_leave" eval="True"/>
+        </record>
+        <record id="hr_attendance.hr_attendance_overtime_non_working_days_rule" model="hr.attendance.overtime.rule">
+            <field name="compensable_as_leave" eval="True"/>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
Enabling 'Give Back as Time Off' by default on default overtime rules as employees often get confused about why their extra hours don’t appear while applying for a time off.

Task: 5380568