### PR TITLE
[FIX] hr: Prevent archiving or unassigning all employee versions

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -266,11 +266,11 @@ class HrVersion(models.Model):
     def write(self, values):
         # Employee Versions Validation
         if 'employee_id' in values:
-            if self.filtered(lambda v: len(v.employee_id.version_ids) == 1 and values['employee_id'] != v.employee_id.id):
-                raise ValidationError(self.env._("Cannot unassign the only active version of an employee."))
+            if self.filtered(lambda v: v.employee_id and v.employee_id.version_ids <= self and values['employee_id'] != v.employee_id.id):
+                raise ValidationError(self.env._("Cannot unassign all the active versions of an employee."))
         if 'active' in values and not values['active']:
-            if self.filtered(lambda v: len(v.employee_id.version_ids) == 1):
-                raise ValidationError(self.env._("Cannot archive the only active version of an employee."))
+            if self.filtered(lambda v: v.employee_id and v.employee_id.version_ids <= self):
+                raise ValidationError(self.env._("Cannot archive all the active versions of an employee."))
 
         if self.env.context.get('sync_contract_dates') or "contract_date_start" not in values and "contract_date_end" not in values:
             return super().write(values)

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -669,3 +669,23 @@ class TestHrVersion(TransactionCase):
             f"""The following _onchange methods on hr.version should have corresponding methods implemented on hr.employee: {not_implemented_onchanges}\n
                 You might need to implement methods with the same name on hr.employee and call the corresponding self.version_id._onchange inside"""
         )
+
+    def test_archive_or_unassign_all_versions(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'John Doe',
+            'date_version': '2020-01-01',
+        })
+        another_employee = self.env['hr.employee'].create({
+            'name': 'Jane Doe'
+        })
+        employee.create_version({
+            'date_version': '2021-01-01',
+        })
+        # make sure there are at least 2 versions
+        self.assertEqual(len(employee.version_ids), 2)
+        # attempt to archive all versions
+        with self.assertRaises(ValidationError):
+            employee.version_ids.action_archive()
+        # attempt to reassign all versions
+        with self.assertRaises(ValidationError):
+            employee.version_ids.write({"employee_id": another_employee.id})


### PR DESCRIPTION
Currently, it is possible to archive or reassign all versions of an employee if there exists more than 1. This leads to issues with generating the necessary SQL views for the `hr.employee.public` model.

To rectify this issue, we check whether the versions of each employee is a subset of the records being written to.

opw-5289226