### PR TITLE
[FIX] mail: fix slight misalignment of composer '+' button (again)

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -163,7 +163,7 @@
 </t>
 
 <t t-name="mail.Composer.moreActions">
-    <button class="btn btn-link p-0 d-flex" t-att-disabled="areAllActionsDisabled" t-ref="more-actions">
+    <button class="btn btn-link p-0 d-flex border-0" t-att-disabled="areAllActionsDisabled" t-ref="more-actions">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <t t-set="moreName">More Actions</t>
             <ActionList inline="true" actions="[{


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/229025

PR above fixed an issue of misalignment of "+" button of composer. However this was still not exactly perfect: the button was still slightly misaligned.

This comes from buttons having a border by default, and this border impact button by misaligning it by 1 px.

We don't want border for these buttons, as these buttons are just icons. Quick actions of composer, i.e. buttons on right, already have border removed hence why they were properly aligned.

This commit fixes the issue by setting no border to "+" button, similar to other composer buttons.

Before
<img width="515" height="65" alt="Screenshot 2025-12-02 at 15 20 46" src="https://github.com/user-attachments/assets/6d31f0b3-b515-4b9c-8e69-ef206b436bee" />

After
<img width="513" height="63" alt="Screenshot 2025-12-02 at 15 20 39" src="https://github.com/user-attachments/assets/9bd4dc2c-8fe0-4ed7-ae6c-9f5533ec2c2c" />
