### PR TITLE
[FIX] sale: handle variants with duplicate attributes

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -299,7 +299,9 @@ class SaleProductConfiguratorController(Controller):
         )
         product_or_template = product or product_template
         ptals = product_template.attribute_line_ids
-        attrs_map = dict(zip(ptals.ids, ptals.attribute_id.read(['id', 'name', 'display_type'])))
+        attrs_map = {
+            ptal.id: ptal.attribute_id.read(['id', 'name', 'display_type'])[0] for ptal in ptals
+        }
         ptavs = ptals.product_template_value_ids.filtered(lambda p: p.ptav_active or combination and p.id in combination.ids)
         ptavs_map = dict(zip(ptavs.ids, ptavs.read(['name', 'html_color', 'image', 'is_custom'])))
 

--- a/addons/sale/static/tests/tours/product_attribute_value_tour.js
+++ b/addons/sale/static/tests/tours/product_attribute_value_tour.js
@@ -1,5 +1,7 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import productConfiguratorTourUtils from '@sale/js/tours/product_configurator_tour_utils';
+import tourUtils from "@sale/js/tours/tour_utils";
 
 const openProductAttribute = (product_attribute) => [
     ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
@@ -54,3 +56,13 @@ registry.category("web_tour.tours").add('delete_product_attribute_value_tour', {
         }
     ]
 });
+
+registry.category('web_tour.tours').add('duplicate_attribute_lines_no_traceback', {
+    url: '/odoo/orders/new',
+    steps: () => [
+        ...tourUtils.addProduct("Duplicated Attribute Product"),
+        ...productConfiguratorTourUtils.saveConfigurator(),
+        ...stepUtils.discardForm(),
+    ]
+});
+

--- a/addons/sale/tests/test_product_attribute_value.py
+++ b/addons/sale/tests/test_product_attribute_value.py
@@ -67,3 +67,26 @@ class TestProductAttributeValue(HttpCase, SaleCommon):
         )
         self.assertFalse(self.order_line.product_no_variant_attribute_value_ids.ptav_active)
         self.start_tour("/odoo", 'delete_product_attribute_value_tour', login="admin")
+
+    def test_duplicate_attribute_lines_no_traceback(self):
+        """
+        Ensure that products with duplicated attribute lines do not cause a traceback when the sale
+        product configurator is invoked.
+        """
+        # Create a product with 2 lines referring to the same attribute
+        self.env['product.template'].create({
+            'name': 'Duplicated Attribute Product',
+            'type': 'consu',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.product_attribute.id,
+                    'value_ids': [Command.set([self.a1.id])],
+                }),
+                Command.create({
+                    'attribute_id': self.product_attribute.id,
+                    'value_ids': [Command.set([self.a2.id, self.a3.id])],
+                }),
+            ],
+        })
+
+        self.start_tour('/odoo/orders/new', 'duplicate_attribute_lines_no_traceback', login='admin')


### PR DESCRIPTION
## Versions
18.0 to saas-18.3
Fixed by 7b56a6afda919f3c09d08eb1256416e0a2b4b1d9 introducing a new logic with https://github.com/odoo/odoo/blob/26f9cab34a8cd594192d9e2a844494196b9ca5b6/addons/sale/controllers/product_configurator.py#L329

## Issue
Duplicating an attribute on a product leads to a traceback when adding the product to a SO.

## Steps to reproduce
*Ensure variants are activated in the settings*
- Create a new test product:
  - Attributes & Variants (on 2 distinct lines):
    - "Brand": 1;
    - "Brand": 2 & 3.
- Create a new SO:
  - Add the test product.

## Cause
The product has 2 attribute lines referring to the same attribute. As both attribute lines point to the same attribute, `ptals.attribute_id.read()` returns only one value for two ptals. The `zip()` call therefore drops the extra ptal, producing an incomplete mapping. When the configurator later tries to access this missing ptal entry, it crashes https://github.com/odoo/odoo/blob/369ca1e5a154235e80b9ea6af7b3f10442c0939f/addons/sale/controllers/product_configurator.py#L321.

opw-5373672