### PR TITLE
  [IMP] (website_)sale_gelato: prevent too long addresses

### DIFF
--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -280,11 +280,11 @@
         <div class="w-100"/>
         <t t-if="zip_before_city">
             <div id="div_zip" class="col-md-4 mb-2">
-                <label class="col-form-label" for="o_zip">
+                <label class="col-form-label" for="o_zip_before_city">
                     Zip Code
                 </label>
                 <input
-                    id="o_zip"
+                    id="o_zip_before_city"
                     type="text"
                     name="zip"
                     class="form-control"
@@ -304,11 +304,11 @@
         </div>
         <t t-if="not zip_before_city">
             <div id="div_zip" class="col-md-4 mb-2">
-                <label class="col-form-label" for="o_zip">
+                <label class="col-form-label" for="o_zip_after_city">
                     Zip Code
                 </label>
                 <input
-                    id="o_zip"
+                    id="o_zip_after_city"
                     type="text"
                     name="zip"
                     class="form-control"

--- a/addons/sale_gelato/models/delivery_carrier.py
+++ b/addons/sale_gelato/models/delivery_carrier.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.sale_gelato import utils
 
@@ -67,11 +67,13 @@ class ProviderGelato(models.Model):
         :return: The shipment rate request results.
         :rtype: dict
         """
-        if error_message := order._ensure_partner_address_is_complete():
+        try:
+            order.partner_shipping_id._gelato_validate_address()
+        except ValidationError as e:
             return {
                 'success': False,
                 'price': 0,
-                'error_message': error_message,
+                'error_message': str(e),
             }
 
         # Fetch the delivery price from Gelato.

--- a/addons/sale_gelato/models/res_partner.py
+++ b/addons/sale_gelato/models/res_partner.py
@@ -1,27 +1,82 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, models
+from odoo.exceptions import ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.sale_gelato import const
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
+    def _gelato_validate_address(self):
+        """Check that all required address fields are set and of correct length.
+
+        :rtype: None
+        :raise ValidationError: If the address is incomplete or too long.
+        """
+        self._gelato_ensure_address_is_complete()
+        self._gelato_check_address_length_limit()
+
+    def _gelato_ensure_address_is_complete(self):
+        """Ensure that all address fields required by Gelato are set.
+
+        :rtype: None
+        :raise ValidationError: If the address is incomplete.
+        """
+        required_address_fields = ['city', 'country_id', 'email', 'name', 'street']
+        if self.country_id.code not in const.COUNTRIES_WITHOUT_ZIPCODE:
+            required_address_fields.append('zip')
+        missing_fields = [
+            self._fields[field_name]
+            for field_name in required_address_fields
+            if not self[field_name]
+        ]
+        if missing_fields:
+            translated_field_names = [f._description_string(self.env) for f in missing_fields]
+            raise ValidationError(_(
+                "The following required address fields are missing: %s",
+                ", ".join(translated_field_names),
+            ))
+
+    def _gelato_check_address_length_limit(self):
+        """Check that the address fields are compliant with Gelato maximum character limit.
+
+        :rtype: None
+        :raise ValidationError: If the address fields are too long.
+        """
+        max_address_lengths = {'street': 35, 'street2': 35, 'city': 30, 'zip': 15, 'phone': 25}
+        exceeding_fields = {}
+        for field, limit in max_address_lengths.items():
+            if self[field] and len(self[field]) > limit:
+                field_name = self._fields[field]._description_string(self.env)
+                exceeding_fields[field_name] = limit
+        if exceeding_fields:
+            message = ", ".join([
+                f"{field_name} (max {limit} characters)"
+                for field_name, limit in exceeding_fields.items()
+            ])
+            raise ValidationError(_("The following address fields are too long: %s", message))
+
     def _gelato_prepare_address_payload(self):
-        """Trim address fields according to maximum length allowed by Gelato."""
+        """Prepare the address payload with the partner details.
+
+        The fields that are not strictly required to be unchanged for the delivery are trimmed to
+        their maximum length allowed by Gelato.
+
+        :return: The address payload with the partner details.
+        :rtype: dict
+        """
         first_name, last_name = payment_utils.split_partner_name(self.name)
-        address_2 = self.street2 or ''
-        if remaining_address := self.street[35:]:
-            address_2 = remaining_address + ' ' + address_2
         return {
             'companyName': (self.commercial_company_name or '')[:60],
-            'firstName': (first_name or last_name)[:25],  # Gelato require a first name.
+            'firstName': (first_name or last_name)[:25],  # Gelato requires a first name.
             'lastName': last_name[:25],
-            'addressLine1': self.street[:35],
-            'addressLine2': address_2[:35],
+            'addressLine1': self.street,
+            'addressLine2': self.street2,
             'state': self.state_id.code,
-            'city': self.city[:30],
+            'city': self.city,
             'postCode': self.zip,
             'country': self.country_id.code,
             'email': self.email,

--- a/addons/sale_gelato/models/sale_order.py
+++ b/addons/sale_gelato/models/sale_order.py
@@ -4,6 +4,8 @@ import logging
 import pprint
 from functools import partial, wraps
 
+from markupsafe import Markup
+
 from odoo import _, api, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -183,9 +185,13 @@ class SaleOrder(models.Model):
                 payload=payload,
                 method='PATCH',
             )
-        except UserError:
+        except UserError as e:
             self.message_post(
-                body=self.env._("Unable to confirm the order %s on Gelato.", gelato_order_id),
+                body=self.env._(
+                    "Unable to confirm the order %(order_reference)s on Gelato.%(error_message)s",
+                    order_reference=gelato_order_id,
+                    error_message=Markup("<br/>%s") % e,
+                ),
                 author_id=self.env.ref('base.partner_root').id,
             )
         finally:
@@ -213,9 +219,13 @@ class SaleOrder(models.Model):
             data = utils.make_request(
                 api_key, 'order', 'v4', f'orders/{gelato_order_id}', method='DELETE'
             )
-        except UserError:
+        except UserError as e:
             self.message_post(
-                body=self.env._("Unable to delete the order %s on Gelato.", gelato_order_id),
+                body=self.env._(
+                    "Unable to delete the order %(order_reference)s on Gelato.%(error_message)s",
+                    order_reference=gelato_order_id,
+                    error_message=Markup("<br/>%s") % e,
+                ),
                 author_id=self.env.ref('base.partner_root').id,
             )
         finally:

--- a/addons/website_sale_gelato/__manifest__.py
+++ b/addons/website_sale_gelato/__manifest__.py
@@ -6,6 +6,7 @@
     'depends': ['sale_gelato', 'website_sale'],
     'data': [
         'data/delivery_carrier_data.xml',
+        'views/address_templates.xml'
     ],
     'auto_install': True,
     'author': 'Odoo S.A.',

--- a/addons/website_sale_gelato/controllers/__init__.py
+++ b/addons/website_sale_gelato/controllers/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
+from . import main

--- a/addons/website_sale_gelato/controllers/main.py
+++ b/addons/website_sale_gelato/controllers/main.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.exceptions import ValidationError
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers import main
+
+
+class WebsiteSale(main.WebsiteSale):
+    def _check_delivery_address(self, partner_sudo):
+        """Override of `website_sale`to check that the shipping address is compliant with Gelato.
+
+        :param res.partner partner_sudo: The partner whose delivery address to check.
+        :return: Whether all checked fields are within length limit.
+        :rtype: bool
+        """
+        res = super()._check_delivery_address(partner_sudo)
+        order_sudo = request.cart
+        if not res or not order_sudo:
+            return res
+
+        if any(order_sudo.order_line.product_id.mapped('gelato_product_uid')):
+            try:
+                partner_sudo._gelato_check_address_length_limit()
+            except ValidationError:
+                return False
+        return True

--- a/addons/website_sale_gelato/views/address_templates.xml
+++ b/addons/website_sale_gelato/views/address_templates.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="website_sale_gelato.limit" inherit_id="website_sale.address_form_fields">
+        <div id="div_name" position="before">
+            <t
+                t-set="is_gelato"
+                t-value="any(website_sale_order.order_line.product_id.mapped('gelato_product_uid'))"
+            />
+            <t t-set="max_length_title_15">Max 15 characters</t>
+            <t t-set="max_length_title_25">Max 25 characters</t>
+            <t t-set="max_length_title_30">Max 30 characters</t>
+            <t t-set="max_length_title_35">Max 35 characters</t>
+        </div>
+        <input id="o_phone" position="attributes">
+            <attribute name="t-att-title">is_gelato and max_length_title_25 or ''</attribute>
+            <attribute name="t-att-pattern">is_gelato and '.{0,25}' or '.*'</attribute>
+            <attribute name="t-att-maxlength">is_gelato and 25 or ''</attribute>
+        </input>
+        <input id="o_street" position="attributes">
+            <attribute name="t-att-title">is_gelato and max_length_title_35 or ''</attribute>
+            <attribute name="t-att-pattern">is_gelato and '.{0,35}' or '.*'</attribute>
+            <attribute name="t-att-maxlength">is_gelato and 35 or ''</attribute>
+        </input>
+        <input id="o_street2" position="attributes">
+            <attribute name="t-att-title">is_gelato and max_length_title_35 or ''</attribute>
+            <attribute name="t-att-pattern">is_gelato and '.{0,35}' or '.*'</attribute>
+            <attribute name="t-att-maxlength">is_gelato and 35 or ''</attribute>
+        </input>
+        <input id="o_zip_before_city" position="attributes">
+            <attribute name="t-att-title">is_gelato and max_length_title_15 or ''</attribute>
+            <attribute name="t-att-pattern">is_gelato and '.{0,15}' or '.*'</attribute>
+            <attribute name="t-att-maxlength">is_gelato and 15 or ''</attribute>
+        </input>
+        <input id="o_city" position="attributes">
+            <attribute name="t-att-title">is_gelato and max_length_title_30 or ''</attribute>
+            <attribute name="t-att-pattern">is_gelato and '.{0,30}' or '.*'</attribute>
+            <attribute name="t-att-maxlength">is_gelato and 30 or ''</attribute>
+        </input>
+        <input id="o_zip_after_city" position="attributes">
+            <attribute name="t-att-title">is_gelato and max_length_title_15 or ''</attribute>
+            <attribute name="t-att-pattern">is_gelato and '.{0,15}' or '.*'</attribute>
+            <attribute name="t-att-maxlength">is_gelato and 15 or ''</attribute>
+        </input>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Order was rejected by Gelato if certain fields of shipping address were
exceeding Gelato's character limit. To prevent sending address with
incorrect length, if the address is not compliant, a warning will be shown
and the possibility of confirming the order is blocked. In ecommerce, it
is not possible to put address longer than the Gelato's character limit
if the order is consisting of Gelato products.

task-5264993