### PR TITLE
[FIX] point_of_sale: compute currency conversion in PoS

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -36,8 +36,8 @@ class ProductProduct(models.Model):
         different_currency = config.currency_id != self.env.company.currency_id
         if different_currency:
             for product in read_records:
-                product['lst_price'] = config.currency_id._convert(
-                    product['lst_price'], self.env.company.currency_id, self.env.company, fields.Date.today()
+                product['lst_price'] = self.env.company.currency_id._convert(
+                    product['lst_price'], config.currency_id, self.env.company, fields.Date.today()
                 )
         return read_records
 

--- a/addons/point_of_sale/tests/test_pos_other_currency_config.py
+++ b/addons/point_of_sale/tests/test_pos_other_currency_config.py
@@ -364,3 +364,18 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
                 debit += line.debit
                 credit += line.credit
             self.assertEqual(tools.float_compare(debit, credit, precision_rounding=self.other_currency_config.currency_id.rounding), 0)  # debit and credit should be equal
+
+    def test_with_session_check_product_cost(self):
+        def find_by(list_of_dicts, key, value):
+            return next((d for d in list_of_dicts if d.get(key) == value), None)
+
+        self.other_currency_config.open_ui()
+        product = self.other_currency_config.current_session_id.load_data([])['product.product']
+
+        self.assertAlmostEqual(find_by(product, 'id', self.product1.id)['lst_price'], 5.00)
+        self.assertAlmostEqual(find_by(product, 'id', self.product2.id)['lst_price'], 10.00)
+        self.assertAlmostEqual(find_by(product, 'id', self.product3.id)['lst_price'], 15.00)
+        self.assertAlmostEqual(find_by(product, 'id', self.product4.id)['lst_price'], 50.00)
+        self.assertAlmostEqual(find_by(product, 'id', self.product5.id)['lst_price'], 100.00)
+        self.assertAlmostEqual(find_by(product, 'id', self.product6.id)['lst_price'], 22.65)
+        self.assertAlmostEqual(find_by(product, 'id', self.product7.id)['lst_price'], 3.50)


### PR DESCRIPTION
Behavior:
When using a Point of Sale configured with a different currency than the current company's currency. The price conversion is inverted.
This occurs when loading the data when accessing PoS, each product should have its currency converted to the config's currency from the company's, however this is currently inverted.
https://github.com/odoo/odoo/blob/e9656230e60fee23cf399f0c6bdefbcedef86768/addons/point_of_sale/models/product_product.py#L36-L40

Steps to reproduce:
- Activate another currency than the initial one and indicate a conversion rate
- Create a new point of sale
- Create new journals for the PoS with the new currency.
- When opening the PoS and adding any product the price will be a lot higher or lower than the expected price.

opw-5266359