### PR TITLE
[FIX] web: extract activity action execution for extensibility

### DIFF
--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -73,6 +73,15 @@ export class ActivityMenu extends Component {
         }
         const views = this.availableViews(group);
 
+        this.executeActivityAction(group, domain, views, context);
+    }
+
+    /**
+     * This logic is extracted into a separate method to allow other modules (e.g., documents)
+     * to override *how* the action is executed (e.g., loading a specific XML ID)
+     * without needing to duplicate the domain and filter preparation logic in `openActivityGroup`.
+     */
+    executeActivityAction(group, domain, views, context) {
         this.action.doAction(
             {
                 context,


### PR DESCRIPTION
The `openActivityGroup` method in `ActivityMenu` currently handles both the preparation of filters (domains, contexts) and the actual execution of the action.

This coupling prevents other modules from intercepting the action execution to inject specific behaviors—such as loading a specific server-side action or specialized views—without completely overriding the method and duplicating the filter logic.

This commit extracts the final execution step into a new method `executeActivityAction`. This allows extending modules (e.g., `documents`) to customize the action load (e.g., to ensure specific JavaScript hooks are initialized) while relying on the base implementation for domain and context generation.

Task-5187045

