### PR TITLE
[IMP] iot_drivers: avoid updating above 19.0

### DIFF
--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -81,9 +81,13 @@ def check_git_branch(server_url=None):
         _logger.warning("Could not get the database branch, skipping git checkout")
         return
 
+    # Avoid checking out above 19.0 to avoid python version incompatibility
+    if float(db_branch.replace("saas-", "")) > 19.0:
+        db_branch = '19.0'
+
     try:
         if not git('ls-remote', 'origin', db_branch):
-            db_branch = 'master'
+            db_branch = '19.0'
 
         local_branch = git('symbolic-ref', '-q', '--short', 'HEAD')
         _logger.info("IoT Box git branch: %s / Associated Odoo db's git branch: %s", local_branch, db_branch)


### PR DESCRIPTION
To avoid reflashing after a db update to 19.1, which would lead to python version incompatibility (3.12 min but iot box v25_07 and under have 3.10), we now prevent checkout above v19.0.

We also ensure that 19.0 IoT Box is compatible with 19.1 db.

Task: 5380815