### PR TITLE
[FIX] account: adapt how account statement validity is computed

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -251,13 +251,15 @@ class AccountBankStatement(models.Model):
                   LEFT JOIN account_journal j ON st.journal_id = j.id
                   LEFT JOIN res_currency currency ON COALESCE(j.currency_id, co.currency_id) = currency.id
                       WHERE st.first_line_index IS NOT NULL
-                      {"" if all_statements else "AND st.id IN %(ids)s"}
+                      {"" if all_statements else "AND st.journal_id IN %(journal_ids)s"}
                   )
            SELECT id
              FROM statements
             WHERE prev_balance_end_real IS NOT NULL
-              AND ROUND(prev_balance_end_real, decimal_places) != ROUND(balance_start, decimal_places);
+              AND ROUND(prev_balance_end_real, decimal_places) != ROUND(balance_start, decimal_places)
+              {"" if all_statements else "AND id IN %(ids)s"};
         """, {
+            'journal_ids': tuple(set(self.journal_id.ids)),
             'ids': tuple(self.ids)
         })
         res = self.env.cr.fetchall()

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -703,6 +703,18 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
              'date': fields.Date.from_string('2020-01-13')},
         ])
 
+        # computing validity of non-consecutive statement shouldn't affect validity
+        line5 = self.create_bank_transaction(-10, '2020-01-13')
+        statement4 = self.env['account.bank.statement'].create({
+            'line_ids': [Command.set(line5.ids)],
+            'balance_start': -15,
+        })
+        (statement1 + statement4).invalidate_recordset(['is_valid'])
+        self.assertRecordValues(statement1 + statement4, [
+            {'is_valid': True},
+            {'is_valid': True},
+        ])
+
         # adding a statement to the first line should make statement1 invalid
         line1.statement_id = statement2
         statement2.flush_model()


### PR DESCRIPTION
Some bank account statements are computed as not valid, although they are valid.

Statement 1 and 3 appear, and statement 3 is shown as invalid, while both statements should be shown as valid.

Statement validity is computed depending on previous statement end balance and current statement start balance. The SQL query uses a window function to retrieve the previous statement. However, the function is applied after the WHERE clause. Therefore, it uses the end_balance of the previously selected statement instead of the previous statement.

#### Step to reproduce:
- In the bank dashboard of the accounting app
- Create journal entry 1
- Create statement 1
- Create journal entry 2
- Create statement 2
- Validate the journal entry 2
- Create journal entry 3
- Create statement 3
- filter statement per "Not Matched"


Ticket [link](https://www.odoo.com/odoo/project.task/5341433)
opw-5341433