### PR TITLE
[FIX] hr_applicant: match applications with its count among companies

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -261,22 +261,7 @@ class HrApplicant(models.Model):
         Note: If self has pool_applicant_id, email, phone number or linkedin set
         this method will include self in the returned count
         """
-        all_emails = {a.email_normalized for a in self if a.email_normalized}
-        all_phones = {a.partner_phone_sanitized for a in self if a.partner_phone_sanitized}
-        all_linkedins = {a.linkedin_profile for a in self if a.linkedin_profile}
-        all_pool_applicants = {a.pool_applicant_id.id for a in self if a.pool_applicant_id}
-
-        domain = Domain.FALSE
-        if all_emails:
-            domain |= Domain("email_normalized", "in", list(all_emails))
-        if all_phones:
-            domain |= Domain("partner_phone_sanitized", "in", list(all_phones))
-        if all_linkedins:
-            domain |= Domain("linkedin_profile", "in", list(all_linkedins))
-        if all_pool_applicants:
-            domain |= Domain("pool_applicant_id", "in", list(all_pool_applicants))
-
-        domain &= Domain("talent_pool_ids", "=", False)
+        domain = self._get_similar_applicants_domain(ignore_talent=True)
         matching_applicants = self.env["hr.applicant"].with_context(active_test=False).search(domain)
 
         email_map = defaultdict(set)
@@ -327,15 +312,12 @@ class HrApplicant(models.Model):
         Returns:
             Domain()
         """
-        domain = Domain.AND([
-            Domain('company_id', 'in', self.mapped('company_id.id')),
-            Domain.OR([
-                Domain("id", "in", self.ids),
-                Domain("email_normalized", "in", [email for email in self.mapped("email_normalized") if email]),
-                Domain("partner_phone_sanitized", "in", [phone for phone in self.mapped("partner_phone_sanitized") if phone]),
-                Domain("linkedin_profile", "in", [linkedin_profile for linkedin_profile in self.mapped("linkedin_profile") if linkedin_profile]),
-                Domain("pool_applicant_id", "in", [pool_applicant.id for pool_applicant in self.mapped("pool_applicant_id") if pool_applicant]),
-            ])
+        domain = Domain.OR([
+            Domain("id", "in", self.ids),
+            Domain("email_normalized", "in", [email for email in self.mapped("email_normalized") if email]),
+            Domain("partner_phone_sanitized", "in", [phone for phone in self.mapped("partner_phone_sanitized") if phone]),
+            Domain("linkedin_profile", "in", [linkedin_profile for linkedin_profile in self.mapped("linkedin_profile") if linkedin_profile]),
+            Domain("pool_applicant_id", "in", [pool_applicant.id for pool_applicant in self.mapped("pool_applicant_id") if pool_applicant]),
         ])
         if ignore_talent:
             domain &= Domain("talent_pool_ids", "=", False)


### PR DESCRIPTION
This commit fixes the issue where applications are not matched are not mathced with thier count among companies in a multi-company environment. The domain on company was removed from `_get_similar_applicants_domain` since there is no domain on company in `_compute_application_count`.

task-5375876


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
