### PR TITLE
[FIX] {purchase_,}mrp: avoid issues on test setup

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -3,7 +3,6 @@
 
 from odoo.tests import Form, tagged
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo import Command
 
 
 @tagged('post_install', '-at_install')
@@ -24,6 +23,8 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         warehouse_form.name = 'Test Warehouse'
         warehouse_form.code = 'TWH'
         cls.warehouse = warehouse_form.save()
+        # Enable MTO
+        cls.warehouse.mto_pull_id.route_id.active = True
 
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
 
@@ -33,7 +34,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         product_form.uom_id = cls.uom_unit
         product_form.is_storable = True
         product_form.route_ids.clear()
-        product_form.route_ids.add(cls.warehouse.manufacture_pull_id.route_id)
         product_form.route_ids.add(cls.warehouse.mto_pull_id.route_id)
         cls.finished_product = product_form.save()
 
@@ -370,7 +370,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
 
         finished_product = self.env['product.product'].create({
             'name': 'Super Product',
-            'route_ids': [Command.link(self.route_manufacture.id)],
             'is_storable': True,
         })
         secondary_product = self.env['product.product'].create({
@@ -433,10 +432,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
     def test_manufacturing_3_steps_trigger_reordering_rules(self):
         with Form(self.warehouse) as warehouse:
             warehouse.manufacture_steps = 'pbm_sam'
-
-        with Form(self.raw_product) as p:
-            p.route_ids.clear()
-            p.route_ids.add(self.warehouse.manufacture_pull_id.route_id)
 
         # Create an additional BoM for component
         product_form = Form(self.env['product.product'])
@@ -760,7 +755,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.env.user.group_ids += self.env.ref('mrp.group_mrp_byproducts')
         demo = self.env['product.product'].create({
             'name': 'DEMO',
-            'route_ids': [Command.link(self.route_manufacture.id)],
             'is_storable': True,
         })
         comp1 = self.env['product.product'].create({

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -137,15 +137,13 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
 
     @classmethod
     def _create_product_with_form(cls, name, uom_id, routes=()):
-        p = Form(cls.env['product.product'])
-        p.name = name
-        p.is_storable = True
-        p.categ_id = cls.env.ref('product.product_category_goods')
-        p.uom_id = uom_id
-        p.route_ids.clear()
-        for r in routes:
-            p.route_ids.add(r)
-        return p.save()
+        return cls.env['product.product'].create({
+            'name': name,
+            'is_storable': True,
+            'categ_id': cls.env.ref('product.product_category_goods').id,
+            'uom_id': uom_id.id,
+            'route_ids': [Command.set([route.id for route in routes])],
+        })
 
         # Helper to process quantities based on a dict following this structure :
         #


### PR DESCRIPTION
Since 19.0, routes are no longer displayed in the product form if no route outside from Buy/Manufacture are enabled, as those two now depend on whether there's a vendor/bom to be enabled for that product.

In the `setUpClass` however, without having the MTO route enabled by other means, there wouldn't be any route to display in the product form, resulting in a traceback at launch as the `route_ids` field would be invisible within the form.

Now we make sure the MTO route is always enabled (as it doesn't make sense to assign an archived route), which also forces the display of `route_ids` in the product form.
Also removes the assignation of the 'Manufacture' route on products, as its no longer necessary on product that have a 
bom.

In `purchase_mrp`, we just remove the usage of the Form for product
creation, as:
- The `routes` argument was never even used
- There was no point in creating these products through a form in the
  first place
This avoids having to enable an extra route for "nothing", just to have
`route_ids` appear in the form.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
