### PR TITLE
[FIX] mrp_subcontracting_purchase: use invoice currency when computing price difference on subcontracted products

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/account_move_line.py
+++ b/addons/mrp_subcontracting_purchase/models/account_move_line.py
@@ -12,7 +12,11 @@ class AccountMoveLine(models.Model):
         if self.product_id.cost_method == 'standard' and self.purchase_line_id:
             components_cost = 0
             subcontract_production = self.purchase_line_id.move_ids._get_subcontract_production()
-            components_cost -= sum(subcontract_production.move_raw_ids.stock_valuation_layer_ids.mapped('value'))
+            valuation_date = subcontract_production.move_raw_ids and max(subcontract_production.move_raw_ids.mapped('date')) or self.date
+            components_cost = self.company_currency_id._convert(
+                -sum(subcontract_production.move_raw_ids.stock_valuation_layer_ids.mapped('value')),
+                self.currency_id, self.company_id, valuation_date, round=False
+            )
             qty = sum(mo.product_uom_id._compute_quantity(mo.qty_producing, self.product_uom_id) for mo in subcontract_production if mo.state == 'done')
             if not float_is_zero(qty, precision_rounding=self.product_uom_id.rounding):
                 price_unit_val_dif = price_unit_val_dif + components_cost / qty


### PR DESCRIPTION
Problem:
When computing the price difference on a vendor bill for a subcontracted product, the component cost is considered in the company's currency regardless of the currency of the invoice. This means the price difference calculation directly compares two different currencies without converting them, resulting in some incorrect values for the price difference invoice lines.

Solution:
We will convert the component cost to the invoice currency when computing price difference.

Steps to reproduce (runbot 18):
- Product with
	- Standard price auto
	- BoM: sbc, one component with nonzero value (e.g. $1)
	- Nonzero value (e.g. $5)
- Another currency
1. Create a PO for the subcontracted product
2. Set the Invoice currency to something other than the company default
3. Confirm the PO and validate the sbc and receipt
4. Create the vendor bill, and bill for the correct value (Whatever $4 is in the invoice currency)

A price difference line will be erroneously generated for some nonsense value, when we expect 0 price difference.

opw-5232917
