### PR TITLE
[FIX] point_of_sale: prevent error on refund payment of returned order

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -158,8 +158,9 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super()._get_new_picking_values()
-        order = self.reference_ids.pos_order_ids
-        if order:
+        orders = self.reference_ids.pos_order_ids
+        if orders:
+            order = orders.filtered(lambda o: o.is_refund and o.state == 'paid')[:1] or orders[:1]
             vals['pos_session_id'] = order.session_id.id
             vals['pos_order_id'] = order.id
         return vals


### PR DESCRIPTION
Currently, an error occurs when processing the payment of a return POS order whose original order has already been shipped.

**Steps to Reproduce:**
1. Install the stock and pos modules with demo data.
2. In config, activate the "**Allow Ship Later**" for _Furniture Shop_.
3. Open register and create an order with a Ship Later date.
4. Inventory > Delivery Orders > Validate the picking generated for that order.
5. Open original POS order (form), click "**Return Products**".
6. Open the returned order, click "**Payment**" and make the payment.

**Error:**
`ValueError - Expected singleton: pos.order(2, 1)`

**Cause:**
At [1], `reference_ids.pos_order_ids` is a many2many relation, but the logic assumes it contains only a single order. As a result, accessing `order.session_id.id` or `order.id` raises a singleton error when multiple related orders are present.

**Fix:**
This commit ensures that picking values are generated using a single pos order reference by selecting the relevant one from the multiple pos orders.

[1] - https://github.com/odoo/odoo/blob/569b2e27699a76f9bac210e61b47f8a5708c814b/addons/point_of_sale/models/stock_picking.py#L157-L160

sentry- 7071798497