### PR TITLE
[FIX] project: show Share Task action for project users

### DIFF
--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -43,6 +43,7 @@ access_project_collaborator_user,project.collaborator.user,model_project_collabo
 access_project_collaborator_portal,project.collaborator.portal,model_project_collaborator,base.group_portal,1,0,0,0
 access_project_share_manager,project.share.wizard.manager,model_project_share_wizard,project.group_project_manager,1,1,1,0
 access_project_task_share_manager,project.task.share.wizard.manager,model_task_share_wizard,project.group_project_manager,1,1,1,0
+access_project_task_share_user,project.task.share.wizard.user,model_task_share_wizard,base.group_partner_manager,1,1,1,0
 access_project_share_collaborator_manager,project.share.collaborator.wizard.manager,model_project_share_collaborator_wizard,project.group_project_manager,1,1,1,1
 access_project_personal_stage,project.personal.stage.user,model_project_task_stage_personal,base.group_user,1,1,1,1
 access_mail_activity_plan_project_manager,mail.activity.plan.project.manager,mail.model_mail_activity_plan,project.group_project_manager,1,1,1,1


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install project with demo data.
2. Go to Tasks → cog menu → observe the "Share Task" action.
3. Log in as the demo user.
4. Observe that the "Share Task" action is missing.

Issue:
--------
The "Share Task" action is not visible for project users.

Cause:
--------
After this b396f9608390ee57dda3670ccc575986f3c205be, the model changed from `portal.share` to `task.share.wizard`.
The security file only grants access to project managers: https://github.com/odoo/odoo/blob/bf83a4efefedae61e06a6b29ad82e647fd673ce2/addons/project/security/ir.model.access.csv#L45

Solution:
---------
Grant project users necessary access to `task.share.wizard`.

opw-5342875


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
