### PR TITLE
[FIX] stock: show units on backorder lines in delivery slip report

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -247,7 +247,7 @@
             <td class="text-center" name="move_line_aggregated_qty_ordered">
                 <span t-esc="aggregated_lines[line]['qty_ordered']"
                     t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
-                <span t-esc="aggregated_lines[line]['product_uom'].name"/>
+                <span t-esc="aggregated_lines[line]['product_uom'].name" groups="uom.group_uom"/>
                 <span t-if="aggregated_lines[line]['packaging'].name">
                     (<span t-out="aggregated_lines[line]['packaging_qty']" t-options='{"widget": "integer"}'/> <span t-out="aggregated_lines[line]['packaging'].name"/>)
                 </span>
@@ -256,7 +256,7 @@
                 <t t-if="aggregated_lines[line]['quantity']">
                     <span t-esc="aggregated_lines[line]['quantity']"
                         t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
-                    <span t-esc="aggregated_lines[line]['product_uom'].name"/>
+                    <span t-esc="aggregated_lines[line]['product_uom'].name" groups="uom.group_uom"/>
                     <span t-if="aggregated_lines[line]['packaging'].name">
                         (<span t-out="aggregated_lines[line]['packaging_quantity']" t-options='{"widget": "integer"}'/> <span t-out="aggregated_lines[line]['packaging'].name"/>)
                     </span>


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **Stock** module with demo data.
* Create a delivery with quantity **N** and click **Mark as To Do**.
* Set the delivered quantity to less than the demanded quantity .
* Validate the delivery, with the creation of a **backorder**.
* Print the **Delivery Slip** report.

**Observed behavior:**
* Backorder lines appear **without units of measure**, while 
other lines correctly display their units.

**Cause:**
* The backorder line includes a **group restriction** that hides 
the unit unless the *Unit of Measure* setting is enabled.

**Fix:**
* Remove the group restriction so units of measure are 
always visible on backorder lines same as others.

<details>
    <summary>Click here to see the results:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/5f21139a-a4ab-4c39-8b16-3c68c94a163e" />
    After:
   <img src="https://github.com/user-attachments/assets/dd4de18b-dc2e-4686-8435-30864fe40aa4" />

</details>


---

> NOTE - This fix done after receiving confirmation from PO(dala)

---

opw-5265051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
