### PR TITLE
[FIX] website: sync theme color as default highlight selector

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -72,7 +72,7 @@ export class HighlightConfigurator extends Component {
                 revertHighlight: this.props.revertHighlight,
                 style: `
                     --text-highlight-width: ${(this.state.thickness || 2) / fontRatio}px;
-                    --text-highlight-color: ${this.state.color || "var(--o-color-1)"};
+                    --text-highlight-color: ${this.state.color || "var(--hb-cp-o-color-1)"};
                 `,
             },
             _t("Select a highlight"),

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -120,7 +120,7 @@ export class HighlightPlugin extends Plugin {
             );
             this.highlightState.color = style.every((v) => v === style[0])
                 ? style[0]
-                : getComputedStyle(this.document.body).getPropertyValue("--o-color-1");
+                : getComputedStyle(this.document.body).getPropertyValue("--hb-cp-o-color-1");
             const thickness = nodes.map((node) =>
                 getComputedStyle(node).getPropertyValue("--text-highlight-width")
             );


### PR DESCRIPTION
Steps to reproduce:
1. Go to the theme tab and change the colors of the main preset.
2. Select any text in the footer.
3. Expand the toolbar and click the highlight option.

Issue:
The highlight selector still uses the default purple color instead of adapting to the updated theme preset. This happens because the text highlight color uses "--o-color-1", which does not update when the theme colors are modified.

Fix:
Used "var(--hb-cp-o-color-1)" as the default text highlight color instead of "--o-color-1", ensuring the highlight automatically adapts to theme changes.

Before This Fix:
| highlight selector color before changing theme preset | highlight selector color after changing theme preset |
|-----------------------------|---------------------------------|
| <img width="450" height="404" alt="image" src="https://github.com/user-attachments/assets/c92eed7e-1856-4e08-879a-a74e2506ab9c" /> | <img width="399" height="389" alt="image" src="https://github.com/user-attachments/assets/9a938e80-9e01-49fd-b6a1-cf9baaa64358" /> |


After This Fix:
| highlight selector color before changing theme preset | highlight selector color after changing theme preset |
|-----------------------------|---------------------------------|
| <img width="394" height="413" alt="image" src="https://github.com/user-attachments/assets/674958bc-7df7-44fa-97c0-5ae78608dc6a" /> | <img width="408" height="428" alt="image" src="https://github.com/user-attachments/assets/1d48ca49-7d18-4681-8443-b9887eef0dbf" /> |

task-5375414

Co-author: Alay Patel <alap@odoo.com>
