### PR TITLE
[IMP] im_livechat: persist info panel toggle across livechat sessions

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
@@ -2,6 +2,7 @@ import { fields } from "@mail/core/common/record";
 import { DiscussApp } from "@mail/core/public_web/discuss_app_model";
 import { effectWithDebouncedCleanup } from "@mail/utils/common/misc";
 
+import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
@@ -10,6 +11,7 @@ import { patch } from "@web/core/utils/patch";
 // when the user closes the sidebar or switches to another app, wait for 5
 // minutes before unsubscribing.
 export const LFH_UNSUBSCRIBE_DELAY = 5 * 60 * 1000;
+const LIVECHAT_INFO_DEFAULT_OPEN_LS = "im_livechat.isInfoPanelOpenByDefault";
 
 const discussAppStaticPatch = {
     new() {
@@ -82,6 +84,19 @@ patch(DiscussApp.prototype, {
         });
         this.lastThread = fields.One("Thread");
         this.livechats = fields.Many("Thread", { inverse: "appAsLivechats" });
+        this.isLivechatInfoPanelOpenByDefault = fields.Attr(true, {
+            compute() {
+                return browser.localStorage.getItem(LIVECHAT_INFO_DEFAULT_OPEN_LS) !== "false";
+            },
+            /** @this {import("models").DiscussApp} */
+            onUpdate() {
+                if (this.isLivechatInfoPanelOpenByDefault) {
+                    browser.localStorage.removeItem(LIVECHAT_INFO_DEFAULT_OPEN_LS);
+                } else {
+                    browser.localStorage.setItem(LIVECHAT_INFO_DEFAULT_OPEN_LS, "false");
+                }
+            },
+        });
     },
 
     _threadOnUpdate() {
@@ -96,5 +111,12 @@ patch(DiscussApp.prototype, {
         }
         this.lastThread = this.thread;
         super._threadOnUpdate();
+    },
+
+    onStorage(ev) {
+        super.onStorage(ev);
+        if (ev.key === LIVECHAT_INFO_DEFAULT_OPEN_LS) {
+            this.isLivechatInfoPanelOpenByDefault = ev.newValue !== "false";
+        }
     },
 });

--- a/addons/im_livechat/static/src/core/web/discuss_content_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_content_patch.js
@@ -1,10 +1,14 @@
 import { DiscussContent } from "@mail/core/public_web/discuss_content";
+
 import { patch } from "@web/core/utils/patch";
 
 patch(DiscussContent.prototype, {
     actionPanelAutoOpenFn() {
         if (!this.threadActions.activeAction) {
-            this.threadActions.actions.find((a) => a.id === "livechat-info")?.open();
+            if (this.store.discuss.isLivechatInfoPanelOpenByDefault) {
+                this.threadActions.actions.find((a) => a.id === "livechat-info")?.open();
+            }
+            return;
         }
         super.actionPanelAutoOpenFn();
     },

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -12,6 +12,12 @@ registerThreadAction("livechat-info", {
     panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     icon: "fa fa-fw fa-info",
     name: _t("Information"),
+    open: ({ store }) => {
+        store.discuss.isLivechatInfoPanelOpenByDefault = true;
+    },
+    close: ({ store }) => {
+        store.discuss.isLivechatInfoPanelOpenByDefault = false;
+    },
     sequence: 10,
     sequenceGroup: 7,
     toggle: true,

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -233,3 +233,49 @@ test("Disable actions for non-livechat users", async () => {
     await waitFor("textarea[placeholder='Add your notes here...']:disabled");
     await waitFor(".o-livechat-ExpertiseTagsAutocomplete.o-disabled");
 });
+
+test("info panel toggle state persists across chats", async () => {
+    const pyEnv = await startServer();
+    const [guestId1, guestId2] = pyEnv["mail.guest"].create([
+        { name: "Visitor 1" },
+        { name: "Visitor 2" },
+    ]);
+    pyEnv["discuss.channel"].create([
+        {
+            channel_member_ids: [
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId1, livechat_member_type: "visitor" }),
+            ],
+            channel_type: "livechat",
+            livechat_operator_id: serverState.partnerId,
+        },
+        {
+            channel_member_ids: [
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId2, livechat_member_type: "visitor" }),
+            ],
+            channel_type: "livechat",
+            livechat_operator_id: serverState.partnerId,
+        },
+    ]);
+    await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussSidebarChannel:text('Visitor 1')");
+    await contains(".o-livechat-ChannelInfoList");
+    await click("button[name='livechat-info']");
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+    await click(".o-mail-DiscussSidebarChannel:text('Visitor 2')");
+    await contains(".o-mail-DiscussContent-threadName[title='Visitor 2']");
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+    await click("button[name='livechat-info']");
+    await contains(".o-livechat-ChannelInfoList");
+    await click(".o-mail-DiscussSidebarChannel:text('Visitor 1')");
+    await contains(".o-mail-DiscussContent-threadName[title='Visitor 1']");
+    await contains(".o-livechat-ChannelInfoList");
+});


### PR DESCRIPTION
**Purpose of this PR:**

Previously, the livechat info panel would always open by default when switching between chats, regardless of the user's preference. This required users to manually close the panel repeatedly.

This commit persists the panel's toggle state, so the panel remains open or closed based on the user's last choice across all livechat sessions.

Task-5291258

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
