### PR TITLE
[IMP] account_peppol: autopost bills received through peppol

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -150,6 +150,7 @@ class AccountEdiProxyClientUser(models.Model):
             ),
             attachment_ids=attachment.ids,
         )
+        move._autopost_bill()
         attachment.write({'res_model': 'account.move', 'res_id': move.id})
         return True
 


### PR DESCRIPTION
Currently, even if a partner has auto-post bills enabled, the incoming bills stay in the draft state.

This change addresses that issue.

Task-5373302

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
