### PR TITLE
[FIX] packaging: fix windows uninstaller

### DIFF
--- a/setup/win32/setup.nsi
+++ b/setup/win32/setup.nsi
@@ -389,6 +389,7 @@ SectionEnd
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 Section "Uninstall"
+    SetRegView 64
     # Check if the server is installed
     !insertmacro IfKeyExists "HKLM" "${UNINSTALL_REGISTRY_KEY_SERVER}" "UninstallString"
     Pop $R0


### PR DESCRIPTION
Since d0d0fa2b8e the Windows installer only supports 64 bit version of the OS. It was recently noticed that when uninstalling the app with the provided uninstaller that the app remains listed in the installed software. Although the directories and third party apps were correctly cleaned and removed.

The reason is that the Odoo app registry key is still present after the uninstall process. When a 32 bit process tries to write a registry key in `HKLM\SOFTWARE` it's redirected by the OS to `HKLM\SOFTWARE\WOW6432Node`.

By using the `SetRegView 64` NSIS directive, the installer writes the registry key at the right place ... but the uninstaller is lacking that directive and thus tries to remove a non existing key in `HKLM\SOFTWARE\WOW6432Node`.

With this commit, the uninstaller is fixed by using the directive too.
