### PR TITLE
[IMP] hr_payroll: allow modifications in work entries for reverted/refund payslips

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -326,4 +326,16 @@
         </field>
     </record>
 
+    <record model="ir.actions.server" id="action_hr_work_entry_set_to_draft">
+        <field name="name">Set to Draft</field>
+        <field name="sequence" eval="50"/>
+        <field name="model_id" ref="hr_work_entry.model_hr_work_entry"/>
+        <field name="binding_model_id" ref="hr_work_entry.model_hr_work_entry"/>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">
+records.action_set_to_draft()
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
-Originally, work entries for validated payslips cannot be modified.
-This task allows for the modification of the work entries for the reverted payslips. 
-State of work entries can be modified manually through list view + form view on gear icons

Task-id: #5380821
