### PR TITLE
[IMP] mail: test - keep email_build

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -102,14 +102,17 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         self._init_mail_mock()
 
         def _ir_mail_server_build_email(model, email_from, email_to, subject, body, **kwargs):
-            self._mails.append({
+            data = {
                 'email_from': email_from,
                 'email_to': email_to,
                 'subject': subject,
                 'body': body,
                 **kwargs,
-            })
-            return build_email_origin(model, email_from, email_to, subject, body, **kwargs)
+            }
+            res = build_email_origin(model, email_from, email_to, subject, body, **kwargs)
+            data['EmailMessage'] = res
+            self._mails.append(data)
+            return res
 
         def _mail_mail_create(model, *args, **kwargs):
             res = mail_create_origin(model, *args, **kwargs)

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -442,7 +442,7 @@ class TestMailMail(MailCommon):
             self._reset_data()
             with self.mock_mail_gateway(), mute_logger('odoo.addons.mail.models.mail_mail'):
                 mail.send(raise_exception=False)
-            self.assertFalse(self._mails[0]['email_from'])
+            self.assertEqual(len(self._mails), 0)  # email not send at all
             self.assertEqual(
                 mail.failure_reason,
                 'You must either provide a sender address explicitly or configure using the combination of `mail.catchall.domain` and `mail.default.from` ICPs, in the server configuration file or with the --email-from startup parameter.')


### PR DESCRIPTION
When using MockEmail, you can inspect sent emails through self.mails. However, in some cases we need to test the actual email output instead of only the provided values.
