### PR TITLE
[FIX] pos_loyalty: stop loading programs with different currency

### DIFF
--- a/addons/pos_loyalty/models/loyalty_program.py
+++ b/addons/pos_loyalty/models/loyalty_program.py
@@ -10,7 +10,7 @@ class LoyaltyProgram(models.Model):
 
     # NOTE: `pos_config_ids` satisfies an excpeptional use case: when no PoS is specified, the loyalty program is
     # applied to every PoS. You can access the loyalty programs of a PoS using _get_program_ids() of pos.config
-    pos_config_ids = fields.Many2many('pos.config', compute="_compute_pos_config_ids", store=True, readonly=False, string="Point of Sales", help="Restrict publishing to those shops.")
+    pos_config_ids = fields.Many2many('pos.config', compute="_compute_pos_config_ids", store=True, readonly=False, string="Point of Sales", help="Restrict publishing to those shops. Note: A program will only be used in the shops using the same currency as the program.")
     pos_order_count = fields.Integer("PoS Order Count", compute='_compute_pos_order_count')
     pos_ok = fields.Boolean("Point of Sale", default=True)
     pos_report_print_id = fields.Many2one('ir.actions.report', string="Print Report", domain=[('model', '=', 'loyalty.card')], compute='_compute_pos_report_print_id', inverse='_inverse_pos_report_print_id', readonly=False,

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -18,6 +18,7 @@ class PosConfig(models.Model):
             '|', ('date_from', '=', False), ('date_from', '<=', today),
             '|', ('date_to', '=', False), ('date_to', '>=', today),
             '|', ('pricelist_ids', '=', False), ('pricelist_ids', 'in', self.available_pricelist_ids.ids),
+            ('currency_id', '=', self.currency_id.id)
         ]).filtered(lambda p: not p.limit_usage or p.sudo().total_order_count < p.max_usage)
 
     def _check_before_creating_new_session(self):

--- a/addons/pos_loyalty/tests/test_loyalty_history.py
+++ b/addons/pos_loyalty/tests/test_loyalty_history.py
@@ -120,6 +120,14 @@ class TestPOSLoyaltyHistory(TestPointOfSaleHttpCommon):
         new_pos_order.confirm_coupon_programs(coupon_data)
         check_coupon(40, 2)
 
+    def test_programs_loaded(self):
+        eur_currency = self.setup_other_currency('EUR')
+        usd_loyalty = self.env['loyalty.program'].create({'name': "USD program"})
+        eur_loyalty = self.env['loyalty.program'].create({'name': "EUR program", 'currency_id': eur_currency.id})
+        loaded_programs = self.main_pos_config._get_program_ids()
+        self.assertIn(usd_loyalty, loaded_programs)
+        self.assertNotIn(eur_loyalty, loaded_programs)
+
     def test_gift_card_partner(self):
         """ Test that the gift card's partner is correctly set as the customer who bought it."""
         test_partner = self.env['res.partner'].create({'name': 'Test Partner'})


### PR DESCRIPTION
Currently, the pos does not support multi-currencies. However, nothing was making sure the programs loaded in a shop were compatible in terms of currencies.

Steps to reproduce:
-------------------
* Create a coupon loyalty program, coupons
* Change currency to euro
* Create coupons
* Copy obe of the code
* Open USD Shop
* Apply coupon, cancel order, apply coupon again
> The popup does not show the correct currency

Why the fix:
------------
As the pos is not ready for multi-currency we should not even load programs with different currencies.

opw-5220834