### PR TITLE
[FIX] mail: do not unpin sub-channel twice

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -53,21 +53,36 @@ class ChannelMember(models.Model):
     @api.autovacuum
     def _gc_unpin_outdated_sub_channels(self):
         outdated_dt = fields.Datetime.now() - timedelta(days=2)
-        domain = expression.AND(
-            [
-                [
-                    ("channel_id.parent_channel_id", "!=", False),
-                    ("last_interest_dt", "<", outdated_dt),
-                ],
-                expression.OR(
-                    [
-                        [("channel_id.last_interest_dt", "=", False)],
-                        [("channel_id.last_interest_dt", "<", outdated_dt)],
-                    ]
-                ),
-            ]
+        self.env["discuss.channel"].flush_model()
+        self.env["discuss.channel.member"].flush_model()
+        self.env["mail.message"].flush_model()
+        self.env.cr.execute(
+            """
+            SELECT member.id
+              FROM discuss_channel_member member
+              JOIN discuss_channel channel
+                ON channel.id = member.channel_id
+             WHERE (
+                       member.unpin_dt IS NULL
+                    OR member.last_interest_dt >= member.unpin_dt
+                    OR channel.last_interest_dt >= member.unpin_dt
+               )
+               AND COALESCE(member.last_interest_dt, member.create_date) < %(outdated_dt)s
+               AND COALESCE(channel.last_interest_dt, channel.create_date) < %(outdated_dt)s
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM mail_message
+                    WHERE mail_message.res_id = channel.id
+                      AND mail_message.model = 'discuss.channel'
+                      AND mail_message.id >= member.new_message_separator
+                      AND mail_message.message_type NOT IN ('notification', 'user_notification')
+               )
+            """,
+            {"outdated_dt": outdated_dt},
         )
-        members = self.env["discuss.channel.member"].search(domain)
+        members = self.env["discuss.channel.member"].search(
+            [("id", "in", [row[0] for row in self.env.cr.fetchall()])],
+        )
         members.unpin_dt = fields.Datetime.now()
         for member in members:
             member._bus_send("discuss.channel/unpin", {"id": member.channel_id.id})

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -12,26 +12,40 @@ from odoo.exceptions import UserError, ValidationError
 @tagged("post_install", "-at_install")
 class TestDiscussSubChannels(HttpCase):
     def test_01_gc_unpin_outdated_sub_channels(self):
+        bob = new_test_user(self.env, "bob_user", groups="base.group_user")
         parent = self.env["discuss.channel"].create({"name": "General"})
         parent._create_sub_channel()
         sub_channel = parent.sub_channel_ids[0]
-        sub_channel.add_members(partner_ids=[self.env.user.partner_id.id])
+        sub_channel._add_members(users=self.env.user | bob)
         sub_channel.channel_pin(pinned=True)
         self_member = sub_channel.channel_member_ids.filtered(lambda m: m.is_self)
         self.assertTrue(self_member.is_pinned)
         # Last interrest of the member is older than 2 days, no activity on the
         # channel: should be unpinned.
         two_days_later_dt = datetime.now() + timedelta(days=3)
-        with freeze_time(two_days_later_dt):
+        with freeze_time(two_days_later_dt) as frozen_time:
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertFalse(self_member.is_pinned)
-        # Last interrest of the member is older than 2 days, activity on the
-        # channel: should be kept.
+            unpin_dt = self_member.unpin_dt
+            # The member isn't unpinned again when GC re-runs.
+            frozen_time.tick(delta=timedelta(days=1))
+            self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
+            self.assertEqual(self_member.unpin_dt, unpin_dt)
         sub_channel.channel_pin(pinned=True)
-        with freeze_time(two_days_later_dt):
-            sub_channel.message_post(body="Hey!")
+        with freeze_time(two_days_later_dt) as frozen_time:
+            # Last interrest older than 2 days, activity on the channel: should be kept.
+            message = sub_channel.with_user(bob).message_post(body="Hey!", message_type="comment")
+            self_member._mark_as_read(message.id)
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertTrue(self_member.is_pinned)
+            # Unread messages: should be kept regardless of last interrest.
+            message = sub_channel.with_user(bob).message_post(body="Another message!", message_type="comment")
+            frozen_time.tick(delta=timedelta(days=3))
+            self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
+            self.assertTrue(self_member.is_pinned)
+            self_member._mark_as_read(message.id)
+            self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
+            self.assertFalse(self_member.is_pinned)
 
     def test_02_sub_channel_members_sync_with_parent(self):
         parent = self.env["discuss.channel"].create({"name": "General"})


### PR DESCRIPTION
Before this commit, outdated sub-channels were unpinned
each time the vacuum ran. It occurs because a condition
on sub-channel being pinned is missing.

In practice, it's not a big deal funtionnaly but leads
to useless notifications being sent.

While at it, this PR prevents unpins when there are still
unread messages in the sub-channel: the pin feature is
used to see unread messages on otherwise hidden threads.