### PR TITLE
[IMP] html_editor: create pre block with triple-backtick shorthand

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -280,6 +280,10 @@ export class FontPlugin extends Plugin {
                 pattern: /^>$/,
                 commandId: "setTagQuote",
             },
+            {
+                pattern: /^```$/,
+                commandId: "setTagPre",
+            },
         ],
         hints: [
             { selector: "H1", text: _t("Heading 1") },

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -116,7 +116,7 @@ export class InlineCodePlugin extends Plugin {
         // one in the text.
         let textNode = selection.startContainer;
         const wholeText = textNode.wholeText;
-        const textHasTwoTicks = /`.*`/.test(wholeText);
+        const textHasTwoTicks = /`[^`]+`/.test(wholeText);
         // We don't apply the code tag if there is no content between the two `
         if (textHasTwoTicks && wholeText.replace(/`/g, "").length) {
             let offset = selection.startOffset;

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -298,3 +298,14 @@ describe("inline code", () => {
         });
     });
 });
+
+describe("pre", () => {
+    test("should create pre block on triple-backtick", async () => {
+        await testEditor({
+            contentBefore: "<p>```[]</p>",
+            stepFunction: async (editor) => await insertText(editor, " "),
+            contentAfterEdit: '<pre o-we-hint-text="Code" class="o-we-hint">[]<br></pre>',
+            contentAfter: "<pre>[]<br></pre>",
+        });
+    });
+});

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -272,13 +272,21 @@ describe("inline code", () => {
         });
     });
 
-    test("should create an empty inline code when their is no text in between two backtics", async () => {
+    test("should not create an empty inline code when there is no text between two backticks", async () => {
         await testEditor({
             contentBefore: "<p>a`[]b</p>",
             stepFunction: async (editor) => insertText(editor, "`"),
-            contentAfterEdit:
-                '<p>a\ufeff<code class="o_inline_code">\ufeff[]\ufeff</code>\ufeffb</p>',
-            contentAfter: '<p>a<code class="o_inline_code">[]</code>b</p>',
+            contentAfterEdit: "<p>a``[]b</p>",
+            contentAfter: "<p>a``[]b</p>",
+        });
+    });
+
+    test("should not create an empty inline code when there is a backtick between two backticks", async () => {
+        await testEditor({
+            contentBefore: "<p>a``[]b</p>",
+            stepFunction: async (editor) => insertText(editor, "`"),
+            contentAfterEdit: "<p>a```[]b</p>",
+            contentAfter: "<p>a```[]b</p>",
         });
     });
 


### PR DESCRIPTION
This commit introduces a shorthand that creates a `<pre>` block when
using a triple-backtick at the beginning of a block.

task-5367601
