### PR TITLE
[IMP] sale: add upsales view

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2393,7 +2393,8 @@ class SaleOrder(models.Model):
         return self.currency_id.compare_amounts(self.amount_paid, self.amount_total) >= 0
 
     def _get_lang(self):
-        self.ensure_one()
+        if self:
+            self.ensure_one()
 
         if self.partner_id.lang and not self.partner_id.is_public:
             return self.partner_id.lang

--- a/addons/sale/static/src/views/sale_upsales_list/sale_upsales.js
+++ b/addons/sale/static/src/views/sale_upsales_list/sale_upsales.js
@@ -1,0 +1,36 @@
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { ProductNameAndDescriptionListRendererMixin } from "@product/product_name_and_description/product_name_and_description";
+import { patch } from "@web/core/utils/patch";
+
+export class SaleOrderLineUpsells extends ListRenderer {
+
+    setup() {
+        super.setup();
+        this.descriptionColumn = "name";
+        this.productColumns = ["product_id", "product_template_id"];
+    }
+    
+    getActiveColumns() {
+        let activeColumns = super.getActiveColumns();
+        let productTmplCol = activeColumns.find((col) => col.name === 'product_template_id');
+        let productCol = activeColumns.find((col) => col.name === 'product_id');
+        
+        if (productCol && productTmplCol) {
+            // Hide the template column if the variant one is enabled.
+            activeColumns = activeColumns.filter((col) => col.name != 'product_template_id')
+        }
+        
+        return activeColumns;
+    }
+}
+
+patch(SaleOrderLineUpsells.prototype, ProductNameAndDescriptionListRendererMixin);
+
+export const upsaleOrderLineListView = {
+    ...listView,
+    Renderer: SaleOrderLineUpsells,
+};
+
+registry.category("views").add("upsale_order_line_list", upsaleOrderLineListView);

--- a/addons/sale/views/sale_menus.xml
+++ b/addons/sale/views/sale_menus.xml
@@ -16,6 +16,11 @@
                 groups="sales_team.group_sale_salesman"
                 sequence="10"/>
 
+            <menuitem id="menu_sale_upsells"
+                action="action_upsells"
+                groups="sales_team.group_sale_salesman"
+                sequence="15"/>
+
             <menuitem id="menu_sale_order"
                 name="Orders"
                 action="action_orders"

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- VIEWS -->
+
     <record id="view_order_line_tree" model="ir.ui.view">
         <field name="name">sale.order.line.list</field>
         <field name="model">sale.order.line</field>
@@ -124,6 +126,141 @@
                 </templates>
             </kanban>
         </field>
+    </record>
+
+    <record id="view_sale_order_line_upsells_list" model="ir.ui.view">
+        <field name="name">sale.order.line.upsells.list</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <list string="Upsells" editable="top" js_class="upsale_order_line_list">
+                <field
+                    name="product_template_id"
+                    string="Product"
+                    widget="sol_product_many2one"
+                    domain="[('type', '!=', 'combo')]"
+                    width="800px"
+                />
+                <field
+                    name="product_id"
+                    string="Product Variant"
+                    optional="hide"
+                    widget="sol_product_many2one"
+                    domain="[('type', '!=', 'combo')]"
+                    width="800px"
+                />
+                <field name="name" widget="sol_text" optional="show"/>
+                <field
+                    name="order_id"
+                    widget="sale_order_custom"
+                    placeholder="New Order"
+                    context="{'sale_show_partner_name': True}"
+                    domain="[
+                        ('locked', '=', False),
+                        ('invoice_status', '!=', 'invoiced'),
+                    ]"
+                />
+                <field name="product_uom_qty" string="Quantity"/>
+                <field
+                    name="qty_delivered"
+                    string="Delivered"
+                    readonly="state != 'sale' or qty_delivered_method != 'manual' or is_downpayment"
+                    optional="hide"
+                />
+                <field name="product_uom_id" widget="many2one_uom"/>
+                <field
+                    name="tax_ids"
+                    widget="many2many_tax_tags"
+                    options="{'no_create': True}"
+                    context="{'active_test': True}"
+                    readonly="qty_invoiced &gt; 0 or is_downpayment"
+                    optional="hide"
+                />
+                <field name="qty_invoiced" optional="hide"/>
+                <field name="price_unit" optional="hide"/>
+                <field
+                    name="discount"
+                    groups="sale.group_discount_per_so_line"
+                    optional="hide"
+                />
+                <field name="currency_id" column_invisible="1"/> 
+                <field name="customer_lead" column_invisible="1"/>
+                <field name="date_order" column_invisible="1"/> 
+                <field name="linked_line_id" column_invisible="1"/>
+                <field name="pricelist_id" column_invisible="1"/>
+                <field name="product_custom_attribute_value_ids" column_invisible="1"/>
+                <field name="product_no_variant_attribute_value_ids" column_invisible="1"/>
+                <field
+                    name="create_uid"
+                    string="Creator"
+                    widget="many2one_avatar_user"
+                    optional="hide"
+                />
+                <field name="create_date" optional="hide"/>
+                <button
+                    name="unlink"
+                    type="object"
+                    icon="fa-trash"
+                    title="Delete"
+                    class="text-danger"
+                    width="20px"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_sale_order_line_upsells_search" model="ir.ui.view">
+        <field name="name">sale.order.line.upsells.search</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter
+                    name="my_orders"
+                    string="My"
+                    domain="[('salesman_id','=',uid)]"
+                />
+                <separator/>
+                <filter
+                    name="upsells_today"
+                    string="Today"
+                    domain="[('create_date', '&gt;=', 'today')]"
+                />
+                <group>
+                    <filter name="product" string="Product" context="{'group_by':'product_id'}"/>
+                    <filter name="order" string="Order" context="{'group_by':'order_id'}"/>
+                    <filter
+                        name="salesperson"
+                        string="Salesperson"
+                        context="{'group_by':'salesman_id'}"
+                    />
+                    <filter
+                        name="creation_group_by"
+                        string="Creation Date"
+                        context="{'group_by': 'create_date'}"
+                    />
+                    <filter
+                        name="customer"
+                        string="Customer"
+                        context="{'group_by': 'order_partner_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- ACTIONS (WINDOW) -->
+
+    <record id="action_upsells" model="ir.actions.act_window">
+        <field name="name">Upsells</field>
+        <field name="res_model">sale.order.line</field>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="view_sale_order_line_upsells_list"/>
+        <field name="search_view_id" ref="view_sale_order_line_upsells_search"/>
+        <field name="context">{
+                'search_default_my_orders': 1,
+                'search_default_upsells_today': 1,
+                'from_upsells': 'upsells'
+            }
+        </field>
+        <field name="domain">[('display_type', '=', False), ('is_from_upsells', '=', True)]</field>
     </record>
 
 </odoo>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -695,6 +695,7 @@
 
                                 <!-- Standard fields -->
                                 <field name="sequence" invisible="combo_item_id" widget="handle"/>
+                                <field name="is_from_upsells" column_invisible="1"/>
                                 <field
                                     name="product_id"
                                     string="Product Variant"

--- a/addons/sale_management/static/src/fields/sale_product_field.js
+++ b/addons/sale_management/static/src/fields/sale_product_field.js
@@ -4,8 +4,11 @@ import { patch } from '@web/core/utils/patch';
 patch(SaleOrderLineProductField.prototype, {
     _getAdditionalDialogProps() {
         const props = super._getAdditionalDialogProps();
+        const parentRecord = this.props.record._parentRecord;
+        const isOptionalLine = parentRecord
+            ? this.env.shouldCollapse(this.props.record, 'is_optional')
+            : false;
 
-        const isOptionalLine = this.env.shouldCollapse(this.props.record, 'is_optional');
         props.options = {
             showQuantity: !isOptionalLine,
             showPrice: !isOptionalLine,
@@ -16,7 +19,8 @@ patch(SaleOrderLineProductField.prototype, {
 
     _prepareNewLineData(line, product) {
         const data = super._prepareNewLineData(line, product);
-        if (this.env.shouldCollapse(line, 'is_optional')) {
+        const parentRecord = line._parentRecord;
+        if (parentRecord && this.env.shouldCollapse(line, 'is_optional')) {
             data.quantity = 0;
         }
         return data;

--- a/addons/sale_margin/__manifest__.py
+++ b/addons/sale_margin/__manifest__.py
@@ -10,12 +10,13 @@ This module adds the 'Margin' on sales order.
 This gives the profitability by calculating the difference between the Unit
 Price and Cost Price.
     """,
-    'depends':['sale_management'],
-    'demo':[
+    'depends': ['sale_management'],
+    'demo': [
         'data/sale_margin_demo.xml',
     ],
-    'data':[
+    'data': [
         'views/sale_order_views.xml',
+        'views/sale_order_line_views.xml',
     ],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/sale_margin/views/sale_order_line_views.xml
+++ b/addons/sale_margin/views/sale_order_line_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_sale_order_line_upsells_list_inherit" model="ir.ui.view">
+        <field name="name">sale.order.line.upsells.list.inherit</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="sale.view_sale_order_line_upsells_list"/>
+        <field name="arch" type="xml">
+            <field name="create_date" position="after">
+                <field name="margin" string="Margin" optional="hide"/>
+                <field name="margin_percent" string="Margin %" optional="hide"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -258,6 +258,25 @@ class ProjectProject(models.Model):
             })
         return action_window
 
+    def action_view_upsells(self):
+        self.ensure_one()
+
+        action = self.env.ref('sale.action_upsells').read()[0]
+
+        action['domain'] = [
+            ('project_id', '=', self.id),
+            ('display_type', '=', False),
+            ('is_from_upsells', '=', True),
+        ]
+
+        action['context'] = {
+            **self.env.context,
+            'from_upsells': True,
+            'default_project_id': self.id,
+        }
+
+        return action
+
     def action_get_list_view(self):
         action = super().action_get_list_view()
         if self.allow_billable:

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -53,6 +53,22 @@
         <field name="domain">[('allow_billable', '=', True)]</field>
     </record>
 
+    <record id="project_embedded_action_upsells" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">54</field>
+        <field name="name">Upsells</field>
+        <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
+        <field name="python_method">action_view_upsells</field>
+        <field name="context">
+            {
+                "from_upsells": true,
+                "from_embedded_action": true
+            }
+        </field>
+        <field name="groups_ids" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+        <field name="domain">[('allow_billable', '=', True)]</field>
+    </record>
+
     <record id="project_embedded_action_invoices_dashboard" model="ir.embedded.actions">
         <field name="parent_res_model">project.project</field>
         <field name="sequence">60</field>


### PR DESCRIPTION
- Added an Upsales view to quickly add products to an existing sales order
- Removes the need to manually locate and update the sales order

task-5180804

