### PR TITLE
[FIX] account_edi_ubl_cii: fix cases where VAT is '/'

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -56,6 +56,9 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
+        if not partner.vat or partner.vat == '/':
+            return []
+
         # [BR-CO-09] if the PartyTaxScheme/TaxScheme/ID == 'VAT', CompanyID must start with a country code prefix.
         # In some countries however, the CompanyID can be with or without country code prefix and still be perfectly
         # valid (RO, HU, non-EU countries).

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -50,7 +50,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_21
         vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
 
-        if not partner.vat:
+        if not partner.vat or partner.vat == '/':
             return [{
                 'company_id': partner.peppol_endpoint,
                 'tax_scheme_vals': {'id': partner.peppol_eas},

--- a/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
@@ -122,20 +122,6 @@
           <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
-        <cac:RegistrationAddress>
-          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
-          <cac:Country>
-            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
-            <cbc:Name>Saudi Arabia</cbc:Name>
-          </cac:Country>
-        </cac:RegistrationAddress>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
@@ -122,20 +122,6 @@
           <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
-        <cac:RegistrationAddress>
-          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
-          <cac:Country>
-            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
-            <cbc:Name>Saudi Arabia</cbc:Name>
-          </cac:Country>
-        </cac:RegistrationAddress>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -117,20 +117,6 @@
           <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
-        <cac:RegistrationAddress>
-          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
-          <cac:Country>
-            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
-            <cbc:Name>Saudi Arabia</cbc:Name>
-          </cac:Country>
-        </cac:RegistrationAddress>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>


### PR DESCRIPTION
To signify that you know a partner does not have vat, we advise using '/'.
But we should take care of that in the UBL export, to not consider it a real vat

Also, in the cases where we don't have the vat, the CompanyID is supposed to be mandatory.
https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-TaxRepresentativeParty/cac-PartyTaxScheme/ 
So, remove the whole PartyTaxScheme if vat is not present.

Zatca does not override that rule (except enforcing that seller must have vat, which raises a constraint), so we modify the tests for the simplified documents.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
