### PR TITLE
[FIX] html_editor: remove invalid classes when changing media type

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -260,10 +260,8 @@ export class MediaDialog extends Component {
                                 }
                             } else {
                                 // Regex
-                                for (const className of element.classList) {
-                                    if (className.match(candidateName)) {
-                                        return false;
-                                    }
+                                if (candidateName.match(name)) {
+                                    return false;
                                 }
                             }
                         }

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -64,6 +64,31 @@ test("Replace an image with link by a document should remove the link", async ()
     expect("p a[href='http://test.com']").toHaveCount(0);
 });
 
+test("Replace an image by icon should remove invalid classes", async () => {
+    onRpc("ir.attachment", "search_read", () => []);
+    const env = await makeMockEnv();
+    await setupEditor(`<p><img class="img-fluid w-100" src="/web/static/img/logo.png"></p>`, {
+        env,
+    });
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
+    expect("img[src='/web/static/img/logo.png']").toHaveClass("img-fluid w-100");
+    await click("img");
+    await tick(); // selectionchange
+    await waitFor(".o-we-toolbar");
+    expect("button[name='replace_image']").toHaveCount(1);
+    await click("button[name='replace_image']");
+    await animationFrame();
+    await click(".nav-link:contains('Icons')");
+    await animationFrame();
+    await click("span.fa-envelope-o");
+    await animationFrame();
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
+    expect("span").toHaveCount(1);
+    expect("span").toHaveClass("fa fa-envelope-o");
+    expect("span").not.toHaveClass("img-fluid");
+    expect("span").not.toHaveClass("w-100");
+});
+
 test.tags("focus required");
 test("Selection is collapsed after the image after replacing it", async () => {
     onRpc("ir.attachment", "search_read", () => [


### PR DESCRIPTION
Before this commit, switching the media type would not properly remove the classes of the element.
For example, images can have the class "w-100" while icons cannot. If an image had the class "w-100", switching to an icon would keep the class "w-100", even though this class isn't valid for icons.

This commit fixes the code to properly remove all invalid classes.