### PR TITLE
[IMP] website,*: adapt carousel slide height based on section min-height

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -32,9 +32,18 @@
             [data-snippet="s_quotes_carousel_minimal"],
             [data-snippet="s_quotes_carousel"],
             [data-snippet="s_quotes_carousel_compact"] {
-                .carousel-inner, .carousel-inner > .carousel-item {
+                .carousel, .carousel-inner {
+                    min-height: 100%;
+                }
+                .carousel-inner {
+                    display: flex;
+                    align-items: center;
+                }
+                .carousel-inner > .carousel-item {
                     height: fit-content;
                 }
+                display: flex;
+                flex-direction: column;
             }
             [data-snippet="s_three_columns"] .figure-img[style*="height:50vh"] {
                 /* In Travel theme. */

--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -30,9 +30,11 @@
             [data-snippet="s_quotes_carousel_minimal"],
             [data-snippet="s_quotes_carousel"],
             [data-snippet="s_quotes_carousel_compact"] {
-                .carousel-inner, .carousel-inner > .carousel-item {
-                    height: fit-content;
+                .carousel {
+                    min-height: 100% !important;
                 }
+                display: flex;
+                flex-direction: column;
             }
             [data-snippet="s_three_columns"] .figure-img[style*="height:50vh"] {
                 /* In Travel theme. */

--- a/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
@@ -14,6 +14,18 @@ const CarouselSliderEdit = (I) =>
         carouselOptions = { ride: false, pause: true, keyboard: false };
         showClickableSlideLinks = false;
 
+        start() {
+            super.start();
+            // Monitor carousel size changes to update maxHeight
+            const resizeObserver = new ResizeObserver(
+                this.debounced(() => {
+                    this.computeMaxHeight();
+                }, 250)
+            );
+            resizeObserver.observe(this.el);
+            this.registerCleanup(() => resizeObserver.unobserve(this.el));
+        }
+
         onContentChanged() {
             this.computeMaxHeight();
         }

--- a/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
@@ -14,6 +14,39 @@ const CarouselSliderEdit = (I) =>
         carouselOptions = { ride: false, pause: true, keyboard: false };
         showClickableSlideLinks = false;
 
+        start() {
+            super.start();
+            // Recompute the carousel height when its classes change.
+            // This covers scenarios where a custom snippet applies
+            // `o_full_screen_height` and later resets it to `auto`
+            // (e.g., after sliding the carousel), ensuring the correct
+            // min-height is reapplied to carousel items.
+            const sectionEl = this.el.closest("section");
+            if (sectionEl) {
+                this.carouselClassObserver = new MutationObserver((mutationRecords) => {
+                    for (const mutation of mutationRecords) {
+                        const prevValue = mutation.oldValue || "";
+                        const HEIGHT_CLASSES = ["o_full_screen_height", "o_three_quarter_height"];
+                        const hasHeightClassBefore = HEIGHT_CLASSES.some((cls) =>
+                            prevValue.includes(cls)
+                        );
+                        const hasHeightClassNow = HEIGHT_CLASSES.some((cls) =>
+                            sectionEl.classList.contains(cls)
+                        );
+
+                        if (hasHeightClassBefore && !hasHeightClassNow) {
+                            this.computeMaxHeight();
+                        }
+                    }
+                });
+                this.carouselClassObserver.observe(sectionEl, {
+                    attributes: true,
+                    attributeFilter: ["class"],
+                    attributeOldValue: true,
+                });
+                this.registerCleanup(() => this.carouselClassObserver.disconnect());
+            }
+        }
         onContentChanged() {
             this.computeMaxHeight();
         }

--- a/addons/website/static/src/interactions/full_screen_height.js
+++ b/addons/website/static/src/interactions/full_screen_height.js
@@ -31,6 +31,21 @@ export class FullScreenHeight extends Interaction {
         this.isActive = !isVisible(this.el) || currentHeight > idealHeight + 1;
     }
 
+    start() {
+        const carouselEl = this.el.querySelector(".carousel");
+        if (!carouselEl) {
+            return;
+        }
+        // The carousel computes its item's min-height from the rendered
+        // section height, so we notify it once after this interaction
+        // applies its screen-height style and again when that style is
+        // cleaned up (e.g., 100% → auto).
+        const notifyCarouselContentChanged = () =>
+            carouselEl.dispatchEvent(new CustomEvent("content_changed"));
+        requestAnimationFrame(notifyCarouselContentChanged);
+        this.registerCleanup(() => notifyCarouselContentChanged());
+    }
+
     computeIdealHeight() {
         // Compute the smallest viewport height (svh) to use to set up the ideal
         // height of the element, which won't flicker based on the viewport

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1512,6 +1512,18 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
     }
 }
 
+// Defines shared height behavior for carousels in full and three-quarter screen
+// sections. This placeholder is also applied to `s_carousel_intro` and
+// `s_quotes_carousel`.
+%carousel_screen_height {
+    .carousel, .carousel-inner, .carousel-item {
+        min-height: inherit;
+    }
+    .carousel-item {
+        align-content: center;
+    }
+}
+
 .carousel .container {
     .carousel-img img {
         max-height: 95%;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1469,6 +1469,18 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
     }
 }
 
+// Defines shared height behavior for carousels in full and three-quarter screen
+// sections. This placeholder is also applied to `s_carousel_intro` and
+// `s_quotes_carousel`.
+%carousel_screen_height {
+    .carousel, .carousel-inner, .carousel-item {
+        min-height: inherit !important;
+    }
+    .carousel-item {
+        align-content: center;
+    }
+}
+
 .carousel .container {
     .carousel-img img {
         max-height: 95%;

--- a/addons/website/static/src/snippets/s_carousel/001.scss
+++ b/addons/website/static/src/snippets/s_carousel/001.scss
@@ -10,4 +10,7 @@
             }
         }
     }
+    &.o_full_screen_height, &.o_three_quarter_height {
+        @extend %carousel_screen_height;
+    }
 }

--- a/addons/website/static/src/snippets/s_carousel_intro/000.scss
+++ b/addons/website/static/src/snippets/s_carousel_intro/000.scss
@@ -1,4 +1,8 @@
 .s_carousel_intro_wrapper {
+    &.o_full_screen_height, &.o_three_quarter_height {
+        @extend %carousel_screen_height;
+    }
+
     .s_carousel_intro {
         @extend %s_carousel_variants;
 

--- a/addons/website/static/src/snippets/s_quotes_carousel/002.scss
+++ b/addons/website/static/src/snippets/s_quotes_carousel/002.scss
@@ -1,4 +1,8 @@
 .s_quotes_carousel_wrapper[data-vcss='002'] {
+    &.o_full_screen_height, &.o_three_quarter_height {
+        @extend %carousel_screen_height;
+    }
+
     .s_quotes_carousel {
         @extend %s_carousel_variants;
     }

--- a/addons/website/static/tests/builder/website_builder/carousel.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel.test.js
@@ -4,6 +4,7 @@ import {
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { contains } from "@web/../tests/web_test_helpers";
+import { queryFirst } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -170,4 +171,22 @@ test("Test Carousel Option (s_image_gallery)", async () => {
     expect(carouselEl).toHaveAttribute("data-bs-ride", "false");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "5000");
     expect(carouselEl).toHaveStyle({ "--transition-duration": "2000ms" });
+});
+
+test("Test carousel item height matches configured section height", async () => {
+    await setupWebsiteBuilderWithSnippet("s_carousel", { loadIframeBundles: true });
+    await contains(":iframe .s_carousel").click();
+
+    const carouselItemEl = queryFirst(":iframe .carousel-item");
+    const iframeHeight = carouselItemEl.ownerDocument.defaultView.innerHeight;
+
+    await contains("button[data-action-param='o_full_screen_height']").click();
+    expect(carouselItemEl.getBoundingClientRect().height).toBeCloseTo(iframeHeight, {
+        margin: 1,
+    });
+
+    await contains("button[data-action-param='o_three_quarter_height']").click();
+    expect(carouselItemEl.getBoundingClientRect().height).toBeCloseTo(iframeHeight * 0.75, {
+        margin: 1,
+    });
 });

--- a/addons/website/static/tests/builder/website_builder/carousel.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel.test.js
@@ -4,6 +4,7 @@ import {
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { contains } from "@web/../tests/web_test_helpers";
+import { queryFirst } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -119,4 +120,16 @@ test("Test Carousel Option (s_image_gallery)", async () => {
     await contains(".o-hb-select-dropdown-item:contains('Never')").click();
     expect(carouselEl).toHaveAttribute("data-bs-ride", "false");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "1000");
+});
+
+test("Test carousel item height matches viewport when full height is enabled", async () => {
+    await setupWebsiteBuilderWithSnippet("s_carousel", { loadIframeBundles: true });
+    await contains(":iframe .s_carousel").click();
+    await contains("button[data-action-param='o_full_screen_height']").click();
+
+    const carouselItemEl = queryFirst(":iframe .carousel-item");
+    const carouselItemHeight = carouselItemEl.getBoundingClientRect().height;
+    const iframeHeight = carouselItemEl.ownerDocument.defaultView.innerHeight;
+
+    expect(Math.round(carouselItemHeight)).toBe(iframeHeight);
 });


### PR DESCRIPTION
*: html_builder

<img width="920" height="423" alt="image" src="https://github.com/user-attachments/assets/6e537bcd-84aa-4621-b068-25480adc9ddd" />

Improve the behavior of website carousel sections by adjusting the section’s minimum height according to its internal children. The min-height now propagates correctly down to the container, ensuring that carousel slides visually respect the height option defined on the section.

This makes the carousel layout more consistent and avoids cases where the slide content would not align with the configured section height.

task-4992936
