### PR TITLE
[16.0][FIX] website_event: get reCaptcha token on registration form submit

### DIFF
--- a/doc/cla/individual/anjeelharia.md
+++ b/doc/cla/individual/anjeelharia.md
@@ -1,0 +1,11 @@
+India, 2025-12-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Anjeel bytemeasap@gmail.com https://github.com/ByteMeAsap


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Steps to reproduce
===============
1. Enable reCaptcha in Settings and configure keys.
2. Go to an event and click Register.
3. Fill in the form but wait more than 2 minutes.
4. Submit the form
---> An error message is shown.

When reCaptcha was enabled on event registrations, the token was being
requested too early (during `willStart`).
Since a token is only valid for 2 minutes, users who took longer to fill out
the registration form encountered an error when submitting.

After this commit, the reCaptcha token is requested only on submitting.
This way, the token is always valid and the form can be submitted successfully,
even after several minutes.

Backport of https://github.com/odoo/odoo/pull/223538




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
