### PR TITLE
[IMP] website: avoid double `<br/>` in snippets

### DIFF
--- a/addons/website/views/snippets/s_banner.xml
+++ b/addons/website/views/snippets/s_banner.xml
@@ -7,7 +7,9 @@
             <div class="row o_grid_mode" data-row-count="10">
                 <div class="o_grid_item g-height-10 g-col-lg-5 col-lg-5" data-name="Box" style="z-index: 1; grid-area: 1 / 1 / 11 / 6;">
                     <h1 class="display-3">Unleash your <strong>potential.</strong></h1>
-                    <p class="lead"><br/>This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.<br/><br/></p>
+                    <p><br/></p>
+                    <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
+                    <p><br/></p>
                     <p>
                         <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary o_translate_inline">Start Now <span class="fa fa-angle-right ms-2"/></a>
                     </p>

--- a/addons/website/views/snippets/s_bento_banner.xml
+++ b/addons/website/views/snippets/s_bento_banner.xml
@@ -15,8 +15,8 @@
                             <h2 style="text-align: center;">Discover our latest collection</h2>
                             <p style="text-align: center;">
                                 Simple forms. Natural textures. Timeless design. Explore our new furniture collection—crafted to bring calm and clarity to your space.
-                                <br/><br/>
                             </p>
+                            <p style="text-align: center;"><br/></p>
                             <p style="text-align: center;">
                                 <a t-att-href="shop_btn_href"
                                     role="button"

--- a/addons/website/views/snippets/s_cta_box.xml
+++ b/addons/website/views/snippets/s_cta_box.xml
@@ -10,7 +10,8 @@
                 </figure>
                 <div class="card-body">
                     <h2 class="card-title">50,000+ companies run Odoo<br/>to grow their businesses.</h2>
-                    <p class="card-text">Join us and make your company a better place.<br/><br/></p>
+                    <p class="card-text">Join us and make your company a better place.</p>
+                    <p><br/></p>
                     <a t-att-href="cta_btn_href" class="btn btn-lg btn-secondary">Contact Us</a>
                 </div>
              </div>

--- a/addons/website/views/snippets/s_cta_mobile.xml
+++ b/addons/website/views/snippets/s_cta_mobile.xml
@@ -7,7 +7,8 @@
             <div class="row o_grid_mode" data-row-count="8">
                 <div class="o_grid_item g-height-6 g-col-lg-12 col-lg-12 o_cc o_cc2 rounded" style="grid-area: 3 / 1 / 9 / 13; z-index: 1; --grid-item-padding-y: 80px; --grid-item-padding-x: 64px;">
                     <h2 class="h3-fs">50,000+ companies trust Odoo.</h2>
-                    <p class="lead">Join us and make your company a better place.<br/><br/></p>
+                    <p class="lead">Join us and make your company a better place.</p>
+                    <p><br/></p>
                     <a href="https://www.apple.com/app-store/"><img src="/web/image/website.app_store_image" class="img img-fluid" alt="App Store"/></a>
                     <a href="https://play.google.com/store/"><img src="/web/image/website.google_play_image" class="img img-fluid" alt="Google Play"/></a>
                 </div>

--- a/addons/website/views/snippets/s_discovery.xml
+++ b/addons/website/views/snippets/s_discovery.xml
@@ -8,7 +8,8 @@
                 <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/> What's new&#160;? <a href="#">Explore&#160;<i class="fa fa-long-arrow-right" role="img"/></a>
             </span>
             <h1 class="display-2" style="text-align: center;">Discover our solutions</h1>
-            <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.<br/><br/></p>
+            <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
+            <p><br/></p>
             <p style="text-align: center;">
                 <a t-att-href="cta_btn_href" class="btn btn-primary mb-2 o_translate_inline"><t t-out="cta_btn_text">Our store</t></a>
                 <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2 o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a>

--- a/addons/website/views/snippets/s_empowerment.xml
+++ b/addons/website/views/snippets/s_empowerment.xml
@@ -10,7 +10,9 @@
                         <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/> What's new&#160;? <a href="#">Explore&#160;<i class="fa fa-long-arrow-right" role="img"/></a>
                     </span>
                     <h1 class="display-4">Empowering Your Success<br/>with Every Solution.</h1>
-                    <p class="lead"><br/>Delivering tailored, innovative tools to help you overcome challenges and<br/> achieve your goals, ensuring your journey is fully supported.<br/><br/></p>
+                    <p><br/></p>
+                    <p class="lead">Delivering tailored, innovative tools to help you overcome challenges and<br/> achieve your goals, ensuring your journey is fully supported.</p>
+                    <p><br/></p>
                     <p>
                         <a href="#" class="btn btn-primary mb-2 o_translate_inline">Get started</a>
                         <a href="#" class="btn btn-secondary mb-2 o_translate_inline">Learn more</a>

--- a/addons/website/views/snippets/s_sidegrid.xml
+++ b/addons/website/views/snippets/s_sidegrid.xml
@@ -7,7 +7,9 @@
             <div class="row o_grid_mode" data-row-count="13">
                 <div class="o_grid_item g-col-lg-5 g-height-9 col-lg-5" style="z-index: 1; grid-area: 1 / 8 / 10 / 13; --grid-item-padding-x: 24px">
                     <h1 class="display-4">Experience<br/>the real<br/>innovation</h1>
-                    <p class="lead"><br/>Every groundbreaking innovation, whether meticulously engineered or born from spontaneous creativity, contains stories waiting to be discovered.<br/><br/></p>
+                    <p><br/></p>
+                    <p class="lead">Every groundbreaking innovation, whether meticulously engineered or born from spontaneous creativity, contains stories waiting to be discovered.</p>
+                    <p><br/></p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-4 g-col-lg-4 col-lg-4" style="z-index: 2; grid-area: 1 / 1 / 5 / 5;">
                     <img class="img img-fluid rounded" src="/web/image/website.s_sidegrid_default_image_1" alt=""/>

--- a/addons/website/views/snippets/s_split_intro.xml
+++ b/addons/website/views/snippets/s_split_intro.xml
@@ -7,7 +7,9 @@
             <div class="row">
                 <div class="col-lg-4 offset-lg-1 pt120 pb120 order-lg-0" style="order: 1;">
                     <h1 class="display-3">Revolutionize your business</h1>
-                    <p class="lead"><br/>Step into the future with our innovative solutions tailored to meet the unique needs of your business. Don’t let outdated processes hold you back any longer.<br/><br/></p>
+                    <p><br/></p>
+                    <p class="lead">Step into the future with our innovative solutions tailored to meet the unique needs of your business. Don’t let outdated processes hold you back any longer.</p>
+                    <p><br/></p>
                     <p>
                         <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary o_translate_inline">Discover more</a>
                     </p>


### PR DESCRIPTION
In snippets we rely on `<br/>` to create vertical spacing. However it removes the indication of insertable commands. Instead of using `<br/><br/>` we can use `<p><br/><p/>` which is slightly bigger but still provides the insertable command indication.

task-5353641


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
