### PR TITLE
[FIX] l10n_sa_edi: use correct decimal precision for ZATCA XML

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -556,6 +556,18 @@ class AccountEdiXmlUbl_21Zatca(models.AbstractModel):
             ],
         }
 
+    def _add_document_line_price_nodes(self, line_node, vals):
+        """
+        Use 10 decimal places for PriceAmount to satisfy ZATCA validation BR-KSA-EN16931-11
+        """
+        currency_suffix = vals['currency_suffix']
+        line_node['cac:Price'] = {
+            'cbc:PriceAmount': {
+                '_text': round(vals[f'gross_price_unit{currency_suffix}'], 10),
+                'currencyID': vals['currency_name'],
+            },
+        }
+
     # -------------------------------------------------------------------------
     # EXPORT: Helpers for hash generation
     # -------------------------------------------------------------------------


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **Accounting** and **l10n_sa_edi** modules.
* Go to `Sales` journal and in ZATCA section click on **Re-Onboard**.
* Create Tax with 15% tax with **included price** set as **tax-included**.
* Create a customer invoice.
* Set **price_unit = 200**, **quantity = 7**, with **15% tax included** and confirm the invoice.
* Generate the **ZATCA XML** by clicking **Process Now** in the info banner displayed above the invoice.
* Submit the XML to **ZATCA validation**.

**Observed behavior:**
* ZATCA validation fails with error **BR-KSA-EN16931-11**
* The XML uses **PriceAmount (BT-146)** rounded to **2 decimals** (e.g., 173.91).
* ZATCA computes: **173.91 × 7 = 1217.37**, but the XML’s **LineExtensionAmount (BT-131)** is **1217.39**, creating a mismatch and triggering validation failure.

**Cause:**
* In v19, `_add_document_line_price_nodes()` inherited from `account.edi.xml.ubl_20` uses `float_round` with **product_price_dp = 2 decimals** for **PriceAmount**.
* This precision is insufficient when ZATCA recalculates totals for tax-included prices, causing rounding discrepancies.

**Fix:**
* Override `_add_document_line_price_nodes()` in **l10n_sa_edi** to round `gross_price_unit_currency` to **10 decimal places** instead of 2.
* Ensures PriceAmount has sufficient precision to satisfy ZATCA validation rules.

opw-5346886