### PR TITLE
[IMP] payment: review providers kanban image spacing

### DIFF
--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -152,6 +152,7 @@
                             <field type="open"
                                  name="image_128" widget="image"
                                  class="mb-0 o_image_64_max"
+                                 options="{'img_class': 'p-2 border rounded'}"
                                  alt="provider"/>
                         </aside>
                         <main class="ms-2">


### PR DESCRIPTION
This PR fine-tunes the visual result of the `payment_provider_kanban` by adding spacing around the image as well as a border with a radius.

This aims to prevent the image to stick to the sides of the container while providing a sleeker look and feel.

task-5365465

| //// | Master | This PR |
|--------|--------|--------|
| LM | <img width="1919" height="694" alt="image" src="https://github.com/user-attachments/assets/cfe95379-bc1a-4ac8-9719-1d947899ecf5" /> | <img width="1922" height="727" alt="image" src="https://github.com/user-attachments/assets/7ebb4a8f-5757-41a0-8119-e7ea983b8ee4" /> |
| DM | <img width="1919" height="692" alt="image" src="https://github.com/user-attachments/assets/18b287a6-11fe-4089-8385-f512af48120e" /> | <img width="1918" height="695" alt="image" src="https://github.com/user-attachments/assets/47e74294-5385-4b39-9db3-cc3ef935a097" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
