### PR TITLE
[FIX] mail: space insertion after mention

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -225,6 +225,7 @@ export class UseSuggestion {
             this.comp.editor.shared.dom.insert(inlineElement);
             const [anchorNode, anchorOffset] = rightPos(inlineElement);
             this.comp.editor.shared.selection.setSelection({ anchorNode, anchorOffset });
+            this.comp.editor.shared.dom.insert("\u00A0");
             this.comp.editor.shared.history.addStep();
         } else {
             // remove the user-typed search delimiter

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1689,8 +1689,8 @@ test("mentions can be correctly selected with ctrl+A and deleted", async () => {
     await htmlInsertText(editor, "@admin");
     await click(".o-mail-NavigableList-item", { text: "Mitchell Admin" });
     await contains(editor.editable, { text: "@Mitchell Admin" });
-    await htmlInsertText(editor, " Hello");
-    await contains(editor.editable, { textContent: "@Mitchell Admin Hello" });
+    await htmlInsertText(editor, "Hello");
+    await contains(editor.editable, { textContent: "@Mitchell Admin\u00A0Hello" });
     await focus(editor.editable);
     await press("Control+a");
     await press("Backspace");
@@ -1701,8 +1701,8 @@ test("mentions can be correctly selected with ctrl+A and deleted", async () => {
     await click(".o-mail-NavigableList-item", { text: "General" });
     await contains(editor.editable, { text: "General" });
     await contains(editor.editable.querySelector("i.fa-hashtag"));
-    await htmlInsertText(editor, " Hello");
-    await contains(editor.editable, { textContent: "General Hello" });
+    await htmlInsertText(editor, "Hello");
+    await contains(editor.editable, { textContent: "General\u00A0Hello" });
     await focus(editor.editable);
     await press("Control+a");
     await press("Backspace");
@@ -1713,8 +1713,10 @@ test("mentions can be correctly selected with ctrl+A and deleted", async () => {
     await htmlInsertText(editor, "Hello @admin");
     await click(".o-mail-NavigableList-item", { text: "Mitchell Admin" });
     await contains(editor.editable, { text: "@Mitchell Admin" });
-    await htmlInsertText(editor, " nice to meet you!");
-    await contains(editor.editable, { textContent: "Hello @Mitchell Admin nice to meet you!" });
+    await htmlInsertText(editor, "nice to meet you!");
+    await contains(editor.editable, {
+        textContent: "Hello\u00A0@Mitchell Admin\u00A0nice to meet you!",
+    });
     await focus(editor.editable);
     await press("Control+a");
     await press("Backspace");
@@ -1725,8 +1727,8 @@ test("mentions can be correctly selected with ctrl+A and deleted", async () => {
     await click(".o-mail-NavigableList-item", { text: "General" });
     await contains(editor.editable, { text: "General" });
     await contains(editor.editable.querySelector("i.fa-hashtag"));
-    await htmlInsertText(editor, " nice to meet you!");
-    await contains(editor.editable, { textContent: "Hello  General nice to meet you!" });
+    await htmlInsertText(editor, "nice to meet you!");
+    await contains(editor.editable, { textContent: "Hello\u00A0 General\u00A0nice to meet you!" });
     await focus(editor.editable);
     await press("Control+a");
     await press("Backspace");


### PR DESCRIPTION
This commit fixes an issue where there was no space inserted after a mention in the HTML composer.

task-5354233

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
