### PR TITLE
[IMP] hr_attendance: manage checkout breaks in systray and kiosk

### DIFF
--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -70,8 +70,16 @@ actions(Check in/Check out) performed by them.
 
             # Public Kiosk app and its components
             "hr_attendance/static/src/public_kiosk/**/*",
-            'hr_attendance/static/src/components/**/*',
-            ('remove', 'hr_attendance/static/src/components/hr_presence_status/hr_attendance_presence_status.js'),
+            "hr_attendance/static/src/components/attendance_video_stream/**/*",
+            "hr_attendance/static/src/components/break_duration_dialog/**/*",
+            "hr_attendance/static/src/components/card_layout/**/*",
+            "hr_attendance/static/src/components/confirmation/**/*",
+            "hr_attendance/static/src/components/greetings/**/*",
+            "hr_attendance/static/src/components/hooks/use_camera.js",
+            "hr_attendance/static/src/components/kiosk_barcode/**/*",
+            "hr_attendance/static/src/components/manual_selection/**/*",
+            "hr_attendance/static/src/components/new_employee_dialog/**/*",
+            "hr_attendance/static/src/components/pin_code/**/*",
 
             'hr_attendance/static/src/scss/kiosk/hr_attendance.scss',
             "web/static/src/views/fields/formatters.js",

--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -82,14 +82,18 @@ class HrAttendance(http.Controller):
                 'employee_avatar': employee.image_256 and image_data_uri(employee.image_256),
                 'total_overtime': float_round(employee.total_overtime, precision_digits=2),
                 'kiosk_delay': employee.company_id.attendance_kiosk_delay * 1000,
-                'attendance': {'check_in': employee.last_attendance_id.check_in,
-                               'check_out': employee.last_attendance_id.check_out},
+                'attendance': {
+                    'id': employee.last_attendance_id.id,
+                    'check_in': employee.last_attendance_id.check_in,
+                    'check_out': employee.last_attendance_id.check_out,
+                },
                 'overtime_today': sum(request.env['hr.attendance.overtime.line'].sudo().search([
                     ('employee_id', '=', employee.id), ('date', '=', fields.Date.context_today(request.env.user))]).mapped('duration')) or 0,
                 'use_pin': employee.company_id.attendance_kiosk_use_pin,
                 'display_overtime': employee.company_id.hr_attendance_display_overtime,
                 'device_tracking_enabled': employee.company_id.attendance_device_tracking,
                 'is_employee_single_checkin': not employee.version_id.is_flexible and employee.company_id.single_check_in,
+                'break_management_enabled': employee.company_id.attendance_break_management,
             }
         return response
 
@@ -328,6 +332,45 @@ class HrAttendance(http.Controller):
                 )
                 return self._get_attendance_action_response(employee, notification)
         return {}
+
+    @http.route('/hr_attendance/update_break_duration', type="jsonrpc", auth="public")
+    def update_break_duration(
+        self, token, attendance_id=False, break_duration=False,
+        employee_id=False, pin_code=False, barcode=False,
+    ):
+        company = self._get_company(token)
+        if not company or not company.attendance_break_management:
+            return {}
+        employee = request.env['hr.employee'].sudo()
+        if barcode:
+            employee = employee.search([
+                ('barcode', '=', barcode),
+                ('company_id', '=', company.id),
+            ], limit=1)
+        elif employee_id:
+            employee = employee.browse(employee_id)
+            if employee.company_id != company or (
+                company.attendance_kiosk_use_pin and employee.pin != pin_code
+            ):
+                employee = request.env['hr.employee'].sudo()
+        if not employee:
+            return {}
+        if isinstance(attendance_id, bool) or not isinstance(attendance_id, int):
+            return {}
+        attendance = request.env['hr.attendance'].sudo().browse(attendance_id).exists()
+        if (
+            not attendance
+            or attendance.employee_id != employee
+            or attendance != employee.last_attendance_id
+            or not attendance.check_out
+            or (
+                attendance.overtime_status == 'approved'
+                and company.attendance_overtime_validation == 'by_manager'
+            )
+        ):
+            return {}
+        attendance.write({'break_duration': break_duration})
+        return self._get_attendance_action_response(employee)
 
     @http.route('/hr_attendance/employees_infos', type="jsonrpc", auth="public")
     def employees_infos(self, token, limit, offset, domain):

--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -24,17 +24,36 @@ class HrAttendance(http.Controller):
     def _get_user_attendance_data(employee):
         response = {}
         if employee:
+            last_attendance = employee.last_attendance_id.read([
+                'check_in',
+                'check_out',
+                'worked_hours',
+                'break_duration',
+                'can_edit',
+                'in_location',
+                'out_location',
+            ])[0] if employee.last_attendance_id else False
             response = {
                 'id': employee.id,
                 'name': employee.name,
                 'hours_today': float_round(employee.hours_today, precision_digits=3),
                 'hours_previously_today': float_round(employee.hours_previously_today, precision_digits=2),
-                'today_attendance_ids': employee.today_attendance_ids.read(['check_in', 'check_out', 'worked_hours']),
+                'today_attendance_ids': employee.today_attendance_ids.read([
+                    'check_in',
+                    'check_out',
+                    'worked_hours',
+                    'break_duration',
+                    'can_edit',
+                    'in_location',
+                    'out_location',
+                ]),
+                'last_attendance': last_attendance,
                 'last_attendance_worked_hours': float_round(employee.last_attendance_worked_hours, precision_digits=2),
                 'last_check_in': employee.last_check_in,
                 'attendance_state': employee.attendance_state,
                 'display_systray': employee.company_id.attendance_from_systray,
                 'device_tracking_enabled': employee.company_id.attendance_device_tracking,
+                'break_management_enabled': employee.company_id.attendance_break_management,
             }
         return response
 
@@ -42,6 +61,12 @@ class HrAttendance(http.Controller):
     def _get_employee_info_response(employee):
         response = {}
         if employee:
+            overtime_today_group = request.env['hr.attendance.overtime.line'].sudo()._read_group(
+                [('employee_id', '=', employee.id), ('date', '=', datetime.date.today())],
+                ['employee_id'],
+                ['duration:sum'],
+            )
+            overtime_today = overtime_today_group[0][1] if overtime_today_group else 0.0
             response = {
                 **HrAttendance._get_user_attendance_data(employee),
                 'employee_name': employee.name,
@@ -50,14 +75,55 @@ class HrAttendance(http.Controller):
                 'kiosk_delay': employee.company_id.attendance_kiosk_delay * 1000,
                 'attendance': {'check_in': employee.last_attendance_id.check_in,
                                'check_out': employee.last_attendance_id.check_out},
-                'overtime_today': sum(request.env['hr.attendance.overtime.line'].sudo().search([
-                    ('employee_id', '=', employee.id), ('date', '=', datetime.date.today())]).mapped('duration')) or 0,
+                'overtime_today': overtime_today,
                 'use_pin': employee.company_id.attendance_kiosk_use_pin,
                 'display_overtime': employee.company_id.hr_attendance_display_overtime,
                 'device_tracking_enabled': employee.company_id.attendance_device_tracking,
-                'is_employee_single_checkin': not employee.version_id.is_flexible and employee.company_id.single_check_in,
+                'is_employee_single_checkin': (
+                    not employee.version_id.is_flexible
+                    and employee.company_id.single_check_in
+                ),
+                'break_management_enabled': employee.company_id.attendance_break_management,
+                'break_duration': float_round(
+                    employee.last_attendance_id.break_duration or 0.0,
+                    precision_digits=2,
+                ),
+                'attendance_worked_hours': float_round(
+                    employee.last_attendance_id.worked_hours or 0.0,
+                    precision_digits=2,
+                ),
+                'has_timesheet': 'has_timesheet' in employee._fields and bool(employee.has_timesheet),
             }
         return response
+
+    @staticmethod
+    def _get_break_preview_payload(employee):
+        if not employee:
+            return {}
+        return {
+            'employee_name': employee.name,
+            'attendance_state': employee.attendance_state,
+            'break_management_enabled': employee.company_id.attendance_break_management,
+        }
+
+    @staticmethod
+    def _normalize_break_duration(break_duration):
+        if break_duration in (None, False, ''):
+            return None
+        try:
+            duration = float(break_duration)
+        except (TypeError, ValueError):
+            return None
+        if duration < 0.0:
+            return None
+        return duration
+
+    @staticmethod
+    def _set_last_attendance_break_duration(employee, break_duration):
+        if not employee or not employee.last_attendance_id or not employee.last_attendance_id.check_out:
+            return False
+        employee.last_attendance_id.write({'break_duration': break_duration})
+        return employee.last_attendance_id
 
     @staticmethod
     def _get_geoip_response(mode, latitude=False, longitude=False, device_tracking_enabled=True):
@@ -197,6 +263,7 @@ class HrAttendance(http.Controller):
                         'from_trial_mode': from_trial_mode,
                         'barcode_source': company.attendance_barcode_source,
                         'device_tracking_enabled': company.attendance_device_tracking,
+                        'break_management_enabled': company.attendance_break_management,
                         'lang': py_to_js_locale(company.partner_id.lang or company.env.lang),
                         'server_version_info': odoo.release.version_info,
                     },
@@ -212,24 +279,62 @@ class HrAttendance(http.Controller):
                 return self._get_employee_info_response(employee)
         return {}
 
+    @http.route('/hr_attendance/attendance_barcode_preview', type="jsonrpc", auth="public")
+    def attendance_barcode_preview(self, token, barcode):
+        company = self._get_company(token)
+        if not company:
+            return {}
+        employee = request.env['hr.employee'].sudo().search([
+            ('barcode', '=', barcode),
+            ('company_id', '=', company.id),
+        ], limit=1)
+        if not employee:
+            return {}
+        return self._get_break_preview_payload(employee)
+
     @http.route('/hr_attendance/attendance_barcode_scanned', type="jsonrpc", auth="public")
-    def scan_barcode(self, token, barcode):
+    def scan_barcode(self, token, barcode, break_duration=False):
         company = self._get_company(token)
         if company:
             employee = request.env['hr.employee'].sudo().search([('barcode', '=', barcode), ('company_id', '=', company.id)], limit=1)
             if employee:
-                employee._attendance_action_change(self._get_geoip_response('kiosk', device_tracking_enabled=company.attendance_device_tracking))
+                employee._attendance_action_change(
+                    self._get_geoip_response('kiosk', device_tracking_enabled=company.attendance_device_tracking),
+                    break_duration=self._normalize_break_duration(break_duration),
+                )
                 return self._get_employee_info_response(employee)
         return {}
 
     @http.route('/hr_attendance/manual_selection', type="jsonrpc", auth="public")
-    def manual_selection(self, token, employee_id, pin_code, latitude=False, longitude=False):
+    def manual_selection(
+        self, token, employee_id, pin_code, break_duration=False,
+        latitude=False, longitude=False,
+    ):
         company = self._get_company(token)
         if company:
             employee = request.env['hr.employee'].sudo().browse(employee_id)
             if employee.company_id == company and ((not company.attendance_kiosk_use_pin) or (employee.pin == pin_code)):
-                employee.sudo()._attendance_action_change(self._get_geoip_response('kiosk', latitude=latitude, longitude=longitude, device_tracking_enabled=company.attendance_device_tracking))
+                employee.sudo()._attendance_action_change(
+                    self._get_geoip_response(
+                        'kiosk',
+                        latitude=latitude,
+                        longitude=longitude,
+                        device_tracking_enabled=company.attendance_device_tracking,
+                    ),
+                    break_duration=self._normalize_break_duration(break_duration),
+                )
                 return self._get_employee_info_response(employee)
+        return {}
+
+    @http.route('/hr_attendance/attendance_kiosk_break_duration', type="jsonrpc", auth="public")
+    def attendance_kiosk_break_duration(self, token, employee_id, break_duration):
+        company = self._get_company(token)
+        if company:
+            employee = request.env['hr.employee'].sudo().browse(employee_id)
+            duration = self._normalize_break_duration(break_duration)
+            if employee.company_id == company and duration is not None:
+                if self._set_last_attendance_break_duration(employee, duration):
+                    return self._get_employee_info_response(employee)
         return {}
 
     @http.route('/hr_attendance/employees_infos', type="jsonrpc", auth="public")
@@ -259,13 +364,18 @@ class HrAttendance(http.Controller):
         return []
 
     @http.route('/hr_attendance/systray_check_in_out', type="jsonrpc", auth="user")
-    def systray_attendance(self, latitude=False, longitude=False):
+    def systray_attendance(self, latitude=False, longitude=False, break_duration=False):
         employee = request.env.user.employee_id
         geo_ip_response = self._get_geoip_response(mode='systray',
                                                   latitude=latitude,
                                                   longitude=longitude,
-                                                  device_tracking_enabled=employee.company_id.attendance_device_tracking)
-        employee.with_context({'is_from_systray_check_in_out': True})._attendance_action_change(geo_ip_response)
+                                                  device_tracking_enabled=(
+                                                      employee.company_id.attendance_device_tracking
+                                                  ))
+        employee.with_context(is_from_systray_check_in_out=True)._attendance_action_change(
+            geo_ip_response,
+            break_duration=self._normalize_break_duration(break_duration),
+        )
         return self._get_employee_info_response(employee)
 
     @http.route('/hr_attendance/attendance_user_data', type="jsonrpc", auth="user", readonly=True)

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -16,6 +16,7 @@ from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools import convert, format_datetime, format_duration, format_time
 from odoo.tools.date_utils import sum_intervals
+from odoo.tools.float_utils import float_compare, float_is_zero
 from odoo.tools.intervals import Intervals
 
 
@@ -80,6 +81,8 @@ class HrAttendance(models.Model):
     expected_hours = fields.Float(compute="_compute_expected_hours", store=True, aggregator="sum")
     device_tracking_enabled = fields.Boolean(related="employee_id.company_id.attendance_device_tracking")
     linked_overtime_ids = fields.Many2many('hr.attendance.overtime.line', compute='_compute_linked_overtime_ids', readonly=False)
+    break_duration = fields.Float(string="Break Duration", default=0.0, tracking=True,
+        help="Extra unpaid break duration (hours)")
 
     @api.depends("check_in", "employee_id")
     def _compute_date(self):
@@ -173,14 +176,18 @@ class HrAttendance(models.Model):
         self.ensure_one()
         return self.employee_id.resource_calendar_id or self.employee_id.company_id.resource_calendar_id
 
-    @api.depends('check_in', 'check_out')
+    @api.depends('check_in', 'check_out', 'break_duration')
     def _compute_worked_hours(self):
         """ Computes the worked hours of the attendance record.
             The worked hours of resource with flexible calendar is computed as the difference
             between check_in and check_out, without taking into account the lunch_interval"""
         for attendance in self:
             if attendance.check_out and attendance.check_in and attendance.employee_id:
-                attendance.worked_hours = attendance._get_worked_hours_in_range(attendance.check_in, attendance.check_out)
+                attendance.worked_hours = max(
+                    attendance._get_worked_hours_in_range(attendance.check_in, attendance.check_out)
+                    - max(attendance.break_duration or 0.0, 0.0),
+                    0.0,
+                )
             else:
                 attendance.worked_hours = False
 
@@ -202,6 +209,19 @@ class HrAttendance(models.Model):
 
         attendance_intervals = Intervals([(start_dt_tz, end_dt_tz, self)])
         return sum_intervals(attendance_intervals)
+
+    @api.constrains('break_duration', 'check_in', 'check_out')
+    def _check_break_duration(self):
+        for attendance in self:
+            duration = attendance.break_duration or 0.0
+            if float_compare(duration, 0.0, precision_digits=4) < 0:
+                raise exceptions.ValidationError(_("Break duration cannot be negative."))
+            if not attendance.check_out and not float_is_zero(duration, precision_digits=4):
+                raise exceptions.ValidationError(_("You can only set a break duration once the employee has checked out."))
+            if attendance.check_in and attendance.check_out and duration:
+                total_hours = (attendance.check_out - attendance.check_in).total_seconds() / 3600.0
+                if float_compare(duration, total_hours, precision_digits=4) > 0:
+                    raise exceptions.ValidationError(_("Break duration cannot exceed the attendance duration."))
 
     @api.constrains('check_in', 'check_out')
     def _check_validity_check_in_check_out(self):
@@ -371,7 +391,7 @@ class HrAttendance(models.Model):
             raise AccessError(_("Do not have access, user cannot edit the attendances that are not their own or if they are not the attendance manager of the employee."))
         domain_pre = self._get_overtimes_to_update_domain()
         result = super().write(vals)
-        if any(field in vals for field in ['employee_id', 'check_in', 'check_out']):
+        if any(field in vals for field in ['employee_id', 'check_in', 'check_out', 'break_duration']):
             # Merge attendance dates before and after write to recompute the
             # overtime if the attendances have been moved to another day
             domain_post = self._get_overtimes_to_update_domain()

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -53,6 +53,10 @@ class HrEmployee(models.Model):
         'hr.attendance.overtime.line', 'employee_id', groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     total_overtime = fields.Float(compute='_compute_total_overtime', compute_sudo=True)
     display_extra_hours = fields.Boolean(related='company_id.hr_attendance_display_overtime')
+    attendance_break_management = fields.Boolean(
+        related='company_id.attendance_break_management',
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user",
+    )
 
     ruleset_id = fields.Many2one(readonly=False, related="version_id.ruleset_id", inherited=True, groups="hr.group_hr_manager")
 
@@ -179,8 +183,23 @@ class HrEmployee(models.Model):
                 worked_hours = 0
                 attendance_worked_hours = 0
                 for attendance in attendances:
-                    delta = (attendance.check_out or now) - max(attendance.check_in, start_naive)
-                    attendance_worked_hours = delta.total_seconds() / 3600.0
+                    if attendance.check_out:
+                        interval_start = max(attendance.check_in, start_naive)
+                        interval_end = min(attendance.check_out, now)
+                        if interval_end <= interval_start:
+                            attendance_worked_hours = 0.0
+                        else:
+                            attendance_worked_hours = attendance._get_worked_hours_in_range(interval_start, interval_end)
+                            total_duration = (attendance.check_out - attendance.check_in).total_seconds() / 3600.0
+                            if attendance.break_duration and total_duration > 0:
+                                overlap_duration = (interval_end - interval_start).total_seconds() / 3600.0
+                                attendance_worked_hours = max(
+                                    attendance_worked_hours - attendance.break_duration * overlap_duration / total_duration,
+                                    0.0,
+                                )
+                    else:
+                        delta = (attendance.check_out or now) - max(attendance.check_in, start_naive)
+                        attendance_worked_hours = delta.total_seconds() / 3600.0
                     worked_hours += attendance_worked_hours
                     hours_previously_today += attendance_worked_hours
                 employee.last_attendance_worked_hours = attendance_worked_hours
@@ -212,7 +231,7 @@ class HrEmployee(models.Model):
         }
         self._bus_send("hr.employee/presence", payload)
 
-    def _attendance_action_change(self, geo_information=None):
+    def _attendance_action_change(self, geo_information=None, break_duration=None):
         """ Check In/Check Out action
             Check In: create a new attendance record
             Check Out: modify check_out field of appropriate attendance record
@@ -241,15 +260,12 @@ class HrEmployee(models.Model):
                 if self.env.context.get('is_from_systray_check_in_out', False):  # throw user error if user tries to checkout from systray.
                     raise exceptions.UserError(self.env._("You've already checked in."))
                 return attendance  # no need to checkout the user if single checkin enabled.
+            vals = {'check_out': action_date}
             if geo_information:
-                attendance.write({
-                    'check_out': action_date,
-                    **{'out_%s' % key: geo_information[key] for key in geo_information}
-                })
-            else:
-                attendance.write({
-                    'check_out': action_date
-                })
+                vals.update({'out_%s' % key: geo_information[key] for key in geo_information})
+            if break_duration is not None:
+                vals['break_duration'] = break_duration
+            attendance.write(vals)
             self._notify_employee_presence_status()
         else:
             raise exceptions.UserError(_(
@@ -257,6 +273,14 @@ class HrEmployee(models.Model):
                 'Your attendances have probably been modified manually by human resources.',
                 empl_name=self.sudo().name))
         return attendance
+
+    def attendance_manual_with_break(self, break_duration=None):
+        self.ensure_one()
+        try:
+            self._attendance_action_change(break_duration=break_duration)
+        except exceptions.UserError as exc:
+            return {'warning': exc.args[0]}
+        return {'action': {'type': 'ir.actions.client', 'tag': 'reload'}}
 
     def action_open_last_month_attendances(self):
         self.ensure_one()

--- a/addons/hr_attendance/models/hr_employee_public.py
+++ b/addons/hr_attendance/models/hr_employee_public.py
@@ -24,6 +24,10 @@ class HrEmployeePublic(models.Model):
     last_check_out = fields.Datetime(related='employee_id.last_check_out',
         groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     display_extra_hours = fields.Boolean(related='company_id.hr_attendance_display_overtime')
+    attendance_break_management = fields.Boolean(
+        related='company_id.attendance_break_management',
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user",
+    )
 
     def action_open_last_month_attendances(self):
         self.ensure_one()

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -42,6 +42,11 @@ class ResCompany(models.Model):
     auto_check_out_tolerance = fields.Float(default=2, export_string_translation=False)
     absence_management = fields.Boolean(string="Absence Management", default=False)
     attendance_device_tracking = fields.Boolean(string="Device & Location Tracking", default=False)
+    attendance_break_management = fields.Boolean(
+        string="Break Management on Checkout",
+        help="If enabled, employees are prompted to enter their total break duration whenever they check out.",
+        default=False,
+    )
 
     @api.depends("attendance_kiosk_key")
     def _compute_attendance_kiosk_url(self):

--- a/addons/hr_attendance/models/res_config_settings.py
+++ b/addons/hr_attendance/models/res_config_settings.py
@@ -25,6 +25,7 @@ class ResConfigSettings(models.TransientModel):
     auto_check_out_tolerance = fields.Float(related="company_id.auto_check_out_tolerance", readonly=False)
     absence_management = fields.Boolean(related="company_id.absence_management", readonly=False)
     attendance_device_tracking = fields.Boolean(related="company_id.attendance_device_tracking", readonly=False)
+    attendance_break_management = fields.Boolean(related="company_id.attendance_break_management", readonly=False)
 
     @api.model
     def get_values(self):

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -4,28 +4,42 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { deserializeDateTime } from "@web/core/l10n/dates";
+import { deserializeDateTime, serializeDateTime } from "@web/core/l10n/dates";
+import { Time } from "@web/core/l10n/time";
 import { rpc, ConnectionLostError } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { formatFloatTime } from "@web/views/fields/formatters";
+import { TimePicker } from "@web/core/time_picker/time_picker";
 import { useService } from "@web/core/utils/hooks";
 import { isIosApp } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
+import { BreakDurationDialog } from "@hr_attendance/components/break_duration_dialog/break_duration_dialog";
 
 export class ActivityMenu extends Component {
-    static components = { Dropdown, DropdownItem };
+    static components = { Dropdown, DropdownItem, TimePicker };
     static props = [];
     static template = "hr_attendance.attendance_menu";
 
     setup() {
         this.ui = useService("ui");
+        this.dialog = useService("dialog");
+        this.actionService = useService("action");
+        this.orm = useService("orm");
         this.lazySession = useService("lazy_session");
         this.notification = useService("notification");
-        this.dialogService = useService("dialog");
-        this.employee = false;
         this.state = useState({
+            employee: null,
+            todayAttendanceRecords: [],
             checkedIn: false,
             isDisplayed: false,
+            activeAttendanceId: null,
+            editingAttendanceId: null,
+            savingAttendance: false,
+            editDraft: {
+                checkIn: null,
+                checkOut: null,
+                breakDuration: "0",
+            },
         });
 
         this.dropdown = useDropdownState();
@@ -33,7 +47,7 @@ export class ActivityMenu extends Component {
         onWillStart(() => {
             this.lazySession.getValue("attendance_user_data", (employee) => {
                 if (employee) {
-                    this.employee = employee;
+                    this.state.employee = employee;
                     this._searchReadEmployeeFill();
                 }
             });
@@ -41,56 +55,371 @@ export class ActivityMenu extends Component {
     }
 
     async searchReadEmployee() {
-        this.employee = await rpc("/hr_attendance/attendance_user_data");
+        this.state.employee = await rpc("/hr_attendance/attendance_user_data");
         this._searchReadEmployeeFill();
     }
 
     _searchReadEmployeeFill() {
-        if (!this.employee?.id) {
+        if (!this.state.employee?.id) {
             this.state.isDisplayed = false;
+            this.state.todayAttendanceRecords = [];
             return;
         }
 
-        this.employeeName = this.employee.name;
-        this.state.isDisplayed = this.employee.display_systray;
-        this.state.checkedIn = this.employee.attendance_state === "checked_in";
+        this.state.isDisplayed = this.state.employee.display_systray;
+        this.state.checkedIn = this.state.employee.attendance_state === "checked_in";
 
-        this.hoursToday = formatFloatTime(this.employee.hours_today, { numeric: true });
+        this.state.todayAttendanceRecords = [...(this.state.employee.today_attendance_ids || [])].sort(
+            (attendanceA, attendanceB) =>
+                deserializeDateTime(attendanceA.check_in).ts -
+                deserializeDateTime(attendanceB.check_in).ts
+        );
 
-        this.attendancesToday = (this.employee.today_attendance_ids || []).map((att) => {
-            const checkIn = deserializeDateTime(att.check_in).toLocaleString({
-                hour: "2-digit",
-                minute: "2-digit",
-            });
-            const checkOut = att.check_out
-                ? deserializeDateTime(att.check_out).toLocaleString({
-                      hour: "2-digit",
-                      minute: "2-digit",
-                  })
-                : null;
-            const duration = att.check_out
-                ? att.worked_hours
-                : this.employee.last_attendance_worked_hours;
+        const fallbackAttendanceId =
+            this.state.employee.last_attendance?.id || this.state.todayAttendanceRecords.at(-1)?.id || null;
+        if (!this._getAttendanceById(this.state.activeAttendanceId)) {
+            this.state.activeAttendanceId = fallbackAttendanceId;
+        }
+        if (this.state.editingAttendanceId && !this._getAttendanceById(this.state.editingAttendanceId)) {
+            this.cancelInlineEdit();
+        }
+
+    }
+    get todayAttendanceSessions() {
+        return this._buildAttendanceSessions();
+    }
+
+    get attendanceDetails() {
+        return this._buildAttendanceReview(this._getAttendanceById(this.state.activeAttendanceId));
+    }
+
+    get hasCheckedInToday() {
+        return this.todayAttendanceSessions.length > 0;
+    }
+
+    _buildAttendanceSessions() {
+        return this.state.todayAttendanceRecords.map((att) => {
+            const checkInDate = deserializeDateTime(att.check_in);
+            const checkOutDate = att.check_out ? deserializeDateTime(att.check_out) : null;
+            const duration = att.check_out ? att.worked_hours : this.state.employee.last_attendance_worked_hours;
             return {
                 id: att.id,
-                start: checkIn,
-                end: checkOut,
-                duration: formatFloatTime(duration, { numeric: true }),
+                canEdit: Boolean(att.can_edit),
+                selected: att.id === this.state.activeAttendanceId,
+                rangeLabel: `${this._formatAttendanceTime(checkInDate)} - ${
+                    checkOutDate ? this._formatAttendanceTime(checkOutDate) : _t("Now")
+                }`,
+                durationLabel: this._formatCompactDuration(duration),
             };
         });
-        this.hasCheckedInToday = this.attendancesToday.length > 0;
     }
 
-    splitTime(timeStr) {
-        const [h, m] = timeStr.split(":");
-        return { h, m };
+    _getAttendanceById(attendanceId) {
+        if (!attendanceId) {
+            return this.state.employee?.last_attendance || null;
+        }
+        return (
+            this.state.todayAttendanceRecords.find((attendance) => attendance.id === attendanceId) ||
+            (this.state.employee?.last_attendance?.id === attendanceId ? this.state.employee.last_attendance : null)
+        );
     }
 
-    async checking(latitude = false, longitude = false) {
+    _buildAttendanceReview(attendance) {
+        if (!(attendance && attendance.check_in)) {
+            return null;
+        }
+        const checkIn = deserializeDateTime(attendance.check_in);
+        const checkOut = attendance.check_out ? deserializeDateTime(attendance.check_out) : null;
+        const daySummary = this._getReviewSummary(attendance);
+        return {
+            id: attendance.id,
+            canEdit: Boolean(attendance.can_edit),
+            dateLabel: this._formatAttendanceDateLabel(checkIn, checkOut),
+            entries: [
+                {
+                    key: "check_in",
+                    label: _t("Check In"),
+                    time: this._formatAttendanceTime(checkIn),
+                    location: attendance.in_location || false,
+                    pending: false,
+                },
+                {
+                    key: "check_out",
+                    label: _t("Check Out"),
+                    time: checkOut ? this._formatAttendanceTime(checkOut) : _t("Pending"),
+                    location: checkOut ? attendance.out_location || false : false,
+                    pending: !checkOut,
+                },
+            ],
+            showBreakSummary: Boolean(this.state.employee.break_management_enabled),
+            breakDisplay: formatFloatTime(daySummary.breakDuration, { numeric: true }),
+            totalDisplay: formatFloatTime(daySummary.workedHours, { numeric: true }),
+            sessions: this.todayAttendanceSessions,
+        };
+    }
+
+    _formatAttendanceDateLabel(checkIn, checkOut) {
+        const options = {
+            weekday: "long",
+            day: "numeric",
+            month: "short",
+        };
+        const startLabel = checkIn.toLocaleString(options);
+        if (!(checkOut && !checkIn.hasSame(checkOut, "day"))) {
+            return startLabel;
+        }
+        return `${startLabel} - ${checkOut.toLocaleString(options)}`;
+    }
+
+    _formatAttendanceTime(dateTime) {
+        return dateTime.toLocaleString({
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    }
+
+    _formatCompactDuration(duration) {
+        return formatFloatTime(duration || 0, { numeric: true }).replace(":", "h");
+    }
+
+    _parseDateTimeInputValue(value) {
+        return value?.isValid ? value : null;
+    }
+
+    _getAttendanceFieldDateTime(attendance, fieldName) {
+        const attendanceField = fieldName === "checkIn" ? "check_in" : "check_out";
+        return attendance?.[attendanceField] ? deserializeDateTime(attendance[attendanceField]) : null;
+    }
+
+    _getInlineTimeValue(dateTime) {
+        const value = this._parseDateTimeInputValue(dateTime);
+        return value ? new Time(value.toObject()) : null;
+    }
+
+    _getInlineEditBaseDate(fieldName) {
+        const currentDraftValue = this._parseDateTimeInputValue(this.state.editDraft[fieldName]);
+        if (currentDraftValue) {
+            return currentDraftValue;
+        }
+        const attendance = this._getAttendanceById(this.state.editingAttendanceId);
+        const attendanceValue = this._getAttendanceFieldDateTime(attendance, fieldName);
+        if (attendanceValue) {
+            return attendanceValue;
+        }
+        if (fieldName === "checkOut") {
+            return (
+                this._parseDateTimeInputValue(this.state.editDraft.checkIn) ||
+                this._getAttendanceFieldDateTime(attendance, "checkIn")
+            );
+        }
+        return null;
+    }
+
+    _formatBreakDurationInputValue(durationHours) {
+        return String(Math.max(durationHours || 0, 0));
+    }
+
+    _parseBreakDurationInputValue(durationValue) {
+        return Math.max(Number(durationValue) || 0, 0);
+    }
+
+    _getAttendanceMetrics(attendance, { includeDraft = false } = {}) {
+        const isEditingAttendance = includeDraft && attendance.id === this.state.editingAttendanceId;
+        if (isEditingAttendance) {
+            const checkInDate = this._parseDateTimeInputValue(this.state.editDraft.checkIn);
+            const checkOutDate = this._parseDateTimeInputValue(this.state.editDraft.checkOut);
+            if (checkInDate?.isValid) {
+                const breakDuration = checkOutDate?.isValid
+                    ? this._parseBreakDurationInputValue(this.state.editDraft.breakDuration)
+                    : 0;
+                const endDate = checkOutDate?.isValid ? checkOutDate : luxon.DateTime.now();
+                const workedHours = Math.max(endDate.diff(checkInDate, "minutes").minutes / 60 - breakDuration, 0);
+                return {
+                    breakDuration,
+                    workedHours,
+                };
+            }
+        }
+        return {
+            breakDuration: attendance.check_out ? attendance.break_duration || 0 : 0,
+            workedHours: attendance.check_out
+                ? attendance.worked_hours || 0
+                : this.state.employee.last_attendance_worked_hours || 0,
+        };
+    }
+
+    _getAttendanceDaySummary({ includeDraft = false } = {}) {
+        return this.state.todayAttendanceRecords.reduce(
+            (summary, attendance) => {
+                const metrics = this._getAttendanceMetrics(attendance, { includeDraft });
+                summary.breakDuration += metrics.breakDuration;
+                summary.workedHours += metrics.workedHours;
+                return summary;
+            },
+            { breakDuration: 0, workedHours: 0 }
+        );
+    }
+
+    _getReviewSummary(attendance, { includeDraft = false } = {}) {
+        if (!attendance) {
+            return { breakDuration: 0, workedHours: 0 };
+        }
+        if (this.state.todayAttendanceRecords.some((todayAttendance) => todayAttendance.id === attendance.id)) {
+            return this._getAttendanceDaySummary({ includeDraft });
+        }
+        return this._getAttendanceMetrics(attendance, { includeDraft });
+    }
+
+    _serializeDateTimeInputValue(inputValue) {
+        const dateTime = this._parseDateTimeInputValue(inputValue);
+        if (!dateTime) {
+            return false;
+        }
+        return serializeDateTime(dateTime.set({ second: 0, millisecond: 0 }));
+    }
+
+    _getInlineEditErrorMessage(error) {
+        return error?.data?.message || error?.message || _t("Could not update this attendance.");
+    }
+
+    updateInlineDateTimeDraft(fieldName, value) {
+        if (fieldName) {
+            const baseDate = this._getInlineEditBaseDate(fieldName);
+            const timeValue = Time.from(value);
+            let nextDateTime = baseDate && timeValue ? baseDate.set(timeValue.toObject()) : null;
+            if (fieldName === "checkOut" && nextDateTime) {
+                const originalCheckOut = this._getAttendanceFieldDateTime(
+                    this._getAttendanceById(this.state.editingAttendanceId),
+                    "checkOut"
+                );
+                const checkInDateTime = this._parseDateTimeInputValue(this.state.editDraft.checkIn);
+                if (!originalCheckOut && checkInDateTime && nextDateTime < checkInDateTime) {
+                    nextDateTime = nextDateTime.plus({ days: 1 });
+                }
+            }
+            this.state.editDraft[fieldName] = nextDateTime;
+        }
+    }
+
+    openAttendanceForm(attendanceId) {
+        const attendance = this._getAttendanceById(attendanceId);
+        if (!attendance) {
+            return;
+        }
+        if (this.state.editingAttendanceId) {
+            this.notification.add(_t("Save or cancel your attendance changes before opening another record."), {
+                title: _t("Attendance Review"),
+                type: "warning",
+            });
+            return;
+        }
+        this.state.activeAttendanceId = attendance.id;
+        this.dropdown.close();
+        this.actionService.doAction({
+            type: "ir.actions.act_window",
+            res_model: "hr.attendance",
+            res_id: attendance.id,
+            views: [[false, "form"]],
+            target: "current",
+        });
+    }
+
+    selectAttendance(attendanceId) {
+        this.openAttendanceForm(attendanceId);
+    }
+
+    isEditing(attendanceDetails) {
+        return Boolean(
+            attendanceDetails &&
+                this.state.editingAttendanceId === attendanceDetails.id
+        );
+    }
+
+    startInlineEdit(attendanceId = this.state.activeAttendanceId) {
+        const attendance = this._getAttendanceById(attendanceId);
+        if (!(attendance && attendance.can_edit)) {
+            return;
+        }
+        this.state.activeAttendanceId = attendance.id;
+        this.state.editingAttendanceId = attendance.id;
+        this.state.editDraft.checkIn = deserializeDateTime(attendance.check_in);
+        this.state.editDraft.checkOut = attendance.check_out ? deserializeDateTime(attendance.check_out) : null;
+        this.state.editDraft.breakDuration = this._formatBreakDurationInputValue(
+            attendance.break_duration || 0
+        );
+    }
+
+    cancelInlineEdit() {
+        this.state.editingAttendanceId = null;
+        this.state.savingAttendance = false;
+        if (!this.state.activeAttendanceId && this.state.employee?.last_attendance?.id) {
+            this.state.activeAttendanceId = this.state.employee.last_attendance.id;
+        }
+    }
+
+    breakDisplay(attendanceDetails) {
+        if (!this.isEditing(attendanceDetails)) {
+            return attendanceDetails.breakDisplay;
+        }
+        const attendance = this._getAttendanceById(attendanceDetails.id);
+        return formatFloatTime(
+            this._getReviewSummary(attendance, { includeDraft: true }).breakDuration,
+            { numeric: true }
+        );
+    }
+
+    totalDisplay(attendanceDetails) {
+        if (!this.isEditing(attendanceDetails)) {
+            return attendanceDetails.totalDisplay;
+        }
+        const attendance = this._getAttendanceById(attendanceDetails.id);
+        return formatFloatTime(
+            this._getReviewSummary(attendance, { includeDraft: true }).workedHours,
+            { numeric: true }
+        );
+    }
+
+    async saveInlineEdit() {
+        const attendanceId = this.state.editingAttendanceId;
+        if (!attendanceId || this.state.savingAttendance) {
+            return;
+        }
+        if (!this._parseDateTimeInputValue(this.state.editDraft.checkIn)) {
+            this.notification.add(_t("Check-in is required."), {
+                title: _t("Attendance Error"),
+                type: "danger",
+            });
+            return;
+        }
+        this.state.savingAttendance = true;
         try {
-            this.employee = await rpc("/hr_attendance/systray_check_in_out", {
+            const vals = {
+                check_in: this._serializeDateTimeInputValue(this.state.editDraft.checkIn),
+                check_out: this.state.editDraft.checkOut
+                    ? this._serializeDateTimeInputValue(this.state.editDraft.checkOut)
+                    : false,
+                break_duration: this.state.editDraft.checkOut
+                    ? this._parseBreakDurationInputValue(this.state.editDraft.breakDuration)
+                    : 0,
+            };
+            await this.orm.write("hr.attendance", [attendanceId], vals);
+            this.state.editingAttendanceId = null;
+            await this.searchReadEmployee();
+        } catch (error) {
+            this.notification.add(this._getInlineEditErrorMessage(error), {
+                title: _t("Attendance Error"),
+                type: "danger",
+            });
+        } finally {
+            this.state.savingAttendance = false;
+        }
+    }
+    async checking(latitude = false, longitude = false, breakDurationHours = null) {
+        try {
+            this.state.employee = await rpc("/hr_attendance/systray_check_in_out", {
                 latitude,
                 longitude,
+                break_duration: breakDurationHours,
             });
             this._searchReadEmployeeFill();
         } catch (error) {
@@ -108,12 +437,12 @@ export class ActivityMenu extends Component {
         }
     }
 
-    confirmChecking() {
-        this.dialogService.add(ConfirmationDialog, {
+    confirmChecking(breakDurationHours = null) {
+        this.dialog.add(ConfirmationDialog, {
             body: _t("Unable to get a valid location. Do you want to proceed with your check-in/out anyway?"),
             confirmLabel: _t("Proceed Anyway"),
-            confirm: async () => await this.checking(),
-            cancel: () => this._attendanceInProgress = false,
+            confirm: async () => await this.checking(false, false, breakDurationHours),
+            cancel: () => (this._attendanceInProgress = false),
         });
     }
 
@@ -124,26 +453,85 @@ export class ActivityMenu extends Component {
         }
         this._attendanceInProgress = true;
 
-        const trackingEnabled = this.employee && this.employee.device_tracking_enabled;
-        if (trackingEnabled && !isIosApp() && navigator.geolocation && navigator.onLine) {
-            // iOS app lacks permissions to call `getCurrentPosition`
-            navigator.geolocation.getCurrentPosition(
-                async ({ coords: { latitude, longitude } }) => {
-                    await this.checking(latitude, longitude);
-                },
-                () => {
-                    this.confirmChecking();
+        try {
+            await this.searchReadEmployee();
+            if (!this.state.employee || !this.state.employee.id) {
+                this._attendanceInProgress = false;
+                return;
+            }
+            let breakDurationHours = null;
+            if (this.state.employee.break_management_enabled && this.state.employee.attendance_state === "checked_in") {
+                const minutes = await this.requestBreakDuration(this._getCurrentAttendanceMaxBreakMinutes());
+                if (minutes === null) {
+                    this._attendanceInProgress = false;
+                    return;
+                }
+                breakDurationHours = (Number(minutes) || 0) / 60;
+            }
+            const trackingEnabled = this.state.employee && this.state.employee.device_tracking_enabled;
+            if (trackingEnabled && !isIosApp() && navigator.geolocation && navigator.onLine) {
+                navigator.geolocation.getCurrentPosition(
+                    async ({ coords: { latitude, longitude } }) => {
+                        await this.checking(latitude, longitude, breakDurationHours);
+                    },
+                    () => {
+                        this.confirmChecking(breakDurationHours);
+                    },
+                    {
+                        enableHighAccuracy: true,
+                        timeout: 10000,
+                    }
+                );
+            } else if (trackingEnabled) {
+                this.confirmChecking(breakDurationHours);
+            } else {
+                await this.checking(false, false, breakDurationHours);
+            }
+        } catch (error) {
+            this._attendanceInProgress = false;
+            throw error;
+        }
+    }
+
+    _getCurrentAttendanceMaxBreakMinutes() {
+        const attendance = this.state.employee?.last_attendance;
+        if (!attendance?.check_in) {
+            return null;
+        }
+        const checkInDate = deserializeDateTime(attendance.check_in);
+        const checkOutDate = attendance.check_out
+            ? deserializeDateTime(attendance.check_out)
+            : luxon.DateTime.now();
+        if (!(checkInDate?.isValid && checkOutDate?.isValid)) {
+            return null;
+        }
+        const durationMinutes = checkOutDate.diff(checkInDate, "minutes").minutes;
+        return Math.max(Math.floor(durationMinutes || 0), 0);
+    }
+
+    async requestBreakDuration(maxMinutes = null) {
+        return new Promise((resolve) => {
+            let settled = false;
+            const finalize = (value) => {
+                if (!settled) {
+                    settled = true;
+                    resolve(value);
+                }
+            };
+            this.dialog.add(
+                BreakDurationDialog,
+                {
+                    employeeName: this.state.employee?.name,
+                    defaultMinutes: 0,
+                    maxMinutes: typeof maxMinutes === "number" ? maxMinutes : undefined,
+                    onConfirm: (minutes) => finalize(minutes),
+                    onCancel: () => finalize(null),
                 },
                 {
-                    enableHighAccuracy: true,
-                    timeout: 10000,
+                    onClose: () => finalize(null),
                 }
             );
-        } else if (trackingEnabled) {
-            this.confirmChecking();
-        } else {
-            await this.checking();
-        }
+        });
     }
 }
 

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
@@ -1,6 +1,118 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
+<t t-name="hr_attendance.AttendanceReviewBlock">
+    <div t-if="attendanceDetails" class="o_attendance_review_wrap">
+        <t t-set="isEditingAttendance" t-value="this.isEditing(attendanceDetails)"/>
+        <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+            <div>
+                <div class="text-uppercase small fw-semibold text-muted">Attendance Review</div>
+                <div class="small text-muted">
+                    <t t-out="attendanceDetails.dateLabel"/>
+                </div>
+            </div>
+            <t t-if="isEditingAttendance">
+                <div class="d-flex gap-2 flex-shrink-0">
+                    <button class="btn btn-primary btn-sm"
+                            t-att-disabled="editState.savingAttendance"
+                            t-on-click="this.saveInlineEdit">
+                        Save
+                    </button>
+                    <button class="btn btn-secondary btn-sm"
+                            t-att-disabled="editState.savingAttendance"
+                            t-on-click="this.cancelInlineEdit">
+                        Cancel
+                    </button>
+                </div>
+            </t>
+            <button t-elif="attendanceDetails.canEdit"
+                    class="btn btn-link btn-sm p-0 text-decoration-none"
+                    t-on-click="() => this.startInlineEdit(attendanceDetails.id)">
+                Edit
+            </button>
+        </div>
+
+        <div class="o_attendance_review_grid mb-3">
+            <div t-foreach="attendanceDetails.entries" t-as="entry" t-key="entry.key" class="o_attendance_review_card">
+                <div class="small text-uppercase fw-semibold text-muted mb-2">
+                    <t t-out="entry.label"/>
+                </div>
+                <t t-if="isEditingAttendance and entry.key === 'check_in'">
+                    <TimePicker inputCssClass="'form-control-sm'"
+                                value="this._getInlineTimeValue(editState.editDraft.checkIn)"
+                                onChange="(value) => this.updateInlineDateTimeDraft('checkIn', value)"
+                                onInvalid="() => this.updateInlineDateTimeDraft('checkIn', null)"
+                                showSeconds="false"
+                                minutesRounding="1"/>
+                </t>
+                <t t-elif="isEditingAttendance and entry.key === 'check_out'">
+                    <TimePicker inputCssClass="'form-control-sm'"
+                                value="this._getInlineTimeValue(editState.editDraft.checkOut)"
+                                onChange="(value) => this.updateInlineDateTimeDraft('checkOut', value)"
+                                onInvalid="() => this.updateInlineDateTimeDraft('checkOut', null)"
+                                showSeconds="false"
+                                minutesRounding="1"/>
+                    <div t-if="attendanceDetails.showBreakSummary and editState.editDraft.checkOut"
+                        class="mt-2 d-flex flex-column">
+                        <label class="small text-uppercase fw-semibold text-muted mb-1">
+                            Break duration
+                        </label>
+                        <div class="d-flex align-items-center gap-3">
+                            <input class="form-control form-control-sm o_attendance_review_break_input"
+                                   type="number"
+                                   min="0"
+                                   step="0.01"
+                                   inputmode="decimal"
+                                   t-model="editState.editDraft.breakDuration"
+                                   t-att-disabled="editState.savingAttendance || !editState.editDraft.checkOut"/>
+                            <span class="small text-muted text-nowrap">Hours</span>
+                        </div>
+                    </div>
+                </t>
+                <t t-else="">
+                    <div class="fs-4 fw-semibold lh-sm" t-att-class="entry.pending ? 'text-muted' : ''">
+                        <t t-out="entry.time"/>
+                    </div>
+                </t>
+                <div class="small text-muted o_attendance_review_location" t-if="entry.location">
+                    <t t-out="entry.location"/>
+                </div>
+            </div>
+        </div>
+
+        <div t-if="attendanceDetails.sessions and attendanceDetails.sessions.length" class="o_attendance_review_sessions">
+            <div t-foreach="attendanceDetails.sessions"
+                 t-as="session"
+                 t-key="session.id"
+                 class="o_attendance_review_session"
+                 t-att-class="(session.selected ? 'o_is_selected ' : '') + 'o_is_selectable'"
+                 t-on-click="() => this.selectAttendance(session.id)">
+                <span class="o_attendance_review_session_range">
+                    <t t-out="session.rangeLabel"/>
+                </span>
+                <strong class="text-nowrap">
+                    <t t-out="session.durationLabel"/>
+                </strong>
+            </div>
+        </div>
+
+        <div class="o_attendance_review_summary">
+            <div t-if="attendanceDetails.showBreakSummary" class="o_attendance_review_summary_item">
+                <strong class="o_attendance_review_summary_value">
+                    <t t-out="this.breakDisplay(attendanceDetails)"/>
+                </strong>
+                <span class="small text-muted text-uppercase">Breaks</span>
+            </div>
+            <div class="o_attendance_review_summary_item" t-att-class="!attendanceDetails.showBreakSummary ? 'w-100' : ''">
+                <strong class="o_attendance_review_summary_value">
+                    <t t-out="this.totalDisplay(attendanceDetails)"/>
+                </strong>
+                <span class="small text-muted text-uppercase">Total hours</span>
+            </div>
+        </div>
+    </div>
+</t>
+
 <t t-name="hr_attendance.attendance_menu">
     <t t-if="this.state.isDisplayed">
         <Dropdown position="'bottom-end'"
@@ -19,56 +131,30 @@
                     <div class="d-flex justify-content-between align-items-center gap-5 border-bottom p-3">
                         <h3 class="mb-0">
                             <t t-if="this.hasCheckedInToday">
-                                <small>Welcome back</small> <span class="d-block"><t t-out="this.employeeName"/>!</span>
+                                <small>Welcome back</small> <span class="d-block"><t t-out="this.state.employee?.name || ''"/>!</span>
                             </t>
                             <t t-else="">
-                                <small>Welcome,</small> <span class="d-block"><t t-out="this.employeeName"/>.</span>
+                                <small>Welcome,</small> <span class="d-block"><t t-out="this.state.employee?.name || ''"/>.</span>
                             </t>
                         </h3>
                     </div>
-                    
+
                     <div class="o_att_today_wrap px-3">
-                        <table class="table mb-0">
-                            <tbody>
-                                <tr t-foreach="this.attendancesToday" t-as="attendance" t-key="attendance.id">
-                                    <td>
-                                        <t t-set="start" t-value="this.splitTime(attendance.start)"/>
-                                        <t t-out="start.h"/>:<span class="text-muted"><t t-out="start.m"/></span>
-                                    </td>
-                                    <td class="px-0">–</td>
-                                    <td>
-                                        <t t-if="attendance.end">
-                                            <t t-set="end" t-value="this.splitTime(attendance.end)"/>
-                                            <t t-out="end.h"/>:<span class="text-muted"><t t-out="end.m"/></span>
-                                        </t>
-                                        <t t-else="">
-                                            Now
-                                        </t>
-                                    </td>
-                                    <td class="ps-4 text-end">
-                                        <t t-set="duration" t-value="this.splitTime(attendance.duration)"/>
-                                        <t t-out="duration.h"/>h<span class="text-muted"><t t-out="duration.m"/></span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td colspan="3" class="border-bottom-0">
-                                        Today
-                                    </td>
-                                    <td class="border-bottom-0 ps-4 text-end">
-                                        <t t-set="total" t-value="this.splitTime(this.hoursToday)"/>
-                                        <t t-out="total.h"/>h<span class="text-muted"><t t-out="total.m"/></span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <t t-set="attendanceDetails" t-value="this.attendanceDetails"/>
+                        <t t-set="editState" t-value="this.state"/>
+                        <t t-call="hr_attendance.AttendanceReviewBlock"/>
                     </div>
 
-                    <div class="o_wrap_btn_sign_out position-md-sticky bottom-0 p-3 z-2">
+                    <div class="o_wrap_btn_sign_out d-flex gap-3 align-items-stretch position-md-sticky bottom-0 p-3 z-2">
                         <button t-on-click="() => this.signInOut()"
-                                t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'primary' }} w-100">
+                                class="btn btn-primary flex-grow-1">
                             <span t-if="!this.state.checkedIn">Check in</span>
                             <span t-else="">Check out</span>
                             <i t-attf-class="fa fa-sign-{{ this.state.checkedIn ? 'out' : 'in' }} ms-1"/>
+                        </button>
+                        <button t-on-click="() => this.dropdown.close()"
+                                class="btn btn-secondary">
+                            Discard
                         </button>
                     </div>
                 </div>

--- a/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.js
+++ b/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.js
@@ -1,0 +1,45 @@
+import { Component, props, proxy, t } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { sprintf } from "@web/core/utils/strings";
+
+export class BreakDurationDialog extends Component {
+    static template = "hr_attendance.BreakDurationDialog";
+    static components = { Dialog };
+    props = props({
+        employeeName: t.string().optional(),
+        onConfirm: t.function(),
+        close: t.function(),
+    });
+
+    setup() {
+        this.notification = useService("notification");
+        this.state = proxy({ minutes: 0 });
+        this.dialogTitle = _t("Break Duration");
+        this.promptText = this.props.employeeName
+            ? sprintf(
+                  _t("Enter the total break duration (in minutes) for %s."),
+                  this.props.employeeName
+              )
+            : _t("Enter the total break duration in minutes.");
+    }
+
+    async confirm() {
+        const rawMinutes = this.state.minutes;
+        const minutes = Number(rawMinutes);
+        if (
+            rawMinutes === "" ||
+            !Number.isFinite(minutes) ||
+            !Number.isInteger(minutes) ||
+            minutes < 0
+        ) {
+            this.notification.add(_t("Enter a valid break duration in whole minutes."), {
+                type: "danger",
+            });
+            return;
+        }
+        await this.props.onConfirm(minutes);
+        this.props.close();
+    }
+}

--- a/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.js
+++ b/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.js
@@ -1,0 +1,57 @@
+import { Component, useRef, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+import { sprintf } from "@web/core/utils/strings";
+
+export class BreakDurationDialog extends Component {
+    static template = "hr_attendance.BreakDurationDialog";
+    static components = { Dialog };
+    static props = {
+        employeeName: { type: String, optional: true },
+        defaultMinutes: { type: Number, optional: true },
+        maxMinutes: { type: Number, optional: true },
+        onConfirm: { type: Function },
+        onCancel: { type: Function, optional: true },
+        close: { type: Function },
+    };
+
+    setup() {
+        this.state = useState({
+            minutes: this.props.defaultMinutes ?? 0,
+        });
+        this.durationInputRef = useRef("durationInput");
+        this.dialogTitle = _t("Break Duration");
+        this.promptText = this.props.employeeName
+            ? sprintf(
+                  _t("Enter the extra break duration (in minutes) for %s."),
+                  this.props.employeeName
+              )
+            : _t("Enter the extra break duration in minutes.");
+    }
+
+    get maxMinutes() {
+        if (typeof this.props.maxMinutes !== "number") {
+            return null;
+        }
+        return Math.max(Math.floor(this.props.maxMinutes), 0);
+    }
+
+    async confirm(ev) {
+        ev.preventDefault();
+        const input = this.durationInputRef.el;
+        if (input && !input.reportValidity()) {
+            return;
+        }
+        const shouldClose = await this.props.onConfirm(Number(this.state.minutes) || 0);
+        if (shouldClose !== false) {
+            this.props.close();
+        }
+    }
+
+    cancel() {
+        if (this.props.onCancel) {
+            this.props.onCancel();
+        }
+        this.props.close();
+    }
+}

--- a/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.xml
+++ b/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_attendance.BreakDurationDialog">
+        <Dialog title="this.dialogTitle">
+            <div class="o_break_duration_dialog">
+                <p t-out="this.promptText"/>
+                <div class="row">
+                    <div class="col-12 col-sm-8 col-md-6 col-lg-5">
+                        <div class="input-group">
+                            <label class="visually-hidden" for="o_break_duration_minutes">
+                                Break duration in minutes
+                            </label>
+                            <input
+                                id="o_break_duration_minutes"
+                                class="form-control"
+                                type="number"
+                                min="0"
+                                step="1"
+                                t-att-value="this.state.minutes"
+                                t-on-input="(ev) => this.state.minutes = ev.target.value"
+                                required="1"
+                            />
+                            <span class="input-group-text">minutes</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button type="button" class="btn btn-primary" t-on-click="this.confirm">Confirm</button>
+                <button type="button" class="btn btn-secondary" t-on-click="this.props.close">Cancel</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.xml
+++ b/addons/hr_attendance/static/src/components/break_duration_dialog/break_duration_dialog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_attendance.BreakDurationDialog">
+        <Dialog title="this.dialogTitle">
+            <div class="o_break_duration_dialog">
+                <p t-out="this.promptText"/>
+                <div class="row">
+                    <div class="col-12 col-sm-8 col-md-6 col-lg-5">
+                        <div class="input-group">
+                            <input
+                                t-ref="durationInput"
+                                class="form-control"
+                                type="number"
+                                min="0"
+                                t-att-max="this.maxMinutes"
+                                step="1"
+                                t-model.number="state.minutes"
+                                required="1"
+                            />
+                            <span class="input-group-text">minutes</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button type="button" class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button type="button" class="btn btn-primary" t-on-click="confirm">Confirm</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/hr_attendance/static/src/components/check_in_out/check_in_out.js
+++ b/addons/hr_attendance/static/src/components/check_in_out/check_in_out.js
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { BreakDurationDialog } from "@hr_attendance/components/break_duration_dialog/break_duration_dialog";
 import { useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 
@@ -12,6 +13,7 @@ export class CheckInOut extends Component {
 
     setup() {
         this.actionService = useService("action");
+        this.dialog = useService("dialog");
         this.orm = useService("orm");
         this.notification = useService("notification");
 
@@ -19,6 +21,21 @@ export class CheckInOut extends Component {
     }
 
     async signInOut() {
+        let breakDurationHours = null;
+        if (this.props.checkedIn) {
+            const [employee] = await this.orm.read(
+                "hr.employee",
+                [this.props.employeeId],
+                ["name", "attendance_state", "attendance_break_management"]
+            );
+            if (employee?.attendance_state === "checked_in" && employee.attendance_break_management) {
+                const minutes = await this.requestBreakDuration(employee.name);
+                if (minutes === null) {
+                    return;
+                }
+                breakDurationHours = (Number(minutes) || 0) / 60;
+            }
+        }
         navigator.geolocation.getCurrentPosition(
             ({coords: {latitude, longitude}}) => {
                 this.orm.call("hr.employee", "update_last_position", [
@@ -34,14 +51,38 @@ export class CheckInOut extends Component {
                     false
                 ])
             })
-        const result = await this.orm.call("hr.employee", "attendance_manual", [
+        const result = await this.orm.call("hr.employee", "attendance_manual_with_break", [
             [this.props.employeeId],
-            this.props.nextAction,
+            breakDurationHours,
         ]);
         if (result.action) {
             this.actionService.doAction(result.action);
         } else if (result.warning) {
             this.notification.add(result.warning, {type: "danger"});
         }
+    }
+
+    async requestBreakDuration(employeeName) {
+        return new Promise((resolve) => {
+            let settled = false;
+            const finalize = (value) => {
+                if (!settled) {
+                    settled = true;
+                    resolve(value);
+                }
+            };
+            this.dialog.add(
+                BreakDurationDialog,
+                {
+                    employeeName,
+                    defaultMinutes: 0,
+                    onConfirm: (minutes) => finalize(minutes),
+                    onCancel: () => finalize(null),
+                },
+                {
+                    onClose: () => finalize(null),
+                }
+            );
+        });
     }
 }

--- a/addons/hr_attendance/static/src/components/greetings/greetings.js
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.js
@@ -1,35 +1,54 @@
-import { Component, onWillDestroy } from "@odoo/owl";
-import { registry } from "@web/core/registry";
+import { Component, computed, onWillDestroy, t, useProps } from "@odoo/owl";
 import { deserializeDateTime } from "@web/core/l10n/dates";
+import { formatDateTime, formatFloatTime } from "@web/views/fields/formatters";
 
 export class KioskGreetings extends Component {
     static template = "hr_attendance.public_kiosk_greetings";
-    static props = {
-        employeeData: { type: Object },
-        kioskReturn: { type: Function },
-    };
+    props = useProps({
+        employeeData: t.object(),
+        kioskReturn: t.function(),
+        kioskContinueBreak: t.function().optional(() => () => {}),
+    });
 
     setup() {
-        this.formatDateTime = registry.category("formatters").get("datetime");
-        this.formatFloatTime = registry.category("formatters").get("float_time");
-        this.employeeName = this.props.employeeData.employee_name;
-        this.employeeAvatar = this.props.employeeData.employee_avatar;
-        this.hoursToday = this.formatFloatTime(this.props.employeeData.hours_today);
-        this.attendance = this.props.employeeData.attendance;
-        this.check_in_time = this.formatDateTime(
-            this.attendance.check_in && deserializeDateTime(this.attendance.check_in)
-        );
-        this.check_out_time = this.formatDateTime(
-            this.attendance.check_out && deserializeDateTime(this.attendance.check_out)
-        );
-        this.isEmployeeSingleCheckIn = this.props.employeeData.is_employee_single_checkin;
-        this.kiosk_delay = setTimeout(() => {
+        this.kioskDelay = setTimeout(() => {
             this.props.kioskReturn(true);
         }, this.props.employeeData.kiosk_delay);
-        if (this.props.employeeData.display_overtime) {
-            this.overtimeToday = this.formatFloatTime(this.props.employeeData.overtime_today);
-            this.totalOvertime = this.formatFloatTime(this.props.employeeData.total_overtime);
-        }
-        onWillDestroy(() => clearTimeout(this.kiosk_delay));
+        onWillDestroy(() => this.clearKioskDelay());
+    }
+
+    get attendance() {
+        return this.props.employeeData.attendance;
+    }
+
+    get isCheckOut() {
+        return Boolean(this.attendance.check_out);
+    }
+
+    checkInTime = computed(() =>
+        this.attendance.check_in ? formatDateTime(deserializeDateTime(this.attendance.check_in)) : ""
+    );
+    checkOutTime = computed(() =>
+        this.attendance.check_out ? formatDateTime(deserializeDateTime(this.attendance.check_out)) : ""
+    );
+    hoursToday = computed(() => formatFloatTime(this.props.employeeData.hours_today));
+    overtimeToday = computed(
+        () =>
+            this.props.employeeData.display_overtime &&
+            formatFloatTime(this.props.employeeData.overtime_today)
+    );
+    totalOvertime = computed(
+        () =>
+            this.props.employeeData.display_overtime &&
+            formatFloatTime(this.props.employeeData.total_overtime)
+    );
+
+    clearKioskDelay() {
+        clearTimeout(this.kioskDelay);
+    }
+
+    continueBreak() {
+        this.clearKioskDelay();
+        this.props.kioskContinueBreak();
     }
 }

--- a/addons/hr_attendance/static/src/components/greetings/greetings.js
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.js
@@ -1,31 +1,112 @@
-import {Component, onWillDestroy} from "@odoo/owl";
+import { Component, onWillDestroy } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { deserializeDateTime } from "@web/core/l10n/dates";
+import { _t } from "@web/core/l10n/translation";
+import { sprintf } from "@web/core/utils/strings";
 
 export class KioskGreetings extends Component {
     static template = "hr_attendance.public_kiosk_greetings";
     static props = {
         employeeData: { type: Object },
         kioskReturn: { type: Function },
+        showCheckoutActions: { type: Boolean, optional: true },
+        savingCheckoutAction: { type: Boolean, optional: true },
+        onSelectBreakTime: { type: Function, optional: true },
+        onSelectOutOfOffice: { type: Function, optional: true },
     };
 
     setup() {
         this.formatDateTime = registry.category("formatters").get("datetime");
         this.formatFloatTime = registry.category("formatters").get("float_time");
-        this.employeeName = this.props.employeeData.employee_name;
-        this.employeeAvatar = this.props.employeeData.employee_avatar;
-        this.hoursToday = this.formatFloatTime(this.props.employeeData.hours_today);
-        this.attendance = this.props.employeeData.attendance;
-        this.check_in_time = this.formatDateTime(this.attendance.check_in && deserializeDateTime(this.attendance.check_in));
-        this.check_out_time = this.formatDateTime(this.attendance.check_out && deserializeDateTime(this.attendance.check_out));
-        this.isEmployeeSingleCheckIn = this.props.employeeData.is_employee_single_checkin;
         this.kiosk_delay = setTimeout(() => {
-            this.props.kioskReturn(true)
-        }, this.props.employeeData.kiosk_delay)
-        if (this.props.employeeData.display_overtime){
-            this.overtimeToday = this.formatFloatTime(this.props.employeeData.overtime_today);
-            this.totalOvertime = this.formatFloatTime(this.props.employeeData.total_overtime);
-        }
+            this.props.kioskReturn(true);
+        }, this.props.employeeData.kiosk_delay);
         onWillDestroy(() => clearTimeout(this.kiosk_delay));
+    }
+
+    get employeeName() {
+        return this.props.employeeData.employee_name;
+    }
+
+    get employeeAvatar() {
+        return this.props.employeeData.employee_avatar;
+    }
+
+    get hoursToday() {
+        return this.formatFloatTime(this.props.employeeData.hours_today);
+    }
+
+    get attendance() {
+        return this.props.employeeData.attendance;
+    }
+
+    get checkInTime() {
+        return this.formatDateTime(
+            this.attendance.check_in && deserializeDateTime(this.attendance.check_in)
+        );
+    }
+
+    get checkOutTime() {
+        return this.formatDateTime(
+            this.attendance.check_out && deserializeDateTime(this.attendance.check_out)
+        );
+    }
+
+    get isCheckOut() {
+        return Boolean(this.attendance.check_out);
+    }
+
+    get greetingTitle() {
+        return this.isCheckOut ? _t("Goodbye") : _t("Welcome");
+    }
+
+    get statusAlertClass() {
+        return this.isCheckOut ? "alert-danger" : "alert-success";
+    }
+
+    get statusMessage() {
+        return this.isCheckOut
+            ? sprintf(_t("Checked out at %s"), this.checkOutTime)
+            : sprintf(_t("Checked in at %s"), this.checkInTime);
+    }
+
+    get isEmployeeSingleCheckIn() {
+        return this.props.employeeData.is_employee_single_checkin;
+    }
+
+    get breakDuration() {
+        return this.props.employeeData.break_duration
+            ? this.formatFloatTime(this.props.employeeData.break_duration)
+            : false;
+    }
+
+    get attendanceWorkedHours() {
+        return this.formatFloatTime(this.props.employeeData.attendance_worked_hours || 0);
+    }
+
+    get hasTimesheet() {
+        return Boolean(this.props.employeeData.has_timesheet);
+    }
+
+    get secondarySummaryLabel() {
+        return this.isCheckOut ? _t("Hours Today") : _t("Hours Previously Today");
+    }
+
+    get overtimeToday() {
+        if (!this.props.employeeData.display_overtime) {
+            return false;
+        }
+        return this.formatFloatTime(this.props.employeeData.overtime_today);
+    }
+
+    get totalOvertime() {
+        if (!this.props.employeeData.display_overtime) {
+            return false;
+        }
+        return this.formatFloatTime(this.props.employeeData.total_overtime);
+    }
+
+    get shouldShowCheckoutActions() {
+        return Boolean(this.props.showCheckoutActions && this.isCheckOut);
     }
 }

--- a/addons/hr_attendance/static/src/components/greetings/greetings.xml
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.xml
@@ -14,64 +14,79 @@
         <t t-if="this.attendance">
             <div class="o_hr_kiosk_mode_main d-flex flex-grow-1 justify-content-center align-items-center">
                 <div class="o_hr_attendance_kiosk_card card rounded-3">
-                    <div class="card-body rounded-3">
-                        <div class="o_hr_attendance_kiosk_card_wrapper d-flex flex-column align-items-center justify-content-center">
-                            <div class="o_hr_attendance_kiosk_card_main p-3 mx-3 mx-xl-0 text-center">
-                                <t t-call="hr_attendance.EmployeeBadge" employeeAvatar="this.employeeAvatar"/>
-                                <h5 class="text-muted mt-2 mb-0">
-                                    <t t-if="this.attendance.check_out" >Goodbye</t>
-                                    <t t-else="">Welcome</t>
-                                </h5>
-                                <h2><t t-out="this.employeeName"/></h2>
-                            </div>
-                            <div class="o_hr_attendance_kiosk_card_bottom d-flex flex-column w-100">
-                                <div class="alert alert-info text-center p-3" role="status">
-                                    <t t-if="this.attendance.check_out">
-                                        Checked out at <strong><t t-out="this.check_out_time"/></strong>
-                                    </t>
-                                    <t t-else="">
-                                        Checked in at <strong><t t-out="this.check_in_time"/></strong>
-                                    </t>
+                    <div class="card-body rounded-3 p-3">
+                        <div class="o_hr_attendance_kiosk_card_wrapper d-flex flex-column
+                            align-items-center justify-content-center">
+                            <div class="o_hr_attendance_kiosk_card_main p-2 mx-3 mx-xl-0 text-center">
+                                <t t-call="hr_attendance.EmployeeBadge"
+                                    employeeAvatar="this.props.employeeData.employee_avatar"
+                                    employeeAvatarHeight="'88'"
+                                />
+                                <div class="d-flex flex-column gap-1 mt-2">
+                                    <h2 class="display-5 lh-1 fw-medium mb-1">
+                                        <t t-if="this.isCheckOut">Goodbye</t>
+                                        <t t-else="">Welcome</t>
+                                    </h2>
+                                    <div class="fs-2 lh-sm text-muted">
+                                        <t t-out="this.props.employeeData.employee_name"/>
+                                    </div>
                                 </div>
-                                <div class="d-flex flex-column w-100">
-                                    <div
-                                        class="alert alert-info text-center p-3"
-                                        t-if="this.hoursToday != '00:00'"
-                                        role="status">
-                                        <t t-if="this.isEmployeeSingleCheckIn and !this.attendance.check_out">
-                                            You’ve already checked in.
-                                        </t>
-                                        <t t-elif="this.attendance.check_out">
-                                            Hours Today: <strong><t t-out="this.hoursToday"/></strong>
+                            </div>
+                            <div class="o_hr_attendance_kiosk_card_bottom d-flex flex-column w-100 gap-2">
+                                <div t-attf-class="alert alert-{{ this.isCheckOut ? 'info' : 'success' }} text-center mb-0 p-2"
+                                    role="status">
+                                    <strong>
+                                        <t t-if="this.isCheckOut">
+                                            Checked out at <t t-out="this.checkOutTime()"/>
                                         </t>
                                         <t t-else="">
-                                            Hours Previously Today: <strong><t t-out="this.hoursToday"/></strong>
+                                            Checked in at <t t-out="this.checkInTime()"/>
                                         </t>
+                                    </strong>
+                                </div>
+                                <div t-if="this.props.employeeData.hours_today" class="alert alert-info text-center mb-0 p-2"
+                                    role="status">
+                                    <t t-if="this.props.employeeData.is_employee_single_checkin and !this.attendance.check_out">
+                                        You've already checked in.
+                                    </t>
+                                    <t t-else="">
+                                        <t t-if="this.isCheckOut">Hours Today</t>
+                                        <t t-else="">Hours Previously Today</t>:
+                                        <strong><t t-out="this.hoursToday()"/></strong>
+                                    </t>
+                                </div>
+                                <div t-if="this.attendance.check_out and this.overtimeToday()"
+                                    class="alert alert-warning d-flex flex-column gap-2 mb-0
+                                    p-2 p-xl-2 border border-warning text-center">
+                                    <div class="small fw-bolder text-uppercase">
+                                        Extra hours
                                     </div>
-                                    <div t-if="this.attendance.check_out and this.overtimeToday" class="alert alert-warning d-flex flex-column gap-2 mb-0 p-2 p-xl-3 border border-warning text-center">
-                                        <div class="small fw-bolder text-uppercase">
-                                            Extra hours
+                                    <div class="d-flex gap-2">
+                                        <div class="d-flex flex-column w-100 mb-0">
+                                            <span class="text-nowrap">Today</span>
+                                            <span class="fs-6"><strong><t t-out="this.overtimeToday()"/></strong></span>
                                         </div>
-                                        <div class="d-flex gap-2">
-                                            <div class="d-flex flex-column w-100 mb-0 ">
-                                                <span class="text-nowrap">Today</span>
-                                                <span class="fs-6"><strong><t t-out="this.overtimeToday"/></strong></span>
-                                            </div>
-                                            <div t-if="this.totalOvertime" class="d-flex flex-column w-100 mb-0 ">
-                                                <span class="text-nowrap">Total</span>
-                                                <span class="fs-6"><strong><t t-out="this.totalOvertime"/></strong></span>
-                                            </div>
+                                        <div t-if="this.totalOvertime()" class="d-flex flex-column w-100 mb-0">
+                                            <span class="text-nowrap">Total</span>
+                                            <span class="fs-6"><strong><t t-out="this.totalOvertime()"/></strong></span>
                                         </div>
                                     </div>
+                                </div>
+                                <div t-if="this.isCheckOut and this.props.employeeData.break_management_enabled"
+                                    role="group" class="alert alert-secondary d-flex flex-column align-items-center">
+                                    <button type="button" class="btn btn-secondary px-4 fw-semibold"
+                                        t-on-click="this.continueBreak">
+                                        Add my break times
+                                    </button>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-            <div class="o_hr_kiosk_mode_bottom my-4 mx-auto">
+            <div class="o_hr_kiosk_mode_bottom my-2 mx-auto flex-shrink-0">
                 <button class="btn btn-primary btn-lg rounded-pill px-5" t-on-click="this.props.kioskReturn">
-                    OK
+                    Next
                 </button>
             </div>
         </t>

--- a/addons/hr_attendance/static/src/components/greetings/greetings.xml
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.xml
@@ -5,8 +5,8 @@
         <div class="o_hr_attendance_user_badge text-center">
             <img
                 class="o_hr_attendance_employee_badge img rounded-circle"
-                t-attf-src="{{employeeAvatar}}"
-                t-attf-height="{{ employeeAvatarHeight or '120'}}"/>
+                t-attf-src="{{badgeAvatar}}"
+                t-attf-height="{{ badgeAvatarHeight or '120'}}"/>
         </div>
     </t>
 
@@ -15,56 +15,80 @@
             <div class="o_hr_kiosk_mode_main d-flex flex-grow-1 justify-content-center align-items-center">
                 <div class="o_hr_attendance_kiosk_card card rounded-3">
                     <div class="card-body rounded-3">
-                        <div class="o_hr_attendance_kiosk_card_wrapper d-flex flex-column align-items-center justify-content-center">
+                        <div
+                            class="o_hr_attendance_kiosk_card_wrapper d-flex flex-column
+                                   align-items-center justify-content-center">
                             <div class="o_hr_attendance_kiosk_card_main p-3 mx-3 mx-xl-0 text-center">
                                 <t t-call="hr_attendance.EmployeeBadge">
-                                    <t t-set="employeeAvatar" t-value="this.employeeAvatar"/>
+                                    <t t-set="badgeAvatar" t-value="this.employeeAvatar"/>
+                                    <t t-set="badgeAvatarHeight" t-value="'88'"/>
                                 </t>
-                                <h5 class="text-muted mt-2 mb-0">
-                                    <t t-if="this.attendance.check_out" >Goodbye</t>
-                                    <t t-else="">Welcome</t>
-                                </h5>
-                                <h2><t t-out="this.employeeName"/></h2>
+                                <div class="o_hr_kiosk_greeting_header mt-2">
+                                    <h2 class="o_hr_kiosk_greeting_title mb-1">
+                                        <t t-out="this.greetingTitle"/>
+                                    </h2>
+                                    <div class="o_hr_kiosk_greeting_name">
+                                        <t t-out="this.employeeName"/>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="o_hr_attendance_kiosk_card_bottom d-flex flex-column w-100">
-                                <div class="alert alert-info text-center p-3" role="status">
-                                    <t t-if="this.attendance.check_out">
-                                        Checked out at <strong><t t-out="this.check_out_time"/></strong>
+                            <div class="o_hr_attendance_kiosk_card_bottom d-flex flex-column w-100 gap-2">
+                                <div
+                                    t-attf-class="alert {{ this.statusAlertClass }}
+                                                  o_hr_kiosk_status_alert text-center mb-0 p-3"
+                                    role="status">
+                                    <strong><t t-out="this.statusMessage"/></strong>
+                                </div>
+                                <div
+                                    t-if="this.hoursToday != '00:00'"
+                                    class="alert alert-info o_hr_kiosk_info_alert text-center mb-0 p-3"
+                                    role="status">
+                                    <t t-if="this.isEmployeeSingleCheckIn and !this.attendance.check_out">
+                                        You’ve already checked in.
                                     </t>
                                     <t t-else="">
-                                        Checked in at <strong><t t-out="this.check_in_time"/></strong>
+                                        <t t-out="this.secondarySummaryLabel"/>:
+                                        <strong><t t-out="this.hoursToday"/></strong>
                                     </t>
                                 </div>
-                                <div class="d-flex flex-column w-100">
-                                    <div
-                                        class="alert alert-info text-center p-3"
-                                        t-if="this.hoursToday != '00:00'"
-                                        role="status">
-                                        <t t-if="this.isEmployeeSingleCheckIn and !this.attendance.check_out">
-                                            You’ve already checked in.
-                                        </t>
-                                        <t t-elif="this.attendance.check_out">
-                                            Hours Today: <strong><t t-out="this.hoursToday"/></strong>
-                                        </t>
-                                        <t t-else="">
-                                            Hours Previously Today: <strong><t t-out="this.hoursToday"/></strong>
-                                        </t>
+                                <div
+                                    t-if="this.attendance.check_out and this.overtimeToday"
+                                    class="alert alert-warning d-flex flex-column gap-2 mb-0
+                                           p-2 p-xl-3 border border-warning text-center">
+                                    <div class="small fw-bolder text-uppercase">
+                                        Extra hours
                                     </div>
-                                    <div t-if="this.attendance.check_out and this.overtimeToday" class="alert alert-warning d-flex flex-column gap-2 mb-0 p-2 p-xl-3 border border-warning text-center">
-                                        <div class="small fw-bolder text-uppercase">
-                                            Extra hours
+                                    <div class="d-flex gap-2">
+                                        <div class="d-flex flex-column w-100 mb-0 ">
+                                            <span class="text-nowrap">Today</span>
+                                            <span class="fs-6"><strong><t t-out="this.overtimeToday"/></strong></span>
                                         </div>
-                                        <div class="d-flex gap-2">
-                                            <div class="d-flex flex-column w-100 mb-0 ">
-                                                <span class="text-nowrap">Today</span>
-                                                <span class="fs-6"><strong><t t-out="this.overtimeToday"/></strong></span>
-                                            </div>
-                                            <div t-if="this.totalOvertime" class="d-flex flex-column w-100 mb-0 ">
-                                                <span class="text-nowrap">Total</span>
-                                                <span class="fs-6"><strong><t t-out="this.totalOvertime"/></strong></span>
-                                            </div>
+                                        <div t-if="this.totalOvertime" class="d-flex flex-column w-100 mb-0 ">
+                                            <span class="text-nowrap">Total</span>
+                                            <span class="fs-6"><strong><t t-out="this.totalOvertime"/></strong></span>
                                         </div>
                                     </div>
+                                </div>
+                            </div>
+                            <div
+                                t-if="this.shouldShowCheckoutActions"
+                                class="o_hr_kiosk_checkout_actions mt-3">
+                                <div class="o_hr_kiosk_checkout_actions_label">Continue as</div>
+                                <div class="o_hr_kiosk_checkout_actions_buttons">
+                                    <button
+                                        type="button"
+                                        class="btn o_hr_kiosk_checkout_action_button"
+                                        t-att-disabled="this.props.savingCheckoutAction"
+                                        t-on-click="this.props.onSelectBreakTime">
+                                        Break time
+                                    </button>
+                                    <button
+                                        type="button"
+                                        class="btn o_hr_kiosk_checkout_action_button"
+                                        t-att-disabled="this.props.savingCheckoutAction"
+                                        t-on-click="this.props.onSelectOutOfOffice">
+                                        Out of office
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -72,8 +96,11 @@
                 </div>
             </div>
             <div class="o_hr_kiosk_mode_bottom my-4 mx-auto">
-                <button class="btn btn-primary btn-lg rounded-pill px-5" t-on-click="this.props.kioskReturn">
-                    OK
+                <button
+                    class="btn btn-secondary btn-lg rounded-pill px-5 o_hr_kiosk_next_button"
+                    t-att-disabled="this.props.savingCheckoutAction"
+                    t-on-click="this.props.kioskReturn">
+                    Next
                 </button>
             </div>
         </t>

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -1,3 +1,4 @@
+import { BreakDurationDialog } from "@hr_attendance/components/break_duration_dialog/break_duration_dialog";
 import { CardLayout } from "@hr_attendance/components/card_layout/card_layout";
 import { KioskConfirmation } from "@hr_attendance/components/confirmation/confirmation";
 import { KioskGreetings } from "@hr_attendance/components/greetings/greetings";
@@ -57,6 +58,7 @@ class kioskAttendanceApp extends Component {
         });
         this.lockScanner = false;
         this.cameraCapture = null;
+        this.lastIdentification = null;
         if (this.state.kioskMode === "settings" || this.props.fromTrialMode) {
             this.manualKioskMode = false;
             useBus(this.barcode.bus, "barcode_scanned", (ev) =>
@@ -194,6 +196,10 @@ class kioskAttendanceApp extends Component {
             check_in_image: checkInImage,
         });
         if (result && result.attendance) {
+            this.lastIdentification = {
+                employeeId,
+                params: { employee_id: employeeId, pin_code: enteredPin },
+            };
             this.employeeData = result;
             this.displayServerNotification(result.notification);
             this.switchDisplay("greet");
@@ -221,6 +227,10 @@ class kioskAttendanceApp extends Component {
             });
 
             if (result && result.employee_name) {
+                this.lastIdentification = {
+                    employeeId: result.id,
+                    params: { barcode },
+                };
                 this.employeeData = result;
                 this.displayServerNotification(result.notification);
                 this.switchDisplay("greet");
@@ -237,10 +247,67 @@ class kioskAttendanceApp extends Component {
         }
     }
 
+    async continueAsBreakTime() {
+        const employee = this.employeeData;
+        if (!employee?.id) {
+            this.kioskReturn();
+            return;
+        }
+
+        const minutes = await this.requestBreakDuration(employee.employee_name);
+        if (minutes === null) {
+            this.kioskReturn();
+            return;
+        }
+
+        this.ui.block();
+        try {
+            const identificationParams =
+                this.lastIdentification?.employeeId === employee.id
+                    ? this.lastIdentification.params
+                    : { employee_id: employee.id };
+            const result = await rpc("update_break_duration", {
+                token: this.props.token,
+                ...identificationParams,
+                attendance_id: employee.attendance.id,
+                break_duration: minutes / 60,
+            });
+
+            if (result && result.attendance) {
+                this.employeeData = result;
+                this.displayServerNotification(result.notification);
+            } else {
+                this.displayNotification(_t("Could not save break duration. Please identify again."));
+            }
+            this.kioskReturn();
+        } catch (error) {
+            this.displayNotification(error?.data?.message || error?.message);
+            this.kioskReturn();
+        } finally {
+            this.ui.unblock();
+        }
+    }
+
     removeDemoMessage() {
         this.state.displayDemoMessage = false;
         browser.localStorage.setItem("hr_attendance.ShowDemoMessage", "false");
         return;
+    }
+
+    requestBreakDuration(employeeName) {
+        return new Promise((resolve) => {
+            let selectedMinutes = null;
+            this.dialogService.add(
+                BreakDurationDialog,
+                {
+                    employeeName,
+                    onConfirm: (minutes) => (selectedMinutes = minutes),
+                },
+                {
+                    onClose: () => resolve(selectedMinutes),
+                }
+            );
+        });
     }
 
     setCameraCapture(capturePicture) {

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -5,6 +5,7 @@ import { KioskManualSelection } from "@hr_attendance/components/manual_selection
 import { makeEnv, startServices } from "@web/env";
 import { getTemplate } from "@web/core/templates";
 import { _t, appTranslateFn } from "@web/core/l10n/translation";
+import { deserializeDateTime } from "@web/core/l10n/dates";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { rpc } from "@web/core/network/rpc";
 import { useService, useBus } from "@web/core/utils/hooks";
@@ -16,6 +17,7 @@ import { browser } from "@web/core/browser/browser";
 import { isIosApp } from "@web/core/browser/feature_detection";
 import { DocumentationLink } from "@web/views/widgets/documentation_link/documentation_link";
 import { NewEmployeeDialog } from "@hr_attendance/components/new_employee_dialog/new_employee_dialog";
+import { BreakDurationDialog } from "@hr_attendance/components/break_duration_dialog/break_duration_dialog";
 import { session } from "@web/session";
 
 class kioskAttendanceApp extends Component{
@@ -29,6 +31,7 @@ class kioskAttendanceApp extends Component{
         barcodeSource: { type: String },
         fromTrialMode: { type: Boolean },
         deviceTrackingEnabled: { type: Boolean },
+        breakManagementEnabled: { type: Boolean },
     };
     static components = {
         KioskBarcodeScanner,
@@ -51,6 +54,9 @@ class kioskAttendanceApp extends Component{
         this.state = useState({
             active_display: "settings",
             displayDemoMessage: browser.localStorage.getItem("hr_attendance.ShowDemoMessage") !== "false",
+            employeeData: null,
+            showGreetingCheckoutActions: false,
+            savingGreetingAction: false,
         });
         this.lockScanner = false;
         if (this.props.kioskMode === 'settings' || this.props.fromTrialMode){
@@ -104,8 +110,8 @@ class kioskAttendanceApp extends Component{
                 'employee_id': employeeId
             })
         if (employee && employee.employee_name){
+            this.state.employeeData = employee;
             if (employee.use_pin){
-                this.employeeData = employee
                 this.switchDisplay('pin')
             }else{
                 await this.onManualSelection(employeeId, false)
@@ -124,10 +130,24 @@ class kioskAttendanceApp extends Component{
         ) {
             this.switchDisplay("settings");
         } else if (this.props.kioskMode === 'manual') {
+            this.clearGreetingCheckoutActions();
             this.switchDisplay("manual");
         } else {
+            this.clearGreetingCheckoutActions();
             this.switchDisplay("main");
         }
+    }
+
+    clearGreetingCheckoutActions() {
+        this.state.showGreetingCheckoutActions = false;
+        this.state.savingGreetingAction = false;
+    }
+
+    shouldShowGreetingCheckoutActions(employeeData) {
+        return Boolean(
+            employeeData?.break_management_enabled
+            && employeeData.attendance_state === "checked_in"
+        );
     }
 
     displayNotification(text){
@@ -162,18 +182,24 @@ class kioskAttendanceApp extends Component{
     }
 
     async onManualSelection(employeeId, enteredPin) {
+        const pendingEmployee = this.state.employeeData;
+        const showGreetingCheckoutActions =
+            this.shouldShowGreetingCheckoutActions(pendingEmployee);
         const result = await this.makeRpcWithGeolocation('manual_selection',
             {
                 'token': this.props.token,
                 'employee_id': employeeId,
-                'pin_code': enteredPin
+                'pin_code': enteredPin,
+                'break_duration': showGreetingCheckoutActions ? 0 : null,
             })
         if (result && result.attendance) {
-            this.employeeData = result
-            this.switchDisplay('greet')
+            this.state.employeeData = result;
+            this.state.showGreetingCheckoutActions = showGreetingCheckoutActions;
+            this.state.savingGreetingAction = false;
+            this.switchDisplay('greet');
         }else{
             if (enteredPin){
-                this.displayNotification(_t("Wrong Pin"))
+                this.displayNotification(_t("Wrong Pin"));
             }
         }
     }
@@ -185,15 +211,21 @@ class kioskAttendanceApp extends Component{
         this.lockScanner = true;
         this.ui.block();
 
-        let result;
         try {
-            result = await rpc("attendance_barcode_scanned", {
+            const result = await rpc("attendance_barcode_scanned", {
                 barcode: barcode,
                 token: this.props.token,
             });
 
             if (result && result.employee_name) {
-                this.employeeData = result;
+                const showGreetingCheckoutActions = Boolean(
+                    this.props.breakManagementEnabled
+                    && result.break_management_enabled
+                    && result.attendance?.check_out
+                );
+                this.state.employeeData = result;
+                this.state.showGreetingCheckoutActions = showGreetingCheckoutActions;
+                this.state.savingGreetingAction = false;
                 this.switchDisplay("greet");
             } else {
                 this.displayNotification(
@@ -201,10 +233,90 @@ class kioskAttendanceApp extends Component{
                 );
             }
         } catch (error) {
-            this.displayNotification(error.data.message);
+            this.displayNotification(error?.data?.message || error?.message);
         } finally {
             this.lockScanner = false;
             this.ui.unblock();
+        }
+    }
+
+    _getAttendanceMaxBreakMinutes(employeeData) {
+        const attendance = employeeData?.attendance;
+        if (!(attendance?.check_in && attendance?.check_out)) {
+            return null;
+        }
+        const checkInDate = deserializeDateTime(attendance.check_in);
+        const checkOutDate = deserializeDateTime(attendance.check_out);
+        if (!(checkInDate?.isValid && checkOutDate?.isValid)) {
+            return null;
+        }
+        const durationMinutes = checkOutDate.diff(checkInDate, "minutes").minutes;
+        return Math.max(Math.floor(durationMinutes || 0), 0);
+    }
+
+    async requestBreakDuration(employeeName, maxMinutes = null) {
+        return new Promise((resolve) => {
+            let settled = false;
+            const finalize = (value) => {
+                if (!settled) {
+                    settled = true;
+                    resolve(value);
+                }
+            };
+            this.dialogService.add(
+                BreakDurationDialog,
+                {
+                    employeeName,
+                    defaultMinutes: 0,
+                    maxMinutes: typeof maxMinutes === "number" ? maxMinutes : undefined,
+                    onConfirm: (minutes) => finalize(minutes),
+                    onCancel: () => finalize(null),
+                },
+                {
+                    onClose: () => finalize(null),
+                }
+            );
+        });
+    }
+
+    async onGreetingBreakTime() {
+        if (!this.state.employeeData) {
+            return;
+        }
+        const maxBreakMinutes = this._getAttendanceMaxBreakMinutes(this.state.employeeData);
+        const minutes = await this.requestBreakDuration(
+            this.state.employeeData.employee_name,
+            maxBreakMinutes
+        );
+        if (minutes === null) {
+            return;
+        }
+        await this.updateGreetingBreakDuration((Number(minutes) || 0) / 60);
+    }
+
+    onGreetingOutOfOffice() {
+        this.clearGreetingCheckoutActions();
+    }
+
+    async updateGreetingBreakDuration(breakDurationHours) {
+        if (!this.state.employeeData) {
+            return;
+        }
+        this.state.savingGreetingAction = true;
+        try {
+            const result = await rpc("attendance_kiosk_break_duration", {
+                token: this.props.token,
+                employee_id: this.state.employeeData.id,
+                break_duration: breakDurationHours,
+            });
+            if (result && result.attendance) {
+                this.state.employeeData = result;
+                this.clearGreetingCheckoutActions();
+            }
+        } catch (error) {
+            this.displayNotification(error?.data?.message || error?.message);
+        } finally {
+            this.state.savingGreetingAction = false;
         }
     }
 
@@ -233,6 +345,7 @@ export async function createPublicKioskAttendance(document, kiosk_backend_info) 
                 barcodeSource: kiosk_backend_info.barcode_source,
                 fromTrialMode: kiosk_backend_info.from_trial_mode,
                 deviceTrackingEnabled: kiosk_backend_info.device_tracking_enabled,
+                breakManagementEnabled: kiosk_backend_info.break_management_enabled,
             },
         dev: env.debug,
         translateFn: appTranslateFn,

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -106,6 +106,7 @@
         companyImageUrl="this.companyImageUrl"
         kioskReturn.bind="this.kioskReturn"
         activeDisplay="this.state.active_display"
+        kioskModeClasses="this.state.active_display === 'greet' ? 'flex-grow-1 h-auto' : ''"
     >
         <t t-if="this.state.active_display === 'settings'">
             <t t-call="hr_attendance.PublicKiosksSettingScreen"/>
@@ -182,7 +183,10 @@
             />
         </t>
         <t t-if="this.state.active_display === 'greet'">
-            <KioskGreetings employeeData="this.employeeData" kioskReturn="() => this.kioskReturn(true)"/>
+            <KioskGreetings
+                employeeData="this.employeeData"
+                kioskReturn="() => this.kioskReturn(true)"
+                kioskContinueBreak.bind="this.continueAsBreakTime"/>
         </t>
         <t t-if="this.state.active_display === 'pin'">
             <KioskPinCode

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -151,11 +151,17 @@
                 token="this.props.token"/>
         </t>
         <t t-if="this.state.active_display === 'greet'">
-            <KioskGreetings employeeData="this.employeeData" kioskReturn="() => this.kioskReturn(true)"/>
+            <KioskGreetings
+                employeeData="this.state.employeeData"
+                kioskReturn="() => this.kioskReturn(true)"
+                showCheckoutActions="this.state.showGreetingCheckoutActions"
+                savingCheckoutAction="this.state.savingGreetingAction"
+                onSelectBreakTime="() => this.onGreetingBreakTime()"
+                onSelectOutOfOffice="() => this.onGreetingOutOfOffice()"/>
         </t>
         <t t-if="this.state.active_display === 'pin'">
             <KioskPinCode
-                employeeData="this.employeeData"
+                employeeData="this.state.employeeData"
                 onPinConfirm="(id, pin) => this.onManualSelection(id, pin)"
                 onClickBack="() => this.kioskReturn()"/>
         </t>

--- a/addons/hr_attendance/static/src/scss/kiosk/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/kiosk/hr_attendance.scss
@@ -75,6 +75,95 @@
     @include media-breakpoint-up(xl) {
         min-width: 35%;
     }
+
+    .o_hr_kiosk_greeting_header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .o_hr_kiosk_greeting_title {
+        font-size: clamp(2.4rem, 3.6vw, 3.35rem);
+        line-height: 1;
+        font-weight: 500;
+        color: $body-color;
+    }
+
+    .o_hr_kiosk_greeting_name {
+        font-size: clamp(1.4rem, 2vw, 2rem);
+        line-height: 1.15;
+        color: $gray-700;
+    }
+
+    .o_hr_kiosk_status_alert,
+    .o_hr_kiosk_info_alert {
+        border-radius: 0.85rem;
+        border-width: 1px;
+    }
+
+    .o_hr_kiosk_status_alert.alert-success {
+        background-color: tint-color($success, 82%);
+        border-color: tint-color($success, 68%);
+        color: shade-color($success, 38%);
+    }
+
+    .o_hr_kiosk_status_alert.alert-danger {
+        background-color: tint-color($danger, 86%);
+        border-color: tint-color($danger, 72%);
+        color: shade-color($danger, 30%);
+    }
+
+    .o_hr_kiosk_info_alert {
+        background-color: tint-color($info, 84%);
+        border-color: tint-color($info, 70%);
+        color: $body-color;
+    }
+}
+
+.o_hr_kiosk_checkout_actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.875rem 1rem 1rem;
+    border: 1px solid var(--#{$prefix}border-color);
+    border-radius: var(--#{$prefix}border-radius-xl);
+    background: var(--#{$prefix}tertiary-bg);
+    color: var(--#{$prefix}secondary-color);
+
+    .o_hr_kiosk_checkout_actions_label {
+        font-size: 1rem;
+        line-height: 1;
+    }
+
+    .o_hr_kiosk_checkout_actions_buttons {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.75rem;
+        width: 100%;
+    }
+
+    .o_hr_kiosk_checkout_action_button {
+        min-width: 10rem;
+        padding: 0.6rem 1.25rem;
+        border: 1px solid var(--#{$prefix}warning-border-subtle, #{$warning});
+        border-radius: $border-radius-xl;
+        color: var(--#{$prefix}warning-text-emphasis, #{$warning});
+        background: var(--#{$prefix}warning-bg-subtle, rgba($warning, 0.12));
+
+        &:hover,
+        &:focus {
+            color: var(--#{$prefix}warning-text-emphasis, #{$warning});
+            background: var(--#{$prefix}warning-bg-subtle, rgba($warning, 0.18));
+            border-color: var(--#{$prefix}warning-border-subtle, #{$warning});
+        }
+    }
+}
+
+.o_hr_kiosk_next_button {
+    min-width: 9rem;
 }
 
 .o_hr_attendance_kiosk_mode {

--- a/addons/hr_attendance/static/src/scss/views/hr_attendance.dark.scss
+++ b/addons/hr_attendance/static/src/scss/views/hr_attendance.dark.scss
@@ -1,6 +1,13 @@
 .att_container {
-    .o_att_today_wrap table {
-        --#{$prefix}table-bg: none;
-        --#{$prefix}table-border-color: #{$gray-400};
+    --o-attendance-review-card-bg: rgba(255, 255, 255, 0.04);
+    --o-attendance-review-card-hover-bg: rgba(255, 255, 255, 0.08);
+    --o-attendance-review-border-color: rgba(255, 255, 255, 0.12);
+
+    .o_attendance_review_card {
+        border-color: var(--o-attendance-review-border-color);
+    }
+
+    .o_attendance_review_summary {
+        background: var(--o-attendance-review-card-bg);
     }
 }

--- a/addons/hr_attendance/static/src/scss/views/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/views/hr_attendance.scss
@@ -13,9 +13,122 @@
 }
 
 .att_container {
+    --o-attendance-review-card-bg: rgba(var(--#{$prefix}body-color-rgb), 0.02);
+    --o-attendance-review-card-hover-bg: rgba(var(--#{$prefix}body-color-rgb), 0.04);
+    --o-attendance-review-border-color: var(--#{$prefix}border-color);
+
     font-variant-numeric: tabular-nums;
+    min-width: 22rem;
 
     .o_wrap_btn_sign_out {
         background: var(--#{$prefix}popover-bg);
+    }
+
+    .o_attendance_review_wrap {
+        padding: 1rem 0;
+        width: 100%;
+    }
+
+    .o_attendance_review_grid {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .o_attendance_review_card {
+        min-width: 0;
+        border: 1px solid var(--o-attendance-review-border-color);
+        border-radius: var(--#{$prefix}border-radius-lg);
+        background: var(--o-attendance-review-card-bg);
+        padding: 0.875rem;
+    }
+
+    .o_attendance_review_location {
+        margin-top: 0.375rem;
+        display: -webkit-box;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+        word-break: break-word;
+    }
+
+    .o_attendance_review_sessions {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 0.75rem;
+        padding: 0.5rem 0.875rem;
+        border: 1px solid var(--o-attendance-review-border-color);
+        border-radius: var(--#{$prefix}border-radius-xl);
+        background: var(--#{$prefix}popover-bg);
+    }
+
+    .o_attendance_review_session {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 0.75rem;
+        align-items: center;
+        padding: 0.4rem 0;
+
+        & + .o_attendance_review_session {
+            border-top: 1px solid var(--o-attendance-review-border-color);
+        }
+
+        &.o_is_selectable {
+            cursor: pointer;
+            transition: background-color 120ms ease-in-out;
+
+            &:hover,
+            &:focus-visible {
+                background: var(--o-attendance-review-card-hover-bg);
+            }
+        }
+
+        &.o_is_selected {
+            background: var(--o-attendance-review-card-hover-bg);
+        }
+    }
+
+    .o_attendance_review_session_range {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--#{$prefix}secondary-color);
+    }
+
+    .o_attendance_review_summary {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        margin-bottom: 1rem;
+        padding: 0.875rem;
+        border-radius: var(--#{$prefix}border-radius-xl);
+        border: 1px solid var(--o-attendance-review-border-color);
+        background: var(--#{$prefix}body-bg);
+        color: var(--#{$prefix}emphasis-color);
+    }
+
+    .o_attendance_review_summary_item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.125rem;
+        min-width: 0;
+        text-align: center;
+
+        &.w-100 {
+            grid-column: 1 / -1;
+        }
+    }
+
+    .o_attendance_review_summary_value {
+        font-size: 1.1rem;
+        line-height: 1.2;
+    }
+
+    .o_attendance_review_break_input {
+        max-width: 10rem;
     }
 }

--- a/addons/hr_attendance/static/tests/greetings.test.js
+++ b/addons/hr_attendance/static/tests/greetings.test.js
@@ -1,0 +1,94 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { BreakDurationDialog } from "@hr_attendance/components/break_duration_dialog/break_duration_dialog";
+import { KioskGreetings } from "@hr_attendance/components/greetings/greetings";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import {
+    assignDialogTestEnv,
+    contains,
+    makeTestApp,
+    mountWithCleanup,
+} from "@web/../tests/web_test_helpers";
+
+defineMailModels();
+
+beforeEach(async () => {
+    assignDialogTestEnv();
+    await makeTestApp();
+});
+
+function getEmployeeData(attendance, breakManagementEnabled = false) {
+    return {
+        attendance,
+        break_management_enabled: breakManagementEnabled,
+        display_overtime: false,
+        employee_avatar: "",
+        employee_name: "Mitchell Admin",
+        hours_today: 2,
+        is_employee_single_checkin: false,
+        kiosk_delay: 60_000,
+    };
+}
+
+test("check-in greeting displays the status and returns to the kiosk", async () => {
+    await mountWithCleanup(KioskGreetings, {
+        props: {
+            employeeData: getEmployeeData({
+                check_in: "2026-07-21 09:30:00",
+                check_out: false,
+            }),
+            kioskReturn: () => expect.step("return"),
+        },
+    });
+
+    expect(".o_hr_attendance_kiosk_card").toHaveText(/Welcome/);
+    expect(".o_hr_attendance_kiosk_card").toHaveText(/Checked in at/);
+    expect("button").not.toHaveText("Add my break times");
+    await contains(".o_hr_kiosk_mode_bottom button").click();
+
+    expect.verifySteps(["return"]);
+});
+
+test("break duration dialog validates and submits whole minutes", async () => {
+    await mountWithCleanup(BreakDurationDialog, {
+        props: {
+            employeeName: "Mitchell Admin",
+            onConfirm: (minutes) => expect.step(`confirmed ${minutes}`),
+            close: () => expect.step("closed"),
+        },
+        noMainContainer: true,
+    });
+
+    expect("label[for='o_break_duration_minutes']").toHaveCount(1);
+    await contains("#o_break_duration_minutes").edit("-1", { instantly: true });
+    await contains(".modal-footer .btn-primary").click();
+
+    expect.verifySteps([]);
+    expect(".modal").toHaveCount(1);
+
+    await contains("#o_break_duration_minutes").edit("10");
+    await contains(".modal-footer .btn-primary").click();
+
+    expect.verifySteps(["confirmed 10", "closed"]);
+});
+
+test("checkout greeting can continue to break entry", async () => {
+    await mountWithCleanup(KioskGreetings, {
+        props: {
+            employeeData: getEmployeeData(
+                {
+                    check_in: "2026-07-21 09:30:00",
+                    check_out: "2026-07-21 11:30:00",
+                },
+                true
+            ),
+            kioskContinueBreak: () => expect.step("continue break"),
+            kioskReturn: () => expect.step("unexpected return"),
+        },
+    });
+
+    expect(".o_hr_attendance_kiosk_card").toHaveText(/Goodbye/);
+    expect(".o_hr_attendance_kiosk_card").toHaveText(/Checked out at/);
+    await contains("button", { text: "Add my break times" }).click();
+
+    expect.verifySteps(["continue break"]);
+});

--- a/addons/hr_attendance/tests/test_hr_attendance_kiosk.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_kiosk.py
@@ -1,9 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
+from datetime import timedelta
 from unittest.mock import patch
 
+from odoo import fields
 from odoo.http.requestlib import Request
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase, JsonRpcException, tagged
+from odoo.tools import mute_logger
 
 
 @tagged('post_install', '-at_install', 'hr_attendance_overtime')
@@ -20,13 +23,31 @@ class TestHrAttendanceKiosk(HttpCase):
 
         cls.employee_A = cls.env['hr.employee'].create({
             'name': 'employee_A',
-             'company_id': cls.company_B.id,
-             'department_id': cls.department_A.id,
+            'company_id': cls.company_B.id,
+            'department_id': cls.department_A.id,
+            'barcode': 'EMPLOYEEA123',
+            'pin': '1234',
         })
         cls.employee_B = cls.env['hr.employee'].create({
             'name': 'employee_B',
             'company_id': cls.company_A.id,
             'department_id': cls.department_A.id,
+        })
+        cls.company_B.attendance_break_management = True
+
+    def _create_checked_out_attendance(self, employee=None):
+        employee = employee or self.employee_A
+        now = fields.Datetime.now()
+        return self.env['hr.attendance'].create({
+            'employee_id': employee.id,
+            'check_in': now - timedelta(hours=2),
+            'check_out': now - timedelta(hours=1),
+        })
+
+    def _update_break(self, **params):
+        return self.make_jsonrpc_request('/hr_attendance/update_break_duration', {
+            'token': self.company_B.attendance_kiosk_key,
+            **params,
         })
 
     def test_employee_count_kiosk(self):
@@ -64,3 +85,77 @@ class TestHrAttendanceKiosk(HttpCase):
         )
         result = json.loads(response.content).get('result')
         self.assertTrue(result['records'])
+
+    def test_update_break_duration_checks_identification_and_attendance(self):
+        attendance = self._create_checked_out_attendance()
+        self.company_B.attendance_kiosk_use_pin = True
+
+        self.assertFalse(self._update_break(
+            employee_id=self.employee_A.id,
+            pin_code='wrong',
+            attendance_id=attendance.id,
+            break_duration=0.5,
+        ))
+        self.assertFalse(self._update_break(
+            employee_id=self.employee_B.id,
+            attendance_id=attendance.id,
+            break_duration=0.5,
+        ))
+        self.assertFalse(self.make_jsonrpc_request('/hr_attendance/update_break_duration', {
+            'token': 'invalid',
+            'barcode': self.employee_A.barcode,
+            'attendance_id': attendance.id,
+            'break_duration': 0.5,
+        }))
+        result = self._update_break(
+            barcode=self.employee_A.barcode,
+            attendance_id=attendance.id,
+            break_duration=0.5,
+        )
+        self.assertTrue(result['attendance'])
+        self.assertEqual(attendance.break_duration, 0.5)
+
+    def test_update_break_duration_only_updates_last_closed_attendance(self):
+        previous_attendance = self._create_checked_out_attendance()
+        now = fields.Datetime.now()
+        latest_attendance = self.env['hr.attendance'].create({
+            'employee_id': self.employee_A.id,
+            'check_in': now - timedelta(minutes=30),
+        })
+
+        self.assertFalse(self._update_break(
+            employee_id=self.employee_A.id,
+            attendance_id=previous_attendance.id,
+            break_duration=0.5,
+        ))
+        self.assertFalse(self._update_break(
+            employee_id=self.employee_A.id,
+            attendance_id=latest_attendance.id,
+            break_duration=0.5,
+        ))
+        latest_attendance.check_out = now
+        with self.assertRaises(JsonRpcException), mute_logger('odoo.http'):
+            self._update_break(
+                employee_id=self.employee_A.id,
+                attendance_id=latest_attendance.id,
+                break_duration=1,
+            )
+
+    def test_update_break_duration_does_not_change_manager_approved_attendance(self):
+        attendance = self._create_checked_out_attendance()
+        self.company_B.attendance_overtime_validation = 'by_manager'
+        self.env['hr.attendance.overtime.line'].create({
+            'attendance_id': attendance.id,
+            'date': attendance.date,
+            'duration': 0.5,
+            'status': 'approved',
+        })
+
+        result = self._update_break(
+            employee_id=self.employee_A.id,
+            attendance_id=attendance.id,
+            break_duration=0.5,
+        )
+
+        self.assertFalse(result)
+        self.assertFalse(attendance.break_duration)

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -176,13 +176,6 @@ class TestHrAttendance(HttpCase, TransactionCase):
             employee.invalidate_recordset(['hours_today'])
             self.assertAlmostEqual(employee.hours_today, 0, places=6)
 
-    def test_break_duration_normalization(self):
-        self.assertEqual(HrAttendance._normalize_break_duration(0), 0.0)
-        self.assertEqual(HrAttendance._normalize_break_duration("0.5"), 0.5)
-        for duration in (None, False, True, "", "invalid", -1, float("inf"), float("nan")):
-            with self.subTest(duration=duration):
-                self.assertIsNone(HrAttendance._normalize_break_duration(duration))
-
     @freeze_time("2024-01-02 12:00:00")
     def test_user_attendance_details_are_opt_in(self):
         now = fields.Datetime.now()

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from odoo import fields
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, new_test_user
 from odoo.tests.common import tagged, TransactionCase, freeze_time
+from odoo.addons.hr_attendance.controllers.main import HrAttendance
 
 
 @tagged('attendance_process')
@@ -90,7 +92,9 @@ class TestHrAttendance(TransactionCase):
         employee = self.env['hr.employee'].create({'name': 'Cunégonde', 'tz': 'Europe/Brussels'})
         self.env['hr.attendance'].create({
             'employee_id': employee.id,
-            'check_in': tz_datetime(2019, 3, 1, 22, 0),  # should count from midnight in the employee's timezone (=the previous day in utc!)
+            'check_in': tz_datetime(
+                2019, 3, 1, 22, 0,
+            ),  # should count from midnight in the employee's timezone (=the previous day in utc!)
             'check_out': tz_datetime(2019, 3, 2, 2, 0),
         })
         self.env['hr.attendance'].create({
@@ -99,7 +103,11 @@ class TestHrAttendance(TransactionCase):
         })
 
         # now = 2019/3/2 14:00 in the employee's timezone
-        with patch.object(fields.Datetime, 'now', lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(UTC).replace(tzinfo=None)):
+        with patch.object(
+            fields.Datetime,
+            'now',
+            lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(UTC).replace(tzinfo=None),
+        ):
             self.assertEqual(employee.hours_today, 5, "It should have counted 5 hours")
 
     def test_remove_check_in_value_from_attendance(self):
@@ -120,6 +128,56 @@ class TestHrAttendance(TransactionCase):
             self.test_employee.action_archive()
             self.assertEqual(test_attendance.check_out, fields.Datetime.now())
             self.assertEqual(test_attendance.worked_hours, 8.0)
+
+    def test_break_duration_updates_worked_hours(self):
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.test_employee.id,
+            'check_in': '2024-01-01 08:00:00',
+            'check_out': '2024-01-01 17:00:00',
+        })
+        initial_hours = attendance.worked_hours
+        attendance.break_duration = 1.0
+        self.assertAlmostEqual(attendance.worked_hours, max(initial_hours - 1.0, 0.0))
+        with patch.object(fields.Datetime, 'now', lambda: datetime(2024, 1, 1, 18, 0, 0)):
+            self.assertAlmostEqual(self.test_employee.hours_today, attendance.worked_hours)
+        with self.assertRaises(ValidationError):
+            attendance.break_duration = -1
+        with self.assertRaises(ValidationError):
+            attendance.break_duration = 12
+
+    def test_break_duration_edit_triggers_overtime_recompute(self):
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.test_employee.id,
+            'check_in': '2024-01-03 08:00:00',
+            'check_out': '2024-01-03 16:00:00',
+        })
+        with patch('odoo.addons.hr_attendance.models.hr_attendance.HrAttendance._update_overtime') as mocked_update:
+            attendance.write({'break_duration': 1.0})
+        self.assertTrue(mocked_update.called)
+
+    def test_break_duration_checkout_action(self):
+        with freeze_time("2024-01-02 08:00:00"):
+            self.test_employee._attendance_action_change()
+        with freeze_time("2024-01-02 17:00:00"):
+            result = self.test_employee.attendance_manual_with_break(0.5)
+        self.assertEqual(result['action']['tag'], 'reload')
+        self.assertAlmostEqual(self.test_employee.last_attendance_id.break_duration, 0.5)
+
+    def test_post_checkout_break_duration_update(self):
+        with freeze_time("2024-01-02 08:00:00"):
+            self.test_employee._attendance_action_change()
+        with freeze_time("2024-01-02 17:00:00"):
+            self.test_employee._attendance_action_change()
+        HrAttendance._set_last_attendance_break_duration(self.test_employee, 0.75)
+        self.assertAlmostEqual(self.test_employee.last_attendance_id.break_duration, 0.75)
+
+    def test_barcode_preview_payload_is_limited(self):
+        payload = HrAttendance._get_break_preview_payload(self.test_employee)
+        self.assertEqual(payload['employee_name'], self.test_employee.name)
+        self.assertEqual(payload['attendance_state'], self.test_employee.attendance_state)
+        self.assertIn('break_management_enabled', payload)
+        self.assertNotIn('attendance', payload)
+        self.assertNotIn('employee_avatar', payload)
 
     # @freeze_time("2024-02-1")
     # def test_change_in_out_mode_when_manual_modification(self):

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -20,6 +20,7 @@
                 <field name="employee_id" widget="many2one_avatar_employee"/>
                 <field name="check_in"/>
                 <field name="check_out" options="{}"/>
+                <field name="break_duration" string="Break Duration" widget="float_time" optional="show"/>
                 <field name="worked_hours" string="Worked Hours" widget="float_time"/>
                 <field name="overtime_hours" string="Worked Extra Hours" optional="show" widget="float_time"/>
                 <field name="validated_overtime_hours" string="Extra Hours" optional="show" widget="float_time"/>
@@ -133,6 +134,7 @@
                                         type="object"
                                         groups="hr_attendance.group_hr_attendance_officer"/>
                                 </div>
+                                <field name="break_duration" widget="float_time" readonly="not can_edit"/>
                             </group>
                         </group>
                         <separator string="Check In"/>
@@ -400,6 +402,7 @@
                 <field name="employee_id" widget="many2one_avatar_employee" readonly="1"/>
                 <field name="check_in" readonly="1"/>
                 <field name="check_out" readonly="1"/>
+                <field name="break_duration" readonly="1" widget="float_time"/>
                 <field name="worked_hours" readonly="1" string="Worked Time" widget="float_time"/>
                 <field name="overtime_hours" string="Worked Extra Hours" widget="float_time"/>
                 <field name="validated_overtime_hours" readonly="overtime_status == 'refused'" string="Extra Hours" widget="float_time"/>

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -156,6 +156,9 @@
             <field name="check_out" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>
+            <field name="break_duration" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </field>
             <field name="validated_overtime_hours" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -38,6 +38,9 @@
                         <setting string="Device &amp; Location Tracking" company_dependent="1" help="Allow the collection of GPS location, IP address, and browser/device details used to track employee access and attendance">
                             <field name="attendance_device_tracking"/>
                         </setting>
+                        <setting string="Break Management on Checkout" company_dependent="1" help="If enabled, employees will be prompted to enter their total break duration when checking out.">
+                            <field name="attendance_break_management"/>
+                        </setting>
                     </block>
                     <block title="Kiosk Settings">
                         <setting invisible="attendance_kiosk_mode == 'manual'" company_dependent="1" help="Define the camera used for the barcode scan.">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Attendance records only represented check-in and check-out times. Unpaid
breaks therefore required manual time corrections and were not consistently
reflected in worked hours, overtime, the attendance systray or the kiosk flow.

Current behavior before PR:

- The complete check-in/check-out interval is treated as worked time.
- Employees cannot review and correct attendance details from the systray.
- Kiosk users cannot record their total break after checking out.

Desired behavior after PR is merged:

Add an optional company-level break management setting and store the total
break duration on each attendance. Validate that breaks apply only to closed
attendances, are non-negative and do not exceed the attendance duration.

Deduct breaks from worked hours, daily attendance totals and overtime.
Recompute overtime when a break changes and expose the break information in
the relevant attendance and employee views.

Add an attendance review to the systray showing today's sessions, check-in and
check-out details, locations, breaks and total worked duration. Allow permitted
users to edit attendance details using explicit Save and Discard actions.
Pending changes are saved before switching sessions or checking in or out,
while validation failures keep the draft available for correction.

Update the kiosk checkout flow with a dedicated dialog for recording break
minutes on the attendance that was just closed. Preserve manual, PIN and
barcode identification and keep server-side validation authoritative if the
attendance changes before the break is saved.

Add backend and HOOT coverage for break validation, worked-hours and overtime
calculations, attendance review editing and synchronization, and kiosk break
updates.

task-5252996



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr