### PR TITLE
[IMP] orm: binary stored as bytes (not base64) 

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -358,6 +358,7 @@ class IrAttachment(models.Model):
             mimetype = mimetypes.guess_type(values['url'].split('?')[0])[0]
         if not mimetype or mimetype == 'application/octet-stream':
             if raw := values.get('raw'):
+                assert isinstance(raw, bytes), f"Expecting raw bytes, got {type(raw)}"
                 mimetype = guess_mimetype(raw)
         return mimetype.lower() if mimetype else 'application/octet-stream'
 
@@ -752,7 +753,7 @@ class IrAttachment(models.Model):
         for values in vals_list:
             # needs to be popped in all cases to bypass `_inverse_datas`
             datas = values.pop('datas', None)
-            if raw := values.get('raw'):
+            if raw := (values.get('raw') or values.get('db_datas')):
                 if isinstance(raw, str):
                     values['raw'] = raw.encode()
             elif datas:

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -294,13 +294,14 @@ class TestHttpStatic(TestHttpStaticCommon):
             res = self.url_open('/web/content/test_http.earth?field=galaxy_picture')
             self.assertEqual(res.status_code, 404)
 
-    def test_static17_content_missing_checksum(self):
+    def test_static17_content_from_db_datas(self):
+        self.env['ir.config_parameter'].set_str('ir_attachment.location', 'db')
         att = self.env['ir.attachment'].create({
             'name': 'testhttp.txt',
-            'db_datas': 'some data',
+            'raw': b'some data',
             'public': True,
         })
-        self.assertFalse(att.checksum)
+        self.assertFalse(att.store_fname)
         self.assertDownload(
             url=f'/web/content/{att.id}',
             headers={},
@@ -314,15 +315,16 @@ class TestHttpStatic(TestHttpStaticCommon):
             assert_content=b'some data',
         )
 
-    def test_static18_image_missing_checksum(self):
+    def test_static18_image_from_db_datas(self):
+        self.env['ir.config_parameter'].set_str('ir_attachment.location', 'db')
         with file_open('test_http/static/src/img/gizeh.png', 'rb') as file:
             att = self.env['ir.attachment'].create({
                 'name': 'gizeh.png',
-                'db_datas': file.read(),
+                'raw': file.read(),
                 'mimetype': 'image/png',
                 'public': True,
             })
-        self.assertFalse(att.checksum)
+        self.assertFalse(att.store_fname)
         self.assertDownloadGizeh(f'/web/image/{att.id}')
 
     def test_static19_fallback_redirection_loop(self):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -2924,7 +2924,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(record_bin_size.image_256, b'424.00 bytes')
         # non-attachment binary fields: value returned as str in a different
         # form, because coming from PostgreSQL instead of filestore
-        self.assertEqual(record_bin_size.image_64, '148 bytes')
+        self.assertEqual(record_bin_size.image_64, '111 bytes')
 
         # ensure image_data_uri works (value must be bytes and not string)
         self.assertEqual(record.image_256[:8], b'iVBORw0K')

--- a/odoo/addons/test_web/tests/test_web_save.py
+++ b/odoo/addons/test_web/tests/test_web_save.py
@@ -41,8 +41,8 @@ class TestWebSave(TransactionCase):
             {'name': 'test', 'image_wo_attachment': SVG_B64},
             {'image_wo_attachment': {}, 'image_wo_attachment_related': {}},
         )
-        self.assertEqual(result['image_wo_attachment'], '432 bytes')  # From PostgreSQL
-        self.assertEqual(result['image_wo_attachment_related'], b'432.00 bytes')  # From human_size
+        self.assertEqual(result['image_wo_attachment'], '322 bytes')  # From PostgreSQL
+        self.assertEqual(result['image_wo_attachment_related'], b'322.00 bytes')  # From human_size
 
         # check cache values
         record = self.env['test_orm.binary_svg'].browse(result['id'])
@@ -60,8 +60,8 @@ class TestWebSave(TransactionCase):
             {'image_wo_attachment': JPG_B64},
             {'image_wo_attachment': {}, 'image_wo_attachment_related': {}},
         )
-        self.assertEqual(result['image_wo_attachment'], '39 kB')  # From PostgreSQL
-        self.assertEqual(result['image_wo_attachment_related'], b'39.30 Kb')  # From human_size
+        self.assertEqual(result['image_wo_attachment'], '29 kB')  # From PostgreSQL
+        self.assertEqual(result['image_wo_attachment_related'], b'29.47 Kb')  # From human_size
 
         # check cache values
         self.assertEqual(record.image_wo_attachment, JPG_B64)


### PR DESCRIPTION
Since we are going to move to a raw bytes representation in the cache, let's store binary fields that are not attachments as raw bytes in the database instead of storing them in base64-encoded raw bytes (which just use more space).


task-4251301
https://github.com/odoo/upgrade/pull/8995


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
