### PR TITLE
[FIX] point_of_sale: order with archived product can be refunded

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -89,7 +89,7 @@ export class DataServiceOptions {
     }
 
     get cleanupModels() {
-        return ["product.template"];
+        return ["product.template", "product.product"];
     }
 
     get prohibitedAutoLoadedFields() {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -963,7 +963,7 @@ registry.category("web_tour.tours").add("test_barcode_search_attributes_preset",
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("test_remove_archived_product_from_cache", {
+registry.category("web_tour.tours").add("test_archived_product_removed_and_order_is_refunded", {
     steps: () =>
         [
             Chrome.startPoS(),
@@ -989,6 +989,12 @@ registry.category("web_tour.tours").add("test_remove_archived_product_from_cache
             BackendUtils.openShopSession("Shop"),
             Dialog.confirm("Open Register"),
             ProductScreen.productIsDisplayed("A Test Product").map(negateStep),
+            // Refund.
+            Chrome.clickOrders(),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("0001"),
+            TicketScreen.confirmRefund(),
+            ProductScreen.clickPayButton(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_pos_cash_rounding.py
+++ b/addons/point_of_sale/tests/test_pos_cash_rounding.py
@@ -450,7 +450,11 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
         })
         self.start_pos_tour('test_cash_rounding_up_with_change')
 
-    def test_remove_archived_product_from_cache(self):
+    def test_archived_product_removed_and_order_is_refunded(self):
+        """
+        Tests that once product is archived after order is created
+        product is not shown but the order can still be refunded.
+        """
         self.pos_admin.write({
             'group_ids': [
                 (4, self.env.ref('product.group_product_manager').id),
@@ -465,6 +469,6 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
-            "test_remove_archived_product_from_cache",
+            "test_archived_product_removed_and_order_is_refunded",
             login="pos_admin"
         )


### PR DESCRIPTION
Step to reproduce:
- start pos and finalize a order with product A
- go backend
- Archive product A
- start the pos again
- try to refund the order

Observation:
- Blank page with traceback in console

```
Caused by: TypeError: Cannot read properties of undefined (reading 'filter')
at __exports.getOrderChanges
at Proxy.getOrderChanges
```


Cause:
- until now `product.template` model is looked for filter after a reload
https://github.com/odoo/odoo/blob/1b2500422209ed5feb6d49716f94d58c931bf541/addons/point_of_sale/static/src/app/models/data_service_options.js#L91-L93
https://github.com/odoo/odoo/blob/1b2500422209ed5feb6d49716f94d58c931bf541/addons/point_of_sale/static/src/app/services/data_service.js#L290-L295
 and not `product.product`, this makes `product_id` available but 
`product_tmpl_id` undefined, causing inconsistency

Fix:
- we add `product.product` in `cleanupModels` for data to in sync with backend 

opw-5237961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
