### PR TITLE
[FIX] hr_work_entry_enterprise: fix error when click on replace in work entry

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -237,6 +237,14 @@ class HrWorkEntry(models.Model):
         work_entries._check_if_error()
         return work_entries
 
+    def check_modification_allowed(self):
+        """
+        Check that the work entries can be modified.
+        A work entry can't be modified if it's validated and linked to a payslip.
+        :return: True if modification is allowed
+        """
+        return True
+
     def write(self, vals):
         skip_check = not bool({'date_start', 'date_stop', 'employee_id', 'work_entry_type_id', 'active'} & vals.keys())
         if 'state' in vals:


### PR DESCRIPTION

When only `hr_work_entry_enterprise` is installed

Steps to Reproduce:
Go to the Gantt view of work entries
Select cells and click on the quick replace button, and BOOM 
Or select cells and click on Set and then on Replace, and BOOM

Cause:
`check_modification_allowed` This method is causing issues because the method is created in hr_payroll and called in hr_work_entry_enterprise. 
If payroll is not installed, it shows a traceback that the method is not defined.

Fix:
Created the same method in `hr_work_entry` so it doesn't show a traceback when only hr_work_entry_enterprise is installed. When hr_payroll is installed, it calls `check_modification_allowed` from hr_payroll, which works fine without any traceback.

task-4222503