### PR TITLE
[IMP] website, html_builder: allow blocks to have hover animation

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -103,10 +103,10 @@ export class ImageShapeOptionPlugin extends Plugin {
     async canHaveHoverEffect(imgEl) {
         const dataset = Object.assign({}, imgEl.dataset, await loadImageInfo(imgEl));
         return (
-            imgEl.tagName === "IMG" &&
-            !this.isDeviceShape(imgEl) &&
-            !this.isAnimableShape(dataset.shape) &&
-            this.isImageSupportedForShapes(imgEl, dataset)
+            !(imgEl.tagName === "IMG") ||
+            (!this.isDeviceShape(imgEl) &&
+                !this.isAnimableShape(dataset.shape) &&
+                this.isImageSupportedForShapes(imgEl, dataset))
         );
     }
     isDeviceShape(img) {

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -109,7 +109,7 @@ class ImageToolOptionPlugin extends Plugin {
         this.htmlStyle = getHtmlStyle(this.document);
     }
     async canHaveHoverEffect(imgEl) {
-        return imgEl.tagName === "IMG" && !(await isImageCorsProtected(imgEl));
+        return !(imgEl.tagName === "IMG") || !(await isImageCorsProtected(imgEl));
     }
     migrateImages(rootEl) {
         for (const el of selectElements(

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -2,7 +2,9 @@ import {
     BaseOptionComponent,
     useDomState,
     SPECIAL_BLOCKQUOTE_SELECTOR,
+    BLOCKQUOTE_PARENT_HANDLERS,
 } from "@html_builder/core/utils";
+import { CARD_PARENT_HANDLERS, SPECIAL_CARD_SELECTOR } from "./utils";
 import {
     isImageSupportedForStyle,
     socialMediaElementsSelector,
@@ -15,8 +17,8 @@ import {
 export class AnimateOption extends BaseOptionComponent {
     static template = "website.AnimateOption";
     static dependencies = ["animateOption"];
-    static selector = ".o_animable, section .row > div, img, .fa, .btn";
-    static exclude = `[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, ${socialMediaElementsSelector}, ${SPECIAL_BLOCKQUOTE_SELECTOR}`;
+    static selector = ".o_animable, section .row > div, img, .fa, .btn, .s_card";
+    static exclude = `[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, ${socialMediaElementsSelector}, ${SPECIAL_BLOCKQUOTE_SELECTOR}, ${SPECIAL_CARD_SELECTOR}`;
     static props = {
         dropdownClass: { type: String, optional: true, default: "o-hb-select-dropdown" },
         requireAnimation: { type: Boolean, optional: true },
@@ -30,11 +32,18 @@ export class AnimateOption extends BaseOptionComponent {
             const hasAnimateClass = editingElement.classList.contains("o_animate");
             this.getDirectionsItems = this.dependencies.animateOption.getDirectionsItems;
             const { getEffectsItems } = this.dependencies.animateOption;
+            const isImage = editingElement.tagName === "IMG";
+            const isCardParent = editingElement.matches(CARD_PARENT_HANDLERS);
+            const isBlockquoteParent = editingElement.matches(BLOCKQUOTE_PARENT_HANDLERS);
 
             return {
                 isOptionActive: this.isOptionActive(editingElement),
                 hasAnimateClass: hasAnimateClass,
                 canHover: await this.canHaveHoverEffect(editingElement),
+                isImage: isImage,
+                isCardParent: isCardParent,
+                isBlockquoteParent: isBlockquoteParent,
+                isBlock: !isImage && !isCardParent && !isBlockquoteParent,
                 isLimitedEffect: this.limitedEffects.some((className) =>
                     editingElement.classList.contains(className)
                 ),

--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -8,7 +8,37 @@
     </BuilderButtonGroup>
 </t>
 
+<t t-name="website.animateOnHoverBlock">
+    <BuilderRow label.translate="Effect" level="1">
+        <BuilderSelect>
+            <BuilderSelectItem classAction="'o_anim_hover_translate'" id="'o_anim_hover_translate_opt'">Translate</BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_anim_hover_overlay'" id="'o_anim_hover_overlay_opt'">Overlay</BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_anim_hover_zoom_in'" id="'o_anim_hover_zoom_in_opt'">Zoom In</BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_anim_hover_zoom_out'" id="'o_anim_hover_zoom_out_opt'">Zoom Out</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Direction" level="2" t-if="isActiveItem('o_anim_hover_translate_opt')">
+        <BuilderSelect>
+            <BuilderSelectItem classAction="''">Top</BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_anim_hover_translate_left'">Left</BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_anim_hover_translate_right'">Right</BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_anim_hover_translate_bottom'">Bottom</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Color" level="2" t-if="isActiveItem('o_anim_hover_overlay_opt')">
+        <BuilderColorPicker styleAction="'--anim-color'" enabledTabs="['custom']"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Shift" level="2" t-if="isActiveItem('o_anim_hover_translate_opt')">
+        <BuilderRange styleAction="'--anim-shift'" min="5" max="25" unit="'px'" displayRangeValue="true"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Intensity" tooltip.translate="Adjust how strong the hover effect is" level="2" t-if="isActiveItem('o_anim_hover_zoom_in_opt') || isActiveItem('o_anim_hover_zoom_out_opt')">
+        <BuilderRange styleAction="'--anim-intensity'" min="1" max="25" unit="'%'" applyWithUnit="false" displayRangeValue="true"/>
+    </BuilderRow>
+</t>
+
 <t t-name="website.AnimateOption">
+    <t t-set="hoverEffectApplyTo" t-if="state.isCardParent">.s_card</t>
+    <t t-set="hoverEffectApplyTo" t-if="state.isBlockquoteParent">.s_blockquote</t>
     <t t-if="this.state.isOptionActive">
         <BuilderRow label.translate="Animation">
             <BuilderSelect t-if="!this.isActiveItem('transform_image')" preview="false" dropdownClass="props.dropdownClass">
@@ -28,7 +58,16 @@
                 <BuilderSelectItem action="'setAnimationMode'" actionValue="'onHover'"
                             classAction="'o_animate_on_hover'"
                             id="'animation_on_hover_opt'"
-                            t-if="state.canHover">On Hover</BuilderSelectItem>
+                            t-if="state.canHover and state.isImage">On Hover</BuilderSelectItem>
+                <BuilderSelectItem
+                            applyTo="hoverEffectApplyTo"
+                            classAction="'o_anim_on_hover'"
+                            id="'animation_on_hover_parent_opt'"
+                            t-if="state.canHover and (state.isCardParent or state.isBlockquoteParent)">On Hover</BuilderSelectItem>
+                <BuilderSelectItem
+                            classAction="'o_anim_on_hover'"
+                            id="'animation_on_hover_block_opt'"
+                            t-if="state.canHover and state.isBlock">On Hover</BuilderSelectItem>
             </BuilderSelect>
             <t t-if="!!props.slots?.animationRowTrailing" t-slot="animationRowTrailing"/>
             <t t-else="" t-call="website.animateOnScrollInOut"/> 
@@ -119,6 +158,10 @@
                     step="1" min="1" unit="'px'" preview="false"/>
             </BuilderRow>
         </t>
+        <BuilderContext applyTo="hoverEffectApplyTo">
+            <t t-if="isActiveItem('animation_on_hover_parent_opt')" t-call="website.animateOnHoverBlock"/>
+        </BuilderContext>
+        <t t-if="this.isActiveItem('animation_on_hover_block_opt')" t-call="website.animateOnHoverBlock"/>
     </t>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -65,12 +65,16 @@ export class AnimateOptionPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         unsplittable_node_predicates: (node) => node.classList?.contains("o_animated_text"),
         lower_panel_entries: withSequence(10, { Component: EmphasizeAnimatedText }),
+        hover_effect_allowed_predicates: (el) => this.canHaveHoverEffect(el),
     };
 
     setup() {
         this.scrollingElement = getScrollingElement(this.document);
     }
 
+    canHaveHoverEffect(el) {
+        return !el.querySelector("input, textarea");
+    }
     getEffectsItems(isActiveItem) {
         const isOnAppearance = () => isActiveItem("animation_on_appearance_opt");
         return [
@@ -344,6 +348,20 @@ export class AnimateOptionPlugin extends Plugin {
     cleanForSave({ root }) {
         for (const el of root.querySelectorAll(".o_animate_preview")) {
             el.classList.remove("o_animate_preview");
+        }
+        for (const el of root.querySelectorAll(".o_anim_on_hover")) {
+            if (!el.classList.contains("o_anim_hover_overlay")) {
+                el.style.removeProperty("--anim-color");
+            }
+            if (!el.classList.contains("o_anim_hover_translate")) {
+                el.style.removeProperty("--anim-shift");
+            }
+            if (
+                !el.classList.contains("o_anim_hover_zoom_in_opt") &&
+                !el.classList.contains("o_anim_hover_zoom_out_opt")
+            ) {
+                el.style.removeProperty("--anim-intensity");
+            }
         }
     }
 }

--- a/addons/website/static/src/builder/plugins/options/utils.js
+++ b/addons/website/static/src/builder/plugins/options/utils.js
@@ -1,5 +1,6 @@
 export const CARD_PARENT_HANDLERS =
     ".s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div, .s_company_team_card .row > div, .s_carousel_cards_item";
+export const SPECIAL_CARD_SELECTOR = `div:is(${CARD_PARENT_HANDLERS}) > .s_card`;
 
 export const BASE_ONLY_BG_IMAGE_SELECTOR = "footer .oe_structure > *:not(.o_footer_bottom_part)";
 

--- a/addons/website/static/src/interactions/animate_overlay.edit.js
+++ b/addons/website/static/src/interactions/animate_overlay.edit.js
@@ -1,0 +1,28 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+const ANIM_REFRESH_OVERLAY =
+    ".o_anim_hover_translate, .o_anim_hover_zoom_in, .o_anim_hover_zoom_out";
+
+// This interaction is used to update the Overlay that would be misplaced
+// because of an translate / zoom animation.
+export class AnimationHoverEdit extends Interaction {
+    static selector = ANIM_REFRESH_OVERLAY;
+    dynamicContent = {
+        _root: {
+            "t-on-pointerleave": this.debounced(this.refreshOverlays, 300),
+        },
+    };
+
+    setup() {
+        this.websiteEditService = this.services.website_edit;
+    }
+
+    refreshOverlays() {
+        this.websiteEditService.callShared("builderOverlay", "refreshOverlays");
+    }
+}
+
+registry.category("public.interactions.edit").add("website.animation_hover_edit", {
+    Interaction: AnimationHoverEdit,
+});

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -3195,6 +3195,61 @@ input[value*="data-oe-translation-source-sha"] {
     transition-timing-function: ease-out;
 }
 
+// On Hover Block /////////////////////////////////////////////////////////////
+
+.o_anim_on_hover {
+    transition: transform 0.3s ease, filter 0.3s ease;
+    --anim-shift: 10px;
+    --anim-color: #00000040;
+    --anim-intensity: 10;
+
+    &.o_anim_hover_overlay {
+        position: relative;
+    }
+
+    &.o_anim_hover_zoom_in, &.o_anim_hover_zoom_out {
+        transform-origin: center center;
+    }
+
+    /* TRANSLATE */
+    &.o_anim_hover_translate:hover {
+        transform: translateY(calc(-1 * var(--anim-shift)));
+        &.o_anim_hover_translate_bottom {
+            transform: translateY(var(--anim-shift));
+        }
+        &.o_anim_hover_translate_left {
+            transform: translateX(calc(-1 * var(--anim-shift)));
+        }
+        &.o_anim_hover_translate_right {
+            transform: translateX(var(--anim-shift));
+        }
+    }
+
+    /* OVERLAY */
+    &.o_anim_hover_overlay::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: var(--anim-color);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        pointer-events: none;
+    }
+    &.o_anim_hover_overlay:hover::after {
+        opacity: 1;
+    }
+
+    /* ZOOM IN */
+    &.o_anim_hover_zoom_in:hover {
+        transform: scale(calc(1 + 0.01 * var(--anim-intensity)));
+    }
+
+    /* ZOOM OUT */
+    &.o_anim_hover_zoom_out:hover {
+        transform: scale(calc(1 - 0.01 * var(--anim-intensity)));
+    }
+}
+
 // Compatibility <= 13.0
 .o_anim_dur500 {
     animation-duration: 500ms;


### PR DESCRIPTION
Before this commit, only images had the option "onHover" for animation.
Many elements could benefits from hover animation (cards, blockquotes,
...), this commit adds basic hover animation on blocks.

A simple interaction was added to update the overlays because the hover
animation can change the size/position of the element before the click.

task-4757043