### PR TITLE
[IMP] l10n_in : hide qr code bool from document layout

### DIFF
--- a/addons/account/wizard/base_document_layout.py
+++ b/addons/account/wizard/base_document_layout.py
@@ -8,6 +8,7 @@ class BaseDocumentLayout(models.TransientModel):
     qr_code = fields.Boolean(related='company_id.qr_code', readonly=False)
     vat = fields.Char(related='company_id.vat', readonly=False,)
     account_number = fields.Char(compute='_compute_account_number', inverse='_inverse_account_number',)
+    country_code = fields.Char(related="company_id.account_fiscal_country_id.code")
 
     def document_layout_save(self):
         """Save layout and onboarding step progress, return super() result"""

--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -58,6 +58,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'views/res_partner_views.xml',
         'views/account_tax_views.xml',
         'views/uom_uom_views.xml',
+        'views/base_document_layout_views.xml',
     ],
     'demo': [
         'demo/product_demo.xml',

--- a/addons/l10n_in/views/base_document_layout_views.xml
+++ b/addons/l10n_in/views/base_document_layout_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_base_document_layout" model="ir.ui.view">
+        <field name="name">Document Layout</field>
+        <field name="model">base.document.layout</field>
+        <field name="inherit_id" ref="account.view_base_document_layout"/>
+        <field name="mode">extension</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='qr_code']" position="attributes">
+                <attribute name="invisible" separator="or" add="country_code == 'IN'"/>
+            </xpath>
+            <xpath expr="//field[@name='account_number']" position="attributes">
+                <attribute name="required" separator="and" add="country_code != 'IN'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
For Indian localisation, we have hidden the
QR code option from `res.config.settings` (Settings)
instead it will be enabled and disabled based on
UPI id (`l10n_in_upi_id`) field.

Before this commit-
When opening Base Document Configurator wizard for an Indian Company
the QR code option is still visible there and you can't proceed without
entering the bank account number

After this commit-
For Indian companies, we hide the QR code option from Document
Configurator and bank account number is no required.

task-5366725