### PR TITLE
[FIX] marketing_card: correct og:description variable in crawler view

### DIFF
--- a/addons/marketing_card/controllers/marketing_card.py
+++ b/addons/marketing_card/controllers/marketing_card.py
@@ -109,6 +109,7 @@ class MarketingCardController(Controller):
             return request.render('marketing_card.card_campaign_crawler', {
                 'image_url': card._get_card_url(),
                 'post_text': campaign_sudo.post_suggestion,
+                'post_suggestion': campaign_sudo.post_suggestion,
                 'target_name': card.display_name or '',
             })
 


### PR DESCRIPTION
**Current Behavior:** description is not available for the Crowler

<img width="1159" height="802" alt="image" src="https://github.com/user-attachments/assets/2979f413-6487-4f44-993c-b9a806e0d0ef" />


**Steps to reproduce:**
1. Install `marketing_card`
2. Create a card campaign
3. Set Recipient, Post Link and Post Suggestion
4. Save and Preview
5. Copy the URL and replace `preview` with `redirect`
6. To reproduce in locale,  in the `contoller` make the marketing_card.card_campaign_crawler template the only return
7. Now paste that URL in the browser

**Issue**
- The `<meta property="og:description">` tag is empty in inspect. It does not contain any content

**Cause:**
- The controller `card_campaign_redirect` passes the campaign's suggestion text to the view using the key `post_text`. However, the template `card_campaign_crawler` attempts to access `post_suggestion`, which is not present in the rendering context.

**Solution:**
- Update the controller to pass `post_suggestion`

opw-5351041