### PR TITLE
[FIX] sale: prevent error on clicking Edit Configuration on a combo

### DIFF
--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -126,7 +126,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         return this.props.record.data.is_configurable_product;
     }
     get isCombo() {
-        return this.props.record.data.product_type === 'combo';
+        return this.props.record.data.product_template_id && this.props.record.data.product_type === 'combo';
     }
     get isDownpayment() {
         return this.props.record.data.is_downpayment;


### PR DESCRIPTION
Currently, when a user adds a combo to an order line, and remove the name of combo and click on Edit Configuration (pencil icon) error is encountered.

Steps to replicate:
- Install `sale_management` with demo and create a new SO.
- Add a combo product and remove the combo name and click Edit Configuration (pencil icon).

Error:
`TypeError: SaleProductConfiguratorController.sale_combo_configurator_get_data() missing 1 required positional argument: 'product_template_id'`

Cause:
- When a user clicks on Edit configuration, the client-side JavaScript makes an RPC call to the server, targeting the `sale_combo_configurator_get_data()` which expects `product_template_id` at [1] and since it is removed from order line the error is encountered.

Solution:
- Changed the content of method `isCombo()` to use the product_template_id to make sure the Edit Configuration is only visible when product template is present.

Similar PR for reference: https://github.com/odoo/odoo/pull/217464

[1]: https://github.com/odoo/odoo/blob/fa4307b9758800f26c9ee87cf3698fd60bfd1ab5/addons/sale/controllers/combo_configurator.py#L12-L14

No ID
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
