### PR TITLE
[FIX] mrp: prevent reordering rule to update locked MO quantity

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1404,6 +1404,10 @@ class MrpProduction(models.Model):
         parent_moves = self.procurement_group_id.stock_move_ids.move_dest_ids
         return (dest_moves | parent_moves).group_id.mrp_production_ids.filtered(lambda p: p.origin != self.origin) - self
 
+    def _product_qty_updatable(self):
+        self.ensure_one()
+        return True
+
     def set_qty_producing(self):
         # This method is used to call `_set_lot_producing` when the onchange doesn't apply.
         self.ensure_one()

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -53,8 +53,8 @@ class StockRule(models.Model):
             mo = self.env['mrp.production']
             if procurement.origin != 'MPS':
                 domain = rule._make_mo_get_domain(procurement, bom)
-                mo = self.env['mrp.production'].sudo().search(domain, limit=1)
-            if not mo:
+                mo = self.env['mrp.production'].sudo().search(domain, limit=1, order='create_date desc')
+            if not mo or not mo._product_qty_updatable():
                 procurement_qty = procurement.product_qty
                 batch_size = procurement.values.get('batch_size', procurement_qty)
                 if batch_size <= 0:
@@ -150,7 +150,7 @@ class StockRule(models.Model):
                        '&', ('state', '=', 'confirmed'), ('date_start', '<=', procurement_date))
         if group:
             domain += (('procurement_group_id', '=', group.id),)
-        return domain
+        return list(domain)
 
     def _prepare_mo_vals(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, bom):
         date_planned = self._get_date_planned(bom, values)


### PR DESCRIPTION
### Issue:
In 18.0-18.2, for product with a Manufacturing BoM containing a Component, a WO and a Quality Point If a Reordering Rule is triggered, odoo try to add the newly ordered quantity to an existing MO But if the MO is "locked" because a quality check has been performed, a Error is raised:
```
Odoo Warning
You cannot update the quantity to do of an ongoing manufacturing order for which quality checks have been performed.
```

### Steps to reproduce:
- Create a product tracked by quantity
- Add a BoM (1 component tracked by Quantity, 1 Operation with 1 Quality Point)
- Create a Reordering Rule (Route: Manufacture, Trigger: Manual, Min/Max: 1)
- Click on Order
- Open the created MO and the Shop Floor (Remove the filters to see the WO)
- Complete the Quality Point
- Modify the Reordering Rule (Min/Max: 2)
- Click on Order - the error should be raised

### Cause:
The MO to update is retrieved here:
https://github.com/odoo/odoo/blob/45184da06cf7b92a48e3e4e90bf8b285bdd9ad6a/addons/mrp/models/stock_rule.py#L53-L57 Using a domain defined in this function:
https://github.com/odoo/odoo/blob/45184da06cf7b92a48e3e4e90bf8b285bdd9ad6a/addons/mrp/models/stock_rule.py#L130-L153

In 18.0-18.2, when validating a `quality check` from the Shop Floor while the WO is in `waiting` state, the MO remains in `confirmed` state This makes the domain match the current WO and MO, triggering `change_prod_qty` even though the MO is locked

In 18.3–18.4, a similar issue can occur with multiple WOs when the first blocks the second and a `quality check` is performed on the latter The `blocked` state behaves like `waiting`, but the issue is avoided when using the Shop Floor because this commit ensures that clicking a card starts the timer and changes the state to `progress`: 67c2127
However, it could still theoretically be triggered under specific conditions

In 19.0, the new stock.reference system (odoo/odoo#212679) ensures the MO is detected as different, so a new one is always created

opw-5012588
enterprise: https://github.com/odoo/enterprise/pull/101313