### PR TITLE
[FIX] l10n_dk_nemhandel: restrict document type check override to Denmark

### DIFF
--- a/addons/l10n_dk_nemhandel/models/res_partner.py
+++ b/addons/l10n_dk_nemhandel/models/res_partner.py
@@ -180,6 +180,9 @@ class ResPartner(models.Model):
         return edi_identification == participant_identifier and service_href.startswith(smp_nemhandel_url)
 
     def _check_document_type_support(self, participant_info, ubl_cii_format):
+        if self._deduce_country_code() != 'DK':
+            return super()._check_document_type_support(participant_info, ubl_cii_format)
+
         service_references = participant_info.findall(
             '{*}ServiceMetadataReferenceCollection/{*}ServiceMetadataReference'
         )


### PR DESCRIPTION
Before:
- The l10n_dk_nemhandel override of _check_document_type_support replaced the generic Peppol logic and did not accept process_type, causing errors when other localizations relied on the base method.

After:
-  Aligned the method and applied the DK-specific logic only for Danish partners, falling back to the generic Peppol behavior otherwise.

Impact:
-  Prevents unintended overrides towards standard Peppol flow.