### PR TITLE
[REF] mail: remove "thread" props from meeting_chat

### DIFF
--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -80,7 +80,6 @@ registerThreadAction("search-messages", {
 });
 registerThreadAction("meeting-chat", {
     actionPanelComponent: MeetingChat,
-    actionPanelComponentProps: ({ thread }) => ({ thread }),
     actionPanelOuterClass: "bg-100 border border-secondary",
     badge: ({ thread }) => thread.isUnread,
     badgeIcon: ({ thread }) => !thread.importantCounter && "fa fa-circle text-700",

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.js
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.js
@@ -20,7 +20,7 @@ export class MeetingChat extends Component {
         Thread,
         Typing,
     };
-    static props = ["thread?"];
+    static props = [];
 
     setup() {
         this.store = useService("mail.store");


### PR DESCRIPTION
This props isn't use anywhere making it dead code.

