### PR TITLE
[FIX] hr_expense: Taxes displayed twices

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -243,7 +243,6 @@
                                        widget="many2many_tax_tags"
                                        readonly="not is_editable"
                                        options="{'no_create': True}"/>
-                                <field name="tax_amount_currency"/>
                             </div>
                             <field name="employee_id" groups="!hr.group_hr_user"
                                    context="{'default_company_id': company_id}" widget="many2one_avatar_employee"


### PR DESCRIPTION
Previously, the tax amount was displayed next the the currency and next to the taxes.

Now, we only have it next to the currency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
