### PR TITLE
[FIX] web: Handle updateRecord errors and revert FullCalendar state.

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -364,12 +364,18 @@ export class CalendarCommonRenderer extends Component {
     }
     onEventDrop(info) {
         this.fc.api.unselect();
-        this.props.model.updateRecord(this.fcEventToRecord(info.event));
+        this.props.model.updateRecord(this.fcEventToRecord(info.event)).catch(e => {
+            info.revert();
+            throw e;
+        });
         this.ref.el.classList.remove("o_interacting", "o_grabbing");
     }
     onEventResize(info) {
         this.fc.api.unselect();
-        this.props.model.updateRecord(this.fcEventToRecord(info.event));
+        this.props.model.updateRecord(this.fcEventToRecord(info.event)).catch(e => {
+            info.revert();
+            throw e;
+        });
     }
     fcEventToRecord(event) {
         const { id, allDay, date, start, end } = event;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

When a drag and drop or resize fails to update the record, the FullCalendar state no longer matches the database.

## Current behavior before PR:

FullCalendar state does not match database.

## Desired behavior after PR is merged:

FullCalendar state is reverted to match database.

Per FullCalendar documentation [^1] [^2],
> revert - A function that, if called, reverts the event’s start/end date to the values before the drag. This is useful if an ajax call should fail.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

[^1]: https://fullcalendar.io/docs/eventDrop
[^2]: https://fullcalendar.io/docs/eventResize
