### PR TITLE
[FIX] sale-subscription: Restore automatic follower copying from parent SO

### DIFF
--- a/addons/sale/security/ir_rules.xml
+++ b/addons/sale/security/ir_rules.xml
@@ -24,7 +24,7 @@
     <record id="sale_order_rule_portal" model="ir.rule">
         <field name="name">Portal Personal Quotations/Sales Orders</field>
         <field name="model_id" ref="sale.model_sale_order"/>
-        <field name="domain_force">[('partner_id','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_unlink" eval="True"/>
         <field name="perm_write" eval="True"/>
@@ -35,7 +35,7 @@
     <record id="sale_order_line_rule_portal" model="ir.rule">
         <field name="name">Portal Sales Orders Line</field>
         <field name="model_id" ref="sale.model_sale_order_line"/>
-        <field name="domain_force">[('order_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('order_id.message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 


### PR DESCRIPTION
[FIX] sale-subscription: Restore automatic follower copying from parent SO

In Odoo 18.2 (Task 4655022), automatic follower addition was removed for all users and limited to internal users. However, for subscriptions, it is logical to automatically copy followers from the parent sale order to renewal and upsell orders. This commit restores that behavior for subscription renewals and upsells while keeping the restriction for other record types.

task - 5002181

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
