### PR TITLE
[FIX] html_editor: handle image resize for wkhtmltopdf

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -273,7 +273,6 @@ export class ImagePlugin extends Plugin {
             return;
         }
         targetedImg.style.width = size || "";
-        targetedImg.style.height = size || "";
         this.dependencies.history.addStep();
     }
 


### PR DESCRIPTION
Problem:
wkhtmltopdf doesn't render images with both width and height set in percentage.

Solution:
When resizing in percentage, set only the width. This effectively reverts a change introduced in
920cea5ff567c9113370174570d0ead0bbfa767a.

Steps to reproduce:
- Add an image to the document footer.
- Set the image size to 50%.
- Print the document.
- The image does not appear.

opw-5168087

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
