### PR TITLE
[PERF] stock: update multiple moves at once in `_set_date_deadline`

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -493,6 +493,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         already_propagate_ids = self.env.context.get('date_deadline_propagate_ids', set())
         already_propagate_ids.update(self.ids)
         self = self.with_context(date_deadline_propagate_ids=already_propagate_ids)
+        moves_by_date = defaultdict(lambda: self.env['stock.move'])
         for move in self:
             moves_to_update = move._get_moves_to_propagate_date_deadline()
             if move.date_deadline:
@@ -505,9 +506,11 @@ Please change the quantity done or the rounding precision of your unit of measur
                 if move_update.id in already_propagate_ids:
                     continue
                 if move_update.date_deadline and delta:
-                    move_update.date_deadline -= delta
+                    moves_by_date[move_update.date_deadline - delta] |= move_update
                 else:
-                    move_update.date_deadline = new_deadline
+                    moves_by_date[new_deadline] |= move_update
+        for date_deadline, moves in moves_by_date.items():
+            moves.write({'date_deadline': date_deadline})
 
     @api.depends('move_line_ids.lot_id', 'move_line_ids.quantity')
     def _compute_lot_ids(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -492,8 +492,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         # Handle the propagation of `date_deadline` fields (up and down stream - only update by up/downstream documents)
         already_propagate_ids = self.env.context.get('date_deadline_propagate_ids', set())
         already_propagate_ids.update(self.ids)
-        self = self.with_context(date_deadline_propagate_ids=already_propagate_ids)
-        moves_by_date = defaultdict(lambda: self.env['stock.move'])
+        moves_by_date = defaultdict(set)
         for move in self:
             moves_to_update = move._get_moves_to_propagate_date_deadline()
             if move.date_deadline:
@@ -506,11 +505,13 @@ Please change the quantity done or the rounding precision of your unit of measur
                 if move_update.id in already_propagate_ids:
                     continue
                 if move_update.date_deadline and delta:
-                    moves_by_date[move_update.date_deadline - delta] |= move_update
+                    moves_by_date[move_update.date_deadline - delta].add(move_update.id)
                 else:
-                    moves_by_date[new_deadline] |= move_update
+                    moves_by_date[new_deadline].add(move_update.id)
         for date_deadline, moves in moves_by_date.items():
-            moves.write({'date_deadline': date_deadline})
+            self.env["stock.move"].browse(moves).with_context(date_deadline_propagate_ids=already_propagate_ids).write(
+                {"date_deadline": date_deadline}
+            )
 
     @api.depends('move_line_ids.lot_id', 'move_line_ids.quantity')
     def _compute_lot_ids(self):


### PR DESCRIPTION
Reduce the total number of calls to `_set_date_deadline` by batching the write of the same `date_deadline` to multiple `stock.move`s at once.

opw-5365026


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
