### PR TITLE
[REF] mail: remove Chatter.props.compactHeight (deadcode) + improve chatter topbar alignment

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -4,19 +4,19 @@
 <t t-name="mail.Chatter">
     <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column bg-inherit" t-att-class="{ 'overflow-auto o-scrollbar-thin': props.isChatterAside, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div class="o-mail-Chatter-top d-print-none position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
-            <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 overflow-x-auto">
+            <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 overflow-x-auto o-gap-0_5">
                 <div t-if="state.isSearchOpen" class="flex-grow-1">
                     <SearchMessageInput closeSearch.bind="closeSearch" messageSearch="messageSearch" thread="state.thread"/>
                 </div>
-                <t t-else="" name="chatter-topbar-left-buttons">
-                    <button class="o-mail-Chatter-sendMessage btn text-nowrap me-1 my-2" t-att-class="{
+                <div t-else="" class="d-flex gap-1">
+                    <button class="o-mail-Chatter-sendMessage btn text-nowrap my-2" t-att-class="{
                         'btn-primary': state.composerType !== 'note',
                         'btn-secondary': state.composerType === 'note',
                         'active': state.composerType === 'message',
                     }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                         Send message
                     </button>
-                    <button class="o-mail-Chatter-logNote btn text-nowrap me-1 my-2" t-att-class="{
+                    <button class="o-mail-Chatter-logNote btn text-nowrap my-2" t-att-class="{
                         'btn-primary active': state.composerType === 'note',
                         'btn-secondary': state.composerType !== 'note',
                     }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
@@ -25,13 +25,13 @@
                     <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap my-2" data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activity</span>
                     </button>
-                    <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
-                    <button class="btn btn-link text-action" aria-label="Search Messages" title="Search Messages" t-on-click="onClickSearch">
-                        <i class="oi oi-search" role="img"/>
-                    </button>
-                </t>
-                <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action" t-on-click="popoutAttachment">
-                    <i class="fa fa-window-restore" aria-hidden="Pop out Attachments" title="Pop out Attachments"/>
+                </div>
+                <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
+                <button class="btn btn-link text-action px-1" aria-label="Search Messages" title="Search Messages" t-on-click="onClickSearch">
+                    <i class="oi oi-search fa-fw" role="img"/>
+                </button>
+                <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action px-1" t-on-click="popoutAttachment">
+                    <i class="fa fa-window-restore fa-fw" aria-hidden="Pop out Attachments" title="Pop out Attachments"/>
                 </button>
                 <FileUploader t-if="attachments.length === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                     <t t-set-slot="toggler">
@@ -39,7 +39,7 @@
                     </t>
                 </FileUploader>
                 <t t-else="" t-call="mail.Chatter.attachFiles"/>
-                <div class="o-mail-Followers d-flex me-1">
+                <div class="o-mail-Followers d-flex">
                     <Dropdown position="'bottom-end'" menuClass="'o-mail-Followers-dropdown ' + store.discussDropdownMenuClass(this)" state="followerListDropdown">
                         <button t-att-class="'o-mail-Followers-button btn btn-link d-flex align-items-center text-action px-1 my-2 ' + (state.thread.selfFollower ? 'active' : '')" t-att-disabled="isDisabled" t-att-title="followerButtonLabel">
                             <i class="fa fa-fw" role="img" t-attf-class="{{ state.thread.selfFollower ? 'fa-user' : 'fa-user-o' }}"/>
@@ -85,7 +85,7 @@
                         />
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                             <t t-set-slot="toggler">
-                                <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">
+                                <button class="btn btn-link px-1" type="button" t-att-disabled="!state.thread.hasWriteAccess">
                                     <i class="fa fa-plus-square"/>
                                     Attach files
                                 </button>
@@ -140,7 +140,7 @@
 
 <t t-name="mail.Chatter.attachFiles">
     <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
-        <i class="fa fa-paperclip fa-lg me-1"/>
+        <i class="fa fa-paperclip fa-lg fa-fw"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>
     </button>

--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -9,22 +9,20 @@
                     <SearchMessageInput closeSearch.bind="closeSearch" messageSearch="messageSearch" thread="state.thread"/>
                 </div>
                 <t t-else="" name="chatter-topbar-left-buttons">
-                    <button class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{
+                    <button class="o-mail-Chatter-sendMessage btn text-nowrap me-1 my-2" t-att-class="{
                         'btn-primary': state.composerType !== 'note',
                         'btn-secondary': state.composerType === 'note',
                         'active': state.composerType === 'message',
-                        'my-2': !props.compactHeight
                     }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                         Send message
                     </button>
-                    <button class="o-mail-Chatter-logNote btn text-nowrap me-1" t-att-class="{
+                    <button class="o-mail-Chatter-logNote btn text-nowrap me-1 my-2" t-att-class="{
                         'btn-primary active': state.composerType === 'note',
                         'btn-secondary': state.composerType !== 'note',
-                        'my-2': !props.compactHeight
                     }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                         Log note
                     </button>
-                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">
+                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap my-2" data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activity</span>
                     </button>
                     <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
@@ -43,7 +41,7 @@
                 <t t-else="" t-call="mail.Chatter.attachFiles"/>
                 <div class="o-mail-Followers d-flex me-1">
                     <Dropdown position="'bottom-end'" menuClass="'o-mail-Followers-dropdown ' + store.discussDropdownMenuClass(this)" state="followerListDropdown">
-                        <button t-att-class="'o-mail-Followers-button btn btn-link d-flex align-items-center text-action px-1 ' + (props.compactHeight ? '' : 'my-2') + ' ' + (state.thread.selfFollower ? 'active' : '')" t-att-disabled="isDisabled" t-att-title="followerButtonLabel">
+                        <button t-att-class="'o-mail-Followers-button btn btn-link d-flex align-items-center text-action px-1 my-2 ' + (state.thread.selfFollower ? 'active' : '')" t-att-disabled="isDisabled" t-att-title="followerButtonLabel">
                             <i class="fa fa-fw" role="img" t-attf-class="{{ state.thread.selfFollower ? 'fa-user' : 'fa-user-o' }}"/>
                             <i t-if="state.thread.id and state.thread.followersCount === undefined" class="fa fa-circle-o-notch fa-spin"/>
                             <sup t-else="" class="o-mail-Followers-counter" t-esc="state.thread.followersCount ?? 0"/>
@@ -141,7 +139,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -42,7 +42,6 @@ Object.assign(Chatter.components, {
 
 Chatter.props.push(
     "close?",
-    "compactHeight?",
     "has_activities?",
     "hasAttachmentPreview?",
     "hasParentReloadOnActivityChanged?",
@@ -58,7 +57,6 @@ Chatter.props.push(
 );
 
 Object.assign(Chatter.defaultProps, {
-    compactHeight: false,
     has_activities: true,
     hasAttachmentPreview: false,
     hasParentReloadOnActivityChanged: false,

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -119,7 +119,7 @@
                     </div>
                     <div t-ref="picker-target"/>
                 </div>
-                <div t-else="" class="d-flex align-items-center gap-1 w-100 pe-2">
+                <div t-else="" class="d-flex align-items-center gap-1 w-100 pe-1">
                     <div class="pt-1" t-att-class="{ 'mt-2': !props.composer.message }">
                         <span t-if="props.composer.message and !ui.isSmall" class="text-muted px-1 small" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText" />
                         <t t-elif="!props.composer.message">
@@ -178,7 +178,7 @@
 </t>
 
 <t t-name="mail.Composer.extraActions">
-    <div class="me-2" t-attf-class="{{ actionsContainerClass }}">
+    <div t-attf-class="{{ actionsContainerClass }}">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <ActionList actions="partitionedActions.other" inline="true"/>
         </div>


### PR DESCRIPTION
Alignment before / after
<img width="1220" height="640" alt="Screenshot 2025-12-05 at 14 44 24" src="https://github.com/user-attachments/assets/5a0cdba0-98fa-4ba0-84b8-446f9924f3e0" /> <img width="1220" height="640" alt="Screenshot 2025-12-05 at 14 43 45" src="https://github.com/user-attachments/assets/1ad902bb-cd12-496b-9ab2-805d8980b104" />


https://github.com/odoo/enterprise/pull/101251