### PR TITLE
[FIX] payment_adyen: skip amount validation for refusal response

### DIFF
--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -314,8 +314,12 @@ class PaymentTransaction(models.Model):
             return super()._extract_amount_data(payment_data)
 
         # Redirection payments and 3DS challenges don't have the amount or currency in their
-        # payment_data, but processing them results in a pending transaction anyway.
-        if payment_data.get('action', {}).get('type') in ['redirect', 'threeDS2']:
+        # payment_data, but processing them results in a pending transaction anyway, neither
+        # does payment refusal response which will result in an error transaction.
+        if (
+            payment_data.get('action', {}).get('type') in ['redirect', 'threeDS2']
+            or payment_data.get('resultCode') in const.RESULT_CODES_MAPPING['refused']
+        ):
             return None  # Skip the validation
 
         amount_data = payment_data.get('amount', {})


### PR DESCRIPTION
When requesting a direct payment (for offline operation) and Adyen reject the it, we will get back a response that may not always have the amount information.

This commit skip the amount and currency validation for refusal, so that the missing amount error message will not shadow the real refusal reason.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
