### PR TITLE
[FIX] account: Exclude other journals when multi-ledger for one company

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2470,7 +2470,11 @@ class AccountMove(models.Model):
     def _search_journal_group_id(self, operator, value):
         field = 'name' if 'like' in operator else 'id'
         journal_groups = self.env['account.journal.group'].search([(field, operator, value)])
-        return [('journal_id', 'not in', journal_groups.excluded_journal_ids.ids)]
+        return Domain.OR([
+            Domain('journal_id', 'not in', group.excluded_journal_ids.ids)
+            & Domain('journal_id.company_id', '=?', group.company_id.id)
+            for group in journal_groups
+        ])
 
     def _search_reconciled_payment_ids(self, operator, value):
         if operator not in ('in', '='):

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1246,9 +1246,7 @@ class AccountMoveLine(models.Model):
     # -------------------------------------------------------------------------
 
     def _search_journal_group_id(self, operator, value):
-        field = 'name' if 'like' in operator else 'id'
-        journal_groups = self.env['account.journal.group'].search([(field, operator, value)])
-        return [('journal_id', 'not in', journal_groups.excluded_journal_ids.ids)]
+        return self.env['account.move']._search_journal_group_id(operator, value)
 
     # -------------------------------------------------------------------------
     # INVERSE METHODS


### PR DESCRIPTION
Following  https://github.com/odoo/enterprise/pull/98546 , journals from other companies were correctly excluded when Ledger selected from Journal filter. However it's not the case when using horizontal groups for multi-ledgers.   

When horizontal groups is set for multiledger, each `column_group` has `journal_group_id` set in `forced_domain` but when building report query `search_journal_group_id` was not filtering out journals belonging to other companies.
This fix ensures the ledger search domain correctly excludes journals from other companies when the ledger defines a company.

task-5384534



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
