### PR TITLE
[FIX] mail: device selection in discuss calls

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -2,8 +2,22 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallDeviceSelect">
-        <select name="inputDevice" class="form-select d-flex shadow-sm" t-on-change="onChangeSelectAudioInput">
-            <option value="">Browser default</option>
+        <select
+            t-if="!isPermissionGranted(props.kind)"
+            name="inputDevice"
+            class="form-select d-flex shadow-sm"
+            t-on-pointerdown.prevent="() => this.showPermissionDialog(props.kind)"
+            t-on-keydown.prevent="() => this.showPermissionDialog(props.kind)"
+        >
+            <option value="">Permission Needed</option>
+        </select>
+        <select
+            t-else=""
+            name="inputDevice"
+            class="form-select d-flex shadow-sm"
+            t-on-change="onChangeSelectAudioInput"
+        >
+            <option t-if="!isBrowserChrome" value="">Browser Default</option>
             <t t-foreach="state.userDevices" t-as="device" t-key="device_index">
                 <option t-if="device.kind === props.kind" t-att-selected="isSelected(device.deviceId)" t-att-value="device.deviceId">
                     <t t-esc="device.label || 'device ' + device_index"/>

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -37,7 +37,8 @@ test("Renders the call settings", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchUiSize({ size: SIZES.SM });
-    await start();
+    const env = await start();
+    const rtc = env.services["discuss.rtc"];
     await openDiscuss(channelId);
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");
@@ -47,7 +48,10 @@ test("Renders the call settings", async () => {
     await contains("label[aria-label='Camera']");
     await contains("label[aria-label='Microphone']");
     await contains("label[aria-label='Audio Output']");
+    await contains("option", { textContent: "Permission Needed", count: 3 });
+    rtc.microphonePermission = "granted";
     await contains("option[value=mockAudioDeviceId]");
+    rtc.cameraPermission = "granted";
     await contains("option[value=mockVideoDeviceId]");
     await contains("button", { text: "Voice Detection" });
     await contains("button", { text: "Push to Talk" });


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/236499

This commit removes the 'Browser Default' placeholder for audio/video device selection on Chromium-based browsers, as they already return their own default device and the placeholder causes confusion.

The device-selection dropdown will now display 'Permission Needed' when permissions are not granted. Clicking the dropdown will trigger the permission dialog if the necessary permissions are not granted.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
