### PR TITLE
[FIX] calendar: update duration when modifying event times in form

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -161,7 +161,7 @@ class Meeting(models.Model):
         help="Start date of an event, without time for full days events")
     stop = fields.Datetime(
         'Stop', required=True, tracking=True, default=_default_stop,
-        compute='_compute_stop', readonly=False, store=True,
+        compute='_compute_stop', inverse='_inverse_stop', readonly=False, store=True,
         help="Stop date of an event, without time for full days events")
     display_time = fields.Char('Event Time', compute='_compute_display_time')
     allday = fields.Boolean('All Day', default=False)
@@ -377,6 +377,11 @@ class Meeting(models.Model):
             event.stop = event.start and event.start + timedelta(minutes=round((event.duration or 1.0) * 60))
             if event.allday:
                 event.stop -= timedelta(seconds=1)
+
+    def _inverse_stop(self):
+        for event in self:
+            if event.start and event.stop:
+                event.duration = event._get_duration(event.start, event.stop)
 
     @api.onchange('start_date', 'stop_date')
     def _onchange_date(self):


### PR DESCRIPTION
**issue:**

calendar event duration displays incorrect values when start or stop times are modified in the popup after initial calendar selection.

**steps to reproduce:**

- in calendar module, select a time slot for a new event
- in the "New Event" popup, modify the stop time to change the duration
- save and close
- navigate to the event form
- duration shows the initial time duration (before changing the stop time)

opw-5089584
