### PR TITLE
[IMP] point_of_sale: improve visiblity of customer account

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -159,13 +159,15 @@
             <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }" t-att-style="ui.isSmall ? 'max-height: 120px;' : ''">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
                     <div t-if="!(this.pos.cashier._role === 'minimal' and paymentMethod.type === 'pay_later')" class="button paymentmethod btn btn-secondary btn-lg lh-lg flex-fill"
-                        t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal, 'd-flex justify-content-between align-items-center': true}"
+                        t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal, 'd-flex flex-column justify-content-center': true}"
                         t-on-click="() => this.addNewPaymentLine(paymentMethod)">
-                        <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">
-                            <img class="payment-method-icon" t-att-src="paymentMethodImage(paymentMethod.id)" />
-                            <span class="payment-name" t-esc="paymentMethod.name" />
+                        <div class="d-flex flex-row justify-content-between align-items-center">
+                            <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">
+                                <img class="payment-method-icon" t-att-src="paymentMethodImage(paymentMethod.id)" />
+                                <span class="payment-name" t-esc="paymentMethod.name" />
+                            </div>
+                            <span class="text-muted" t-esc="pos.getPaymentMethodFmtAmount(paymentMethod, currentOrder)"/>
                         </div>
-                        <span class="text-muted" t-esc="pos.getPaymentMethodFmtAmount(paymentMethod, currentOrder)"/>
                     </div>
                 </t>
             </div>


### PR DESCRIPTION
Before this commit:
===================
- There were no details of customer credits on the PaymentScreen
- Also, when we use the customer credits and print an invoice, it shows that amount paid as `Total Due` instead of `Paid using Customer Account.`

After this commit:
==================
- If the customer is selected we will display their credits below the `Customer Account` payment method
- If the customer account has a balance from the previous session and use those credits, then the invoice shows the correct details.

Task: 5243233
Related Enterprise PR: odoo/enterprise#101297