### PR TITLE
[IMP] point_of_sale, pos_restaurant: add (copy) after name in duplicate records

### DIFF
--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -249,12 +249,12 @@ class TestMyInvoisPoS(TestPoSCommon):
             with patch(CONTACT_PROXY_METHOD, new=self._mock_successful_submission):
                 consolidated_invoice.action_submit_to_myinvois()
                 self.assertRecordValues(consolidated_invoice, [{
-                    'name': 'CINV/2025/00001',
+                    'name': 'CINV/2025/00002',
                     'myinvois_submission_uid': '123456789',
                     'myinvois_external_uuid': '123458974513518',
                     'myinvois_validation_time': fields.Datetime.from_string('2025-01-01 01:00:00'),
                 }, {
-                    'name': 'CINV/2025/00002',
+                    'name': 'CINV/2025/00001',
                     'myinvois_submission_uid': '123456789',
                     'myinvois_external_uuid': '123458974513519',
                     'myinvois_validation_time': fields.Datetime.from_string('2025-01-01 01:00:00'),

--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -84,3 +84,11 @@ class PosCategory(models.Model):
                 raise ValidationError(_('The Availability After must be set between 00:00 and 24:00'))
             if category.hour_until and category.hour_after and category.hour_until < category.hour_after:
                 raise ValidationError(_('The Availability Until must be greater than Availability After.'))
+
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for pos_category, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", pos_category.name)
+        return vals_list

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -659,6 +659,14 @@ class PosConfig(models.Model):
             self._update_preparation_printers_menuitem_visibility()
         return result
 
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for config, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", config.name)
+        return vals_list
+
     def _preprocess_x2many_vals_from_settings_view(self, vals):
         """ From the res.config.settings view, changes in the x2many fields always result to an array of link commands or a single set command.
             - As a result, the items that should be unlinked are not properly unlinked.

--- a/addons/point_of_sale/models/pos_note.py
+++ b/addons/point_of_sale/models/pos_note.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import fields, models, api, _
 
 
 class PosNote(models.Model):
@@ -17,6 +17,14 @@ class PosNote(models.Model):
         'unique (name)',
         'A note with this name already exists',
     )
+
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for note, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", note.name)
+        return vals_list
 
     @api.model
     def _load_pos_data_domain(self, data, config):

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -190,6 +190,8 @@ class PosPaymentMethod(models.Model):
         vals_list = super().copy_data(default=default)
 
         for pm, vals in zip(self, vals_list):
+            if 'name' not in default:
+                vals['name'] = _("%s (copy)", pm.name)
             if pm.journal_id and pm.journal_id.type == 'cash':
                 if ('journal_id' in default and default['journal_id'] == pm.journal_id.id) or ('journal_id' not in default):
                     vals['journal_id'] = False

--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -90,6 +90,14 @@ class PosPreset(models.Model):
 
         return usage
 
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for preset, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", preset.name)
+        return vals_list
+
     def action_open_linked_orders(self):
         self.ensure_one()
         return {

--- a/addons/point_of_sale/models/pos_printer.py
+++ b/addons/point_of_sale/models/pos_printer.py
@@ -54,6 +54,14 @@ class PosPrinter(models.Model):
     )
     use_lna = fields.Boolean(string="Use Local Network Access")
 
+    def copy_data(self, default=None):
+        default = dict(default or {}, pos_config_ids=[(5, 0, 0)], epson_printer_ip="0.0.0.0")
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for printer, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", printer.name)
+        return vals_list
+
     @api.model
     def _load_pos_data_domain(self, data, config):
         return [('id', 'in', config.preparation_printer_ids.ids + config.receipt_printer_ids.ids)]

--- a/addons/pos_restaurant/models/pos_course.py
+++ b/addons/pos_restaurant/models/pos_course.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class PosCourse(models.Model):
@@ -18,6 +18,14 @@ class PosCourse(models.Model):
         'unique (name)',
         'A course with this name already exists',
     )
+
+    def copy_data(self, default=None):
+        default = dict(default or {}, category_ids=[(5, 0, 0)])
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for course, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", course.name)
+        return vals_list
 
     @api.model
     def _load_pos_data_domain(self, data, config):

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -69,6 +69,14 @@ class RestaurantFloor(models.Model):
 
         return super().write(vals)
 
+    def copy_data(self, default=None):
+        default = dict(default or {}, pos_config_ids=[(5, 0, 0)])
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for floor, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", floor.name)
+        return vals_list
+
     def deactivate_floor(self, session_id):
         draft_orders = self.env['pos.order'].search([('session_id', '=', session_id), ('state', '=', 'draft'), ('table_id.floor_id', '=', self.id)])
         if draft_orders:


### PR DESCRIPTION
In this commit:
------------------
- We have appended `(copy)` to the record name when duplicating a record, making it easier to distinguish duplicate entries across the following models.
    - `pos_course`
    - `pos_config`
    - `pos_payment_method`
    - `pos_category`
    - `pos_note`
    - `pos_preset`
    - `restaurant_floor`
    - `pos_printer`

Related PR: https://github.com/odoo/enterprise/pull/101298
task: 5380927
