### PR TITLE
[IMP] event_*: create event from event template

### DIFF
--- a/addons/event/models/event_type.py
+++ b/addons/event/models/event_type.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import api, Command, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 
 
@@ -60,3 +60,25 @@ class EventType(models.Model):
         for template in self:
             if not template.has_seats_limitation:
                 template.seats_max = 0
+
+    def action_create_event(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'event.event',
+            'view_mode': 'form',
+            'context': {
+                'default_date_tz': self.default_timezone,
+                'default_event_mail_ids': [
+                    Command.create(mail._prepare_event_mail_values()) for mail in self.event_type_mail_ids
+                ],
+                'default_event_ticket_ids': [
+                    Command.create(type_ticket._prepare_event_ticket_values()) for type_ticket in self.event_type_ticket_ids
+                ],
+                'default_question_ids': self.question_ids.ids,
+                'default_note': self.note,
+                'default_seats_limited': self.has_seats_limitation,
+                'default_seats_max': self.seats_max,
+                'default_tag_ids': self.tag_ids.ids,
+                'default_ticket_instructions': self.ticket_instructions,
+            },
+        }

--- a/addons/event/models/event_type_ticket.py
+++ b/addons/event/models/event_type_ticket.py
@@ -30,7 +30,12 @@ class EventTypeTicket(models.Model):
             ticket.seats_limited = ticket.seats_max
 
     @api.model
-    def _get_event_ticket_fields_whitelist(self):
-        """ Whitelist of fields that are copied from event_type_ticket_ids to event_ticket_ids when
-        changing the event_type_id field of event.event """
-        return ['sequence', 'name', 'description', 'seats_max']
+    def _prepare_event_ticket_values(self):
+        """Prepare values to copy from template to ticket."""
+        self.ensure_one()
+        return {
+            'sequence': self.sequence,
+            'name': self.name,
+            'description': self.description,
+            'seats_max': self.seats_max
+        }

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -7,6 +7,9 @@
         <field name="model">event.type</field>
         <field name="arch" type="xml">
             <form string="Event Category">
+               <header>
+                    <button name="action_create_event" string="Create event" class="oe_highlight" type="object"/>
+               </header>
                <sheet>
                     <div class="oe_title" name="event_type_title">
                         <label for="name" string="Event Template"/>

--- a/addons/event_booth/models/event_type.py
+++ b/addons/event_booth/models/event_type.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import Command, fields, models
 
 
 class EventType(models.Model):
@@ -10,3 +10,12 @@ class EventType(models.Model):
     event_type_booth_ids = fields.One2many(
         'event.type.booth', 'event_type_id',
         string='Booths', readonly=False, store=True)
+
+    def action_create_event(self):
+        action = super().action_create_event()
+        action['context'].update({
+            'default_event_booth_ids': [
+                Command.create(booth._prepare_event_booth_values()) for booth in self.event_type_booth_ids
+            ]
+        })
+        return action

--- a/addons/event_booth/models/event_type_booth.py
+++ b/addons/event_booth/models/event_type_booth.py
@@ -23,5 +23,9 @@ class EventTypeBooth(models.Model):
         default=_get_default_booth_category, ondelete='restrict', required=True)
 
     @api.model
-    def _get_event_booth_fields_whitelist(self):
-        return ['name', 'booth_category_id']
+    def _prepare_event_booth_values(self):
+        """Prepare values to copy from template to booth."""
+        return {
+            'name': self.name,
+            'booth_category_id': self.booth_category_id.id,
+        }

--- a/addons/event_product/models/event_type_ticket.py
+++ b/addons/event_product/models/event_type_ticket.py
@@ -92,6 +92,8 @@ class EventTypeTicket(models.Model):
         )
 
     @api.model
-    def _get_event_ticket_fields_whitelist(self):
-        """ Add sale specific fields to copy from template to ticket """
-        return super()._get_event_ticket_fields_whitelist() + ['product_id', 'price']
+    def _prepare_event_ticket_values(self):
+        """Add values of sale specific fields to copy from template to ticket."""
+        vals = super()._prepare_event_ticket_values()
+        vals.update({'product_id': self.product_id, 'price': self.price})
+        return vals


### PR DESCRIPTION
To remove the Event Template field from the event form, the events can be created from the event template form. As the event templates are only used to create event, it allows to remove the complexity related to the synchorization between the events and their event template.