### PR TITLE
[IMP] fleet: odometer reporting

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -581,7 +581,7 @@
         <field name="power">49</field>
         <field name="horsepower">67</field>
         <field name="driver_id" ref="base.res_partner_address_17" />
-        <field name="acquisition_date" eval="DateTime.today() - relativedelta(days=481)"/>
+        <field name="acquisition_date" eval="DateTime.today() - relativedelta(days=330)"/>
         <field name="state_id" ref="fleet_vehicle_state_registered"/>
         <field name="odometer_unit">kilometers</field>
         <field name="car_value">20000</field>
@@ -802,6 +802,89 @@
           <field name="value">8001.2</field>
       </record>
 
+    <record id="log_odometer_29" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=330)).strftime('%Y-%m-%d')"/>
+        <field name="value">0</field>
+    </record>
+
+    <record id="log_odometer_30" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=300)).strftime('%Y-%m-%d')"/>
+        <field name="value">620</field>
+    </record>
+
+    <record id="log_odometer_31" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=280)).strftime('%Y-%m-%d')"/>
+        <field name="value">1300</field>
+    </record>
+
+    <record id="log_odometer_32" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=250)).strftime('%Y-%m-%d')"/>
+        <field name="value">2000</field>
+    </record>
+
+    <record id="log_odometer_33" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=220)).strftime('%Y-%m-%d')"/>
+        <field name="value">2700</field>
+    </record>
+
+    <record id="log_odometer_34" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=180)).strftime('%Y-%m-%d')"/>
+        <field name="value">3400</field>
+    </record>
+
+    <record id="log_odometer_35" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=160)).strftime('%Y-%m-%d')"/>
+        <field name="value">3800</field>
+    </record>
+
+    <record id="log_odometer_36" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=135)).strftime('%Y-%m-%d')"/>
+        <field name="value">4200</field>
+    </record>
+
+    <record id="log_odometer_37" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=115)).strftime('%Y-%m-%d')"/>
+        <field name="value">4800</field>
+    </record>
+
+    <record id="log_odometer_38" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=100)).strftime('%Y-%m-%d')"/>
+        <field name="value">5200</field>
+    </record>
+
+    <record id="log_odometer_39" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=80)).strftime('%Y-%m-%d')"/>
+        <field name="value">5900</field>
+    </record>
+
+    <record id="log_odometer_40" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=50)).strftime('%Y-%m-%d')"/>
+        <field name="value">6600</field>
+    </record>
+
+    <record id="log_odometer_41" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=30)).strftime('%Y-%m-%d')"/>
+        <field name="value">7200</field>
+    </record>
+
+    <record id="log_odometer_42" model="fleet.vehicle.odometer">
+        <field name="vehicle_id" ref="vehicle_3"/>
+        <field name="date" eval="(DateTime.now() - timedelta(days=5)).strftime('%Y-%m-%d')"/>
+        <field name="value">8000</field>
+    </record>
 
       <record id="log_service_1" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_2" />

--- a/addons/fleet/report/odometer_report.py
+++ b/addons/fleet/report/odometer_report.py
@@ -21,62 +21,66 @@ class OdometerReport(models.Model):
 
     def init(self):
         query = """
-            -- Step 1: Get the acquisition date for each vehicle
+            -- Step 1: Cast vehicle_odometer timestamp
             WITH vehicle_odometer AS (
-                SELECT vehicle.id AS vehicle_id, odometer.value, CAST(odometer.date AS TIMESTAMP), CAST(vehicle.acquisition_date AS TIMESTAMP)
+                SELECT odometer.vehicle_id, odometer.value, CAST(odometer.date AS TIMESTAMP) AS reading_date
                 FROM fleet_vehicle_odometer odometer
-                LEFT JOIN fleet_vehicle vehicle ON vehicle.id=odometer.vehicle_id
             ),
-            -- Step 2: Select only one odometer record (with max value) per date per vehicle
+            -- Step 2: Select only one odometer record (max value) per date per vehicle
             vehicle_odometer_single_date AS (
-                SELECT DISTINCT ON (vehicle_id, date) t.vehicle_id, t.date, t.value, t.acquisition_date
+                SELECT DISTINCT ON (vehicle_id, reading_date) t.vehicle_id,  t.value, t.reading_date
                 FROM vehicle_odometer t
                 JOIN (
-                    SELECT vehicle_id, date, MAX(value) AS max_value
+                    SELECT vehicle_id, reading_date, MAX(value) AS max_value
                     FROM vehicle_odometer
-                    GROUP BY vehicle_id, date
+                    GROUP BY vehicle_id, reading_date
                 ) t_max_val
-                ON t.vehicle_id = t_max_val.vehicle_id AND t.date = t_max_val.date AND t.value = t_max_val.max_value
+                ON t.vehicle_id = t_max_val.vehicle_id AND t.reading_date = t_max_val.reading_date AND t.value = t_max_val.max_value
             ),
-            -- Step 3: Create a fake odometer reading at 0km if the acquisition date is set and lower than every other reading
-            vehicle_odometer_acquisition_date AS (
-                SELECT vehicle_id, date, value, acquisition_date FROM vehicle_odometer_single_date
+            -- Step 3: Get the acquisition date for each vehicle
+            vehicle_odometer_acquisition AS (
+                SELECT vehicle.id AS vehicle_id, odometer.value, reading_date, CAST(vehicle.acquisition_date AS TIMESTAMP)
+                FROM vehicle_odometer_single_date odometer
+                LEFT JOIN fleet_vehicle vehicle ON vehicle.id=odometer.vehicle_id
+            ),
+            -- Step 4: Add a fake odometer 0 value if the acquisition date is lower than other reading_dates (Interpolation)
+            vehicle_odometer_start_pt AS (
+                SELECT vehicle_id, reading_date, value, acquisition_date FROM vehicle_odometer_acquisition
                 UNION ALL
                 (
-                    SELECT vehicle_id, acquisition_date AS date, 0 AS value, acquisition_date
-                    FROM vehicle_odometer_single_date
+                    SELECT vehicle_id, acquisition_date AS reading_date, 0 AS value, acquisition_date
+                    FROM vehicle_odometer_acquisition
                     GROUP BY vehicle_id, acquisition_date
-                    HAVING acquisition_date < MIN(date)
+                    HAVING acquisition_date < MIN(reading_date)
                 )
-            ),
-            -- Step 4: Compute the previous and next date and value for each odometer reading
-            vehicle_odometer_prev_and_next AS (
-                SELECT vehicle_id, date, value, acquisition_date,
-                    LAG(date) OVER (PARTITION BY vehicle_id ORDER BY date) AS prev_date,
-                    LAG(value) OVER (PARTITION BY vehicle_id ORDER BY date) AS prev_val,
-                    LEAD(date) OVER (PARTITION BY vehicle_id ORDER BY date) AS next_date,
-                    LEAD(value) OVER (PARTITION BY vehicle_id ORDER BY date) AS next_val
-                FROM vehicle_odometer_acquisition_date
+                ORDER BY vehicle_id, reading_date, value DESC
             ),
             -- Step 5: Define the date range for each vehicle's odometer readings
             vehicle_odometer_date_range AS (
                 SELECT
                     vehicle_id,
-                    COALESCE(
-                        CAST(DATE_TRUNC('month', MIN(acquisition_date)) AS TIMESTAMP),
-                        CAST(DATE_TRUNC('month', MIN(date)) AS TIMESTAMP)) AS start_date,
-                    CAST(DATE_TRUNC('month', MAX(date)) AS TIMESTAMP) AS end_date
-                FROM vehicle_odometer_prev_and_next
+                    DATE_TRUNC('month', MIN(COALESCE(acquisition_date, reading_date))) AS start_date,
+                    DATE_TRUNC('month', MAX(reading_date)) AS end_date
+                FROM vehicle_odometer_start_pt
                 GROUP BY vehicle_id
             ),
-            -- Step 6: Generate a complete list of months for each vehicle within the date range (empty value, prev* and next*)
-            vehicle_odometer_date_range_min_date AS (
+            -- Step 6: Compute the previous and next date and value for each odometer reading
+            vehicle_odometer_prev_and_next AS (
+                SELECT vehicle_id, reading_date, value,
+                    LAG(reading_date) OVER (PARTITION BY vehicle_id ORDER BY reading_date) AS prev_date,
+                    LAG(value) OVER (PARTITION BY vehicle_id ORDER BY reading_date) AS prev_val,
+                    LEAD(reading_date) OVER (PARTITION BY vehicle_id ORDER BY reading_date) AS next_date,
+                    LEAD(value) OVER (PARTITION BY vehicle_id ORDER BY reading_date) AS next_val
+                FROM vehicle_odometer_start_pt
+            ),
+            -- Step 7: Generate a complete timeline list of months for each vehicle within the date range (empty value, prev* and next*)
+            vehicle_odometer_timeline AS (
                 SELECT
                     date_range.vehicle_id,
-                    CAST(COALESCE(odometer.date, generated_months.date) AS TIMESTAMP) AS date,
+                    CAST(COALESCE(odometer.reading_date, generated_months.date) AS TIMESTAMP) AS date,
                     COALESCE(odometer.value, 0) AS value, -- Odometer value set to 0 if no reading exists
                     CAST(
-                        FIRST_VALUE(COALESCE(odometer.date, generated_months.date)) OVER (
+                        FIRST_VALUE(COALESCE(odometer.reading_date, generated_months.date)) OVER (
                             PARTITION BY date_range.vehicle_id
                             ORDER BY generated_months.date
                         ) AS TIMESTAMP
@@ -85,29 +89,29 @@ class OdometerReport(models.Model):
                     odometer.prev_val,
                     odometer.next_date,
                     odometer.next_val
-                FROM vehicle_odometer_date_range date_range
+                FROM vehicle_odometer_date_range AS date_range
                 CROSS JOIN LATERAL GENERATE_SERIES(
                     date_range.start_date,
                     date_range.end_date,
                     '1 month'::INTERVAL
                 ) generated_months (date)
-                LEFT JOIN vehicle_odometer_prev_and_next odometer
+                LEFT JOIN vehicle_odometer_prev_and_next AS odometer
                     ON date_range.vehicle_id = odometer.vehicle_id
-                    AND generated_months.date = DATE_TRUNC('month', odometer.date)
+                    AND generated_months.date = DATE_TRUNC('month', odometer.reading_date)
             ),
-            -- Step 7: Compute the previous/next dates for every newly added readings
+            -- Step 8: Fill Null previous/next dates for every newly added readings
             vehicle_odometer_prev_next_date AS (
                 SELECT odometer.vehicle_id, odometer.date,
                 MAX(COALESCE(odometer.prev_date, odo_prev_next.prev_date)) AS prev_date,
                 MIN(COALESCE(odometer.next_date, odo_prev_next.next_date)) AS next_date
-                FROM vehicle_odometer_date_range_min_date odometer
+                FROM vehicle_odometer_timeline odometer
                 LEFT JOIN vehicle_odometer_prev_and_next odo_prev_next
                     ON odometer.vehicle_id = odo_prev_next.vehicle_id
                     AND (odo_prev_next.prev_date IS NULL OR odo_prev_next.prev_date < odometer.date)
                     AND (odo_prev_next.next_date IS NULL OR odo_prev_next.next_date > odometer.date)
                 GROUP BY odometer.vehicle_id, odometer.date
             ),
-            -- Step 8: Compute the previous/next values for every newly added readings
+            -- Step 9: Fill Null previous/next values for every newly added readings & add strict previous date
             vehicle_odometer_prev_next_complete AS (
                 SELECT DISTINCT
                     odo_dates.vehicle_id,
@@ -117,85 +121,83 @@ class OdometerReport(models.Model):
                     odo_dates.prev_date,
                     odometer_prev.value AS prev_value,
                     odo_dates.next_date,
-                    odometer_next.value AS next_value
+                    odometer_next.value AS next_value,
+                    LAG(odo_dates.date) OVER (
+                        PARTITION BY odo_dates.vehicle_id
+                        ORDER BY odo_dates.date
+                    ) AS strict_prev_date
                 FROM vehicle_odometer_prev_next_date odo_dates
-                LEFT JOIN vehicle_odometer_date_range_min_date odometer ON odo_dates.vehicle_id = odometer.vehicle_id AND odo_dates.date = odometer.date
-                LEFT JOIN vehicle_odometer_date_range_min_date odometer_prev ON odo_dates.vehicle_id = odometer_prev.vehicle_id AND odo_dates.prev_date = odometer_prev.date
-                LEFT JOIN vehicle_odometer_date_range_min_date odometer_next ON odo_dates.vehicle_id = odometer_next.vehicle_id AND odo_dates.next_date = odometer_next.date
+                LEFT JOIN vehicle_odometer_timeline odometer ON odo_dates.vehicle_id = odometer.vehicle_id AND odo_dates.date = odometer.date
+                LEFT JOIN vehicle_odometer_timeline odometer_prev ON odo_dates.vehicle_id = odometer_prev.vehicle_id AND odo_dates.prev_date = odometer_prev.date
+                LEFT JOIN vehicle_odometer_timeline odometer_next ON odo_dates.vehicle_id = odometer_next.vehicle_id AND odo_dates.next_date = odometer_next.date
             ),
-            -- Step 9: Compute the strict previous date for each odometer reading
-            vehicle_odometer_strict_prev AS (
-                SELECT vehicle_id, date, min_date, value, prev_date, prev_value, next_date, next_value,
-                    LAG(date) OVER (
-                        PARTITION BY vehicle_id
-                        ORDER BY date
-                    ) AS strict_previous_date
-                FROM vehicle_odometer_prev_next_complete
-            ),
-            -- Step 9: Fill in gaps (interpolate) in odometer readings using previous and next known values
-            vehicle_odometer_filled_gaps AS (
-                SELECT vehicle_id, date, value,
+            -- INTERPOLATION --
+            -- Step 10: Interpolate to get raw_mileage_delta using previous and next known values
+            vehicle_odometer_raw_delta AS (
+                SELECT vehicle_id, date, value, strict_prev_date,
                     CASE
                         WHEN value = 0 AND prev_value IS NOT NULL AND next_value IS NOT NULL
                             THEN (next_value - prev_value) * (
-                                EXTRACT(DAY FROM (date - strict_previous_date)) /
+                                EXTRACT(DAY FROM (date - strict_prev_date)) /
                                 NULLIF(EXTRACT(DAY FROM (next_date - prev_date)), 0)
                             )
                         WHEN prev_value IS NULL THEN value
                         ELSE (value - prev_value) * (
-                            EXTRACT(DAY FROM (date - strict_previous_date)) /
+                            EXTRACT(DAY FROM (date - strict_prev_date)) /
                             NULLIF(EXTRACT(DAY FROM (date - prev_date)), 0)
                         )
                     END AS raw_mileage_delta
-                FROM vehicle_odometer_strict_prev
+                FROM vehicle_odometer_prev_next_complete
             ),
-            -- Step 10: Sum the interpolated mileage delta values to have an odometer per month
+            -- Step 11: Interpolates values for missing months
             vehicle_odometer_interpolated AS (
                 SELECT
                     vehicle_id,
                     date,
+                    strict_prev_date,
                     CASE
                         WHEN value = 0 AND raw_mileage_delta IS NOT NULL
                             THEN SUM(raw_mileage_delta) OVER (PARTITION BY vehicle_id ORDER BY date)
                         ELSE value
                     END AS value
-                FROM vehicle_odometer_filled_gaps
+                FROM vehicle_odometer_raw_delta
             ),
-            -- Step 11: Calculate the days span between every odometer's reading date
+            -- MONTHS WEIGHT --
+            -- Step 12: Calculate the days span between every odometer's reading date
             vehicle_odometer_days_diff AS (
                 SELECT
                     vehicle_id,
                     date,
                     value,
                     value - COALESCE(LAG(value) OVER (PARTITION BY vehicle_id ORDER BY date), 0) AS raw_mileage_delta,
-                    LAG(date) OVER (PARTITION BY vehicle_id ORDER BY date) AS prev_date,
+                    strict_prev_date,
                     EXTRACT(DAY FROM date::TIMESTAMP - LAG(date) OVER (PARTITION BY vehicle_id ORDER BY date)::TIMESTAMP) AS days_span
                 FROM vehicle_odometer_interpolated
             ),
-            -- Step 12: Compute weighted mileage for each month
-            vehicle_weighted_mileage AS (
+            -- Step 13: Compute weighted mileage for each month
+            vehicle_odometer_weighted_mileage AS (
                 SELECT
                     vehicle_id,
                     date,
                     value,
                     raw_mileage_delta,
-                    prev_date,
                     days_span,
-                    DATE_TRUNC('month', prev_date) AS prev_month,
+                    DATE_TRUNC('month', strict_prev_date) AS prev_month,
                     DATE_TRUNC('month', date) AS current_month,
                     CASE
-                        WHEN TO_CHAR(prev_date, 'YYYY-MM') = TO_CHAR(date, 'YYYY-MM') THEN raw_mileage_delta
+                        WHEN TO_CHAR(strict_prev_date, 'YYYY-MM') = TO_CHAR(date, 'YYYY-MM') THEN raw_mileage_delta
                         ELSE raw_mileage_delta * COALESCE(
                             (EXTRACT(DAY FROM date::TIMESTAMP - DATE_TRUNC('month', date)::TIMESTAMP) / NULLIF(days_span, 0)), 1
                         )
                     END AS current_month_mileage,
                     CASE
-                        WHEN TO_CHAR(prev_date, 'YYYY-MM') = TO_CHAR(date, 'YYYY-MM') THEN 0
-                        ELSE raw_mileage_delta * (EXTRACT(DAY FROM DATE_TRUNC('month', date)::TIMESTAMP - prev_date::TIMESTAMP) / NULLIF(days_span, 0))
+                        WHEN TO_CHAR(strict_prev_date, 'YYYY-MM') = TO_CHAR(date, 'YYYY-MM') THEN 0
+                        ELSE raw_mileage_delta * (EXTRACT(DAY FROM DATE_TRUNC('month', date)::TIMESTAMP - strict_prev_date::TIMESTAMP) / NULLIF(days_span, 0))
                     END AS prev_month_mileage
                 FROM vehicle_odometer_days_diff
             ),
-            -- Step 13: Aggregate final results
+            -- AGGREGATE --
+            -- Step 14: Aggregate final results
             final_results AS (
                 SELECT
                     vehicle_id,
@@ -205,18 +207,18 @@ class OdometerReport(models.Model):
                 FROM (
                     SELECT vehicle_id, date, SUM(mileage_delta) AS mileage_delta
                     FROM (
-                        SELECT vehicle_id, prev_month AS date, prev_month_mileage AS mileage_delta FROM vehicle_weighted_mileage WHERE prev_month IS NOT NULL
+                        SELECT vehicle_id, prev_month AS date, prev_month_mileage AS mileage_delta FROM vehicle_odometer_weighted_mileage WHERE prev_month IS NOT NULL
                         UNION ALL
-                        SELECT vehicle_id, current_month AS date, current_month_mileage AS mileage_delta FROM vehicle_weighted_mileage
+                        SELECT vehicle_id, current_month AS date, current_month_mileage AS mileage_delta FROM vehicle_odometer_weighted_mileage
                     ) t
                     GROUP BY vehicle_id, date
                 ) t
             ),
-            -- Step 14: Handle the first recorded month with zero odometer
+            -- Step 15: Handle the first recorded month with zero odometer
             min_month AS (
                 SELECT vehicle_id, MIN(recorded_date) AS min_month_minus_one FROM final_results GROUP BY vehicle_id
             )
-            -- Step 15: Generate final result set with a row number
+            -- Step 16: Generate final result set with a row number
             SELECT row_number() OVER () AS id, * FROM (
                 SELECT vehicle_id, min_month_minus_one AS recorded_date, 0 AS odometer_value, 0 AS mileage_delta FROM min_month
                 UNION ALL

--- a/addons/fleet/views/fleet_vehicle_odometer_report.xml
+++ b/addons/fleet/views/fleet_vehicle_odometer_report.xml
@@ -20,6 +20,7 @@
         <field name="arch" type="xml">
             <graph string="Vehicle Odometer Timeline" stacked="0" type="line" sample="1" disable_linking="1">
                 <field name="mileage_delta" type="measure"/>
+                <field name="odometer_value"/>
             </graph>
         </field>
     </record>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -431,22 +431,10 @@
         </field>
     </record>
 
-    <record id="fleet_vehicle_odometer_view_graph" model="ir.ui.view">
-       <field name="name">fleet.vehicle.odometer.graph</field>
-       <field name="model">fleet.vehicle.odometer</field>
-       <field name="arch" type="xml">
-            <graph string="Odometer Values Per Vehicle" sample="1">
-                <field name="vehicle_id"/>
-                <field name="value" type="measure"/>
-            </graph>
-        </field>
-    </record>
-
     <record id='fleet_vehicle_odometer_action' model='ir.actions.act_window'>
         <field name="name">Odometers</field>
         <field name="res_model">fleet.vehicle.odometer</field>
-        <field name="view_mode">list,form,graph</field>
-        <field name="context"></field>
+        <field name="view_mode">list,form</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Create a new odometer log


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Current behavior before PR:**
. odometer_reporting for all vehicles is working
. there's no a report for each vehicle odometer values

**Desired behavior after PR is merged:**
. Refactored the fleet.vehicle.odometer.report to enhance performance by removing computationally expensive joins and eliminating duplicate columns. While making these optimizations, care was taken to preserve the original logic, the sequence of steps, and the Common Table Expression (CTE) structure so that the report’s functionality remains consistent.
. Added a vehicle-specific graph inside the fleet.vehicle.odometer.report form view to display odometer readings
. Added demonstration data to showcase the performance improvements achieved with the refactored SQL queries, allowing for easy comparison of response times before and after the optimization.

Attached two screenshots demonstrating the response times of the refactored SQL. While the difference is about 20ms with the demo data, the refactored query clearly enhances performance. This improvement may seem small for a limited dataset with 1000 records, but it is expected to make a more significant difference when handling large volumes of real-world data, leveraging the optimization capabilities of the PostgreSQL engine.

original SQL response time
<img width="1920" height="302" alt="original_performance_with_1k_records_average (1)" src="https://github.com/user-attachments/assets/1c7d2cbe-e498-4cb6-aa93-6e8f840ca295" />

new refactored SQL response time
<img width="1917" height="346" alt="my_performance_with_1k_records_average" src="https://github.com/user-attachments/assets/14c2380b-d0fa-4977-8dd2-afa7c119a73b" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
