### PR TITLE
[FIX] website, *: restore GIF image size display in builder sidebar

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_size.js
+++ b/addons/html_builder/static/src/plugins/image/image_size.js
@@ -30,9 +30,6 @@ export class ImageSize extends BaseOptionComponent {
                 imageCacheSize.set(src, size);
             }
         }
-        if (size === undefined) {
-            return;
-        }
         return `${(size / 1024).toFixed(1)} kB`;
     }
 }

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -260,11 +260,7 @@ export class ImagePostProcessPlugin extends Plugin {
     }
     async getProcessedImageSize(img) {
         const processed = await this._processImage({ img });
-        // return undefined if the image is a gif
-        if (!shouldPreventGifTransformation(processed.newDataset)) {
-            return getDataURLBinarySize(processed.url);
-        }
-        return undefined;
+        return getDataURLBinarySize(processed.url);
     }
     async postProcessImage(url, newDataset, processContext) {
         for (const cb of this.getResource("process_image_post_handlers")) {

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -39,7 +39,7 @@ function expectAround(value, expected, delta = 0.2) {
     expect(value).toBeLessThan(expected + delta);
 }
 
-test("the GIF image should NOT show its size", async () => {
+test("the GIF image should show its size", async () => {
     const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testGifImg}
@@ -47,10 +47,13 @@ test("the GIF image should NOT show its size", async () => {
     `);
     await contains(":iframe .test-options-target img").click();
     await waitSidebarUpdated();
-    expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+    const selector = `[data-container-title="Image"] [title="Size"]`;
+    await waitFor(selector);
+    const size = parseFloat(document.querySelector(selector).innerHTML);
+    expectAround(size, 325.2);
 });
 
-test("the GIF background image should NOT show its size", async () => {
+test("the GIF background image should show its size", async () => {
     const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             <section style="background-image: url(${testGifImgSrc});">text</section>
@@ -58,5 +61,8 @@ test("the GIF background image should NOT show its size", async () => {
     `);
     await contains(":iframe .test-options-target section").click();
     await waitSidebarUpdated();
-    expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+    const selector = `[data-label="Image"] [title="Size"]`;
+    await waitFor(selector);
+    const size = parseFloat(document.querySelector(selector).innerHTML);
+    expectAround(size, 325.2);
 });


### PR DESCRIPTION
`*` = html_builder, html_editor

A previous workaround [[1]](https://github.com/odoo/odoo/commit/520dde6f20742229de32c7bf781ab4208284ee79) hid GIF file sizes in the builder because
`_processImage` used to return incorrect data for GIFs, causing their
size to appear as "NaN kb".

The underlying `_processImage` issue was fixed in [[2]](https://github.com/odoo/odoo/commit/27be6d81497b49939d039361dc602d4575e23502), but the
workaround from [[1]](https://github.com/odoo/odoo/commit/520dde6f20742229de32c7bf781ab4208284ee79) was never reverted. This commit removes that
leftover logic and restores correct size display for GIF images,
bringing them back in line with other image types.

task-[5071548](https://www.odoo.com/odoo/project.task/5071548)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
