### PR TITLE
[IMP] project,project_todo: optimize title spacing

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -150,11 +150,11 @@
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <div class="d-flex justify-content-between align-items-center">
+                    <div class="d-flex flex-wrap-reverse flex-lg-nowrap justify-content-between align-items-center gap-2 mb-3 mb-lg-0">
                         <h1 class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>
-                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template">
+                        <div class="d-flex justify-content-between justify-content-lg-end align-items-center px-1 w-100 w-lg-auto" invisible="not active or is_template">
                             <field name="priority" class="h3 pe-2" widget="priority"/>
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -418,7 +418,7 @@
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_template"/>
                     <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not is_template"/>
-                    <div class="d-flex justify-content-between align-items-center">
+                    <div class="d-flex flex-wrap-reverse flex-lg-nowrap justify-content-between align-items-center gap-2 mb-3 mb-lg-0">
                         <h1 class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -93,11 +93,11 @@
                 </header>
                 <sheet class="o_todo_form_sheet_bg">
                     <widget name="web_ribbon" class="todo_archived" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <div class="d-flex justify-content-between align-items-center">
+                    <div class="d-flex flex-wrap-reverse flex-lg-nowrap justify-content-between align-items-center gap-2 mb-3 mb-lg-0">
                         <h1 class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>
-                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active">
+                        <div class="d-flex justify-content-between justify-content-lg-end align-items-center px-1 w-100 w-lg-auto" invisible="not active">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
                             <field name="state" widget="todo_done_checkmark" class="o_task_state_widget" />
                         </div>


### PR DESCRIPTION
On smaller viewport (< lg) the priority and status are displayed next to the title, taking some valuable space that could benefit the title.

This PR wraps the title to the next line freeing up the space

task-5380811


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
