### PR TITLE
[FIX] website_sale: Product image auto crop

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1015,6 +1015,11 @@ $-product-ratios-map: (
     .o_wsale_image_viewer_ratio_#{$-ratio-name},
     .o_wsale_product_page_opt_image_ratio_#{$-ratio-name} {
         --o-wsale-product-image-ratio: #{$-ratio-value};
+        @if($-ratio-name == 'auto') {
+            & img {
+                object-fit: contain !important; 
+            }
+        }
     }
 }
 @each $-ratio-name, $-ratio-value in $-product-ratios-map {


### PR DESCRIPTION
When the "auto-crop" option was disabled for a product's image,
the image in the product carousel was still being cropped.

Steps to reproduce:
===================
1. Navigate to a product page  with multiple images & enter Edit mode.
2. Change the main product image.
3. In the media dialog, Put "auto-crop" option to disabled.

-> The image in the product is still cropped.

Cause:
======
A CSS rule was forcing images within the product carousel
(`#o-carousel-product`) to use `object-fit: cover;`.
https://github.com/odoo/odoo/blob/726af8b5c0f40f2eea7a3cfa5004c56df128c248/addons/website_sale/static/src/scss/website_sale.scss#L1517

This property sizes an image to fill its container, cropping any parts
that overflow the aspect ratio. This rule took precedence over the
user's choice, meaning disabling "auto-crop" setting had no visible
effect on the carousel image.

the commit that cause the issue (see [2])

Solution:
=========
apply `object-fit: contain;` when auto-crop was disabled

`object-fit: contain` scales the image to fit inside the container
while preserving its aspect ratio,

See [1] to learn more about object-fit CSS property

[1]:https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-fit

[2]:https://github.com/odoo/odoo/commit/670b1daa2254d7600b54bae675dd673f457aa8fa#diff-e7fd12b506f935d1a853ecff44d3fedf867796ddef908e32fd15b5da672a851bR1455

opw-5359460