### PR TITLE
[FIX] hw_drivers: Catch print exceptions on Windows

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -6,6 +6,7 @@ import logging
 from base64 import b64decode
 import io
 import win32print
+import pywintypes
 import ghostscript
 
 from odoo.addons.hw_drivers.controllers.proxy import proxy_drivers
@@ -101,12 +102,27 @@ class PrinterDriver(Driver):
         event_manager.device_changed(self)
 
     def print_raw(self, data):
-        with win32print_lock:
-            win32print.StartDocPrinter(self.printer_handle, 1, ('', None, "RAW"))
-            win32print.StartPagePrinter(self.printer_handle)
-            win32print.WritePrinter(self.printer_handle, data)
-            win32print.EndPagePrinter(self.printer_handle)
-            win32print.EndDocPrinter(self.printer_handle)
+        job_id = False
+        page_started = False
+        try:
+            with win32print_lock:
+                job_id = win32print.StartDocPrinter(self.printer_handle, 1, ('', None, "RAW"))
+                win32print.StartPagePrinter(self.printer_handle)
+                page_started = True
+                win32print.WritePrinter(self.printer_handle, data)
+                win32print.EndPagePrinter(self.printer_handle)
+                win32print.EndDocPrinter(self.printer_handle)
+        except pywintypes.error as error:
+            _logger.error("Error while printing raw data to printer %s: %s", self.device_name, error)
+            if job_id or page_started:
+                try:
+                    with win32print_lock:
+                        if page_started:
+                            win32print.EndPagePrinter(self.printer_handle)
+                        if job_id:
+                            win32print.EndDocPrinter(self.printer_handle)
+                except pywintypes.error as err:
+                    _logger.error("Error while finalizing print job to printer %s after failure: %s", self.device_name, err)
 
     def print_report(self, data):
         with win32print_lock:


### PR DESCRIPTION
This commit adds the try/except block around print_raw method of the virtual iot box to allow catching exceptions when printing on Windows