### PR TITLE
[FIX] pos_hr: allow connecter user to go backend

### DIFF
--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
@@ -11,9 +11,6 @@ patch(Navbar.prototype, {
     },
     get showBackend() {
         const cashier = this.pos.get_cashier_user_id();
-        return (
-            !this.pos.config.module_pos_hr ||
-            (cashier && cashier.id === this.pos.session.user_id?.id)
-        );
+        return !this.pos.config.module_pos_hr || (cashier && cashier.id === this.pos.user?.id);
     },
 });

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -257,3 +257,24 @@ registry.category("web_tour.tours").add("pos_hr_go_backend_opened_registered", {
             Chrome.clickMenuOption("Backend", { expectUnloadPage: true }),
         ].flat(),
 });
+
+registry
+    .category("web_tour.tours")
+    .add("pos_hr_go_backend_opened_registered_different_user_logged", {
+        steps: () =>
+            [
+                Chrome.clickBtn("Unlock Register"),
+                PosHr.clickLoginButton(),
+
+                // Employee, connected user
+                SelectionPopup.has("Pos Employee1", { run: "click" }),
+                PosHr.enterPin("2580"),
+                Chrome.existMenuOption("Backend"),
+
+                // Manager that opened the session, not connected user
+                PosHr.clickCashierName(),
+                SelectionPopup.has("Test Manager 1", { run: "click" }),
+                PosHr.enterPin("5651"),
+                Chrome.notExistMenuOption("Backend"),
+            ].flat(),
+    });

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -51,7 +51,7 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
         emp1_user = new_test_user(
             cls.env,
             login="emp1_user",
-            groups="base.group_user",
+            groups="base.group_user, point_of_sale.group_pos_user",
             name="Pos Employee1",
             email="emp1_user@pos.com",
         )
@@ -168,3 +168,4 @@ class TestUi(TestPosHrHttpCommon):
 
         self.start_pos_tour("pos_hr_go_backend_closed_registered", login="manager_user")
         self.start_pos_tour("pos_hr_go_backend_opened_registered", login="manager_user")
+        self.start_pos_tour("pos_hr_go_backend_opened_registered_different_user_logged", login="emp1_user")


### PR DESCRIPTION
Currently a user that connected to a pos user cannot go backend if he was not the person who opened the session the first time.

Steps to reproduce:
-------------------
* Modify settings of the shop to use employee feature
* Make sure admin and demo can access the shop, set them advenced employee for example.
* Logged as Mitchell Admin, open the pos (It should have been closed before)
* Use Mitchel admin employee
* Complete cash control
* Go backend
* Log out
* Log back in with Marc Demo
* Enter the shop (it was already "opened" by Admin)
* Use Marc demo employee
* Now try to see the backend button
> Observation: Backend button is not available

Why the fix:
------------
Quoting this commit: https://github.com/odoo/odoo/commit/61df2871e1aac0144d26022a2a49c75ea9ecad4a
> Now, the only employees that can go back to the backend are those binded to the user connected.

However, `this.pos.session.user_id` only reflects the user who opened the pos the first time, in our case Mitchell Admin. It does not represent the connected user.

opw-5276950