### PR TITLE
[FIX] sale,web: make sure the button disable when no text

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -20,6 +20,20 @@ registry.category("web_tour.tours").add('sale_signature', {
         run: "click",
     },
     {
+        content: "clear the signature name",
+        trigger: '.modal .o_web_sign_name_and_signature input',
+        run: "clear",
+    },
+    {
+        content: "check submit is disabled when name is empty",
+        trigger: '.modal .o_portal_sign_submit:disabled',
+    },
+    {
+        content: "reset signature name",
+        trigger: '.modal .o_web_sign_name_and_signature input',
+        run: "fill Joel Willis",
+    },
+    {
         content: "check submit is enabled",
         trigger: '.o_portal_sign_submit:enabled',
     },

--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -103,6 +103,10 @@ export class NameAndSignature extends Component {
     async drawCurrentName() {
         const font = this.fonts[this.currentFont];
         const text = this.getCleanedName();
+        if (text.trim() === "") {
+            this.clear();
+            return;
+        }
         const canvas = this.signatureRef.el;
         const img = this.getSVGText(font, text, canvas.width, canvas.height);
         await this.printImage(img);


### PR DESCRIPTION
**Steps to produce:**
- Install `sale_management` module.
- `Create a SO > Click on Preview > Sign and Pay`.
- Remove all text from the Full Name`.

**Issue:**
- The `Accept & Sign` button remains enabled even when the Full Name field is empty.

**Root cause:**
- At [1], When the `drawCurrentName` method is called, it retrieves text using `getCleanedName`. This method returns an empty string when no name is provided
- Despite this, the code still generates an image and passes it to `printImage`, which keeps the button enabled.

**Solution:**
- If the cleaned name is empty or contains only spaces, do not generate image.
- Instead, immediately clear the signature pad so the button remains disabled.

[1]https://github.com/odoo/odoo/blob/9dedf75810bd6b7a92fe5bd279bf6bae98834750/addons/web/static/src/core/signature/name_and_signature.js#L103-L109

**Before:**
<img width="400" height="400" alt="before" src="https://github.com/user-attachments/assets/5ebdf852-4cba-4e1d-9ae4-7373e4b8b91d" />

**After:**
<img width="400" height="400" alt="after" src="https://github.com/user-attachments/assets/9280aa66-4f22-40d6-8a22-326cec24378d" />


**opw-5361890**
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
