### PR TITLE
[FIX] point_of_sale: fix orderline merge with higher price precision

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -322,10 +322,9 @@ export class PosOrderline extends Base {
         const price = window.parseFloat(
             roundDecimals(this.price_unit || 0, productPriceUnit).toFixed(productPriceUnit)
         );
-        let order_line_price = orderline
+        const order_line_price = orderline
             .get_product()
             .get_price(orderline.order_id.pricelist_id, this.get_quantity());
-        order_line_price = roundDecimals(order_line_price, this.currency.decimal_places);
 
         const isSameCustomerNote =
             (Boolean(orderline.get_customer_note()) === false &&
@@ -341,7 +340,9 @@ export class PosOrderline extends Base {
             // don't merge discounted orderlines
             this.get_discount() === 0 &&
             floatIsZero(
-                price - order_line_price - orderline.get_price_extra(),
+                roundDecimals(price, this.currency.decimal_places) -
+                    roundDecimals(order_line_price, this.currency.decimal_places) -
+                    orderline.get_price_extra(),
                 this.currency.decimal_places
             ) &&
             !this.isLotTracked() &&

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -790,3 +790,16 @@ registry.category("web_tour.tours").add("test_dynamic_product_price", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_orderline_merge_with_higher_price_precision", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("High Precision Product"),
+            ProductScreen.selectedOrderlineHas("High Precision Product", "1.0", "8.25"),
+            ProductScreen.clickDisplayedProduct("High Precision Product"),
+            ProductScreen.selectedOrderlineHas("High Precision Product", "2.0", "16.49"), // 8.245 * 2 = 16.49
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2244,6 +2244,19 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_disallowLineQuantityChange', login="pos_user")
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_disallowLineQuantityChange_2', login="pos_user")
 
+    def test_orderline_merge_with_higher_price_precision(self):
+        """ Test that orderline merging works correctly when product price has a higher precision than the currency. """
+        self.env['decimal.precision'].search([('name', '=', 'Product Price')]).digits = 3
+
+        self.env['product.product'].create({
+            'name': 'High Precision Product',
+            'list_price': 8.245,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_orderline_merge_with_higher_price_precision', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, when a product had a price with more decimals than the currency, adding it multiple times to the order would create multiple orderlines instead of merging them. This was due to rounding issue when comparing the prices of the orderlines.

opw-5341735

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
