### PR TITLE
[IMP] html_editor: remove non-editable elements with backspace

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -146,6 +146,12 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
             const newEnd = collapsed ? newStart : selectionEnd + insertedChars;
             this.textarea.setSelectionRange(newStart, newEnd, this.textarea.selectionDirection);
             this.embeddedState.value = this.textarea.value;
+        } else if (ev.key === "Backspace") {
+            // Transform empty code block into base container on backspace.
+            if (this.textarea.value === "") {
+                ev.preventDefault();
+                this.props.convertToParagraph({ target: this.pre });
+            }
         }
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -14,6 +14,7 @@ const CODE_BLOCK_SELECTOR = `div.${CODE_BLOCK_CLASS}`;
 export class SyntaxHighlightingPlugin extends Plugin {
     static id = "syntaxHighlighting";
     static dependencies = [
+        "baseContainer",
         "overlay",
         "history",
         "selection",
@@ -120,16 +121,11 @@ export class SyntaxHighlightingPlugin extends Plugin {
                     this.dependencies.history.stageSelection();
                     const component = target.closest(`[data-embedded='${name}']`);
                     const embeddedProps = getEmbeddedProps(component);
-                    const value = embeddedProps.value;
-                    const p = this.document.createElement("div");
-                    p.classList.add("o-paragraph");
-                    p.textContent = value;
-                    component.before(p);
-                    component.remove();
-                    newlinesToLineBreaks(p);
-                    this.dependencies.selection.setSelection({
-                        anchorNode: p,
-                    });
+                    const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                    baseContainer.textContent = embeddedProps.value;
+                    component.replaceWith(baseContainer);
+                    newlinesToLineBreaks(baseContainer);
+                    this.dependencies.selection.setCursorStart(baseContainer);
                     this.dependencies.history.addStep();
                 },
             });

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -177,6 +177,21 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     );
 });
 
+test("should convert empty banner into basecontainer on backspace", async () => {
+    const { el } = await setupEditor(
+        `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                <p>[]<br></p>
+            </div>
+        </div>`
+    );
+    await press("Backspace");
+    expect(getContent(el)).toBe(
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+    );
+});
+
 test("Can change an emoji banner", async () => {
     const { editor } = await setupEditor("<p>Test[]</p>");
     await insertText(editor, "/bannerinfo");

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -228,6 +228,23 @@ test("should fill an empty pre", async () => {
     });
 });
 
+test("should convert empty codeblock into base container on backspace", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: "<pre></pre>",
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "" }) +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+        stepFunction: async () => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+            await pressAndWait("Backspace");
+        },
+        contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+        contentAfter: `<p>[]<br></p>`,
+    });
+});
+
 test("the textarea should never contains zws", async () => {
     await testEditorWithHighlightedContent({
         contentBefore: "<pre>a\u200bb\ufeffc</pre>",
@@ -1141,8 +1158,8 @@ test("restore paragraph from code block", async () => {
         stepFunction: async () => {
             await click(".o_code_toolbar span.fa-paragraph");
         },
-        contentAfterEdit: '<div class="o-paragraph">[]abc</div>',
-        contentAfter: `<div>[]abc</div>`,
+        contentAfterEdit: "<p>[]abc</p>",
+        contentAfter: `<p>[]abc</p>`,
         config: configWithEmbeddings,
     });
 });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

-  Pressing `Backspace` inside an empty banner or code block did nothing.

### Desired behavior after PR is merged:

- Pressing `Backspace` in an empty banner or code block will transform them into a base container.

task- 5384545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
