### PR TITLE
[IMP] l10n_in_edi: Add Tax value in Total for Export with payment of tax

### DIFF
--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -716,7 +716,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                       'StateCesAmt': 0.0,
                       'StateCesNonAdvlAmt': 0.0,
                       'OthChrg': 0.0,
-                      'TotItemVal': 1000.0
+                      'TotItemVal': 1180.0
                     }
                   ],
                   'ValDtls': {
@@ -728,7 +728,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                     'StCesVal': 0.0,
                     'Discount': 0.0,
                     'RndOffAmt': 0.0,
-                    'TotInvVal': 1000.0
+                    'TotInvVal': 1180.0
                   },
                   'ExpDtls': {
                     'RefClm': 'Y',
@@ -873,7 +873,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                       'StateCesAmt': 0.0,
                       'StateCesNonAdvlAmt': 0.0,
                       'OthChrg': 0.0,
-                      'TotItemVal': 1000.0
+                      'TotItemVal': 1180.0
                     }
                   ],
                   'ValDtls': {
@@ -885,7 +885,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                     'StCesVal': 0.0,
                     'Discount': 0.0,
                     'RndOffAmt': 0.0,
-                    'TotInvVal': 1000.0
+                    'TotInvVal': 1180.0
                   },
                   'ExpDtls': {
                     'RefClm': 'Y',


### PR DESCRIPTION
Following the task- https://www.odoo.com/odoo/project.task/4878805 and PR- https://github.com/odoo/odoo/pull/213931

Here we are not collecting tax from the customer but the company has pay taxes to the goverment and after that the company can claim refund for the taxes. So when we are sending data to goverment then we need to include tax part into the invoice total

task-5369117



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
