### PR TITLE
[FIX] web: list_view: save fields with color widget

### DIFF
--- a/addons/web/static/src/views/fields/color/color_field.js
+++ b/addons/web/static/src/views/fields/color/color_field.js
@@ -1,24 +1,40 @@
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "../standard_field_props";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 export class ColorField extends Component {
     static template = "web.ColorField";
     static props = {
         ...standardFieldProps,
+        autosave: { type: Boolean, optional: true },
     };
 
     get color() {
         return this.props.record.data[this.props.name] || "";
+    }
+
+    onChange(ev) {
+        this.props.record.update(
+            { [this.props.name]: ev.target.value },
+            { save: this.props.autosave }
+        );
     }
 }
 
 export const colorField = {
     component: ColorField,
     supportedTypes: ["char"],
-    extractProps(fieldInfo, dynamicInfo) {
+    extractProps({ viewType, options }, dynamicInfo) {
+        let autosave = false;
+        if ("autosave" in options) {
+            autosave = exprToBoolean(options.autosave);
+        } else if (["list", "kanban"].includes(viewType)) {
+            autosave = true;
+        }
         return {
             readonly: dynamicInfo.readonly,
+            autosave,
         };
     },
 };

--- a/addons/web/static/src/views/fields/color/color_field.xml
+++ b/addons/web/static/src/views/fields/color/color_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.ColorField">
         <div class="o_field_color d-flex" t-att-class="{ 'o_field_cursor_disabled': props.readonly }" t-attf-style="background: #{color or 'url(/web/static/img/transparent.png)'}">
-            <input t-on-click.stop="" class="w-100 h-100 opacity-0" type="color" t-att-value="color" t-att-disabled="props.readonly" t-on-input="(ev) => this.color = ev.target.value" t-on-change="(ev) => this.props.record.update({ [this.props.name]: ev.target.value })" />
+            <input t-on-click.stop="" class="w-100 h-100 opacity-0" type="color" t-att-value="color" t-att-disabled="props.readonly" t-on-input="(ev) => this.color = ev.target.value" t-on-change="onChange" />
         </div>
     </t>
 


### PR DESCRIPTION
This commit fixes the issue where editing a field with widget="color" does not save it when the list is in editable="bottom" mode.

project.task~5262582

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
