### PR TITLE
[FIX] hw_drivers: increase log sent to db timeout

### DIFF
--- a/addons/hw_drivers/server_logger.py
+++ b/addons/hw_drivers/server_logger.py
@@ -25,9 +25,9 @@ class AsyncHTTPHandler(logging.Handler):
     _MAX_BATCH_SIZE = 50
     """Maximum number of sent logs batched at once. Used to avoid too heavy request. Log records still in the queue will
     be handle in future flushes"""
-    _FLUSH_INTERVAL = 0.5
+    _FLUSH_INTERVAL = 12
     """How much seconds it will sleep before checking for new logs to send"""
-    _REQUEST_TIMEOUT = 0.5
+    _REQUEST_TIMEOUT = 10
     """Amount of seconds to wait per log to send before timeout"""
     _DELAY_BEFORE_NO_SERVER_LOG = 5 * 60  # 5 minutes
     """Minimum delay in seconds before we log a server disconnection.
@@ -105,8 +105,8 @@ class AsyncHTTPHandler(logging.Handler):
             if not self._next_disconnection_time or now >= self._next_disconnection_time:
                 _logger.info("Connection with the server to send the logs failed. It is likely down: %s", request_errors)
                 self._next_disconnection_time = now + self._DELAY_BEFORE_NO_SERVER_LOG
-        except Exception as _:
-            _logger.exception('Unexpected error happened while sending logs to server')
+        except Exception:  # noqa: BLE001
+            _logger.error('Unexpected error happened while sending logs to server')
 
     def emit(self, record):
         # This is important that this method is as fast as possible.


### PR DESCRIPTION
Currently the request to send logs to the db from the iot box is at 0.5s timeout.
This leads to many exceptions and failed requests. This commit sets the timeout for such requests to 10s (previously 0 5s) and the frequency of sending logs to every 12s (previously 0.5s)

