### PR TITLE
[IMP] hr_recruitment: unhide key identifiers in duplicate applications view

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -31,10 +31,10 @@
                 <field name="date_last_stage_update" column_invisible="True"/>
                 <field name="partner_name" string="Name" readonly="1" optional="show"/>
                 <field name="create_date" readonly="1" optional="show" options="{'show_time': False}"/>
-                <field name="email_from" readonly="1" optional="hide"/>
-                <field name="partner_phone" widget="phone" readonly="1" optional="hide"/>
+                <field name="email_from" readonly="1" optional="show"/>
+                <field name="partner_phone" widget="phone" readonly="1" optional="show"/>
                 <field name="job_id" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
-                <field name="stage_id" widget="rotting" optional="show" column_invisible="context.get('default_talent_pool_ids')" options="{'no_open': True}"/>
+                <field name="stage_id" widget="rotting" optional="hide" column_invisible="context.get('default_talent_pool_ids')" options="{'no_open': True}"/>
                 <field name="kanban_state" widget="state_selection" string="State" optional="hide"/> 
                 <field name="priority" widget="priority" nolabel="1" optional="show"/>
                 <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" optional="show"/>


### PR DESCRIPTION
Before:
- The Stage column was shown even though the records can be easily grouped by Stage.
- The main identifiers used to recognize an application (email and phone number) were hidden, and the user had to manually enable them.

After:
- The `Stage` column is now hidden, as it is unnecessary when the view is already grouped by stage.
- The primary identifiers (phone number and email) are now visible by default.

Impact:
Improves the readability and usability of the view by hiding the unnecessary `Stage` column and displaying key identifiers.

Task: 5373017

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
