### PR TITLE
[FIX] bus: ensure user presence updates even when clicks don't propagate

### DIFF
--- a/addons/bus/static/src/services/presence_service.js
+++ b/addons/bus/static/src/services/presence_service.js
@@ -47,8 +47,8 @@ export const presenceService = {
         browser.addEventListener("focus", () => onFocusChange(true));
         browser.addEventListener("blur", () => onFocusChange(false));
         browser.addEventListener("pagehide", () => onFocusChange(false));
-        browser.addEventListener("click", onPresence);
-        browser.addEventListener("keydown", onPresence);
+        browser.addEventListener("click", onPresence, true);
+        browser.addEventListener("keydown", onPresence, true);
 
         return {
             bus,


### PR DESCRIPTION
Before this PR,
Elements that stopped event propagation (e.g., using event.stopPropagation()) 
prevented the global click listener from firing. As a result, user activity 
wasn't detected, and the presence status stayed "away" instead of switching 
back to "online".

This PR fixes the issue by enabling event capturing on the global 
click listener (useCapture: true). With capture mode, the listener receives the 
event during the capture phase before any element can stop propagation.

Bug:
![bug](https://github.com/user-attachments/assets/88c7d9a7-2c43-4947-a070-507d0b197e5e)


task-[4892229](https://www.odoo.com/odoo/project/1519/tasks/4892229)