### PR TITLE
[FIX] mrp: prevent `product_id` change in gantt

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -953,6 +953,8 @@ class MrpProduction(models.Model):
                 raise UserError(_("You cannot set more than 1 lot"))
 
     def write(self, vals):
+        if 'product_id' in vals and self.state != 'draft':
+            vals.pop('product_id')
         if 'move_byproduct_ids' in vals and 'move_finished_ids' not in vals:
             vals['move_finished_ids'] = vals.get('move_finished_ids', []) + vals['move_byproduct_ids']
             del vals['move_byproduct_ids']


### PR DESCRIPTION
Steps to reproduce:
1- Create MO and confirm
2- In gantt view move it to another product's line

Issue:
Product is changed, after being confirmed and it causes a lot of inconsistencies, as it changes into the new product with the main product's component and in the shop floor the main product is shown as a by-product even if the by-products are disabled.

Task: 5362247





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
