### PR TITLE
[FIX] html_editor: consider configuration in base containers handling

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -12,7 +12,6 @@ import { Plugin } from "../plugin";
 import { fillEmpty } from "@html_editor/utils/dom";
 import {
     BASE_CONTAINER_CLASS,
-    SUPPORTED_BASE_CONTAINER_NAMES,
     baseContainerGlobalSelector,
     createBaseContainer,
 } from "../utils/base_container";
@@ -74,7 +73,7 @@ export class BaseContainerPlugin extends Plugin {
             (node) =>
                 !node ||
                 node.nodeType !== Node.ELEMENT_NODE ||
-                !SUPPORTED_BASE_CONTAINER_NAMES.includes(node.tagName) ||
+                !this.config.baseContainers.includes(node.tagName) ||
                 isProtected(node) ||
                 isProtecting(node) ||
                 isMediaElement(node),
@@ -112,7 +111,7 @@ export class BaseContainerPlugin extends Plugin {
         let anchorNode = node.parentElement;
         if (
             anchorNode === closestEditable(node) ||
-            !SUPPORTED_BASE_CONTAINER_NAMES.includes(anchorNode.nodeName) ||
+            !this.config.baseContainers.includes(anchorNode.nodeName) ||
             this.getResource("unremovable_node_predicates").some((p) => p(anchorNode))
         ) {
             return;

--- a/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
+++ b/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
@@ -48,6 +48,22 @@ test("should insert a newline instead of splitting an explicit contenteditable='
         contentAfter: `<div contenteditable="false"><p contenteditable="true">ab<br>[]<br></p></div>`,
     });
 });
+test("should split a div (if it is eligible for baseContainer)", async () => {
+    await testEditor({
+        contentBefore: `<div>a[]b</div>`,
+        stepFunction: splitBlock,
+        contentAfter: `<div>a</div><div>[]b</div>`,
+        config: { baseContainers: ["P", "DIV"] },
+    });
+});
+test("should not split a div (if it isn't eligible for baseContainer)", async () => {
+    await testEditor({
+        contentBefore: `<div>a[]b</div>`,
+        stepFunction: splitBlock,
+        contentAfter: `<div>a<br>[]b</div>`,
+        config: { baseContainers: ["P"] },
+    });
+});
 test("should keep the last line break in the old paragraph", async () => {
     await testEditor({
         contentBefore: "<div><p>abc<br>[]<br></p></div>",


### PR DESCRIPTION
Since commit [1], the editor's configuration can include an array of nodes that are eligible to be base containers. That array has to be a subset of the constant `SUPPORTED_BASE_CONTAINER_NAMES`. But in some cases we failed to take the configuration into account and matched against the constant instead. In practice, this led to `div`s that aren't base containers to be considered splittable as if they were, whereas they shouldn't be.

[1]: https://github.com/odoo/odoo/commit/f6bae187fbef6e7b87e10c057f721b36b551a72a

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
