### PR TITLE
[FIX] html_editor: support vnd.odoo.odoo-editor in HtmlViewer clipboard

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -6,6 +6,7 @@ import {
 } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
+import { fillClipboardData } from "../utils/clipboard";
 import {
     unwrapContents,
     wrapInlinesInBlocks,
@@ -228,14 +229,7 @@ export class ClipboardPlugin extends Plugin {
                 }
             }
         }
-        const dataHtmlElement = this.document.createElement("data");
-        dataHtmlElement.append(clonedContents);
-        prependOriginToImages(dataHtmlElement, window.location.origin);
-        const odooHtml = dataHtmlElement.innerHTML;
-        const odooText = selection.textContent();
-        ev.clipboardData.setData("text/plain", odooText);
-        ev.clipboardData.setData("text/html", odooHtml);
-        ev.clipboardData.setData("application/vnd.odoo.odoo-editor", odooHtml);
+        fillClipboardData(ev, selection.textContent(), clonedContents);
         if (commonAncestor && commonAncestor.nodeType === Node.ELEMENT_NODE) {
             this.dispatchTo("normalize_handlers", commonAncestor);
         }
@@ -804,17 +798,4 @@ export function isHtmlContentSupported(node) {
         node,
         '[data-oe-model]:not([data-oe-field="arch"]):not([data-oe-type="html"]),[data-oe-translation-id]'
     );
-}
-
-/**
- * Add origin to relative img src.
- * @param {string} origin
- */
-function prependOriginToImages(doc, origin) {
-    doc.querySelectorAll("img").forEach((img) => {
-        const src = img.getAttribute("src");
-        if (src && !/^(http|\/\/|data:)/.test(src)) {
-            img.src = origin + (src.startsWith("/") ? src : "/" + src);
-        }
-    });
 }

--- a/addons/html_editor/static/src/utils/clipboard.js
+++ b/addons/html_editor/static/src/utils/clipboard.js
@@ -1,0 +1,33 @@
+/**
+ * Add origin to relative img src.
+ * @param {Document} doc
+ * @param {string} origin
+ */
+function prependOriginToImages(doc, origin) {
+    doc.querySelectorAll("img").forEach((img) => {
+        const src = img.getAttribute("src");
+        if (src && !/^(http|\/\/|data:)/.test(src)) {
+            img.src = origin + (src.startsWith("/") ? src : "/" + src);
+        }
+    });
+}
+
+/**
+ * Fills clipboard data, also with the
+ * application/vnd.odoo.odoo-editor mimetype so that it can recognized
+ * on paste inside an editor.
+ * @param {ClipboardEvent} ev copy event
+ * @param {string} textContent
+ * @param {DocumentFragment} clonedContents
+ */
+export function fillClipboardData(ev, textContent, clonedContents) {
+    const doc = ev.target.ownerDocument;
+    const dataHtmlElement = doc.createElement("data");
+    dataHtmlElement.append(clonedContents);
+    prependOriginToImages(dataHtmlElement, doc.defaultView.location.origin);
+    const odooHtml = dataHtmlElement.innerHTML;
+    const odooText = textContent;
+    ev.clipboardData.setData("text/plain", odooText);
+    ev.clipboardData.setData("text/html", odooHtml);
+    ev.clipboardData.setData("application/vnd.odoo.odoo-editor", odooHtml);
+}

--- a/addons/html_editor/static/tests/html_viewer.test.js
+++ b/addons/html_editor/static/tests/html_viewer.test.js
@@ -1,5 +1,6 @@
 import { HtmlViewer } from "@html_editor/fields/html_viewer";
 import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { markup } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
@@ -20,5 +21,48 @@ test(`XML-like self-closing elements are fixed in a standalone HtmlViewer`, asyn
     await animationFrame();
     expect(".o_readonly").toHaveInnerHTML(
         `<a href="#" target="_blank" rel="noreferrer"></a>outside<a href="#" target="_blank" rel="noreferrer">inside</a>`
+    );
+});
+
+test(`copy from HtmlViewer must support application/vnd.odoo.odoo-editor`, async () => {
+    await mountWithCleanup(WebClient);
+
+    registry.category("main_components").add("mycomponent", {
+        Component: HtmlViewer,
+        props: {
+            config: {
+                value: markup(`
+                    <p>before</p>
+                    <table class="table table-bordered o_table">
+                        <tbody>
+                            <tr style="height: 49.1875px;">
+                                <td style="background-color: rgba(214, 239, 214, 0.6); color: rgb(55, 65, 81);">
+                                    <p>A</p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p>after</p>
+                `),
+            },
+        },
+    });
+    await animationFrame();
+    const beforeNode = await waitFor("p:contains('before')");
+    const afterNode = await waitFor("p:contains('after')");
+    const range = new Range();
+    range.setStart(beforeNode, 1);
+    range.setEnd(afterNode, 0);
+    getSelection().addRange(range);
+    await animationFrame();
+
+    const clipboardData = new DataTransfer();
+    const ev = new ClipboardEvent("copy", { bubbles: true, clipboardData });
+    beforeNode.dispatchEvent(ev);
+
+    expect(clipboardData.getData("text/plain").trim()).toBe("A");
+    expect(clipboardData.getData("text/html")).toInclude("background-color");
+    expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe(
+        clipboardData.getData("text/html")
     );
 });


### PR DESCRIPTION
To make it possible to properly copy DOM elements across editors, the `application/vnd.odoo.odoo-editor` mimetype was introduced in the `ClipboardPlugin`.
However, this was not used inside the `HtmlViewer`. Because of this, some content formatting could be lost when copying elements from an `HtmlViewer` to an editor.

This commit solves this by also invoking the code that fills the clipboard in `ClipboardPlugin` when content is copied in an `HtmlViewer`.

Steps to reproduce:
- Insert a table in Knowledge
- Set a background color on a few cells
- Use the "lock" feature of Knowledge (inside a dropdown the menu on the right)
- Select the entire table
- Copy/paste it in a project task

=> The background colors in the cells were lost

task-4017841
