### PR TITLE
[FIX] point_of_sale: ensure products from draft orders are loaded

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -221,6 +221,10 @@ class ProductTemplate(models.Model):
         if products.filtered(lambda p: p.pos_optional_product_ids):
             products |= products.mapped("pos_optional_product_ids")
 
+        # Ensure products from loaded orders are loaded
+        if data.get('pos.order.line'):
+            products += self.env['product.product'].browse([l['product_id'] for l in data['pos.order.line']]).product_tmpl_id
+
         return self._load_pos_data_read(products, config)
 
     @api.model


### PR DESCRIPTION
Before this commit, when loading products, if limited product loading was enabled, it was possible that products present in draft POS orders were not loaded, leading to issues.

opw-5386056

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
