### PR TITLE
[FIX] l10n_tw_edi_ecpay: prevent error on send and print invoice

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -674,8 +674,7 @@ class AccountMove(models.Model):
 
         if self.partner_id.commercial_partner_id.contact_address_inline:
             buyer_json_data["Address"] = self.partner_id.commercial_partner_id.contact_address_inline
-        if self.partner_id.commercial_partner_id.phone or self.partner_id.commercial_partner_id.mobile:
-            number = self.partner_id.commercial_partner_id.phone or self.partner_id.commercial_partner_id.mobile
+        if number := self.partner_id.commercial_partner_id.phone:
             buyer_json_data["TelephoneNumber"] = self._reformat_phone_number(number)
 
         return call_ecpay_api("/MaintainMerchantCustomerData", buyer_json_data, self.company_id,


### PR DESCRIPTION
This error occurs when the user try to send invoice.

Steps to reproduce:
- Install `l10n_tw_edi_ecpay` module > Switch to `Taiwan` company
- SetUp `Taiwan Electronic Invoicing` in settings
- Create a New Customer with `Email` and `Tax ID` (eg: 12345678) - and no `phone` number.
- Create New Invoice with created Customer > Confirm > Send > `Send to Ecpay` > Generate

Traceback:
`AttributeError: 'res.partner' object has no attribute 'mobile'`

This issue occurs at [1] because when the `phone` field is not set, the system tries to fall back to the `mobile` field. However, the `mobile` field was removed from `res.partner` (see related reference), and it was reintroduced in the referenced [commit].

This commit cleans up the logic to avoid referencing a non-existent field.

[1]: https://github.com/odoo/odoo/blob/f1deed16e2355a74fea522439826625535eb7052/addons/l10n_tw_edi_ecpay/models/account_move.py#L677-L678

reference- https://github.com/odoo/odoo/pull/189739

[commit]: https://github.com/odoo/odoo/pull/236938/commits/c7404dff58f232103af4271a445d3841a82be8a3

sentry-7086174794