### PR TITLE
[FIX] account: Delete unnecesary depence for low performance

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -425,7 +425,6 @@ class AccountAccount(models.Model):
             record.opening_credit = res['credit']
             record.opening_balance = res['balance']
 
-    @api.depends('code')
     def _compute_account_type(self):
         """ Compute the account type based on the account code.
         Search for the closest parent account code and sets the account type according to the parent.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In debit notes wizards: If we make a wrong credit note and we want to correct it we must generate a debit note related to it.
Currently odoo only allows to generate debit notes from an invoice.

Steps to reproduce the error.
Install the Argentine localization
Create an invoice and post it
From the invoice using the wizard create a credit note and post it.
From the credit note open the wizard to create a debit note.
On submit the wizard we obtain an exception "You can not use a credit_note document type with a invoice"
This happens because the debit note wizard use copy method without change the l10n_latam_document_type_id value.

Current behavior before PR:
When creating a debit note from a credit note get an error.

Desired behavior after PR is merged:
We can create a debit memo from a credit note.

Adhoc tiket 69428 - 69854





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
