### PR TITLE
[FIX] account: Bills ZIP Export

### DIFF
--- a/addons/account/tests/test_download_docs.py
+++ b/addons/account/tests/test_download_docs.py
@@ -98,7 +98,7 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
             self.assertEqual(file_names, attachment_names)
 
     def test_download_moves_attachments_with_bills(self):
-        bill = self.init_invoice('in_invoice', products=self.product_a)
+        bill = self.init_invoice('in_invoice', products=self.product_a, post=True)
         bill.message_main_attachment_id = self.env['ir.attachment'].create({'name': "Attachment", 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})
         attachment_names = [bill.message_main_attachment_id.name]
         self.authenticate(self.env.user.login, self.env.user.login)
@@ -110,9 +110,9 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
             self.assertEqual(file_names, attachment_names)
 
     def test_download_moves_attachments_with_duplicate_names(self):
-        bill_1 = self.init_invoice('in_invoice', products=self.product_a)
-        bill_2 = self.init_invoice('in_invoice', products=self.product_a)
-        bill_3 = self.init_invoice('in_invoice', products=self.product_a)
+        bill_1 = self.init_invoice('in_invoice', products=self.product_a, post=True)
+        bill_2 = self.init_invoice('in_invoice', products=self.product_a, post=True)
+        bill_3 = self.init_invoice('in_invoice', products=self.product_a, post=True)
         att_name = "Attachment"
         bill_1.message_main_attachment_id = self.env['ir.attachment'].create({'name': att_name, 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})
         bill_2.message_main_attachment_id = self.env['ir.attachment'].create({'name': att_name, 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})


### PR DESCRIPTION
After this PR: https://github.com/odoo/odoo/pull/235934, clients can't export bills because they were never sent.

Allow clients to export bills.

Related feedback on task-4946367


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
