### PR TITLE
[FIX] website: improve date/datetime picker behavior on mobile

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -131,6 +131,9 @@ import wUtils from '@website/js/utils';
                         value: defaultValue && DateTime.fromSeconds(parseInt(defaultValue)),
                     },
                 }).enable();
+                // Disable virtual keyboard to fix popover display issues on
+                // small screens
+                input.setAttribute("inputmode", "none");
             }
             this.$allDates.addClass('s_website_form_datepicker_initialized');
 

--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -100,6 +100,11 @@
             background-color: darken($o-gray-200, 4.5%);
         }
     }
+    @include media-breakpoint-down(md) {
+        .datetimepicker-input{
+            caret-color: transparent;
+        }
+    }
 }
 
 body:not(.editor_enable) .s_website_form[data-vcss="001"] {


### PR DESCRIPTION
Steps to reproduce:

In a module, add a field with tracking=True on any model
Change this field on any record, to force the creation of a tracking value
Remove the field from the code
Update the module
Result:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/service/server.py", line 1313, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 114, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 536, in load_modules
    env['ir.model.data']._process_end(processed_modules)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2558, in _process_end
    self._process_end_unlink_record(record)
  File "/home/odoo/custom/odoo/addons/website/models/ir_model_data.py", line 36, in _process_end_unlink_record
    return super()._process_end_unlink_record(record)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2487, in _process_end_unlink_record
    record.unlink()
  File "/home/odoo/custom/odoo/addons/mail/models/ir_model_fields.py", line 52, in unlink
    'sequence': self.env[field.model_id.model]._mail_track_get_field_sequence(field.name),
  File "/home/odoo/custom/odoo/addons/mail/models/models.py", line 181, in _mail_track_get_field_sequence
    self._fields[fname], 'tracking',
KeyError: 'field_name'




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
