### PR TITLE
[IMP] pos_hr: add notification when employee is not linked to logged-in user

### DIFF
--- a/addons/pos_hr/static/src/app/screens/login_screen/login_screen.js
+++ b/addons/pos_hr/static/src/app/screens/login_screen/login_screen.js
@@ -53,16 +53,14 @@ patch(LoginScreen.prototype, {
             this.pos.login = false;
         } else {
             const employee = await this.selectCashier();
-            if (employee && employee.user_id?.id === this.pos.user.id) {
-                super.clickBack();
+            if (!employee) {
                 return;
-            } else if (employee) {
+            }
+            if (employee.user_id?.id === this.pos.user.id) {
+                return super.clickBack();
+            } else {
                 this.pos.notification.add(
-                    _t(
-                        "Only the cashier linked to the logged-in user (%s) can proceed to the Backend.",
-                        this.pos.user.name
-                    ),
-                    { type: "danger" }
+                    _t("%s is not linked to the User who is currently logged in.", employee.name)
                 );
             }
         }


### PR DESCRIPTION
Before this commit:
---
- No notification was shown when the selected employee was not linked to the currently logged-in POS user.

After this commit:
---
- Display a warning notification informing the user that the chosen employee is not linked to the logged-in user.
- Improves clarity when attempting to go back with an unauthorised employee.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
