### PR TITLE
[IMP] mrp, repair: centralize button visibility logic for action buttons

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -302,6 +302,8 @@ class MrpProduction(models.Model):
         search='_search_date_category', readonly=True
     )
     serial_numbers_count = fields.Integer("Count of serial numbers", compute='_compute_serial_numbers_count')
+    display_produce_all = fields.Boolean(compute='_compute_produce_visibility')
+    confirm_at_produce = fields.Boolean(compute='_compute_produce_visibility')
 
     _name_uniq = models.Constraint(
         'unique(name, company_id)',
@@ -868,6 +870,12 @@ class MrpProduction(models.Model):
             qty_none_or_all = production.qty_producing in (0, production.product_qty)
             production.show_produce_all = state_ok and qty_none_or_all
             production.show_produce = state_ok and not qty_none_or_all
+
+    @api.depends('move_raw_ids')
+    def _compute_produce_visibility(self):
+        for production in self:
+            production.display_produce_all = production.move_raw_ids
+            production.confirm_at_produce = not production.move_raw_ids
 
     def _search_is_delayed(self, operator, value):
         if operator not in ('in', 'not in'):

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -188,11 +188,11 @@
                     <field name="show_lock" invisible="1"/>
                     <field name="show_produce" invisible="1"/>
                     <field name="show_produce_all" invisible="1"/>
-                    <button name="button_mark_done" invisible="not move_raw_ids or not show_produce" string="Produce" type="object" class="oe_highlight" data-hotkey="g"/>
-                    <button name="button_mark_done" invisible="not move_raw_ids or not show_produce_all" string="Produce All" type="object" class="oe_highlight" data-hotkey="g"/>
-                    <button name="button_mark_done" invisible="move_raw_ids or not show_produce" string="Produce" type="object" class="oe_highlight" data-hotkey="g"
+                    <button name="button_mark_done" invisible="not (display_produce_all and show_produce)" string="Produce" type="object" class="oe_highlight" data-hotkey="g"/>
+                    <button name="button_mark_done" invisible="not (display_produce_all and show_produce_all)" string="Produce All" type="object" class="oe_highlight" data-hotkey="g"/>
+                    <button name="button_mark_done" invisible="not (confirm_at_produce and show_produce)" string="Produce" type="object" class="oe_highlight" data-hotkey="g"
                             confirm="There are no components to consume. Are you still sure you want to continue?"/>
-                    <button name="button_mark_done" invisible="move_raw_ids or not show_produce_all" string="Produce All" type="object" class="oe_highlight" data-hotkey="g"
+                    <button name="button_mark_done" invisible="not (confirm_at_produce and show_produce_all)" string="Produce All" type="object" class="oe_highlight" data-hotkey="g"
                             confirm="There are no components to consume. Are you still sure you want to continue?"/>
                     <button name="action_confirm" invisible="state != 'draft'" string="Confirm" type="object" class="oe_highlight" data-hotkey="q"/>
                     <button name="button_plan" invisible="state not in ('confirmed', 'progress', 'to_close') or is_planned" type="object" string="Plan" class="oe_highlight" data-hotkey="z"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -70,8 +70,8 @@
                <header>
                    <button name="action_validate" invisible="state != 'draft'" type="object" string="Confirm Repair" class="oe_highlight" data-hotkey="v"/>
                    <button name="action_repair_start" invisible="state != 'confirmed'" type="object" string="Start Repair" class="oe_highlight" data-hotkey="q"/>
-                   <button name="action_repair_end" invisible="state != 'under_repair' or not has_uncomplete_moves" type="object" string="End Repair" class="oe_highlight" data-hotkey="x" confirm="For some of the parts, there is a difference between the initial demand and the actual quantity that was used. Are you sure you want to confirm ?"/>
-                   <button name="action_repair_end" invisible="state != 'under_repair' or has_uncomplete_moves" type="object" string="End Repair" class="oe_highlight" data-hotkey="x"/>
+                   <button name="action_repair_end" invisible="not confirm_at_repair_end" type="object" string="End Repair" class="oe_highlight" data-hotkey="x" confirm="For some of the parts, there is a difference between the initial demand and the actual quantity that was used. Are you sure you want to confirm ?"/>
+                   <button name="action_repair_end" invisible="not display_repair_end" type="object" string="End Repair" class="oe_highlight" data-hotkey="x"/>
                    <button name="action_assign" invisible="not reserve_visible" string="Check availability" type="object"/>
                    <button name="action_unreserve" type="object" string="Unreserve" invisible="not unreserve_visible" data-hotkey="w"/>
                    <button name="action_create_sale_order" type="object" string="Create Quotation" invisible="not partner_id or (state == 'cancel' or sale_order_id)"/>


### PR DESCRIPTION
Introduce computed boolean fields to represent the shared visibility conditions for the `Produce` and `Produce All` buttons in MRP and the `End Repair` button in Repair. Enterprise modules now reuse these fields instead of duplicating the logic inside the XML `invisible` attributes.

This reduces code duplication, avoids inconsistencies between Community and Enterprise, and makes future overrides simpler and safer.

Task ID: 4898373