### PR TITLE
[FIX] _*: add widget on street fields for address autocomplete

### DIFF
--- a/addons/base_address_extended/models/res_partner.py
+++ b/addons/base_address_extended/models/res_partner.py
@@ -54,3 +54,17 @@ class ResPartner(models.Model):
             self.city = False
             self.zip = False
             self.state_id = False
+
+    @api.model
+    def _get_res_city_by_name(self, name, country_id):
+        ResCity = self.env['res.city']
+        if not name or not country_id:
+            return ResCity
+
+        if self.env.user._is_public():
+            ResCity = ResCity.sudo()
+
+        return ResCity.search([
+            ('name', '=ilike', name),
+            ('country_id', '=', country_id),
+        ], limit=1)

--- a/addons/google_address_autocomplete/controllers/google_address_autocomplete.py
+++ b/addons/google_address_autocomplete/controllers/google_address_autocomplete.py
@@ -60,12 +60,24 @@ class AutoCompleteController(http.Controller):
                         )
                         continue
                     state = request.env['res.country.state'].search(
-                        [('code', '=', google_field['short_name'].upper()),
-                         ('country_id', '=', standard_data['country'][0])])
+                        [
+                            ('country_id', '=', standard_data['country'][0]),
+                            '|',
+                            ('code', '=', google_field['short_name'].upper()),
+                            ('name', 'ilike', google_field['long_name']),
+                        ],
+                    )
                     if len(state) == 1:
                         standard_data[field_standard] = [state.id, state.name]
                 else:
                     standard_data[field_standard] = google_field['long_name']
+        city_name = standard_data.get('city')
+        country = standard_data.get('country')
+        country_id = country[0] if country else False
+        if city := self.env['res.partner']._get_res_city_by_name(city_name, country_id):
+            standard_data['city_id'] = [city.id, city.name]
+            if not standard_data.get('state') and city.state_id:  # Derive state from city if missing
+                standard_data['state'] = [city.state_id.id, city.state_id.name]
         return standard_data
 
     def _guess_number_from_input(self, source_input, standard_address):

--- a/addons/google_address_autocomplete/models/__init__.py
+++ b/addons/google_address_autocomplete/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import res_config_settings
+from . import res_partner

--- a/addons/google_address_autocomplete/models/res_partner.py
+++ b/addons/google_address_autocomplete/models/res_partner.py
@@ -1,0 +1,15 @@
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        if view_type == 'form' and 'enforce_cities' in self.env['res.country']._fields:
+            # added widget to street and street_name because some localizations might use their own template
+            for node in (arch.xpath("//field[@name='street' or @name='street_name']")):
+                node.set('widget', 'google_address_autocomplete')
+
+        return arch, view

--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
@@ -30,6 +30,10 @@ const standardAddressFields = {
     country_id: {
         label: _t("Country field"),
         type: ["char", "many2one"]
+    },
+    city_id: {
+        label: _t("City Id field"),
+        type: ["many2one"]
     }
 }
 
@@ -118,7 +122,7 @@ export class AddressAutoComplete extends CharField {
                     value = value[1];
                 }
                 valuesToUpdate[recordFieldName] = value || false;
-            } else if (!(recordFieldName in fields)) {
+            } else if (!(recordFieldName in fields) && value) {
                 value = Array.isArray(value) ? value[1] : value;
                 rest.push(value);
             }

--- a/addons/website_sale_autocomplete/static/src/interactions/address_form.js
+++ b/addons/website_sale_autocomplete/static/src/interactions/address_form.js
@@ -9,13 +9,18 @@ export class AddressForm extends Interaction {
     static selectorHas = "input[name='street'][data-autocomplete-enabled='1']";
     dynamicContent = {
         "input[name='street']": { "t-on-input.withTarget": this.debounced(this.onStreetInput, 200) },
+        "input[name='street_name']": { "t-on-input.withTarget": this.debounced(this.onStreetInput, 200) },
         ".js_autocomplete_result": { "t-on-click.withTarget": this.onClickAutocompleteResult },
     };
 
     setup() {
         this.streetAndNumberInput = this.el.querySelector("input[name='street']");
+        this.streetNameInput = this.el.querySelector("input[name='street_name']");
+        this.streetNumberInput = this.el.querySelector("input[name='street_number']");
+        this.street2Input = this.el.querySelector("input[name='street2']");
         this.cityInput = this.el.querySelector("input[name='city']");
         this.zipInput = this.el.querySelector("input[name='zip']");
+        this.citySelect = this.el.querySelector("select[name='city_id']");
         this.countrySelect = this.el.querySelector("select[name='country_id']");
         this.stateSelect = this.el.querySelector("select[name='state_id']");
         this.keepLast = new KeepLast();
@@ -64,9 +69,16 @@ export class AddressForm extends Interaction {
         if (address.formatted_street_number) {
             this.streetAndNumberInput.value = address.formatted_street_number;
         }
+        if (this.streetNameInput && address.street) {
+            this.streetNameInput.value = address.street;
+        }
+        if (this.streetNumberInput && address.number) {
+            this.streetNumberInput.value = address.number;
+        }
         // Text fields, empty if no value in order to avoid the user missing old data.
         this.zipInput.value = address.zip || "";
         this.cityInput.value = address.city || "";
+        this.street2Input.value = address.street2 || "";
 
         // Selects based on odoo ids
         if (address.country) {
@@ -78,8 +90,19 @@ export class AddressForm extends Interaction {
             // Waits for the stateSelect to update before setting the state.
             new MutationObserver((entries, observer) => {
                 this.stateSelect.value = address.state[0];
+                this.stateSelect.dispatchEvent(new Event("change", { bubbles: true }));
                 observer.disconnect();
             }).observe(this.stateSelect, {
+                childList: true, // Trigger only if the options change
+            });
+        }
+        if (this.citySelect && address.city_id) {
+            // Waits for the citySelect to update before setting the city.
+            new MutationObserver((entries, observer) => {
+                this.citySelect.value = address.city_id[0];
+                this.citySelect.dispatchEvent(new Event("change", { bubbles: true }));
+                observer.disconnect();
+            }).observe(this.citySelect, {
                 childList: true, // Trigger only if the options change
             });
         }

--- a/addons/website_sale_autocomplete/static/tests/l10n_br_extended_autocomplete_address_tour.js
+++ b/addons/website_sale_autocomplete/static/tests/l10n_br_extended_autocomplete_address_tour.js
@@ -1,0 +1,42 @@
+import { registry } from "@web/core/registry";
+import * as tourUtils from "@website_sale/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add('autocomplete_br_tour', {
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "A test product", expectUnloadPage: true }),
+        tourUtils.goToCart(),
+        tourUtils.goToCheckout(),
+        {
+            content: "Set Brazil first",
+            trigger: 'select[name="country_id"]',
+            run: "selectByLabel Brazil",
+        },
+        {
+            content: 'Input in Street field (handles both standard and extended)',
+            trigger: 'input[name="street_name"]',
+            run: "edit Hello",
+        },
+        {
+            content: 'Wait for results',
+            trigger: '.js_autocomplete_result',
+        },
+        {
+            content: 'Click result 0',
+            trigger: ".dropdown-menu .js_autocomplete_result:first",
+            run: "click",
+        },
+        {
+            content: 'Check Street Name (Extended)',
+            trigger: 'input[name="street_name"]:value(Hello world)',
+        },
+        {
+            content: 'Check Zip code',
+            trigger: 'input[name="zip"]:value(12345)',
+        },
+        {
+            content: 'Check Street 2',
+            trigger: 'input[name="street2"]:value(Bye Bye)',
+        },
+    ],
+});

--- a/addons/website_sale_autocomplete/static/tests/l10n_pe_autocomplete_address_tour.js
+++ b/addons/website_sale_autocomplete/static/tests/l10n_pe_autocomplete_address_tour.js
@@ -1,0 +1,31 @@
+import { registry } from "@web/core/registry";
+import * as tourUtils from '@website_sale/js/tours/tour_utils';
+
+registry.category("web_tour.tours").add('autocomplete_pe_tour', {
+    url: '/shop', 
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "A test product", expectUnloadPage: true }),
+        tourUtils.goToCart(),
+        tourUtils.goToCheckout(),
+        
+        {
+            content: 'Type address in street field',
+            trigger: 'input[name="street"]',
+            run: "edit Avenida Larco",
+        }, {
+            content: 'Wait for results to appear',
+            trigger: '.js_autocomplete_result',
+        }, {
+            content: 'Click the first mock result',
+            trigger: ".dropdown-menu .js_autocomplete_result:first:contains(Peru Result 0)",
+            run: "click",
+        },
+        {
+            content: 'Check that City ID (Province) is selected (not the placeholder)',
+            trigger: 'select[name="city_id"]:value(/^[0-9]+$/)',
+        }, {
+            content: 'Check Zip code value',
+            trigger: 'input[name="zip"]:value(/^15001$/)',
+        }
+    ]
+});

--- a/addons/website_sale_autocomplete/tests/test_ui.py
+++ b/addons/website_sale_autocomplete/tests/test_ui.py
@@ -42,3 +42,59 @@ class TestUI(HttpCase):
                                  } for x in range(5)]}):
             self.env['website'].get_current_website().google_places_api_key = MOCK_API_KEY
             self.start_tour('/shop/address', 'autocomplete_tour')
+
+    def test_autocomplete_br(self):
+        if self.env['ir.module.module']._get('l10n_br').state != 'installed':
+            self.skipTest("l10n_br module is not installed")
+
+        website = self.env['website'].get_current_website()
+        website.company_id.account_fiscal_country_id = website.company_id.country_id = self.env.ref("base.br")
+
+        with patch.object(AutoCompleteController, '_perform_complete_place_search',
+                        lambda controller, *args, **kwargs: {
+                            'country': [self.env['res.country'].search([('code', '=', 'BR')]).id, 'Brazil'],
+                            'zip': '12345',
+                            'street': 'Hello world',
+                            'street_number': '42',
+                            'street2': 'Bye Bye',
+                            }), \
+            patch.object(AutoCompleteController, '_perform_place_search',
+                        lambda controller, *args, **kwargs: {
+                            'results': [{
+                                'formatted_address': f'Result {x}',
+                                'google_place_id': MOCK_GOOGLE_ID
+                            } for x in range(5)]}):
+
+            website.google_places_api_key = MOCK_API_KEY
+            self.start_tour('/shop/address', 'autocomplete_br_tour')
+
+    def test_autocomplete_pe(self):
+        if self.env['ir.module.module']._get('l10n_pe').state != 'installed':
+            self.skipTest("l10n_pe module is not installed")
+
+        website = self.env['website'].get_current_website()
+        peru_country = self.env.ref("base.pe")
+        website.company_id.account_fiscal_country_id = website.company_id.country_id = peru_country
+
+        target_state = self.env['res.country.state'].search([('country_id', '=', peru_country.id)], limit=1)
+        target_city = self.env['res.city'].search([('state_id', '=', target_state.id)], limit=1)
+
+        with patch.object(AutoCompleteController, '_perform_complete_place_search',
+                        lambda controller, *args, **kwargs: {
+                            'country': [peru_country.id, 'Peru'],
+                            'state': [target_state.id, target_state.name],
+                            'city_id': [target_city.id, target_city.name],
+                            'zip': '15001',
+                            'street': 'Avenida Larco',
+                            'street_number': '123',
+                            'formatted_street_number': '123 Avenida Larco'
+                            }), \
+            patch.object(AutoCompleteController, '_perform_place_search',
+                        lambda controller, *args, **kwargs: {
+                            'results': [{
+                                'formatted_address': f'Peru Result {x}',
+                                'google_place_id': MOCK_GOOGLE_ID
+                            } for x in range(5)]}):
+
+            website.google_places_api_key = MOCK_API_KEY
+            self.start_tour('/shop/address', 'autocomplete_pe_tour')

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1108,6 +1108,10 @@ class ResPartner(models.Model):
             'country': self.country_id.code,
         }]
 
+    @api.model
+    def _get_res_city_by_name(self, name, country_id):
+        pass
+
 
 class ResPartnerIndustry(models.Model):
     _name = 'res.partner.industry'


### PR DESCRIPTION
_= base,base_address_extended,google_address_autocomplete,website_sale_autocomplete

The Google autocomplete feature was breaking when modules
such as base_extended_address modified the address form
(e.g., replacing street with street_name, street_number, etc.).

In this commit:
---
- Add the Google autocomplete widget to street-related fields.
- Also same thing handled in frontened (e-commerce address autocomplete).
- and update 'city_id' from available cities records if matches with google result.
- ```update access_rights for RecCity Model - grant read access to public user```

---
task-5382984
opw-5362597