### PR TITLE
[FIX] account: allow non-admin to validate a return

### DIFF
--- a/addons/account/models/account_lock_exception.py
+++ b/addons/account/models/account_lock_exception.py
@@ -233,7 +233,7 @@ class AccountLock_Exception(models.Model):
 
     def action_revoke(self):
         """Revokes an active exception."""
-        if not self.env.user.has_group('account.group_account_manager'):
+        if not self.env.user.has_group('account.group_account_manager') and not self.env.su:
             raise UserError(_("You cannot revoke Lock Date Exceptions. Ask someone with the 'Adviser' role."))
         for record in self:
             if record.state == 'active':


### PR DESCRIPTION
Before this fix, trying to validate a return with lesser accounting rights than admin raised an access error, stating that the user could not revoke lock date exceptions (whether such exception existed or not). The function used to revoke exceptions was called with sudo(), with the intent of bypassing any such check, but it relied on checking the user group, which sudo() has no impact on. We just patch the condition so that calling the function with sudo() does not block anymore, and revokes the exceptions as expected.

Note that this means a non-admin user could revoke a lock date exception set by an admin this way. This is a functional choice, to make the flow easier for everyone. In practice, such a situation could be prevented by checks, and just regular communication and work processes between users.
