### PR TITLE
[IMP] web: graphs in kandan cards

### DIFF
--- a/addons/account/static/src/scss/account_journal_dashboard.scss
+++ b/addons/account/static/src/scss/account_journal_dashboard.scss
@@ -29,7 +29,11 @@
         }
 
         .o_dashboard_graph {
-            margin-bottom: -$o-horizontal-padding/2;
+            margin-bottom: -#{map-get($spacers, 2)};
+        }
+
+        .o_graph_barchart {
+            margin-bottom: -#{map-get($spacers, 1)};
         }
 
         .o_field_widget.o_field_kanban_vat_activity {
@@ -68,7 +72,7 @@
 // Style for the widget "dashboard_graph"
 .o_dashboard_graph {
     position: relative;
-    margin: 16px -16px;
+    margin: $spacer (-$spacer);
 
     canvas {
         height: 150px;

--- a/addons/web/static/src/views/fields/journal_dashboard_graph/journal_dashboard_graph_field.js
+++ b/addons/web/static/src/views/fields/journal_dashboard_graph/journal_dashboard_graph_field.js
@@ -53,6 +53,7 @@ export class JournalDashboardGraphField extends Component {
         const labels = this.data[0].values.map(function (pt) {
             return pt.x;
         });
+
         const color10 = getColor(3, cookie.get("color_scheme"), "odoo");
         const borderColor = this.data[0].is_sample_data ? hexToRGBA(color10, 0.1) : color10;
         const backgroundColor = this.data[0].is_sample_data
@@ -66,21 +67,44 @@ export class JournalDashboardGraphField extends Component {
                     {
                         backgroundColor,
                         borderColor,
+                        pointBackgroundColor: (ctx) => {
+                            const index = ctx.index;
+                            const length = this.data[0].values.length;
+                            if (index === 0 || index === length - 1) {
+                                return "transparent";
+                            }
+                            return borderColor;
+                        },
+                        pointBorderColor: "transparent",
+                        hoverBackgroundColor: borderColor,
+                        pointHoverBorderColor: borderColor,
                         data: this.data[0].values,
                         fill: "start",
                         label: this.data[0].key,
                         borderWidth: 2,
+                        cubicInterpolationMode: "monotone",
                     },
                 ],
             },
             options: {
+                layout: {
+                    autoPadding: false,
+                },
                 plugins: {
                     legend: { display: false },
                     tooltip: {
                         enabled: !this.data[0].is_sample_data,
                         intersect: false,
-                        position: "nearest",
+                        position: "average",
                         caretSize: 0,
+                        usePointStyle: true,
+                        callbacks: {
+                            labelColor: (context) => {
+                                return {
+                                    backgroundColor: borderColor,
+                                };
+                            }
+                        }
                     },
                 },
                 scales: {
@@ -96,6 +120,10 @@ export class JournalDashboardGraphField extends Component {
                     line: {
                         tension: 0.000001,
                     },
+                },
+                interaction: {
+                    intersect: false,
+                    mode: 'index',
                 },
             },
         };
@@ -148,7 +176,14 @@ export class JournalDashboardGraphField extends Component {
                     },
                     x: {
                         grid: {
-                            color: GRAPH_GRID_COLOR,
+                            color: (ctx) => {
+                                const index = ctx.tick?.value;
+                                const length = this.data[0].length;
+                                if (index === 0 || index === length) {
+                                    return "transparent";
+                                }
+                                return GRAPH_GRID_COLOR;
+                            },
                         },
                         ticks: {
                             color: GRAPH_LABEL_COLOR,
@@ -159,6 +194,10 @@ export class JournalDashboardGraphField extends Component {
                     },
                 },
                 maintainAspectRatio: false,
+                interaction: {
+                    intersect: false,
+                    mode: 'index',
+                },
                 elements: {
                     line: {
                         tension: 0.000001,


### PR DESCRIPTION
This PR aims to modernize the graphs in the kanban card.

The graphs now fill the entire available space.

For the bar chart, external borders have been removed, and the hover effect has been change to also highlight the bar if the column is hovered.

For the line chart, external dots have been removed aswell, and the line is now curved.

task-5186572

| Type | Before | After |
|--------|--------|--------|
| Line | <img width="731" height="521" alt="image" src="https://github.com/user-attachments/assets/c3e8737c-ed5e-44ff-a9e8-98dd66d36c0a" /> | <img width="732" height="524" alt="image" src="https://github.com/user-attachments/assets/7d04db72-a0ac-448b-a4cf-a127948211b5" /> |
| Bar | <img width="734" height="434" alt="image" src="https://github.com/user-attachments/assets/a0b7a1a2-872a-46ef-a5aa-0c65efa4ad30" /> | <img width="733" height="440" alt="image" src="https://github.com/user-attachments/assets/ce3ac50d-78d5-4821-bbcd-edf9023b516e" /> | 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
