### PR TITLE
[FIX] mrp{,_subcontracting}: allow custom serials list

### DIFF
--- a/addons/mrp/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.py
@@ -56,15 +56,13 @@ class MrpProductionSerials(models.TransientModel):
         ])
         existing_lot_names = existing_lots.mapped('name')
         new_lots = []
-        for lot_name in lots:
+        for lot_name in sorted(lots):
             if lot_name in existing_lot_names:
                 continue
 
-            if self.lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
+            if lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
                 if self.production_id.product_id.lot_sequence_id:
-                    lot_name = self.production_id.product_id.lot_sequence_id.next_by_id()
-                else:
-                    lot_name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
+                    self.production_id.product_id.lot_sequence_id.number_next_actual += 1
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id

--- a/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
@@ -20,14 +20,12 @@ class MrpProductionSerials(models.TransientModel):
         ])
         existing_lot_names = existing_lots.mapped('name')
         new_lots = []
-        for lot_name in lots:
+        for lot_name in sorted(lots):
             if lot_name in existing_lot_names:
                 continue
-            if self.lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
+            if lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
                 if self.production_id.product_id.lot_sequence_id:
-                    lot_name = self.production_id.product_id.lot_sequence_id.next_by_id()
-                else:
-                    lot_name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
+                    self.production_id.product_id.lot_sequence_id.number_next_actual += 1
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -878,7 +878,7 @@ class ProductTemplate(models.Model):
             else:
                 template.lot_sequence_id = self.env.ref('stock.sequence_production_lots', raise_if_not_found=False)
 
-    @api.depends('serial_prefix_format', 'lot_sequence_id')
+    @api.depends('lot_sequence_id.number_next_actual')
     def _compute_next_serial(self):
         for template in self:
             if template.lot_sequence_id:


### PR DESCRIPTION
### Context:
In the Manufacturing app, users can create Manufacturing Orders to
create multiple products while assigning a unique serial number to each.
Users can either generate a list of serial numbers starting from a
first serial number, or provide a list of serial numbers themselves.

### Issue:
When providing a list of serial numbers without modifying the first
serial number field (`mrp.production.serials.lot_name`), the inputted
list is not used. Instead, another list starting with the unmodified
`lot_name` is generated and used.

### Cause:
In the `MrpProductionSerials.action_apply` method, the serial numbers
are updated if the first serial number field (`self.lot_name` in the
following code snippet) is left unchanged. This behavior overwrites
the list of serial numbers provided by the user.

https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/mrp/wizard/mrp_production_serial_numbers.py#L63-L67

### Steps to reproduce:
1. Install *Manufacturing* (`mrp`)
2. In Settings > Inventory, toggle *Lots & Serial Numbers*
3. Create a product tracked *By Unique Serial Number*
4. Create a Bill of Materials for the product
    - The BoM is required but its content is not relevant.
    Adding a single component with a quantity of one is enough.
5. Update the quantity of the component to be able to produce two products.
6. In *Manufacturing*, create a new *Manufacturing Order*.
    - Select the product and set the quantity to 2, then *Confirm*
7. Click *Generate Serial* or *Produce All*
8. **Do not** modify the *First SN* field, but write two serial numbers
(one per line) in the field below, then click *Apply*.
9. Click the *Serial Numbers (2)* smart button. The serial numbers we
used in step 8 were overwritten by the default *First SN* and its following SN.

### Solution:
This commit addresses the second bug described in https://github.com/odoo/odoo/commit/20158a115ef3dfb9fe2dd5103d3bed7e87e37940 without ever renaming
the serial numbers used for the MO. Now, the `product_id.next_serial`
matches a serial number from the list of provided/generated serial numbers.
The list of serial numbers is sorted to correctly handle cases such as:
```
First SN (self.lot_name) = '0000001'
self.serial_numbers = ['0000003', '0000002', '0000001']
```
In this scenario, we expect the *First SN* of the next MO to start at '0000004'.

The `else` clause of the condition was removed, as it would only be executed
if the `stock.sequence_production_lots` were removed. In that case,
`next_by_code('stock.lot.serial')` would return `False`, preventing
`lot_name` (or `next_serial`) from being updated correctly.

### Reason for second commit

The issue fixed by the first commit was replicated by https://github.com/odoo/odoo/commit/2548fd8d7f3b53a62089ac9122bd17524500ea1a in the subcontracting module (`mrp_subcontracting`). 
The first commit fixes the issue in the Manufacturing app (`mrp`), while the second commit fixes the issue in the subcontracting module (`mrp_subcontracting`). The fix and the test are similar in both commits.

opw-5373745