### PR TITLE
[FIX] stock_account: consider already processed qty in fifo

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -398,6 +398,9 @@ class ProductProduct(models.Model):
             fifo_stack_size = lot.product_qty
         else:
             fifo_stack_size = self._with_valuation_context().with_context(to_date=at_date).qty_available
+        if self.env.context.get('fifo_qty_already_processed'):
+            # When validating multiple moves at the same time, the qty_available won't be up to date yet
+            fifo_stack_size -= self.env.context['fifo_qty_already_processed']
         if self.uom_id.compare(fifo_stack_size, 0) <= 0:
             return fifo_stack, 0
 

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -241,6 +241,7 @@ class StockMove(models.Model):
         """
         products_to_recompute = set()
         lots_to_recompute = set()
+        fifo_qty_processed = defaultdict(float)
 
         for move in self:
             # Incoming moves
@@ -270,7 +271,9 @@ class StockMove(models.Model):
                 continue
 
             if move.product_id.cost_method == 'fifo':
-                move.value = move.product_id._run_fifo(move._get_valued_qty())
+                valued_qty = move._get_valued_qty()
+                move.value = move.product_id.with_context(fifo_qty_already_processed=fifo_qty_processed[move.product_id])._run_fifo(valued_qty)
+                fifo_qty_processed[move.product_id] += valued_qty
             else:
                 qty = move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id, rounding_method='HALF-UP')
                 move.value = move.product_id.standard_price * qty


### PR DESCRIPTION
Steps to reproduce:
- Have a product valued in fifo
- Create 3 PO for it, each for 1 qty of price 10, 20 and 30.
- Confirm these PO & validate their receipts
- Create 2 SO for this product, each for 1 qty
- Confirm these SO & validate their deliveries together

Issue:
The value associated to the delivery moves (and so the cogs generated from them) is 10 for both.

When calling `_action_done()` on the moves, we'll set the value of each move before moving them.
To get the correct value from the fifo stack, we rely on the `qty_available` at the time. However, since we're going to set the value of multiple moves before validating them, the `qty_available` won't be updated between each call.

opw-5359484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
