### PR TITLE
[FIX] l10n_din5008: print incoterms on DIN5008 invoice layout

### DIFF
--- a/addons/l10n_din5008/models/account_move.py
+++ b/addons/l10n_din5008/models/account_move.py
@@ -18,6 +18,13 @@ class AccountMove(models.Model):
                 data.append((_("Invoice Date"), format_date(self.env, record.invoice_date)))
             if record.invoice_date_due:
                 data.append((_("Due Date"), format_date(self.env, record.invoice_date_due)))
+            if record.invoice_incoterm_id:
+                value = (
+                    f"{record.invoice_incoterm_id.code} - {record.incoterm_location}"
+                    if record.incoterm_location
+                    else record.invoice_incoterm_id.code
+                )
+                data.append((_("Incoterm"), value))
             if record.delivery_date:
                 data.append((_("Delivery Date"), format_date(self.env, record.delivery_date)))
             if record.invoice_origin:


### PR DESCRIPTION
**Steps to reproduce:**

1. Install the modules account and l10n_din5008.
2. Go to Settings and set DIN5008 as the default invoice report template.
3. Navigate to Configuration → Settings and set a default Incoterm.
4. Create a new customer invoice.
5. Print the DIN5008 Invoice Report.

**Issue:**
The DIN5008 invoice report did not display the Incoterms, while other invoice layouts printed them correctly.

**Cause:**
This was due to missing logic in l10n_din5008 report to include Incoterm data. Confirmed with TSB that the DIN5008 layout should display Incoterms.

**Fix:**
This commit adds the Incoterm information to the DIN5008 template data:
- Always include the Incoterm code
- If an Incoterm location is set, display it as `CODE - LOCATION`

**opw-5349267**
