### PR TITLE
[FIX] l10n_in_pos, pos_loyalty: show customer name once in receipt

### DIFF
--- a/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="l10n_in_pos.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
+        <xpath expr="//div[hasclass('pos-receipt-customer')]" position="inside">
             <t t-if="order.partner_id and order.company?.country_id?.code == 'IN'">
-                <div class="pos-receipt-center-align">
-                    <div t-if="order.preset_id?.identification != 'address'" t-out="order.partner_id.name"/>
-                    <t t-if="order.partner_id.phone">
-                        <div>
-                            <span>Phone: </span>
-                            <t t-out="order.partner_id.phone" />
-                        </div>
-                    </t>
-                    <br />
-                </div>
+                <t t-if="order.partner_id.phone">
+                    <div>
+                        <span>Phone: </span>
+                        <t t-out="order.partner_id.phone" />
+                    </div>
+                </t>
+                <br />
             </t>
         </xpath>
         <xpath expr="//span[hasclass('pos-receipt-vat')]" position="after">

--- a/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -27,12 +27,6 @@
                     </div>
                 </t>
             </t>
-            <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
-                <div class="d-flex pt-3" style="font-size: 75%;">
-                    <span>Customer</span>
-                    <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
-                </div>
-            </t>
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
                 <div class="pos-coupon-rewards pt-3">
                     <t t-foreach="order.new_coupon_info" t-as="coupon_info" t-key="coupon_info.code">


### PR DESCRIPTION
When printing receipts in POS with Indian localization, the customer's name was displayed twice if the customer was selected. Also, when using the loyalty module, the customer name was shown. As the customer name is already displayed in the receipt header, this commit removes the redundant occurrences to enhance clarity.

opw-5386345

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
