### PR TITLE
[REF] mail: remove thread props from message_seen_indicator

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -25,7 +25,7 @@
             <div class="text-truncate base-fs fw-bolder mb-0 mx-2 px-1" t-esc="props.chatWindow.channel.displayName"/>
             <t t-set="message" t-value="channel.newestPersistentOfAllMessage" />
             <div t-if="previewText" class="text-truncate small mx-2 px-1 text-muted">
-                <MessageSeenIndicator t-if="message.showSeenIndicator(channel.thread)" message="message" thread="channel.thread" />
+                <MessageSeenIndicator t-if="message.showSeenIndicator(channel.thread)" message="message"/>
                 <t t-out="message.previewText" />
             </div>
         </div>

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -33,7 +33,7 @@
                 <div class="d-flex o-mail-NotificationItem-line">
                     <div class="o-mail-NotificationItem-text" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate, 'small': !ui.isSmall }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
-                        <MessageSeenIndicator t-if="message?.showSeenIndicator(props.thread)" message="message" thread="props.thread" />
+                        <MessageSeenIndicator t-if="message?.showSeenIndicator(props.thread)" message="message"/>
                         <t t-if="props.slots?.body" name="notificationBody" t-slot="body"/>
                     </div>
                     <div class="flex-grow-1"/>

--- a/addons/mail/static/src/discuss/core/common/message_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/message_patch.xml
@@ -6,7 +6,6 @@
                 <MessageSeenIndicator
                     t-if="props.message.showSeenIndicator(props.thread)"
                     message="props.message"
-                    thread="props.thread"
                 />
             </div>
         </xpath>
@@ -15,7 +14,6 @@
                 <MessageSeenIndicator
                     t-if="props.message.showSeenIndicator(props.thread)"
                     message="props.message"
-                    thread="props.thread"
                 />
             </div>
         </xpath>

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
@@ -33,7 +33,7 @@ class MessageSeenIndicatorDialog extends Component {
  */
 export class MessageSeenIndicator extends Component {
     static template = "mail.MessageSeenIndicator";
-    static props = ["message", "thread", "className?"];
+    static props = ["message", "className?"];
 
     setup() {
         super.setup();
@@ -42,8 +42,10 @@ export class MessageSeenIndicator extends Component {
 
     get summary() {
         if (this.props.message.hasEveryoneSeen) {
-            if (this.props.thread.channel?.channel_member_ids.length === 2) {
-                return _t("Seen by %(user)s", { user: this.props.thread.correspondent.name });
+            if (this.props.message.channel_id.channel_member_ids.length === 2) {
+                return _t("Seen by %(user)s", {
+                    user: this.props.message.channel_id.correspondent.name,
+                });
             }
             return _t("Seen by everyone");
         }


### PR DESCRIPTION
Channel can now be accessed directly from message, removing the need for thread as a props.
