### PR TITLE
[FIX] web: prevent calendar event flicker during drag and drop

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -76,8 +76,11 @@ export class CalendarModel extends Model {
         }
         browser.localStorage.setItem(this.storageKey, this.meta.scale);
         const data = { ...this.data };
-        // notify with basic data to render a simple calendar before updating them
-        this.notify();
+        if (params.date) {
+            // notify with basic data to render a simple calendar before updating them
+            // to avoid flickering on date change
+            this.notify();
+        }
         await this.keepLast.add(this.updateData(data));
         this.data = data;
         this.notify();


### PR DESCRIPTION
The calendar event would flicker on drag and drop because the calendar was rendered twice: once before and once after the event date was updated.

This double-render behavior was previously introduced to fix a flicker issue when the calendar date itself changed. This commit restricts the pre-rendering logic to only **calendar date updates**, thus avoiding the unnecessary and buggy double render when events are moved via drag and drop.
