### PR TITLE
[FIX] html_builder,website: publish delayed translations on save

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -13,7 +13,7 @@ declare module "plugins" {
     import { OperationShared } from "@html_builder/core/operation_plugin";
     import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
     import { empty_node_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
-    import { after_save_handlers, before_save_handlers, get_dirty_els, savable_selectors, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
+    import { after_save_handlers, before_save_handlers, get_dirty_els, pre_save_handlers, savable_selectors, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
     import { after_setup_editor_handlers, before_setup_editor_handlers, o_editable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
     import { target_hide, target_show, VisibilityShared } from "@html_builder/core/visibility_plugin";
     import { default_shape_handlers, image_shape_groups_providers, post_compute_shape_listeners } from "@html_builder/plugins/image/image_shape_option_plugin";
@@ -95,6 +95,7 @@ declare module "plugins" {
         on_will_clone_handlers: on_will_clone_handlers;
         on_will_remove_handlers: on_will_remove_handlers;
         post_compute_shape_listeners: post_compute_shape_listeners;
+        pre_save_handlers: pre_save_handlers;
         save_element_handlers: save_element_handlers;
         save_handlers: save_handlers;
         snippet_preview_dialog_stylesheets_handlers: snippet_preview_dialog_stylesheets_handlers;

--- a/addons/website/static/src/builder/plugins/save_translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/save_translation_plugin.js
@@ -8,9 +8,38 @@ export class SaveTranslationPlugin extends Plugin {
 
     /** @type {import("plugins").WebsiteResources} */
     resources = {
+        pre_save_handlers: this.saveDelayTranslations.bind(this),
         save_elements_overrides: withSequence(20, this.saveTranslationElements.bind(this)),
     };
 
+    async saveDelayTranslations(groupedDirtyElements) {
+        // Don't take dirty elements as they will be saved
+        const cleanDelayTranslationEls = [
+            ...this.editable.querySelectorAll(".o_delay_translation:not(.o_dirty)"),
+        ];
+        const groupedDelayTranslationElements =
+            this.dependencies.savePlugin.groupElements(cleanDelayTranslationEls);
+        const updateTranslationProms = [];
+        const currentWebsiteLang = this.services.website.currentWebsite.metadata.lang;
+        const translations = {};
+        translations[currentWebsiteLang] = {};
+        for (const [key, els] of Object.entries(groupedDelayTranslationElements)) {
+            // Keep only delay translation related to particular field that will
+            // not be updated by a modified (dirty) element
+            if (groupedDirtyElements[key]) {
+                continue;
+            }
+            updateTranslationProms.push(
+                rpc("/website/field/translation/update", {
+                    model: els[0].dataset["oeModel"],
+                    record_id: [Number(els[0].dataset["oeId"])],
+                    field_name: els[0].dataset["oeField"],
+                    translations,
+                })
+            );
+        }
+        return Promise.all(updateTranslationProms);
+    }
     /**
      * If the elements hold a translation, saves it. Otherwise, fallback to the
      * standard saving with the lang kept.


### PR DESCRIPTION
Scenario:

- have two languages on website
- drop a snippet on a page in main language
- go to secondary language => you see the previous page version, and a
  notification with `Click on "Edit/Translate" to apply changes made on
  default language.` is shown
- click on Edit: Translate => you see the version with the change from
  main language applied
- save without doing a change

Result: nothing is saved

Expectation: delayed translations that we are seeing when editing
translation should be saved.

Cause:

Delayed translation (draft version from change of main language) on
website were added or disabled with:

- 2d08f97c0778469b409fca23f2be5f5a98ce3df8 (October 2023) in 17.0 added
  the delay translation feature
- 0e0a74f8c5fc9f45311e629a76608c6c986d635d (December 2023) in 17.0
  disabled the feature
- 03a85b13b2c46ef7174123d902e95d5103031c6c (September 2025) in 19.0
  enabled the feature again

Currently delayed translations are only updated if there is a part of
that translation that has been edited and is dirty.

Fix: when we save translations, we should also save o_delay_translation
that are not dirty. These translations if there is a delayed translation
will publish the delayed translation.

opw-5187670
opw-5240423
opw-5250497
opw-5254832
opw-5344412
opw-5347408
opw-5419427
opw-5424761
opw-5892371