### PR TITLE
[FIX] sale_project : Handle multi-company access check

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -114,7 +114,6 @@ class SaleOrder(models.Model):
 
     @api.depends('order_line.product_id', 'order_line.project_id')
     def _compute_project_ids(self):
-        is_project_manager = self.env.user.has_group('project.group_project_manager')
         projects = self.env['project.project'].search(['|', ('sale_order_id', 'in', self.ids), ('reinvoiced_sale_order_id', 'in', self.ids)])
         projects_per_so = defaultdict(lambda: self.env['project.project'])
         for project in projects:
@@ -124,8 +123,7 @@ class SaleOrder(models.Model):
             projects |= order.project_id
             projects |= order.order_line.mapped('project_id')
             projects |= projects_per_so[order.id or order._origin.id]
-            if not is_project_manager:
-                projects = projects._filtered_access('read')
+            projects = projects._filtered_access('read')
             order.project_ids = projects
             order.project_count = len(projects.filtered('active'))
 

--- a/addons/sale_project/tests/__init__.py
+++ b/addons/sale_project/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_reinvoice
 from . import test_sale_project
 from . import test_so_line_milestones
 from . import test_sale_project_dashboard
+from . import test_sale_project_multicompany_access

--- a/addons/sale_project/tests/test_sale_project_multicompany_access.py
+++ b/addons/sale_project/tests/test_sale_project_multicompany_access.py
@@ -1,0 +1,71 @@
+from odoo.tests import TransactionCase
+from odoo.tests import Form
+
+
+class TestSaleOrderAccess(TransactionCase):
+
+    def setUp(self):
+
+        self.company_1 = self.env['res.company'].create({
+            'name': 'Company 1',
+            'currency_id': self.env.ref('base.USD').id,
+        })
+        self.company_2 = self.env['res.company'].create({
+            'name': 'Company 2',
+            'currency_id': self.env.ref('base.EUR').id,
+        })
+        self.user_company_1 = self.env['res.users'].create({
+            'name': 'User 1',
+            'login': 'user1',
+            'password': 'password',
+            'company_ids': [(6, 0, [self.company_1.id])],
+            'company_id': self.company_1.id,
+            'group_ids': [(6, 0, [
+                self.env.ref('sales_team.group_sale_manager').id,
+                self.env.ref('project.group_project_manager').id,
+            ])]
+        })
+        self.admin_user = self.env['res.users'].create({
+            'name': 'Admin User',
+            'login': 'adminn',
+            'password': 'password',
+            'company_ids': [(6, 0, [self.company_1.id, self.company_2.id])],
+            'company_id': self.company_1.id,
+            'group_ids': [(6, 0, [
+                self.env.ref('sales_team.group_sale_manager').id,
+                self.env.ref('project.group_project_manager').id,
+            ])],
+            })
+        self.partner = self.env['res.partner'].create({
+            'name': 'XYZ',
+            'type': 'contact'
+        })
+        self.project_company_2 = self.env['project.project'].create({
+            'name': 'Project Company 2',
+            'user_id': self.admin_user.id,
+            'company_id': self.company_2.id,
+            'partner_id': self.partner.id,
+            'allow_billable': True,
+        })
+        self.sale_order_company_1 = self.env['sale.order'].create({
+            'user_id': self.admin_user.id,
+            'partner_id': self.partner.id,
+            'company_id': self.company_1.id,
+            'state': 'sale',
+            'project_id': self.project_company_2.id
+        })
+        self.sale_line = self.env['sale.order.line'].create({
+            'name': 'XA',
+            'product_uom_qty': 1.00,
+            'price_unit': 20.00,
+            'order_id': self.sale_order_company_1.id,
+            'project_id': self.project_company_2.id,
+        })
+        self.project_company_2.write({
+            'sale_order_id': self.sale_order_company_1.id,
+            'sale_line_id': self.sale_line.id,
+        })
+
+    def test_user_with_company_1_access_can_open_sale_order(self):
+        Form(self.sale_order_company_1.with_user(self.admin_user).with_company(self.company_1))
+        Form(self.sale_order_company_1.with_user(self.user_company_1).with_company(self.company_1))


### PR DESCRIPTION
**Steps to reproduce the issue**

1. Create a database in Odoo 19.0.
2. Create a second company (so now you have two companies).
3. Install the **sale_project** app.
4. In **Company 1**, create a Sales Order.
5. In **Company 2**, create a Project that belongs **only** to Company 2 and mark it as *billable*.
6. Inside this Project, create a Task and link it to the Sales Order from Company 1. Make sure both companies are selected in the company switcher.
7. Now, switch to **only Company 1**, then try to open that Sales Order.
8. You will get an **AccessError**, even though the user has access rights in both companies.

**Second scenario**

1. Create another user (User 2) who has access **only** to Company 1.
2. Give User 2 manager access in both Sales and Project.
3. Log in as User 2 and try to open the Sales Order.
4. You will again get an **AccessError**.

**What is the actual issue?**

The AccessError happens in multi-company setups.

Even if a user has read access to the Sales Order, The error still blocks them from opening it if:

* The Sales Order belongs to Company A
* The linked Project belongs to Company B
* The user currently has only Company A selected or have Access to company A only.

This is because of the `_compute_project_ids`
https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/sale_project/models/sale_order.py#L127

This logic causes problems because:

* It only uses this check when the user is *not* a project manager.
* Even project managers can get AccessErrors if they don’t have the other company selected or not have access of other company.
* This is wrong because a user who **has the right to access the Sales Order** should still be allowed to open it, even if they don’t have access to the project in the other company.

**How the issue is fixed**

I removed the condition: `if not is_project_manager` This allows the system to skip the problematic filtering behavior. A user who has access rights to the Sales Order can now open it normally even if the linked project belongs to another company.

OPW: [5229806](https://www.odoo.com/odoo/project/70/tasks/5229806)
UPG: [3485646](https://upgrade.odoo.com/odoo/upgrade.request/3485646)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
