### PR TITLE
[FIX] partner_autocomplete: Avoid api calls on runbot demo data load

### DIFF
--- a/addons/partner_autocomplete/models/iap_autocomplete_api.py
+++ b/addons/partner_autocomplete/models/iap_autocomplete_api.py
@@ -17,7 +17,8 @@ class IapAutocompleteEnrichAPI(models.AbstractModel):
 
     @api.model
     def _contact_iap(self, local_endpoint, action, params, timeout=15):
-        if self.env.registry.in_test_mode():
+        is_runbot_env = not self.env["ir.config_parameter"].sudo().get_param("saas_client.database_uuid", False)
+        if self.env.registry.in_test_mode() or is_runbot_env:
             raise exceptions.ValidationError(_('Test mode'))
         account = self.env['iap.account'].get('partner_autocomplete')
         if not account.account_token:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
