### PR TITLE
[FIX] stock: process increase outside of inventory location

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2284,15 +2284,15 @@ Please change the quantity done or the rounding precision of your unit of measur
                 continue
 
             # find a quant similar to the move line on which we can reserve
-            ml_quants = self.env['stock.quant']._get_reserve_quantity(self.product_id,
-                                                                      ml.location_id,
-                                                                      qty,
-                                                                      lot_id=ml.lot_id,
-                                                                      package_id=ml.package_id,
-                                                                      owner_id=ml.owner_id,
-                                                                      strict=True)
-            avail_qty = sum(q[1] for q in ml_quants)
-            # the quant did not add the quantity reserved on this specific move line
+            ml_quants = self.env['stock.quant']
+            if not ml.location_id.should_bypass_reservation() and product.is_storable:
+                ml_quants = self.env['stock.quant']._get_reserve_quantity(
+                    self.product_id, ml.location_id, qty, lot_id=ml.lot_id,
+                    package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
+                avail_qty = sum(q[1] for q in ml_quants)
+            else:
+                avail_qty = qty
+            # the quant did not add the quantity reserved on this specific move lines
             consumed_quant |= {q[0].id for q in ml_quants}
             if float_compare(avail_qty, qty, precision_rounding=self.product_uom.rounding) <= 0:
                 qty -= avail_qty  # decrease the target quantity for the next move lines


### PR DESCRIPTION
Usecase to reproduce:
- Create a MO for 10 units
- Produce 15 units insead of the 10
- Check the `stock.move.line`

Expected behavior:
Only a single sml with 15 units since there is no complex config and they share the exact same data.

Current behavior:
A new `stock.move.line` with 5 units + another of 10 units (with same data)

It happens because `process_increase` method looping on the existing sml and check if there is some quantities on a similar quant to reserve. However sometimes the source location of the `stock.move.line` doesn't manage reservation. In this case we should just consider everything as available and reserve on it.

opw-5364883

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
