### PR TITLE
Move tests from at_install to post_install

### DIFF
--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -10,7 +10,6 @@ from zeep import Client, Transport
 from zeep.wsdl import Document
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStructure(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -3,12 +3,11 @@
 from datetime import datetime, timedelta
 
 from odoo.tests.common import TransactionCase, new_test_user
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.exceptions import AccessError
 from odoo.tools import mute_logger
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestAccessRights(TransactionCase):
 
     @classmethod

--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -4,12 +4,11 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo.tests.common import TransactionCase, new_test_user
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo import fields, Command
 from freezegun import freeze_time
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEventNotifications(TransactionCase):
 
     @classmethod

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -7,11 +7,10 @@ from datetime import datetime, timedelta
 
 from odoo import fields, Command
 from odoo.exceptions import AccessError
-from odoo.tests import tagged, Form, new_test_user
+from odoo.tests import Form, new_test_user
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestCalendar(SavepointCaseWithUserDemo):
 
     def setUp(self):

--- a/addons/calendar/tests/test_recurrence_rule.py
+++ b/addons/calendar/tests/test_recurrence_rule.py
@@ -2,10 +2,9 @@
 
 from datetime import datetime
 
-from odoo.tests.common import tagged, TransactionCase
+from odoo.tests.common import TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestRecurrenceRule(TransactionCase):
 
     def test_daily_count(self):

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -17,7 +17,6 @@ from odoo.tools import mute_logger
 
 
 @tagged('lead_internals')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestCRMLead(TestCrmCommon):
 
     @classmethod

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -60,7 +60,6 @@ class TestLeadAssignCommon(TestLeadConvertCommon):
 
 
 @tagged('lead_assign')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestLeadAssign(TestLeadAssignCommon):
     """ Test lead assignment feature added in saas-14.2 """
 

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -56,7 +56,6 @@ class TestLeadConvertForm(crm_common.TestLeadConvertCommon):
 
 
 @tagged('lead_manage')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestLeadConvert(crm_common.TestLeadConvertCommon):
     """
     TODO: created partner (handle assignment) has team of lead

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -34,7 +34,6 @@ class TestLeadMergeCommon(TestLeadConvertMassCommon):
 
 
 @tagged('lead_manage')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestLeadMerge(TestLeadMergeCommon):
 
     def _run_merge_wizard(self, leads):

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -54,7 +54,6 @@ class TestEventInternalsCommon(EventCase):
 
 
 @tagged('event_event')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEventData(TestEventInternalsCommon):
 
     @users('user_eventmanager')

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -9,7 +9,6 @@ from odoo.tests.common import users
 
 
 @tagged('event_flow')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEventSale(TestEventSaleCommon):
 
     @classmethod

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -14,7 +14,6 @@ from odoo import Command, tools
 
 
 @patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSyncGoogle2Odoo(TestSyncGoogle):
 
     def setUp(self):

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -10,12 +10,10 @@ from odoo.addons.google_calendar.models.res_users import ResUsers
 from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle, patch_api
 from odoo.tests.common import users, warmup
 from odoo.tests import tagged
-from odoo import tools
 
 
 @tagged('odoo2google', 'calendar_performance', 'is_query_count')
 @patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSyncOdoo2Google(TestSyncGoogle):
 
     def setUp(self):

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -12,7 +12,39 @@ from odoo.tools import mute_logger
 from odoo.exceptions import ValidationError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('at_install', '-post_install')
+class TestHrEmployeeAtInstall(TestHrCommon):
+    def test_set_user_on_new_employee(self):
+        test_company = self.env['res.company'].create({
+            'name': 'Test User Company',
+        })
+        self.env['hr.employee'].create({
+            'name': 'Hr Officer - employee',
+            'user_id': self.res_users_hr_officer.id,
+            'company_id': test_company.id,
+        })
+
+        self.res_users_hr_officer.write({'company_ids': test_company.ids, 'company_id': test_company.id})
+
+        # Try to set the user with existing employee in the company, on a new employee form
+        employee_form = Form(self.env['hr.employee'].with_user(self.res_users_hr_officer).with_company(company=test_company.id))
+        employee_form.name = "Second employee"
+        employee_form.user_id = self.res_users_hr_officer
+        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
+            employee_form.save()
+
+        employee_2 = self.env['hr.employee'].create({
+            'name': 'Hr 2 - employee',
+            'company_id': test_company.id,
+        })
+
+        # Try to set the user with existing employee in the company, on another existing employee
+        employee_2_form = Form(employee_2.with_user(self.res_users_hr_officer).with_company(company=test_company.id))
+        employee_2_form.user_id = self.res_users_hr_officer
+        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
+            employee_2_form.save()
+
+
 class TestHrEmployee(TestHrCommon):
 
     def setUp(self):
@@ -274,37 +306,6 @@ class TestHrEmployee(TestHrCommon):
         user_fields = ['email', 'phone', 'im_status']
         for field in user_fields:
             self.assertEqual(employee[field], user[field])
-
-    def test_set_user_on_new_employee(self):
-        test_company = self.env['res.company'].create({
-            'name': 'Test User Company',
-        })
-        self.env['hr.employee'].create({
-            'name': 'Hr Officer - employee',
-            'user_id': self.res_users_hr_officer.id,
-            'company_id': test_company.id,
-        })
-
-        self.res_users_hr_officer.write({'company_ids': test_company.ids, 'company_id': test_company.id})
-
-        # Try to set the user with existing employee in the company, on a new employee form
-        employee_form = Form(self.env['hr.employee'].with_user(self.res_users_hr_officer).with_company(company=test_company.id))
-        employee_form.name = "Second employee"
-        employee_form.user_id = self.res_users_hr_officer
-        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
-            employee_form.save()
-
-        employee_2 = self.env['hr.employee'].create({
-            'name': 'Hr 2 - employee',
-            'company_id': test_company.id,
-        })
-
-        # Try to set the user with existing employee in the company, on another existing employee
-        employee_2_form = Form(employee_2.with_user(self.res_users_hr_officer).with_company(company=test_company.id))
-        employee_2_form.user_id = self.res_users_hr_officer
-        with mute_logger('odoo.sql_db'), self.assertRaises(UniqueViolation), self.assertRaises(ValidationError):
-            employee_2_form.save()
-
 
     @users('admin')
     def test_change_user_on_employee(self):

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -8,7 +8,6 @@ from odoo.tests.common import tagged
 
 
 @tagged('hr_attendance_overtime')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestHrAttendanceOvertime(HttpCase):
     """ Tests for overtime """
 

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -9,7 +9,6 @@ from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 @tagged('work_hours')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestWorkingHours(TestHrCalendarCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -11,7 +11,6 @@ from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 
 
 @tagged('allocation')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestAllocations(TestHrHolidaysCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -6,7 +6,6 @@ from odoo.tests import tagged, Form
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestAutomaticLeaveDates(TestHrHolidaysCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -7,7 +7,6 @@ from odoo.addons.hr_holidays.tests.common import TestHolidayContract
 
 
 @tagged('multi_contract')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestHolidaysMultiContract(TestHolidayContract):
 
     @classmethod

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -8,7 +8,6 @@ from odoo.tests import tagged, TransactionCase, Form
 
 
 @tagged('recruitment')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestRecruitment(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
+++ b/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
@@ -7,7 +7,6 @@ from odoo.exceptions import ValidationError
 
 
 @tagged("recruitment")
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestRecruitmentTalentPool(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_recruitment_skills/tests/test_applicant_skills.py
+++ b/addons/hr_recruitment_skills/tests/test_applicant_skills.py
@@ -6,7 +6,6 @@ from odoo.tests import Form, TransactionCase, tagged
 
 
 @tagged("recruitment")
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestApplicantSkills(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
+++ b/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
@@ -6,7 +6,6 @@ from odoo.tests.common import new_test_user
 
 
 @tagged("recruitment")
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestRecruitmentSkills(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/hr_skills/tests/test_employee_skill.py
+++ b/addons/hr_skills/tests/test_employee_skill.py
@@ -9,14 +9,13 @@ from odoo.tests import tagged, Form
 from odoo.tests.common import TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEmployeeSkills(TransactionCase):
 
     @classmethod
-    def _create_skill_types(self, vals_list):
-        skill_types = self.env['hr.skill.type']
+    def _create_skill_types(cls, vals_list):
+        skill_types = cls.env['hr.skill.type']
         for vals in vals_list:
-            with Form(self.env['hr.skill.type']) as skill_type_form:
+            with Form(cls.env['hr.skill.type']) as skill_type_form:
                 skill_type_form.name = vals['name']
                 skill_type_form.is_certification = vals.get('certificate', False)
                 for skill_val in vals['skills']:

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -113,7 +113,6 @@ class TestCommonTimesheet(TransactionCase):
         )
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestTimesheet(TestCommonTimesheet):
 
     def setUp(self):

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -157,6 +157,23 @@ class TestMailRenderCommon(common.MailCommon):
 
 @tagged('mail_render')
 @tagged('at_install', '-post_install')  # LEGACY at_install
+class TestMailRenderAtInstall(TestMailRenderCommon):
+
+    @users('employee')
+    def test_render_field_not_existing(self):
+        """ Test trying to render a not-existing field: raise a proper ValueError
+        instead of crashing / raising a KeyError """
+        template = self.env['mail.template'].browse(self.test_template.ids)
+        partner = self.env['res.partner'].browse(self.render_object_fr.ids)
+        with self.assertRaises(ValueError):
+            _rendered = template._render_field(
+                'not_existing',
+                partner.ids,
+                compute_lang=True
+            )[partner.id]
+
+
+@tagged('mail_render')
 class TestMailRender(TestMailRenderCommon):
 
     @users('employee')
@@ -244,19 +261,6 @@ class TestMailRender(TestMailRenderCommon):
                     if not res_ids:
                         self.assertFalse(rendered_all,
                                          'Rendering: void input -> void output')
-
-    @users('employee')
-    def test_render_field_not_existing(self):
-        """ Test trying to render a not-existing field: raise a proper ValueError
-        instead of crashing / raising a KeyError """
-        template = self.env['mail.template'].browse(self.test_template.ids)
-        partner = self.env['res.partner'].browse(self.render_object_fr.ids)
-        with self.assertRaises(ValueError):
-            _rendered = template._render_field(
-                'not_existing',
-                partner.ids,
-                compute_lang=True
-            )[partner.id]
 
     @users('employee')
     def test_render_template_inline_template(self):
@@ -516,7 +520,6 @@ class TestRegexRendering(common.MailCommon):
 
 
 @tagged('mail_render')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMailRenderSecurity(TestMailRenderCommon):
     """ Test security of rendering, based on qweb finding + restricted rendering
     group usage. """

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -5,7 +5,6 @@ import base64
 import re
 from ast import literal_eval
 from datetime import datetime
-from unittest.mock import patch
 
 from freezegun import freeze_time
 from psycopg2 import IntegrityError
@@ -22,7 +21,6 @@ BASE_64_STRING = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A
 
 
 @tagged("mass_mailing")
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMassMailValues(MassMailCommon):
 
     @classmethod

--- a/addons/microsoft_calendar/tests/test_delete_events.py
+++ b/addons/microsoft_calendar/tests/test_delete_events.py
@@ -20,7 +20,6 @@ from odoo.addons.microsoft_calendar.tests.common import (
 
 
 @patch.object(ResUsers, '_get_microsoft_calendar_token', mock_get_token)
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestDeleteEvents(TestCommon):
 
     @patch_api

--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -5,12 +5,9 @@ from datetime import datetime, UTC
 from dateutil.relativedelta import relativedelta
 
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
-from odoo.tests import tagged
-
 from odoo.addons.microsoft_calendar.tests.common import TestCommon, patch_api
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMicrosoftEvent(TestCommon):
 
     @patch_api

--- a/addons/microsoft_calendar/tests/test_microsoft_service.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_service.py
@@ -8,13 +8,12 @@ from odoo import fields
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_account.models.microsoft_service import MicrosoftService
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import TransactionCase
 
 
 DEFAULT_TIMEOUT = 20
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMicrosoftService(TransactionCase):
 
     def _do_request_result(self, data):

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -13,7 +13,6 @@ from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCal
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_calendar.models.res_users import ResUsers
 from odoo.addons.microsoft_calendar.tests.common import TestCommon, mock_get_token, _modified_date_in_the_future, patch_api
-from odoo.tests import tagged
 
 from odoo.exceptions import UserError, ValidationError
 
@@ -21,7 +20,6 @@ _logger = logging.getLogger(__name__)
 
 
 @patch.object(ResUsers, '_get_microsoft_calendar_token', mock_get_token)
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestUpdateEvents(TestCommon):
 
     @patch_api

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -8,7 +8,6 @@ from odoo.tests import tagged, Form
 from odoo.tests.common import TransactionCase, freeze_time
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMrpProductionBackorder(TestMrpCommon):
 
     @classmethod

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -6,7 +6,6 @@ from odoo.tests import tagged, common, Form
 from odoo.exceptions import UserError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMrpMulticompany(common.TransactionCase):
 
     @classmethod

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -8,7 +8,6 @@ from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestProcurement(TestMrpCommon):
 
     def test_procurement(self):

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -5,12 +5,11 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from json import loads
 
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo import fields, Command
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMrpReplenish(TestMrpCommon):
 
     def _create_wizard(self, product, warehouse):

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.stock.tests.test_report import TestReportsCommon
 from odoo import Command
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMrpStockReports(TestReportsCommon):
     def test_report_forecast_1_mo_count(self):
         """ Creates and configures a product who could be produce and could be a component.

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -13,7 +13,6 @@ from freezegun import freeze_time
 _logger = logging.getLogger(__name__)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestTraceability(TestMrpCommon):
     TRACKING_TYPES = ['none', 'serial', 'lot']
 

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -2,12 +2,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestUnbuild(TestMrpCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/product_expiry/tests/test_generate_serial_numbers.py
+++ b/addons/product_expiry/tests/test_generate_serial_numbers.py
@@ -5,12 +5,10 @@ from freezegun import freeze_time
 
 from odoo.addons.stock.tests.test_generate_serial_numbers import StockGenerateCommon
 from odoo.addons.stock.tests.test_picking_tours import TestStockPickingTour
-from odoo.tests import tagged
 
 from odoo.tools.misc import get_lang
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockLot(StockGenerateCommon):
 
     def _import_lots(self, lots, move):

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -7,10 +7,9 @@ from dateutil.relativedelta import relativedelta
 from odoo import fields, Command
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.stock.tests.common import TestStockCommon
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockLot(TestStockCommon):
 
     @classmethod

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -20,7 +20,6 @@ class TestAccessRights(TestProjectCommon):
         return self.env['project.task'].with_user(with_user or self.env.user).create(values)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestCRUDVisibilityFollowers(TestAccessRights):
 
     def setUp(self):

--- a/addons/project/tests/test_project_recurrence.py
+++ b/addons/project/tests/test_project_recurrence.py
@@ -8,7 +8,6 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestProjectRecurrence(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -85,7 +85,6 @@ class TestProjectSharingCommon(TestProjectCommon):
 
 
 @tagged('project_sharing')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestProjectSharing(TestProjectSharingCommon):
 
     def test_project_share_wizard(self):

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -1,11 +1,8 @@
-from .test_multicompany import TestMultiCompanyProject
-
-from odoo.tests import tagged
-
 from odoo.exceptions import UserError
 
+from .test_multicompany import TestMultiCompanyProject
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+
 class TestProjectStagesMulticompany(TestMultiCompanyProject):
 
     @classmethod

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections import defaultdict
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
 from odoo import Command
-from odoo.tests import tagged, common
+from odoo.tests import common
 from odoo.exceptions import UserError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestTimesheetGlobalTimeOff(common.TransactionCase):
 
     def setUp(self):

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -3,12 +3,11 @@
 from datetime import date, datetime, timedelta
 
 from odoo import Command
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.product.tests.common import ProductVariantsCommon
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestCreatePicking(ProductVariantsCommon):
 
     @classmethod

--- a/addons/purchase_stock/tests/test_lot_valuation.py
+++ b/addons/purchase_stock/tests/test_lot_valuation.py
@@ -1,11 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged
-
 from odoo.addons.stock_account.tests.test_lot_valuation import TestLotValuation
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestLotValuationPurchase(TestLotValuation):
     def test_poline_price_unit(self):
         """ Purchase order line price unit is the average of the lots from the product form """

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -8,7 +8,6 @@ from odoo.tests import tagged, Form
 from .common import PurchaseTestCommon
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestReplenishWizard(PurchaseTestCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/sale_loyalty/tests/test_program_with_code_operations.py
+++ b/addons/sale_loyalty/tests/test_program_with_code_operations.py
@@ -3,12 +3,9 @@
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
 
-from odoo.tests import tagged
-
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestProgramWithCodeOperations(TestSaleCouponCommon):
     # Test the basic operation (apply_coupon) on an coupon program on which we should
     # apply the reward when the code is correct or remove the reward automatically when the reward is

--- a/addons/sale_project/tests/test_child_tasks.py
+++ b/addons/sale_project/tests/test_child_tasks.py
@@ -3,10 +3,9 @@
 
 from odoo import Command
 
-from odoo.tests.common import tagged, TransactionCase, new_test_user
+from odoo.tests.common import TransactionCase, new_test_user
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestNestedTaskUpdate(TransactionCase):
 
     @classmethod

--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -4,14 +4,13 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import Command
 from odoo.exceptions import ValidationError
-from odoo.tests import tagged, Form, TransactionCase
+from odoo.tests import Form, TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestInventory(TransactionCase):
     @classmethod
     def setUpClass(cls):
-        super(TestInventory, cls).setUpClass()
+        super().setUpClass()
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
         cls.pack_location = cls.env.ref('stock.location_pack_zone')
         cls.pack_location.active = True

--- a/addons/stock/tests/test_multicompany.py
+++ b/addons/stock/tests/test_multicompany.py
@@ -5,7 +5,6 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged, Form, TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMultiCompany(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -19,7 +19,6 @@ class TestPackingCommon(TestStockCommon):
         ])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestPacking(TestPackingCommon):
 
     def test_put_in_pack(self):

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -6,10 +6,9 @@
 
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.exceptions import UserError
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestVirtualAvailable(TestStockCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -12,7 +12,6 @@ from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tests import tagged, Form
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockQuant(TestStockCommon):
 
     @classmethod

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -2,11 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.tests import tagged, Form, TransactionCase
+from odoo.tests import Form, TransactionCase
 from odoo.exceptions import AccessError, UserError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEditableQuant(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -2,11 +2,10 @@
 
 from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.tests.common import new_test_user
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestWarehouse(TestStockCommon):
 
     @classmethod

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -9,7 +9,6 @@ from odoo import Command
 
 
 @skip('Temporary to fast merge new valuation')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestLotValuation(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -12,7 +12,6 @@ from odoo.tests import tagged, Form
 from odoo.addons.stock_account.tests.common import TestStockValuationCommon
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockValuation(TestStockValuationCommon):
     def test_realtime(self):
         """ Stock moves update stock value with product x cost price,

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -1,13 +1,10 @@
 """ Implementation of "INVENTORY VALUATION TESTS" spreadsheet. """
 
 from odoo import Command
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.common import TestStockValuationCommon
-from odoo.exceptions import ValidationError
 from odoo.tests import Form, tagged
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockValuationStandard(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):
@@ -199,7 +196,6 @@ class TestStockValuationStandard(TestStockValuationCommon):
         self.assertEqual(sub_loc_quant.quantity, 30)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockValuationAVCO(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):
@@ -434,7 +430,6 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.assertEqual(self.product.qty_available, 2)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestStockValuationFIFO(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -11,7 +11,6 @@ from odoo.tests import Form, HttpCase, tagged
 from odoo.tests.common import TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestBatchPicking(TransactionCase):
 
     @classmethod

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -3,11 +3,10 @@
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestBatchPicking(TransactionCase):
 
     @classmethod

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -8,10 +8,9 @@ from freezegun import freeze_time
 from odoo import _, Command, fields
 from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.survey.tests import common
-from odoo.tests.common import tagged, users
+from odoo.tests.common import users
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSurveyInternals(common.TestSurveyCommon, MailCase):
 
     @users('survey_manager')

--- a/addons/survey/tests/test_survey_results.py
+++ b/addons/survey/tests/test_survey_results.py
@@ -10,7 +10,6 @@ from odoo.addons.http_routing.tests.common import MockRequest
 
 
 @tagged("is_query_count")
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSurveyResults(common.TestSurveyResultsCommon):
     """ Check the results and the performance of the different filters combinations.
     The filters can be combined but their query count doesn't add up if their

--- a/addons/test_import_export/tests/test_export_impex.py
+++ b/addons/test_import_export/tests/test_export_impex.py
@@ -306,7 +306,6 @@ class test_reference(CreatorCase):
         self.assertEqual(self.export(self.ref_value, context={'import_compat': False}), [[self.ref_record.display_name]])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class test_o2m(CreatorCase):
     model_name = 'export.one2many'
     commands = [

--- a/addons/test_import_export/tests/test_import.py
+++ b/addons/test_import_export/tests/test_import.py
@@ -543,7 +543,6 @@ class TestPreview(TransactionCase):
         self.assertEqual(result['preview'], [['foo', 'bar', 'aux'], ['1', '3', '5'], ['2', '4', '6']])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class test_convert_import_data(TransactionCase):
     """ Tests conversion of base_import.import input into data which
     can be fed to Model.load

--- a/addons/test_import_export/tests/test_load.py
+++ b/addons/test_import_export/tests/test_load.py
@@ -666,7 +666,6 @@ class test_selection_function(ImporterCase):
         self.assertEqual(len(result['ids']), 1)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class test_m2o(ImporterCase):
     model_name = 'export.many2one'
 
@@ -1068,7 +1067,6 @@ class test_m2m(ImporterCase):
         self.assertEqual(values(b[0].value), [84, 9])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class test_o2m(ImporterCase):
     model_name = 'export.one2many'
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -118,7 +118,6 @@ class TestMailComposer(MailCommon, TestRecipients):
 
 
 @tagged('mail_composer')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestComposerForm(TestMailComposer):
 
     @classmethod
@@ -588,7 +587,6 @@ class TestComposerForm(TestMailComposer):
 
 
 @tagged('mail_composer')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestComposerInternals(TestMailComposer):
 
     @users('employee')
@@ -1424,7 +1422,6 @@ class TestComposerInternals(TestMailComposer):
 
 
 @tagged('mail_composer', 'multi_lang', 'multi_company')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestComposerResultsComment(TestMailComposer, CronMixinCase):
     """ Test global output of composer used in comment mode. Test notably
     notification and emails generated during this process. """

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -17,7 +17,6 @@ from odoo.tools import mute_logger
 
 
 @tagged('mail_followers')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class BaseFollowersTest(MailCommon):
 
     @classmethod

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -241,7 +241,6 @@ class MailGatewayCommon(MailCommon):
 
 
 @tagged('mail_gateway')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMailgateway(MailGatewayCommon):
 
     def test_assert_initial_values(self):

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -17,12 +17,11 @@ from odoo import api, Command, fields, SUPERUSER_ID
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError, LockError
-from odoo.tests import common, tagged, users
+from odoo.tests import tagged, users
 from odoo.tools import formataddr, mute_logger
 
 
 @tagged('mail_mail')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMailMail(MailCommon):
 
     @classmethod

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -79,7 +79,6 @@ class ThreadRecipients(MailCommon, TestRecipients):
 
 
 @tagged('mail_thread', 'mail_thread_api', 'mail_tools')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestAPI(ThreadRecipients):
 
     @classmethod

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -12,7 +12,6 @@ from odoo.tools import mute_logger
 
 
 @tagged('mail_track')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestTracking(MailCommon):
 
     @classmethod
@@ -427,7 +426,6 @@ class TestTracking(MailCommon):
 
 
 @tagged('mail_track')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestTrackingInternals(MailCommon):
 
     @classmethod

--- a/addons/test_mail_sms/tests/test_sms_post.py
+++ b/addons/test_mail_sms/tests/test_sms_post.py
@@ -10,7 +10,6 @@ from odoo.tests import tagged
 
 
 @tagged('sms_post')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSMSPost(SMSCommon, TestSMSRecipients, CronMixinCase):
     """ TODO
 
@@ -303,7 +302,6 @@ class TestSMSPost(SMSCommon, TestSMSRecipients, CronMixinCase):
 
 
 @tagged('sms_post')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSMSPostException(SMSCommon, TestSMSRecipients):
 
     @classmethod

--- a/addons/test_mail_sms/tests/test_sms_sms.py
+++ b/addons/test_mail_sms/tests/test_sms_sms.py
@@ -12,7 +12,6 @@ from odoo.tests import tagged
 
 
 @tagged('link_tracker')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSMSPost(SMSCommon, MockLinkTracker):
 
     @classmethod

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -9,7 +9,6 @@ from odoo.tools import mute_logger, email_normalize
 
 
 @tagged('mass_mailing')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMassMailing(TestMassMailCommon):
 
     @mute_logger('odoo.addons.mail.models.mail_mail')

--- a/addons/website/tests/test_converter.py
+++ b/addons/website/tests/test_converter.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import threading
-import unicodedata
 
 from odoo.tests.common import tagged, BaseCase
 from odoo.modules.registry import Registry
@@ -50,7 +49,6 @@ class TestSlugUnslug(BaseCase):
             self.assertEqual(slug(value), expected, "%r case failed" % (value,))
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestTitleToSlug(BaseCase):
     """
     Those tests should pass with or without python-slugify

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -206,7 +206,6 @@ class TestCustomizeView(common.HttpCase):
         self.assertEqual('Test name (3)', name)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestViewSaving(TestViewSavingCommon):
 
     def eq(self, a, b):

--- a/addons/website_forum/tests/test_forum_karma_access.py
+++ b/addons/website_forum/tests/test_forum_karma_access.py
@@ -135,7 +135,6 @@ class TestForumCRUD(TestForumCommon):
         (new_employee_vote + new_portal_vote).with_user(self.user_admin).read(['vote'])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestForumKarma(TestForumCommon):
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')

--- a/addons/website_slides/tests/test_security.py
+++ b/addons/website_slides/tests/test_security.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
 
-from odoo import http
 from odoo.addons.base.tests.test_mimetypes import PNG
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.website_slides.tests import common
@@ -12,7 +11,6 @@ from odoo.tools import mute_logger
 
 
 @tagged('security')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestAccess(common.SlidesCase):
 
     @mute_logger('odoo.models', 'odoo.addons.base.models.ir_rule')

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -10,7 +10,68 @@ from odoo.tests import tagged
 from odoo.exceptions import AccessError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('at_install', '-post_install')
+class TestAPIAtInstall(SavepointCaseWithUserDemo):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAPI, cls).setUpClass()
+        cls._load_partners_set()
+
+    @mute_logger('odoo.models', 'odoo.addons.base.models.ir_model')
+    def test_50_environment(self):
+        """ Test environment on records. """
+        # partners and reachable records are attached to self.env
+        partners = self.env['res.partner'].search([('name', 'ilike', 'j'), ('id', 'in', self.partners.ids)])
+        self.assertEqual(partners.env, self.env)
+        for x in (partners, partners[0], partners[0].company_id):
+            self.assertEqual(x.env, self.env)
+        for p in partners:
+            self.assertEqual(p.env, self.env)
+
+        # check that the current user can read and modify company data
+        partners[0].company_id.name
+        partners[0].company_id.write({'name': 'Fools'})
+
+        # create an environment with a demo user
+        demo = self.env['res.users'].create({
+            'name': 'test_environment_demo',
+            'login': 'test_environment_demo',
+            'password': 'test_environment_demo',
+        })
+        demo_env = self.env(user=demo)
+        self.assertNotEqual(demo_env, self.env)
+
+        # partners and related records are still attached to self.env
+        self.assertEqual(partners.env, self.env)
+        for x in (partners, partners[0], partners[0].company_id):
+            self.assertEqual(x.env, self.env)
+        for p in partners:
+            self.assertEqual(p.env, self.env)
+
+        # create record instances attached to demo_env
+        demo_partners = partners.with_user(demo)
+        self.assertEqual(demo_partners.env, demo_env)
+        for x in (demo_partners, demo_partners[0], demo_partners[0].company_id):
+            self.assertEqual(x.env, demo_env)
+        for p in demo_partners:
+            self.assertEqual(p.env, demo_env)
+
+        # demo user can read but not modify company data
+        demo_partner = self.env['res.partner'].search([('name', '=', 'Landon Roberts')]).with_user(demo)
+        self.assertTrue(demo_partner.company_id, 'This partner is supposed to be linked to a company')
+        demo_partner.company_id.name
+        with self.assertRaises(AccessError):
+            demo_partner.company_id.write({'name': 'Pricks'})
+
+        # remove demo user from all groups
+        demo.write({'group_ids': [Command.clear()]})
+
+        # demo user can no longer access partner data
+        with self.assertRaises(AccessError):
+            demo_partner.company_id.name
+
+
 class TestAPI(SavepointCaseWithUserDemo):
     """ test the new API of the ORM """
 
@@ -163,60 +224,6 @@ class TestAPI(SavepointCaseWithUserDemo):
             p.write({'active': False})
         for p in partners:
             self.assertFalse(p.active)
-
-    @mute_logger('odoo.models')
-    @mute_logger('odoo.addons.base.models.ir_model')
-    def test_50_environment(self):
-        """ Test environment on records. """
-        # partners and reachable records are attached to self.env
-        partners = self.env['res.partner'].search([('name', 'ilike', 'j'), ('id', 'in', self.partners.ids)])
-        self.assertEqual(partners.env, self.env)
-        for x in (partners, partners[0], partners[0].company_id):
-            self.assertEqual(x.env, self.env)
-        for p in partners:
-            self.assertEqual(p.env, self.env)
-
-        # check that the current user can read and modify company data
-        partners[0].company_id.name
-        partners[0].company_id.write({'name': 'Fools'})
-
-        # create an environment with a demo user
-        demo = self.env['res.users'].create({
-            'name': 'test_environment_demo',
-            'login': 'test_environment_demo',
-            'password': 'test_environment_demo',
-        })
-        demo_env = self.env(user=demo)
-        self.assertNotEqual(demo_env, self.env)
-
-        # partners and related records are still attached to self.env
-        self.assertEqual(partners.env, self.env)
-        for x in (partners, partners[0], partners[0].company_id):
-            self.assertEqual(x.env, self.env)
-        for p in partners:
-            self.assertEqual(p.env, self.env)
-
-        # create record instances attached to demo_env
-        demo_partners = partners.with_user(demo)
-        self.assertEqual(demo_partners.env, demo_env)
-        for x in (demo_partners, demo_partners[0], demo_partners[0].company_id):
-            self.assertEqual(x.env, demo_env)
-        for p in demo_partners:
-            self.assertEqual(p.env, demo_env)
-
-        # demo user can read but not modify company data
-        demo_partner = self.env['res.partner'].search([('name', '=', 'Landon Roberts')]).with_user(demo)
-        self.assertTrue(demo_partner.company_id, 'This partner is supposed to be linked to a company')
-        demo_partner.company_id.name
-        with self.assertRaises(AccessError):
-            demo_partner.company_id.write({'name': 'Pricks'})
-
-        # remove demo user from all groups
-        demo.write({'group_ids': [Command.clear()]})
-
-        # demo user can no longer access partner data
-        with self.assertRaises(AccessError):
-            demo_partner.company_id.name
 
     @mute_logger('odoo.models')
     def test_60_cache(self):

--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -11,7 +11,6 @@ from odoo.tools import mute_logger
 from odoo.tools.safe_eval import safe_eval, const_eval, expr_eval
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSafeEval(BaseCase):
     def test_const(self):
         # NB: True and False are names in Python 2 not consts

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -10,7 +10,6 @@ from odoo.tests import tagged
 _FALSE_LEAF, _TRUE_LEAF = (0, '=', 1), (1, '=', 1)
 
 
-@tagged('at_install', '-post_install')
 class TransactionExpressionCase(TransactionCase):
 
     def _search(self, model, domain, init_domain=Domain.TRUE, test_complement=True):
@@ -47,7 +46,6 @@ class TransactionExpressionCase(TransactionCase):
 
 
 @tagged('res_partner')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
 
     @classmethod
@@ -1442,6 +1440,7 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
 
 
 @tagged('res_partner')
+@tagged('at_install', '-post_install')
 class TestExpression2(TransactionExpressionCase):
 
     def test_long_table_alias(self):
@@ -1452,6 +1451,7 @@ class TestExpression2(TransactionExpressionCase):
 
 
 @tagged('res_partner')
+@tagged('at_install', '-post_install')
 class TestBypassAccess(TransactionExpressionCase):
 
     def test_bypass_search_access(self):
@@ -2680,7 +2680,6 @@ class TestMany2many(TransactionCase):
             self.User.search([('group_ids', '=', False)], order='id')
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestAnyfy(TransactionCase):
     def _test_combine_anies(self, domain, expected):
         model = self.env['res.partner']

--- a/odoo/addons/base/tests/test_image.py
+++ b/odoo/addons/base/tests/test_image.py
@@ -8,14 +8,13 @@ from PIL import Image, ImageDraw, PngImagePlugin
 
 from odoo.tools import image as tools
 from odoo.exceptions import UserError
-from odoo.tests.common import tagged, TransactionCase
+from odoo.tests.common import TransactionCase
 
 
 def img_open(data):
     return Image.open(io.BytesIO(data))
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestImage(TransactionCase):
     """Tests for the different image tools helpers."""
     def setUp(self):

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -21,7 +21,6 @@ from odoo.tools.image import image_to_base64
 HASH_SPLIT = 2      # FIXME: testing implementations detail is not a good idea
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestIrAttachment(TransactionCaseWithUserDemo):
     def setUp(self):
         super(TestIrAttachment, self).setUp()

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -71,7 +71,6 @@ class CronMixinCase:
         return {'name': f'Dummy partner for TestIrCron {unique}'}
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestIrCron(TransactionCase, CronMixinCase):
 
     @classmethod

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -24,7 +24,6 @@ from . import mail_examples
 
 
 @tagged('mail_sanitize')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSanitizer(BaseCase):
     """ Test the html sanitizer that filters html to remove unwanted attributes """
 
@@ -552,7 +551,6 @@ class TestHtmlTools(BaseCase):
 
 
 @tagged('mail_tools')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEmailTools(BaseCase):
     """ Test some of our generic utility functions for emails """
 

--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     magic = None
 
-from odoo.tests.common import tagged, BaseCase
+from odoo.tests.common import BaseCase
 from odoo.tools.mimetypes import fix_filename_extension, get_extension, guess_mimetype
 
 PNG = b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4//8/AAX+Av7czFnnAAAAAElFTkSuQmCC'
@@ -63,7 +63,6 @@ Hello world!
 """
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class test_guess_mimetype(BaseCase):
 
     def test_default_mimetype_empty(self):

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -482,7 +482,6 @@ class TestUrlValidate(BaseCase):
         self.assertEqual(validate_url('#model=project.task&id=3603607'), 'http://#model=project.task&id=3603607')
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestUrlJoin(BaseCase):
     # simple path joins
     def test_basic_relative_path(self):

--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -6,7 +6,6 @@ from odoo.tools import mute_logger
 from odoo import Command
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestORM(TransactionCase):
     """ test special behaviors of ORM CRUD functions """
 

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -46,7 +46,6 @@ class UsersCommonCase(TransactionCase):
         users.invalidate_recordset()
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestUsers(UsersCommonCase):
 
     def test_name_search(self):

--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -6,7 +6,6 @@ from odoo.tests.common import tagged, BaseCase, TransactionCase
 from odoo.tools import SQL, mute_logger, sql
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSQL(BaseCase):
 
     def test_sql_empty(self):

--- a/odoo/addons/test_orm/tests/test_company_checks.py
+++ b/odoo/addons/test_orm/tests/test_company_checks.py
@@ -1,10 +1,9 @@
 from odoo import Command
 from odoo.exceptions import AccessError, UserError
-from odoo.tests import common, patch, tagged
+from odoo.tests import common, patch
 from odoo.tools import frozendict
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestCompanyCheck(common.TransactionCase):
 
     @classmethod

--- a/odoo/addons/test_orm/tests/test_convert.py
+++ b/odoo/addons/test_orm/tests/test_convert.py
@@ -6,7 +6,7 @@ import collections
 from lxml import etree as ET
 from lxml.builder import E
 
-from odoo.tests import common, tagged
+from odoo.tests import common
 from odoo.tools.convert import _eval_xml, convert_file, xml_import
 from odoo.tools.misc import file_path
 
@@ -14,7 +14,6 @@ Field = E.field
 Value = E.value
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestEvalXML(common.TransactionCase):
     def eval_xml(self, node, obj=None):
         return _eval_xml(obj, node, self.env)

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -9,6 +9,7 @@ from odoo.tools import SQL, OrderedSet
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 
 
+@tagged('at_install', '-post_install')
 class TestDomain(TransactionExpressionCase):
 
     def _search(self, model, domain, init_domain=Domain.TRUE, test_complement=False):
@@ -338,6 +339,7 @@ class TestDomain(TransactionExpressionCase):
         self.assertEqual(res_search, child_2 + child_3)
 
 
+@tagged('at_install', '-post_install')
 class TestDomainComplement(TransactionExpressionCase):
 
     def test_inequalities_int(self):
@@ -395,7 +397,6 @@ class TestDomainComplement(TransactionExpressionCase):
             self._search(Model, [('parent_id', '>=', 'Par')])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestDomainOptimize(TransactionCase):
     number_domain = Domain('number', '>', 5)
 

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -19,7 +19,227 @@ from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('at_install', '-post_install')
+class TestFieldsAtInstall(TransactionCaseWithUserDemo, TransactionExpressionCase):
+    def test_13_inverse_with_unlink(self):
+        """ test x2many delete command combined with an inverse field """
+
+        country1 = self.env['res.country'].create({'name': 'test country', 'code': 'ZV'})
+        country2 = self.env['res.country'].create({'name': 'other country', 'code': 'ZX'})
+        company = self.env['res.company'].create({
+            'name': 'test company',
+            'child_ids': [
+                (0, 0, {'name': 'Child Company 1'}),
+                (0, 0, {'name': 'Child Company 2'}),
+            ],
+        })
+        child_company = company.child_ids[0]
+
+        # check first that the field has an inverse and is not stored
+        field = type(company).country_id
+        self.assertFalse(field.store)
+        self.assertTrue(field.inverse)
+
+        company.write({'country_id': country1.id})
+        self.assertEqual(company.country_id, country1)
+
+        company.write({
+            'country_id': country2.id,
+            'child_ids': [(2, child_company.id)],
+        })
+        self.assertEqual(company.country_id, country2)
+
+    def test_23_relation(self):
+        """ test relation fields """
+        demo = self.user_demo
+        message = self.env.ref('test_orm.message_0_0')
+
+        # check environment of record and related records
+        self.assertEqual(message.env, self.env)
+        self.assertEqual(message.discussion.env, self.env)
+
+        demo_env = self.env(user=demo)
+        self.assertNotEqual(demo_env, self.env)
+
+        # check environment of record and related records
+        self.assertEqual(message.env, self.env)
+        self.assertEqual(message.discussion.env, self.env)
+
+        # "migrate" message into demo_env, and check again
+        demo_message = message.with_user(demo)
+        self.assertEqual(demo_message.env, demo_env)
+        self.assertEqual(demo_message.discussion.env, demo_env)
+
+        # See YTI FIXME
+        self.env.invalidate_all()
+
+        # assign record's parent to a record in demo_env
+        message.discussion = message.discussion.copy({'name': 'Copy'})
+
+        # both message and its parent field must be in self.env
+        self.assertEqual(message.env, self.env)
+        self.assertEqual(message.discussion.env, self.env)
+
+    def test_28_company_dependent_search(self):
+        """ Test the search on company-dependent fields in all corner cases.
+            This assumes that filtered_domain() correctly filters records when
+            its domain refers to company-dependent fields.
+        """
+        IrDefault = self.env['ir.default']
+        Model = self.env['test_orm.company']
+
+        # create 4 records for all cases: two with explicit truthy values, one
+        # with an explicit falsy value, and one without an explicit value
+        records = Model.create([{}] * 4)
+        record_fallback = Model.create({})
+
+        # For each field, we assign values to the records, and test a number of
+        # searches.  The search cases are given by comparison operators, and for
+        # each operator, we test a number of possible operands.  Every search()
+        # returns a subset of the records, and we compare it to an equivalent
+        # search performed by filtered_domain().
+
+        def test_field(field_name, truthy_values, operations):
+            # set ir.defaults to all records except the last one
+            for rec, val in zip(records, truthy_values + [False]):
+                rec[field_name] = val
+
+            # test without default value
+            test_cases(field_name, operations)
+
+            # set default value to False
+            IrDefault.set(Model._name, field_name, False)
+            self.env.flush_all()
+            self.env.invalidate_all()
+            for rec, val in zip(records, truthy_values + [False]):
+                rec[field_name] = val
+            test_cases(field_name, operations, False)
+
+            # set default value to truthy_values[0]
+            IrDefault.set(Model._name, field_name, truthy_values[0])
+            self.env.flush_all()
+            self.env.invalidate_all()
+            for rec, val in zip(records, truthy_values + [False]):
+                rec[field_name] = val
+            test_cases(field_name, operations, truthy_values[0])
+
+        def test_cases(field_name, operations, default=None):
+            model = self.env['test_orm.company']
+            field = model._fields[field_name]
+            field_fallback = field.get_company_dependent_fallback(model)
+            record_fallback[field_name] = field_fallback
+            current_thread = threading.current_thread()
+
+            for operator, values in operations.items():
+                for value in values:
+                    domain = [(field_name, operator, value)]
+                    company_dependent_column_not_null = not record_fallback.filtered_domain(domain)
+                    if company_dependent_column_not_null:
+                        with self.subTest(domain=domain, default=default):
+                            Model.search([('id', 'in', records.ids)] + domain)
+                            current_thread.query_count = 0
+                            current_thread.query_time = 0
+                            Model.search([('id', 'in', records.ids)] + domain)  # warmup
+                            if current_thread.query_count:
+                                # parent_of and child_of may need extra queries
+                                expected_contained_sqls = [''] * (current_thread.query_count - 1) + [f'"test_orm_company"."{field_name}" IS NOT NULL']
+                                with self.assertQueriesContain(expected_contained_sqls):
+                                    Model.search([('id', 'in', records.ids)] + domain)
+
+                    with self.subTest(domain=domain, default=default):
+                        self._search(
+                            Model,
+                            [('id', 'in', records.ids)] + domain,
+                            [('id', 'in', records.ids)],
+                            test_complement=True,
+                        )
+
+        # boolean fields
+        test_field('truth', [True, True], {
+            '=': (True, False),
+            '!=': (True, False),
+        })
+        # integer fields
+        test_field('count', [10, -2], {
+            '=': (10, -2, 0, False),
+            '!=': (10, -2, 0, False),
+            '<': (10, -2, 0),
+            '>=': (10, -2, 0),
+            '<=': (10, -2, 0),
+            '>': (10, -2, 0),
+        })
+        # float fields
+        test_field('phi', [1.61803, -1], {
+            '=': (1.61803, -1, 0, False),
+            '!=': (1.61803, -1, 0, False),
+            '<': (1.61803, -1, 0),
+            '>=': (1.61803, -1, 0),
+            '<=': (1.61803, -1, 0),
+            '>': (1.61803, -1, 0),
+        })
+        # char fields
+        test_field('foo', ['qwer', 'azer'], {
+            'like': ('qwer', 'azer'),
+            'ilike': ('qwer', 'azer'),
+            'not like': ('qwer', 'azer'),
+            'not ilike': ('qwer', 'azer'),
+            '=': ('qwer', 'azer', False),
+            '!=': ('qwer', 'azer', False),
+            'not in': (['qwer', 'azer'], ['qwer', False], [False], []),
+            'in': (['qwer', 'azer'], ['qwer', False], [False], []),
+        })
+        # date fields
+        date1, date2 = date(2021, 11, 22), date(2021, 11, 23)
+        test_field('date', [date1, date2], {
+            '=': (date1, date2, False),
+            '!=': (date1, date2, False),
+            '<': (date1, date2),
+            '>=': (date1, date2),
+            '<=': (date1, date2),
+            '>': (date1, date2),
+        })
+        # datetime fields
+        moment1, moment2 = datetime(2021, 11, 22), datetime(2021, 11, 23)
+        test_field('moment', [moment1, moment2], {
+            '=': (moment1, moment2, False),
+            '!=': (moment1, moment2, False),
+            '<': (moment1, moment2),
+            '>=': (moment1, moment2),
+            '<=': (moment1, moment2),
+            '>': (moment1, moment2),
+        })
+        # many2one fields
+        tag1, tag2 = self.env['test_orm.multi.tag'].create([{'name': 'one'}, {'name': 'two'}])
+        test_field('tag_id', [tag1.id, tag2.id], {
+            'like': (tag1.name, tag2.name),
+            'ilike': (tag1.name, tag2.name),
+            'not like': (tag1.name, tag2.name),
+            'not ilike': (tag1.name, tag2.name),
+            '=': (tag1.id, tag2.id, False),
+            '!=': (tag1.id, tag2.id, False),
+            'in': ([tag1.id, tag2.id], [tag2.id, False], [False], []),
+            'not in': ([tag1.id, tag2.id], [tag2.id, False], [False], []),
+            'any': ([('name', '=', tag1.name)], [('name', '=', False)], []),
+            'not any': ([('name', '=', tag1.name)], [('name', '=', False)], []),
+        })
+
+        company0 = self.env.ref('base.main_company')
+        company1 = self.env['res.company'].create({'name': 'A1', 'parent_id': company0.id})
+        company2 = self.env['res.company'].create({'name': 'B1', 'parent_id': company1.id})
+
+        company1.partner_id.parent_id = company0.partner_id
+        company2.partner_id.parent_id = company1.partner_id
+        self.env.invalidate_all()
+        test_field('company_id', [company1.id, company2.id], {
+            'child_of': (company0.id, company1.id, company2.id),
+            'parent_of': (company0.id, company1.id, company2.id),
+        })
+        test_field('partner_id', [company1.id, company2.id], {
+            'child_of': (company0.partner_id.id, company1.partner_id.id, company2.partner_id.id),
+            'parent_of': (company0.partner_id.id, company1.partner_id.id, company2.partner_id.id),
+        })
+
+
 class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
 
     def setUp(self):
@@ -749,34 +969,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         with self.assertRaises(AccessError):
             foo.with_user(user).display_name = 'Forbidden'
 
-    def test_13_inverse_with_unlink(self):
-        """ test x2many delete command combined with an inverse field """
-
-        country1 = self.env['res.country'].create({'name': 'test country', 'code': 'ZV'})
-        country2 = self.env['res.country'].create({'name': 'other country', 'code': 'ZX'})
-        company = self.env['res.company'].create({
-            'name': 'test company',
-            'child_ids': [
-                (0, 0, {'name': 'Child Company 1'}),
-                (0, 0, {'name': 'Child Company 2'}),
-            ],
-        })
-        child_company = company.child_ids[0]
-
-        # check first that the field has an inverse and is not stored
-        field = type(company).country_id
-        self.assertFalse(field.store)
-        self.assertTrue(field.inverse)
-
-        company.write({'country_id': country1.id})
-        self.assertEqual(company.country_id, country1)
-
-        company.write({
-            'country_id': country2.id,
-            'child_ids': [(2, child_company.id)],
-        })
-        self.assertEqual(company.country_id, country2)
-
     def test_14_search(self):
         """ test search on computed fields """
         discussion = self.env.ref('test_orm.discussion_0')
@@ -1199,36 +1391,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             record_list.state = 'zz_ZZ'
         record_call.lang = 'zz_ZZ'
 
-    def test_23_relation(self):
-        """ test relation fields """
-        demo = self.user_demo
-        message = self.env.ref('test_orm.message_0_0')
-
-        # check environment of record and related records
-        self.assertEqual(message.env, self.env)
-        self.assertEqual(message.discussion.env, self.env)
-
-        demo_env = self.env(user=demo)
-        self.assertNotEqual(demo_env, self.env)
-
-        # check environment of record and related records
-        self.assertEqual(message.env, self.env)
-        self.assertEqual(message.discussion.env, self.env)
-
-        # "migrate" message into demo_env, and check again
-        demo_message = message.with_user(demo)
-        self.assertEqual(demo_message.env, demo_env)
-        self.assertEqual(demo_message.discussion.env, demo_env)
-
-        # See YTI FIXME
-        self.env.invalidate_all()
-
-        # assign record's parent to a record in demo_env
-        message.discussion = message.discussion.copy({'name': 'Copy'})
-
-        # both message and its parent field must be in self.env
-        self.assertEqual(message.env, self.env)
-        self.assertEqual(message.discussion.env, self.env)
 
     def test_24_reference(self):
         """ test reference fields. """
@@ -1646,165 +1808,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             record.search([('id', '=', record.id), ('tag_id', '=', False)]),
             record,
         )
-
-    def test_28_company_dependent_search(self):
-        """ Test the search on company-dependent fields in all corner cases.
-            This assumes that filtered_domain() correctly filters records when
-            its domain refers to company-dependent fields.
-        """
-        IrDefault = self.env['ir.default']
-        Model = self.env['test_orm.company']
-
-        # create 4 records for all cases: two with explicit truthy values, one
-        # with an explicit falsy value, and one without an explicit value
-        records = Model.create([{}] * 4)
-        record_fallback = Model.create({})
-
-        # For each field, we assign values to the records, and test a number of
-        # searches.  The search cases are given by comparison operators, and for
-        # each operator, we test a number of possible operands.  Every search()
-        # returns a subset of the records, and we compare it to an equivalent
-        # search performed by filtered_domain().
-
-        def test_field(field_name, truthy_values, operations):
-            # set ir.defaults to all records except the last one
-            for rec, val in zip(records, truthy_values + [False]):
-                rec[field_name] = val
-
-            # test without default value
-            test_cases(field_name, operations)
-
-            # set default value to False
-            IrDefault.set(Model._name, field_name, False)
-            self.env.flush_all()
-            self.env.invalidate_all()
-            for rec, val in zip(records, truthy_values + [False]):
-                rec[field_name] = val
-            test_cases(field_name, operations, False)
-
-            # set default value to truthy_values[0]
-            IrDefault.set(Model._name, field_name, truthy_values[0])
-            self.env.flush_all()
-            self.env.invalidate_all()
-            for rec, val in zip(records, truthy_values + [False]):
-                rec[field_name] = val
-            test_cases(field_name, operations, truthy_values[0])
-
-        def test_cases(field_name, operations, default=None):
-            model = self.env['test_orm.company']
-            field = model._fields[field_name]
-            field_fallback = field.get_company_dependent_fallback(model)
-            record_fallback[field_name] = field_fallback
-            current_thread = threading.current_thread()
-
-            for operator, values in operations.items():
-                for value in values:
-                    domain = [(field_name, operator, value)]
-                    company_dependent_column_not_null = not record_fallback.filtered_domain(domain)
-                    if company_dependent_column_not_null:
-                        with self.subTest(domain=domain, default=default):
-                            Model.search([('id', 'in', records.ids)] + domain)
-                            current_thread.query_count = 0
-                            current_thread.query_time = 0
-                            Model.search([('id', 'in', records.ids)] + domain)  # warmup
-                            if current_thread.query_count:
-                                # parent_of and child_of may need extra queries
-                                expected_contained_sqls = [''] * (current_thread.query_count - 1) + [f'"test_orm_company"."{field_name}" IS NOT NULL']
-                                with self.assertQueriesContain(expected_contained_sqls):
-                                    Model.search([('id', 'in', records.ids)] + domain)
-
-                    with self.subTest(domain=domain, default=default):
-                        self._search(
-                            Model,
-                            [('id', 'in', records.ids)] + domain,
-                            [('id', 'in', records.ids)],
-                            test_complement=True,
-                        )
-
-        # boolean fields
-        test_field('truth', [True, True], {
-            '=': (True, False),
-            '!=': (True, False),
-        })
-        # integer fields
-        test_field('count', [10, -2], {
-            '=': (10, -2, 0, False),
-            '!=': (10, -2, 0, False),
-            '<': (10, -2, 0),
-            '>=': (10, -2, 0),
-            '<=': (10, -2, 0),
-            '>': (10, -2, 0),
-        })
-        # float fields
-        test_field('phi', [1.61803, -1], {
-            '=': (1.61803, -1, 0, False),
-            '!=': (1.61803, -1, 0, False),
-            '<': (1.61803, -1, 0),
-            '>=': (1.61803, -1, 0),
-            '<=': (1.61803, -1, 0),
-            '>': (1.61803, -1, 0),
-        })
-        # char fields
-        test_field('foo', ['qwer', 'azer'], {
-            'like': ('qwer', 'azer'),
-            'ilike': ('qwer', 'azer'),
-            'not like': ('qwer', 'azer'),
-            'not ilike': ('qwer', 'azer'),
-            '=': ('qwer', 'azer', False),
-            '!=': ('qwer', 'azer', False),
-            'not in': (['qwer', 'azer'], ['qwer', False], [False], []),
-            'in': (['qwer', 'azer'], ['qwer', False], [False], []),
-        })
-        # date fields
-        date1, date2 = date(2021, 11, 22), date(2021, 11, 23)
-        test_field('date', [date1, date2], {
-            '=': (date1, date2, False),
-            '!=': (date1, date2, False),
-            '<': (date1, date2),
-            '>=': (date1, date2),
-            '<=': (date1, date2),
-            '>': (date1, date2),
-        })
-        # datetime fields
-        moment1, moment2 = datetime(2021, 11, 22), datetime(2021, 11, 23)
-        test_field('moment', [moment1, moment2], {
-            '=': (moment1, moment2, False),
-            '!=': (moment1, moment2, False),
-            '<': (moment1, moment2),
-            '>=': (moment1, moment2),
-            '<=': (moment1, moment2),
-            '>': (moment1, moment2),
-        })
-        # many2one fields
-        tag1, tag2 = self.env['test_orm.multi.tag'].create([{'name': 'one'}, {'name': 'two'}])
-        test_field('tag_id', [tag1.id, tag2.id], {
-            'like': (tag1.name, tag2.name),
-            'ilike': (tag1.name, tag2.name),
-            'not like': (tag1.name, tag2.name),
-            'not ilike': (tag1.name, tag2.name),
-            '=': (tag1.id, tag2.id, False),
-            '!=': (tag1.id, tag2.id, False),
-            'in': ([tag1.id, tag2.id], [tag2.id, False], [False], []),
-            'not in': ([tag1.id, tag2.id], [tag2.id, False], [False], []),
-            'any': ([('name', '=', tag1.name)], [('name', '=', False)], []),
-            'not any': ([('name', '=', tag1.name)], [('name', '=', False)], []),
-        })
-
-        company0 = self.env.ref('base.main_company')
-        company1 = self.env['res.company'].create({'name': 'A1', 'parent_id': company0.id})
-        company2 = self.env['res.company'].create({'name': 'B1', 'parent_id': company1.id})
-
-        company1.partner_id.parent_id = company0.partner_id
-        company2.partner_id.parent_id = company1.partner_id
-        self.env.invalidate_all()
-        test_field('company_id', [company1.id, company2.id], {
-            'child_of': (company0.id, company1.id, company2.id),
-            'parent_of': (company0.id, company1.id, company2.id),
-        })
-        test_field('partner_id', [company1.id, company2.id], {
-            'child_of': (company0.partner_id.id, company1.partner_id.id, company2.partner_id.id),
-            'parent_of': (company0.partner_id.id, company1.partner_id.id, company2.partner_id.id),
-        })
 
     def test_29_company_dependent_html(self):
         company0 = self.env.ref('base.main_company')
@@ -3275,6 +3278,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(related_float_field.column_type[1], 'numeric')
 
 
+@tagged('at_install', '-post_install')
 class TestX2many(TransactionExpressionCase):
 
     @classmethod
@@ -3973,7 +3977,6 @@ class TestMagicFields(TransactionCase):
         self.assertTrue(field.store)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestParentStore(TransactionCaseWithUserDemo):
 
     @classmethod
@@ -4240,6 +4243,7 @@ class TestRequiredMany2oneTransient(TransactionCase):
 
 
 @tagged('m2oref')
+@tagged('at_install', '-post_install')
 class TestMany2oneReference(TransactionExpressionCase):
 
     def test_delete_m2o_reference_records(self):
@@ -4332,7 +4336,6 @@ class TestSelectionUpdates(TransactionCase):
 
 
 @tagged('selection_ondelete_base')
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSelectionOndelete(TransactionCase):
 
     MODEL_BASE = 'test_orm.model_selection_base'

--- a/odoo/addons/test_orm/tests/test_guess_mimetypes.py
+++ b/odoo/addons/test_orm/tests/test_guess_mimetypes.py
@@ -1,7 +1,7 @@
 import os.path
 import unittest
 
-from odoo.tests import tagged, BaseCase
+from odoo.tests import BaseCase
 from odoo.tools.mimetypes import _odoo_guess_mimetype, guess_mimetype
 from odoo.tools.misc import file_open
 
@@ -92,7 +92,6 @@ class MimeGuessingCases:
         )
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMimeGuessingOdoo(BaseCase, MimeGuessingCases):
     guess_mimetype = staticmethod(_odoo_guess_mimetype)
 
@@ -104,7 +103,6 @@ class TestMimeGuessingOdoo(BaseCase, MimeGuessingCases):
 
 
 @unittest.skipIf(guess_mimetype is _odoo_guess_mimetype, "python-magic not installed")
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestMimeGuessingMagic(BaseCase, MimeGuessingCases):
     guess_mimetype = staticmethod(guess_mimetype)
 

--- a/odoo/addons/test_orm/tests/test_inherits.py
+++ b/odoo/addons/test_orm/tests/test_inherits.py
@@ -1,10 +1,10 @@
-from odoo.tests import tagged, common
-from odoo.exceptions import ValidationError
-from odoo import Command
 from unittest.mock import patch
 
+from odoo.tests import common
+from odoo.exceptions import ValidationError
+from odoo import Command
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+
 class test_inherits(common.TransactionCase):
 
     def test_ir_model_inherit(self):

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Command
-from odoo.tests import tagged, TransactionCase, users
+from odoo.tests import TransactionCase, users
 from odoo.tools import mute_logger
 
 
@@ -114,7 +114,6 @@ class TestPropertiesMixin(TransactionCase):
         return field._list_to_dict(read_value)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class PropertiesCase(TestPropertiesMixin):
 
     @mute_logger('odoo.sql_db')

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -1,8 +1,7 @@
 from odoo import Command, fields
-from odoo.tests import common, new_test_user, tagged
+from odoo.tests import common, new_test_user
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestPrivateReadGroup(common.TransactionCase):
 
     @classmethod

--- a/odoo/addons/test_orm/tests/test_schema.py
+++ b/odoo/addons/test_orm/tests/test_schema.py
@@ -226,7 +226,6 @@ class TestReflection(common.TransactionCase):
                             self.assertEqual(field_description['sortable'], field.type != 'binary')
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSchema(common.TransactionCase):
 
     def get_table_data(self, tablename):

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -3,7 +3,6 @@ from odoo.fields import Command, Domain
 from odoo.tests import tagged, TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSubqueries(TransactionCase):
     """ Test the subqueries made by search() with relational fields. """
     maxDiff = None
@@ -417,7 +416,6 @@ class TestSubqueries(TransactionCase):
             Head.search([('node_id', 'parent_of', nodes.ids)])
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSearchRelated(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -1502,7 +1500,6 @@ class TestSearchAny(TransactionCase):
             model.search(Domain('foo_ids', 'any', Domain('bar_id', 'any', Domain('name', '=', 'a'))))
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestFlushSearch(TransactionCase):
 
     @classmethod
@@ -1817,6 +1814,7 @@ class TestFlushSearch(TransactionCase):
         self.assertEqual(self.env['test_orm.custom.table_query_sql'].search([]).sum_quantity, 25)
 
 
+@tagged('at_install', '-post_install')
 class TestDatePartNumber(TransactionExpressionCase):
     @classmethod
     def setUpClass(cls):

--- a/odoo/addons/test_orm/tests/test_sort.py
+++ b/odoo/addons/test_orm/tests/test_sort.py
@@ -2,10 +2,9 @@
 
 from odoo.api import NewId
 from odoo.fields import Command
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import TransactionCase
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSort(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/odoo/addons/test_orm/tests/test_timeit.py
+++ b/odoo/addons/test_orm/tests/test_timeit.py
@@ -12,7 +12,6 @@ from odoo.tests.common import tagged, TransactionCase
 _logger = logging.getLogger(__name__)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestPerformanceTimeit(TransactionCase):
 
     @classmethod


### PR DESCRIPTION
A number of formerly-implicitly-at-install tests never needed to be at_install in the first place. Move them over: at_install can not be parallelised so they create a hard limit on the build duration, the less tests in at_install the better. Furthermore it's really convenient to be able to just run a test, especially when the module it's in has a large number of dependencies: it might take a few seconds to run the test, but minutes until you can install its module.