### PR TITLE
[IMP] core: catch invalid onchange warnings

### DIFF
--- a/odoo/tests/form.py
+++ b/odoo/tests/form.py
@@ -5,6 +5,7 @@ view for server-side unit tests.
 """
 import ast
 import collections
+import collections.abc
 import itertools
 import logging
 import time
@@ -542,8 +543,15 @@ class Form:
         self._env.flush_all()
         self._env.clear()  # discard cache and pending recomputations
 
-        if result.get('warning'):
-            _logger.getChild('onchange').warning("%(title)s %(message)s", result['warning'])
+        if w := result.get('warning'):
+            if isinstance(w, collections.abc.Mapping) and w.keys() >= {'title', 'message'}:
+                _logger.getChild('onchange').warning("%(title)s %(message)s", w)
+            else:
+                _logger.getChild('onchange').error(
+                    "received invalid warning %r from onchange on %r (should be a dict with keys `title` and `message`)",
+                    w,
+                    field_names,
+                )
 
         if not field_name:
             # fill in whatever fields are still missing with falsy values


### PR DESCRIPTION
Related to https://runbot.odoo.com/odoo/error/234669: somewhere somehow an onchange warning is malformed (it's not a mapping) and the Form is unable to cope with it, leading to a rather unhelpful error. TBH I don't understand how it can happen as `onchange` has a rewriting layer between the `warning` out of onchange methods and the one it sends to the client. And most of the `onchange` overrides are preprocessing not post. And the two overrides which do postprocess modify `values` in place.

Add a fallback to attempt to get more insight into this error.
