### PR TITLE
[FIX] sale: avoid uom widget error when no product_id

### DIFF
--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -14,8 +14,7 @@
                 <field name="qty_delivered"/>
                 <field name="qty_invoiced"/>
                 <field name="qty_to_invoice"/>
-                <field name="product_id" column_invisible="True"/>  <!-- Needed for many2one_uom widget  -->
-                <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom"/>
+                <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom" options="{'product_field': 'product_id'}"/>
                 <field name="price_subtotal" sum="Total" widget="monetary"/>
                 <field name="currency_id" column_invisible="True"/>
             </list>

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -14,6 +14,7 @@
                 <field name="qty_delivered"/>
                 <field name="qty_invoiced"/>
                 <field name="qty_to_invoice"/>
+                <field name="product_id" column_invisible="True"/>  <!-- Needed for many2one_uom widget  -->
                 <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom"/>
                 <field name="price_subtotal" sum="Total" widget="monetary"/>
                 <field name="currency_id" column_invisible="True"/>

--- a/addons/uom/static/src/components/many2one_uom/many2one_uom_field.js
+++ b/addons/uom/static/src/components/many2one_uom/many2one_uom_field.js
@@ -101,4 +101,20 @@ registry.category("fields").add("many2one_uom", {
             availableTypes: ["many2one"],
         },
     ],
+    fieldDependencies: ({ type, options }) => {
+        const deps = [];
+        if (options.product_field) {
+            deps.push({
+                name: options.product_field,
+                type,
+            });
+        }
+        if (options.quantity_field) {
+            deps.push({
+                name: options.quantity_field,
+                type,
+            });
+        }
+        return deps;
+    },
 });

--- a/addons/uom/static/src/components/many2one_uom/many2one_uom_field.js
+++ b/addons/uom/static/src/components/many2one_uom/many2one_uom_field.js
@@ -104,10 +104,20 @@ registry.category("fields").add("many2one_uom", {
     fieldDependencies: ({ type, options }) => {
         const deps = [];
         if (options.product_field) {
-            deps.push({
+            const productDep = {
                 name: options.product_field,
                 type,
-            });
+            }
+            // Deduce the field relation (see getProductRelatedModel) so that the widget can work
+            // out of the box even if the specified product field is not present in the view.
+            // If we cannot deduce the field relation, the field has to be specified in the view
+            // for the client to know its relation already (and for the widget to work).
+            if (options.product_field === 'product_id') {
+                productDep.relation = 'product.product';
+            } else if (['product_tmpl_id', 'product_template_id'].includes(options.product_field)) {
+                productDep.relation = 'product.template';
+            }
+            deps.push(productDep);
         }
         if (options.quantity_field) {
             deps.push({


### PR DESCRIPTION
For some reason the `view_order_line_tree` view does not include the product it's related to. This made it so the `many2one_uom` widget would throw an error in some cases because it can't find the corresponding product that it should be matched to at:

https://github.com/odoo/odoo/blob/aceff9d54867849eab11a0d060e31e15cd0452a1/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js#L14-L18

This would lead to an OWL error if the view is
used while UoMs are active. Bug was discovered due to the view being used by default with a studio added O2M field.

Steps to reproduce:
- Open a SO + studio + edit SOL List view
- Add a new M2O field with Contact (res.partner) model
- Add a contact to the SOL
- Open a contact (form view) + studio + add the O2M field added to the SOL to the form view
- Activate UoMs + open the contact assigned to the SOL

Expected result:
- see the O2M field in the contact form

Actual result:
- OWL error caused by: Caused by: Error: The widget 'Many2OneUomField' (field 'product_uom_id') needs a 'product.product' or 'product.template' field. 'product_id' is used but is related to 'undefined' model.

opw-5359835


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
