### PR TITLE
[IMP] web: cache search and pager requests

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -294,13 +294,6 @@ export class DynamicList extends DataPoint {
         return unlinked;
     }
 
-    async _leaveSampleMode() {
-        if (this.model.useSampleModel) {
-            await this._load(this.offset, this.limit, this.orderBy, this.domain);
-            this.model.useSampleModel = false;
-        }
-    }
-
     async _multiSave(editedRecord, changes) {
         if (!Object.keys(changes).length || editedRecord === this._recordToDiscard) {
             return;

--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -55,7 +55,11 @@ export class DynamicRecordList extends DynamicList {
      */
     addNewRecord(atFirstPosition = false) {
         return this.model.mutex.exec(async () => {
-            await this._leaveSampleMode();
+            if (this.model.useSampleModel) {
+                // leave sample mode
+                this._setData({ records: [], length: 0 });
+                this.model.useSampleModel = false;
+            }
             return this._addNewRecord(atFirstPosition);
         });
     }

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -51,6 +51,7 @@
                         aria-label="Remove"
                         title="Remove"
                         t-on-click="() => this.onFacetRemove(facet)"
+                        data-available-offline=""
                     />
                 </div>
             </div>
@@ -86,7 +87,7 @@
     </t>
 
     <t t-name="web.SearchBar">
-        <div t-if="visibilityState.showSearchBar and !offlineService.offline" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
+        <div t-if="visibilityState.showSearchBar" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
             <Dropdown
                 state="inputDropdownState"
                 manual="true"

--- a/addons/web/static/src/search/search_bar/search_bar_toggler.xml
+++ b/addons/web/static/src/search/search_bar/search_bar_toggler.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.SearchBar.Toggler">
-        <button t-if="props.isSmall" t-attf-class="btn btn-secondary {{ props.showSearchBar ? 'active' : '' }}" t-on-click="props.toggleSearchBar">
+        <button t-if="props.isSmall" t-attf-class="btn btn-secondary {{ props.showSearchBar ? 'active' : '' }}" t-on-click="props.toggleSearchBar" data-available-offline="">
             <i class="fa fa-fw fa-search"/>
         </button>
     </t>

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -11,6 +11,7 @@
                 class="o_searchview_dropdown_toggler d-print-none btn btn-outline-secondary o-dropdown-caret rounded-start-0"
                 data-hotkey="shift+q"
                 title="Toggle Search Panel"
+                data-available-offline=""
             >
             </button>
             <t t-set-slot="content">

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -520,7 +520,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
                 },
             },
         },
-        settings: { silent: false, cache: false },
+        settings: { silent: false },
         error: {
             name: "RPC_ERROR",
             type: "server",


### PR DESCRIPTION
Before this commit, only the first request (to load the initial root) was cached in form/list/kanban views. This allowed to speed up navigation and the opening of actions. However, offline, we want more. We want to be able to use the pager and to apply filters, assuming we already did that in the past. For instance, a user that frequently toggles a given filter in a view, like "My Tasks" in the project task pipeline, would like to be able to do that offline as well. This commit enables this. Following [1], we now have a control on the amount of disk space used by the cache, so we can use the cache more extensively.

[1] https://github.com/odoo/odoo/pull/237075

Task~5232751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
