### PR TITLE
[FIX] website: set form input placeholder correctly

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -404,7 +404,7 @@ const FieldEditor = FormEditor.extend({
         const input = this.$target[0].querySelector('input[type="text"], input[type="email"], input[type="number"], input[type="tel"], input[type="url"], textarea');
         const fileInputEl = this.$target[0].querySelector("input[type=file]");
         const description = this.$target[0].querySelector('.s_website_form_field_description');
-        field.placeholder = input && input.placeholder;
+        field.placeholder = (input && input.placeholder) || '';
         if (input) {
             // textarea value has no attribute,  date/datetime timestamp property is formated
             field.value = input.getAttribute('value') || input.value;


### PR DESCRIPTION
Steps to see the issue:
- Open website and start editing
- Drop a form
- Add a new field, or click on an optional field, the type of which we can modify
- Set the field type to 'Selection' or 'Radio Buttons' (or any other that does not have placeholders)
- Set the field type back to 'Text'

=> Field's placeholder is `'null'`, but it should just be empty.

task-5383835
