### PR TITLE
[FIX] hr: fix demo for future install

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -224,8 +224,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-125-2389</field>
             <field name="work_email">admin@yourcompany.example.com</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_3')])]"/>
-            <field name="date_version" eval="time.strftime('%Y')+'-01-01'"/>
-            <field name="contract_date_start" eval="time.strftime('%Y')+'-01-01'"/>
+            <field name="date_version" eval="'2020-01-01'"/>
+            <field name="contract_date_start" eval="'2020-01-01'"/>
             <field name="contract_date_end" eval="False"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>


### PR DESCRIPTION
Before this commit, the relative date used to generate Mitchell Admin's contract was always at January 1st of the current year, making the payroll demo data install fail when at the start of the year.

This commit sets a fixed year in the past for Mitchell's contract.

runbot error 234623 and 234612