### PR TITLE
[FIX] hr: consider leave type in `_get_expected_attendances()`

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1673,7 +1673,7 @@ We can redirect you to the public employee list."""
                                     tz=employee_tz,
                                     resources=self.resource_id,
                                     compute_leaves=True,
-                                    domain=[('company_id', 'in', [False, self.company_id.id])])[self.resource_id.id]
+                                    domain=[('company_id', 'in', [False, self.company_id.id]), ('time_type', '=', 'leave')])[self.resource_id.id]
             duration_data = duration_data | version_intervals
         return duration_data
 

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -254,6 +254,47 @@ class TestHolidaysOvertime(TransactionCase):
         self.assertEqual(self.employee.total_overtime, 0, 'Should have 0 hours of overtime')
         self.assertEqual(self.manager.total_overtime, 8, 'Should have 8 hours of overtime (there is one hour of lunch)')
 
+    def test_worked_leave_type_overtime(self):
+        """ Test that an attendance during a worked time off doesn't count as overtime. """
+        calendar = self.env['resource.calendar'].create({'name': 'Calendar'})
+        self.env['hr.version'].create({
+            'date_version': datetime(2021, 1, 1),
+            'contract_date_start': datetime(2021, 1, 1),
+            'contract_date_end': datetime(2021, 12, 31),
+            'name': 'Contract 2021',
+            'resource_calendar_id': calendar.id,
+            'wage': 5000.0,
+            'employee_id': self.employee.id,
+        })
+
+        leave_type_worked = self.env['hr.leave.type'].create({
+            'name': 'Worked Leave Type',
+            'company_id': self.company.id,
+            'requires_allocation': False,
+            'overtime_deductible': False,
+            'time_type': 'other',
+        })
+
+        leave = self.env['hr.leave'].create({
+            'name': 'no overtime',
+            'employee_id': self.employee.id,
+            'holiday_status_id': leave_type_worked.id,
+            'request_date_from': datetime(2021, 1, 5),
+            'request_date_to': datetime(2021, 1, 5),
+        })
+        leave._action_validate()
+
+        att = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2021, 1, 5, 8),
+            'check_out': datetime(2021, 1, 5, 16),
+        })
+
+        self.assertEqual(att.overtime_hours, 0)
+        self.assertEqual(att.worked_hours, 7)
+
+        self.assertEqual(self.employee.total_overtime, 0, 'Should have 0 hours of overtime')
+
     def test_overtime_approval_after_refusal(self):
         self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))
         self.new_attendance(check_in=datetime(2021, 1, 3, 8), check_out=datetime(2021, 1, 3, 16))


### PR DESCRIPTION
### Issue:
When an employee has time off counting as working hours and we create
 an attendance for this employee, extra hours are created.

### Steps to reproduce:
- Create a new Time Off Type with "Count as Worked Time"
- Have an employee with the overtime ruleset "Default Ruleset"
- Assign this employee a time off of the type just created
- During this time off, create an attendance for this employee
- On the attendance, all the "Worked Time" is counted as "Extra Hours"

### Cause:
[This commit](https://github.com/odoo/odoo/commit/6d7f4012cfa06b35089e7557522fcbf658978b37) adding the ruleset logic, added a domain in the call of `_work_intervals_batch()` in `_get_expected_attendances()` ([src](https://github.com/odoo/odoo/blame/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/hr/models/hr_employee.py#L1675-L1676)). The domain is then given to `_leave_intervals_batch()` to get the leave intervals. But this method adds `('time_type', '=', 'leave')` in the domain only when its value is `None`. So the domain is not appended and the method returns the leaves of type "Worked Time".

In the end `_get_expected_attendances()` does not consider the time off day as a worked day
and so the attendance is considered overtime.

### Solution:
Add `('time_type', '=', 'leave')` in the domain when calling `_work_intervals_batch()` in `_get_expected_attendances()`.

opw-5264657