### PR TITLE
[IMP] im_livechat: toast notification for live chat rating

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -663,11 +663,11 @@ class DiscussChannel(models.Model):
         :type reason: str
         """
         self.ensure_one()
+        user, guest = self.env["res.users"]._get_current_persona()
         # sudo - rating.rating: live chat customers are allowed to update their rating
         if rating_sudo := self.sudo().rating_ids[:1]:
             rating_sudo.write({"rating": rate, "feedback": reason})
         else:
-            user, _ = self.env["res.users"]._get_current_persona()
             # sudo: rating.rating - live chat customers can create ratings
             rating_values = {
                 "rating": rate,
@@ -697,6 +697,20 @@ class DiscussChannel(models.Model):
             rating_id=rating_sudo.id,
             subtype_xmlid="mail.mt_comment",
         )
+        if rating_sudo.rated_partner_id not in self.channel_member_ids.partner_id:
+            store = Store(bus_channel=rating_sudo.rated_partner_id.sudo().user_ids)
+            store.add(user, lambda res: res.one("partner_id", ["name"]))
+            store.add(guest, ["name"]).add(self, [])
+            store.add(rating_sudo, ["feedback", "rating_image_url"])
+            rating_sudo.rated_partner_id.sudo().user_ids._bus_send(
+                "livechat_rating_notification", {
+                    "guest_id": guest.id,
+                    "user_id": user.id,
+                    "rating_id": rating_sudo.id,
+                    "channel_id": self.id,
+                    "store_data": store.get_result(),
+                },
+            )
 
     # =======================
     # Chatbot

--- a/addons/im_livechat/static/src/core/public_web/livechat_rating_notification_message.xml
+++ b/addons/im_livechat/static/src/core/public_web/livechat_rating_notification_message.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.RatingNotificationMessage">
+        <div class="d-flex gap-1 fw-bold">
+            <img class="o_livechat_emoji_rating" t-att-src="rating.rating_image_url"/>
+            <t t-out="title"/>
+        </div>
+        <div t-out="rating.markupFeedback"/>
+        <div class="text-end">
+            <a class="btn btn-link m-0" t-attf-href="/odoo/discuss?active_id=discuss.channel_{{channel.id}}" target="_blank">
+                View Chat <i class="oi oi-arrow-right"/> 
+            </a>
+        </div>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/public_web/livechat_rating_notification_service.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_rating_notification_service.js
@@ -1,0 +1,30 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+import { renderToMarkup } from "@web/core/utils/render";
+
+export const livechatRatingNotificationService = {
+    dependencies: ["bus_service", "notification", "mail.store"],
+
+    start(env, { bus_service, notification, ["mail.store"]: store }) {
+        bus_service.subscribe(
+            "livechat_rating_notification",
+            ({ guest_id, user_id, rating_id, channel_id, store_data }) => {
+                store.insert(store_data);
+                const user = store["res.users"].get(user_id);
+                const guest = store["mail.guest"].get(guest_id);
+                const rating = store["rating.rating"].get(rating_id);
+                const title = _t("%(name)s left a rating:", { name: user?.name ?? guest.name });
+                const message = renderToMarkup("im_livechat.RatingNotificationMessage", {
+                    title,
+                    rating,
+                    channel: store["discuss.channel"].get(channel_id),
+                });
+                notification.add(message, { type: "info" });
+            }
+        );
+        bus_service.start();
+    },
+};
+
+registry.category("services").add("livechatRatingNotification", livechatRatingNotificationService);

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -368,6 +368,10 @@ export function convertBrToLineBreak(str) {
     return createDocumentFragmentFromContent(str).body.textContent;
 }
 
+export function convertLineBreakToBr(str) {
+    return htmlReplace(str, /(\r|\n)/g, () => markup`<br/>`);
+}
+
 export function cleanTerm(term) {
     return typeof term === "string" ? normalize(term) : "";
 }

--- a/addons/rating/static/src/core/common/rating_model.js
+++ b/addons/rating/static/src/core/common/rating_model.js
@@ -1,4 +1,5 @@
 import { Record } from "@mail/model/export";
+import { convertLineBreakToBr } from "@mail/utils/common/format";
 
 export class Rating extends Record {
     static _name = "rating.rating";
@@ -11,5 +12,12 @@ export class Rating extends Record {
     rating_image_url;
     /** @type {string} */
     rating_text;
+    /** @type {string} */
+    feedback;
+
+    /** @returns {markup} */
+    get markupFeedback() {
+        return convertLineBreakToBr(this.feedback);
+    }
 }
 Rating.register();


### PR DESCRIPTION
With this commit, agents in live chats that have left the channel will receive a toast notification when rated by a customer. This is done to facilitate reaching out and/or creating a ticket for the customer.

task-5152434