### PR TITLE
[IMP] certificate, account_edi_proxy_client: manage CA certificate stores

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -111,13 +111,16 @@ class AccountEdiProxyClientUser(models.Model):
             raise AccountEdiProxyError("block_demo_mode", "Can't access the proxy in demo mode")
 
         try:
-            response = requests.post(
+            res = requests.post(
                 url,
                 json=payload,
                 timeout=TIMEOUT,
                 headers={'content-type': 'application/json'},
-                auth=OdooEdiProxyAuth(user=self)).json()
-        except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError):
+                auth=OdooEdiProxyAuth(user=self))
+            res.raise_for_status()
+            response = res.json()
+        except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError) as e:
+            _logger.warning('Connection error <%(url)s>: %(error)s', {'url': url, 'error': e})
             raise AccountEdiProxyError('connection_error',
                 _('The url that this service requested returned an error. The url it tried to contact was %s', url))
 

--- a/addons/account_peppol/tests/common.py
+++ b/addons/account_peppol/tests/common.py
@@ -139,7 +139,7 @@ class PeppolConnectorCommon(AccountTestInvoicingCommon):
                         'kwargs': kwargs,
                     }
                     results = replacement_method(url, **kwargs)
-                    return DotDict({**results, 'json': lambda: results})
+                    return DotDict({**results, 'json': lambda: results, 'raise_for_status': lambda: None})
             self.assertFalse(url, "Missing mock!")
 
         with patch('requests.get', mock_request), patch('requests.post', mock_request):


### PR DESCRIPTION
Our webservice client (`zeep`) connections lacked a way to use `certificate.certificate` models to verify the connection with server identification. 
This is rather complicated, since PyOpenSSL only allows filenames with their default methods. 
We now add the feature to pass these certificate records, load them into memory buffers, and add them to the CA store.

IAP PR: odoo/iap-apps#1308

Task [link](https://www.odoo.com/odoo/project.task/5068741)
task-5068741