### PR TITLE
[FIX] base: add leading zero to sequence date test

### DIFF
--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -221,7 +221,7 @@ class TestIrSequenceGenerate(BaseCase):
             isoyear, isoweek, weekday = datetime.now().isocalendar()
             self.assertEqual(
                 env['ir.sequence'].next_by_code('test_sequence_type_9'),
-                f"{isoyear}/{isoyear % 100}/1/{isoweek}/{weekday % 7}",
+                f"{isoyear}/{isoyear % 100:02d}/1/{isoweek:02d}/{weekday % 7}",
             )
 
     def test_ir_sequence_suffix(self):


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Run `test_ir_sequence_iso_directives` in January or February.

Issue
-----
Test fails due to the sequence generated having a leading zero on the ISO week number, whereas the comparison string doesn't.

Cause
-----
We get the week number from the comparison string from the `isocalendar` method as a simple `int`, hence we it doesn't automatically get formatted with a leading zero.

Solution
--------
In the comparison string, ensure the `isoy` and `isoweek` parts are always formatted with 2 width, adding a leading zero when needed.

runbot-234592