### PR TITLE
[IMP] resoure,test_resource: add tools to convert and map domains

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -5,7 +5,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.models import TableSQL
 from odoo.tools import SQL
-from odoo.addons.resource.models.utils import filter_domain_leaf
+from odoo.addons.resource.models.utils import filter_map_domain
 
 
 class ProjectTaskBurndownChartReport(models.AbstractModel):
@@ -227,14 +227,28 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
         * A domain that only contains fields that are specific to `project.task.burndown.chart.report`
         * A domain that only contains fields that are specific to `project.task`
 
-        See `filter_domain_leaf` for more details on the new domains.
+        See `filter_map_domain` for more details on the new domains.
 
         :param domain: The domain that has been passed to the read_group.
         :return: A tuple containing the non `project.task` specific domain and the `project.task` specific domain.
         """
         burndown_chart_specific_fields = list(set(self._fields) - set(self.task_specific_fields))
-        task_specific_domain = filter_domain_leaf(domain, lambda field: field not in burndown_chart_specific_fields)
-        non_task_specific_domain = filter_domain_leaf(domain, lambda field: field not in self.task_specific_fields)
+        task_specific_domain = filter_map_domain(
+            domain,
+            lambda condition: (
+                None
+                if condition.field_expr in burndown_chart_specific_fields
+                else condition
+            ),
+        )
+        non_task_specific_domain = filter_map_domain(
+            domain,
+            lambda condition: (
+                None
+                if condition.field_expr in self.task_specific_fields
+                else condition
+            ),
+        )
         return non_task_specific_domain, task_specific_domain
 
     def _read_group_select(self, table, aggregate_spec):

--- a/addons/resource/models/utils.py
+++ b/addons/resource/models/utils.py
@@ -1,4 +1,4 @@
-from odoo.fields import Domain
+from odoo.fields import Domain, parse_field_expr
 
 # Default hour per day value. The one should
 # only be used when the one from the calendar
@@ -6,34 +6,26 @@ from odoo.fields import Domain
 HOURS_PER_DAY = 8
 
 
-def filter_domain_leaf(domain, field_check, field_name_mapping=None):
+def filter_map_domain(domain, map_function) -> Domain:
     """
-    filter_domain_lead only keep the leaves of a domain that verify a given check. Logical operators that involves
-    a leaf that is undetermined (because it does not pass the check) are ignored.
+    Applies map_function to each condition in the domain. Filters out the domain
+    condition if map_function returns None for it.
 
-    each operator is a logic gate:
-    - '&' and '|' take two entries and can be ignored if one of them (or the two of them) is undetermined
-    -'!' takes one entry and can be ignored if this entry is undetermined
-
-    params:
-        - domain: the domain that needs to be filtered
-        - field_check: the function that the field name used in the leaf needs to verify to keep the leaf
-        - field_name_mapping: dictionary of the form {'field_name': 'new_field_name', ...}. Occurences of 'field_name'
-          in the first element of domain leaves will be replaced by 'new_field_name'. This is usefull when adapting a
-          domain from one model to another when some field names do not match the names of the corresponding fields in
-          the new model.
-    returns: The filtered version of the domain
+    :param domain: The original domain to process. Remains unmodified.
+    :param map_function: A callable that takes a condition and returns either:
+        - A modified Domain, or
+        - None (discards the condition).
+    :return: A new domain containing only the transformed conditions.
     """
-    field_name_mapping = field_name_mapping or {}
-
     def adapt_condition(condition, ignored):
-        field_name = condition.field_expr
-        if not field_check(field_name):
+        mapped_condition = map_function(condition)
+        if mapped_condition is None:
             return ignored
-        field_name = field_name_mapping.get(field_name)
-        if field_name is None:
-            return condition
-        return Domain(field_name, condition.operator, condition.value)
+        assert isinstance(
+            mapped_condition,
+            Domain,
+        ), f"map_function() returned {mapped_condition} instead of <Domain | None>"
+        return mapped_condition
 
     def adapt_domain(domain: Domain, ignored) -> Domain:
         if hasattr(domain, 'OPERATOR'):
@@ -51,3 +43,40 @@ def filter_domain_leaf(domain, field_check, field_name_mapping=None):
     if domain.is_false():
         return domain
     return adapt_domain(domain, ignored=Domain.TRUE)
+
+
+def extract_comodel_domain(
+    model,
+    domain,
+    field_expr: str,
+):
+    """
+    Converts a domain to make it usable on the comodel pointed to by `field_expr`
+
+    :param model: The model on which the domain was originally meant for. Usually `self`
+    :param domain: The domain we want to convert
+    :param field_expr: The field pointing to the comodel we want to translate the domain for.
+        e.g.: "employee_id"
+    :return: The converted domain, with only the fields meant for the comodel.
+        The domain's fields are converted for use on that comodel.
+    """
+    domain = Domain(domain).optimize_full(model)
+    field_name, rest = parse_field_expr(field_expr)
+    field = model._fields[field_name]
+    if field.related:
+        suffix = f'.{rest}' if rest else ''
+        return extract_comodel_domain(model, domain, field.related + suffix)
+
+    def _convert_field(condition):
+        if (
+            hasattr(condition, 'field_expr')
+            and condition.field_expr == field_name
+        ):
+            return Domain('id', condition.operator, condition.value)
+        return None
+
+    domain = filter_map_domain(domain, _convert_field)
+    comodel = model.env[field.comodel_name]
+    if rest:
+        return extract_comodel_domain(comodel, domain, rest)
+    return domain.optimize_full(comodel)

--- a/addons/resource/tests/__init__.py
+++ b/addons/resource/tests/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 
+from . import test_filter_map_domain
 from . import test_utils
 from . import test_resource_calendar
 from . import test_flexible_resource_calendar

--- a/addons/resource/tests/test_filter_map_domain.py
+++ b/addons/resource/tests/test_filter_map_domain.py
@@ -1,0 +1,467 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Domain
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.resource.models.utils import filter_map_domain
+
+
+@tagged('-at_install', 'post_install')
+class TestFilterMapDomain(TransactionCase):
+    """
+    _filter_map_domain() can filter and map domain
+    conditions while still keeping the RPN structure valid.
+
+    This function needs to handle multiple cases for domains:
+    - Nested domains
+    - Not break due to the internal usage of None
+    - Keep the structure as valid RPN, removing some operators if needed
+
+    If everything is filtered out (when the map function returns None for each
+    condition), then Domain.TRUE should be returned (which also represents an
+    empty domain)
+
+    This test suite will try to ensure all of the above.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.complex_domain = Domain(
+            [
+                '|',
+                    '&',
+                        ('overtime_hours', '>=', 2),
+                        ('manager_email', 'ilike', 'tecna'),
+                    '&',
+                        '|',
+                            ('department_id', 'in', [4, 5]),
+                            ('department_manager', 'ilike', 'Tecna'),
+                        '|',
+                            '&',
+                                ('employee_id', 'in', [1, 2, 3]),
+                                ('manager_id', 'ilike', 'Flora'),
+                            ('color', '=', 1),
+            ],
+        )
+
+    def test_translation_only(self):
+        def map_function(condition):
+            field_expr, operator, value = (
+                condition.field_expr,
+                condition.operator,
+                condition.value,
+            )
+            field_expr = {
+                'overtime_hours': 'extra_mile',
+                'department_manager': 'big_boss',
+                'color': 'darkness',
+            }.get(field_expr, field_expr)
+            if operator == '>=':
+                operator = '<'
+            if not isinstance(value, list):
+                value = {
+                    'tecna': 'death',
+                    'Tecna': 'Death',
+                    'Flora': 'Sorrow',
+                }.get(value, value)
+            return Domain(field_expr, operator, value)
+
+        expected_domain = Domain(
+            [
+                '|',
+                    '&',
+                        ('extra_mile', '<', 2),
+                        ('manager_email', 'ilike', 'death'),
+                    '&',
+                        '|',
+                            ('department_id', 'in', [4, 5]),
+                            ('big_boss', 'ilike', 'Death'),
+                        '|',
+                            '&',
+                                ('employee_id', 'in', [1, 2, 3]),
+                                ('manager_id', 'ilike', 'Sorrow'),
+                        ('darkness', '=', 1),
+            ],
+        )
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(
+                self.complex_domain,
+                map_function,
+            ),
+        )
+
+    def test_filter_only(self):
+        def map_function(condition):
+            if condition.field_expr in [
+                'manager_email',
+                'color',
+                'department_id',
+            ]:
+                return None
+            return condition
+
+        expected_domain = Domain(
+            [
+                '|',
+                    ('overtime_hours', '>=', 2),
+                    '&',
+                        ('department_manager', 'ilike', 'Tecna'),
+                        '&',
+                            ('employee_id', 'in', [1, 2, 3]),
+                            ('manager_id', 'ilike', 'Flora'),
+            ],
+        )
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(
+                self.complex_domain,
+                map_function,
+            ),
+        )
+
+    def test_filter_all(self):
+        def map_function(condition):
+            return None
+
+        expected_domain = Domain.TRUE
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(
+                self.complex_domain,
+                map_function,
+            ),
+        )
+
+    def test_do_nothing(self):
+        def map_function(condition):
+            if condition.field_expr == 'will_never_exist':
+                return None
+            return condition
+
+        expected_domain = self.complex_domain
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(
+                self.complex_domain,
+                map_function,
+            ),
+        )
+
+    def test_do_nothing_empty_function(self):
+        def map_function(condition):
+            return condition
+
+        expected_domain = self.complex_domain
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(
+                self.complex_domain,
+                map_function,
+            ),
+        )
+
+    def test_simple_domain_map(self):
+        def map_function(condition):
+            if condition.field_expr == 'child_id':
+                return Domain('parent_id', condition.operator, condition.value)
+            return condition
+
+        # map_domain should convert this list to Domain automatically
+        simple_domain = [('child_id', '=', 7)]
+        expected_domain = Domain('parent_id', '=', 7)
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(simple_domain, map_function),
+        )
+
+    def test_simple_domain_filter(self):
+        def map_function(condition):
+            if condition.field_expr == 'child_id':
+                return None
+            return condition
+
+        # map_domain should convert this list to Domain automatically
+        simple_domain = [('child_id', '=', 7)]
+        expected_domain = Domain.TRUE
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(simple_domain, map_function),
+        )
+
+    def test_domain_falsy_values(self):
+        def map_function(condition):
+            field_expr, operator, value = (
+                condition.field_expr,
+                condition.operator,
+                condition.value,
+            )
+            if value == '':  # noqa: PLC1901
+                value = 'so many things'
+            if value == False:  # noqa: E712
+                value = True
+            if operator == 'ilike':
+                operator = 'like'
+            if field_expr == 'money':
+                field_expr = 'problems'
+                operator = '<'
+                value = 1
+            if field_expr == 'cookie':
+                return None
+            return Domain(field_expr, operator, value)
+
+        domain_with_falsy_values = [
+            '&',
+                '|',
+                    '&',
+                        ('cookie', '=', []),
+                        ('reason_to_live', '=', None),
+                    '&',
+                        ('things', 'ilike', ''),
+                        ('smile', '=', False),
+                ('money', '=', 0),
+        ]
+        # None will now be true since Domain() converts None to False
+        expected_domain = Domain(
+            [
+                '&',
+                    '|',
+                        ('reason_to_live', '=', True),
+                        '&',
+                            ('things', 'like', 'so many things'),
+                            ('smile', '=', True),
+                    ('problems', '<', 1),
+            ],
+        )
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(
+                domain_with_falsy_values,
+                map_function,
+            ),
+        )
+
+    def test_swap_fields(self):
+        def map_function(condition):
+            if condition.field_expr == 'employee_id':
+                return Domain('manager_id', condition.operator, condition.value)
+            if condition.field_expr == 'manager_id':
+                return Domain(
+                    'employee_id',
+                    condition.operator,
+                    condition.value,
+                )
+            return None
+
+        domain = Domain(
+            [
+                '|',
+                    '&',
+                        ('employee_id', 'in', [1, 2, 3]),
+                        ('manager_id', '=', 7),
+                    '&',
+                        ('employee_id', '=', 0),
+                        ('manager_id', 'in', [8, 9, 5]),
+            ],
+        )
+        expected_domain = Domain(
+            [
+                '|',
+                    '&',
+                        ('manager_id', 'in', [1, 2, 3]),
+                        ('employee_id', '=', 7),
+                    '&',
+                        ('manager_id', '=', 0),
+                        ('employee_id', 'in', [8, 9, 5]),
+            ],
+        )
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(domain, map_function),
+        )
+
+    def test_not_operator(self):
+        """
+        The not operator is not removed by Domain() when field_expr is dotted
+        filter_map_domain thus needs to support not operators.
+        """
+
+        def map_function(condition):
+            if condition.field_expr == 'c.d':
+                return Domain('e.f', condition.operator, condition.value)
+            return None
+
+        domain = Domain(
+            [
+                '|',
+                    '!',
+                        ('a.b', 'in', [1, 2, 3]),
+                    '!',
+                        ('c.d', '=', 7),
+            ],
+        )
+        expected_domain = Domain(
+            [
+                '!',
+                    ('e.f', '=', 7),
+            ],
+        )
+        self.assertEqual(
+            expected_domain,
+            filter_map_domain(domain, map_function),
+        )
+
+    def test_filter_domain_leaf_filter(self):
+        """
+        filter_map_domain() replaces filter_domain_leaf()
+        We thus moved the old filter_domain_leaf tests to make sure
+        filter_map_domain is backwards compatible
+        """
+        domains = [
+            ['|', ('skills', '=', 1), ('admin', '=', True)],
+            [
+                '|',
+                ('skills', '=', 1),
+                ('admin', '=', True),
+                '|',
+                ('skills', '=', 2),
+                ('admin', '=', True),
+            ],
+            [
+                '|',
+                ('skills', '=', 1),
+                ('skills', '=', 2),
+                '|',
+                ('skills', '=', 2),
+                ('admin', '=', True),
+            ],
+            [
+                '|',
+                '|',
+                ('skills', '=', 1),
+                ('skills', '=', True),
+                '|',
+                ('skills', '=', 2),
+                ('admin', '=', True),
+            ],
+            [
+                '|',
+                '|',
+                ('admin', '=', 1),
+                ('admin', '=', True),
+                '&',
+                ('skills', '=', 2),
+                ('admin', '=', True),
+            ],
+            [
+                '|',
+                '|',
+                '!',
+                ('admin', '=', 1),
+                ('admin', '=', True),
+                '!',
+                '&',
+                '!',
+                ('skills', '=', 2),
+                ('admin', '=', True),
+            ],
+            ['&', '!', ('skills', '=', 2), ('admin', '=', True)],
+            [
+                ['start_datetime', '<=', '2022-12-17 22:59:59'],
+                ['end_datetime', '>=', '2022-12-10 23:00:00'],
+            ],
+            [
+                ('admin', '=', 1),
+                ('admin', '=', 1),
+                '|',
+                ('admin', '=', 1),
+                ('admin', '=', 1),
+                ('skills', '=', 2),
+            ],
+        ]
+        fields_to_remove = [['skills'], ['admin', 'skills']]
+        expected_results = [
+            [
+                [('admin', '=', True)],
+                [('admin', '=', True), ('admin', '=', True)],
+                [('admin', '=', True)],
+                [('admin', '=', True)],
+                [
+                    '|',
+                    '|',
+                    ('admin', '=', 1),
+                    ('admin', '=', True),
+                    ('admin', '=', True),
+                ],
+                [
+                    '|',
+                    '|',
+                    '!',
+                    ('admin', '=', 1),
+                    ('admin', '=', True),
+                    '!',
+                    ('admin', '=', True),
+                ],
+                [('admin', '=', True)],
+                [
+                    ['start_datetime', '<=', '2022-12-17 22:59:59'],
+                    ['end_datetime', '>=', '2022-12-10 23:00:00'],
+                ],
+                [
+                    ('admin', '=', 1),
+                    ('admin', '=', 1),
+                    '|',
+                    ('admin', '=', 1),
+                    ('admin', '=', 1),
+                ],
+            ],
+            [
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [
+                    ['start_datetime', '<=', '2022-12-17 22:59:59'],
+                    ['end_datetime', '>=', '2022-12-10 23:00:00'],
+                ],
+                [],
+            ],
+        ]
+
+        for idx, fields in enumerate(fields_to_remove):
+
+            def map_function(condition):
+                if condition.field_expr in fields:
+                    return None
+                return condition
+
+            results = [filter_map_domain(dom, map_function) for dom in domains]
+            self.assertEqual(
+                results,
+                [Domain(expected) for expected in expected_results[idx]],
+            )
+
+    # second part from old test_filter_domain_leaf
+    def test_filter_domain_leaf_map(self):
+        def map_function(condition):
+            if condition.field_expr != 'field3':
+                return None
+            return Domain('field4', condition.operator, condition.value)
+
+        self.assertEqual(
+            Domain('field4', '!=', 'test'),
+            filter_map_domain(
+                [
+                    '|',
+                        ('field1', 'in', [1, 2]),
+                        '!',
+                        ('field2', '=', False),
+                    ('field3', '!=', 'test'),
+                ],
+                map_function,
+            ),
+        )

--- a/addons/resource/tests/test_utils.py
+++ b/addons/resource/tests/test_utils.py
@@ -1,65 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from dateutil.relativedelta import relativedelta
 
-from odoo.fields import Datetime, Domain
+from odoo.fields import Datetime
 from odoo.tests.common import TransactionCase
-from odoo.addons.resource.models import utils
 from odoo.tests import tagged, Form
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
 class TestExpression(TransactionCase):
-
-    def test_filter_domain_leaf(self):
-        domains = [
-            ['|', ('skills', '=', 1), ('admin', '=', True)],
-            ['|', ('skills', '=', 1), ('admin', '=', True), '|', ('skills', '=', 2), ('admin', '=', True)],
-            ['|', ('skills', '=', 1), ('skills', '=', 2), '|', ('skills', '=', 2), ('admin', '=', True)],
-            ['|', '|', ('skills', '=', 1), ('skills', '=', True), '|', ('skills', '=', 2), ('admin', '=', True)],
-            ['|', '|', ('admin', '=', 1), ('admin', '=', True), '&', ('skills', '=', 2), ('admin', '=', True)],
-            ['|', '|', '!', ('admin', '=', 1), ('admin', '=', True), '!', '&', '!', ('skills', '=', 2), ('admin', '=', True)],
-            ['&', '!', ('skills', '=', 2), ('admin', '=', True)],
-            [['start_datetime', '<=', '2022-12-17 22:59:59'], ['end_datetime', '>=', '2022-12-10 23:00:00']],
-            [('admin', '=', 1), ('admin', '=', 1), '|', ('admin', '=', 1), ('admin', '=', 1), ('skills', '=', 2)]
-        ]
-        fields_to_remove = [['skills'], ['admin', 'skills']]
-        expected_results = [
-            [
-                [('admin', '=', True)],
-                [('admin', '=', True), ('admin', '=', True)],
-                [('admin', '=', True)],
-                [('admin', '=', True)],
-                ['|', '|', ('admin', '=', 1), ('admin', '=', True), ('admin', '=', True)],
-                ['|', '|', '!', ('admin', '=', 1), ('admin', '=', True), '!', ('admin', '=', True)],
-                [('admin', '=', True)],
-                [['start_datetime', '<=', '2022-12-17 22:59:59'], ['end_datetime', '>=', '2022-12-10 23:00:00']],
-                [('admin', '=', 1), ('admin', '=', 1), '|', ('admin', '=', 1), ('admin', '=', 1)],
-            ],
-            [
-                [],
-                [],
-                [],
-                [],
-                [],
-                [],
-                [],
-                [['start_datetime', '<=', '2022-12-17 22:59:59'], ['end_datetime', '>=', '2022-12-10 23:00:00']],
-                [],
-            ],
-        ]
-        for idx, fields in enumerate(fields_to_remove):
-            results = [utils.filter_domain_leaf(dom, lambda field: field not in fields) for dom in domains]
-            self.assertEqual(results, [Domain(expected) for expected in expected_results[idx]])
-
-        # Testing field mapping 1
-        self.assertEqual(
-            Domain('field4', '!=', 'test'),
-            utils.filter_domain_leaf(
-                ['|', ('field1', 'in', [1, 2]), '!', ('field2', '=', False), ('field3', '!=', 'test')],
-                lambda field: field == 'field3',
-                field_name_mapping={'field3': 'field4'},
-            )
-        )
 
     def test_resource_calendar_leave_compute_date_to(self):
         """

--- a/addons/test_resource/models/test_resource.py
+++ b/addons/test_resource/models/test_resource.py
@@ -10,3 +10,36 @@ class ResourceTest(models.Model):
     _inherit = ['resource.mixin']
 
     name = fields.Char()
+    size = fields.Float()
+
+
+class RelatedResourceTest1(models.Model):
+    _name = "related.resource.test.1"
+    _description = "First related node for resource test"
+
+    resource_test_id = fields.Many2one("resource.test")
+    size_related = fields.Float(related='resource_test_id.size')
+    is_valid = fields.Boolean()
+    surname = fields.Char()
+
+
+class RelatedResourceTest2(models.Model):
+    _name = "related.resource.test.2"
+    _description = "Second related node for resource test"
+
+    profile_picture = fields.Image()
+    related_resource_test_1_id = fields.Many2one("related.resource.test.1")
+    related_resource_test_id = fields.Many2one(
+        string="Related Resource Test Id",
+        related="related_resource_test_1_id.resource_test_id",
+    )
+    size_related_2 = fields.Float(
+        related='related_resource_test_1_id.size_related',
+    )
+    is_valid_related = fields.Boolean(
+        related='related_resource_test_1_id.is_valid',
+    )
+    resource_test_id = fields.Many2one("resource.test")
+    name_related_orig = fields.Char(
+        related='resource_test_id.name',
+    )

--- a/addons/test_resource/security/ir.model.access.csv
+++ b/addons/test_resource/security/ir.model.access.csv
@@ -1,2 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_resource_test_all,resource.test.all,model_resource_test,base.group_user,1,1,1,1
+access_related_resource_test_1_all,related.resource.test.1.all,model_related_resource_test_1,base.group_user,1,1,1,1
+access_related_resource_test_2_all,related.resource.test.2.all,model_related_resource_test_2,base.group_user,1,1,1,1

--- a/addons/test_resource/tests/__init__.py
+++ b/addons/test_resource/tests/__init__.py
@@ -2,6 +2,7 @@
 
 from . import (
     test_calendar,
+    test_extract_comodel_domain,
     test_mixin,
     test_performance,
     test_resource,

--- a/addons/test_resource/tests/test_extract_comodel_domain.py
+++ b/addons/test_resource/tests/test_extract_comodel_domain.py
@@ -1,0 +1,166 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Domain
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.resource.models.utils import extract_comodel_domain
+
+
+@tagged('-at_install', 'post_install')
+class TestExtractComodelDomain(TransactionCase):
+    def test_convert_model_name(self):
+        """
+        comparing on relation id should compare on name/display_name
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_id'
+        domain = Domain('related_resource_test_id', '=', 'Moxxie')
+        wanted_domain = Domain('name', 'in', ['Moxxie'])
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_field_prefix(self):
+        """
+        base case, 'relation_field.field' should just resolve to 'field'
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_1_id'
+        domain = Domain('related_resource_test_1_id.surname', '=', 'Moxxie')
+        wanted_domain = Domain('surname', 'in', ['Moxxie'])
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_irrelevant_field(self):
+        """
+        fields that are not part of the comodel should be removed
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_1_id'
+        domain = Domain('profile_picture', '=', False)
+        wanted_domain = Domain.TRUE
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_non_existant_field(self):
+        """
+        Fields that simply don't exist should raise an error
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_1_id'
+        domain = Domain('field_that_does_not_exist', '=', 4)
+        with self.assertRaises(ValueError):
+            extract_comodel_domain(model, domain, field_expr)
+
+    def test_convert_model_related_no_prefix(self):
+        """
+        size_related_2 is related to related_resource_test_1_id.size_related
+        which is also related to resource_test_id.size
+        So in the end we should get resource_test_id.size (with "any!" due to
+        the internal use of optimize_full()
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_1_id'
+        domain = Domain('size_related_2', '>', 3)
+        wanted_domain = Domain('resource_test_id', 'any!', [('size', '>', 3)])
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_related_basic(self):
+        """
+        is_valid_related is a related to related_resource_test_1_id.is_valid
+        so the function should simply resolve to is_valid
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_1_id'
+        domain = Domain('is_valid_related', '=', True)
+        wanted_domain = Domain('is_valid', 'in', [True])
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_related_wrong_field(self):
+        """
+        name_related_orig is a related to an irrelevant model.
+        It should thus be ignored.
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_1_id'
+        domain = Domain('name_related_orig', '=', True)
+        wanted_domain = Domain.TRUE
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_recursive_id(self):
+        """
+        related_resource_test_id is by itself a related field. The function
+        should still be able to treat it normally in that case
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_id'
+        domain = Domain('related_resource_test_id.size', '>', 3)
+        wanted_domain = Domain('size', '>', 3)
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_convert_model_recursive(self):
+        """
+        related_resource_test_id is the same (related) as
+        "related_resource_test_1_id.resource_test_id", so it should also be able
+        to convert fields starting with
+        "related_resource_test_1_id.resource_test_id"
+        """
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_id'
+        domain = Domain(
+            'related_resource_test_1_id.resource_test_id.size',
+            '>',
+            3,
+        )
+        wanted_domain = Domain('size', '>', 3)
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+        )
+
+    def test_extract_comodel_domain_multiple_conditions(self):
+        model = self.env['related.resource.test.2']
+        field_expr = 'related_resource_test_id'
+
+        # both are the same - will only keep "name"
+        domain = Domain('related_resource_test_id', '=', 'Moxxie')
+        domain &= Domain('related_resource_test_1_id.surname', '=', 'Moxxie')
+        wanted_domain = Domain('name', 'in', ['Moxxie'])
+        wanted_domain &= Domain('surname', 'in', ['Moxxie'])
+        domain &= Domain('profile_picture', '=', False)  # should be ignored
+        domain |= Domain('size_related_2', '>', 3)
+        # not in related_resource_test_id - ignored
+        domain |= Domain('is_valid_related', '=', True)
+        domain &= Domain('name_related_orig', '=', True)  # should be ignored
+        wanted_domain = Domain.OR(
+            [
+                Domain('name', 'in', ['Moxxie']),
+                Domain('size', '>', 3),
+            ],
+        )
+        self.assertEqual(
+            tuple(extract_comodel_domain(model, domain, field_expr)),
+            tuple(wanted_domain),
+            """
+            extract_comodel_domain() did not return the converted, optimized
+            model that is usable on the comodel pointed by the field_expr
+            'related_resource_test_id'
+            """,
+        )


### PR DESCRIPTION
We noticed that many people were doing the same operations for
read_groups calls in gantt views.
Usually, some rows had to be added based on the user domain, so
employees had to parse the domain to see if it was compatible with the
model used in group_by (e.g.: `employee_id`), then convert that domain to
that specifiec model.

This operation would (almost) always introduce bugs depending of the
emplementation the employee chose.

This commit adds tools to unify such process:

- `filter_map_domain()` can now be used to convert domain conditions and discard
them based on a function passed as an argument, it was previously a less
generic function named `filter_domain_leaf()`
- `extract_comodel_name()` can be used to convert a domain that was initially
used on one model (`model` argument) to a domain that can be used for
the model pointed to by `field_expr`. It internally uses
`Domain.optimize_full()` and `filter_map_domain()` to achive its goal.

`extract_comodel_name()` can now be used to acheive the domain
convertion for the gantt views.

Since `filter_domain_leaf()` has been changed and renamed, all the
parts using it had to be changed to only take a function instead of a
function + a map

task-5379826