### PR TITLE
[FIX] account_peppol: add a warning for 9925 registrations

### DIFF
--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -106,13 +106,21 @@ class PeppolRegistration(models.TransientModel):
                 and not wizard.company_id._check_peppol_endpoint_number(warning=True)
             ):
                 peppol_warnings['company_peppol_endpoint_warning'] = {
+                    'level': 'warning',
                     'message': _("The endpoint number might not be correct. "
                                 "Please check if you entered the right identification number."),
                 }
             if wizard.peppol_endpoint and not wizard.smp_registration:
                 peppol_warnings['company_on_another_smp'] = {
+                    'level': 'info',
                     'message': _("Your company is already registered on another Access Point for receiving invoices."
                                  "We will register you as a sender only.")
+                }
+            if wizard.peppol_eas == '9925':
+                peppol_warnings['be_9925_warning'] = {
+                    'level': 'warning',
+                    'message': _("You are about to register with your VAT number. Make sure you register with your "
+                                "Company Registry (BCE/KBO) first to be compliant with the new regulation."),
                 }
             wizard.peppol_warnings = peppol_warnings or False
 


### PR DESCRIPTION
The Belgian Peppol Authority wants us to register belgian users with 0208 (BCE/KBO) and not 9925 (BE VAT).
It should still be possible to register with 9925 for some edge case, but let's make it clear to our users that this is not the regular path.

task-none (feedback from support + TSB)
