### PR TITLE
[FIX] mrp: fix printing multiple generated sn labels

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2884,6 +2884,21 @@ class MrpProduction(models.Model):
             clean_action(action, self.env)
             return action
 
+    def _autoprint_mass_generated_lots(self):
+        actions = []
+        productions_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_generated_mrp_lot)
+        productions_by_print_formats = productions_to_print.grouped(lambda p: p.picking_type_id.generated_mrp_lot_label_to_print)
+        for print_format in productions_to_print.picking_type_id.mapped('generated_mrp_lot_label_to_print'):
+            grouped_productions = productions_by_print_formats.get(print_format)
+            lots_to_print = grouped_productions.mapped('lot_producing_id')
+            if print_format == 'pdf':
+                action = self.env.ref("stock.action_report_lot_label").report_action(lots_to_print.ids, config=False)
+            elif print_format == 'zpl':
+                action = self.env.ref("stock.label_lot_template").report_action(lots_to_print.ids, config=False)
+            clean_action(action, self.env)
+            actions.append(action)
+        return actions
+
     def _prepare_finished_extra_vals(self):
         self.ensure_one()
         if self.lot_producing_id:

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -120,7 +120,17 @@ class MrpBatchProduct(models.TransientModel):
 
         if mark_done:
             return productions.with_context(from_wizard=True).button_mark_done()
-        return
+
+        print_actions = productions._autoprint_mass_generated_lots()
+        if print_actions:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'do_multi_print',
+                'context': {},
+                'params': {
+                    'reports': print_actions,
+                }
+            }
 
     def _process_components(self, production, components_line):
         lot_names = []


### PR DESCRIPTION
This commit fixes the issue of not printing Lot/SN labels when generating them on the MO that has more than 1 unit on the quantity to produce.

To reproduce the bug:
1- Go to Operation Types → Manufacturing → Hardware → activate the print `Lot/SN Label` (Print When "Create New Lot/SN")
2- Create an MO with quantity of 5 for a tracked product. 
3- Click on `Produce All` and use the wizard to generate SNs and produce or confirm the MO.

= SNs should be printed but they are not.

opw-5347787
