### PR TITLE
[REF] iot_drivers: simplify server logger

### DIFF
--- a/addons/iot_drivers/server_logger.py
+++ b/addons/iot_drivers/server_logger.py
@@ -4,168 +4,125 @@ import requests
 import threading
 import time
 
+from collections.abc import Generator
 from odoo.addons.iot_drivers.tools import helpers, system
-from odoo.addons.iot_drivers.tools.system import IS_TEST, IOT_IDENTIFIER
+from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 from odoo.netsvc import ColoredFormatter
 
 _logger = logging.getLogger(__name__)
 
-IOT_LOG_TO_SERVER_CONFIG_NAME = 'iot_log_to_server'  # config name in odoo.conf
 
+@helpers.require_db
+class ServerLogger(logging.Handler):
+    _previous_disconnection: float = 0.0
+    _MAX_QUEUE_SIZE: int = 1000
 
-class AsyncHTTPHandler(logging.Handler):
-    """
-    Custom logging handler which send IoT logs using asynchronous requests.
-    To avoid spamming the server, we send logs by batch each X seconds
-    """
-    _MAX_QUEUE_SIZE = 1000
-    """Maximum queue size. If a log record is received but the queue if full it will be discarded"""
-    _MAX_BATCH_SIZE = 50
-    """Maximum number of sent logs batched at once. Used to avoid too heavy request. Log records still in the queue will
-    be handle in future flushes"""
-    _FLUSH_INTERVAL = 0.5
-    """How much seconds it will sleep before checking for new logs to send"""
-    _REQUEST_TIMEOUT = 10
-    """Amount of seconds to wait per log to send before timeout"""
-    _DELAY_BEFORE_NO_SERVER_LOG = 5 * 60  # 5 minutes
-    """Minimum delay in seconds before we log a server disconnection.
-    Used in order to avoid the IoT log file to have a log recorded each _FLUSH_INTERVAL (as this value is very small)"""
+    def __init__(self, server_url=None):
+        """Custom logging handler which send IoT logs using asynchronous requests.
+        To avoid spamming the server, we send logs by batch each X seconds
 
-    def __init__(self, odoo_server_url, active):
-        """
-        :param odoo_server_url: Odoo Server URL
+        :param str server_url: URL of the Odoo server (provided by decorator).
         """
         super().__init__()
-        self._odoo_server_url = odoo_server_url
+        self.setFormatter(
+            ColoredFormatter('%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s %(perf_info)s')
+        )
+        self.addFilter(self._logs_filter)
+        self._server_iot_log_url = server_url + '/iot/log'
         self._db_name = system.get_conf('db_name') or ''
-        self._log_queue = queue.Queue(self._MAX_QUEUE_SIZE)
-        self._flush_thread = None
-        self._active = None
-        self._next_disconnection_time = None
-        self.toggle_active(active)
+        self._queue = queue.Queue(self._MAX_QUEUE_SIZE)
+        self._active = True
+        self._flush_thread = threading.Thread(target=self.share_logs_loop, name="ThreadServerLogger", daemon=True)
+        self._flush_thread.start()
 
-    def toggle_active(self, is_active):
-        """
-        Switch it on or off the handler (depending on the IoT setting) without the need to close/reset it
-        """
-        self._active = is_active
-        if self._active and self._odoo_server_url:
-            # Start the thread to periodically flush logs
-            self._flush_thread = threading.Thread(target=self._periodic_flush, name="ThreadServerLogSender", daemon=True)
-            self._flush_thread.start()
-        else:
-            self._flush_thread and self._flush_thread.join()  # let a last flush
+    def share_logs_loop(self):
+        while self._active:  # allow to exit the loop on thread.join
+            time.sleep(0.5)  # sleep before sending logs
+            self._share_logs()
 
-    def _periodic_flush(self):
+    def get_batch(self) -> Generator[bytes]:
+        """Generate a batch of log records to send to the server.
+        The amount of log records is limited to 50 to avoid too heavy requests.
+        """
+        yield f"identifier {IOT_IDENTIFIER}<log/>\n".encode()
+        for _ in range(50):  # max 50 logs per batch
+            try:
+                log_record = self._queue.get_nowait()
+                yield self.format_logs(log_record.levelno, self.format(log_record))
+            except queue.Empty:
+                break
+
+        # Report to the server if the queue is close from saturation
+        queue_size = self._queue.qsize()
+        if queue_size >= .8 * self._MAX_QUEUE_SIZE:
+            log_message = f"The Server Logger queue is {100 * queue_size / self._MAX_QUEUE_SIZE:.2f}%"
+            _logger.warning(log_message)  # As we don't log our own logs, this will be part of the IoT logs
+            # In order to report this to the server (on the current batch) we will append it manually
+            yield self.format_logs(logging.WARNING, log_message)
+
+    def _share_logs(self):
         odoo_session = requests.Session()
-        while self._odoo_server_url and self._active:  # allow to exit the loop on thread.join
-            time.sleep(self._FLUSH_INTERVAL)
-            self._flush_logs(odoo_session)
-
-    def _flush_logs(self, odoo_session):
-        def convert_to_byte(s):
-            return bytes(s, encoding="utf-8") + b'<log/>\n'
-
-        def convert_server_line(log_level, line_formatted):
-            return convert_to_byte(f"{log_level},{line_formatted}")
-
-        def empty_queue():
-            yield convert_to_byte(f"identifier {IOT_IDENTIFIER}")
-            for _ in range(self._MAX_BATCH_SIZE):
-                # Use a limit to avoid having too heavy requests & infinite loop of the queue receiving new entries
-                try:
-                    log_record = self._log_queue.get_nowait()
-                    yield convert_server_line(log_record.levelno, self.format(log_record))
-                except queue.Empty:
-                    break
-
-            # Report to the server if the queue is close from saturation
-            if queue_size >= .8 * self._MAX_QUEUE_SIZE:
-                log_message = "The IoT {} queue is saturating: {}/{} ({:.2f}%)".format(  # noqa: UP032
-                    self.__class__.__name__, queue_size, self._MAX_QUEUE_SIZE,
-                    100 * queue_size / self._MAX_QUEUE_SIZE)
-                _logger.warning(log_message)  # As we don't log our own logs, this will be part of the IoT logs
-                # In order to report this to the server (on the current batch) we will append it manually
-                yield convert_server_line(logging.WARNING, log_message)
-
-        queue_size = self._log_queue.qsize()  # This is an approximate value
-
-        if not self._odoo_server_url or queue_size == 0:
+        odoo_session.headers = {
+            'X-Odoo-Database': self._db_name,
+            'User-Agent': 'OdooIoTBox/1.0',
+        }
+        if self._queue.qsize() == 0:
             return
         try:
             odoo_session.post(
-                self._odoo_server_url + '/iot/log',
-                data=empty_queue(),
-                headers={'X-Odoo-Database': self._db_name},
-                timeout=self._REQUEST_TIMEOUT
+                self._server_iot_log_url,
+                data=self.get_batch(),
+                timeout=10
             ).raise_for_status()
-            self._next_disconnection_time = None
-        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError) as request_errors:
+            self._previous_disconnection = 0.0
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError) as e:
             now = time.time()
-            if not self._next_disconnection_time or now >= self._next_disconnection_time:
-                _logger.info("Connection with the server to send the logs failed. It is likely down: %s", request_errors)
-                self._next_disconnection_time = now + self._DELAY_BEFORE_NO_SERVER_LOG
+            if now > self._previous_disconnection + 5 * 60:  # 5 minutes
+                _logger.info("Failed to send logs to the db. It is likely down: %s", e)
+                self._previous_disconnection = now
         except Exception:  # noqa: BLE001
-            _logger.error('Unexpected error happened while sending logs to server')
+            _logger.exception('Unexpected error happened while sending logs to server')
 
-    def emit(self, record):
-        # This is important that this method is as fast as possible.
-        # The log calls will be waiting for this function to finish
+    def emit(self, record: logging.LogRecord) -> None:
+        """This is important that this method is as fast as possible.
+        The log calls will be waiting for this function to finish
+        """
         if not self._active:
             return
         try:  # noqa: SIM105
-            self._log_queue.put_nowait(record)
+            self._queue.put_nowait(record)
         except queue.Full:
             pass
 
     def close(self):
-        self.toggle_active(False)
+        self._active = False
+        self._flush_thread and self._flush_thread.join()  # let a last flush
         super().close()
 
+    @staticmethod
+    def format_logs(log_level: int, log_message: str) -> bytes:
+        """Format log message to be sent to the server.
 
-def close_server_log_sender_handler():
-    _server_log_sender_handler.close()
+        :param log_level: Logging level of the message.
+        :param log_message: The log message.
+        :return: Formatted log message.
+        """
+        return f"{log_level},{log_message}<log/>\n".encode()
 
-
-def get_odoo_config_log_to_server_option():
-    # Enabled by default if not in test mode
-    return not IS_TEST and (system.get_conf(IOT_LOG_TO_SERVER_CONFIG_NAME, section='options') or True)
-
-
-def check_and_update_odoo_config_log_to_server_option(new_state):
-    """
-    :return: wherever the config file need to be updated or not
-    """
-    if get_odoo_config_log_to_server_option() != new_state:
-        system.update_conf({IOT_LOG_TO_SERVER_CONFIG_NAME, new_state}, section='options')
-        _server_log_sender_handler.toggle_active(new_state)
-        return True
-    return False
-
-
-def _server_log_sender_handler_filter(log_record):
-    def _filter_my_logs():
-        """Filter out our own logs (to avoid infinite loop)"""
-        return log_record.name == __name__
-
-    def _filter_frequent_irrelevant_calls():
-        """Filter out this frequent irrelevant HTTP calls, to avoid spamming the server with useless logs"""
+    @staticmethod
+    def _logs_filter(log_record):
         return (
-            log_record.name == 'werkzeug'
-            and log_record.args
-            and len(log_record.args) > 0
-            and str(log_record.args[0]).startswith('GET /hw_proxy/hello ')
+                log_record.name != __name__
+                and not (
+                    log_record.name == "werkzeug"
+                    and log_record.args
+                    and len(log_record.args) > 0
+                    and str(log_record.args[0]).startswith('GET /hw_proxy/hello ')
+            )
         )
 
-    return not (_filter_my_logs() or _filter_frequent_irrelevant_calls())
 
-
-# The server URL is set once at initlialisation as the IoT will always restart if the URL is changed
-# The only other possible case is when the server URL value is "Cleared",
-# in this case we force close the log handler (as it does not make sense anymore)
-_server_log_sender_handler = AsyncHTTPHandler(helpers.get_odoo_server_url(), get_odoo_config_log_to_server_option())
-if not IS_TEST:
-    _server_log_sender_handler.setFormatter(ColoredFormatter('%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s %(perf_info)s'))
-    _server_log_sender_handler.addFilter(_server_log_sender_handler_filter)
+server_logger = ServerLogger()
+if server_logger:
     # Set it in the 'root' logger, on which every logger (including odoo) is a child
-    logging.getLogger().addHandler(_server_log_sender_handler)
+    logging.getLogger().addHandler(server_logger)

--- a/addons/iot_drivers/static/src/app/components/dialog/HandlerDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/HandlerDialog.js
@@ -106,15 +106,6 @@ export class HandlerDialog extends Component {
                     </div>
                     <div class="mb-3">
                         <h5>Global logs level</h5>
-                        <div class="form-check mb-3">
-                            <input name="log-to-server"
-                                id="log-to-server"
-                                class="form-check-input cursor-pointer"
-                                type="checkbox"
-                                t-att-checked="this.state.handlerData.is_log_to_server_activated"
-                                t-on-change="(ev) => this.onChange(ev.target.name, ev.target.checked)" />
-                            <label class="form-check-label cursor-pointer" for="log-to-server">IoT logs automatically send to server logs</label>
-                        </div>
                         <div t-foreach="Object.entries(this.state.globalLogger)" t-as="global" t-key="global[0]" class="input-group input-group-sm mb-3">
                             <label class="input-group-text w-50" t-att-for="global[0]" t-esc="global[0]" />
                             <select t-att-name="global[0]"

--- a/addons/iot_drivers/tools/communication.py
+++ b/addons/iot_drivers/tools/communication.py
@@ -4,7 +4,7 @@ import time
 from odoo.addons.iot_drivers import main
 from odoo.addons.iot_drivers.tools import helpers, system
 from odoo.addons.iot_drivers.tools.system import IS_WINDOWS, IOT_IDENTIFIER
-from odoo.addons.iot_drivers.server_logger import close_server_log_sender_handler
+from odoo.addons.iot_drivers.server_logger import server_logger
 
 _logger = logging.getLogger(__name__)
 
@@ -40,7 +40,8 @@ def handle_message(message_type: str, **kwargs: dict) -> dict:
             _logger.info("device '%s' action finished - %.*f", device_identifier, 3, time.perf_counter() - start_operation_time)
         case 'server_clear':
             helpers.disconnect_from_server()
-            close_server_log_sender_handler()
+            if server_logger:
+                server_logger.close()
         case 'server_update':
             system.update_conf({
                 'remote_server': kwargs['server_url']


### PR DESCRIPTION
To share the IoT Box logs to the database it's connected to, we use a specific thread sending logs by batch using http requests.

We simplified this class to make it easier to read and debug.
