### PR TITLE
[FIX] product_expiry: import lot expiration dates

### DIFF
--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -24,7 +24,7 @@ class StockMove(models.Model):
             from_date = picking.scheduled_date or fields.Datetime.today()
             expiration_date = from_date + datetime.timedelta(days=product.expiration_time)
             for vals in vals_list:
-                vals['expiration_date'] = expiration_date
+                vals['expiration_date'] = vals.get('expiration_date') or expiration_date
         return vals_list
 
     def _generate_serial_move_line_commands(self, field_data, location_dest_id=False, origin_move_line=None):

--- a/addons/product_expiry/tests/test_generate_serial_numbers.py
+++ b/addons/product_expiry/tests/test_generate_serial_numbers.py
@@ -3,12 +3,22 @@
 from datetime import datetime
 from freezegun import freeze_time
 
+from odoo import Command
 from odoo.addons.stock.tests.test_generate_serial_numbers import StockGenerateCommon
 from odoo.addons.stock.tests.test_picking_tours import TestStockPickingTour
 from odoo.tools.misc import get_lang
 
 
 class TestStockLot(StockGenerateCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_lot = cls.env['product.product'].create({
+            'name': 'Tracked by Lot Numbers',
+            'tracking': 'lot',
+            'is_storable': True,
+            'use_expiration_date': True,
+        })
 
     def _import_lots(self, lots, move):
         location_id = move.location_id
@@ -21,12 +31,6 @@ class TestStockLot(StockGenerateCommon):
         Checks the values are correctly interpreted and the expiration dates are correctly created
         depending of the user lang's date format.
         """
-        product_lot = self.env['product.product'].create({
-            'name': 'Tracked by Lot Numbers',
-            'tracking': 'lot',
-            'is_storable': True,
-            'use_expiration_date': True,
-        })
         user_lang = self.env['res.lang'].browse([get_lang(self.env).id])
         # Try first with the "day/month/year" date format.
         user_lang.date_format = "%d/%m/%y"
@@ -38,7 +42,7 @@ class TestStockLot(StockGenerateCommon):
             {'lot_name': "ln05", "date": "03/07/25", "datetime": datetime.strptime('2025-07-03', "%Y-%m-%d")},
         ]
         list_as_string = '\n'.join([f'{line["lot_name"]};{line["date"]}' for line in list_lot_and_qty])
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
         for i, move_line in enumerate(move.move_line_ids):
@@ -56,7 +60,7 @@ class TestStockLot(StockGenerateCommon):
             {'lot_name': "ln05", "date": "03/07/25", "datetime": datetime.strptime('2025-03-07', "%Y-%m-%d")},
         ]
         list_as_string = '\n'.join([f'{line["lot_name"]};{line["date"]}' for line in list_lot_and_qty])
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
         for i, move_line in enumerate(move.move_line_ids):
@@ -69,11 +73,7 @@ class TestStockLot(StockGenerateCommon):
         Checks the values are correctly interpreted and since the product doesn't use expiration
         date, the expiration dates should be ignored.
         """
-        product_lot = self.env['product.product'].create({
-            'name': 'Tracked by Lot Numbers',
-            'tracking': 'lot',
-            'is_storable': True,
-        })
+        self.product_lot.use_expiration_date = False
         user_lang = self.env['res.lang'].browse([get_lang(self.env).id])
         # Try first with the "day/month/year" date format.
         user_lang.date_format = "%d/%m/%y"
@@ -85,7 +85,7 @@ class TestStockLot(StockGenerateCommon):
             {'lot_name': "ln05", "date": "03/07/25", "datetime": datetime.strptime('2025-07-03', "%Y-%m-%d")},
         ]
         list_as_string = '\n'.join([f'{line["lot_name"]};{line["date"]}' for line in list_lot_and_qty])
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
         for i, move_line in enumerate(move.move_line_ids):
@@ -97,12 +97,6 @@ class TestStockLot(StockGenerateCommon):
         """ Checks if the given dates don't follow the user lang's date format, the created expiration
         date will follow the first given date's format (at least in the scope of the limitations).
         """
-        product_lot = self.env['product.product'].create({
-            'name': 'Tracked by Lot Numbers',
-            'tracking': 'lot',
-            'is_storable': True,
-            'use_expiration_date': True,
-        })
         user_lang = self.env['res.lang'].browse([get_lang(self.env).id])
         # Month first in the system but day in the first place in the given dates.
         user_lang.date_format = "%m/%d/%y"
@@ -114,7 +108,7 @@ class TestStockLot(StockGenerateCommon):
             {'lot_name': "ln05", "date": "01/07/25", "datetime": datetime.strptime('2025-07-01', "%Y-%m-%d")},
         ]
         list_as_string = '\n'.join([f'{line["lot_name"]};{line["date"]}' for line in list_lot_and_qty])
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
         for i, move_line in enumerate(move.move_line_ids):
@@ -132,7 +126,7 @@ class TestStockLot(StockGenerateCommon):
             {'lot_name': "ln05", "date": "04/07/08", "datetime": datetime.strptime('2004-07-08', "%Y-%m-%d")},
         ]
         list_as_string = '\n'.join([f'{line["lot_name"]};{line["date"]}' for line in list_lot_and_qty])
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
         for i, move_line in enumerate(move.move_line_ids):
@@ -143,19 +137,13 @@ class TestStockLot(StockGenerateCommon):
     def test_set_multiple_lot_name_with_expiration_date_04_written_months(self):
         """ Checks the expiration date is correctly created when the month is written in letters.
         """
-        product_lot = self.env['product.product'].create({
-            'name': 'Tracked by Lot Numbers',
-            'tracking': 'lot',
-            'is_storable': True,
-            'use_expiration_date': True,
-        })
         list_lot_and_qty = [
             {'lot_name': "ln01", "date": "01 march 2077", "datetime": datetime.strptime('2077-03-01', "%Y-%m-%d")},
             {'lot_name': "ln02", "date": "11 april 2077", "datetime": datetime.strptime('2077-04-11', "%Y-%m-%d")},
             {'lot_name': "ln03", "date": "10 december 2077", "datetime": datetime.strptime('2077-12-10', "%Y-%m-%d")},
         ]
         list_as_string = '\n'.join([f'{line["lot_name"]};{line["date"]}' for line in list_lot_and_qty])
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
         for i, move_line in enumerate(move.move_line_ids):
@@ -163,18 +151,47 @@ class TestStockLot(StockGenerateCommon):
             self.assertEqual(move_line.quantity, 1)
             self.assertEqual(move_line.expiration_date, list_lot_and_qty[i]["datetime"])
 
+    @freeze_time('2025-9-13')
+    def test_set_multiple_lot_name_with_expiration_date_05_import_dates(self):
+        """ When importing lot names, quantities and expiration dates, make sure the date is not
+        replaced by the computed date and if there's no date, it takes the computed date. """
+        self.product_lot.expiration_time = 10
+        receipt_picking = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.in_type_id.id,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+            'state': 'draft',
+            'move_ids': [Command.create({
+                'product_id': self.product_lot.id,
+                'product_uom_qty': 20,
+                'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                'location_dest_id': self.warehouse.lot_stock_id.id,
+            })]
+        })
+        action_context = {
+            'default_company_id': self.env.company.id,
+            'default_picking_id': receipt_picking.id,
+            'default_picking_type_id': self.warehouse.in_type_id.id,
+            'default_location_id': receipt_picking.location_id.id,
+            'default_location_dest_id': receipt_picking.location_dest_id.id,
+            'default_product_id': self.product_lot.id,
+            'default_tracking': 'lot',
+        }
+        move_line_vals = self.env['stock.move'].action_generate_lot_line_vals(
+            action_context, 'import', None, 0, 'lot1;10;2025-12-31\nlot2;7\nlot3;3;1970-1-1'
+        )
+        self.assert_move_line_vals_values(move_line_vals, [
+            {'quantity': 10, 'lot_name': 'lot1', 'expiration_date': datetime.strptime('2025-12-31', "%Y-%m-%d")},
+            {'quantity': 7, 'lot_name': 'lot2', 'expiration_date': datetime.strptime('2025-9-23', "%Y-%m-%d")},
+            {'quantity': 3, 'lot_name': 'lot3', 'expiration_date': datetime.strptime('1970-1-1', "%Y-%m-%d")},
+        ])
+
     @freeze_time('2023-04-17')
     def test_set_multiple_lot_name_with_expiration_date_05_wrong_given_date(self):
         """ This test ensure when the given dates aren't correctly written, the
         full string is used as the lot's name.
         """
         today = datetime(day=17, month=4, year=2023)
-        product_lot = self.env['product.product'].create({
-            'name': 'Tracked by Lot Numbers',
-            'tracking': 'lot',
-            'is_storable': True,
-            'use_expiration_date': True,
-        })
         list_lot_and_qty = [
             "ln01\t31/12",  # Day is missing but the date is valid.
             "ln02\t1989-04",  # Day is missing but the date is valid.
@@ -186,7 +203,7 @@ class TestStockLot(StockGenerateCommon):
             "ln08\tdecember",  # Day and year are missing but the date is valid.
         ]
         list_as_string = '\n'.join(list_lot_and_qty)
-        move = self.get_new_move(product=product_lot)
+        move = self.get_new_move(product=self.product_lot)
         self._import_lots(list_as_string, move)
         self.assertEqual(len(move.move_line_ids), len(list_lot_and_qty))
 
@@ -225,16 +242,10 @@ class TestStockLot(StockGenerateCommon):
     def test_set_multiple_lot_name_with_expiration_date_06_one_line(self):
         """ Checks the pasted data are correctly parsed even if the user pastes only one line.
         """
-        product_lot = self.env['product.product'].create({
-            'name': 'Tracked by Lot Numbers',
-            'tracking': 'lot',
-            'is_storable': True,
-            'use_expiration_date': True,
-        })
         user_lang = self.env['res.lang'].browse([get_lang(self.env).id])
         user_lang.date_format = "%d/%m/%y"
         for lot_name in ["lot-001;20;4 Aug 2048", "lot-001\t04/08/2048\t20"]:
-            move = self.get_new_move(product=product_lot)
+            move = self.get_new_move(product=self.product_lot)
             self._import_lots(lot_name, move)
             self.assertEqual(move.move_line_ids.lot_name, "lot-001")
             self.assertEqual(move.move_line_ids.quantity, 20)


### PR DESCRIPTION
When import lots via text on a receipt, the expiration date should not be overwritten if it was provided in the import text.

Steps:
- create a product tracked by lots and with expiration dates
- create a receipt picking for the product
- confirm the picking
- in the detailed operations, import lots with an expiration date

opw-5215986


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
