### PR TITLE
[FIX] mail: do not crash when scheduling message on 'no model'

### DIFF
--- a/addons/mail/models/mail_message_schedule.py
+++ b/addons/mail/models/mail_message_schedule.py
@@ -67,6 +67,7 @@ class MailMessageSchedule(models.Model):
                 existing = records.exists()
             else:
                 records = [self.env['mail.thread']] * len(schedules)
+                existing = records
 
             for record, schedule in zip(records, schedules):
                 if record not in existing:


### PR DESCRIPTION
In rare case when we would like to schedule messages without model a variable is not defined in that scope.