### PR TITLE
[FIX] mass_mailing: set snippet_menu default state to folded

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
@@ -145,10 +145,10 @@ export class MassMailingWysiwyg extends Wysiwyg {
      * @override
      */
     async _insertSnippetMenu() {
-        const res = await super._insertSnippetMenu();
         // Hide the snippetsMenu at first, other code will handle
         // if it should be shown or not.
         this.state.snippetsMenuFolded = true;
+        const res = await super._insertSnippetMenu();
         return res;
     }
     /**


### PR DESCRIPTION
**Steps to reproduce:**
- Go to the Email Marketing app
- Create a new campaign and select the "Plain Text" Mail body for the template
- Change between Mail body and Settings tabs
- On Mail body tab, the right-hand building block section appears briefly (1 second) and then disappears

**Issue:**
Default state of the snippet menu has `snippetsMenuFolded` set to False before being inserted.

**Fix:**
As described in the comment just after the insert:
```
// Hide the snippetsMenu at first, other code will handle
// if it should be shown or not.
```
So the fix ensure the menu is folded by default (not sure as to why the state was changed after inserting, so maybe it's expected).

opw-5130191
