### PR TITLE
[FIX] project_mrp_account: ensure project dashboard reflects MO updates

### DIFF
--- a/addons/project_mrp_account/models/mrp_production.py
+++ b/addons/project_mrp_account/models/mrp_production.py
@@ -28,5 +28,6 @@ class MrpProduction(models.Model):
         res = super().write(vals)
         for production in self:
             if 'project_id' in vals and production.state != 'draft':
+                production.move_raw_ids._create_analytic_move()
                 production.workorder_ids._create_or_update_analytic_entry()
         return res


### PR DESCRIPTION
**Steps to produce:**
- Install `project_mrp_account` and `sale_management` with demo data.
- Create a `Service` product with `Create on Order as Project`.
- Create and confirm a Sales Order using that product.
- Go to `Manufacturing Orders`, open the first MO, and in `Miscellaneous`,
  set the `Project` to the newly created one.
- Click on Produce All on MO.
- Open the Our Project > Dashboard (via 3 dots) > Manufacturing details
  show correctly.
- From embedded actions, go to Manufacturing Orders.
- Edit the MO and remove the Project value in Miscellaneous.

**Issue:**
- The project dashboard still shows the Manufacturing details even after the project is removed from the MO.

**Root cause:**
- In [1], the method `_account_analytic_entry_move` was removed. As a result, removing the project value from the MO no longer updates the analytic lines.
- And we use the analytic line data for showing the MO data on the project dashboard, so stale analytic lines cause the dashboard to continue displaying Manufacturing details.

**Solution:**
- In [2], the method `_create_analytic_move` was introduced.
- When `_create_analytic_move` is called, it internally calls
  `_prepare_analytic_lines` and super calls.
- At [3], the `_prepare_analytic_lines` method is executed, which triggers
  `_perform_analytic_distribution`.
- Inside `_perform_analytic_distribution` at [4], the existing analytic
  line are unlinked.
- As a result, the analytic lines are properly removed. Since the project
  dashboard loads its data from analytic account lines (as explained [here]),
  the dashboard now reflects the correct Manufacturing data after the project
  value is removed.

**Note:**
- Before this commit (in 19.0), when a user set the project value on a Done
  MO, no analytic line was created for the product move.
- In saas‑18.4, however, an analytic line was also generated for the
  product move.
- After this commit, the analytic line is correctly created in 19.0 as
  well, ensuring consistent behavior with saas‑18.4.

[1]: https://github.com/odoo/odoo/commit/08b62a4bbcc6f9a391b2cc00a621ef4c76100229
[2]: https://github.com/odoo/odoo/commit/35db55618fa70146afc89e662410aca95947e17b
[3]: https://github.com/odoo/odoo/blob/2294f7174c52ebb95ec3ad1d120a896b694c6add/addons/stock_account/models/stock_move.py#L546
[4]: https://github.com/odoo/odoo/blob/2294f7174c52ebb95ec3ad1d120a896b694c6add/addons/stock_account/models/analytic_account.py#L53
[Here]: https://github.com/odoo/odoo/blob/2294f7174c52ebb95ec3ad1d120a896b694c6add/addons/project_mrp_account/models/project_project.py#L33-L36

**Before:**
<img width="959" height="197" alt="before" src="https://github.com/user-attachments/assets/4f28ee12-3625-44c7-ada4-1f1d89344d94" />

**After:**
<img width="959" height="172" alt="after" src="https://github.com/user-attachments/assets/5a45d266-6902-4ab8-9c88-3ed844207f8c" />

opw-5346505
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
