### PR TITLE
[FIX] website_sale: hide simple attribute table when spec uses accordion

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2174,7 +2174,7 @@
                                     />
                                     <div
                                         id="product_attributes_simple"
-                                        t-if="single_value_attributes"
+                                        t-if="single_value_attributes and not is_view_active('website_sale_comparison.accordion_specs_item')"
                                         class="o_wsale_product_details_content_section o_wsale_product_details_content_section_specs mb-4"
                                     >
                                         <table t-attf-class="table table-sm text-muted {{'' if single_value_attributes else 'd-none'}}">


### PR DESCRIPTION
Currently, when the product specification is shown in an accordion, single-value attributes are displayed twice, causing duplicate information to appear.

**Steps to replicate:**
* Install `website_sale` with demo data.
* Open Products, pick any product, and add an attribute with a single value.
* Edit that product’s website page and set Specification → In accordion.

**Observed Behavior:**
* Specifications for single valued attributes are shown twice.

**Root cause:**
* This happens because [1] always shows single attribute values, regardless of the specification display style.

**Solution:**
* Hide the extra table when accordion is active.

**Before:**
<img width="1851" height="928" alt="image" src="https://github.com/user-attachments/assets/dbaccc28-dbbb-41df-9a04-b0330479e480" />
**After:**
<img width="1858" height="927" alt="image" src="https://github.com/user-attachments/assets/09317662-3d40-4128-a6d3-9f9c0af618c4" />

[1]:
https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/website_sale/views/templates.xml#L2175-L2195

opw-5382484
