### PR TITLE
[IMP] point_of_sale: implement customer barcode prefix check ('042')

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -53,6 +53,14 @@ class ResPartner(models.Model):
             'account.fiscal.position': self.env['account.fiscal.position']._load_pos_data_read(fiscal_positions, config),
         }
 
+    @api.constrains('barcode')
+    def _check_barcode_prefix(self):
+        for partner in self:
+            if partner.barcode and not partner.barcode.startswith("042"):
+                self.env.user._bus_send("simple_notification", {
+                    'message': _("Barcode must start with 042")
+            })
+
     @api.model
     def _load_pos_data_domain(self, data, config):
         # Collect partner IDs from loaded orders

--- a/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
@@ -1,6 +1,7 @@
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as Notification from "@point_of_sale/../tests/generic_helpers/notification_util";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -98,6 +99,10 @@ registry.category("web_tour.tours").add("BarcodeScanPartnerTour", {
             // scan the customer barcode
             scan_barcode("0421234567890"),
             ProductScreen.customerIsSelected("John Doe"),
+            scan_barcode("0241234567890"),
+            Notification.has(
+                "Unknown Barcode 0241234567890. The Point of Sale could not find any product, customer, employee or action associated with the scanned barcode."
+            ),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1506,6 +1506,10 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'John Doe',
             'barcode': '0421234567890',
         })
+        self.env['res.partner'].create({
+            'name': 'Dusty-Bun',
+            'barcode': '0241234567890',
+        })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'BarcodeScanPartnerTour', login="pos_user")
 

--- a/addons/point_of_sale/views/res_partner_view.xml
+++ b/addons/point_of_sale/views/res_partner_view.xml
@@ -17,7 +17,7 @@
                 </div>
                 <xpath expr="//group[@name='purchase']" position="after">
                     <group string="Point Of Sale" name="point_of_sale" groups="point_of_sale.group_pos_user">
-                        <field name="barcode"/>
+                        <field name="barcode" help="Barcode must start with `042`"/>
                     </group>
                 </xpath>
             </field>


### PR DESCRIPTION
Following this commit:
- Tooltip is been updated to `Barcode must begin with 042`
- Added warning that customer barcode value should begin with `042` without blcoking the flow.

task-5380953