### PR TITLE
[IMP] web: specify forbidden fetch url during tests

### DIFF
--- a/addons/web/static/lib/hoot/mock/network.js
+++ b/addons/web/static/lib/hoot/mock/network.js
@@ -311,10 +311,12 @@ export function cleanupNetwork() {
 
 /** @type {typeof fetch} */
 export async function mockedFetch(input, init) {
-    if (!mockFetchFn) {
-        throw new Error("Can't make a request when fetch is not mocked");
-    }
     const strInput = String(input);
+    if (!mockFetchFn) {
+        throw new Error(
+            `Can't make a request when fetch is not mocked.\nReceived fetch call to: "${strInput}"`
+        );
+    }
     const controller = markOpen(new AbortController());
 
     init = { ...init };


### PR DESCRIPTION
Prior to this commit, when a fetch occured during a test at a timing where
`mockedFetchFn` was already cleaned, the resulting error message did not give a
clue as to what request was attempted. In order to help investigations of
difficult to reproduce non-deterministic errors, the url "input" is now also
provided.