### PR TITLE
[IMP] mail_plugin: allow the mail plugin to know the Odoo version

### DIFF
--- a/addons/mail_plugin/controllers/authenticate.py
+++ b/addons/mail_plugin/controllers/authenticate.py
@@ -53,6 +53,12 @@ class Authenticate(http.Controller):
         updated_redirect = parsed_redirect.replace(query=werkzeug.urls.url_encode(params))
         return request.redirect(updated_redirect.to_url(), local=False)
 
+    @http.route(['/mail_plugin/auth/check_version'], type='json', auth="none", cors="*",
+                methods=['POST', 'OPTIONS'])
+    def auth_check_version(self):
+        """Allow to know if the module is installed and which addin version is supported."""
+        return 1
+
     # In this case, an exception will be thrown in case of preflight request if only POST is allowed.
     @http.route(['/mail_client_extension/auth/access_token', '/mail_plugin/auth/access_token'], type='json', auth="none", cors="*",
                 methods=['POST', 'OPTIONS'])


### PR DESCRIPTION
Purpose
=======
Backport of https://github.com/odoo/odoo/commit/f1bc56523875f1f9c55dd33b575063f67ac192ee

The new addin has been refactored and doesn't work with older Odoo version, and so we add an endpoint to be able to show a message if we don't support that Odoo version.

Task-4727609