### PR TITLE
[17.0][IMP] fields: SQL for related fields excluding NULL values

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1076,7 +1076,8 @@ class Field(MetaField('DummyField', (object,), {})):
             """ UPDATE %(model_table)s AS x
                 SET %(model_field)s = y.%(comodel_field)s
                 FROM %(comodel_table)s AS y
-                WHERE x.%(join_field)s = y.id """,
+                WHERE x.%(join_field)s = y.id
+                AND y.%(comodel_field)s IS NOT NULL """,
             model_table=SQL.identifier(model._table),
             model_field=SQL.identifier(self.name),
             comodel_table=SQL.identifier(comodel._table),


### PR DESCRIPTION
Removing NULL values before doing the UPDATE reduces the dataset. This difference helps avoid unnecessary rows being processed and therefore improves performance.

Coming from https://github.com/OCA/OpenUpgrade/pull/5465#issuecomment-3615603528

@Tecnativa 