### PR TITLE
[FIX] packaging: remove python3-tz dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,7 +57,6 @@ Depends:
  python3-reportlab,
  python3-requests,
  python3-stdnum,
- python3-tz,
  python3-urllib3,
  python3-vobject,
  python3-werkzeug,


### PR DESCRIPTION
Since #236660 python3-tz is not necessary anymore.


