### PR TITLE
[IMP] project, sale_project: show Customer Rating button only when appropriate

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -479,6 +479,9 @@
                                         <div class="d-inline-block" role="menuitem" name="project_burndown_menu" groups="project.group_project_user">
                                             <a name="action_project_task_burndown_chart_report" type="object">Burndown Chart</a>
                                         </div>
+                                        <div class="d-inline-block" t-if="record.show_ratings.raw_value" role="menuitem" name="project_customer_rating_menu" groups="project.group_project_manager">
+                                            <a name="action_view_all_rating" type="object">Customer Ratings</a>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="o_kanban_card_manage_settings row">

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -137,4 +137,22 @@
             <field name="sale_line_id" position="replace"/>
         </field>
     </record>
+
+    <record id="project_project_view_kanban_inherit_sale_project" model="ir.ui.view">
+        <field name="name">project.project.kanban.inherit.sale.project</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//templates" position="before">
+                <field name="show_ratings"/>
+                <field name="allow_billable"/>
+            </xpath>
+            <xpath expr="//div[@name='project_customer_rating_menu']" position="attributes">
+                <attribute name="t-if">record.show_ratings.raw_value and record.allow_billable.raw_value</attribute>
+            </xpath>
+            <xpath expr="//div[@t-if='record.show_ratings.raw_value and record.rating_count.raw_value &gt; 0']" position="attributes">
+                <attribute name="t-if">record.show_ratings.raw_value and record.allow_billable.raw_value and record.rating_count.raw_value &gt; 0 </attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -123,13 +123,6 @@
                 <field name="sale_order_id" invisible="1"/>
                 <field name="pricing_type" invisible="1"/>
             </xpath>
-            <xpath expr="//div[hasclass('o_kanban_manage_reporting')]" position="inside">
-                <div role="menuitem" t-if="record.show_ratings.raw_value" groups="project.group_project_manager">
-                   <a name="action_view_all_rating" type="object">
-                    Customer Ratings
-                    </a>
-                </div>
-            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
**Before this commit:**

- The Customer Rating button in the project kanban view was only shown based when sale_timesheet is installed.
- When sale_project was installed button appear for non-billable projects.

**After this commit:**

- The Customer Rating button is shown when the project module is installed and the rating feature is enabled.
- If sale_project is installed, the button is shown only when the project is billable (i.e. rating feature enabled AND project is billable).

**task-5364377**