### PR TITLE
[FIX] odoo/tools/translate: Missing confirm-title as translatable attribute

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -74,7 +74,7 @@ TRANSLATED_ELEMENTS = {
 TRANSLATED_ATTRS = {
     'string', 'add-label', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
-    'value_label', 'data-tooltip', 'label', 'confirm-label', 'cancel-label',
+    'value_label', 'data-tooltip', 'label', 'confirm-label', 'cancel-label', 'confirm-title',
 }
 
 TRANSLATED_ATTRS.update({f't-attf-{attr}' for attr in TRANSLATED_ATTRS})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The texts from the "confirm-title" attribute of a <button> tag are missing from the POT files.

Current behavior before PR:
In this line there is a text (the caption of the confirmation window): https://github.com/odoo/odoo/blob/19.0/addons/mass_mailing/views/mailing_mailing_views.xml#L66
"Ready to unleash emails?" - This text is missing from the POT file.

Desired behavior after PR is merged:
* These texts will apeear in POT files.
* Someone needs to translated them
* It will show up as translated texts in UI



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
