### PR TITLE
[IMP] repair, stock_account: partner in valuation journal entries

### DIFF
--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -93,6 +93,7 @@ class StockMove(models.Model):
             move.group_id = move.repair_id.procurement_group_id.id
             move.origin = move.name
             move.picking_type_id = move.repair_id.picking_type_id.id
+            move.partner_id = move.repair_id.partner_id.id
             repair_moves |= move
         no_repair_moves = moves - repair_moves
         draft_repair_moves = repair_moves.filtered(lambda m: m.state == 'draft' and m.repair_id.state in ('confirmed', 'under_repair'))

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -655,7 +655,8 @@ class StockMove(models.Model):
         return rslt
 
     def _get_partner_id_for_valuation_lines(self):
-        return (self.picking_id.partner_id and self.env['res.partner']._find_accounting_partner(self.picking_id.partner_id).id) or False
+        partner = self.picking_id.partner_id or self.partner_id
+        return (partner and self.env['res.partner']._find_accounting_partner(partner).id) or False
 
     def _prepare_move_split_vals(self, uom_qty):
         vals = super(StockMove, self)._prepare_move_split_vals(uom_qty)


### PR DESCRIPTION
Steps to reproduce:

- Set a product category to real time inventory valuation and create a product on that category, and update the quantity to ensure you have stock of that product
- Create a repair with at least one product to be consumed (the one created before) and a customer on it
- Finish the repair
- Check the stock moves created -> the customer of the repair is not in the stock move
- Check the journal items for the valuation of the products consumed -> The customer is not in the journal items

Why is this needed? For reporting purposes valuation by customers on repairs

A forward port is not needed due to the refactor done in stock_account in v19