### PR TITLE
[FIX] sale: Prefetch values to avoid memory error

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -905,6 +905,7 @@ class SaleOrderLine(models.Model):
     def _compute_qty_delivered_at_date(self):
         if not self._date_in_the_past():
             # Avoid useless compute if we don't look in the past.
+            self.fetch(["qty_delivered"])
             for line in self:
                 line.qty_delivered_at_date = line.qty_delivered
             return
@@ -985,6 +986,7 @@ class SaleOrderLine(models.Model):
     def _compute_qty_invoiced_at_date(self):
         if not self._date_in_the_past():
             # Avoid useless compute if we don't look in the past.
+            self.fetch(["qty_invoiced"])
             for line in self:
                 line.qty_invoiced_at_date = line.qty_invoiced
             return


### PR DESCRIPTION
**Description:**

- The ir.actions.act_window [Invoices To Be Issued and Invoiced Not Delivered](https://github.com/odoo/enterprise/blob/19.0/sale_account_accountant/views/sale_order_line_views.xml#L73-L91) menus from the sale_account_accountant module were causing memory errors on databases with millions of sale.order.line records. These actions call [_search_invoice_to_be_issued and _search_deferred_revenue](https://github.com/odoo/enterprise/blob/master/sale_account_accountant/models/sale_order_line.py#L17-L29), which iterate over all lines and access the non-stored computed fields [qty_delivered_at_date](https://github.com/odoo/odoo/blob/master/addons/sale/models/sale_order_line.py#L905) and [qty_invoiced_at_date](https://github.com/odoo/odoo/blob/master/addons/sale/models/sale_order_line.py#L985) As a result, qty_delivered and qty_invoiced were repeatedly recomputed, leading to excessive memory usage.

- To fix this, we now pre-fetch these fields so the compute method can directly use the values already loaded in memory.

```
matu_3306966_19.0=> select count(*) from sale_order_line;
  count
---------
 2159957
(1 row)
```

**Traceback1:**
```
2025-12-03 07:02:25,973 9344 ␛[1;31m␛[1;49mERROR␛[0m matu_3306966_19.0 odoo.addons.base.maintenance.migrations.base.testsodoo.upgrade.base.tests.test_mock_crawl: Adding menu ('sale_account_accountant.menu_sale_order_line_accrual_to_bill_action', 1295, 'Accounting > Review > Sales > Invoices To Be Issued', 2690) to the failing menus
Traceback (most recent call last):
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 644, in mock_view_list
    return self.mock_view_tree(model, view, fields_list, domain, group_by)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 655, in mock_view_tree
    self.mock_web_read_group(model, view, domain, group_by, fields_list, limit_group=5)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 713, in mock_web_read_group
    data = model.web_read_group(domain, [groupby], aggregates, limit=limit)["groups"]
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 397, in web_read_group
    groups, length = self._formatted_read_group_with_length(
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 465, in _formatted_read_group_with_length
    groups = self.formatted_read_group(
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 830, in formatted_read_group
    groups = self._read_group(
  File "/home/odoo/src/enterprise/19.0/sale_account_accountant/models/sale_order_line.py", line 33, in _read_group
    return self._read_group_for_accrual(domain, groupby, aggregates, having, offset, limit, order)
  File "/home/odoo/src/enterprise/19.0/account_accountant/models/analytic_mixin.py", line 21, in _read_group_for_accrual
    return super()._read_group(domain, groupby, aggregates, having, offset, limit, order)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 1904, in _read_group
    query = self._search(domain)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5361, in _search
    domain = domain.optimize_full(self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 445, in optimize_full
    return self._optimize(model, OptimizationLevel.FULL)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 459, in _optimize
    previous, domain = domain, domain._optimize_step(model, next_level)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 653, in _optimize_step
    children = self._flatten(child._optimize(model, level) for child in self.children)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 608, in _flatten
    for child in children:
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 653, in <genexpr>
    children = self._flatten(child._optimize(model, level) for child in self.children)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 459, in _optimize
    previous, domain = domain, domain._optimize_step(model, next_level)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 957, in _optimize_step
    domain = self._optimize_field_search_method(model)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 1016, in _optimize_field_search_method
    return Domain.OR(Domain(field.determine_domain(model, '=', v), internal=True) for v in value)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 309, in OR
    return DomainOr.apply(Domain(item) for item in items)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 595, in apply
    children = cls._flatten(items)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 608, in _flatten
    for child in children:
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 309, in <genexpr>
    return DomainOr.apply(Domain(item) for item in items)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 1016, in <genexpr>
    return Domain.OR(Domain(field.determine_domain(model, '=', v), internal=True) for v in value)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1921, in determine_domain
    return determine(self.search, records, operator, value)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
  File "/home/odoo/src/enterprise/19.0/sale_account_accountant/models/sale_order_line.py", line 28, in _search_invoice_to_be_issued
    ids = [line.id for line in so_lines if line.qty_invoiced_at_date < line.qty_delivered_at_date]
  File "/home/odoo/src/enterprise/19.0/sale_account_accountant/models/sale_order_line.py", line 28, in <listcomp>
    ids = [line.id for line in so_lines if line.qty_invoiced_at_date < line.qty_delivered_at_date]
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1737, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1908, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/19.0/addons/base_automation/models/base_automation.py", line 907, in _compute_field_value
    return _compute_field_value.origin(self, field)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4949, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/19.0/addons/sale/models/sale_order_line.py", line 989, in _compute_qty_invoiced_at_date
    line.qty_invoiced_at_date = line.qty_invoiced
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1693, in __get__
    recs._fetch_field(self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3769, in _fetch_field
    self.fetch(fnames)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3809, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3930, in _fetch_query
    field._insert_cache(fetched, values)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1600, in _insert_cache
    collections.deque(map(field_cache.setdefault, records._ids, values), maxlen=0)
MemoryError
```

**Traceback2:**
```
2025-12-03 07:02:30,098 9344 ␛[1;31m␛[1;49mERROR␛[0m matu_3306966_19.0 odoo.addons.base.maintenance.migrations.base.testsodoo.upgrade.base.tests.test_mock_crawl: Adding menu ('sale_account_accountant.menu_sale_order_line_accrual_deferred_revenues_action', 1296, 'Accounting > Review > Sales > Invoiced Not Delivered', 2691) to the failing menus
Traceback (most recent call last):
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 644, in mock_view_list
    return self.mock_view_tree(model, view, fields_list, domain, group_by)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 655, in mock_view_tree
    self.mock_web_read_group(model, view, domain, group_by, fields_list, limit_group=5)
  File "/tmp/tmpe9cqlr9_/migrations/base/tests/test_mock_crawl.py", line 713, in mock_web_read_group
    data = model.web_read_group(domain, [groupby], aggregates, limit=limit)["groups"]
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 397, in web_read_group
    groups, length = self._formatted_read_group_with_length(
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 465, in _formatted_read_group_with_length
    groups = self.formatted_read_group(
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 830, in formatted_read_group
    groups = self._read_group(
  File "/home/odoo/src/enterprise/19.0/sale_account_accountant/models/sale_order_line.py", line 33, in _read_group
    return self._read_group_for_accrual(domain, groupby, aggregates, having, offset, limit, order)
  File "/home/odoo/src/enterprise/19.0/account_accountant/models/analytic_mixin.py", line 21, in _read_group_for_accrual
    return super()._read_group(domain, groupby, aggregates, having, offset, limit, order)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 1904, in _read_group
    query = self._search(domain)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5361, in _search
    domain = domain.optimize_full(self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 445, in optimize_full
    return self._optimize(model, OptimizationLevel.FULL)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 459, in _optimize
    previous, domain = domain, domain._optimize_step(model, next_level)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 653, in _optimize_step
    children = self._flatten(child._optimize(model, level) for child in self.children)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 608, in _flatten
    for child in children:
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 653, in <genexpr>
    children = self._flatten(child._optimize(model, level) for child in self.children)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 459, in _optimize
    previous, domain = domain, domain._optimize_step(model, next_level)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 957, in _optimize_step
    domain = self._optimize_field_search_method(model)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 1016, in _optimize_field_search_method
    return Domain.OR(Domain(field.determine_domain(model, '=', v), internal=True) for v in value)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 309, in OR
    return DomainOr.apply(Domain(item) for item in items)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 595, in apply
    children = cls._flatten(items)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 608, in _flatten
    for child in children:
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 309, in <genexpr>
    return DomainOr.apply(Domain(item) for item in items)
  File "/home/odoo/src/odoo/19.0/odoo/orm/domains.py", line 1016, in <genexpr>
    return Domain.OR(Domain(field.determine_domain(model, '=', v), internal=True) for v in value)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1921, in determine_domain
    return determine(self.search, records, operator, value)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
  File "/home/odoo/src/enterprise/19.0/sale_account_accountant/models/sale_order_line.py", line 21, in _search_deferred_revenue
    ids = [line.id for line in so_lines if line.qty_invoiced_at_date > line.qty_delivered_at_date]
  File "/home/odoo/src/enterprise/19.0/sale_account_accountant/models/sale_order_line.py", line 21, in <listcomp>
    ids = [line.id for line in so_lines if line.qty_invoiced_at_date > line.qty_delivered_at_date]
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1737, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1908, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/19.0/addons/base_automation/models/base_automation.py", line 907, in _compute_field_value
    return _compute_field_value.origin(self, field)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4949, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/19.0/addons/sale/models/sale_order_line.py", line 989, in _compute_qty_invoiced_at_date
    line.qty_invoiced_at_date = line.qty_invoiced
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1693, in __get__
    recs._fetch_field(self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3769, in _fetch_field
    self.fetch(fnames)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3809, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3930, in _fetch_query
    field._insert_cache(fetched, values)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields_textual.py", line 243, in _insert_cache
    super()._insert_cache(records, values)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1600, in _insert_cache
    collections.deque(map(field_cache.setdefault, records._ids, values), maxlen=0)
MemoryError
```

- opw-5238152, 5269996
- upg-3306966, 3444833

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
