### PR TITLE
[FIX] stock_account: exclude consignment quantity in cogs

### DIFF
--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -63,12 +63,10 @@ class AccountMoveLine(models.Model):
         if original_line:
             return original_line.price_unit
 
-        if self.product_id.cost_method in ['standard', 'average']:
-            return self.product_id.standard_price
-
-        # FIFO
         moves = self._get_stock_moves()
         if not moves:
+            if self.product_id.cost_method in ['standard', 'average']:
+                return self.product_id.standard_price
             return self.product_id._run_fifo(self.quantity)
         return moves._get_price_unit()
 

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -216,7 +216,7 @@ class StockMove(models.Model):
             return 0
         total_value = sum(self.mapped('value'))
         total_qty = sum(m._get_valued_qty() for m in self)
-        return total_value / total_qty if total_qty else self.product_id.standard_price
+        return total_value / total_qty if total_qty else 0
 
     @api.model
     def _get_valued_types(self):


### PR DESCRIPTION
Computing cogs value will ignore the potential owner_id set in the stock move related to the invoice being posted when computing the cogs price unit in `_get_price_unit()`.
This commit looks up related stock move of the invoice for all cost method to compute the cost based on the valued stock move line.

opw: 5266208

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
