### PR TITLE
[FIX] auth_totp_portal: fix dynamic content in interactions

### DIFF
--- a/addons/auth_totp_portal/static/src/interactions/revoke_all_trusted_devices.js
+++ b/addons/auth_totp_portal/static/src/interactions/revoke_all_trusted_devices.js
@@ -6,7 +6,7 @@ import { user } from "@web/core/user";
 
 export class RevokeAllTrustedDevices extends Interaction {
     static selector = "#auth_totp_portal_revoke_all_devices";
-    dynamiContent = {
+    dynamicContent = {
         _root: { "t-on-click.prevent": this.onClick },
     };
 

--- a/addons/auth_totp_portal/static/src/interactions/revoke_trusted_device.js
+++ b/addons/auth_totp_portal/static/src/interactions/revoke_trusted_device.js
@@ -5,7 +5,7 @@ import { handleCheckIdentity } from "@portal/interactions/portal_security";
 
 export class RevokeTrustedDevice extends Interaction {
     static selector = "#totp_wizard_view + * .fa.fa-trash.text-danger";
-    dynamiContent = {
+    dynamicContent = {
         _root: { "t-on-click.prevent": this.onClick },
     };
 


### PR DESCRIPTION
After public widgets have been rewritten as Interactions [1], there were 2 typos in `dynamicContent` that led to the wrong behavior. Because of that, we couldn't revoke a trusted device, or all of them.
Steps to see the issue,
- Turn the 2FA on
- Add a trusted device, for example, by checking `Don't ask again on this device` when prompted to enter the authentication code while logging in.
- Go to /my/security
- Try to revoke a trusted device, either just by clicking on the trash icon button, or the 'Revoke all' button.

=> Nothing happens.

[1]: https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba