### PR TITLE
[IMP] l10n_in: remove 'View Journal Item(s)' action from TDS/TCS warning

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -259,22 +259,8 @@ class AccountMove(models.Model):
                     }
 
                 if applicable_sections := move._get_l10n_in_tds_tcs_applicable_sections():
-                    tds_tcs_applicable_lines = (
-                        move.move_type == 'out_invoice'
-                        and move._get_tcs_applicable_lines(move.invoice_line_ids)
-                        or move.invoice_line_ids
-                    )
                     warnings['tds_tcs_threshold_alert'] = {
                         'message': applicable_sections._get_warning_message(),
-                        'action': tds_tcs_applicable_lines.with_context(
-                            default_tax_type_use=True,
-                            move_type=move.move_type == 'in_invoice'
-                        )._get_records_action(
-                            name=action_name,
-                            domain=[('id', 'in', tds_tcs_applicable_lines.ids)],
-                            views=[(_xmlid_to_res_id("l10n_in.view_move_line_list_l10n_in_withholding"), "list")]
-                        ),
-                        'action_text': action_text,
                     }
 
             if (

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -98,21 +98,4 @@
         </field>
     </record>
 
-    <record id="view_move_line_list_l10n_in_withholding" model="ir.ui.view">
-        <field name="name">account.move.line.list.l10n.in.withholding</field>
-        <field name="model">account.move.line</field>
-        <field name="arch" type="xml">
-            <list string="Journal items" editable="top" create="0" default_group_by="l10n_in_tds_tcs_section_id">
-                <field name="product_id" readonly="1"/>
-                <field name="name" widget="section_and_note_text"/>
-                <field name="account_id"/>
-                <field name="tax_ids"
-                       widget="many2many_tax_tags"
-                       domain="[('type_tax_use', '=', context.get('default_tax_type_use'))]"
-                       column_invisible="context.get('move_type')"/>
-                <field name="l10n_in_tds_tcs_section_id" string="Suggested Section"/>
-                <field name="price_total"/>
-            </list>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
The "View Journal Item(s)" link was originally added to help users Manually check invoice journal items before choosing a TDS/TCS section.

For TDS, the wizard already suggests the correct tax section, so this extra review step is no longer useful. For TCS, the most commonly used section (206C(1H)) has been removed by law from 01-Apr-2025, making the button unnecessary.

Before:
A link appeared in the TDS/TCS warning allowing users to open the invoice’s journal items for manual verification.

After:
The link and its supporting logic have been removed to keep the flow simple and avoid unnecessary actions.

Task - 5315061

Upgrade PR - https://github.com/odoo/upgrade/pull/9015
