### PR TITLE
[FIX] mrp_account: fix mo/wo state concern

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -107,5 +107,5 @@ class MrpProduction(models.Model):
 
     def _post_inventory(self, cancel_backorder=False):
         res = super()._post_inventory(cancel_backorder=cancel_backorder)
-        self.filtered(lambda mo: mo.state == 'done')._post_labour()
+        self.filtered(lambda mo: not mo.reservation_state and mo.state == 'done')._post_labour()
         return res


### PR DESCRIPTION
Due to the dependencies between mo state, components_availability_state, reservation state and wo state, we had to make sure that the state is always computed before the reservation_state.
This is the purpose of (1) merged in 17.0

A non-related mrp_account fix (2) has been merged in 18.0 with the side-effect of firing a reservation_state compute with no state, invalidating the previous fix.

As _post_inventory occurs under button_mark_done which changes at least the mo's state and may fire the computes on another mos, we have to make sure reservation_state and state are computed in one go, the correct order being handled by (1).

Please note that of workorder revamp (3) has been merged in 18.3, solving the dependencies.

(1) https://github.com/odoo/odoo/pull/185092
(2) https://github.com/odoo/odoo/pull/201764
(3) https://github.com/odoo/odoo/pull/194841

task: 5247116

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
