### PR TITLE
[IMP] mass_mailing: allow disabling the exclusion list

### DIFF
--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -254,6 +254,9 @@ class CardCampaign(models.Model):
                 'default_card_campaign_id': self.id,
                 'default_mailing_model_id': self.env['ir.model']._get_id(self.res_model),
                 'default_body_arch': self._action_share_get_default_body(),
+                # even if excluded, consider communication to speaker might be important
+                # (main usage of marketing card)
+                'default_use_exclusion_list': False,
             },
             'views': [[False, 'form']],
             'target': 'current',

--- a/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_field.js
+++ b/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_field.js
@@ -1,0 +1,28 @@
+import { registry } from "@web/core/registry";
+import { DomainField, domainField } from "@web/views/fields/domain/domain_field";
+import { MassMailingDomainSelector } from "./mass_mailing_domain_selector";
+
+/**
+ * Domain field that toggles `use_exclusion_list` instead of
+ * changing the domain to include archived records.
+ */
+export class MassMailingDomainField extends DomainField {
+    static template = "mass_mailing.MassMailingDomainField";
+    static props = {
+        ...DomainField.props,
+    };
+    static components = {
+        DomainSelector: MassMailingDomainSelector,
+    };
+
+    updateUseExclusionList(value) {
+        this.props.record.update({ use_exclusion_list: value });
+    }
+}
+
+export const massMailingDomainField = {
+    ...domainField,
+    component: MassMailingDomainField,
+};
+
+registry.category("fields").add("mass_mailing_domain", massMailingDomainField);

--- a/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_field.xml
+++ b/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_field.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mass_mailing.MassMailingDomainField" t-inherit="web.DomainField">
+        <xpath expr="//DomainSelector" position="attributes">
+            <attribute name="updateUseExclusionList">
+                updateUseExclusionList.bind(this)
+            </attribute>
+            <attribute name="useExclusionList">
+                this.props.record.data.use_exclusion_list
+            </attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_selector.js
+++ b/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_selector.js
@@ -1,0 +1,10 @@
+import { DomainSelector } from "@web/core/domain_selector/domain_selector";
+
+export class MassMailingDomainSelector extends DomainSelector {
+    static template = "mass_mailing.MassMailingDomainSelector";
+    static props = {
+        ...DomainSelector.props,
+        updateUseExclusionList: { type: Function },
+        useExclusionList: { type: Boolean },
+    };
+}

--- a/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_selector.xml
+++ b/addons/mass_mailing/static/src/fields/mass_mailing_domain_field/mass_mailing_domain_selector.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mass_mailing.MassMailingDomainSelector" t-inherit="web.DomainSelector">
+        <xpath expr="//CheckBox[@value='includeArchived']" position="replace">
+            <CheckBox
+                t-if="props.resModel !== 'mailing.contact'"
+                value="!props.useExclusionList"
+                disabled="props.readonly"
+                className="'form-switch'"
+                onChange.bind="(value) => props.updateUseExclusionList(!value)"
+            >
+                Include Blacklisted Recipients
+            </CheckBox>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -235,9 +235,10 @@
                                         </div>
                                     </div>
                                     <div class="col-md-auto flex-grow-1 pt-1" invisible="mailing_on_mailing_list or not mailing_model_id">
-                                        <field name="mailing_domain" widget="domain"
+                                        <field name="mailing_domain" widget="mass_mailing_domain"
                                             options="{'model': 'mailing_model_real', 'foldable': True}"
                                             readonly="state in ('sending', 'done')"/>
+                                        <field name="use_exclusion_list" invisible="1"/> <!-- Used by `mass_mailing_domain` -->
                                     </div>
                                     <div invisible="mailing_on_mailing_list" class="col-md-auto o_mailing_filter_width flex-shrink-1" title="Save as favorite">
                                         <field name="mailing_filter_id" placeholder="Reload a favorite filter" nolabel="1"
@@ -371,8 +372,6 @@
                                         <field name="name" string="Name" required="False" readonly="state in ('sending', 'done')"/>
                                         <field name="mail_server_id" invisible="not mail_server_available" readonly="state in ('sending', 'done')"/>
                                         <field name="keep_archives" readonly="state in ('sending', 'done')"/>
-                                        <!-- Not using a dedicated server and being set means generic sending, won't allow disabling it. -->
-                                        <field name="use_exclusion_list" invisible="not mail_server_id and use_exclusion_list" readonly="state != 'draft'"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/mass_mailing_event/models/event_event.py
+++ b/addons/mass_mailing_event/models/event_event.py
@@ -18,6 +18,9 @@ class EventEvent(models.Model):
                 'default_mailing_model_id': self.env.ref('event.model_event_registration').id,
                 'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', 'not in', ['cancel', 'draft'])]),
                 'default_subject': _("Event: %s", self.name),
+                # even if excluded, consider event communication might be important
+                # (tickets, venue, ...)
+                'default_use_exclusion_list': False,
             },
         }
 

--- a/addons/mass_mailing_event_track/models/event_event.py
+++ b/addons/mass_mailing_event_track/models/event_event.py
@@ -18,6 +18,9 @@ class EventEvent(models.Model):
                 default_mailing_model_id=self.env.ref('website_event_track.model_event_track').id,
                 default_mailing_domain=repr([('event_id', 'in', self.ids), ('stage_id.is_cancel', '!=', True)]),
                 default_subject=_("Event: %s", self.name),
+                # even if excluded, consider speaker communication might be important
+                # (venue, organization, ...)
+                default_use_exclusion_list=False,
             ),
         )
         return mass_mailing_action

--- a/addons/mass_mailing_slides/models/slide_channel.py
+++ b/addons/mass_mailing_slides/models/slide_channel.py
@@ -18,6 +18,9 @@ class SlideChannel(models.Model):
             context=dict(
                 default_mailing_model_id=self.env.ref('base.model_res_partner').id,
                 default_mailing_domain=domain,
+                # even if excluded, consider attendee communication might be important
+                # (update on courses, etc)
+                default_use_exclusion_list=False,
             ),
         )
         return mass_mailing_action

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -479,6 +479,17 @@ class TestMassMailing(TestMassMailCommon):
 
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_mailing_w_blacklist_reset(self):
+        """Check that we automatically use the exclusion list for mailing lists and contacts."""
+        self.assertTrue(self.mailing_bl.use_exclusion_list)
+        for model in ('mailing.list', 'mailing.contact'):
+            mailing = self.mailing_bl.copy()
+            mailing.use_exclusion_list = False
+            mailing.mailing_model_id = self.env['ir.model']._get(model)
+            self.assertTrue(mailing.use_exclusion_list)
+
+    @users('user_marketing')
+    @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_mailing_w_blacklist_nomixin(self):
         """Test that blacklist is applied even if the target model doesn't inherit
         from mail.thread.blacklist."""


### PR DESCRIPTION
Purpose
=======
At the moment, we can change `use_exclusion_list` only if a dedicated server is used for the mailing. We want to always show the option (except for mailing contact and mailing list).

When coming from event, slides or marketing card, we automatically skip the exclusion list.

Task-5149177