### PR TITLE
[FIX] l10n_tw_edi_ecpay: remove usage of removed `mobile` field

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -674,8 +674,8 @@ class AccountMove(models.Model):
 
         if self.partner_id.commercial_partner_id.contact_address_inline:
             buyer_json_data["Address"] = self.partner_id.commercial_partner_id.contact_address_inline
-        if self.partner_id.commercial_partner_id.phone or self.partner_id.commercial_partner_id.mobile:
-            number = self.partner_id.commercial_partner_id.phone or self.partner_id.commercial_partner_id.mobile
+        if self.partner_id.commercial_partner_id.phone:
+            number = self.partner_id.commercial_partner_id.phone
             buyer_json_data["TelephoneNumber"] = self._reformat_phone_number(number)
 
         return call_ecpay_api("/MaintainMerchantCustomerData", buyer_json_data, self.company_id,

--- a/addons/l10n_tw_edi_ecpay/models/account_move_send.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move_send.py
@@ -110,7 +110,7 @@ class AccountMoveSend(models.AbstractModel):
                     }
             if 'tw_ecpay_send' in invoice_data['extra_edis'] or 'tw_ecpay_issue_allowance' in invoice_data['extra_edis']:
                 if self._can_commit():
-                    self._cr.commit()
+                    self.env.cr.commit()
 
     def _call_web_service_after_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'
@@ -126,7 +126,7 @@ class AccountMoveSend(models.AbstractModel):
                 }
             # We commit again if possible, to ensure that the invoice status is set in the database in case of errors later.
             if self._can_commit():
-                self._cr.commit()
+                self.env.cr.commit()
 
     @api.model
     def _link_invoice_documents(self, invoices_data):


### PR DESCRIPTION
**Steps to reproduce:**
1. Install l10n_tw_edi_ecpay.
2. Switch to the TW company.
3. Go to Configuration → search for "ECPay".
4. Enable staging mode.
5. Enter all credentials.
6. Create a new invoice → select “Taiwan Semiconductor” as customer → set an email and leave the phone field empty.
7. Add a product → confirm → click “Send” → select only “Send to ECPay” → send.
 
> You can find ECPay testing credentials here : https://developers.ecpay.com.tw/?p=24174

**Issue:**
A traceback occurs while sending the e-invoice:
`AttributeError: 'res.partner' object has no attribute 'mobile'`
    
**Cause:**
In commit https://github.com/odoo/odoo/commit/6b820eb6fc6f782ba6a83d605d87b4a1dd2a87be the `mobile` field was removed from `res.partner`. The ECPay integration still attempted to read `partner.mobile`, which causes the traceback on versions where the field no longer exists.

Additionally, the code was still using the deprecated `self._cr` cursor reference, which was replaced by `self.env.cr` as part of the cleanup in: https://github.com/odoo/odoo/pull/193636/commits/ad7606195a4ba44bf9854506bf2e305d3dd13dbb

**Fix:**
Remove the reference to the obsolete `mobile` field and rely solely on the `phone` field, which is the only supported contact number field in 19.0. 
Also replace deprecated `self._cr` with `self.env.cr`

**opw-5357429**

