### PR TITLE
[PERF] point_of_sale: Optimize price computations for paid orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -170,7 +170,7 @@ export class PosOrderlineAccounting extends Base {
         return accountTaxHelpers.prepare_base_line_for_taxes_computation(
             this,
             this.prepareBaseLineForTaxesComputationExtraValues({
-                price_unit: this.productProductPrice,
+                price_unit: this.price_unit,
                 quantity: this.getQuantity(),
                 tax_ids: this.tax_ids,
                 ...opts,


### PR DESCRIPTION
Before this commit, the POS system would recompute product prices even for orders that were already paid. This led to unnecessary calculations.

opw-5263663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
