### PR TITLE
[FIX] point_of_sale, pos_hr, l10n_fr_pos_cert: edit payment button visiblity

### DIFF
--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -36,11 +36,14 @@ The module adds following features:
     ],
     'post_init_hook': '_setup_inalterability',
     'assets': {
+        'web.assets_unit_tests': [
+            'l10n_fr_pos_cert/static/tests/unit/**/*',
+        ],
         'point_of_sale._assets_pos': [
             'l10n_fr_pos_cert/static/src/**/*',
         ],
         'web.assets_tests': [
-            'l10n_fr_pos_cert/static/tests/**/*',
+            'l10n_fr_pos_cert/static/tests/tours/**/*',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/l10n_fr_pos_cert/static/src/app/services/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/app/services/pos.js
@@ -15,4 +15,7 @@ patch(PosStore.prototype, {
         }
         return french_countries.includes(this.company.country_id?.code);
     },
+    canEditPayment(order) {
+        return this.is_french_country() ? false : super.canEditPayment(order);
+    },
 });

--- a/addons/l10n_fr_pos_cert/static/tests/unit/data/pos_config.data.js
+++ b/addons/l10n_fr_pos_cert/static/tests/unit/data/pos_config.data.js
@@ -1,0 +1,6 @@
+import { PosConfig } from "@point_of_sale/../tests/unit/data/pos_config.data";
+
+PosConfig._records = PosConfig._records.map((record) => ({
+    ...record,
+    company_id: 251,
+}));

--- a/addons/l10n_fr_pos_cert/static/tests/unit/data/res_company.data.js
+++ b/addons/l10n_fr_pos_cert/static/tests/unit/data/res_company.data.js
@@ -1,0 +1,26 @@
+import { ResCompany } from "@point_of_sale/../tests/unit/data/res_company.data";
+
+ResCompany._records = [
+    ...ResCompany._records,
+    {
+        id: 251,
+        currency_id: 125,
+        email: false,
+        website: false,
+        company_registry: false,
+        vat: false,
+        name: "My FR Company",
+        phone: "",
+        partner_id: 1,
+        country_id: 75,
+        state_id: false,
+        tax_calculation_rounding_method: "round_per_line",
+        point_of_sale_use_ticket_qr_code: true,
+        point_of_sale_ticket_unique_code: false,
+        point_of_sale_ticket_portal_url_display_mode: "qr_code_and_url",
+        street: "",
+        city: "",
+        zip: "",
+        account_fiscal_country_id: 75,
+    },
+];

--- a/addons/l10n_fr_pos_cert/static/tests/unit/data/res_country.data.js
+++ b/addons/l10n_fr_pos_cert/static/tests/unit/data/res_country.data.js
@@ -1,0 +1,11 @@
+import { ResCountry } from "@point_of_sale/../tests/unit/data/res_country.data";
+
+ResCountry._records = [
+    ...ResCountry._records,
+    {
+        id: 75,
+        name: "France",
+        code: "FR",
+        vat_label: "VAT",
+    },
+];

--- a/addons/l10n_fr_pos_cert/static/tests/unit/services/pos_store.test.js
+++ b/addons/l10n_fr_pos_cert/static/tests/unit/services/pos_store.test.js
@@ -1,0 +1,13 @@
+import { test, expect } from "@odoo/hoot";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+test("canEditPayment", async () => {
+    const store = await setupPosEnv();
+    store.addNewOrder();
+    const order = store.getOrder();
+    // In FR localisation, edit payment should not be visble even when order.nb_print === 0
+    expect(store.canEditPayment(order)).toBe(false);
+});

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -15,7 +15,7 @@
                                 </span>
                                 <div class="fs-4 fw-bold d-flex justify-content-center align-items-center gap-2">
                                     <span t-esc="orderAmountPlusTip" />
-                                    <span t-if="this.currentOrder.nb_print === 0" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.currentOrder)">Edit Payment</span>
+                                    <span t-if="this.pos.canEditPayment(currentOrder)" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.currentOrder)">Edit Payment</span>
                                 </div>
                             </div>
                             <div class="receipt-options d-flex flex-column gap-2">

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2835,6 +2835,10 @@ export class PosStore extends WithLazyGetterTrap {
     get showSaveOrderButton() {
         return this.config.raw.trusted_config_ids.length > 0;
     }
+
+    canEditPayment(order) {
+        return order.nb_print === 0;
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};

--- a/addons/point_of_sale/static/tests/unit/data/res_currency.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/res_currency.data.js
@@ -27,6 +27,16 @@ export class ResCurrency extends webModels.ResCurrency {
             decimal_places: 2,
             iso_numeric: 840,
         },
+        {
+            id: 125,
+            name: "EUR",
+            symbol: "€",
+            position: "after",
+            rounding: 0.01,
+            rate: 1.0,
+            decimal_places: 2,
+            iso_numeric: 978,
+        },
         ...webModels.ResCurrency._records.filter((record) => record.id !== 1),
     ];
 }

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -422,6 +422,14 @@ describe("pos_store.js", () => {
         expect(store.getPaymentMethodFmtAmount(card2, order)).toBeEmpty();
     });
 
+    test("canEditPayment", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        expect(store.canEditPayment(order)).toBe(true);
+        order.nb_print = 1;
+        expect(store.canEditPayment(order)).toBe(false);
+    });
+
     describe("cacheReceiptLogo", () => {
         function getCompanyLogo256Url(companyId) {
             const fullUrl = imageUrl("res.company", companyId, "logo", {

--- a/addons/pos_hr/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/pos_hr/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<templates id="template" xml:space="preserve">
-    <t t-name="ReceiptScreen" t-inherit="point_of_sale.ReceiptScreen" t-inherit-mode="extension">
-        <xpath expr="//span[hasclass('edit-order-payment')]" position="attributes">
-            <attribute name="t-if">(!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin) and this.currentOrder.nb_print === 0</attribute>
-        </xpath>
-    </t>
-</templates>

--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -143,4 +143,7 @@ patch(PosStore.prototype, {
         }
         return await super.allowProductCreation();
     },
+    canEditPayment(order) {
+        return super.canEditPayment(order) && (!this.config.module_pos_hr || this.employeeIsAdmin);
+    },
 });

--- a/addons/pos_hr/static/tests/unit/services/pos_store.test.js
+++ b/addons/pos_hr/static/tests/unit/services/pos_store.test.js
@@ -48,3 +48,14 @@ test("addLineToCurrentOrder", async () => {
     });
     expect(result.order_id.employee_id.id).toBe(2);
 });
+test("canEditPayment", async () => {
+    const store = await setupPosEnv();
+    store.addNewOrder();
+    const order = store.getOrder();
+    const admin = store.models["hr.employee"].get(2);
+    store.setCashier(admin);
+    expect(store.canEditPayment(order)).toBe(true);
+    const emp = store.models["hr.employee"].get(3);
+    store.setCashier(emp);
+    expect(store.canEditPayment(order)).toBe(false);
+});


### PR DESCRIPTION
Before this commit:
===================
- On the Payment Screen, the `Edit Payment` button was visible in the
`l10n_fr_pos_cert` and `l10n_at_pos` localizations.
- This was incorrect because fiscal compliance in these countries does not allow
altering order details at this stage.
- The visibility logic for this button was unintentionally modified in `pos_hr`.

After this commit:
==================
The visibility of the `Edit Payment` button is now correctly enforced:

- `point_of_sale`: visible only until the receipt is printed.
- `pos_hr`: visible only when the logged-in user is an admin (except in AT and
FR localization).
- `l10n_fr_pos_cert`: never visible.
- `l10n_at_pos`: visible only when the company is `not FON Authenticated`.

Task: 5384822
Related Enterprise PR: https://github.com/odoo/enterprise/pull/101460