### PR TITLE
[FIX] account: allow to group by account_root with full domain optimization

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -426,11 +426,17 @@ class AccountAccount(models.Model):
             record.root_id = self.env['account.root']._from_account_code(record.placeholder_code)
 
     def _search_account_root(self, operator, value):
-        if operator not in ('in', 'child_of'):
+        if operator not in ('in', 'child_of', 'any'):
             return NotImplemented
-        roots = self.env['account.root'].browse(value)
+        if operator == 'any':
+            if isinstance(value, Domain) and value.field_expr == 'display_name' and value.operator == 'in':
+                roots = self.env['account.root'].browse(value.value)
+            else:
+                return NotImplemented
+        else:
+            roots = self.env['account.root'].browse(value)
         return Domain.OR(
-            Domain('placeholder_code', '=ilike', root.name + ('' if operator == 'in' and not root.parent_id else '%'))
+            Domain('placeholder_code', '=ilike', root.name + ('' if operator in ['in', 'any'] and not root.parent_id else '%'))
             for root in roots
         )
 


### PR DESCRIPTION
Access records in a grouped by `account_root` list failed, showing an error message: 

    Unsupported operator on Root 'Account' (account.account) in [('root_id', 'any', [('display_name', 'in', [10])])]

Step to reproduce:
- New DB with `accountant` module
- Accounting -> Chart of accounts
- Group By "Root"
- Open any grouped record set

When opening the record set, Odoo fetches data using the domain `[('id', '=', '10')]`
The domain goes through optimization as follows:

```
          [('id', '=', '10')]
 basic :  [('id', 'in', ['10'])]
 full :	  [('root_id', 'any', [('display_name', 'in', [10])])]
```

However, the `_search_account_root` method protects the technical field `account_root`.
This commit adapts it to allow full optimized domain search and solving the error.

Ticket [link](https://www.odoo.com/odoo/project.task/5178896)
opw-5178896