### PR TITLE
[PERF] orm: cache for check field access

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -139,7 +139,7 @@ class DocController(http.Controller):
                     for field in ir_model.field_id
                     # sorted(ir_model.field_id, key=partial(sort_key_field, modules, Model))
                     if field.name in Model._fields  # band-aid, see task 5172546
-                    if Model._has_field_access(Model._fields[field.name], 'read')
+                    if Model.has_field_access(Model._fields[field.name], 'read')
                 },
                 'methods': [
                     method_name

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -284,7 +284,7 @@ class Base_ImportImport(models.TransientModel):
             # ignore if you cannot access to the target model or the field definition
             if not target_model.has_access('read'):
                 continue
-            if not target_model._has_field_access(target_model._fields[definition_record_field], 'read'):
+            if not target_model.has_field_access(target_model._fields[definition_record_field], 'read'):
                 continue
 
             # Do not take into account the definition of archived parents,

--- a/addons/bus/models/ir_model.py
+++ b/addons/bus/models/ir_model.py
@@ -26,7 +26,7 @@ class IrModel(models.Model):
                     inverse_fields = [
                         field for field in model.pool.field_inverses[model._fields[fname]]
                         if field.model_name in model_names_to_fetch
-                        and model.env[field.model_name]._has_field_access(field, 'read')
+                        and model.env[field.model_name].has_field_access(field, 'read')
                     ]
                     if inverse_fields:
                         field_data['inverse_fname_by_model_name'] = {field.model_name: field.name for field in inverse_fields}

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -304,7 +304,7 @@ class HrEmployee(models.Model):
         result = super()._prepare_create_values(vals_list)
         new_vals_list = []
         Version = self.env['hr.version']
-        version_fields = [fname for fname, field in Version._fields.items() if Version._has_field_access(field, 'write')]
+        version_fields = [fname for fname, field in Version._fields.items() if Version.has_field_access(field, 'write')]
         for vals in result:
             employee_vals = {}
             version_vals = {}
@@ -1514,7 +1514,7 @@ class HrEmployee(models.Model):
         self.env['hr.version'].new({
             f_name: value
             for f_name, value in version_vals.items()
-            if self.env['hr.version']._has_field_access(self.env['hr.version']._fields[f_name], 'read')
+            if self.env['hr.version'].has_field_access(self.env['hr.version']._fields[f_name], 'read')
         })
         return employee
 

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -49,7 +49,7 @@ def field_employee(field_type: type[fields.Field], name: str, *, field_name='', 
             return NotImplemented
         subdomain = Domain(name, operator, value)
         Employee = self.env['hr.employee']
-        if Employee.has_access('read') and Employee._has_field_access(Employee._fields[name], 'read'):
+        if Employee.has_access('read') and Employee.has_field_access(Employee._fields[name], 'read'):
             return Domain('employee_id', 'any', subdomain)
         else:
             user = self.env.user.employee_id.filtered_domain(subdomain).user_id

--- a/addons/html_builder/models/ir_ui_view.py
+++ b/addons/html_builder/models/ir_ui_view.py
@@ -129,7 +129,7 @@ class IrUiView(models.Model):
         record_to.check_access('write')
         field_from = records_from._fields[name_field_from]
         field_to = record_to._fields[name_field_to]
-        record_to._check_field_access(field_to, 'write')
+        record_to.check_field_access(field_to, 'write')
 
         error_callable_msg = "'translate' property of field %r is not callable"
         if not callable(field_from.translate):

--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -652,8 +652,8 @@ class HTML_Editor(http.Controller):
         document.check_access('read')
         document.check_access('write')
         if field := document._fields.get(field_name):
-            document._check_field_access(field, 'read')
-            document._check_field_access(field, 'write')
+            document.check_field_access(field, 'read')
+            document.check_field_access(field, 'write')
 
         channel = (request.db, 'editor_collaboration', model_name, field_name, int(res_id))
         bus_data.update({'model_name': model_name, 'field_name': field_name, 'res_id': res_id})

--- a/addons/html_editor/models/ir_websocket.py
+++ b/addons/html_editor/models/ir_websocket.py
@@ -32,8 +32,8 @@ class IrWebsocket(models.AbstractModel):
                             document.check_access('read')
                             document.check_access('write')
                             if field := document._fields.get(field_name):
-                                document._check_field_access(field, 'read')
-                                document._check_field_access(field, 'write')
+                                document.check_field_access(field, 'read')
+                                document.check_field_access(field, 'write')
                         except AccessError:
                             continue
 

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1345,7 +1345,7 @@ class MailMessage(models.Model):
             and (not self.subtype_id or not self.subtype_id.description)
             and not self.attachment_ids
             and not (
-                self._has_field_access(self._fields["tracking_value_ids"], "read")
+                self.has_field_access(self._fields["tracking_value_ids"], "read")
                 and self.tracking_value_ids
             )
             and not self.has_poll

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -47,7 +47,7 @@ class MailTrackingValue(models.Model):
                 return env.is_system()
             model = env[tracking.field_id.model]
             model_field = model._fields.get(tracking.field_id.name)
-            return model._has_field_access(model_field, 'read') if model_field else False
+            return model.has_field_access(model_field, 'read') if model_field else False
 
         return self.filtered(has_field_access)
 

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -835,7 +835,7 @@ class ProjectTask(models.Model):
             {
                 k: v
                 for k, v in vals.items()
-                if self._has_field_access(self._fields[k], 'read')
+                if self.has_field_access(self._fields[k], 'read')
             }
             for vals in vals_list
         ]
@@ -1081,7 +1081,7 @@ class ProjectTask(models.Model):
         # (portal) users that don't have write access can still create a task
         # in the project that will be checked using record rules
         new_context["default_create_in_project_id"] = default_project_id
-        if not self._has_field_access(self._fields['user_ids'], 'write'):
+        if not self.has_field_access(self._fields['user_ids'], 'write'):
             # remove user_ids if we have no access to it
             new_context.pop('default_user_ids', False)
         self_ctx = self.with_context(new_context)
@@ -1136,7 +1136,7 @@ class ProjectTask(models.Model):
         # create the task, write computed inaccessible fields in sudo
         for vals, computed_vals in zip(vals_list, additional_vals_list):
             for field_name in list(computed_vals):
-                if self_ctx._has_field_access(self_ctx._fields[field_name], 'write'):
+                if self_ctx.has_field_access(self_ctx._fields[field_name], 'write'):
                     vals[field_name] = computed_vals.pop(field_name)
         # no track when the portal user create a task to avoid using during tracking
         # process since the portal does not have access to tracking models

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -50,7 +50,7 @@ class MailMessage(models.Model):
             return (
                 records
                 and issubclass(self.pool[records._name], self.pool["rating.mixin"])
-                and records._has_field_access(records._fields["rating_avg"], "read")
+                and records.has_field_access(records._fields["rating_avg"], "read")
             )
 
         for records in records_by_model.values():

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -107,7 +107,7 @@ class SaleOrderDiscount(models.TransientModel):
             if (
                 self.env['product.product'].has_access('create')
                 and company.has_access('write')
-                and company._has_field_access(company._fields['sale_discount_product_id'], 'write')
+                and company.has_field_access(company._fields['sale_discount_product_id'], 'write')
             ):
                 company.sale_discount_product_id = self.env['product.product'].create(
                     self._prepare_discount_product_values()

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -61,7 +61,7 @@ class ProductTemplate(models.Model):
             product_template.cost_method = (
                 product_template.categ_id.with_company(
                     product_template.company_id
-                ).property_cost_method
+                ).sudo().property_cost_method
                 or (product_template.company_id or self.env.company).sudo().cost_method
             )
 

--- a/addons/web/controllers/json.py
+++ b/addons/web/controllers/json.py
@@ -151,7 +151,7 @@ class WebJsonController(http.Controller):
             domains.append([('activity_ids', '!=', False)])
             # add activity fields
             for field_name, field in model._fields.items():
-                if field_name.startswith('activity_') and field_name not in spec and model._has_field_access(field, 'read'):
+                if field_name.startswith('activity_') and field_name not in spec and model.has_field_access(field, 'read'):
                     spec[field_name] = {}
 
         # Group by

--- a/addons/web/models/ir_model.py
+++ b/addons/web/models/ir_model.py
@@ -81,7 +81,7 @@ class IrModel(models.Model):
                     inverse_fields = [
                         field for field in model.pool.field_inverses[model._fields[fname]]
                         if field.model_name in model_names
-                        and model.env[field.model_name]._has_field_access(field, 'read')
+                        and model.env[field.model_name].has_field_access(field, 'read')
                     ]
                     if inverse_fields:
                         field_data['inverse_fname_by_model_name'] = {field.model_name: field.name for field in inverse_fields}

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -529,7 +529,7 @@ class IrAttachment(models.Model):
                     except KeyError:
                         # field does not exist
                         field = None
-                    if field is None or not self._has_field_access(field, operation):
+                    if field is None or not self.has_field_access(field, operation):
                         forbidden_ids.add(att_id)
                         continue
             if res_model and res_id:
@@ -636,7 +636,7 @@ class IrAttachment(models.Model):
                         field.name
                         for field in comodel._fields.values()
                         if field.type == 'binary' or (field.relational and field.comodel_name == self._name)
-                        if comodel._has_field_access(field, 'read')
+                        if comodel.has_field_access(field, 'read')
                     ]
                     accessible_fields.append(False)
                     codomain &= Domain('res_field', 'in', accessible_fields)

--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -70,7 +70,7 @@ class IrBinary(models.AbstractModel):
             return record._to_http_stream()
 
         field = record._fields[field_name]
-        record._check_field_access(field, 'read')
+        record.check_field_access(field, 'read')
 
         if field.attachment:
             field_attachment = self.env['ir.attachment'].sudo().search(

--- a/odoo/addons/base/tests/test_acl.py
+++ b/odoo/addons/base/tests/test_acl.py
@@ -32,7 +32,7 @@ class TestACL(TransactionCaseWithUserDemo):
     def _set_field_groups(self, model, field_name, groups):
         field = model._fields[field_name]
         self.patch(field, 'groups', groups)
-        self.env.invalidate_all()
+        self.env.transaction.reset()
         self.env.registry.clear_cache('templates')
 
     def test_field_visibility_restriction(self):

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -395,6 +395,7 @@ class TestPermissions(TransactionCaseWithUserDemo):
 
         # Patch the field `res.partner.image_128` to make it unreadable by the demo user
         self.patch(self.env.registry['res.partner']._fields['image_128'], 'groups', 'base.group_system')
+        self.env.transaction.reset()
 
         # Assert the field can't be read
         with self.assertRaises(AccessError):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1001,7 +1001,7 @@ class DomainCondition(Domain):
         field = self._field(model)
         if not model.env.su:
             if self.operator not in ('any!', 'not any!'):
-                model._check_field_access(field, 'read')
+                model.check_field_access(field, 'read')
             if field.compute_sudo:
                 # run search in sudo because the compute is done in sudo as well
                 model = model.sudo()
@@ -1113,7 +1113,7 @@ class DomainCondition(Domain):
 
         model = table._model
         field = self._field(model)
-        model._check_field_access(field, 'read')
+        model.check_field_access(field, 'read')
         return field.condition_to_sql(table, field_expr, operator, value)
 
 

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -518,6 +518,11 @@ class Environment(Mapping[str, "BaseModel"]):
         return {}
 
     @functools.cached_property
+    def _field_access_memo(self) -> set[Field]:
+        """Memo for `model.has_field_access(field, 'read')`.  Do not use it."""
+        return set()
+
+    @functools.cached_property
     def _field_dirty(self):
         """ Map fields to set of dirty ids. """
         return self.transaction.field_dirty
@@ -788,7 +793,7 @@ class Cache:
 
     def _get_field_cache(self, model: BaseModel, field: Field) -> Mapping[IdType, typing.Any]:
         """ Return the field cache of the given field, but not for modifying it. """
-        return self._set_field_cache(model, field)
+        return field._get_cache(model.env)
 
     def _set_field_cache(self, model: BaseModel, field: Field) -> dict[IdType, typing.Any]:
         """ Return the field cache of the given field for modifying it. """

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1233,7 +1233,7 @@ class Field(typing.Generic[T]):
         The query object is necessary for fields that need to add tables to the query.
         """
         model = table._model
-        model._check_field_access(self, 'read')
+        model.check_field_access(self, 'read')
         if self.compute_sql:
             if self.compute_sudo:
                 model = model.sudo()
@@ -1681,10 +1681,10 @@ class Field(typing.Generic[T]):
             return self         # the field is accessed through the owner class
 
         env = record.env
-        if not (env.su or record._has_field_access(self, 'read')):
-            # optimization: we called _has_field_access() to avoid an extra
-            # function call in _check_field_access()
-            record._check_field_access(self, 'read')
+        if not (env.su or record.has_field_access(self, 'read')):
+            # optimization: we called has_field_access() to avoid an extra
+            # function call in check_field_access()
+            record.check_field_access(self, 'read')
 
         record_len = len(record._ids)
         if record_len != 1:

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1680,11 +1680,9 @@ class Field(typing.Generic[T]):
         if record is None:
             return self         # the field is accessed through the owner class
 
+        # check field access
         env = record.env
-        if not (env.su or record.has_field_access(self, 'read')):
-            # optimization: we called has_field_access() to avoid an extra
-            # function call in check_field_access()
-            record.check_field_access(self, 'read')
+        env.su or self in env._field_access_memo or record.check_field_access(self, 'read')
 
         record_len = len(record._ids)
         if record_len != 1:

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -44,7 +44,7 @@ class _Relational(Field[BaseModel]):
         if records is None or len(records._ids) <= 1:
             return super().__get__(records, owner)
 
-        records._check_field_access(self, 'read')
+        records.check_field_access(self, 'read')
 
         # multi-record case
         if self.compute and self.store:

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -44,14 +44,15 @@ class _Relational(Field[BaseModel]):
         if records is None or len(records._ids) <= 1:
             return super().__get__(records, owner)
 
-        records.check_field_access(self, 'read')
+        # check field access
+        env = records.env
+        env.su or self in env._field_access_memo or records.check_field_access(self, 'read')
 
         # multi-record case
         if self.compute and self.store:
             self.recompute(records)
 
         # get the cache
-        env = records.env
         field_cache = self._get_cache(env)
 
         # retrieve values in cache, and fetch missing ones

--- a/odoo/orm/models_cached.py
+++ b/odoo/orm/models_cached.py
@@ -45,7 +45,7 @@ class CachedModel(Model):
 
     def _fetch_field(self, field):
         if any(self._ids) and field.name in self._cached_data_fields:
-            self._check_field_access(field, 'read')
+            self.check_field_access(field, 'read')
             data = self._cached_data()
             field._insert_cache(self.browse(data['id']), data[field.name])
             data_ids = set(data['id'])


### PR DESCRIPTION
`Model._has_field_access` depends on the model (not any particular record) and the context that is defined by the environment. Therefore checking field access for a model can be done by the environment.

We add a cached version as public methods `Model.check_field_access(field, 'read')` similar to the API of checking record access. That cache is set of the environment and used to speed-up field check access when getting them.

Performance:
```py
partner = env['res.partner'].with_user(5).search([], limit=1)

%timeit partner.name
# before vs after (no groups on field)
# 512 ns ± 5.17 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
# (similar)

%timeit partner.opportunity_count
# before vs after (has groups on field)
# 4.08 μs ± 15.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# 410 ns ± 2.08 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
