### PR TITLE
[FIX] website_sale: ensure Product Design is saved on /shop edit

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -241,6 +241,9 @@ export class BuilderOptionsPlugin extends Plugin {
         }
 
         const newContainers = this.computeContainers(this.target);
+        if (newContainers.length === 0 && this.lastContainers.length === 0) {
+            return;
+        }
         // Do not update the containers if they did not change and are not
         // forced to update.
         if (

--- a/addons/website/static/tests/builder/custom_tab/main_page_option.test.js
+++ b/addons/website/static/tests/builder/custom_tab/main_page_option.test.js
@@ -1,0 +1,23 @@
+import { expect, test } from "@odoo/hoot";
+import { xml } from "@odoo/owl";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    addOption,
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("switch to custom tab and click on a main page option", async () => {
+    addOption({
+        selector: "main",
+        template: xml`<BuilderButton classAction="'my-custom-class'"/>`,
+    });
+    await setupWebsiteBuilder(`<main>b</main>`);
+    await contains('[id="customize-tab"]').click();
+    await contains("[data-class-action='my-custom-class']").click();
+    expect(".options-container").toBeDisplayed();
+    expect("[data-class-action='my-custom-class']").toHaveCount(1);
+    expect(":iframe main").toHaveClass("my-custom-class");
+});

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.js
@@ -4,7 +4,8 @@ import { products_sort_mapping } from "@website_sale/website_builder/shared";
 
 export class ProductsListPageOption extends BaseOptionComponent {
     static template = "website_sale.ProductsListPageOption";
-    static selector = "#o_wsale_container";
+    static selector = "main:has(#o_wsale_container)";
+    static applyTo = "#o_wsale_container";
     static title = _t("Products Page");
     static groups = ["website.group_website_designer"];
     static editableOnly = false;

--- a/addons/website_sale_wishlist/static/src/website_builder/wishlist_page_option_plugin.js
+++ b/addons/website_sale_wishlist/static/src/website_builder/wishlist_page_option_plugin.js
@@ -1,14 +1,14 @@
 
 import { Plugin } from "@html_editor/plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class WishlistPageOption extends BaseOptionComponent {
     static template = "website_sale_wishlist.WishlistPageOption";
-    static selector = ".o_wishlist_table"
+    static selector = "main:has(.o_wishlist_table)";
+    static applyTo = ".o_wishlist_table";
     static editableOnly = false;
     static title = _t("Wishlist Page");
     static groups = ["website.group_website_designer"];
@@ -21,25 +21,24 @@ class WishlistPageOptionPlugin extends Plugin {
         builder_actions: {
             WishlistGridColumnsAction,
             WishlistMobileColumnsAction,
-            WishlistSetGapAction
+            WishlistSetGapAction,
         },
-        save_handlers: this.onSave.bind(this),
+        product_design_list_to_save: {
+            selector: ".o_wishlist_table",
+            getData(el) {
+                const productOptClasses = Array.from(el.classList).filter((className) =>
+                    className.startsWith("o_wsale_products_opt_")
+                );
+                return {
+                    wishlist_grid_columns: parseInt(el.dataset.wishlistGridColumns) || 5,
+                    wishlist_mobile_columns: parseInt(el.dataset.wishlistMobileColumns) || 2,
+                    wishlist_gap:
+                        el.style.getPropertyValue("--o-wsale-wishlist-grid-gap") || "16px",
+                    wishlist_opt_products_design_classes: productOptClasses.join(" "),
+                };
+            },
+        },
     };
-
-    async onSave() {
-        const wishlistEl = this.editable.querySelector(".o_wishlist_table");
-        if (!wishlistEl) return;
-
-        const gridColumns = parseInt(wishlistEl.dataset.wishlistGridColumns) || 5;
-        const mobileColumns = parseInt(wishlistEl.dataset.wishlistMobileColumns) || 2;
-        const gap = wishlistEl.style.getPropertyValue("--o-wsale-wishlist-grid-gap") || "16px";
-
-        return rpc("/shop/config/website", {
-            wishlist_grid_columns: gridColumns,
-            wishlist_mobile_columns: mobileColumns,
-            wishlist_gap: gap,
-        });
-    }
 }
 
 export class WishlistGridColumnsAction extends BuilderAction {


### PR DESCRIPTION
Steps to reproduce:
=======
1. Go to /shop in edit mode.
2. Change the Product Design.
3. Switch to the "Blocks" tab (so the "Style" tab is not visible).
4. Click on "Save".

Before this commit:
======
The selected Product Design was not saved.

After this commit:
======
The Product Design is now always saved correctly, even if the `ProductsDesignPanel` component has been unmounted.

Technical reason:
=======
The save behavior depended on whether the
`ProductsDesignPanel` component was still mounted at the moment of saving. If it was not alive, changes were lost.

Solution:
=====
We no longer depend on the component being alive. When the Product Design or the Gap is modified, we mark the product list with the `o_dirty_product_design_list` class. On save, we look for elements with this class, retrieve their modified data, and apply the changes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
