### PR TITLE
[PERF] account_edi_format: Speedup product search

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -516,17 +516,18 @@ class AccountEdiFormat(models.Model):
             domains.append([('default_code', '=', default_code)])
         if name:
             domains += [[('name', '=', name)], [('name', 'ilike', name)]]
-        products = self.env['product.product'].search(
-            expression.AND([
-                expression.OR(domains),
-                [('company_id', 'in', [False, self.env.company.id])],
-            ]),
-        )
-        if products:
-            for domain in domains:
-                products_by_domain = products.filtered_domain(domain)
-                if products_by_domain:
-                    return products_by_domain[0]
+
+        for domain in domains:
+            product = self.env['product.product'].search(
+                expression.AND([
+                    domain,
+                    [('company_id', 'in', [False, self.env.company.id])],
+                ]),
+                limit=1
+            )
+            # We need a single product. Exit early if one is found (implements the priority logic).
+            if product:
+                return product
         return self.env['product.product']
 
     def _retrieve_tax(self, amount, type_tax_use):


### PR DESCRIPTION
The \_retrieve \_product() function relies on a query with multiple domains OR'ed together. As the search will require a LEFT JOIN with the product_template table, the use of OR in the query prevents Postgres from utilizing indexes. This becomes a problem in databases with a large number of products since a seq scan would be very slow.

This commit changes the way this is done by performing separate queries instead of a single query with multiple conditions within an OR statement. Although this might seem a performance degradation, it actually allows these separate queries to utilize indexes and run much faster compared to the original approach. It also simplifies the priority logic and allows for faster early exits compared to the original one.

This function is mainly used with EDI crons (such as PEPPOL where this problem was noticed), which could require hundreds of product searches as it does a search per invoice line.

Benchmarks:

Importing a peppol document of 173 invoice lines.

| Num products | Num invoice lines | Before   | After   |
| ------------ | ----------------- | -------- | ------- |
| 864873       | 173               | 868.18 s | 19.43 s |
| 397005       | 173               | 468.91 s | 20.68 s |
| 8064         | 173               | 125.08 s | 20.1 s  |
| 564          | 173               | 119.9 s  | 20.21 s |

opw-5245007


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
