### PR TITLE
[IMP] web, *: improve dialogs design

### DIFF
--- a/addons/account/static/src/services/account_move_service.js
+++ b/addons/account/static/src/services/account_move_service.js
@@ -18,7 +18,7 @@ export class AccountMoveService {
         const isMoveEndOfChain = await this.orm.call("account.move", "check_move_sequence_chain", [moveIds]);
         if (!isMoveEndOfChain) {
             const message = _t("This operation will create a gap in the sequence.");
-            return markup`<div class="text-danger">${message}</div>${body}`;
+            return markup`<div class="alert alert-warning mt-2">${message}</div>${body}`;
         }
         return body;
     }

--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -56,7 +56,7 @@ test("Confirmation dialog on delete contains a warning", async () => {
     });
     await contains(".o_cp_action_menus button").click();
     await contains(".o_menu_item:contains(Delete)").click();
-    expect(".o_dialog div.text-danger").toHaveText(
+    expect(".o_dialog div.alert.alert-warning").toHaveText(
         "This operation will create a gap in the sequence.",
         { message: "warning message has been added in the dialog" }
     );

--- a/addons/calendar/static/src/scss/calendar_event_views.scss
+++ b/addons/calendar/static/src/scss/calendar_event_views.scss
@@ -15,20 +15,11 @@
  **********************************************************/
 
 .modal-dialog:has(.o_calendar_event_form_quick_create) {
-    --modal-width: 490px;
+    --modal-width: #{$o-modal-sm};
 }
 
 .o_calendar_event_form_quick_create {
     .o_form_nosheet {
-        padding: 0;
-        > div {
-            margin-top: 0.5rem;
-            margin-left: 5px;
-            margin-right: 5px;
-        }
-    }
-    i.fa {
-        text-align: center;
-        min-width: 2rem;
+        padding-bottom: map-get($spacers, 2);
     }
 }

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -193,6 +193,7 @@ export class AttendeeCalendarModel extends CalendarModel {
                     body: deleteConfirmationMessage,
                     confirm: resolve.bind(null, true),
                     confirmLabel: _t("Delete"),
+                    confirmClass: "btn-danger",
                     cancel: () => resolve.bind(null, false),
                     cancelLabel: _t("No, keep it"),
                 });

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -334,15 +334,15 @@
         <field name="arch" type="xml">
             <form string="Meetings" class="o_calendar_event_form_quick_create" js_class="calendar_quick_create_form_view">
                 <field name="invalid_email_partner_ids" invisible="1"/> <!--used in many2many_attendees widget-->
-                <div class="d-flex align-items-center" colspan="2">
-                    <i class="fa fa-tag text-600" title="Booking Name"/>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-tag text-600 me-2" title="Booking Name"/>
                     <field name="name" nolabel="1"
                         placeholder="Add Title"
                         class="w-100 mb-0"
                     />
                 </div>
-                <div class="d-flex align-items-center" colspan="2">
-                    <i class="fa fa-clock-o text-600" title="Dates"/>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-clock-o text-600 me-2" title="Dates"/>
                     <!--when "stop" is set manually, "duration" is computed. When "start" is changed
                     "stop" is computed based on the previously-computed "duration". Hence we need to
                     keep the last computed duration in the front-end model and send it with "start"
@@ -365,16 +365,16 @@
                     </span>
                     <field name="stop" invisible="1"/>
                 </div>
-                <div class="d-flex" colspan="2">
-                    <i class="fa fa-user mt-1 text-600" title="Participants"/>
+                <div class="d-flex pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-user mt-1 text-600 me-2" title="Participants"/>
                     <field name="partner_ids" nolabel="1"
                         widget="many2many_tags"
                         placeholder="Participants"
                         class="w-75 mb-0"
                     />
                 </div>
-                <div class="d-flex align-items-center" colspan="2">
-                    <i class="fa fa-map text-600" title="Location"/>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-map text-600 me-2" title="Location"/>
                     <field name="location" nolabel="1"
                         placeholder="Location"
                         class="w-100 mb-0"
@@ -384,25 +384,25 @@
                     <field name="access_token" force_save="1" invisible="1"/>
                     <field name="videocall_location" force_save="1" invisible="1"/>
                     <field name="videocall_source" force_save="1" invisible="1"/>
-                    <button name="set_discuss_videocall_location" type="object" class="mx-1 btn-link text-nowrap"
+                    <button name="set_discuss_videocall_location" type="object" class="ms-1 pe-0 btn-link text-nowrap"
                         invisible="videocall_location" context="{'recurrence_update': recurrence_update}">
                         <span class="fa fa-plus me-1"/>Video
                     </button>
                 </div>
-                <div class="d-flex align-items-center" colspan="2" invisible="not videocall_location">
-                    <i class="fa fa-video-camera text-600" title="Videocall URL"/>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2" invisible="not videocall_location">
+                    <i class="fa fa-fw flex-shrink-0 fa-video-camera text-600 me-2" title="Videocall URL"/>
                     <field name="videocall_location" nolabel="1"
                         widget="CopyClipboardChar"
                         class="w-100 mb-0 o_field_CopyClipboardChar"
                     />
                     <button name="clear_videocall_location" class="btn btn-sm px-0"><i class="fa fa-remove" title="Remove"/></button>
                 </div>
-                <div class="d-flex align-items-center" colspan="2">
-                    <i class="fa fa-lock text-600" title="Visibility"/>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-lock text-600 me-2" title="Visibility"/>
                     <field name="privacy" nolabel="1" class="w-100 mb-0" placeholder="Visibility"/>
                 </div>
-                <div class="d-flex" colspan="2">
-                    <i class="fa fa-sticky-note mt-2 text-600" title="Notes"/>
+                <div class="d-flex pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-sticky-note mt-2 text-600 me-2" title="Notes"/>
                     <field name="notes" nolabel="1" class="w-100" placeholder="Notes" widget="calendar_event_notes_html"/>
                 </div>
             </form>

--- a/addons/event/models/event_slot.py
+++ b/addons/event/models/event_slot.py
@@ -60,8 +60,8 @@ class EventSlot(models.Model):
             if not (event_start <= slot.start_datetime <= event_end) or not (event_start <= slot.end_datetime <= event_end):
                 raise ValidationError(_(
                     "A slot cannot be scheduled outside of its event time range.\n\n"
-                    "Event:\t\t%(event_start)s - %(event_end)s\n"
-                    "Slot:\t\t%(slot_name)s",
+                    "Event:\t%(event_start)s - %(event_end)s\n"
+                    "Slot:\t%(slot_name)s",
                     event_start=format_datetime(self.env, event_start, tz=slot.date_tz, dt_format='medium'),
                     event_end=format_datetime(self.env, event_end, tz=slot.date_tz, dt_format='medium'),
                     slot_name=slot.display_name,

--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
@@ -2,12 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallPermissionDialog">
-        <Dialog title="''" size="'md'">
-            <h5 class="fw-medium fs-2 mb-2" t-out="permissionPrompt"/>
-            <small class="text-muted" t-out="permissionNote"/>
+        <Dialog title="permissionPrompt" size="'sm'">
+            <p class="mb-0" t-out="permissionNote"/>
             <t t-set-slot="footer">
-                <button class="btn btn-primary px-4" t-on-click="props.media === 'microphone' ? onClickUseMicrophone : onClickUseCamera" t-out="primaryActionText"/>
-                <button class="btn btn-outline-primary px-4" t-if="rtc.cameraPermission !== 'denied'" t-on-click="onClickUseMicAndCamera">Use microphone and camera</button>
+                <button class="btn btn-primary" t-on-click="props.media === 'microphone' ? onClickUseMicrophone : onClickUseCamera" t-out="primaryActionText"/>
+                <button class="btn btn-secondary" t-if="rtc.cameraPermission !== 'denied'" t-on-click="onClickUseMicAndCamera">Use microphone and camera</button>
             </t>
         </Dialog>
     </t>

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings_client_action.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings_client_action.js
@@ -7,7 +7,7 @@ export class DiscussNotificationSettingsClientAction extends Component {
     static components = { DiscussNotificationSettings };
     static props = ["*"];
     static template = xml`
-        <div class="o-mail-DiscussNotificationSettingsClientAction mx-3 my-2">
+        <div class="o-mail-DiscussNotificationSettingsClientAction mt-2 mx-3 mb-4">
             <DiscussNotificationSettings/>
         </div>
     `;

--- a/addons/product/static/src/js/product_attribute_value_list.js
+++ b/addons/product/static/src/js/product_attribute_value_list.js
@@ -33,6 +33,7 @@ export class PAVListRenderer extends ListRenderer {
                 title: _t("Bye-bye, record!"),
                 body: deleteConfirmationMessage,
                 confirmLabel: _t("Delete"),
+                confirmClass: "btn-danger",
                 confirm: () => this.onConfirmDelete(record).then(resolve),
                 cancel: resolve,
                 cancelLabel: _t("No, keep it"),

--- a/addons/project/static/tests/project_project_calendar.test.js
+++ b/addons/project/static/tests/project_project_calendar.test.js
@@ -35,8 +35,8 @@ test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", as
     await runAllTimers();
     expect(".o_popover").toHaveCount(1);
     expect(".o_popover .card-footer .btn").toHaveCount(3);
-    expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", ""]);
-    expect(".o_popover .card-footer .btn i.fa-trash").toHaveCount(1);
+    expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", "Delete"]);
+    expect(".o_popover .card-footer .btn.btn-danger").toHaveCount(1);
 
     await click(".o_popover .card-footer a:contains(View Tasks)");
     await click(".o_popover .card-footer a:contains(Edit)");

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -76,7 +76,7 @@
         pointer-events: auto;
         touch-action: none;
         z-index: $zindex-offcanvas - 1;
-        backdrop-filter: blur(0px) grayscale(0%);
+        backdrop-filter: grayscale(0%);
     }
 
     // Dismiss area
@@ -138,7 +138,7 @@
 
         .o_bottom_sheet_backdrop {
             opacity: MAX(var(--BottomSheet-progress, 0), 0.2);
-            backdrop-filter: blur(.5px) grayscale(50%);
+            backdrop-filter: grayscale(50%);
         }
     }
 
@@ -182,7 +182,7 @@
 
         .o_bottom_sheet_backdrop {
             opacity: 0;
-            backdrop-filter: blur(0) grayscale(0%);
+            backdrop-filter: grayscale(0%);
             @media (prefers-reduced-motion: no-preference) {
                 transition: all var(--BottomSheet-slideOut-duration, 300ms) var(--BottomSheet-slideOut-easing, ease-in);
             }

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -5,9 +5,8 @@ import { useChildRef } from "@web/core/utils/hooks";
 import { Component } from "@odoo/owl";
 
 export const deleteConfirmationMessage = _t(
-    `Ready to make your record disappear into thin air? Are you sure?
-It will be gone forever!
-
+    `Ready to make your record disappear into thin air? Are you sure? It will be gone forever!
+    
 Think twice before you click that 'Delete' button!`
 );
 

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.ConfirmationDialog">
-    <Dialog size="'md'" title="props.title" modalRef="modalRef">
+    <Dialog size="'sm'" title="props.title" modalRef="modalRef">
       <p t-out="props.body" class="text-prewrap mb-0"/>
       <t t-set-slot="footer">
         <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>
@@ -13,7 +13,7 @@
 
   <t t-name="web.AlertDialog">
     <Dialog size="'sm'" title="props.title" contentClass="props.contentClass">
-      <p t-out="props.body" class="text-prewrap"/>
+      <p t-out="props.body" class="text-prewrap mb-0"/>
       <t t-set-slot="footer">
         <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel"/>
         <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel"/>

--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -1,7 +1,8 @@
 .modal.o_technical_modal {
     --o-control-panel-breadcrumbs-display: none;
+    --formView-sheetBg-padding-x: var(--modal-padding);
 
-    backdrop-filter: blur(.5px) grayscale(50%);
+    backdrop-filter: grayscale(50%);
 
     .modal-content {
         .modal-header .modal-title {
@@ -9,6 +10,10 @@
             white-space: nowrap;
             text-overflow: ellipsis;
         }
+    }
+
+    &.o_modal_no_body_padding .modal-body {
+        padding: 0;
     }
 
     .modal-footer {
@@ -23,18 +28,18 @@
         }
 
         @include media-breakpoint-down(md) {
+            .btn, .o_file_input {
+                width: 100%;
+            }
+
             .btn {
-                width: 45%;
                 text-overflow: ellipsis;
                 white-space: inherit;
             }
         }
 
         @include media-breakpoint-down(sm) {
-            > .btn {
-                padding-top: map-get($spacers, 2);
-                padding-bottom: map-get($spacers, 2);
-            }
+            --btn-padding-y: #{map-get($spacers, 2)};
         }
     }
 
@@ -42,8 +47,29 @@
         --modal-header-border-width: 0;
         --modal-footer-border-width: 0;
 
-        .modal-body {
-            padding: 0 var(--modal-padding);
+        $_halfPadding: calc(var(--modal-padding) * 0.5);
+
+        --modal-padding: var(--Dialog-padding, #{map-get($spacers, 3)});
+        --modal-header-padding-x: var(--modal-padding);
+        --modal-header-padding-y: var(--modal-padding);
+        --modal-header-padding: var(--modal-padding) var(--modal-padding) #{$_halfPadding};
+        
+        &.o_modal_no_body_padding .modal-body {
+            padding: 0;
+
+            .o_form_sheet_bg {
+                --formView-sheetBg-padding-x: var(--modal-padding);
+            }
+        }
+
+        &.o_modal_body_padding {
+            .modal-body {
+                padding: #{$_halfPadding} var(--modal-padding);
+            }
+
+            @include media-breakpoint-up(sm) {
+                --Dialog-padding: #{map-get($spacers, 4)};
+            }
         }
 
         @include media-breakpoint-down(sm) {
@@ -58,6 +84,12 @@
 
             .modal-content {
                 max-height: calc(100vh - #{$modal-dialog-margin * 8});
+            }
+        }
+
+        @include media-breakpoint-up(sm) {
+            .btn-close.position-sm-absolute {
+                margin: map-get($spacers, 2);
             }
         }
     }
@@ -76,21 +108,20 @@
             }
 
             .modal-header {
-                padding: 0;
-
-                .modal-title {
-                    padding: var(--modal-header-padding);
-                    padding-right: 0;
+                button.oi-arrow-left, .o_expand_button {
+                    // Use BS default btn-close padding logic
+                    padding: calc(var(--#{$prefix}modal-header-padding-y) * .5) calc(var(--#{$prefix}modal-header-padding-x) * .5);
                 }
 
-                .btn-close, .oi-arrow-left[data-bs-dismiss="modal"] {
-                    padding: var(--modal-header-padding);
+                .o_expand_button {
+                    // Use BS default btn-close margin logic
+                    margin: calc(-.5 * var(--#{$prefix}modal-header-padding-y)) calc(-.5 * var(--#{$prefix}modal-header-padding-x)) calc(-.5 * var(--#{$prefix}modal-header-padding-y)) auto;
                 }
 
-                .oi-arrow-left[data-bs-dismiss="modal"] + .modal-title {
-                    padding-left: 0;
+                button.oi-arrow-left {
+                    // Invert BS default btn-close margin logic
+                    margin: calc(-.5 * var(--#{$prefix}modal-header-padding-y)) auto calc(-.5 * var(--#{$prefix}modal-header-padding-y)) calc(-.5 * var(--#{$prefix}modal-header-padding-x));
                 }
-
             }
 
             .modal-body {

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -6,7 +6,7 @@
             <div role="dialog" class="modal d-block"
                 tabindex="-1"
                 t-att-class="{ o_technical_modal: props.technical, o_modal_full: isFullscreen, o_inactive_modal: !data.isActive }"
-                t-attf-class="o_modal_design_{{ design }}"
+                t-attf-class="o_modal_design_{{ design }} {{ !props.withBodyPadding ? 'o_modal_no_body_padding': 'o_modal_body_padding' }}"
                 t-ref="modalRef"
                 >
                 <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" t-attf-class="modal-{{props.size}}">
@@ -19,10 +19,10 @@
                                 </t>
                             </t>
                         </header>
-                        <main class="modal-body" t-attf-class="{{ props.bodyClass }} {{ !props.withBodyPadding ? 'p-0': '' }}">
+                        <main class="modal-body" t-attf-class="{{ props.bodyClass }}">
                             <t t-slot="default" close="() => this.data.close()" />
                         </main>
-                        <footer t-if="props.footer" class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
+                        <footer t-if="props.footer" class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-2 w-100">
                             <t t-slot="footer" close="() => this.data.close()"/>
                         </footer>
                     </div>
@@ -35,14 +35,14 @@
         <t t-if="fullscreen">
             <button class="btn oi oi-arrow-left oi-large" aria-label="Close" tabindex="-1" t-on-click="dismiss" data-available-offline=""/>
         </t>
-        <h4 class="modal-title text-break flex-grow-1" t-att-class="{ 'me-auto': fullscreen, 'fs-5': props.size == 'sm' }">
+        <h4 class="modal-title text-wrap text-break fs-3 flex-grow-1" t-att-class="{ 'me-auto ms-3': fullscreen }">
             <t t-esc="props.title"/>
         </h4>
         <t t-if="onExpand">
-            <button type="button" class="fa fa-expand btn opacity-75 opacity-100-hover o_expand_button" aria-label="Expand" tabindex="-1" t-on-click="onExpand" data-available-offline=""/>
+            <button type="button" class="fa fa-expand btn opacity-50 opacity-100-hover o_expand_button" aria-label="Expand" tabindex="-1" t-on-click="onExpand" data-available-offline=""/>
         </t>
         <t t-if="!fullscreen">
-            <button type="button" class="btn-close" t-att-class="{'position-absolute top-0 end-0 mt-1 me-1': design == 'minimal' and !onExpand  }" aria-label="Close" tabindex="-1" t-on-click="dismiss" data-available-offline=""/>
+            <button type="button" class="btn-close" title="Close" t-att-class="{'position-sm-absolute top-0 end-0': design == 'minimal' and !onExpand }" aria-label="Close" tabindex="-1" t-on-click="dismiss" data-available-offline=""/>
         </t>
     </t>
 </templates>

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="web.WarningDialog">
-        <Dialog title="title" size="'md'" contentClass="'o_error_dialog'">
+        <Dialog title="title" size="'sm'" contentClass="'o_error_dialog'">
             <div role="alert">
-                <p t-esc="message" class="text-prewrap"/>
+                <p t-esc="message" class="text-prewrap mb-0"/>
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="props.close" data-available-offline="">Close</button>
@@ -51,7 +51,7 @@
     </t>
 
     <t t-name="web.ErrorDialog">
-        <Dialog title.translate="Oops!" size="state.showTraceback ? 'xl' : 'md'" contentClass="'o_error_dialog'">
+        <Dialog title.translate="Oops!" size="state.showTraceback ? 'lg' : 'sm'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p>
                     Something went wrong... If you really are stuck, share the report with your friendly support service

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -263,6 +263,8 @@ $modal-lg: $o-modal-lg !default;
 $modal-md: $o-modal-md !default;
 $modal-sm: $o-modal-sm !default;
 
+$modal-backdrop-opacity: .25 !default;
+
 $modal-content-border-radius: $border-radius !default;
 $modal-content-bg: $o-view-background-color !default;
 

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -184,8 +184,8 @@ $o-statbutton-height: 44px !default;
 $o-statbutton-spacing: 6px !default;
 
 $o-modal-lg: 980px !default;
-$o-modal-md: 600px !default;
-$o-modal-sm: 360px !default;
+$o-modal-md: 620px !default;
+$o-modal-sm: 460px !default;
 
 $o-modal-animation-duration: .4s !default;
 

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -77,7 +77,10 @@
             </a>
         </t>
         <t t-if="isEventDeletable">
-            <a href="#" class="btn btn-secondary o_cw_popover_delete" t-on-click="onDeleteEvent"><i class="fa fa-trash"/></a>
+            <a href="#" class="btn btn-danger o_cw_popover_delete" t-on-click="onDeleteEvent">
+                <i class="fa fa-trash" role="presentation"/>
+                Delete
+            </a>
         </t>
     </t>
 

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -366,6 +366,7 @@ export class CalendarController extends Component {
                 this.model.unlinkRecord(record.id);
             },
             confirmLabel: _t("Delete"),
+            confirmClass: "btn-danger",
             cancel: () => {
                 // `ConfirmationDialog` needs this prop to display the cancel
                 // button but we do nothing on cancel.

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -642,6 +642,7 @@ export class PropertiesField extends Component {
             title: _t("Delete Property Field"),
             body: message,
             confirmLabel: _t("Delete Field"),
+            confirmClass: "btn-danger",
             cancelLabel: _t("Discard"),
             confirm: () => {
                 const propertiesDefinitions = this.propertiesList;

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -210,10 +210,7 @@
         // entire available room. To define its properties we use sheet's CSS
         // variables in order to keep consistency and ease inner components
         // contextual adaptations (notepad, alerts, listView...).
-        --formView-sheet-padding-y: #{$o-sheet-vpadding};
-        --formView-sheet-padding-x: #{$o-horizontal-padding};
-
-        padding: var(--formView-sheet-padding-y) var(--formView-sheet-padding-x);
+        padding: var(--formView-sheet-padding-y, #{$o-sheet-vpadding}) var(--formView-sheet-padding-x, #{$o-horizontal-padding});
         background-color: $o-view-background-color;
 
         .o_notebook {
@@ -246,11 +243,8 @@
 
     // Sheet
     .o_form_sheet {
-        --formView-sheet-padding-y: #{map-get($spacers, 3)};
-        --formView-sheet-padding-x: #{map-get($spacers, 3)};
-
         margin: 0 var(--formView-sheet-margin-x, calc(var(--formView-sheetBg-padding-x) * -1));
-        padding: var(--formView-sheet-padding-y) var(--formView-sheet-padding-x);
+        padding: var(--formView-sheet-padding-y, #{map-get($spacers, 3)}) var(--formView-sheet-padding-x, #{map-get($spacers, 3)});
         border-style: solid;
         border-color: $border-color;
         border-width: var(--formView-sheet-border-width, 1px 0 1px 0);

--- a/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.xml
+++ b/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.xml
@@ -2,11 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FormErrorDialog">
-        <Dialog header="false" size="'md'" contentClass="'o_error_dialog o_form_error_dialog'">
-            <div role="alert">
-                <h1 class="text-danger">Oh snap!</h1>
-                <p t-esc="message" class="text-prewrap"/>
-            </div>
+        <Dialog size="'sm'" title.translate="'Oh snap!'" contentClass="'o_error_dialog o_form_error_dialog'">
+            <p t-esc="message" class="text-prewrap"/>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="stay">Stay here</button>
                 <button class="btn btn-secondary" t-if="redirectAction" t-on-click="onRedirectBtnClicked"><t t-esc="redirectBtnLabel"/></button>

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.scss
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.scss
@@ -1,4 +1,22 @@
 .modal .o_kanban_cover_container .o_kanban_cover_image {
-    height: 120px;
-    width: 120px;
+    img {
+        object-position: center 25%;
+        transform: scale(0.98);
+    }
+
+    &:hover, &.o_selected {
+        --border-color: #{$o-action};
+    }
+
+    &.o_selected {
+        &:after {
+            @include o-position-absolute(.5rem, .5rem);
+            overflow: hidden;
+            border-radius: 100%;
+            font: normal normal normal 1rem/0.87 FontAwesome;
+            color: $o-action;
+            backdrop-filter: brightness(100);
+            content: "\f058"; //fa-check-circle
+        }
+    }
 }

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
@@ -2,42 +2,50 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanCoverImageDialog">
-        <Dialog title.translate="Set a Cover Image" size="'lg'">
-            <div t-if="attachments.length" class="o_kanban_cover_container bg-100">
+        <Dialog title.translate="Set a Cover Image" size="'md'">
+            <div t-if="attachments.length" class="o_kanban_cover_container grid gap-3 gap-lg-2">
                 <t t-foreach="attachments" t-as="attachment" t-key="attachment.id">
-                    <div class="o_kanban_cover_image position-relative d-inline-block m-2 border bg-white o_cursor_pointer" t-att-class="{
-                        'o_selected border-primary': state.selectedAttachmentId === attachment.id,
-                    }">
+                    <div class="o_kanban_cover_image position-relative overflow-hidden g-col-6 g-col-md-4 g-col-lg-3 border bg-white w-auto cursor-pointer rounded ratio ratio-1x1"
+                         t-att-class="{
+                            'o_selected border-2': state.selectedAttachmentId === attachment.id
+                         }"
+                    >
                         <img t-attf-src="/web/image/{{attachment.id}}?unique=1"
-                            class="position-absolute start-0 end-0 top-0 bottom-0 mw-100 mh-100 m-auto"
+                            class="object-fit-cover h-100 w-100"
                             alt="Attachment"
-                            t-on-click="() => this.selectAttachment(attachment, false)"
-                            t-on-dblclick="() => this.selectAttachment(attachment, true)"
+                            t-on-click="() => this.selectAttachment(attachment, true)"
                         />
                     </div>
                 </t>
             </div>
             <t t-else="">There is no available image to be set as cover.</t>
             <t t-set-slot="footer" t-slot-scope="dialog">
-                <button t-if="attachments.length" class="btn btn-primary" t-on-click="setCover" t-att-disabled="!state.selectedAttachmentId">
-                    Select
-                </button>
                 <FileInput
                     autoOpen="!attachments.length"
                     acceptedFileExtensions="'image/*'"
                     onUpload.bind="onUpload"
                     resModel="props.record.resModel"
                     resId="props.record.resId">
-                        <button class="btn btn-primary w-auto" t-on-click="uploadImage">
-                            Upload and Set
+                        <button
+                            class="btn btn-primary"
+                            t-on-click="uploadImage"
+                        >
+                            <i class="fa fa-cloud-upload me-1" aria-hidden="true"/>
+                            Upload New
                         </button>
                 </FileInput>
-                <button t-if="hasCoverImage" class="btn btn-secondary" t-on-click="removeCover">
-                    Remove Cover Image
-                </button>
-                <button class="btn btn-secondary" t-on-click="dialog.close">
+                <button class="btn btn-secondary d-none d-md-inline-block" t-on-click="dialog.close">
                     Discard
                 </button>
+
+                <t t-if="hasCoverImage">
+                    <button
+                        t-if="hasCoverImage"
+                        class="btn btn-danger ms-auto" t-on-click="removeCover"
+                    >
+                        Remove Cover
+                    </button>
+                </t>
             </t>
         </Dialog>
     </t>

--- a/addons/web/static/src/views/view_hook.js
+++ b/addons/web/static/src/views/view_hook.js
@@ -208,6 +208,7 @@ export function useDeleteRecords(model) {
             cancelLabel: _t("No, keep it"),
             confirm,
             confirmLabel: _t("Delete"),
+            confirmClass: "btn-danger",
             title: _t("Bye-bye, record!"),
         };
     }

--- a/addons/web/static/src/webclient/actions/action_dialog.scss
+++ b/addons/web/static/src/webclient/actions/action_dialog.scss
@@ -1,7 +1,6 @@
 .modal.o_technical_modal {
     .modal-content {
         .modal-body.o_act_window {
-            padding: 0;
 
             @include media-breakpoint-down(md) {
                 .o_action {

--- a/addons/web/static/src/webclient/settings_form_view/settings_confirmation_dialog.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_confirmation_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.SettingsConfirmationDialog">
-        <Dialog size="'md'" title="props.title" modalRef="modalRef">
+        <Dialog size="'sm'" title="props.title" modalRef="modalRef">
             <t t-esc="props.body" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="_confirm">

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -1156,7 +1156,7 @@ test(`create and change events on desktop`, async () => {
     await contains(`.o_cw_popover_delete`).click();
     expect(`.modal-title`).toHaveText("Bye-bye, record!");
 
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect(`.o_event[data-event-id="4"]`).toHaveCount(0);
     expect(`.o_event`).toHaveCount(10);
 
@@ -1271,7 +1271,7 @@ test(`create and change events on mobile`, async () => {
     await contains(`.o_cw_popover_delete`).click();
     expect(`.modal-title`).toHaveText("Bye-bye, record!");
 
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect(`.o_event[data-event-id="4"]`).toHaveCount(0);
     expect(`.o_event`).toHaveCount(10);
 
@@ -1419,7 +1419,7 @@ test(`create event with timezone in week mode European locale`, async () => {
 
     await clickEvent(1);
     await contains(`.o_cw_popover_delete`).click();
-    await contains(`.modal button.btn-primary`).click();
+    await contains(`.modal button.btn-danger`).click();
     expect(`.fc-event-main`).toHaveCount(0);
 });
 
@@ -1763,7 +1763,7 @@ test(`create event with timezone in week mode American locale`, async () => {
     // delete record
     await clickEvent(1);
     await contains(`.o_cw_popover_delete`).click();
-    await contains(`.modal button.btn-primary`).click();
+    await contains(`.modal button.btn-danger`).click();
     expect(`.fc-event-main`).toHaveCount(0);
 });
 
@@ -5537,7 +5537,7 @@ test("calendar: popover is rendered as dialog in mobile", async () => {
 
     expect(".modal-footer .btn").toHaveCount(2);
     expect(".modal-footer .btn.btn-primary.o_cw_popover_edit").toHaveCount(1);
-    expect(".modal-footer .btn.btn-secondary.o_cw_popover_delete").toHaveCount(1);
+    expect(".modal-footer .btn.btn-danger.o_cw_popover_delete").toHaveCount(1);
 });
 
 test.tags("mobile");

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -1895,7 +1895,7 @@ test("properties: form view and falsy domain, properties are not empty", async (
     await animationFrame();
     await click(".o_field_property_definition_delete");
     await animationFrame();
-    await click(".modal-content .btn-primary");
+    await click(".modal-content .btn-danger");
     await animationFrame();
     expect(".o_test_properties_not_empty").toHaveCount(1);
 
@@ -1904,7 +1904,7 @@ test("properties: form view and falsy domain, properties are not empty", async (
     await animationFrame();
     await click(".o_field_property_definition_delete");
     await animationFrame();
-    await click(".modal-content .btn-primary");
+    await click(".modal-content .btn-danger");
     await animationFrame();
     expect(".o_test_properties_not_empty").toHaveCount(1);
 
@@ -1914,7 +1914,7 @@ test("properties: form view and falsy domain, properties are not empty", async (
     await animationFrame();
     await click(".o_field_property_definition_delete");
     await animationFrame();
-    await click(".modal-content .btn-primary");
+    await click(".modal-content .btn-danger");
     await animationFrame();
     expect(".o_test_properties_not_empty").toHaveCount(0);
 });

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -6179,7 +6179,7 @@ test(`deleting a record`, async () => {
     await toggleMenuItem("Delete");
     expect(`.modal`).toHaveCount(1);
 
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect(`.o_breadcrumb`).toHaveText("second record");
     expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
 });
@@ -6201,7 +6201,7 @@ test(`deleting a record on desktop`, async () => {
     await toggleActionMenu();
     await toggleMenuItem("Delete");
 
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect(getPagerValue()).toEqual([1]);
     expect(getPagerLimit()).toBe(2);
 });
@@ -6227,7 +6227,7 @@ test(`deleting the last record`, async () => {
     expect(`.modal`).toHaveCount(1);
     expect.verifySteps([]);
 
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect(`.modal`).toHaveCount(0);
     expect.verifySteps(["unlink", "history-back"]);
 });
@@ -6249,7 +6249,7 @@ test("delete the last record (without previous action)", async () => {
     await mountWithCleanup(WebClient);
     await toggleActionMenu();
     await toggleMenuItem("Delete");
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect.verifySteps(["__DEFAULT_ACTION__ called"]);
 });
 
@@ -9493,7 +9493,7 @@ test(`delete a duplicated record`, async () => {
     await toggleMenuItem("Delete");
     expect(`.modal`).toHaveCount(1);
 
-    await contains(`.modal-footer .btn-primary`).click();
+    await contains(`.modal-footer .btn-danger`).click();
     expect(`.o_field_widget`).toHaveText("first record");
     expect.verifySteps(["unlink"]);
 });
@@ -11799,7 +11799,7 @@ test(`prevent recreating a deleted record`, async () => {
     await contains(`.o-dropdown--menu .dropdown-item:contains(Delete)`).click();
     expect(`.modal`).toHaveCount(1);
 
-    await contains(`.modal-footer button.btn-primary`).click();
+    await contains(`.modal-footer button.btn-danger`).click();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(0);
 });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1,7 +1,6 @@
 import { after, beforeEach, expect, getFixture, resize, test } from "@odoo/hoot";
 import {
     click,
-    dblclick,
     drag,
     edit,
     hover,
@@ -6105,7 +6104,7 @@ test(`kanban should ask to scroll to top on page changes (mobile)`, async () => 
 
 test.tags("desktop");
 test("set cover image", async () => {
-    expect.assertions(9);
+    expect.assertions(8);
 
     IrAttachment._records = [
         {
@@ -6171,8 +6170,8 @@ test("set cover image", async () => {
         message: "Initially there is no image.",
     });
 
+    // The image is immediately assigned on click
     await contains(".modal .o_kanban_cover_image img").click();
-    await contains(".modal .btn-primary:first-child").click();
 
     expect('img[data-src*="/web/image/1"]').toHaveCount(1);
 
@@ -6182,11 +6181,10 @@ test("set cover image", async () => {
     await contains(coverButton).click();
 
     expect(".modal .o_kanban_cover_image").toHaveCount(1);
-    expect(".modal .btn:contains(Select)").toHaveCount(1);
     expect(".modal .btn:contains(Discard)").toHaveCount(1);
-    expect(".modal .btn:contains(Remove Cover Image)").toHaveCount(0);
+    expect(".modal .btn:contains(Remove Cover)").toHaveCount(0);
 
-    await dblclick(".modal .o_kanban_cover_image img"); // doesn't work
+    await contains(".modal .o_kanban_cover_image img").click(); // Assign the image as cover in one click
     await animationFrame();
 
     expect('img[data-src*="/web/image/2"]').toHaveCount(1);
@@ -6314,11 +6312,10 @@ test("unset cover image", async () => {
     ).toHaveCount(1);
 
     expect(".modal .o_kanban_cover_image").toHaveCount(1);
-    expect(".modal .btn:contains(Select)").toHaveCount(1);
     expect(".modal .btn:contains(Discard)").toHaveCount(1);
-    expect(".modal .btn:contains(Remove Cover Image)").toHaveCount(1);
+    expect(".modal .btn:contains(Remove Cover)").toHaveCount(1);
 
-    await contains(".modal .btn-secondary").click(); // click on "Remove Cover Image" button
+    await contains(".modal .btn-danger").click(); // click on "Remove Cover" button
 
     expect(queryAll("img", { root: getKanbanRecord({ index: 0 }) })).toHaveCount(0, {
         message: "The cover image should be removed.",
@@ -6329,7 +6326,7 @@ test("unset cover image", async () => {
     expect(queryText(coverButton)).toBe("Set Cover Image");
     await contains(coverButton).click();
 
-    await dblclick(".modal .o_kanban_cover_image img"); // doesn't work
+    await contains(".modal .o_kanban_cover_image img").click(); // Assign the image as cover in one click
     await animationFrame();
 
     expect(queryAll("img", { root: getKanbanRecord({ index: 1 }) })).toHaveCount(0, {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1382,7 +1382,7 @@ test("pager, ungrouped, deleting all records from last page", async () => {
     await contains(".o_kanban_record a").click();
 
     expect(".o_dialog").toHaveCount(1);
-    await contains(".o_dialog footer .btn-primary").click();
+    await contains(".o_dialog footer .btn-danger").click();
 
     expect(getPagerValue()).toEqual([1, 3]);
     expect(getPagerLimit()).toBe(3);
@@ -1453,7 +1453,7 @@ test("click on a button type='delete' to delete a record in a column", async () 
     await animationFrame();
     expect(".modal").toHaveCount(1);
 
-    await contains(".modal .btn-primary").click();
+    await contains(".modal .btn-danger").click();
 
     expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(1);
     expect(queryAll(".o_kanban_load_more", { root: getKanbanColumn(0) })).toHaveCount(0);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2797,7 +2797,7 @@ test(`enabling delete in list when groupby m2m field`, async () => {
     });
 
     await toggleMenuItem("Delete"); // toggle delete action
-    await contains(`.modal-footer .btn-primary`).click(); // confirm the delete action
+    await contains(`.modal-footer .btn-danger`).click(); // confirm the delete action
     // check that after delete the record is deleted in both 2nd and 3rd groups
     expect(`.o_data_row`).toHaveCount(3, {
         message: "record should be deleted from both the groups",
@@ -2838,7 +2838,7 @@ test(`enabling delete in list when groupby m2m field and multi selecting the sam
     await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
 
     await toggleMenuItem("Delete"); // toggle delete action
-    await contains(`.modal-footer .btn-primary`).click(); // confirm the delete action
+    await contains(`.modal-footer .btn-danger`).click(); // confirm the delete action
     // check that after delete the record is deleted in both 2nd and 3rd groups
     expect(`.o_data_row`).toHaveCount(3, {
         message: "record should be deleted from both the groups",
@@ -4815,7 +4815,7 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
     expect(`.o_data_row_selected`).toHaveCount(3);
     await toggleActionMenu();
     await toggleMenuItem("Delete");
-    await contains(`.o_dialog footer .btn-primary`).click(); // confirm
+    await contains(`.o_dialog footer .btn-danger`).click(); // confirm
     expect(`.o_data_row`).toHaveCount(0);
     expect(`.o_group_header:last`).toHaveText("Yes 0 0.00", { inline: true });
 });
@@ -5615,7 +5615,7 @@ test(`deleting one record and verify context key`, async () => {
         message: "body should have modal-open class",
     });
 
-    await contains(`.modal footer button.btn-primary`).click();
+    await contains(`.modal footer button.btn-danger`).click();
     expect.verifySteps(["unlink"]);
     expect(`tbody td.o_field_cell`).toHaveCount(3, { message: "should have 3 records" });
 });
@@ -5675,7 +5675,7 @@ test(`deleting record which throws UserError should close confirmation dialog`, 
 
     expect.errors(1);
 
-    await contains(`.modal footer button.btn-primary`).click();
+    await contains(`.modal footer button.btn-danger`).click();
     await waitFor(".modal .modal-title:contains(Invalid Operation)");
 
     expect.verifyErrors(["Odoo Server Error"]);
@@ -5715,7 +5715,7 @@ test(`delete all records matching the domain`, async () => {
     await toggleMenuItem("Delete");
     expect(`.modal`).toHaveCount(1, { message: "a confirm modal should be displayed" });
 
-    await contains(`.modal footer button.btn-primary`).click();
+    await contains(`.modal footer button.btn-danger`).click();
     expect.verifySteps(["unlink"]);
 });
 
@@ -5758,7 +5758,7 @@ test(`delete all records matching the domain (limit reached)`, async () => {
     await toggleMenuItem("Delete");
     expect(`.modal`).toHaveCount(1, { message: "a confirm modal should be displayed" });
 
-    await contains(`.modal footer button.btn-primary`).click();
+    await contains(`.modal footer button.btn-danger`).click();
     expect.verifySteps(["unlink", "notify"]);
 });
 
@@ -6117,7 +6117,7 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
     await clickRecordSelector();
     await toggleActionMenu();
     await toggleMenuItem("Delete");
-    await contains(`.modal .btn-primary`).click();
+    await contains(`.modal .btn-danger`).click();
     expect(`.o_group_header:eq(0)`).toHaveText("blip 5", { inline: true });
     expect(`.o_group_header:eq(2)`).toHaveText("Yes 3", { inline: true });
 });
@@ -6145,7 +6145,7 @@ test(`grouped list, reload aggregates when a record is deleted`, async () => {
     await clickRecordSelector();
     await toggleActionMenu();
     await toggleMenuItem("Delete");
-    await contains(`.modal-footer .btn-primary`).click();
+    await contains(`.modal-footer .btn-danger`).click();
     expect(".o_group_header .o_list_number").toHaveText("1,000");
 });
 
@@ -7661,7 +7661,7 @@ test(`non empty editable list with sample data: delete all records`, async () =>
     await contains(`thead .o_list_record_selector input`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Delete");
-    await contains(`.modal-footer .btn-primary`).click();
+    await contains(`.modal-footer .btn-danger`).click();
 
     // Final state: no more sample data, but nocontent helper displayed
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
@@ -7744,7 +7744,7 @@ test(`empty editable list with sample data: create and delete record`, async () 
     await contains(`.o_data_row input`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Delete");
-    await contains(`.modal-footer .btn-primary`).click();
+    await contains(`.modal-footer .btn-danger`).click();
 
     // Final state: there should be no table, but the no content helper
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
@@ -12856,7 +12856,7 @@ test(`list view move to previous page when all records from last page deleted`, 
 
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.o-dropdown--menu .o_menu_item:contains(Delete)`).click();
-    await contains(`.modal button.btn-primary`).click();
+    await contains(`.modal button.btn-danger`).click();
     expect(getPagerValue()).toEqual([1, 3]);
     expect(getPagerLimit()).toBe(3);
     expect.verifySteps([
@@ -12899,7 +12899,7 @@ test(`grouped list view move to previous page of group when all records from las
     await contains(`.o_data_row .o_list_record_selector input`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
-    await contains(`.modal .btn-primary`).click();
+    await contains(`.modal .btn-danger`).click();
     expect(`th.o_group_name:eq(0) .o_pager:visible`).toHaveCount(0);
     expect(`.o_data_row`).toHaveCount(2);
 });
@@ -12940,7 +12940,7 @@ test(`grouped list view move to previous page of group when all records from las
     await contains(`.o_data_row .o_list_record_selector input`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
-    await contains(`.modal .btn-primary`).click();
+    await contains(`.modal .btn-danger`).click();
     expect(`th.o_group_name:eq(0) .o_pager_counter`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(2);
 });
@@ -12974,7 +12974,7 @@ test(`grouped list view move to next page when all records from the current page
     await contains(`thead .o_list_record_selector input`).click();
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
-    await contains(`.modal .btn-primary`).click();
+    await contains(`.modal .btn-danger`).click();
     expect(`.o_group_header:eq(0) .o_group_name`).toHaveText(`Value 1 1-2 / 4`, {
         inline: true,
     });

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -729,7 +729,7 @@ test("A new form view can be reloaded after a failed one", async () => {
     await contains(".o_cp_action_menus .fa-cog").click();
     await contains(".o_menu_item:contains(Delete)").click();
     expect(".modal").toHaveCount(1, { message: "a confirm modal should be displayed" });
-    await contains(".modal-footer button.btn-primary").click();
+    await contains(".modal-footer button.btn-danger").click();
     // The form view is automatically switched to the next record
     expect(".o_last_breadcrumb_item").toHaveText("Second record");
     expect(browser.location.pathname).toBe("/odoo/action-3/2");
@@ -2735,7 +2735,7 @@ test("click on breadcrumb of a deleted record", async () => {
     expect(".o_dialog").toHaveCount(1);
 
     // confirm
-    await contains(".o_dialog .modal-footer .btn-primary").click();
+    await contains(".o_dialog .modal-footer .btn-danger").click();
 
     expect(".o_form_view").toHaveCount(1);
     expect(queryAllTexts(".breadcrumb-item")).toEqual(["", "First record", "Partners"]);

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -460,8 +460,8 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
     });
     const expectedModalHtml = /* xml */ `
         <header class="modal-header">
-            <h4 class="modal-title text-break flex-grow-1">Oops!</h4>
-            <button type="button" class="btn-close position-absolute top-0 end-0 mt-1 me-1" aria-label="Close" tabindex="-1" data-available-offline=""></button>
+            <h4 class="modal-title text-wrap text-break fs-3 flex-grow-1">Oops!</h4>
+            <button type="button" class="btn-close position-sm-absolute top-0 end-0" title="Close" aria-label="Close" tabindex="-1" data-available-offline=""></button>
         </header>
         <main class="modal-body">
             <div role="alert">
@@ -481,7 +481,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
                 </details>
             </div>
         </main>
-        <footer class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
+        <footer class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-2 w-100">
             <button class="btn btn-primary o-default-button" data-available-offline="">Close</button>
         </footer>`
         .trim()

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -77,7 +77,7 @@
         </CheckBox>
 
         <t t-set-slot="footer">
-            <button class="btn btn-primary" t-on-click="() => this.onClickDelete()"  t-att-disabled="!this.state.confirm">
+            <button class="btn btn-danger" t-on-click="() => this.onClickDelete()"  t-att-disabled="!this.state.confirm">
                 Delete
             </button>
             <button class="btn btn-secondary" t-on-click="() => this.props.close()">

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -144,7 +144,7 @@ const deleteSelectedPage = [
     },
     {
         content: "Click on OK",
-        trigger: ".modal-content footer button.btn-primary:not([disabled])",
+        trigger: ".modal-content footer button.btn-danger:not([disabled])",
         run: "click",
     },
 ];

--- a/odoo/addons/base/wizard/base_module_update_views.xml
+++ b/odoo/addons/base/wizard/base_module_update_views.xml
@@ -34,6 +34,7 @@
             <field name="res_model">base.module.update</field>
             <field name="view_mode">form</field>
             <field name="target">new</field>
+            <field name="context">{'dialog_size': 'small'}</field>
         </record>
 
         <menuitem


### PR DESCRIPTION
Requires:
- https://github.com/odoo/enterprise/pull/101466

---

This PR reviews the overall visual result of dialogs in different circumstances and assigns the desired size to specific dialogs accordingly.

<details><summary>Details</summary>
<p>

1. Increase the 'small' and 'medium' sizes to accommodate more content.

2. For 'small' dialogs specifically, increase padding and adapt elements
   to make the dialog more prominent. These changes have no effect on
   'medium' size version (and up).
   
3. Rework the `withBodyPadding` prop behavior. Rather than applying a
   `p-0` class that comes with an `!important` flag, the prop now
   toggles between `o_modal_no_body_padding` and `o_modal_body_padding`
   classes on a parent element. This change allows inner components
   awareness of the context where they will be rendered while easing
   customization. Indeed, you may not want the default padding while
   still being able to define one. `p-0` prevented that.
   
4. Reduce backdrop opacity and remove the blur effect.
   Blur was initially introduced for any stacking level, but has
   been recently removed from the bottomSheet. Removing it for dialogs
   as well for consistency.
   
5. Mobile: ensure that footer buttons are aligned in one column by
   default to avoid cropped labels/awkward layouts.
   
6. Address an issue in the formView where CSS variable fallback
   values were incorrectly set, invalidating contextual adaptations.
   
7. For "Remove" operations, set the default button color to "danger".

8. Improve "Expand" button contrast when hovered.

----


</p>
</details> 

It also totally redesign the kanban "Set cover Image" dialog and adapts custom dialogs in order to avoid undesired side-effects.

task-5159944

| master | this pr |
|--------|--------|
| <img width="2124" height="1534" alt="image" src="https://github.com/user-attachments/assets/ae69994c-1568-4c28-bb5c-0119445945c9" /> | <img width="2124" height="1534" alt="image" src="https://github.com/user-attachments/assets/92134247-28bb-403b-af3b-42ba0ac45698" /> |
| <img width="2124" height="1534" alt="image" src="https://github.com/user-attachments/assets/800da171-cd1c-48bc-82c5-e75b1528fde8" /> | <img width="2124" height="1534" alt="image" src="https://github.com/user-attachments/assets/7a514edb-0e92-4aea-a17d-4d53c49f4d29" /> |
| <img width="2124" height="1534" alt="image" src="https://github.com/user-attachments/assets/1bbfc107-df7e-4a30-a89e-3eb703ac3061" /> | <img width="2124" height="1534" alt="image" src="https://github.com/user-attachments/assets/1b580774-9230-4f14-9714-12a7f382df44" /> |
| <img width="1148" height="800" alt="image" src="https://github.com/user-attachments/assets/2a6dfcb8-209a-4dc5-80d9-e3a3884fbdfe" /> | <img width="1147" height="800" alt="image" src="https://github.com/user-attachments/assets/ab76f1c5-3674-4526-9dbb-c5fed880f623" /> |
| <img width="374" height="615" alt="image" src="https://github.com/user-attachments/assets/e3007676-15d0-41a9-88ef-0fde235836bc" /> | <img width="371" height="613" alt="image" src="https://github.com/user-attachments/assets/cca47c81-29cc-401c-98ba-82ea1ccec3d1" /> | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
