### PR TITLE
[FIX] html_editor: banner insertion should not remove next block

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -137,10 +137,6 @@ export class BannerPlugin extends Plugin {
         this.dependencies.selection.setCursorEnd(
             bannerElement.querySelector(`.o_editor_banner_content > ${baseContainer.tagName}`)
         );
-        // Remove the old element.
-        if (bannerElement.nextSibling?.nodeName === blockEl.nodeName) {
-            bannerElement.nextSibling.remove();
-        }
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -283,3 +283,19 @@ test("should move heading element inside the banner, with paragraph element afte
             </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
     );
 });
+
+test("Inserting a banner should not remove the next sibling block", async () => {
+    const { el, editor } = await setupEditor("<p><br>[]</p><p>b</p>");
+    await insertText(editor, "/banner");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Info");
+    await press("enter");
+    expect(getContent(el)).toBe(
+        `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                    <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+                </div>
+            </div><p>b</p>`
+    );
+});


### PR DESCRIPTION
Steps to reproduce:
- Add a sentence.
- Insert a paragraph above it.
- Insert a banner.
- The sentence disappears.

**Description of the issue:**
- When the banner is inserted, the block that comes after it is removed unintentionally.

Cause:

- During banner insertion, the banner replaces an existing block. After insertion, the code checks whether the banner’s next sibling has the same node name as the old block and removes it. However, the old block has already been removed during the insert process, so this check ends up matching the actual next sibling and removed the wrong block.

Solution:

- Remove the code that deletes the banner’s next sibling, as it is responsible for removing the wrong block.

task-5384531
