### PR TITLE
[IMP] mail: improve channel access UI

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -415,6 +415,16 @@ class DiscussChannel(models.Model):
                 fields.Datetime.now() if channel.livechat_status == "need_help" else None
             )
 
+    def _compute_visibility_policy(self):
+        livechats = self.filtered(lambda c: c.channel_type == "livechat")
+        livechats.filtered(lambda c: not c.visibility_policy).visibility_policy = "member"
+        super(DiscussChannel, self - livechats)._compute_visibility_policy()
+
+    def _compute_membership_policy(self):
+        livechats = self.filtered(lambda c: c.channel_type == "livechat")
+        livechats.filtered(lambda c: not c.membership_policy).membership_policy = "invite"
+        super(DiscussChannel, self - livechats)._compute_membership_policy()
+
     def _sync_field_names(self, res):
         super()._sync_field_names(res)
         res[None].attr("livechat_end_dt", predicate=is_livechat_channel)

--- a/addons/im_livechat/tests/test_member_history.py
+++ b/addons/im_livechat/tests/test_member_history.py
@@ -118,7 +118,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
 
     def test_can_only_create_history_for_livechats(self):
         john = self._create_operator("fr_FR")
-        channel = self.env["discuss.channel"]._create_channel(name="General", group_id=None)
+        channel = self.env["discuss.channel"]._create_channel(name="General")
         member = channel.add_members(partner_ids=john.partner_id.ids)
         with self.assertRaises(ValidationError):
             self.env["im_livechat.channel.member.history"].create({"member_id": member.id}).channel_id

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -78,10 +78,7 @@ class DiscussChannelWebclientController(WebclientController):
                 params["partners_to"],
             )
         if name == "/discuss/create_channel":
-            resolve_channel = request.env["discuss.channel"]._create_channel(
-                params["name"],
-                params["group_id"],
-            )
+            resolve_channel = request.env["discuss.channel"]._create_channel(params["name"])
         if name == "/discuss/create_group":
             resolve_channel = request.env["discuss.channel"]._create_group(
                 params["partners_to"],

--- a/addons/mail/data/discuss_channel_data.xml
+++ b/addons/mail/data/discuss_channel_data.xml
@@ -5,12 +5,16 @@
         <record model="discuss.channel" id="mail.channel_all_employees">
             <field name="name">general</field>
             <field name="description">General announcements for all employees.</field>
+            <field name="membership_policy">open</field>
+            <field name="visibility_policy">group</field>
         </record>
 
         <record model="discuss.channel" id="mail.channel_admin">
             <field name="name">Administrators</field>
             <field name="description">General channel for administrators.</field>
             <field name="group_public_id" ref="base.group_system"/>
+            <field name="membership_policy">open</field>
+            <field name="visibility_policy">group</field>
         </record>
 
         <!-- notify all employees of module installation -->

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -69,6 +69,32 @@ class DiscussChannel(models.Model):
     active = fields.Boolean(default=True, help="Set active to false to hide the channel without removing it.")
     can_join = fields.Boolean("Can Join", compute="_compute_can_join")
     can_leave = fields.Boolean("Can Leave", compute="_compute_can_leave")
+    visibility_policy = fields.Selection(
+        compute="_compute_visibility_policy",
+        help="Determine who can see this channel",
+        recursive=True,
+        string="Visibility Policy",
+        store=True,
+        selection=[
+            ("member", "Members"),
+            ("member_and_group", "Members belonging to the authorized group"),
+            ("internal", "All internal Users"),
+            ("group", "Users from the authorized group"),
+            ("public", "Anyone with the link"),
+        ],
+    )
+    membership_policy = fields.Selection(
+        compute="_compute_membership_policy",
+        help="Determine how users can join this channel",
+        recursive=True,
+        string="Membership Policy",
+        store=True,
+        selection=[
+            ("blocked", "No one"),
+            ("invite", "By invitation"),
+            ("open", "Anyone who can view the channel"),
+        ],
+    )
     channel_type = fields.Selection([
         ('chat', 'Chat'),
         ('channel', 'Channel'),
@@ -130,12 +156,9 @@ class DiscussChannel(models.Model):
         'UNIQUE(uuid)',
         'The channel UUID must be unique',
     )
-    _group_public_id_check = models.Constraint(
-        "CHECK (channel_type = 'channel' OR group_public_id IS NULL)",
-        'Group authorization and group auto-subscription are only supported on channels.',
-    )
 
     # CONSTRAINTS
+
     @api.constrains("from_message_id")
     def _constraint_from_message_id(self):
         # sudo: discuss.channel - skipping ACL for constraint, more performant and no sensitive information is leaked
@@ -178,14 +201,37 @@ class DiscussChannel(models.Model):
             if len(ch.channel_member_ids) > 2:
                 raise ValidationError(_("A channel of type 'chat' cannot have more than two users."))
 
-    @api.constrains('group_public_id', 'group_ids')
+    @api.constrains("group_ids")
     def _constraint_group_id_channel(self):
         # sudo: discuss.channel - skipping ACL for constraint, more performant and no sensitive information is leaked
-        failing_channels = self.sudo().filtered(lambda channel: channel.channel_type != 'channel' and (channel.group_public_id or channel.group_ids))
+        failing_channels = self.sudo().filtered(lambda channel: channel.channel_type != 'channel' and channel.group_ids)
         if failing_channels:
-            raise ValidationError(_("For %(channels)s, channel_type should be 'channel' to have the group-based authorization or group auto-subscription.", channels=', '.join([ch.name for ch in failing_channels])))
+            raise ValidationError(
+                self.env._(
+                    "For %(channels)s, channel_type should be 'channel' to have group auto-subscription.",
+                    channels=", ".join([ch.name for ch in failing_channels]),
+                ),
+            )
 
     # COMPUTE / INVERSE
+
+    @api.depends("parent_channel_id.visibility_policy", "visibility_policy")
+    def _compute_visibility_policy(self):
+        for channel in self.filtered(lambda c: not c.visibility_policy):
+            if channel.parent_channel_id:
+                channel.visibility_policy = channel.parent_channel_id.visibility_policy
+            else:
+                channel.visibility_policy = "member"
+
+    @api.depends("channel_type", "membership_policy", "parent_channel_id.membership_policy")
+    def _compute_membership_policy(self):
+        for channel in self.filtered(lambda c: not c.membership_policy):
+            if channel.parent_channel_id:
+                channel.membership_policy = channel.parent_channel_id.membership_policy
+                continue
+            channel.membership_policy = (
+                "invite" if channel.channel_type in ("channel", "group") else "blocked"
+            )
 
     @api.depends("channel_name_member_ids", "name")
     def _compute_display_name(self):
@@ -372,15 +418,16 @@ class DiscussChannel(models.Model):
         for channel in self:
             channel.message_count = message_count_by_channel_id.get(channel.id, 0)
 
-    @api.depends("channel_type", "parent_channel_id.group_public_id")
+    @api.depends("parent_channel_id.group_public_id", "visibility_policy")
     def _compute_group_public_id(self):
-        channels = self.filtered(lambda channel: channel.channel_type == "channel")
-        for channel in channels:
+        for channel in self:
             if channel.parent_channel_id:
                 channel.group_public_id = channel.parent_channel_id.group_public_id
-            elif not channel.group_public_id:
+                continue
+            if channel.visibility_policy == "internal":
                 channel.group_public_id = self.env.ref("base.group_user")
-        (self - channels).group_public_id = None
+            elif channel.visibility_policy not in ("group", "member_and_group"):
+                channel.group_public_id = None
 
     @api.depends('uuid')
     def _compute_invitation_url(self):
@@ -1396,21 +1443,20 @@ class DiscussChannel(models.Model):
         return Store().add(self, "_store_open_chat_window_fields").get_client_action()
 
     @api.model
-    def _create_channel(self, name, group_id):
-        """ Create a channel and add the current partner, broadcast it (to make the user directly
-            listen to it when polling)
-            :param name : the name of the channel to create
-            :param group_id : the group allowed to join the channel.
-            :return dict : channel header
+    def _create_channel(self, name, *, visibility_policy=None, membership_policy=None):
+        """Create a channel and add the current partner as a member.
+
+        :param name : the name of the channel to create
+        :param visibility_policy: The visibility policy of the channel.
+        :param membership_policy: The membership_policy of the channel.
+        :returns: The newly created discuss channel recordset.
+
         """
-        # create the channel
-        vals = {
-            'channel_type': 'channel',
-            'name': name,
-        }
-        new_channel = self.create(vals)
-        group = self.env['res.groups'].search([('id', '=', group_id)]) if group_id else None
-        new_channel.group_public_id = group.id if group else None
+        new_channel = self.create({"channel_type": "channel", "name": name})
+        if visibility_policy:
+            new_channel.visibility_policy = visibility_policy
+        if membership_policy:
+            new_channel.membership_policy = membership_policy
         notification = Markup('<div class="o_mail_notification">%s</div>') % _("created this channel.")
         new_channel.message_post(body=notification, message_type="notification", subtype_xmlid="mail.mt_comment")
         return new_channel

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -1,32 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
         <record id="ir_rule_discuss_channel_all" model="ir.rule">
-            <field name="name">discuss.channel: can access channels (as member or as group allowed)</field>
+            <field name="name">discuss.channel: can access channels (group allowed and access mode matching)</field>
             <field name="model_id" ref="mail.model_discuss_channel"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
                     "|",
-                        "&amp;",
-                            ("channel_type", "!=", "channel"),
-                            "|",
-                                ("is_member", "=", True),
-                                ("parent_channel_id.is_member", "=", True),
-                        "&amp;",
-                            ("channel_type", "=", "channel"),
-                            "|",
-                                ("group_public_id", "=", False),
-                                ("group_public_id", "in", user.all_group_ids.ids),
+                        ("group_public_id", "=", False),
+                        ("group_public_id", "in", user.all_group_ids.ids),
+                    "|",
+                        ("visibility_policy", "not in", ("member", "member_and_group")),
+                        "|",
+                            ("is_member", "=", True),
+                            ("parent_channel_id.is_member", "=", True)
                 ]
             </field>
         </record>
-
         <record id="ir_rule_discuss_channel_group_system" model="ir.rule">
             <field name="name">discuss.channel: admin full access</field>
             <field name="model_id" ref="mail.model_discuss_channel"/>
@@ -37,21 +27,13 @@
         <record id="ir_rule_discuss_channel_member_is_self_all" model="ir.rule">
             <field name="name">discuss.channel.member: access their own entries</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
-                    ('is_self', '=', True),
+                    ("is_self", "=", True),
                     "|",
-                        ("channel_id.channel_type", "!=", "channel"),
-                        "|",
-                            ("channel_id.group_public_id", "=", False),
-                            ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                        ("channel_id.group_public_id", "=", False),
+                        ("channel_id.group_public_id", "in", user.all_group_ids.ids),
                 ]
             </field>
             <!--
@@ -69,26 +51,17 @@
         <record id="ir_rule_discuss_channel_member_read_all" model="ir.rule">
             <field name="name">discuss.channel.member: read members of accessible channels</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
                     "|",
-                        "&amp;",
-                            ("channel_id.channel_type", "!=", "channel"),
-                            "|",
-                                ("channel_id.is_member", "=", True),
-                                ("channel_id.parent_channel_id.is_member", "=", True),
-                        "&amp;",
-                            ("channel_id.channel_type", "=", "channel"),
-                            "|",
-                                ("channel_id.group_public_id", "=", False),
-                                ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                        ("channel_id.group_public_id", "=", False),
+                        ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                    "|",
+                        ("channel_id.visibility_policy", "not in", ("member", "member_and_group")),
+                        "|",
+                            ("channel_id.is_member", "=", True),
+                            ("channel_id.parent_channel_id.is_member", "=", True)
                 ]
             </field>
             <field name="perm_create" eval="False"/>
@@ -99,13 +72,7 @@
         <record id="ir_rule_discuss_channel_member_is_channel_owner_unlink" model="ir.rule">
             <field name="name">discuss.channel.member: channel owner can remove members except owners</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
                     ("channel_id.self_member_id.channel_role", "=", "owner"),
@@ -122,13 +89,7 @@
         <record id="ir_rule_discuss_channel_member_is_channel_admin_unlink" model="ir.rule">
             <field name="name">discuss.channel.member: channel admin can remove members except admins and owners</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
                     ("channel_id.self_member_id.channel_role", "=", "admin"),
@@ -143,60 +104,42 @@
             <field name="perm_write" eval="False"/>
         </record>
         <record id="ir_rule_discuss_channel_member_create_is_group_matching_all" model="ir.rule">
-            <field name="name">discuss.channel.member: can join group restricted channels when group is matching</field>
+            <field name="name">discuss.channel.member: can join open accessible channels</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
-                    ('is_self', '=', True),
-                    ('channel_id.channel_type', '=', 'channel'),
-                    '|',
-                        ('channel_id.group_public_id', '=', False),
-                        ('channel_id.group_public_id', 'in', user.all_group_ids.ids)
+                    ("is_self", "=", True),
+                    ("channel_id.membership_policy", "=", "open"),
+                    "|",
+                        ("channel_id.group_public_id", "=", False),
+                        ("channel_id.group_public_id", "in", user.all_group_ids.ids),
                 ]
             </field>
-            <!--
-                This is the only case where the current user can join themselves (is_self = True) when the channel
-                is already created, in all other cases they must be invited by someone else.
-            -->
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="False"/>
             <field name="perm_unlink" eval="False"/>
         </record>
 
         <record id="ir_rule_discuss_channel_member_create_is_group_matching_group_user" model="ir.rule">
-            <field name="name">discuss.channel.member: internal users can invite others in group restricted channels when group is matching</field>
+            <field name="name">discuss.channel.member: internal users can invite others in accessible channels matching membership policy</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
             <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
             <field name="domain_force">
                 [
-                    ('is_self', '=', False),
-                    ('channel_id.channel_type', '=', 'channel'),
-                    '|',
-                        ('channel_id.group_public_id', '=', False),
-                        ('channel_id.group_public_id', 'in', user.all_group_ids.ids)
-                ]
-            </field>
-            <field name="perm_read" eval="False"/>
-            <field name="perm_write" eval="False"/>
-            <field name="perm_unlink" eval="False"/>
-        </record>
-
-        <record id="ir_rule_discuss_channel_member_create_is_member_group_user" model="ir.rule">
-            <field name="name">discuss.channel.member: internal users can invite others in channels they are member of</field>
-            <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
-            <field name="domain_force">
-                [
-                    ('is_self', '=', False),
-                    ('channel_id.channel_type', 'not in', ('channel', 'chat')),
-                    ('channel_id.is_member', '=', True)
+                    ("is_self", "=", False),
+                    ("channel_id.membership_policy", "!=", "blocked"),
+                    "|",
+                        ("channel_id.group_public_id", "=", False),
+                        ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                    "|",
+                        ("channel_id.visibility_policy", "not in", ("member", "member_and_group")),
+                        "|",
+                            ("channel_id.is_member", "=", True),
+                            ("channel_id.parent_channel_id.is_member", "=", True),
+                    "|",
+                        ("channel_id.membership_policy", "!=", "invite"),
+                        ("channel_id.is_member", "=", True),
                 ]
             </field>
             <!--
@@ -211,26 +154,17 @@
         <record id="ir_rule_discuss_call_history_read_all" model="ir.rule">
             <field name="name">discuss.call.history: read call history of accessible channels</field>
             <field name="model_id" ref="mail.model_discuss_call_history"/>
-            <field name="groups"
-                eval="[
-                    Command.link(ref('base.group_user')),
-                    Command.link(ref('base.group_portal')),
-                    Command.link(ref('base.group_public')),
-                ]"
-            />
+            <field name="groups" eval="[Command.link(ref('base.group_everyone'))]"/>
             <field name="domain_force">
                 [
                     "|",
-                        "&amp;",
-                            ("channel_id.channel_type", "!=", "channel"),
-                            "|",
-                                ("channel_id.is_member", "=", True),
-                                ("channel_id.parent_channel_id.is_member", "=", True),
-                        "&amp;",
-                            ("channel_id.channel_type", "=", "channel"),
-                            "|",
-                                ("channel_id.group_public_id", "=", False),
-                                ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                        ("channel_id.group_public_id", "=", False),
+                        ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                    "|",
+                        ("channel_id.visibility_policy", "not in", ("member", "member_and_group")),
+                        "|",
+                            ("channel_id.is_member", "=", True),
+                            ("channel_id.parent_channel_id.is_member", "=", True)
                 ]
             </field>
             <field name="perm_create" eval="False"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -124,7 +124,7 @@ commandSetupRegistry.add("@", {
 async function makeNewChannel(name, store) {
     const { channel } = await store.fetchStoreData(
         "/discuss/create_channel",
-        { name, group_id: store.internalUserGroupId },
+        { name },
         { readonly: false, requestData: true }
     );
     channel.open({ focus: true, bypassCompact: true });

--- a/addons/mail/tests/discuss/test_discuss_binary_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_binary_controller.py
@@ -12,7 +12,8 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
             {"name": "Private Channel", "channel_type": "group"}
         )
         cls.public_channel = cls.env["discuss.channel"]._create_channel(
-            name="Public Channel", group_id=None
+            name="Public Channel",
+            visibility_policy="public",
         )
         cls.users = (
             cls.user_public + cls.user_portal + cls.user_employee + cls.user_admin

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from itertools import product
 from psycopg2.errors import UniqueViolation
 
 from odoo.addons.mail.tests.common import mail_new_test_user
@@ -12,253 +13,177 @@ class TestDiscussChannelAccess(MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._channel_type_channel_access_cases = [
-            ("public", "no_group", "member", "read", True),
-            ("public", "no_group", "member", "write", False),
-            ("public", "no_group", "member", "unlink", False),
-            ("public", "no_group", "outside", "create", False),
-            ("public", "no_group", "outside", "read", True),
-            ("public", "no_group", "outside", "write", False),
-            ("public", "no_group", "outside", "unlink", False),
-            ("public", "group_matching", "member", "read", True),
-            ("public", "group_matching", "member", "write", False),
-            ("public", "group_matching", "member", "unlink", False),
-            ("public", "group_matching", "outside", "create", False),
-            ("public", "group_matching", "outside", "read", True),
-            ("public", "group_matching", "outside", "write", False),
-            ("public", "group_matching", "outside", "unlink", False),
-            ("public", "group_failing", "member", "read", False),
-            ("public", "group_failing", "member", "write", False),
-            ("public", "group_failing", "member", "unlink", False),
-            ("public", "group_failing", "outside", "create", False),
-            ("public", "group_failing", "outside", "read", False),
-            ("public", "group_failing", "outside", "write", False),
-            ("public", "group_failing", "outside", "unlink", False),
-            ("portal", "no_group", "member", "read", True),
-            ("portal", "no_group", "member", "write", False),
-            ("portal", "no_group", "member", "unlink", False),
-            ("portal", "no_group", "outside", "create", False),
-            ("portal", "no_group", "outside", "read", True),
-            ("portal", "no_group", "outside", "write", False),
-            ("portal", "no_group", "outside", "unlink", False),
-            ("portal", "group_matching", "member", "read", True),
-            ("portal", "group_matching", "member", "write", False),
-            ("portal", "group_matching", "member", "unlink", False),
-            ("portal", "group_matching", "outside", "create", False),
-            ("portal", "group_matching", "outside", "read", True),
-            ("portal", "group_matching", "outside", "write", False),
-            ("portal", "group_matching", "outside", "unlink", False),
-            ("portal", "group_failing", "member", "read", False),
-            ("portal", "group_failing", "member", "write", False),
-            ("portal", "group_failing", "member", "unlink", False),
-            ("portal", "group_failing", "outside", "create", False),
-            ("portal", "group_failing", "outside", "read", False),
-            ("portal", "group_failing", "outside", "write", False),
-            ("portal", "group_failing", "outside", "unlink", False),
-            ("user", "no_group", "member", "read", True),
-            ("user", "no_group", "member", "write", True),
-            ("user", "no_group", "member", "unlink", False),
-            ("user", "no_group", "outside", "create", True),
-            ("user", "no_group", "outside", "read", True),
-            ("user", "no_group", "outside", "write", True),
-            ("user", "no_group", "outside", "unlink", False),
-            ("user", "group_matching", "member", "read", True),
-            ("user", "group_matching", "member", "write", True),
-            ("user", "group_matching", "member", "unlink", False),
-            ("user", "group_matching", "outside", "create", True),
-            ("user", "group_matching", "outside", "read", True),
-            ("user", "group_matching", "outside", "write", True),
-            ("user", "group_matching", "outside", "unlink", False),
-            ("user", "group_failing", "member", "read", False),
-            ("user", "group_failing", "member", "write", False),
-            ("user", "group_failing", "member", "unlink", False),
-            ("user", "group_failing", "outside", "create", False),
-            ("user", "group_failing", "outside", "read", False),
-            ("user", "group_failing", "outside", "write", False),
-            ("user", "group_failing", "outside", "unlink", False),
+        # user, visibility_policy, membership, operation
+        all_channel_cases = [
+            case
+            for case in product(
+                ["portal", "public", "user"],
+                [
+                    "group_failing",
+                    "group_matching",
+                    "internal",
+                    "member_and_group_failing",
+                    "member_and_group_matching",
+                    "public",
+                ],
+                ["member", "outside"],
+                ["create", "read", "unlink", "write"],
+            )
+            # member+create: doesn't make sense, the channel already exists.
+            if case[2] != "member" or case[3] != "create"
         ]
-        cls._channel_type_channel_member_access_cases = [
-            ("public", "no_group", "member", "self", "create", False),
-            ("public", "no_group", "member", "self", "read", True),
-            ("public", "no_group", "member", "self", "write", True),
-            ("public", "no_group", "member", "self", "unlink", True),
-            ("public", "no_group", "member", "other", "create", False),
-            ("public", "no_group", "member", "other", "read", True),
-            ("public", "no_group", "member", "other", "write", False),
-            ("public", "no_group", "member", "other", "unlink", False),
-            ("public", "no_group", "outside", "self", "create", True),
-            ("public", "no_group", "outside", "other", "create", False),
-            ("public", "no_group", "outside", "other", "read", True),
-            ("public", "no_group", "outside", "other", "write", False),
-            ("public", "no_group", "outside", "other", "unlink", False),
-            ("public", "group_matching", "member", "self", "create", False),
-            ("public", "group_matching", "member", "self", "read", True),
-            ("public", "group_matching", "member", "self", "write", True),
-            ("public", "group_matching", "member", "self", "unlink", True),
-            ("public", "group_matching", "member", "other", "create", False),
-            ("public", "group_matching", "member", "other", "read", True),
-            ("public", "group_matching", "member", "other", "write", False),
-            ("public", "group_matching", "member", "other", "unlink", False),
-            ("public", "group_matching", "outside", "self", "create", True),
-            ("public", "group_matching", "outside", "other", "create", False),
-            ("public", "group_matching", "outside", "other", "read", True),
-            ("public", "group_matching", "outside", "other", "write", False),
-            ("public", "group_matching", "outside", "other", "unlink", False),
-            ("public", "group_failing", "member", "self", "create", False),
-            ("public", "group_failing", "member", "self", "read", False),
-            ("public", "group_failing", "member", "self", "write", False),
-            ("public", "group_failing", "member", "self", "unlink", False),
-            ("public", "group_failing", "member", "other", "create", False),
-            ("public", "group_failing", "member", "other", "read", False),
-            ("public", "group_failing", "member", "other", "write", False),
-            ("public", "group_failing", "member", "other", "unlink", False),
-            ("public", "group_failing", "outside", "self", "create", False),
-            ("public", "group_failing", "outside", "other", "create", False),
-            ("public", "group_failing", "outside", "other", "read", False),
-            ("public", "group_failing", "outside", "other", "write", False),
-            ("public", "group_failing", "outside", "other", "unlink", False),
-            ("portal", "no_group", "member", "self", "create", False),
-            ("portal", "no_group", "member", "self", "read", True),
-            ("portal", "no_group", "member", "self", "write", True),
-            ("portal", "no_group", "member", "self", "unlink", True),
-            ("portal", "no_group", "member", "other", "create", False),
-            ("portal", "no_group", "member", "other", "read", True),
-            ("portal", "no_group", "member", "other", "write", False),
-            ("portal", "no_group", "member", "other", "unlink", False),
-            ("portal", "no_group", "outside", "self", "create", True),
-            ("portal", "no_group", "outside", "other", "create", False),
-            ("portal", "no_group", "outside", "other", "read", True),
-            ("portal", "no_group", "outside", "other", "write", False),
-            ("portal", "no_group", "outside", "other", "unlink", False),
-            ("portal", "group_matching", "member", "self", "create", False),
-            ("portal", "group_matching", "member", "self", "read", True),
-            ("portal", "group_matching", "member", "self", "write", True),
-            ("portal", "group_matching", "member", "self", "unlink", True),
-            ("portal", "group_matching", "member", "other", "create", False),
-            ("portal", "group_matching", "member", "other", "read", True),
-            ("portal", "group_matching", "member", "other", "write", False),
-            ("portal", "group_matching", "member", "other", "unlink", False),
-            ("portal", "group_matching", "outside", "self", "create", True),
-            ("portal", "group_matching", "outside", "other", "create", False),
-            ("portal", "group_matching", "outside", "other", "read", True),
-            ("portal", "group_matching", "outside", "other", "write", False),
-            ("portal", "group_matching", "outside", "other", "unlink", False),
-            ("portal", "group_failing", "member", "self", "create", False),
-            ("portal", "group_failing", "member", "self", "read", False),
-            ("portal", "group_failing", "member", "self", "write", False),
-            ("portal", "group_failing", "member", "self", "unlink", False),
-            ("portal", "group_failing", "member", "other", "create", False),
-            ("portal", "group_failing", "member", "other", "read", False),
-            ("portal", "group_failing", "member", "other", "write", False),
-            ("portal", "group_failing", "member", "other", "unlink", False),
-            ("portal", "group_failing", "outside", "self", "create", False),
-            ("portal", "group_failing", "outside", "other", "create", False),
-            ("portal", "group_failing", "outside", "other", "read", False),
-            ("portal", "group_failing", "outside", "other", "write", False),
-            ("portal", "group_failing", "outside", "other", "unlink", False),
-            ("user", "no_group", "member", "self", "create", False),
-            ("user", "no_group", "member", "self", "read", True),
-            ("user", "no_group", "member", "self", "write", True),
-            ("user", "no_group", "member", "self", "unlink", True),
-            ("user", "no_group", "member", "other", "create", True),
-            ("user", "no_group", "member", "other", "read", True),
-            ("user", "no_group", "member", "other", "write", False),
-            ("user", "no_group", "member", "other", "unlink", False),
-            ("user", "no_group", "outside", "self", "create", True),
-            ("user", "no_group", "outside", "other", "create", True),
-            ("user", "no_group", "outside", "other", "read", True),
-            ("user", "no_group", "outside", "other", "write", False),
-            ("user", "no_group", "outside", "other", "unlink", False),
-            ("user", "group_matching", "member", "self", "create", False),
-            ("user", "group_matching", "member", "self", "read", True),
-            ("user", "group_matching", "member", "self", "write", True),
-            ("user", "group_matching", "member", "self", "unlink", True),
-            ("user", "group_matching", "member", "other", "create", True),
-            ("user", "group_matching", "member", "other", "read", True),
-            ("user", "group_matching", "member", "other", "write", False),
-            ("user", "group_matching", "member", "other", "unlink", False),
-            ("user", "group_matching", "outside", "self", "create", True),
-            ("user", "group_matching", "outside", "other", "create", True),
-            ("user", "group_matching", "outside", "other", "read", True),
-            ("user", "group_matching", "outside", "other", "write", False),
-            ("user", "group_matching", "outside", "other", "unlink", False),
-            ("user", "group_failing", "member", "self", "create", False),
-            ("user", "group_failing", "member", "self", "read", False),
-            ("user", "group_failing", "member", "self", "write", False),
-            ("user", "group_failing", "member", "self", "unlink", False),
-            ("user", "group_failing", "member", "other", "create", False),
-            ("user", "group_failing", "member", "other", "read", False),
-            ("user", "group_failing", "member", "other", "write", False),
-            ("user", "group_failing", "member", "other", "unlink", False),
-            ("user", "group_failing", "outside", "self", "create", False),
-            ("user", "group_failing", "outside", "other", "create", False),
-            ("user", "group_failing", "outside", "other", "read", False),
-            ("user", "group_failing", "outside", "other", "write", False),
-            ("user", "group_failing", "outside", "other", "unlink", False),
+        ok_channel_cases = {
+            *product(
+                ["portal", "public"],
+                ["group_matching", "public"],
+                ["member", "outside"],
+                ["read"],
+            ),
+            *product(
+                ["portal", "public"],
+                ["member", "member_and_group_matching"],
+                ["member"],
+                ["read"],
+            ),
+            *product(
+                ["user"],
+                [
+                    "group_matching",
+                    "internal",
+                    "member",
+                    "member_and_group_matching",
+                    "public",
+                ],
+                ["outside"],
+                ["create"],
+            ),
+            *product(
+                ["user"],
+                ["group_matching", "internal", "public"],
+                ["member", "outside"],
+                ["read", "write"],
+            ),
+            *product(
+                ["user"],
+                ["member", "member_and_group_matching"],
+                ["member"],
+                ["read", "write"],
+            ),
+        }
+        cls._channel_access_cases = [
+            # Membership policy is irrelevant to channel access, ignore it.
+            (*case[:2], None, *case[2:], case in ok_channel_cases) for case in all_channel_cases
         ]
-        cls._group_type_channel_access_cases = [
-            ("public", "group", "member", "read", True),
-            ("public", "group", "member", "write", False),
-            ("public", "group", "member", "unlink", False),
-            ("public", "group", "outside", "create", False),
-            ("public", "group", "outside", "read", False),
-            ("public", "group", "outside", "write", False),
-            ("public", "group", "outside", "unlink", False),
-            ("portal", "group", "member", "read", True),
-            ("portal", "group", "member", "write", False),
-            ("portal", "group", "member", "unlink", False),
-            ("portal", "group", "outside", "create", False),
-            ("portal", "group", "outside", "read", False),
-            ("portal", "group", "outside", "write", False),
-            ("portal", "group", "outside", "unlink", False),
-            ("user", "group", "member", "read", True),
-            ("user", "group", "member", "write", True),
-            ("user", "group", "member", "unlink", False),
-            ("user", "group", "outside", "create", True),
-            ("user", "group", "outside", "read", False),
-            ("user", "group", "outside", "write", False),
-            ("user", "group", "outside", "unlink", False),
+        all_channel_member_access_cases = [
+            case
+            for case in product(
+                ["portal", "public", "user"],
+                [
+                    "group_failing",
+                    "group_matching",
+                    "internal",
+                    "member",
+                    "member_and_group_failing",
+                    "member_and_group_matching",
+                    "public",
+                ],
+                ["open", "invite", "blocked"],
+                ["member", "outside"],
+                ["self", "other"],
+                ["create", "write", "unlink", "read"],
+            )
+            if not (
+                # self+outside: only create makes sense as the member doesn't exist.
+                (case[3] == "outside" and case[4] == "self" and case[5] != "create")
+                # self+member+create: doesn't make sense, the member already exists.
+                or (case[3] == "member" and case[4] == "self" and case[5] == "create")
+            )
         ]
-        cls._group_type_channel_member_access_cases = [
-            ("public", "group", "member", "self", "create", False),
-            ("public", "group", "member", "self", "read", True),
-            ("public", "group", "member", "self", "write", True),
-            ("public", "group", "member", "self", "unlink", True),
-            ("public", "group", "member", "other", "create", False),
-            ("public", "group", "member", "other", "read", True),
-            ("public", "group", "member", "other", "write", False),
-            ("public", "group", "member", "other", "unlink", False),
-            ("public", "group", "outside", "self", "create", False),
-            ("public", "group", "outside", "other", "create", False),
-            ("public", "group", "outside", "other", "read", False),
-            ("public", "group", "outside", "other", "write", False),
-            ("public", "group", "outside", "other", "unlink", False),
-            ("portal", "group", "member", "self", "create", False),
-            ("portal", "group", "member", "self", "read", True),
-            ("portal", "group", "member", "self", "write", True),
-            ("portal", "group", "member", "self", "unlink", True),
-            ("portal", "group", "member", "other", "create", False),
-            ("portal", "group", "member", "other", "read", True),
-            ("portal", "group", "member", "other", "write", False),
-            ("portal", "group", "member", "other", "unlink", False),
-            ("portal", "group", "outside", "self", "create", False),
-            ("portal", "group", "outside", "other", "create", False),
-            ("portal", "group", "outside", "other", "read", False),
-            ("portal", "group", "outside", "other", "write", False),
-            ("portal", "group", "outside", "other", "unlink", False),
-            ("user", "group", "member", "self", "create", False),
-            ("user", "group", "member", "self", "read", True),
-            ("user", "group", "member", "self", "write", True),
-            ("user", "group", "member", "self", "unlink", True),
-            ("user", "group", "member", "other", "create", True),
-            ("user", "group", "member", "other", "read", True),
-            ("user", "group", "member", "other", "write", False),
-            ("user", "group", "member", "other", "unlink", False),
-            ("user", "group", "outside", "self", "create", False),
-            ("user", "group", "outside", "other", "create", False),
-            ("user", "group", "outside", "other", "read", False),
-            ("user", "group", "outside", "other", "write", False),
-            ("user", "group", "outside", "other", "unlink", False),
+        ok_channel_member_access_cases = {
+            # Everyone can read/write/unlink self on accessible channels.
+            *product(
+                ["portal", "public", "user"],
+                [
+                    "group_matching",
+                    "member",
+                    "member_and_group_matching",
+                    "public",
+                ],
+                ["open", "invite", "blocked"],
+                ["member"],
+                ["self"],
+                ["read", "write", "unlink"],
+            ),
+            *product(
+                ["user"],
+                ["internal"],
+                ["open", "invite", "blocked"],
+                ["member"],
+                ["self"],
+                ["read", "write", "unlink"],
+            ),
+            # Everyone can read others on accessible channels.
+            *product(
+                ["portal", "public", "user"],
+                ["group_matching", "public"],
+                ["open", "invite", "blocked"],
+                ["member", "outside"],
+                ["other"],
+                ["read"],
+            ),
+            *product(
+                ["portal", "public", "user"],
+                ["member", "member_and_group_matching"],
+                ["open", "invite", "blocked"],
+                ["member"],
+                ["other"],
+                ["read"],
+            ),
+            *product(
+                ["user"],
+                ["internal"],
+                ["open", "invite", "blocked"],
+                ["member", "outside"],
+                ["other"],
+                ["read"],
+            ),
+            # Everyone can self-join opened, accessible channels.
+            *product(
+                ["portal", "public", "user"],
+                ["group_matching", "public"],
+                ["open"],
+                ["outside"],
+                ["self"],
+                ["create"],
+            ),
+            ("user", "internal", "open", "outside", "self", "create"),
+            # Internal users can create others on accessible channels
+            # (according to membership policy).
+            *product(
+                ["user"],
+                ["group_matching", "internal", "public"],
+                ["open"],
+                ["outside"],
+                ["other"],
+                ["create"],
+            ),
+            *product(
+                ["user"],
+                [
+                    "group_matching",
+                    "internal",
+                    "member",
+                    "member_and_group_matching",
+                    "public",
+                ],
+                ["open", "invite"],
+                ["member"],
+                ["other"],
+                ["create"],
+            ),
+        }
+        cls._channel_member_access_cases = [
+            (*case, case in ok_channel_member_access_cases) for case in all_channel_member_access_cases
         ]
         cls.secret_group = cls.env["res.groups"].create({"name": "Secret User Group"})
         cls.env["ir.model.data"].create(
@@ -275,35 +200,35 @@ class TestDiscussChannelAccess(MailCommon):
                 cls.env,
                 login="public1",
                 name="A Public User",
-                groups="base.group_public,mail.secret_group",
+                groups="base.group_everyone,base.group_public,mail.secret_group",
             ),
             "portal": mail_new_test_user(
                 cls.env,
                 login="portal1",
                 name="A Portal User",
-                groups="base.group_portal,mail.secret_group",
+                groups="base.group_everyone,base.group_portal,mail.secret_group",
             ),
             "user": mail_new_test_user(
                 cls.env,
                 login="user1",
                 name="An Internal User",
-                groups="base.group_user,mail.secret_group",
+                groups="base.group_everyone,base.group_user,mail.secret_group",
             ),
         }
         cls.other_user = mail_new_test_user(
             cls.env,
             login="other1",
             name="Another User 1",
-            groups="base.group_user,mail.secret_group",
+            groups="base.group_everyone,base.group_user,mail.secret_group",
         )
         cls.other_user_2 = mail_new_test_user(
             cls.env,
             login="other2",
             name="Another User 2",
-            groups="base.group_user,mail.secret_group",
+            groups="base.group_everyone,base.group_user,mail.secret_group",
         )
 
-    def _test_discuss_channel_access(self, cases, for_sub_channel):
+    def _test_discuss_channel_access(self, cases, for_sub_channel=False):
         """
         Executes a list of operations on channels in various setups and checks whether the outcomes
         match the expected results.
@@ -311,9 +236,13 @@ class TestDiscussChannelAccess(MailCommon):
         :param cases: A list of test cases, where each tuple contains:
 
             - user_key (``"portal"`` | ``"public"`` | ``"user"``): The user performing the operation.
-            - group_key (``"chat"`` | ``"group"`` | ``"no_group"`` | ``"group_matching"`` |
-            ``"group_failing"``): The group specification to use. ``chat`` and ``group`` define the
-            channel type, while the others configure group setups for the channels.
+            - visibility_policy (``"internal"`` | ``"public"`` | ``"member_and_group_failing"`` |
+                ``"member_and_group_matching"`` | ``"group_failing"`` | ``"group_matching"``
+                | ``None``): The visibility policy of the channel.
+                ``None`` uses the default policy for the channel type. ``"_matching/_failing"`` policies is used
+                to set up channels with groups that either match or do not match the user's groups.
+            - membership_policy (``"blocked"`` | ``"open"`` | ``"private"`` | ``None``): The membership policy of
+                the channel. ``None`` uses the default policy for the channel type.
             - membership (``"member"`` | ``"outside"``): Whether the user is a member of the channel.
             - operation (``"create"`` | ``"read"`` | ``"write"`` | ``"unlink"``): The action being tested.
             - expected_result (bool): Whether the action is expected to be allowed (``True``) or denied
@@ -322,16 +251,18 @@ class TestDiscussChannelAccess(MailCommon):
         :param for_sub_channel: Whether the operation is being tested on a sub-channel. In this case, the
             ``cases`` parameter is used to configure the parent channel.
         """
-        for user_key, channel_key, membership, operation, result in cases:
+        for user_key, visibility_policy, membership_policy, membership, operation, result in cases:
+            err_msg = (
+                f"(user={user_key}, visibility_policy={visibility_policy}, membership_policy={membership_policy}"
+                f", membership={membership}, operation={operation}) " + ("should not raise" if result else "should raise")
+            )
             if result:
                 try:
                     self._execute_action_channel(
-                        user_key, channel_key, membership, operation, result, for_sub_channel
+                        user_key, visibility_policy, membership_policy, membership, operation, result, for_sub_channel
                     )
                 except Exception as e:  # noqa: BLE001 - re-raising, just with a more contextual message
-                    raise AssertionError(
-                        f"{user_key, channel_key, membership, operation} should not raise"
-                    ) from e
+                    raise AssertionError(err_msg) from e
             else:
                 try:
                     with self.assertRaises(AccessError), mute_logger("odoo.sql_db"), mute_logger(
@@ -340,46 +271,21 @@ class TestDiscussChannelAccess(MailCommon):
                         "odoo.models.unlink"
                     ):
                         self._execute_action_channel(
-                            user_key, channel_key, membership, operation, result, for_sub_channel
+                            user_key, visibility_policy, membership_policy, membership, operation, result, for_sub_channel
                         )
                 except AssertionError as e:
-                    raise AssertionError(
-                        f"{user_key, channel_key, membership, operation} should raise"
-                    ) from e
+                    raise AssertionError(err_msg) from e
 
     def test_01_discuss_channel_access(self):
-        cases = [
-            *self._channel_type_channel_access_cases,
-            *self._group_type_channel_access_cases,
-            ("public", "chat", "outside", "create", False),
-            ("public", "chat", "outside", "read", False),
-            ("public", "chat", "outside", "write", False),
-            ("public", "chat", "outside", "unlink", False),
-            ("portal", "chat", "member", "read", True),
-            ("portal", "chat", "member", "write", False),
-            ("portal", "chat", "member", "unlink", False),
-            ("portal", "chat", "outside", "create", False),
-            ("portal", "chat", "outside", "read", False),
-            ("portal", "chat", "outside", "write", False),
-            ("portal", "chat", "outside", "unlink", False),
-            ("user", "chat", "member", "read", True),
-            ("user", "chat", "member", "write", True),
-            ("user", "chat", "member", "unlink", False),
-            ("user", "chat", "outside", "create", True),
-            ("user", "chat", "outside", "read", False),
-            ("user", "chat", "outside", "write", False),
-            ("user", "chat", "outside", "unlink", False),
-        ]
-        self._test_discuss_channel_access(cases, for_sub_channel=False)
+        self._test_discuss_channel_access(self._channel_access_cases)
 
     def test_02_discuss_sub_channel_access(self):
-        cases = [
-            *self._channel_type_channel_access_cases,
-            *self._group_type_channel_access_cases,
-        ]
-        self._test_discuss_channel_access(cases, for_sub_channel=True)
+        self._test_discuss_channel_access(
+            self._channel_access_cases,
+            for_sub_channel=True,
+        )
 
-    def _test_discuss_channel_member_access(self, cases, for_sub_channel):
+    def _test_discuss_channel_member_access(self, cases, for_sub_channel=False):
         """
         Executes a list of operations on channel members in various setups and checks whether the
         outcomes match the expected results.
@@ -387,10 +293,14 @@ class TestDiscussChannelAccess(MailCommon):
         :param cases: A list of test cases, where each tuple contains:
             - user_key (``"portal"`` | ``"public"`` | ``"user"``):
                 The user performing the operation.
-            - group_key (``"chat"`` | ``"group"`` | ``"no_group"`` | ``"group_matching"`` |
-            ``"group_failing"``):
-                The group specification to use. ``chat`` and ``group`` define the channel type, while the
-                others configure group setups for the channels.
+            - channel_type (``"channel"`` | ``"chat"`` | ``"group"``): The type of the channel.
+            - visibility_policy (``"internal"`` | ``"public"`` | ``"member_and_group_failing"`` |
+                ``"member_and_group_matching"`` | ``"group_failing"`` | ``"group_matching"``
+                | ``None``): The visibility policy of the channel.
+                ``None`` uses the default policy for the channel type. ``"_matching/_failing"`` policies is used
+                to set up channels with groups that either match or do not match the user's groups.
+            - membership_policy (``"blocked"`` | ``"open"`` | ``"private"`` | ``None``): The membership policy of
+                the channel. ``None`` uses the default policy for the channel type.
             - membership (``"member"`` | ``"outside"``):
                 Whether the user is a member of the channel.
             - target (``"self"`` | ``"other"``):
@@ -403,15 +313,25 @@ class TestDiscussChannelAccess(MailCommon):
         :param for_sub_channel: Whether the operation is being tested on a sub-channel. In this case, the
             ``cases`` parameter is used to configure the parent channel's member.
         """
-        for user_key, channel_key, membership, target, operation, result in cases:
-            channel_id = self._get_channel_id(user_key, channel_key, membership, for_sub_channel)
+        for user_key, visibility_key, membership_policy, membership, target, operation, result in cases:
+            group_config = None
+            visibility_policy = visibility_key
+            if visibility_key:
+                parts = visibility_key.split("_")
+                if parts[-1] in {"matching", "failing"}:
+                    group_config = parts[-1]
+                    visibility_policy = "_".join(parts[:-1])
+            err_msg = (
+                f"(user={user_key}, visibility_policy={visibility_policy}, group_config={group_config}"
+                f", membership_policy={membership_policy}, membership={membership}, target={target}"
+                f", operation={operation})  " + ("should not raise" if result else "should raise")
+            )
+            channel_id = self._get_channel_id(user_key, visibility_policy, membership_policy, group_config, membership, for_sub_channel)
             if result:
                 try:
                     self._execute_action_member(channel_id, user_key, target, operation, result)
                 except Exception as e:  # noqa: BLE001 - re-raising, just with a more contextual message
-                    raise AssertionError(
-                        f"{user_key, channel_key, membership, target, operation} should not raise"
-                    ) from e
+                    raise AssertionError(err_msg) from e
             else:
                 try:
                     with self.assertRaises(AccessError), mute_logger("odoo.sql_db"), mute_logger(
@@ -426,56 +346,18 @@ class TestDiscussChannelAccess(MailCommon):
                         except (UniqueViolation, UserError) as e:
                             raise AccessError("expected errors as access error") from e
                 except AssertionError as e:
-                    raise AssertionError(
-                        f"{user_key, channel_key, membership, target, operation} should raise access error"
-                    ) from e
+                    raise AssertionError(err_msg) from e
 
     def test_10_discuss_channel_member_access(self):
-        cases = [
-            *self._channel_type_channel_member_access_cases,
-            *self._group_type_channel_member_access_cases,
-            ("public", "chat", "outside", "self", "create", False),
-            ("public", "chat", "outside", "other", "create", False),
-            ("public", "chat", "outside", "other", "read", False),
-            ("public", "chat", "outside", "other", "write", False),
-            ("public", "chat", "outside", "other", "unlink", False),
-            ("portal", "chat", "member", "self", "create", False),
-            ("portal", "chat", "member", "self", "read", True),
-            ("portal", "chat", "member", "self", "write", True),
-            ("portal", "chat", "member", "self", "unlink", True),
-            ("portal", "chat", "member", "other", "create", False),
-            ("portal", "chat", "member", "other", "read", True),
-            ("portal", "chat", "member", "other", "write", False),
-            ("portal", "chat", "member", "other", "unlink", False),
-            ("portal", "chat", "outside", "self", "create", False),
-            ("portal", "chat", "outside", "other", "create", False),
-            ("portal", "chat", "outside", "other", "read", False),
-            ("portal", "chat", "outside", "other", "write", False),
-            ("portal", "chat", "outside", "other", "unlink", False),
-            ("user", "chat", "member", "self", "create", False),
-            ("user", "chat", "member", "self", "read", True),
-            ("user", "chat", "member", "self", "write", True),
-            ("user", "chat", "member", "self", "unlink", True),
-            ("user", "chat", "member", "other", "create", False),
-            ("user", "chat", "member", "other", "read", True),
-            ("user", "chat", "member", "other", "write", False),
-            ("user", "chat", "member", "other", "unlink", False),
-            ("user", "chat", "outside", "self", "create", False),
-            ("user", "chat", "outside", "other", "create", False),
-            ("user", "chat", "outside", "other", "read", False),
-            ("user", "chat", "outside", "other", "write", False),
-            ("user", "chat", "outside", "other", "unlink", False),
-        ]
-        self._test_discuss_channel_member_access(cases, for_sub_channel=False)
+        self._test_discuss_channel_member_access(self._channel_member_access_cases)
 
     def test_11_discuss_sub_channel_member_access(self):
-        cases = [
-            *self._channel_type_channel_member_access_cases,
-            *self._group_type_channel_member_access_cases,
-        ]
-        self._test_discuss_channel_member_access(cases, for_sub_channel=True)
+        self._test_discuss_channel_member_access(
+            self._channel_member_access_cases,
+            for_sub_channel=True,
+        )
 
-    def _get_channel_id(self, user_key, channel_key, membership, sub_channel):
+    def _get_channel_id(self, user_key, visibility_policy, membership_policy, group_config, membership, sub_channel):
         user = self.env["res.users"] if user_key == "public" else self.users[user_key]
         partner = user.partner_id
         guest = self.guest if user_key == "public" else self.env["mail.guest"]
@@ -483,21 +365,21 @@ class TestDiscussChannelAccess(MailCommon):
         if membership == "member":
             partners += partner
         DiscussChannel = self.env["discuss.channel"].with_user(self.other_user)
-        if channel_key == "group":
-            channel = DiscussChannel._create_group(partners.ids)
-            if membership == "member":
-                channel._add_members(users=user, guests=guest)
-        elif channel_key == "chat":
-            channel = DiscussChannel._get_or_create_chat(partners.ids)
-        else:
-            channel = DiscussChannel._create_channel("Channel", group_id=None)
-            if membership == "member":
-                channel._add_members(users=user, guests=guest)
-        if channel_key == "no_group":
-            channel.group_public_id = None
-        elif channel_key == "group_matching":
+        channel = DiscussChannel.create(
+            {
+                "channel_type": "channel",
+                "name": f"channel_visibility_{visibility_policy}_membership_{membership_policy}",
+            },
+        )
+        if membership == "member":
+            channel.sudo()._add_members(users=user, guests=guest)
+        if membership_policy:
+            channel.membership_policy = membership_policy
+        if visibility_policy:
+            channel.visibility_policy = visibility_policy
+        if group_config == "matching":
             channel.group_public_id = self.secret_group
-        elif channel_key == "group_failing":
+        elif group_config == "failing":
             channel.group_public_id = self.env.ref("base.group_system")
         if sub_channel:
             channel.sudo()._create_sub_channel()
@@ -506,25 +388,33 @@ class TestDiscussChannelAccess(MailCommon):
                 channel.sudo()._add_members(users=user, guests=guest)
         return channel.id
 
-    def _execute_action_channel(self, user_key, channel_key, membership, operation, result, for_sub_channel):
+    def _execute_action_channel(self, user_key, visibility_key, membership_policy, membership, operation, result, for_sub_channel=False):
         current_user = self.users[user_key]
         guest = self.guest if user_key == "public" else self.env["mail.guest"]
         ChannelAsUser = self.env["discuss.channel"].with_user(current_user).with_context(guest=guest)
+        group_config = None
+        visibility_policy = visibility_key
+        if visibility_key:
+            parts = visibility_key.split("_")
+            if parts[-1] in {"matching", "failing"}:
+                group_config = parts[-1]
+                visibility_policy = "_".join(parts[:-1])
+        group_public_id = None
         if operation == "create":
             group_public_id = None
-            if channel_key == "group_matching":
+            if group_config == "matching":
                 group_public_id = self.secret_group.id
-            elif channel_key == "group_failing":
+            elif group_config == "failing":
                 group_public_id = self.env.ref("base.group_system").id
-            data = {
-                "name": "Test Channel",
-                "channel_type": channel_key if channel_key in ("group", "chat") else "channel",
-                "group_public_id": group_public_id,
-            }
+            data = {"name": "Test Channel", "channel_type": "channel", "group_public_id": group_public_id}
+            if visibility_policy:
+                data["visibility_policy"] = visibility_policy
+            if membership_policy:
+                data["membership_policy"] = membership_policy
             ChannelAsUser.create(data)
         else:
             channel = ChannelAsUser.browse(
-                self._get_channel_id(user_key, channel_key, membership, for_sub_channel)
+                self._get_channel_id(user_key, visibility_policy, membership_policy, group_config, membership, for_sub_channel)
             )
             self.assertEqual(len(channel), 1, "should find the channel")
             if operation == "read":
@@ -568,3 +458,14 @@ class TestDiscussChannelAccess(MailCommon):
                 member.write({"custom_channel_name": "new name"})
             elif operation == "unlink":
                 member.unlink()
+
+    def test_channel_type_default_policies(self):
+        chat = self.env["discuss.channel"].create({"channel_type": "chat", "name": "Chat"})
+        self.assertEqual(chat.visibility_policy, "member")
+        self.assertEqual(chat.membership_policy, "blocked")
+        channel = self.env["discuss.channel"].create({"channel_type": "channel", "name": "Channel"})
+        self.assertEqual(channel.visibility_policy, "member")
+        self.assertEqual(channel.membership_policy, "invite")
+        group = self.env["discuss.channel"].create({"channel_type": "group", "name": "Group"})
+        self.assertEqual(group.visibility_policy, "member")
+        self.assertEqual(group.membership_policy, "invite")

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -28,7 +28,10 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         )
         guest = self.env['mail.guest'].create({'name': 'Guest Mario'})
 
-        self.channel = self.env['discuss.channel']._create_channel(group_id=None, name='Test channel')
+        self.channel = self.env["discuss.channel"]._create_channel(
+            name="Test channel",
+            visibility_policy="public",
+        )
         self.channel._add_members(users=portal_user)
         self.channel._add_members(users=internal_user)
         self.channel._add_members(guests=guest)
@@ -105,20 +108,26 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         channel = self.env['discuss.channel'].search([('uuid', '=', 'xyz')])
         self.assertEqual(len(channel), 1)
 
-    def test_channel_invitation_from_token(self):
-        public_channel = self.env["discuss.channel"]._create_channel(name="Public Channel", group_id=None)
-        internal_channel = self.env["discuss.channel"]._create_channel(name="Internal Channel", group_id=self.env.ref("base.group_user").id)
-
-        public_response = self.url_open(public_channel.invitation_url)
+    def test_restricted_channel_invitation_url_is_not_found(self):
+        public_response = self.url_open(self.channel.invitation_url)
         self.assertEqual(public_response.status_code, 200)
-
+        internal_channel = self.env["discuss.channel"]._create_channel(
+            name="Internal Channel",
+            visibility_policy="internal",
+        )
         internal_response = self.url_open(internal_channel.invitation_url)
         self.assertEqual(internal_response.status_code, 404)
 
     def test_sidebar_in_public_page(self):
         guest = self.env['mail.guest'].create({'name': 'Guest'})
-        channel_1 = self.env["discuss.channel"]._create_channel(name="Channel 1", group_id=None)
-        channel_2 = self.env["discuss.channel"]._create_channel(name="Channel 2", group_id=None)
+        channel_1 = self.env["discuss.channel"]._create_channel(
+            name="Channel 1",
+            visibility_policy="public",
+        )
+        channel_2 = self.env["discuss.channel"]._create_channel(
+            name="Channel 2",
+            visibility_policy="public",
+        )
         channel_1._add_members(guests=guest)
         channel_2._add_members(guests=guest)
         self.start_tour(f"/discuss/channel/{channel_1.id}", "sidebar_in_public_page_tour", cookies={guest._cookie_name: guest._format_auth_cookie()})

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -32,9 +32,9 @@ class TestDiscussChannelMember(MailCommon):
         cls.group.channel_member_ids.unlink()
 
     def test_cannot_change_member_immutable_fields(self):
-        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
+        channel = self.env["discuss.channel"]._create_channel(name="General")
         bob = new_test_user(self.env, "bob", groups="base.group_user")
-        another_channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Another channel")
+        another_channel = self.env["discuss.channel"]._create_channel(name="Another channel")
         another_partner = self.env["res.partner"].create({"name": "John"})
         guest = self.env["mail.guest"].create({"name": "Jane"})
         member = channel._add_members(users=bob)
@@ -46,7 +46,7 @@ class TestDiscussChannelMember(MailCommon):
             member.guest_id = guest
 
     def test_user_public_cannot_join_channel(self):
-        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Public")
+        channel = self.env["discuss.channel"]._create_channel(name="Public")
         public = new_test_user(self.env, "public_user", groups="base.group_public")
         with self.assertRaises(ValidationError):
             channel._add_members(users=public)
@@ -67,7 +67,7 @@ class TestDiscussChannelMember(MailCommon):
     # ------------------------------------------------------------
 
     def test_channel_member_invite_with_guest(self):
-        public_channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Public")
+        public_channel = self.env["discuss.channel"]._create_channel(name="Public")
         guest = self.env['mail.guest'].create({'name': 'Guest'})
         partner = self.env['res.partner'].create({
             'name': 'ToInvite',
@@ -88,7 +88,11 @@ class TestDiscussChannelMember(MailCommon):
     # ------------------------------------------------------------
 
     def test_unread_counter_with_message_post(self):
-        channel_as_user_1 = self.env['discuss.channel'].with_user(self.user_1)._create_channel(group_id=None, name='Public channel')
+        channel_as_user_1 = (
+            self.env["discuss.channel"]
+            .with_user(self.user_1)
+            ._create_channel(name="Public channel", visibility_policy="public")
+        )
         channel_as_user_1.with_user(self.user_1)._add_members(users=self.user_1)
         channel_as_user_1.with_user(self.user_1)._add_members(users=self.user_2)
         channel_1_rel_user_2 = self.env['discuss.channel.member'].search([
@@ -105,8 +109,8 @@ class TestDiscussChannelMember(MailCommon):
         self.assertEqual(channel_1_rel_user_2.message_unread_counter, 1, "should have 1 unread message after someone else posted a message")
 
     def test_unread_counter_with_message_post_multi_channel(self):
-        channel_1_as_user_1 = self.env['discuss.channel'].with_user(self.user_1)._create_channel(group_id=None, name='wololo channel')
-        channel_2_as_user_2 = self.env['discuss.channel'].with_user(self.user_2)._create_channel(group_id=None, name='walala channel')
+        channel_1_as_user_1 = self.env['discuss.channel'].with_user(self.user_1)._create_channel(name='wololo channel')
+        channel_2_as_user_2 = self.env['discuss.channel'].with_user(self.user_2)._create_channel(name='walala channel')
         channel_1_as_user_1._add_members(users=self.user_2)
         channel_2_as_user_2._add_members(users=self.user_1)
         channel_2_as_user_2._add_members(users=self.user_3)

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -320,7 +320,10 @@ class TestMessageLinks(MailCommon, HttpCase):
         super().setUpClass()
 
         cls.user_employee_1 = mail_new_test_user(cls.env, login='tao1', groups='base.group_user', name='Tao Lee')
-        cls.public_channel = cls.env['discuss.channel']._create_channel(name='Public Channel1', group_id=None)
+        cls.public_channel = cls.env["discuss.channel"]._create_channel(
+            name="Public Channel1",
+            visibility_policy="public",
+        )
         cls.private_group = cls.env['discuss.channel']._create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")
 
     @users('employee')

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -88,13 +88,12 @@
                             <field name="description" placeholder="Topics discussed in this group..." readonly="not is_editable"/>
                         </group>
                         <notebook>
-                            <page string="Privacy" name="privacy">
+                            <page string="Privacy" name="privacy" invisible="parent_channel_id" groups="base.group_erp_manager">
                                 <group class="o_label_nowrap">
-                                    <field name="group_public_id"
-                                        invisible="channel_type != 'channel' or parent_channel_id" readonly="not is_editable"/>
-                                    <field name="group_ids" widget="many2many_tags"
-                                        invisible="channel_type != 'channel'"
-                                        string="Auto Subscribe Groups" readonly="not is_editable"/>
+                                    <field name="visibility_policy" widget="radio" readonly="not is_editable"/>
+                                    <field name="group_public_id" invisible="visibility_policy not in ('group', 'member_and_group', 'member_or_group')" readonly="not is_editable"/>
+                                    <field name="membership_policy" widget="radio" readonly="not is_editable"/>
+                                    <field name="group_ids" widget="many2many_tags" string="Auto Subscribe Groups" readonly="not is_editable"/>
                                 </group>
                             </page>
                             <page string="Members" name="members">


### PR DESCRIPTION
Channel access is determined by the `group_public_id` fields which determines which groups are allowed to access the channel.

However, it's not easy for users to understand how that works:
- It’s unclear that leaving the field empty makes the channel accessible to anyone with the link.
- Users may not know which users belong to which groups, so they don’t always realize who they’re giving access to.

This commit adds a selection fields that updates the `group_public_id` technical field in order to ease channel access configuration.

part of task-5231553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
