### PR TITLE
[IMP] web: increase test_load_menus_perf query count

### DIFF
--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -56,8 +56,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 14
-        # - All modules 57
-        with self.assertQueryCount(57):
+        # - All modules 60
+        with self.assertQueryCount(60):
             self.env['ir.ui.menu'].load_web_menus(False)
 
         # cold fields cache:
@@ -72,8 +72,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 14
-        # - All modules 57
-        with self.assertQueryCount(57):
+        # - All modules 60
+        with self.assertQueryCount(60):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache:


### PR DESCRIPTION
Due to changes in the enterprise PR, there is now an extra check on the company uom when loading the menu blacklist in Timesheets, which is causing a few extra queries.

This commit increases the query count in the test.

Task-5167914
