### PR TITLE
[IMP] html_editor: batch text node edition steps on undo/redo

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -257,7 +257,7 @@ export class DeletePlugin extends Plugin {
             throw new Error("Invalid direction");
         }
         this.dispatchTo("delete_handlers");
-        this.dependencies.history.addStep();
+        this.dependencies.history.addStep({ batchable: true });
     }
 
     // --------------------------------------------------------------------------

--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -19,7 +19,7 @@ export class InputPlugin extends Plugin {
     }
 
     onInput(ev) {
-        this.dependencies.history.addStep();
+        this.dependencies.history.addStep({ batchable: ev.inputType === "insertText" });
         this.dispatchTo("input_handlers", ev);
     }
 }

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -2,6 +2,7 @@ import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { findInSelection } from "@html_editor/utils/selection";
 import {
     animationFrame,
+    advanceTime,
     click,
     manuallyDispatchProgrammaticEvent,
     press,
@@ -13,8 +14,17 @@ import { execCommand } from "./userCommands";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { isTextNode } from "@html_editor/utils/dom_info";
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { STEP_DEBOUNCE_DELAY } from "@html_editor/core/history_plugin";
 
 /** @typedef {import("@html_editor/plugin").Editor} Editor */
+
+/**
+ * Makes enough time pass to ensure that undo/redo will not collapse
+ * steps before and after this call.
+ */
+export async function ensureDistinctHistoryStep() {
+    await advanceTime(STEP_DEBOUNCE_DELAY + 1);
+}
 
 /**
  * Simulates text insertion in the editor by dispatching keyboard/input events

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -15,7 +15,12 @@ import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embeddi
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
-import { deleteBackward, deleteForward, insertText } from "./_helpers/user_actions";
+import {
+    deleteBackward,
+    deleteForward,
+    ensureDistinctHistoryStep,
+    insertText,
+} from "./_helpers/user_actions";
 import { cleanHints } from "./_helpers/dispatch";
 import { getContent, setSelection } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
@@ -368,6 +373,7 @@ test("undo in a caption undoes the last caption action then returns to regular e
         contentBefore: `<p><img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption="${caption}"></p><h1>[]Heading</h1>`,
         stepFunction: async (editor) => {
             await insertText(editor, "a");
+            await ensureDistinctHistoryStep();
             const heading = queryOne("h1");
             expect(heading.textContent).toBe("aHeading");
             await toggleCaption();
@@ -378,6 +384,7 @@ test("undo in a caption undoes the last caption action then returns to regular e
             await editor.document.execCommand("insertText", false, "b");
             await editor.document.execCommand("insertText", false, "c");
             await editor.document.execCommand("insertText", false, "d");
+            await ensureDistinctHistoryStep();
             await editor.document.execCommand("delete", false, null); // Backspace.
             expect(input.value).toBe(`${caption}bc`);
 

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -31,7 +31,14 @@ import {
 import { cleanHints } from "./_helpers/dispatch";
 import { unformat } from "./_helpers/format";
 import { getContent } from "./_helpers/selection";
-import { addStep, deleteBackward, deleteForward, redo, undo } from "./_helpers/user_actions";
+import {
+    addStep,
+    deleteBackward,
+    deleteForward,
+    ensureDistinctHistoryStep,
+    redo,
+    undo,
+} from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 import { wrapInlinesInBlocks } from "@html_editor/utils/dom";
 
@@ -1143,6 +1150,7 @@ describe("Collaboration with embedded components", () => {
             )
         );
         e1.shared.history.addStep();
+        await ensureDistinctHistoryStep();
         mergePeersSteps(peerInfos);
         await animationFrame();
         deleteBackward(e1);

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -6,7 +6,13 @@ import { browser } from "@web/core/browser/browser";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent, setSelection } from "../_helpers/selection";
-import { deleteBackward, insertText, tripleClick, undo } from "../_helpers/user_actions";
+import {
+    deleteBackward,
+    ensureDistinctHistoryStep,
+    insertText,
+    tripleClick,
+    undo,
+} from "../_helpers/user_actions";
 import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import {
     compareHighlightedContent,
@@ -158,6 +164,7 @@ describe("Selection collapsed", () => {
                 contentBefore: "<p>ab<b>c[]</b>de</p>",
                 stepFunction: async (editor) => {
                     deleteBackward(editor);
+                    await ensureDistinctHistoryStep();
                     await insertText(editor, "x");
                     undo(editor);
                 },

--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -4,7 +4,7 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { loadBundle } from "@web/core/assets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { insertText, undo } from "./_helpers/user_actions";
+import { ensureDistinctHistoryStep, insertText, undo } from "./_helpers/user_actions";
 import { expectElementCount } from "./_helpers/ui_expectations";
 
 test.tags("desktop");
@@ -43,6 +43,7 @@ test("undo an emoji", async () => {
     expect(getContent(el)).toBe("<p>ab[]</p>");
 
     await insertText(editor, "test");
+    await ensureDistinctHistoryStep();
     await insertText(editor, "/emoji");
     await press("enter");
     await waitFor(".o-EmojiPicker", { timeout: 1000 });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -42,7 +42,13 @@ import { delay } from "@web/core/utils/concurrency";
 import { FormController } from "@web/views/form/form_controller";
 import { Counter, EmbeddedWrapperMixin } from "./_helpers/embedded_component";
 import { moveSelectionOutsideEditor, setSelection } from "./_helpers/selection";
-import { insertText, pasteOdooEditorHtml, pasteText, undo } from "./_helpers/user_actions";
+import {
+    ensureDistinctHistoryStep,
+    insertText,
+    pasteOdooEditorHtml,
+    pasteText,
+    undo,
+} from "./_helpers/user_actions";
 import { unformat } from "./_helpers/format";
 import { expandToolbar } from "./_helpers/toolbar";
 import { expectElementCount } from "./_helpers/ui_expectations";
@@ -834,7 +840,9 @@ test("undo after discard html field changes in form", async () => {
     // move the hoot focus in the editor
     await click(".odoo-editor-editable");
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "test");
+    await insertText(htmlEditor, "tes");
+    await ensureDistinctHistoryStep();
+    await insertText(htmlEditor, "t");
     await animationFrame();
     expect(".odoo-editor-editable p").toHaveText("testfirst");
     expect(`.o_form_button_cancel`).toBeVisible();
@@ -1529,7 +1537,10 @@ test("edit and enable/disable codeview with editor toolbar", async () => {
     });
 
     setSelectionInHtmlField();
-    await insertText(htmlEditor, "Hello ");
+    await insertText(htmlEditor, "Hello");
+    await ensureDistinctHistoryStep();
+    await insertText(htmlEditor, " ");
+    await ensureDistinctHistoryStep();
     expect("[name='txt'] .odoo-editor-editable").toHaveInnerHTML("<p>Hello first </p>");
 
     // Switch to code view

--- a/addons/html_editor/static/tests/link/transform.test.js
+++ b/addons/html_editor/static/tests/link/transform.test.js
@@ -5,7 +5,7 @@ import { onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts } from "../_helpers/format";
 import { getContent, setSelection } from "../_helpers/selection";
-import { insertSpace, insertText, undo } from "../_helpers/user_actions";
+import { ensureDistinctHistoryStep, insertSpace, insertText, undo } from "../_helpers/user_actions";
 import { expectElementCount } from "../_helpers/ui_expectations";
 
 /**
@@ -132,7 +132,9 @@ test("should not transform url after two space", async () => {
 
 test("transform text url into link and undo it", async () => {
     const { el, editor } = await setupEditor(`<p>[]</p>`);
-    await insertText(editor, "www.abc.jpg ");
+    await insertText(editor, "www.abc.jpg");
+    await ensureDistinctHistoryStep();
+    await insertText(editor, " ");
     expect(cleanLinkArtifacts(getContent(el))).toBe(
         '<p><a href="https://www.abc.jpg">www.abc.jpg</a>&nbsp;[]</p>'
     );

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -21,7 +21,7 @@ import {
 } from "./_helpers/collaboration";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { insertText, redo, undo } from "./_helpers/user_actions";
+import { ensureDistinctHistoryStep, insertText, redo, undo } from "./_helpers/user_actions";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { PowerboxPlugin } from "@html_editor/main/powerbox/powerbox_plugin";
 import { SearchPowerboxPlugin } from "@html_editor/main/powerbox/search_powerbox_plugin";
@@ -689,7 +689,14 @@ test("should discard /command insertion from history when command is executed", 
     // @todo @phoenix: remove this once we manage inputs.
     // Simulate <br> removal by contenteditable when something is inserted
     el.querySelector("p > br").remove();
-    await insertText(editor, "abc/heading1");
+    await insertText(editor, "a");
+    await ensureDistinctHistoryStep();
+    await insertText(editor, "b");
+    await ensureDistinctHistoryStep();
+    await insertText(editor, "c");
+    await ensureDistinctHistoryStep();
+    await insertText(editor, "/heading1");
+    await ensureDistinctHistoryStep();
     expect(getContent(el)).toBe("<p>abc/heading1[]</p>");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 1);
@@ -714,7 +721,10 @@ test("should discard /command insertion from history when command is executed", 
 
 test("should adapt the search of the powerbox when undo/redo", async () => {
     const { editor, el } = await setupEditor("<p>ab[]</p>");
-    await insertText(editor, "/heading1");
+    await insertText(editor, "/heading");
+    await ensureDistinctHistoryStep();
+    await insertText(editor, "1");
+    await ensureDistinctHistoryStep();
     await animationFrame();
     expect(commandNames(el)).toEqual(["Heading 1"]);
 

--- a/addons/html_editor/static/tests/selection_placeholder.test.js
+++ b/addons/html_editor/static/tests/selection_placeholder.test.js
@@ -2,7 +2,12 @@ import { expect, test } from "@odoo/hoot";
 import { testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { animationFrame, press, tick } from "@odoo/hoot-dom";
-import { insertText, simulateArrowKeyPress, splitBlock } from "./_helpers/user_actions";
+import {
+    ensureDistinctHistoryStep,
+    insertText,
+    simulateArrowKeyPress,
+    splitBlock,
+} from "./_helpers/user_actions";
 import { getContent } from "./_helpers/selection";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { isTableCell } from "@html_editor/utils/dom_info";
@@ -452,7 +457,7 @@ test("enter in a selection placeholder persists it", async () => {
 });
 
 test.tags("focus required");
-test("can undo/redo the persiting of selection placeholders", async () => {
+test("can undo/redo the persisting of selection placeholders", async () => {
     const makeContent = (inTable = "", placeholder = "") =>
         unformat(
             `<p>a</p>
@@ -469,6 +474,7 @@ test("can undo/redo the persiting of selection placeholders", async () => {
         contentBeforeEdit: makeContent("b[]", '<p data-selection-placeholder=""><br></p>'),
         stepFunction: async (editor) => {
             await insertText(editor, "c");
+            await ensureDistinctHistoryStep();
             expect(getContent(editor.editable)).toBe(
                 makeContent("bc[]", '<p data-selection-placeholder=""><br></p>'),
                 {

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
 import { getContent } from "./_helpers/selection";
 import { animationFrame, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
-import { insertText, splitBlock } from "./_helpers/user_actions";
+import { ensureDistinctHistoryStep, insertText, splitBlock } from "./_helpers/user_actions";
 import {
     compareHighlightedContent,
     highlightedPre,
@@ -20,6 +20,7 @@ import { parseHTML } from "@html_editor/utils/html";
 const pressAndWait = async (...args) => {
     await press(...args);
     await animationFrame(); // wait for effect
+    await ensureDistinctHistoryStep();
 };
 
 const insertPre = async (editor) => {
@@ -472,6 +473,7 @@ test("can switch between code blocks without issues", async () => {
     editor.shared.selection.setCursorEnd(p1);
     // Action 3: insert "c" in first paragraph.
     await insertText(editor, "c");
+    await ensureDistinctHistoryStep();
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(
@@ -756,7 +758,10 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
 
     // Write in the P.
     actions.push("type: insert 'o' into the paragraph", "type: insert '!' into the paragraph");
-    await insertText(editor, "o!"); // <wrapper><pre>some code</pre></wrapper><p>hello![]</p>
+    await insertText(editor, "o"); // <wrapper><pre>some code</pre></wrapper><p>hello[]</p>
+    await ensureDistinctHistoryStep();
+    await insertText(editor, "!"); // <wrapper><pre>some code</pre></wrapper><p>hello![]</p>
+    await ensureDistinctHistoryStep();
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
@@ -823,7 +828,10 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     const p = queryOne("p:not([data-selection-placeholder])");
     await click(p);
     editor.shared.selection.setCursorEnd(p);
-    await insertText(editor, "ok"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok[]</p>
+    await insertText(editor, "o"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!o[]</p>
+    await ensureDistinctHistoryStep();
+    await insertText(editor, "k"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok[]</p>
+    await ensureDistinctHistoryStep();
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -5,6 +5,7 @@ import {
 } from "@website/../tests/builder/website_helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { getDragHelper, waitForEndOfOperation } from "@html_builder/../tests/helpers";
+import { ensureDistinctHistoryStep } from "@html_editor/../tests/_helpers/user_actions";
 import { click, queryOne, animationFrame, edit, waitFor } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
@@ -215,6 +216,7 @@ test("reorder social medias", async () => {
 
     await contains("tr:nth-child(3) input[type=checkbox]").click();
     await contains("tr:nth-child(3) button.o_drag_handle").dragAndDrop("tr:nth-child(1)");
+    await ensureDistinctHistoryStep();
     await contains("tr:nth-child(3) button.o_drag_handle").dragAndDrop("tr:nth-child(1)");
 
     expect("tr:nth-child(1) input[type=text]").toHaveValue("https://www.example.com/first");

--- a/addons/website/static/tests/builder/website_builder/table_of_content_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/table_of_content_option.test.js
@@ -1,5 +1,10 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
-import { deleteBackward, insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
+import {
+    deleteBackward,
+    ensureDistinctHistoryStep,
+    insertText,
+    undo,
+} from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
 import {
     animationFrame,
@@ -36,7 +41,10 @@ test("edit title in content with table of content", async () => {
 
     const h2 = queryAll(":iframe .s_table_of_content_main h2:contains('Intuitive system')")[0];
     setSelection({ anchorNode: h2, anchorOffset: 0 });
-    await insertText(editor, "New Title:");
+    await insertText(editor, "New Title");
+    await ensureDistinctHistoryStep();
+    await insertText(editor, ":");
+    await ensureDistinctHistoryStep();
     expect(
         queryAllTexts(":iframe .s_table_of_content_navbar a.table_of_content_link_depth_0")
     ).toEqual(["New Title:Intuitive system", "Design features"]);


### PR DESCRIPTION
This commit undoes/redoes all consecutive steps that modify the same text node in a single call to `undo/redo()`.

task-5155954
