### PR TITLE
[FIX] hr_holidays: prevent errors when changing the Time Off Type

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -434,7 +434,7 @@ Versions:
                 holiday.date_from = False
                 continue
 
-            if not holiday.request_unit_half and not holiday.request_unit_hours and not holiday.request_date_to:
+            if not holiday.request_date_to:
                 holiday.date_to = False
                 continue
 

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -2115,3 +2115,11 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_req_form.employee_id = self.employee_responsible
 
         self.assertFalse(leave_req_form.can_approve)
+
+    def test_change_leave_type_on_leave_req_without_end_date(self):
+        """Test changing the leave type on a leave request without an end date."""
+        leave_req_form = Form(self.env['hr.leave'].with_user(self.user_hrmanager_id))
+        leave_req_form.request_date_to = False
+        leave_req_form.holiday_status_id = self.holidays_type_hours
+
+        self.assertFalse(leave_req_form.date_to)


### PR DESCRIPTION
Currently, an error occurs when the user changes the Time Off Type.

**Steps to Reproduce  Error 1:**

 - Install the `hr_holidays` module.
 - Go to `Management > Time Off`.
 - Create a `new time off`.
 - Remove the `end date` and change the `leave type` to `Unpaid Leave (because its duration type is hours)`.

`TypeError: combine() argument 1 must be datetime.date, not bool`

**Steps to Reproduce  Error 2:**

 - Follow the first 3 steps from above.
 - Change the `leave type to Unpaid`.
 - Remove the `hours` and then remove the `end date`.
 - Change the `leave type` again.

`ValueError: Target Date cannot be empty`

**Cause:**
This error occurs when the user removes the end date and then changes the leave type. If they select Unpaid (which has the duration type Hour), then Specific Time (request_unit_hours) becomes true and the flow goes to [1]. It then checks the hours because, in the first error, they are set. From there, it goes to [2] and tries to calculate the date in datetime format, which raises the error [3] due to empty date. For the second error, after selecting the unpaid leave type and removing the hours and the end date, the flow again tries to calculate the hours from [4], and it raises ValueError.

**Fix:**
This commit ensures that if there is no Request End Date for the leave, the End Date is set to False.

[1]: https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/hr_holidays/models/hr_leave.py#L441-L442

[2]: https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/hr_holidays/models/hr_leave.py#L465

[3]: https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/hr_holidays/models/hr_leave.py#L1553

[4]: https://github.com/odoo/odoo/blob/ac6960dc553088894e688bcc0f4a49245aa02d6c/addons/resource/models/resource_calendar.py#L936-L938

**No Task ID**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
