### PR TITLE
[FIX] website_sale: ensure correct confirmation email template is used

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -237,6 +237,15 @@ class SaleOrder(models.Model):
     def _get_amount_total_excluding_delivery(self):
         return sum(self._get_non_delivery_lines().mapped('price_total'))
 
+    def _get_confirmation_template(self):
+        """Override of `sale` to use the website specific order confirmation email template if set."""
+        self.ensure_one()
+
+        if self.website_id and self.website_id.confirmation_email_template_id:
+            return self.website_id.confirmation_email_template_id
+
+        return super()._get_confirmation_template()
+
     def action_confirm(self):
         carts = self.filtered('website_id')
         if self.env.su:

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -26,6 +26,7 @@ from . import test_website_sale_gmc
 from . import test_website_sale_image
 from . import test_website_sale_invoice
 from . import test_website_sale_mail
+from . import test_website_sale_mail_template
 from . import test_website_sale_pricelist
 from . import test_website_sale_product_attribute_value_config
 from . import test_website_sale_product_configurator

--- a/addons/website_sale/tests/test_website_sale_mail_template.py
+++ b/addons/website_sale/tests/test_website_sale_mail_template.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+from odoo.addons.sale.tests.common import SaleCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleOrderEmailTemplate(SaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env['website'].create({
+            'name': 'Test Website for Email Template',
+        })
+        cls.sale_order.website_id = cls.website.id
+
+    def test_website_specific_confirmation_template_is_used(self):
+        """Ensure _get_confirmation_template returns the website-specific template when set."""
+        template = self.env['mail.template'].create({
+            'name': "Website Custom Confirmation Template",
+            'model_id': self.env.ref('sale.model_sale_order').id,
+            'subject': "Website Confirmation",
+            'body_html': '<p>Hello</p>',
+        })
+        self.website.confirmation_email_template_id = template
+        with patch.object(self.env.registry['sale.order'], '_send_order_notification_mail') as mock:
+            self.sale_order._send_order_confirmation_mail()
+            mock.assert_called_once()
+            returned_confirmation_template = mock.call_args[0][0]
+            self.assertEqual(returned_confirmation_template, template)


### PR DESCRIPTION
**Steps to produce:**
- Install the `website_sale` module.
- Create an order from ecommerce and make a payment.
- Check the sent mail > it uses the default Sale Order confirmation template.
- Go to Settings > Website > eCommerce > change the `Email in order confirmation` template.
- Again, create a Sales Order and make a payment from the website.

**Issue:**
- The confirmation email still uses the default template, ignoring the
 updated template set in Website settings.

**Root cause:**
- During payment, `action_confirm` is called in `website_sale` [1].
- The super call delegates to `sale.order` [2], which fetches the default confirmation template [3].

**Solution:**
- Override `_get_confirmation_template` in `website_sale` to return the template
defined in Website settings.
- This ensures that the updated template is respected when sending confirmation
 emails after payment.

[1]: https://github.com/odoo/odoo/blob/1fcba6fe896acfef7c409eac7af002740e05a63c/addons/website_sale/models/sale_order.py#L240
[2]: https://github.com/odoo/odoo/blob/2ec06924ac50e82460b7a2856f74a115d3b874f9/addons/sale/models/sale_order.py#L1149
[3]: https://github.com/odoo/odoo/blob/2ec06924ac50e82460b7a2856f74a115d3b874f9/addons/sale/models/sale_order.py#L1123-L1137

opw-5352437
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
