### PR TITLE
[IMP] core: disable audio during tours

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1119,6 +1119,7 @@ class ChromeBrowser:
             '--remote-debugging-port': str(self.remote_debugging_port),
             '--no-sandbox': '',
             '--disable-gpu': '',
+            '--mute-audio': '',
             '--remote-allow-origins': '*',
             # '--enable-precise-memory-info': '', # uncomment to debug memory leaks in qunit suite
             # '--js-flags': '--expose-gc', # uncomment to debug memory leaks in qunit suite


### PR DESCRIPTION
When running tests locally, it's really annoying (and sometimes really jarring / surprising) to hear random beeps and boops from your machine, especially when it's an old timey ringtone from voip.

Make it stop.
