### PR TITLE
[REF] website: adding export to the `TextDescription` component

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -541,7 +541,7 @@ class SEOPreview extends Component {
         return this.props.description || "";
     }
 }
-class TitleDescription extends Component {
+export class TitleDescription extends Component {
     static template = "website.TitleDescription";
     static props = {
         canEditSeo: Boolean,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR exposes the `TextDescription` component such that it can be patched.

Current behavior before PR:

Currently the `TextDescription` component of the website cannot be overridden since it is not exported.

Desired behavior after PR is merged:

The `TextDescription` component can be patched.

Enterprise PR: https://github.com/odoo/enterprise/pull/101488

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
