### PR TITLE
[FIX] pos_self_order: pay unapid order from kiosk in POS

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -582,7 +582,7 @@ class PosOrder(models.Model):
                     raise UserError(_('The paid amount is different from the total amount of the order.'))
                 elif totally_paid_or_more > 0 and order.state == 'paid':
                     list_line.append(_("Warning, the paid amount is higher than the total amount. (Difference: %s)", formatLang(self.env, order.amount_paid - order.amount_total, currency_obj=order.currency_id)))
-                if order.nb_print > 0 and vals.get('payment_ids'):
+                if order.nb_print > 0 and any(command[0] in [0, 1] and command[2].get('payment_status') and command[2]['payment_status'] != 'cancelled' for command in vals.get('payment_ids')):
                     raise UserError(_('You cannot change the payment of a printed order.'))
 
         if len(list_line) > 0:

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -259,6 +259,21 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_pay_unpaid_order_from_kiosk", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickOrders(),
+            TicketScreen.selectOrder(2.53),
+            TicketScreen.loadSelectedOrder(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("refund_multiple_products_amounts_compliance", {
     steps: () =>
         [

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -209,6 +209,17 @@ registry.category("web_tour.tours").add("test_self_order_pricelist", {
     ],
 });
 
+registry.category("web_tour.tours").add("test_self_order_kiosk_unpaid", {
+    steps: () => [
+        Utils.clickBtn("Order now"),
+        ProductPage.clickCategory("Miscellaneous"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Checkout"),
+        Utils.clickBtn("Order"),
+        ConfirmationPage.orderNumberShown(),
+    ],
+});
+
 registry.category("web_tour.tours").add("test_self_order_kiosk_product_availability", {
     steps: () => [
         Utils.clickBtn("Order Now"),

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -213,6 +213,27 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, 'test_self_order_pricelist')
 
+    def test_self_order_kiosk_to_cashier_payment(self):
+        self.pos_config.write({
+            'use_presets': False,
+            'default_preset_id': False,
+            'available_preset_ids': [Command.clear()],
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'use_pricelist': True,
+        })
+        cashier_pos = self.env['pos.config'].create({
+            'name': 'Shop',
+            'module_pos_restaurant': False,
+            'cash_control': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, 'test_self_order_kiosk_unpaid')
+        self.start_tour(f"/pos/ui/{cashier_pos.id}", 'test_pay_unpaid_order_from_kiosk', login="admin")
+
     def test_self_order_kiosk_ordering_images_public(self):
         def assert_all_image_public():
             self.assertTrue(all(img.public for img in self.pos_config.self_ordering_image_home_ids))


### PR DESCRIPTION
We have a check when validating an order on the POS that would not let you change the payment method if a ticket is already printed. This makes it impossible to create payments from POS for unpaid orders from the kiosk.

I added an extra check during the validation to see that the payments are actually done, and only then forbid changing the payment method.

Task-[5388807](https://www.odoo.com/odoo/project/1737/tasks/5388807)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
