### PR TITLE
[FIX] html_editor: toggle block button default type

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="html_editor.EmbeddedToggleBlock">
        <div class="d-flex flex-row align-items-center">
-            <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" t-on-click="onToggle">
+            <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" t-on-click="onToggle" type="button">
                 <i t-attf-class="fa align-self-center fa-caret-{{this.state.showContent ? 'down' : 'right'}}"/>
             </button>
             <div class="flex-fill ms-1" t-ref="title"/>

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -75,7 +75,7 @@ describe("deleteBackward applied to toggle", () => {
                 <p><br></p>
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -118,7 +118,7 @@ describe("deleteBackward applied to toggle", () => {
             <p><br></p>
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -236,7 +236,7 @@ describe("deleteForward applied to toggle", () => {
             unformat(`
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -310,7 +310,7 @@ describe("deleteForward applied to toggle", () => {
             unformat(`
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -357,7 +357,7 @@ describe("deleteForward applied to toggle", () => {
             unformat(`
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -407,7 +407,7 @@ describe("deleteForward applied to toggle", () => {
             unformat(`
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -459,7 +459,7 @@ describe("Enter applied to toggle title", () => {
             unformat(`
                 <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{"toggleBlockId":"2"}'>
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -476,7 +476,7 @@ describe("Enter applied to toggle title", () => {
                 </div>
                 <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                             <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
@@ -524,7 +524,7 @@ describe("Enter applied to toggle title", () => {
             unformat(`
             <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-right"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -541,7 +541,7 @@ describe("Enter applied to toggle title", () => {
             </div>
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{"toggleBlockId":"2"}'>
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-right"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -583,7 +583,7 @@ describe("Enter applied to toggle title", () => {
             unformat(`
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -663,7 +663,7 @@ describe("Tab applied to toggle title", () => {
             unformat(`
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -676,7 +676,7 @@ describe("Tab applied to toggle title", () => {
                     <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
                         <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
                             <div class="d-flex flex-row align-items-center">
-                                <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                                <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                                     <i class="fa align-self-center fa-caret-right"></i>
                                 </button>
                                 <div class="flex-fill ms-1">
@@ -730,7 +730,7 @@ describe("Tab applied to toggle title", () => {
             unformat(`
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -743,7 +743,7 @@ describe("Tab applied to toggle title", () => {
                     <div data-embedded-editable="content" data-oe-protected="false" contenteditable="true">
                         <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
                             <div class="d-flex flex-row align-items-center">
-                                <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                                <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                                     <i class="fa align-self-center fa-caret-down"></i>
                                 </button>
                                 <div class="flex-fill ms-1">
@@ -799,7 +799,7 @@ describe("Shift+Tab applied to toggle title", () => {
             unformat(`
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -816,7 +816,7 @@ describe("Shift+Tab applied to toggle title", () => {
             </div>
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
                 <div class="d-flex flex-row align-items-center">
-                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
+                    <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button">
                         <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
@@ -899,7 +899,7 @@ describe("Insert (paste, drop) inside toggle title", () => {
             unformat(`
                 <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                     <div class="d-flex flex-row align-items-center">
-                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light"><i class="fa align-self-center fa-caret-right"></i></button>
+                        <button class="btn p-0 border-0 align-items-center justify-content-center btn-light" type="button"><i class="fa align-self-center fa-caret-right"></i></button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
                                 <div class="o-paragraph">HelloNew</div>


### PR DESCRIPTION
**Context**
If you add a toggle block element in the ecommerce description of a product in your backend, it will be rendered inside a `<form />` element on your website's product page.

**Before this commit**
The button controlling the toggling of this element does not have an explicit "type" attribute set. This has the effect that these buttons will act as "submit" buttons for the form element on the website, causing a page reload.
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type

**After this commit**
Explicitly set the "type" attribute to be "button" so that toggling a block doesn't reload the user's website.

opw-5369171