### PR TITLE
[FIX] mail: don't leak agent name with mentions

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1092,7 +1092,13 @@ class MailMessage(models.Model):
             "message_type",
             "model",  # keep for iOS app
             # sudo: res.partner: reading limited data of recipients is acceptable
-            Store.Many("partner_ids", ["avatar_128", "name"], sort="id", sudo=True),
+            Store.Many(
+                "partner_ids",
+                "avatar_128",
+                dynamic_fields=lambda m: m._get_store_partner_name_fields(),
+                sort="id",
+                sudo=True,
+            ),
             "pinned_at",
             # sudo: mail.message - reading reactions on accessible message is allowed
             Store.Attr("reactions", value=lambda m: Store.Many(m.sudo().reaction_ids)),

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -357,7 +357,7 @@ export class Composer extends Component {
     }
 
     get thread() {
-        return this.props.composer.replyToMessage?.thread ?? this.props.composer.thread ?? null;
+        return this.props.composer.targetThread;
     }
 
     get allowUpload() {
@@ -423,7 +423,8 @@ export class Composer extends Component {
                             };
                         } else {
                             return {
-                                label: suggestion.name,
+                                label: this.thread?.getPersonaName(suggestion) ?? suggestion.name,
+                                thread: this.thread,
                                 partner: suggestion,
                                 classList: "o-mail-Composer-suggestion",
                             };

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -197,6 +197,9 @@
         <ImStatus t-if="partner" persona="partner"/>
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
             <t t-esc="partner.name"/>
+            <t t-if="option.thread and partner.name !== option.thread.getPersonaName(partner)">
+                "<t t-esc="option.thread.getPersonaName(partner)"/>"
+            </t>
         </strong>
         <span t-if="partner.email" class="text-600 text-truncate align-self-center">(<t t-esc="partner.email"/>)</span>
     </t>

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -58,8 +58,12 @@ export class Composer extends Record {
                 mentionedChannels: this.mentionedChannels,
                 mentionedPartners: this.mentionedPartners,
                 mentionedRoles: this.mentionedRoles,
+                thread: this.targetThread,
             });
-            const prettifiedHtml = prettifyMessageText(this.composerText, { validMentions });
+            const prettifiedHtml = prettifyMessageText(this.composerText, {
+                validMentions,
+                thread: this.targetThread,
+            });
             if (this.composerHtml.toString() !== prettifiedHtml.toString()) {
                 this.updateFrom = "text";
                 this.composerHtml = prettifiedHtml;
@@ -121,7 +125,7 @@ export class Composer extends Record {
     }
 
     get targetThread() {
-        return this.replyToMessage?.thread ?? this.thread ?? null;
+        return this.replyToMessage?.thread ?? this.thread ?? this.message?.thread ?? null;
     }
 }
 

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -552,6 +552,7 @@ export class Message extends Record {
             mentionedChannels,
             mentionedPartners,
             mentionedRoles,
+            thread: this.thread,
         });
         const hadLink = this.hasLink; // to remove old previews if message no longer contains any link
         const updateData = {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -560,7 +560,7 @@ export class Store extends BaseStore {
 
     getMentionsFromText(
         body,
-        { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [] } = {}
+        { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [], thread } = {}
     ) {
         const validMentions = {};
         validMentions.threads = mentionedChannels.filter((thread) => {
@@ -572,7 +572,7 @@ export class Store extends BaseStore {
             return body.includes(`#${thread.displayName}`);
         });
         validMentions.partners = mentionedPartners.filter((partner) =>
-            body.includes(`@${partner.name}`)
+            body.includes(`@${thread?.getPersonaName(partner) ?? partner.name}`)
         );
         validMentions.roles = mentionedRoles.filter((role) => body.includes(`@${role.name}`));
         validMentions.specialMentions = this.specialMentions
@@ -599,6 +599,7 @@ export class Store extends BaseStore {
             mentionedChannels,
             mentionedPartners,
             mentionedRoles,
+            thread,
         });
         const partner_ids = validMentions?.partners.map((partner) => partner.id) ?? [];
         const role_ids = validMentions?.roles.map((role) => role.id) ?? [];

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -212,7 +212,7 @@ export class UseSuggestion {
         if (this.comp.composerService.htmlEnabled) {
             let inlineElement;
             if (option.partner) {
-                inlineElement = generatePartnerMentionElement(option.partner);
+                inlineElement = generatePartnerMentionElement(option.partner, this.thread);
             } else if (option.isSpecial) {
                 inlineElement = generateSpecialMentionElement(option.label);
             } else if (option.role) {


### PR DESCRIPTION
Before this commit, when mentioning an internal user in live chat it would show their name in the message body.
This leads to the agent's name being leaked when a live chat username is set.

This commit fixes the issue by using the user's live chat username (when available and in the context of live chats) in the generated mention element.
This commit also changes `mail_message@_to_store_defaults` to send, when available, the `user_livechat_username` of the recipients of a message.

task-5384305