### PR TITLE
[FIX] web: display unescaped HTML entities in search suggestions

### DIFF
--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -55,7 +55,7 @@ export function highlightText(query, text, classes) {
     let result = text;
     for (const match of matches) {
         const regex = new RegExp(
-            `(${escapeRegExp(htmlEscape(match))})(?=(?:[^>]*<[^<]*>)*[^<>]*$)`,
+            `(?<!&[^;]{0,5})(${escapeRegExp(htmlEscape(match))})(?=(?:[^>]*<[^<]*>)*[^<>]*$)`,
             "ig"
         );
         result = htmlReplace(result, regex, (_, match) => {

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -1291,16 +1291,21 @@ test("bold the searchValue on the commands with special char", async () => {
     const action = () => {};
     const providers = [
         {
+            namespace: "/",
             provide: () => [
                 {
                     name: "Test&",
+                    action,
+                },
+                {
+                    name: "Research & Development",
                     action,
                 },
             ],
         },
     ];
     const config = {
-        searchValue: "&",
+        searchValue: "/",
         providers,
     };
     getService("dialog").add(CommandPalette, {
@@ -1308,9 +1313,29 @@ test("bold the searchValue on the commands with special char", async () => {
     });
     await animationFrame();
     expect(".o_command_palette").toHaveCount(1);
-    expect(".o_command").toHaveCount(1);
-    expect(queryAllTexts(".o_command")).toEqual(["Test&"]);
-    expect(queryAllTexts(".o_command .fw-bolder")).toEqual(["&"]);
+    expect(".o_command").toHaveCount(2);
+    expect(queryAllTexts(".o_command")).toEqual(["Test&", "Research & Development"]);
+    expect(queryAllTexts(".o_command .fw-bolder")).toEqual([]);
+
+    await click(".o_command_palette_search input");
+    await edit("/a");
+    await runAllTimers();
+    expect(".o_command").toHaveCount(2);
+    expect(
+        queryAll(".o_command").map((command) =>
+            queryAllTexts(".o_command_name .fw-bolder", { root: command })
+        )
+    ).toEqual([[], ["a"]]);
+
+    await click(".o_command_palette_search input");
+    await edit("/&");
+    await runAllTimers();
+    expect(".o_command").toHaveCount(2);
+    expect(
+        queryAll(".o_command").map((command) =>
+            queryAllTexts(".o_command_name .fw-bolder", { root: command })
+        )
+    ).toEqual([["&"], ["&"]]);
 });
 
 test("bold the searchValue on the commands with accents", async () => {

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -4037,7 +4037,7 @@ test("many2one search with formatted name", async () => {
         {
             id: 1,
             display_name: "Paul Eric",
-            __formatted_display_name: "Test: **Paul** --Eric-- `good guy`\n\tMore text",
+            __formatted_display_name: "Research & Development Test: **Paul** --Eric-- `good guy`\n\tMore text",
         },
     ]);
     await mountView({
@@ -4053,7 +4053,7 @@ test("many2one search with formatted name", async () => {
     expect(
         ".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)"
     ).toHaveInnerHTML(
-        `Test: <b>Paul</b> <span class="text-muted">Eric</span> <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">good guy</span><br/><span style="margin-left: 2em"></span>More text`
+        `Research & Development Test: <b>Paul</b> <span class="text-muted">Eric</span> <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">good guy</span><br/><span style="margin-left: 2em"></span>More text`
     );
     await contains(
         ".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)"

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -2369,3 +2369,27 @@ test("settings search is accent-insensitive", async () => {
     await editSearch("àz");
     expect(queryAllTexts(".highlighter")).toEqual(["ÄZ", "áz"]);
 });
+
+test("settings search does not highlight escaped characters when highlighting the searched text", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.config.settings",
+        arch: /* xml */ `
+            <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
+                <app string="CRM" name="crm">
+                    <block title="Research &amp; Development">
+                        <setting help="This is Research &amp; Development Settings">
+                            <field name="bar"/>
+                            <div>This test is to check whether &amp; gets escaped during search or not.</div>
+                        </setting>
+                    </block>
+                </app>
+            </form>
+        `,
+    });
+
+    await editSearch("a");
+    expect(queryAllTexts(".highlighter")).toEqual(["a", "a", "a", "a", "a"]);
+    await editSearch("&");
+    expect(queryAllTexts(".highlighter")).toEqual(["&", "&", "&"]);
+});


### PR DESCRIPTION
**Before this commit:**
Search suggestions **(Command Palette, Many2X fields, Settings)** displayed escaped HTML entities because both the user input and the source data were being escaped before regex matching. For eg: **(e.g. & -> &amp;)**.

**After this commit:**
Search suggestions now displays unescaped HTML entities. This is achieved by refining the regex to avoid matching characters inside **&...;** sequences. The regex is tailored around the characters escaped by `htmlEscape` in **OWL: ["&", "<", ">", "'", "\"", ""]`**.

task-5124883

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
