### PR TITLE
[IMP] im_livechat: livechat channel joined indicator in discuss app

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_categories_patch.scss
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_categories_patch.scss
@@ -1,0 +1,4 @@
+.o-mail-DiscussSidebarCategory-livechatJoinedIndicatorCompact {
+    right: 11px;
+    bottom: 1px;
+}

--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_categories_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_categories_patch.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.DiscussSidebarCategory.main" t-inherit-mode="extension">
+        <xpath expr="//*[@name='titleText']" position="before">
+            <i t-if="!store.discuss.isSidebarCompact and category.livechat_channel_id?.are_you_inside" class="fa fa-circle text-success o-xxsmaller me-1" title="You have joined this live chat channel"/>
+        </xpath>
+        <xpath expr="//*[@name='header']" position="inside">
+            <i t-if="store.discuss.isSidebarCompact and category.livechat_channel_id?.are_you_inside" class="fa fa-circle text-success o-xxxs position-absolute o-mail-DiscussSidebarCategory-livechatJoinedIndicatorCompact"/>
+        </xpath>
+    </t>
+    <t t-inherit="mail.DiscussSidebarCategory" t-inherit-mode="extension">
+        <xpath expr="//*[@t-ref='floatingCategoryName']" position="after">
+            <span t-if="category.livechat_channel_id?.are_you_inside" class="d-flex align-items-center">
+                <i class="fa fa-circle text-success o-xxxs me-1"/>
+                <span class="text-muted smaller fst-italic text-success pe-1">joined</span>
+            </span>
+        </xpath>
+    </t>
+</templates>

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -65,12 +65,22 @@ test("from the discuss app", async () => {
     ]);
     await start();
     await openDiscuss();
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat:has(:text('HR')) .fa-circle[title='You have joined this live chat channel']"
+    );
     await click("[title='Leave HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat:has(:text('HR')) .fa-circle[title='You have joined this live chat channel']",
+        { count: 0 }
+    );
     await click("[title='Join HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat:has(:text('HR')) .fa-circle[title='You have joined this live chat channel']"
+    );
     await click("[title='Chat Actions']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "guest_1" }],
     });

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -290,6 +290,10 @@ $o-mail-utilities: map-merge(
     font-size: 0.5rem;
 }
 
+.o-xxxs {
+    font-size: 0.35rem;
+}
+
 .o-yellow {
     color: $yellow;
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -22,7 +22,7 @@
             <t t-call="mail.DiscussSidebarCategory.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                    <span class="fw-bold text-uppercase o-xsmaller user-select-none text-muted" t-esc="category.name"/>
+                    <span class="fw-bold text-uppercase o-xsmaller user-select-none text-muted" t-ref="floatingCategoryName" t-esc="category.name"/>
                     <t t-call="mail.DiscussSidebarCategory.actions"/>
                 </div>
             </t>
@@ -43,12 +43,8 @@
                 <t t-else="">
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50 o-mt-0_5"/></span>
                     <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller fa-fw position-absolute ms-n3 align-self-center o-mt-0_5" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
-                    <span class="o-mail-DiscussSidebarCategory-title text-break smaller"
-                        t-att-class="{
-                            'fs-bold': category.open,
-                        }"
-                    >
-                        <t t-esc="category.name"/>
+                    <span class="o-mail-DiscussSidebarCategory-title text-break smaller d-flex align-items-center" t-att-class="{ 'fs-bold': category.open }">
+                        <t name="titleText" t-esc="category.name"/>
                     </span>
                 </t>
             </button>


### PR DESCRIPTION
Before this commit, seeing whether a livechat channel was joined or not in discuss app sidebar required to mouse-hover the category and seeing whether the action join or leave was present.

This is a problem because using livechat as an agent requires frequent join and leave. The mouse-hover is too subtle to know for sure whether the channel is joined or not, which is crucial for agent to not mistakenly forgetting to join the channel at the start of their shift or leaving at the end of their shift.

Also the mouse-hover technique on category shows the icon in muted state, and it's not easy to get at a quick glance since the icon are quite similar. The color is only shown on exact mouse-hover on the join/leave action.

In previous versions, these category actions were always displayed on the sidebar, but have their visibility reduced in 19.0 to declutter the discuss app sidebar visually. However this introduced this UX regression.

This commit fixes the issue by adding a small indicator on livechat categories that the user has joined as a tiny green dot. That way the discuss sidebar stays relatively simple visually but there's a quick and very easy indicator that the livechat channel has been joined. The agent can easily deduced the channel hasn't been joined by the non-presence of this indicator.

Before:
<img width="300" height="754" alt="Screenshot 2025-12-05 at 15 46 42" src="https://github.com/user-attachments/assets/f8940e69-779a-431d-ac2e-1b51fe36a2d5" />


After:
<img width="308" height="735" alt="Screenshot 2025-12-05 at 15 31 57" src="https://github.com/user-attachments/assets/586be26e-3ab3-4d00-ba13-7255c1b74ec4" />
<img width="353" height="741" alt="Screenshot 2025-12-05 at 15 31 32" src="https://github.com/user-attachments/assets/43a91144-07f7-474a-84d1-b8f3718a1ace" />