### PR TITLE
[FIX] purchase_stock: prevent compensation aml when PO other currency

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -205,7 +205,8 @@ class StockMove(models.Model):
             unit_diff = layer._get_layer_price_unit() - returned_layer._get_layer_price_unit() if returned_layer else 0
         elif returned_move and returned_move._is_out() and returned_move._is_returned(valued_type='out'):
             returned_layer = returned_move.stock_valuation_layer_ids.filtered(lambda svl: not svl.stock_valuation_layer_id)[:1]
-            unit_diff = returned_layer._get_layer_price_unit() - self.purchase_line_id._get_gross_price_unit()
+            origin_layer = returned_move.origin_returned_move_id.stock_valuation_layer_ids.filtered(lambda svl: not svl.stock_valuation_layer_id)[:1]
+            unit_diff = returned_layer._get_layer_price_unit() - origin_layer._get_layer_price_unit() if returned_layer and origin_layer else 0
         else:
             return am_vals_list
 

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3550,6 +3550,46 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         ])
         self.assertTrue(all(aml.full_reconcile_id for aml in in_stock_amls))
 
+    def test_avco_return_and_returned_back_different_currency(self):
+        """ Check that when a PO is in a different currency than the company,
+        the compensation amls are not wrongfully created when the return
+        of the return is validated with no price change.(ie: no extra aml with
+        credit of 9.0)
+        """
+        self.env['res.currency.rate'].search([]).unlink()
+        self.product1.categ_id.property_cost_method = 'fifo'
+        self.product1.categ_id.property_valuation = 'real_time'
+        avco_prod = self.product1
+        self.env.ref('base.EUR').active = True
+        euro_id = self.env.ref('base.EUR').id
+        self.env['res.currency.rate'].create([
+            {'currency_id': euro_id, 'rate': 10},
+        ])
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': euro_id,
+            'order_line': [Command.create({
+                'product_id': avco_prod.id,
+                'product_uom_qty': 1,
+                'price_unit': 10,
+            })],
+        })
+        purchase_order.button_confirm()
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+        initial_return = self._return(receipt)
+        # return the initial return
+        self._return(initial_return)
+        in_stock_amls = self.env['account.move.line'].search([('account_id', '=', self.stock_input_account.id)], order='id')
+        self.assertRecordValues(in_stock_amls, [
+            # Receive
+            {'debit': 0.0, 'credit': 1.0},
+            # Return
+            {'debit': 1.0, 'credit': 0.0},
+            # ReReturn
+            {'debit': 0.0, 'credit': 1.0},
+        ])
+
     def test_incoming_with_negative_qty(self):
         """
                 FIFO/AVCO Auto


### PR DESCRIPTION
**Steps to reproduce:**
- enable automatic accounting
- set dollars as the main currency
- activate euro and set a rate of 10 euro -> 1$
- create a storable product with category fifo/ automated
- create and confirm a PO for 1 unit for 10 euros (no tax)
- validate the receipt
- return the product and validate return
- return the return and validate
- open journal items and search your product

**Current behavior:**
- there is 6 correct lines (those with credit or debit of
1$)
- there is two incorrect extra lines one with credit 9$ and
one with debit 9$

**Expected behavior:**
those two extra lines should not be there

**Cause of the issue:**
those lines are compensation account move lines
for the case where the price of the product returned
is different than the price of the product initially received,
in the cases of:
- a return: compensate the difference.
- the return of a return (our case): de-compensate the difference.

(see PR https://github.com/odoo/odoo/pull/162697 and more specifically
test test_fifo_return_twice_and_bill).
But in this case, the compensation is wrongly triggered because
the difference comes from the fact that the currency is not
taken into account.
https://github.com/odoo/odoo/blob/c89d109c460d51fc90b6b13d5f6bc114c7316e42/addons/purchase_stock/models/stock_move.py#L208

**Fix:**
we use the original svl instead of the PO
because it avoids currency problem.
If we wanted to convert the currency of the PO,
we would need to find the date that was used to convert
the value at the creation of the first svl.
And that date came from _get_currency_convert-date()
https://github.com/odoo/odoo/blob/d3599e70973e27ed17e403cf498f76bd31e9c236/addons/purchase_stock/models/stock_move.py#L97
which can take the date of the last invoice
(if product was invoiced before the move was validated).
https://github.com/odoo/odoo/blob/57c1c510425dcd491c794a0262063db398348640/addons/purchase_stock/models/stock_move.py#L123-L125
We can not use this method because we're doing the
return of a return and if the first return
also has an invoice, the return value
of the method could be the date of this invoice
(which is not the date we're looking for).
Furthermore there is no way to know if the date returned
by _get_currency_convert_date() at the time of the creation
of the first svl is the date of the time of the creation of
the svl or the date of an invoice previously confirmed.


opw-5179239