### PR TITLE
[FIX] sale: fix so amount_to_invoice with downpayment

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -754,7 +754,9 @@ class SaleOrder(models.Model):
     @api.depends('order_line.amount_to_invoice')
     def _compute_amount_to_invoice(self):
         for order in self:
-            order.amount_to_invoice = sum(order.order_line.mapped('amount_to_invoice'))
+            amount_to_invoice = sum(order.order_line.mapped('amount_to_invoice'))
+            downpayment_amount = sum(order.order_line.filtered('is_downpayment').mapped('amount_invoiced'))
+            order.amount_to_invoice = amount_to_invoice - downpayment_amount
 
     @api.depends('order_line.amount_invoiced')
     def _compute_amount_invoiced(self):

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -1340,3 +1340,15 @@ class TestSaleToInvoice(TestSaleCommon):
             invoice.team_id, team2,
             "Invoice team should be the same as the order's team",
         )
+
+    def test_amount_to_invoice_downpayment(self):
+        self.sale_order.action_confirm()
+        downpayment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
+            'advance_payment_method': 'fixed',
+            'fixed_amount': 100,
+        })
+        pre_invoice_amount = self.sale_order.amount_to_invoice
+        downpayment.create_invoices()
+        self.sale_order.invoice_ids.action_post()
+        self.assertEqual(self.sale_order.amount_invoiced, 100.0)
+        self.assertEqual(self.sale_order.amount_to_invoice, pre_invoice_amount - 100.0)


### PR DESCRIPTION
#### Versions:
18.0+

### Issue:
Sales' uninvoiced balance (`amount_to_invoice`) is not updated with downpayments.

#### Steps to reproduce:
Requires Studio
- Enter the Sales app:
- Change the list view with Studio:
- Add the field `Un-invoiced Balance` (amount_to_invoice) as a new column.
- Create a new quotation with a product having the `Ordered quantities` invoicing policy;
- Confirm the quote;
- Create and confirm a downpayment invoice based on fixed amount;
- Go back to the quotation list view:
- The "Un-invoiced Balance" field is not updated and still shows the total amount of the quotation.

### Cause:
Downpayments have no quantity, so they are not considered in the computation of the uninvoiced balance as they are set to 0 in the method `_compute_amount_to_invoice`:
https://github.com/odoo/odoo/blob/70d16283b58ab8f379279de54de81bdb680e0887/addons/sale/models/sale_order_line.py#L1146

opw-5274918