### PR TITLE
[FIX] hw_drivers: fix flush interval for server logger

### DIFF
--- a/addons/hw_drivers/server_logger.py
+++ b/addons/hw_drivers/server_logger.py
@@ -25,7 +25,7 @@ class AsyncHTTPHandler(logging.Handler):
     _MAX_BATCH_SIZE = 50
     """Maximum number of sent logs batched at once. Used to avoid too heavy request. Log records still in the queue will
     be handle in future flushes"""
-    _FLUSH_INTERVAL = 12
+    _FLUSH_INTERVAL = 0.5
     """How much seconds it will sleep before checking for new logs to send"""
     _REQUEST_TIMEOUT = 10
     """Amount of seconds to wait per log to send before timeout"""


### PR DESCRIPTION
Based on this review of https://github.com/odoo/odoo/pull/238740 this pr reverts the flush interval to 0.5s introduced in https://github.com/odoo/odoo/pull/238648 to avoid queue saturation.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
