### PR TITLE
[FIX] stock_delivery: correctly compute package/picking shipping weight

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -75,7 +75,7 @@ class StockPicking(models.Model):
             # if shipping weight is not assigned => default to calculated product weight
             picking.shipping_weight = (
                 picking.weight_bulk +
-                sum(pack.shipping_weight or pack.weight for pack in picking.package_ids.sudo())
+                sum(pack.shipping_weight or pack.with_context(picking_id=picking.id).weight for pack in picking.package_ids.sudo())
             )
 
     def _get_default_weight_uom(self):

--- a/addons/stock_delivery/tests/test_packing_delivery.py
+++ b/addons/stock_delivery/tests/test_packing_delivery.py
@@ -290,3 +290,34 @@ class TestPacking(TestPackingCommon):
         company_a_user.groups_id = [Command.unlink(self.env.ref('stock.group_stock_multi_warehouses').id)]
         res = delivery_company_a.with_user(company_a_user).read()
         self.assertTrue(res)
+
+    def test_delivery_shipping_weight_with_package_before_validation(self):
+        """Check that package and picking shipping weights are correctly computed
+        on delivery pickings when products are put into a package.
+        """
+        self.env['stock.quant']._update_available_quantity(self.product_aw, self.stock_location, 1)
+        picking_ship = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'move_ids': [Command.create({
+                'name': self.product_aw.name,
+                'product_id': self.product_aw.id,
+                'quantity': 1,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id
+            })],
+        })
+        picking_ship.action_confirm()
+        self.assertEqual(picking_ship.shipping_weight, self.product_aw.weight)
+        picking_ship.action_put_in_pack()
+        package = picking_ship.package_ids
+        self.assertEqual(picking_ship.shipping_weight, self.product_aw.weight)
+        self.assertEqual(package.weight, self.product_aw.weight, "The package weight is correctly computed using the picking context "
+                                                                    "and cached during the picking shipping weight computation.")
+        self.assertFalse(package.quant_ids, "No quant should be linked to the package yet.")
+        picking_ship.button_validate()
+        self.assertEqual(picking_ship.state, 'done')
+        self.assertTrue(package.quant_ids)
+        self.assertEqual(package.weight, self.product_aw.weight, "As the package contains quants, its weight is correctly computed from them.")
+        self.assertEqual(picking_ship.shipping_weight, self.product_aw.weight)


### PR DESCRIPTION
Steps to reproduce:
- Enable “Packaging” in Inventory settings.
- Create a storable product “P1” with:
    - weight: 10 kg
- Create a delivery picking:
    - Add one unit of P1
    - Mark as “To Do”
    - Set quantity to 1 → the move becomes assigned and the picking weight is correctly computed to 10
- Click “Put in Pack” → a package is created with `shipping_weight = 0`, and the picking weight incorrectly computed to 0

Problem:
- `picking.shipping_weight` is computed as: `weight_bulk` + sum(`pack.shipping_weight or pack.weight`) https://github.com/odoo/odoo/blob/17.0/addons/stock_delivery/models/stock_picking.py#L72-L79
- Once the product is placed in a package:
    - `weight_bulk` becomes 0 (because Total weight of products which are not in a package). https://github.com/odoo/odoo/blob/17.0/addons/stock_delivery/models/stock_picking.py#L96
    - `pack.shipping_weight` is 0 on creation.
    - The fallback `pack.weight` is 0 because its compute depends on the `picking_id` in context. Without this context, the compute uses only quants https://github.com/odoo/odoo/blob/f7c033eff7b7bc83d6d18fc5e4df320f43ae5021/addons/delivery/models/stock_quant_package.py#L11-L13

opw-5357843
