### PR TITLE
[FIX] stock: show lot location for multiple quants

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -168,7 +168,8 @@ class StockLot(models.Model):
     def _compute_single_location(self):
         for lot in self:
             quants = lot.quant_ids.filtered(lambda q: q.quantity > 0)
-            lot.location_id = quants.location_id if len(quants.location_id) == 1 else False
+            locations = quants.location_id
+            lot.location_id = locations[0] if locations else False
 
     def _set_single_location(self):
         quants = self.quant_ids.filtered(lambda q: q.quantity > 0)


### PR DESCRIPTION
Fixed (Issue #237701  )

Description of the issue/feature this PR addresses: When a Lot/Serial Number has positive stock spread across multiple locations, the field lot.location_id is currently set to False

Current behavior before PR: The Lot/Serial form shows no location
Users cannot see where the stock actually exists
If stock exists in multiple locations → the location is cleared (False)

Desired behavior after PR is merged:
Users always see a stock location when stock exists
A valid stock location will still be shown instead of None
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
