### PR TITLE
[FIX] base: no traceback when Attachment file not found

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -137,6 +137,8 @@ class IrAttachment(models.Model):
         try:
             with open(full_path, 'rb') as f:
                 return f.read(size)
+        except FileNotFoundError:
+            _logger.warning("File not found %s", full_path)
         except OSError:
             _logger.info("_read_file reading %s", full_path, exc_info=True)
         return b''


### PR DESCRIPTION
When an attachment file is not found, an error is logged along with a
Python traceback.

This is inconvenient when working with a copy of a database where only
the PosgreSQL dump was restored, and the data files are missing.

With this change, the file not found exception is specifically handled
to print a warning to the log, without opriting a full stack trace.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
