### PR TITLE
[FIX] hr_holidays: only skip future leave if more accrual possible

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -203,7 +203,11 @@ class HrEmployeeBase(models.AbstractModel):
                     leave_duration = leave[leave_duration_field]
                     skip_excess = False
 
-                    if sorted_leave_allocations.filtered(lambda alloc: alloc.allocation_type == 'accrual') and leave.date_from.date() > target_date:
+                    if leave.date_from.date() > target_date and sorted_leave_allocations.filtered(lambda a: 
+                        a.allocation_type == 'accrual' and 
+                        (a.date_to >= target_date or not a.date_to) and
+                        a.date_from <= leave.date_to.date()
+                    ):
                         to_recheck_leaves_per_leave_type[employee][leave_type]['to_recheck_leaves'] |= leave
                         skip_excess = True
                         continue


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This ticket: https://www.odoo.com/odoo/project/49/tasks/5218745

Current behavior before PR:
If an employee has an accrual allocation from any time, their future 
leaves do not get counted against the “Days Available” on their 
Time Off Dashboard.

Desired behavior after PR is merged:
If an employee has an accrual allocation between today’s date and
the date of a future leave, that future leave does not get counted
against the “Days Available” on their Time Off Dashboard.

In the above ticket, an employee Norbert Loibl (hr.employee 18) had 
an allocation from Feb. 2023 to May 2024 where `allocation_type` is 
`accrual` (hr.leave.allocation 19). Since then, all his allocations have 
had the `allocation_type` of `regular`.

Currently, if an employee has *ever* had an accrual allocation (with 
the relevant `holiday_status_id`), future leaves do not get used in 
determining that employee’s `allocation_remaining_display`. And so 
that employee’s future leaves do not get counted against the “Days 
Available” displayed on their Time Off Dashboard. This happens with 
Norbert. The customer who submitted the ticket found this confusing, 
as this Nobert is the only employee whose future leaves don’t get 
counted against his “Days Available”. And, I can’t think of a reason not
to count Norbert’s future leaves. Norbert is not accruing vacation days 
any longer, so there is no possibility of Norbert gaining more vacation 
days between today’s date and the time the leave arrives. 

My thought is that we should count future leaves against an employee’s
`allocation_remainining_display` unless there is a possibility of the 
employee gaining more vacation days between today’s date and the date 
of the leave. Currently, in `_get_consumed_leaves`, we iterate through 
all a given employee’s leaves with a given `holiday_status_id`. We check 
if a leave is in the future, and we check if there is *any* accrual 
allocation for the same employee with a matching `holiday_status_id`.
If both conditions are met, we continue on to the next leave before any 
of the logic that gets used to determine the remaining days in an
allocation.

In this PR, that check if modified. We still check if a leave is in the 
future. But then, we check if there is an accrual allocation for the 
same employee with a matching `holiday_status_id` that falls between
today’s date and the date of the leave (inclusive on both ends). Only
an accrual allocation between today and the leave could potentially
result in the employee gaining more vacation days before the leave. 

I considered the possibility that current allocation could be an accrual
allocation, but the leave could fall under a future regular allocation.
But it seems like leave accrued in an accrual allocation could carry 
over into the next allocation, even if it’s a regular allocation. (I 
think.) In that case, vacation days accrued in the current allocation
could result in the employee having more vacation days available
in the next allocation at the time of the leave. If you want to be more
sophisticated, you could check whether the relevant accrual 
allocations are set to have carry over days or not, or look into the 
specific carry over settings.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
