### PR TITLE
[FIX] hr_holidays: show correct ValidationError when creating employee

### DIFF
--- a/addons/hr_holidays/models/hr_version.py
+++ b/addons/hr_holidays/models/hr_version.py
@@ -29,27 +29,27 @@ class HrVersion(models.Model):
         all_new_leave_vals = []
         leaves_state = {}
         created_versions = self.env['hr.version']
-        try:
-            for vals in vals_list:
-                if not 'employee_id' in vals or not 'resource_calendar_id' in vals:
-                    created_versions |= super().create(vals)
-                    continue
-                leaves = self._get_leaves_from_vals(vals)
-                is_created = False
-                for leave in leaves:
-                    leaves_state = self._refuse_leave(leave, leaves_state)
-                    if not is_created:
-                        created_versions |= super().create([vals])
-                        is_created = True
-                    overlapping_contracts = self._check_overlapping_contract(leave)
-                    if not overlapping_contracts:
-                        continue
-                    all_new_leave_origin, all_new_leave_vals = self._populate_all_new_leave_vals_from_split_leave(
-                        all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state)
-                # TODO FIXME
-                # to keep creation order, not ideal but ok for now.
+        for vals in vals_list:
+            if not 'employee_id' in vals or not 'resource_calendar_id' in vals:
+                created_versions |= super().create(vals)
+                continue
+            leaves = self._get_leaves_from_vals(vals)
+            is_created = False
+            for leave in leaves:
+                leaves_state = self._refuse_leave(leave, leaves_state)
                 if not is_created:
                     created_versions |= super().create([vals])
+                    is_created = True
+                overlapping_contracts = self._check_overlapping_contract(leave)
+                if not overlapping_contracts:
+                    continue
+                all_new_leave_origin, all_new_leave_vals = self._populate_all_new_leave_vals_from_split_leave(
+                    all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state)
+            # TODO FIXME
+            # to keep creation order, not ideal but ok for now.
+            if not is_created:
+                created_versions |= super().create([vals])
+        try:
             if all_new_leave_vals:
                 self._create_all_new_leave(all_new_leave_origin, all_new_leave_vals)
         except ValidationError:


### PR DESCRIPTION
Issue:

* When creating an employee with negative fixed allowance values, the system should show a payroll validation error.
* Instead, a leave-related error from hr_holidays always appeared because the module wrapped the entire create() method in a broad try/except, catching all ValidationError messages including those from payroll.

Fix:

* Restricted the try/except only to the part that actually creates a new leave entries.

Impact:

* Users now see the correct and relevant error message when the fixed allowance values are invalid.

task-5383700



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
