### PR TITLE
[PERF] hr_timesheet: Avoid OOM on install

### DIFF
--- a/addons/hr_timesheet/__init__.py
+++ b/addons/hr_timesheet/__init__.py
@@ -9,6 +9,7 @@ from . import wizard
 from odoo import fields
 
 from odoo.addons.project import _check_exists_collaborators_for_project_sharing
+from odoo.tools.sql import SQL
 
 
 def create_internal_project(env):
@@ -47,3 +48,23 @@ def _uninstall_hook(env):
         project_ids.write({'active': False})
 
     env['ir.model.data'].search([('name', 'ilike', 'internal_project_default_stage')]).unlink()
+
+
+def _pre_init_hook(env):
+    """
+    Create manually new compute+stored columns to allow installing the module on large databases without trigger an Out-of-memory error.
+    """
+    env.cr.execute(SQL("""
+       ALTER TABLE account_analytic_line
+       -- The task_id is set to False when there is no project_id on the line, but at installation,
+       -- no line is associated with a project -> task_id = False
+       ADD COLUMN IF NOT EXISTS task_id        INT4,
+       -- At fresh installation, `task_id` is False -> parent_task_id, which is related to it, will also be False
+       ADD COLUMN IF NOT EXISTS parent_task_id INT4,
+       -- The project_id is defined as being the same as the one from the task, but task_id = False -> project_id = False
+       ADD COLUMN IF NOT EXISTS project_id     INT4,
+       -- The department_id is the one from the `employee_id`, but `employee_id` by default is False -> department_id = False
+       ADD COLUMN IF NOT EXISTS department_id  INT4,
+       -- The manager_id is the manager of the employee_id, but there is no `employee_id` by default -> manager_id = False
+       ADD COLUMN IF NOT EXISTS manager_id     INT4
+    """))

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -47,6 +47,7 @@ up a management by affair.
         'data/hr_timesheet_demo.xml',
     ],
     'installable': True,
+    'pre_init_hook': '_pre_init_hook',
     'post_init_hook': 'create_internal_project',
     'uninstall_hook': '_uninstall_hook',
     'assets': {


### PR DESCRIPTION
Description
-----------
On databases with a large count of existing `account.analytic.line` records, installing modules like `hr_timesheet`, which adds compute stored or related stored fields to this model can trigger a memory error due to the volume of records that need to be recomputed.

This commit creates the columns manually with the correct default value that is inferred from the state and implementation of said fields.

Reference
---------
opw-5234833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
