### PR TITLE
[REF] html_editor: improve cursor management in `preserveSelection`

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -26,7 +26,6 @@ import { _t } from "@web/core/l10n/translation";
 import { withSequence } from "@html_editor/utils/resource";
 import { isBlock } from "@html_editor/utils/blocks";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
-import { nodeSize } from "@html_editor/utils/position";
 
 const RGBA_OPACITY = 0.6;
 const HEX_OPACITY = "99";
@@ -336,12 +335,6 @@ export class ColorPlugin extends Plugin {
                         font = this.dependencies.split.splitAroundUntil(
                             selectedChildren,
                             splitnode
-                        );
-                        cursors.setAnchorOffset(
-                            Math.min(nodeSize(cursors.anchor.node), cursors.anchor.offset)
-                        );
-                        cursors.setFocusOffset(
-                            Math.min(nodeSize(cursors.focus.node), cursors.focus.offset)
                         );
                         // After splitting we need to clear the new nodes created by
                         // `splitElement` that contains only empty text nodes.

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -15,6 +15,7 @@ import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, tripleClick } from "./_helpers/user_actions";
+import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 
 test("getEditableSelection should work, even if getSelection returns null", async () => {
     const { editor } = await setupEditor("<p>a[b]</p>");
@@ -1542,4 +1543,93 @@ test("should not autoscroll if selection is partially visible in viewport", asyn
     // Ensure that extending selection did not trigger any auto-scrolling.
     expect(scrollableElement.scrollTop).toBe(scrollTop);
     expect(isInViewPort(lastParagraph)).toBe(false);
+});
+
+describe("Preserve selection", () => {
+    const isSameCursor = (cursor1, cursor2) => {
+        return (
+            cursor1.anchor.node === cursor2.anchor.node &&
+            cursor1.anchor.offset === cursor2.anchor.offset &&
+            cursor1.focus.node === cursor2.focus.node &&
+            cursor1.focus.offset === cursor2.focus.offset
+        );
+    };
+
+    test("Should properly sync cursors (1)", async () => {
+        const { editor, el } = await setupEditor(
+            `<p><span class="a">a</span><span class="b">b</span></p>`
+        );
+        const [span1, span2] = el.querySelectorAll("span");
+        setSelection({
+            anchorNode: span1,
+            anchorOffset: 0,
+            focusNode: span2,
+            focusOffset: 0,
+        });
+        const c1 = editor.shared.selection.preserveSelection();
+        const c2 = editor.shared.selection.preserveSelection();
+        c1.update(callbacksForCursorUpdate.remove(span1));
+        c2.update(callbacksForCursorUpdate.remove(span1));
+        span1.remove();
+        c1.restore();
+        c2.restore();
+        expect(isSameCursor(c1, c2)).toBe(true);
+    });
+
+    test("Should properly sync cursors (2)", async () => {
+        const { editor, el } = await setupEditor(
+            `<p><span class="a">a</span><span class="b">b</span></p>`
+        );
+        const [span1, span2] = el.querySelectorAll("span");
+        setSelection({
+            anchorNode: span1,
+            anchorOffset: 0,
+            focusNode: span2,
+            focusOffset: 0,
+        });
+        const c1 = editor.shared.selection.preserveSelection();
+        const c2 = editor.shared.selection.preserveSelection();
+        c1.update(callbacksForCursorUpdate.remove(span1));
+        span1.remove();
+        c1.restore();
+        expect(isSameCursor(c1, c2)).toBe(true);
+    });
+
+    test("Should properly sync cursors (3)", async () => {
+        const { editor, el } = await setupEditor(
+            `<p><span class="a">a</span><span class="b">b</span></p>`
+        );
+        const [span1, span2] = el.querySelectorAll("span");
+        setSelection({
+            anchorNode: span1,
+            anchorOffset: 0,
+            focusNode: span2,
+            focusOffset: 0,
+        });
+        const c1 = editor.shared.selection.preserveSelection();
+        const c2 = editor.shared.selection.preserveSelection();
+        c1.update(callbacksForCursorUpdate.remove(span1));
+        span1.remove();
+        c2.restore();
+        expect(isSameCursor(c1, c2)).toBe(true);
+    });
+
+    test("Should properly sync cursors (4)", async () => {
+        const { editor, el } = await setupEditor(
+            `<p><span class="a">a</span><span class="b">b</span></p>`
+        );
+        const [span1, span2] = el.querySelectorAll("span");
+        setSelection({
+            anchorNode: span1,
+            anchorOffset: 0,
+            focusNode: span2,
+            focusOffset: 0,
+        });
+        const c1 = editor.shared.selection.preserveSelection();
+        const c2 = editor.shared.selection.preserveSelection();
+        c2.update(callbacksForCursorUpdate.remove(span1));
+        span1.remove();
+        c1.restore();
+        expect(isSameCursor(c1, c2)).toBe(true);
+    });
 });


### PR DESCRIPTION
Summary:
Refactor `preserveSelection()` to use a stack-based approach (`preservedCursors` array) instead of a single cursor reference. This allows nested calls to `preserveSelection()` to operate independently while keeping cursor updates synchronized across active contexts.

Problem:
Using a single stored cursor caused issues in nested calls to `preserveSelection()`:

1. **State overwrite:** Inner calls could overwrite or clear the outer cursor.
2. **Stale references:** If an inner function replaced a DOM node, the outer cursor could still point to a removed node and fail on restore.

Solution:
Use an array of cursor subscribers

- **Shared updates:** When calling `remapNode` on a cursor, it iterates over all active subscribers in the stack. This ensures node replacements performed in inner contexts also update outer cursor references.
- **Scoped cleanup:** `restore()` now removes only the corresponding cursor instance from the stack, ensuring proper lifecycle management.

Example:
The key improvement is that outer scopes receive updates performed by inner scopes.

```javascript
// Function A (outer)
function wrapperFunction() {
    const cursor = this.preserveSelection();
    replaceTextWithSpan();
    cursor.restore();
}

// Function B (inner)
function replaceTextWithSpan() {
    const innerCursor = this.preserveSelection();
    const oldNode = document.querySelector('text');
    const newNode = document.createElement('span');
    oldNode.replaceWith(newNode);
    innerCursor.remapNode(oldNode, newNode);
    innerCursor.restore();
}
```
opw-5386862

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
