### PR TITLE
[FIX] loyalty: include missing field in kanban view

### DIFF
--- a/addons/loyalty/views/loyalty_rule_views.xml
+++ b/addons/loyalty/views/loyalty_rule_views.xml
@@ -62,6 +62,7 @@
                 <field name="minimum_amount_tax_mode"/>
                 <field name="program_type"/>
                 <field name="user_has_debug"/>
+                <field name="reward_point_split"/>
                 <templates>
                     <t t-name="card" class="flex-row">
                         <div class="mw-75 flex-grow-1">


### PR DESCRIPTION
This fix addresses an issue where selling multiple gift cards in a single POS order results in only one gift card being created with the total amount, instead of multiple gift cards with the correct individual amounts.

Step to reproduce:
- Create a new gift card and enable the option to sell this card in the POS
- Open the POS and try to sell multiple gift cards in the same order
- Validate the order
- Check the generated gift cards, only one gift card will be created with the total amount instead of multiple gift cards with the correct individual amounts

This issue occurs because the field `reward_point_split` is missing from the kanban view of loyalty rules. So, when creating a new gift card, this field value, which should be True for gift cards, is not returned by the onchange method, and since nothing triggers a new computation unless the program type is changed, the field remains False.

This fix simply restores this field in the kanban view (like before https://github.com/odoo/odoo/pull/172561) so that its value is correctly taken into account when creating a new gift card.

opw-5103652