### PR TITLE
[IMP] account: Suggest eInvoice format via placeholder instead of auto-selection

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -217,8 +217,9 @@
                                    string="Customer Invoices"
                                    groups="account.group_account_invoice,account.group_account_readonly">
                                 <field name="invoice_sending_method" placeholder="e-Invoicing &amp; Email"/>
+                                <field name="invoice_edi_format_placeholder" invisible="1"/>
                                 <field name="invoice_edi_format"
-                                       placeholder="XML format"
+                                       options="{'placeholder_field': 'invoice_edi_format_placeholder'}"
                                        invisible="not display_invoice_edi_format"/>
                                 <field name="invoice_template_pdf_report_id"
                                        invisible="not display_invoice_template_pdf_report_id"

--- a/addons/l10n_dk/tests/test_nemhandel_messages.py
+++ b/addons/l10n_dk/tests/test_nemhandel_messages.py
@@ -55,6 +55,7 @@ class TestNemhandelMessage(TestAccountMoveSendCommon):
             'city': 'Copenhagen',
             'country_id': cls.env.ref('base.dk').id,
             'invoice_sending_method': 'nemhandel',
+            'invoice_edi_format': 'oioubl_21',
             'vat': 'DK12345674',
         }, {
             'name': 'Molly',
@@ -63,6 +64,7 @@ class TestNemhandelMessage(TestAccountMoveSendCommon):
             'email': 'Namur@company.com',
             'country_id': cls.env.ref('base.dk').id,
             'invoice_sending_method': 'nemhandel',
+            'invoice_edi_format': 'oioubl_21',
             'vat': 'DK12345666',
         }])
 
@@ -297,6 +299,7 @@ class TestNemhandelMessage(TestAccountMoveSendCommon):
             'city': 'Copenhagen',
             'country_id': self.env.ref('base.dk').id,
             'invoice_sending_method': 'nemhandel',
+            'invoice_edi_format': 'oioubl_21',
 
         })
         self.assertRecordValues(


### PR DESCRIPTION
Before this PR:
The eInvoice format field was automatically computed based on the partner’s country. This behavior was incorrect, as we should not select a format value on behalf of the user.

After this PR:
The eInvoice format field is no longer computed. Instead, the system suggests an appropriate format through the field’s placeholder, based on the partner’s country, leaving the actual choice to the user.

task-5232400
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
