### PR TITLE
[FIX] point_of_sale: prevent duplicate preparation tickets

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -18,6 +18,7 @@ patch(ActionpadWidget.prototype, {
     setup() {
         super.setup();
         this.doSubmitOrder = useTrackedAsync(() => this.pos.submitOrder());
+        this.doReprintOrder = useTrackedAsync(() => this.pos.reprintOrder());
     },
     get swapButton() {
         return (

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -50,9 +50,9 @@
                 </button>
                 <button
                     class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
-                    t-on-click="() => doSubmitOrder.call()"
+                    t-on-click="() => doReprintOrder.call()"
                     t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint"
-                    t-att-disabled="doSubmitOrder.status === 'loading'">
+                    t-att-disabled="doReprintOrder.status === 'loading'">
                     <i class="fa fa-cutlery" aria-hidden="true"></i>
                 </button>
                 <button

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
@@ -14,6 +14,7 @@ patch(ProductScreen.prototype, {
         this.state.tableBuffer = "";
         this.state.isValidBuffer = true;
         this.doSubmitOrder = useTrackedAsync(() => this.pos.submitOrder());
+        this.doReprintOrder = useTrackedAsync(() => this.pos.reprintOrder());
         useBus(this.numberBuffer, "buffer-update", ({ detail: value }) => {
             this.checkIsValid(value);
         });

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
@@ -24,9 +24,9 @@
                     </button>
                     <button
                             class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
-                            t-on-click="() => doSubmitOrder.call()"
+                            t-on-click="() => doReprintOrder.call()"
                             t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint"
-                            t-att-disabled="doSubmitOrder.status === 'loading'">
+                            t-att-disabled="doReprintOrder.status === 'loading'">
                         <i class="fa fa-cutlery" aria-hidden="true"></i>
                     </button>
                     <button

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -570,6 +570,11 @@ patch(PosStore.prototype, {
         this.addPendingOrder([order.id]);
         this.showDefault();
     },
+    async reprintOrder() {
+        const order = this.getOrder();
+        await this.sendOrderInPreparation(order, { explicitReprint: true });
+        this.showDefault();
+    },
     async getServerOrders() {
         if (this.config.module_pos_restaurant) {
             const tableIds = [].concat(


### PR DESCRIPTION
When a preparation printer is configured to print only specific product categories (e.g., drinks only), adding items from other categories (e.g., food) would cause the printer to reprint the previous order with a "NEW (DUPLICATE!)" label.

Steps to reproduce:
-------------------
* Configure a restaurant/bar POS with a preparation printer set to print only drinks
* On a table, order a drink item → printer correctly prints "NEW" ticket with the drink
* On the same table, add a food item (not in printer categories)
* Trigger sending to preparation (e.g., validate order or send to kitchen)

> Observation: The printer prints a duplicate of the previous drink order showing "NEW (DUPLICATE!)" instead of staying silent.

Why the fix:
------------
The `sendOrderInPreparation` method was automatically reusing `order.uiState.lastPrint` when no preparation category changes were detected, causing an implicit reprint. This behavior is incorrect when the order only contains items outside preparation printer categories - the printer should simply not print anything.

The fix:
- Prevents automatic reprint when there are no prep category changes
- Still calls `updateLastOrderChange()` to mark the order as "sent" and prevent the restaurant popup warning about unsent orders
- Only allows explicit reprints via `opts.explicitReprint` flag for future use cases