### PR TITLE
[FIX] website_sale_mondialrelay: remove tooltip cleanup

### DIFF
--- a/addons/website_sale_mondialrelay/static/src/interactions/checkout.js
+++ b/addons/website_sale_mondialrelay/static/src/interactions/checkout.js
@@ -6,6 +6,7 @@ import { Checkout } from '@website_sale/interactions/checkout';
 // temporary for OnNoResultReturned bug
 import { registry } from '@web/core/registry';
 import { ThirdPartyScriptError } from '@web/core/errors/error_service';
+
 const errorHandlerRegistry = registry.category('error_handlers');
 
 function corsIgnoredErrorHandler(env, error) {
@@ -25,8 +26,7 @@ patch(Checkout.prototype, {
         const useDeliveryAsBillingLabel = this.el.querySelector('#use_delivery_as_billing_label');
         if (useDeliveryAsBillingLabel) {
             this.useDeliveryAsBillingTooltip = window.Tooltip
-                .getOrCreateInstance(useDeliveryAsBillingLabel);
-            this.registerCleanup(() => this.useDeliveryAsBillingTooltip.dispose());
+                .getInstance(useDeliveryAsBillingLabel);
         }
         this._adaptUseDeliveryAsBillingToggle();
     },


### PR DESCRIPTION
Steps to reproduce:
1) Install mondialrelay
2) Add a deliverable product and checkout
3) Add a new delivery address
4) Switch delivery addresses
5) Observe a traceback

Since 1bb05d7161e387bd59265784010ee67a05138860 there is no need to create and enable tooltips; however, this tooltip was not adapted and caused a traceback.
