### PR TITLE
[FIX] stock_account: do not rely on account.change.lock.date in …

### DIFF
--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -277,19 +277,22 @@ class TestAccountMove(TestStockValuationCommon):
         receipts.action_confirm()
         receipt_done.button_validate()
         # Check that the purchase, sale and tax lock dates do not impose any restrictions
-        lock_date_setting = self.env['account.change.lock.date'].create({
+        self.env.company.write({
             'sale_lock_date': lock_date,
             'purchase_lock_date': lock_date,
             'tax_lock_date': lock_date,
         })
-        lock_date_setting.change_lock_date()
         # Receipts can be backdated
         receipt.scheduled_date = prior_to_lock_date
         receipt_done.date_done = prior_to_lock_date
 
         # Check that the fiscal year lock date imposes restrictions
-        lock_date_setting.fiscalyear_lock_date = lock_date
-        lock_date_setting.change_lock_date()
+        self.env.company.write({
+            'sale_lock_date': False,
+            'purchase_lock_date': False,
+            'tax_lock_date': False,
+            'fiscalyear_lock_date': lock_date,
+        })
         # Receipts can not be backdated prior to lock date
         receipt.scheduled_date = post_to_lock_date
         receipt_done.date_done = post_to_lock_date
@@ -299,11 +302,10 @@ class TestAccountMove(TestStockValuationCommon):
             receipt_done.date_done = prior_to_lock_date
 
         # Check that the hard lock date imposes restrictions
-        lock_date_setting.write({
+        self.env.company.write({
             'fiscalyear_lock_date': False,
             'hard_lock_date': lock_date,
         })
-        lock_date_setting.change_lock_date()
         # Receipts can not be backdated prior to lock date
         receipt.scheduled_date = post_to_lock_date
         receipt_done.date_done = post_to_lock_date


### PR DESCRIPTION
…test_backdate_picking_with_lock_date

### Issue:

The test `test_backdate_picking_with_lock_date` added in https://github.com/odoo/odoo/commit/4ea1853108a73f3d6b593785432f10b41ccc0041 fails in community builds.

### Cause of the issue:

The `account.change.lock.date` model is defined in `account_accountant`:
https://github.com/odoo/enterprise/blob/b3679bc04d4fcef1da7251e5ca061dfeabe89eae/account_accountant/wizard/account_change_lock_date.py#L11-L16
However, this module is not a dependency of the `stock_account` module.

### Fix:

We set the lock_dates directly just as in the `account` tests:
https://github.com/odoo/odoo/blob/e91c3817574af8bd48a634e3fb0b2f0e08b21ee9/addons/account/tests/test_account_move_date_algorithm.py#L52-L53

runbot-234673

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
