### PR TITLE
[IMP] html_editor: cancel file uploading

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.js
@@ -12,6 +12,7 @@ export class ProgressBar extends Component {
         size: { type: String, optional: true },
         errorMessage: { type: String, optional: true },
         mimetype: { type: String, optional: true },
+        cancelUpload: { type: Function, optional: true },
     };
     static defaultProps = {
         progress: 0,
@@ -20,6 +21,7 @@ export class ProgressBar extends Component {
         size: "",
         errorMessage: "",
         mimetype: "",
+        cancelUpload: () => {},
     };
 
     get errorMessage() {

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
@@ -16,7 +16,10 @@
         <small t-if="props.hasError" class="text-danger fw-bold" t-esc="errorMessage"/>
     </div>
     <div class="o_notification_indicator d-flex align-items-center justify-content-center pt-2">
-        <i t-if="!props.hasError and !props.uploaded" class="fa fa-circle-o-notch fa-spin fs-4"/>
+        <t t-if="!props.hasError and !props.uploaded">
+            <i class="fa fa-circle-o-notch fa-spin fs-4"/>
+            <span class="fa fa-trash cursor-pointer fs-4 p-1 mx-1" t-on-click="props.cancelUpload" title="Cancel Upload"/>
+        </t>
         <span t-if="props.uploaded" class="o_notification_indicator_success d-flex align-items-center justify-content-center p-1 rounded-5 text-bg-success smaller">
             <i class="fa fa-check"/>
         </span>
@@ -35,6 +38,7 @@
                             hasError="file_value.hasError"
                             name="file_value.name"
                             uploaded="file_value.uploaded"
+                            cancelUpload="file_value.cancelUpload"
                             size="file_value.size"
                             mimetype="file_value.mimetype"/>
                     </div>

--- a/addons/html_editor/static/tests/upload_service.test.js
+++ b/addons/html_editor/static/tests/upload_service.test.js
@@ -1,0 +1,123 @@
+import { animationFrame, expect, test } from "@odoo/hoot";
+import { delay, click, queryOne } from "@odoo/hoot-dom";
+import {
+    defineModels,
+    fields,
+    getService,
+    models,
+    mountView,
+    onRpc,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
+
+class Test extends models.Model {
+    name = fields.Char();
+    txt = fields.Html();
+    _records = [{ id: 1, name: "Test", txt: "<p><br></p>" }];
+}
+
+defineModels([Test]);
+
+test("should be able to cancel a file upload", async () => {
+    onRpc("/html_editor/attachment/add_data", async (request) => {
+        const { params } = await request.json();
+        await delay(1000); // Delay to keep progressbar visible longer
+        return {
+            name: params.name,
+        };
+    });
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "test",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    const fileUploadService = await getService("upload");
+    let xhr;
+    const waitForRequest = new Promise((res) => {
+        patchWithCleanup(XMLHttpRequest.prototype, {
+            open() {
+                xhr = this;
+                super.open(...arguments);
+                res();
+            },
+            abort() {
+                xhr.dispatchEvent(new Event("abort"));
+                super.abort();
+            },
+        });
+    });
+
+    const file = new File(["test"], "fake_file.txt", { type: "text/plain", size: 100 });
+    const uploadedFiles = [];
+    const fileUploadProm = fileUploadService.uploadFiles(
+        [file],
+        { resModel: "test", resId: 1 },
+        ({ name }) => {
+            uploadedFiles.push(name);
+        }
+    );
+    await animationFrame();
+    expect(".o_we_progressbar").toHaveCount(1);
+    await waitForRequest;
+    const progressEv = new Event("progress");
+    progressEv.loaded = 40;
+    progressEv.total = 100;
+    xhr.upload.dispatchEvent(progressEv);
+    await animationFrame();
+    expect(queryOne(".o_we_progressbar .progress-bar").style.width).toBe("40%");
+    await click(".o_notification_indicator .fa-trash");
+    await animationFrame();
+    expect(".o_we_progressbar").toHaveCount(0);
+    await fileUploadProm;
+    expect(uploadedFiles.length).toBe(0);
+});
+
+test("should be able to cancel a file when uploading multiple files", async () => {
+    onRpc("/html_editor/attachment/add_data", async (request) => {
+        const { params } = await request.json();
+        await delay(500);
+        return {
+            name: `${params.name}`,
+        };
+    });
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "test",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    const fileUploadService = await getService("upload");
+    const files = [
+        new File(["test1"], "fake_file1.txt", { type: "text/plain", size: 100 }),
+        new File(["test2"], "fake_file2.txt", { type: "text/plain", size: 200 }),
+        new File(["test3"], "fake_file3.txt", { type: "text/plain", size: 300 }),
+    ];
+    const uploadedFiles = [];
+    const fileUploadProm = fileUploadService.uploadFiles(
+        files,
+        { resModel: "test", resId: 1 },
+        ({ name }) => {
+            uploadedFiles.push(name);
+        }
+    );
+    await animationFrame();
+    expect(".o_we_progressbar").toHaveCount(3);
+    await click(".o_we_progressbar:nth-child(2) .fa-trash"); // Delete 2nd file
+    await animationFrame();
+    expect(".o_we_progressbar").toHaveCount(2);
+    await fileUploadProm;
+    expect(uploadedFiles).toMatchObject(["fake_file1.txt", "fake_file3.txt"]);
+});


### PR DESCRIPTION
Currently upload_service doesn't support cancel an ongoing upload. This PR aims to add a fa-trash button in upload progress toast. Clicking on it will cancel the ongoing upload for corresponding file.

task-5262931




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
