### PR TITLE
[IMP] hr_attendance: Hide Zero Extra Hours Attendance

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -436,7 +436,7 @@
                 "search_default_activeemployees": 1,
             }
         </field>
-        <field name="domain">[('check_out', '!=', False)]</field>
+        <field name="domain">[('check_out', '!=', False), ('overtime_hours', '&gt;', 0)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No attendance records found


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Current behavior before PR:
. If the employee has several attendance records in the same day resulting in overtime hours being calculated, all the attendance records will appear in the 'To Approve' filter even though only one record will show extra hours recorded. 
Desired behavior after PR is merged:
. Hide attendance records that have zero extra hours from the managment list

task-5395268

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
