### PR TITLE
[FIX] web: fix internal URLs in tests

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/events.js
+++ b/addons/web/static/lib/hoot-dom/helpers/events.js
@@ -1172,7 +1172,8 @@ async function _fill(target, value, options) {
 
     if (getTag(target) === "input") {
         switch (target.type) {
-            case "color": {
+            case "color":
+            case "time": {
                 target.value = String(value);
                 await _dispatch(target, "input");
                 await _dispatch(target, "change");

--- a/addons/web/static/lib/hoot/hoot.js
+++ b/addons/web/static/lib/hoot/hoot.js
@@ -80,7 +80,7 @@ export { disableAnimations, enableTransitions } from "./mock/animation";
 export { mockDate, mockLocale, mockTimeZone, onTimeZoneChange } from "./mock/date";
 export { makeSeededRandom } from "./mock/math";
 export { mockPermission, mockSendBeacon, mockUserAgent, mockVibrate } from "./mock/navigator";
-export { mockFetch, mockLocation, mockWebSocket, mockWorker } from "./mock/network";
+export { mockFetch, mockLocation, mockWebSocket, mockWorker, withFetch } from "./mock/network";
 export { flushNotifications } from "./mock/notification";
 export {
     mockMatchMedia,

--- a/addons/web/static/lib/hoot/main_runner.js
+++ b/addons/web/static/lib/hoot/main_runner.js
@@ -11,6 +11,15 @@ let runner;
 // Exports
 //-----------------------------------------------------------------------------
 
+/**
+ * @param {string} funcName
+ */
+export function ensureTest(funcName) {
+    if (!runner?.getCurrent().test) {
+        throw new Error(`Cannot call '${funcName}' from outside a test`);
+    }
+}
+
 export function getRunner() {
     return runner;
 }

--- a/addons/web/static/lib/hoot/mock/animation.js
+++ b/addons/web/static/lib/hoot/mock/animation.js
@@ -2,6 +2,7 @@
 
 import { on } from "@odoo/hoot-dom";
 import { MockEventTarget } from "../hoot_utils";
+import { ensureTest } from "../main_runner";
 
 //-----------------------------------------------------------------------------
 // Global
@@ -95,6 +96,7 @@ export function cleanupAnimations() {
  * @param {boolean} [enable=false]
  */
 export function disableAnimations(enable = false) {
+    ensureTest("disableAnimations");
     allowAnimations = enable;
 }
 
@@ -105,6 +107,7 @@ export function disableAnimations(enable = false) {
  * @param {boolean} [enable=true]
  */
 export function enableTransitions(enable = true) {
+    ensureTest("enableTransitions");
     allowTransitions = enable;
     animationChangeBus.dispatchEvent(new CustomEvent("toggle-transitions"));
 }

--- a/addons/web/static/lib/hoot/mock/date.js
+++ b/addons/web/static/lib/hoot/mock/date.js
@@ -2,6 +2,7 @@
 
 import { getTimeOffset, isTimeFrozen, resetTimeOffset } from "@web/../lib/hoot-dom/helpers/time";
 import { createMock, HootError, isNil } from "../hoot_utils";
+import { ensureTest } from "../main_runner";
 
 /**
  * @typedef DateSpecs
@@ -170,6 +171,7 @@ export function cleanupDate() {
  *  mockDate("2019-02-11 09:30:00.001", +2);
  */
 export function mockDate(date, tz) {
+    ensureTest("mockDate");
     setDateParams(date ? parseDateParams(date) : DEFAULT_DATE);
     if (!isNil(tz)) {
         setTimeZone(tz);
@@ -187,6 +189,7 @@ export function mockDate(date, tz) {
  *  mockTimeZone("ja-JP"); // UTC + 9
  */
 export function mockLocale(newLocale) {
+    ensureTest("mockLocale");
     locale = newLocale;
 
     if (!isNil(locale) && isNil(timeZoneName)) {
@@ -213,6 +216,7 @@ export function mockLocale(newLocale) {
  *  mockTimeZone(null) // Resets to test default (+1)
  */
 export function mockTimeZone(tz) {
+    ensureTest("mockTimeZone");
     setTimeZone(tz);
 }
 

--- a/addons/web/static/lib/hoot/mock/navigator.js
+++ b/addons/web/static/lib/hoot/mock/navigator.js
@@ -9,6 +9,7 @@ import {
     MockEventTarget,
     setSyncValue,
 } from "../hoot_utils";
+import { ensureTest } from "../main_runner";
 
 /**
  * @typedef {"android" | "ios" | "linux" | "mac" | "windows"} Platform
@@ -297,6 +298,7 @@ export function cleanupNavigator() {
  * @param {PermissionState} [value]
  */
 export function mockPermission(name, value) {
+    ensureTest("mockPermission");
     if (!(name in currentPermissions)) {
         throw new TypeError(
             `The provided value '${name}' is not a valid enum value of type PermissionName`
@@ -316,6 +318,7 @@ export function mockPermission(name, value) {
  * @param {Navigator["sendBeacon"]} callback
  */
 export function mockSendBeacon(callback) {
+    ensureTest("mockSendBeacon");
     mockValues.sendBeacon = callback;
 }
 
@@ -323,6 +326,7 @@ export function mockSendBeacon(callback) {
  * @param {Platform} platform
  */
 export function mockUserAgent(platform = "linux") {
+    ensureTest("mockUserAgent");
     mockValues.userAgent = makeUserAgent(platform);
 }
 
@@ -330,5 +334,6 @@ export function mockUserAgent(platform = "linux") {
  * @param {Navigator["vibrate"]} callback
  */
 export function mockVibrate(callback) {
+    ensureTest("mockVibrate");
     mockValues.vibrate = callback;
 }

--- a/addons/web/static/lib/hoot/mock/network.js
+++ b/addons/web/static/lib/hoot/mock/network.js
@@ -312,9 +312,14 @@ export function cleanupNetwork() {
 /** @type {typeof fetch} */
 export async function mockedFetch(input, init) {
     const strInput = String(input);
+    const isInternalUrl = R_INTERNAL_URL.test(strInput);
     if (!mockFetchFn) {
+        if (isInternalUrl) {
+            // Internal URL without mocked 'fetch': directly handled by the browser
+            return fetch(input, init);
+        }
         throw new Error(
-            `Can't make a request when fetch is not mocked.\nReceived fetch call to: "${strInput}"`
+            `Could not fetch "${strInput}": cannot make a request when fetch is not mocked`
         );
     }
     const controller = markOpen(new AbortController());
@@ -367,7 +372,7 @@ export async function mockedFetch(input, init) {
         throw error;
     }
 
-    if (isNil(result) && R_INTERNAL_URL.test(strInput)) {
+    if (isInternalUrl && isNil(result)) {
         // Internal URL without mocked result: directly handled by the browser
         return fetch(input, init);
     }

--- a/addons/web/static/lib/hoot/mock/network.js
+++ b/addons/web/static/lib/hoot/mock/network.js
@@ -15,6 +15,7 @@ import {
     MockEventTarget,
     setSyncValue,
 } from "../hoot_utils";
+import { ensureTest } from "../main_runner";
 
 /**
  * @typedef {ResponseInit & {
@@ -454,6 +455,7 @@ export async function mockedFetch(input, init) {
  *  });
  */
 export function mockFetch(fetchFn) {
+    ensureTest("mockFetch");
     mockFetchFn = fetchFn;
 }
 
@@ -465,6 +467,7 @@ export function mockFetch(fetchFn) {
  * @param {typeof mockWebSocketConnection} [onWebSocketConnected]
  */
 export function mockWebSocket(onWebSocketConnected) {
+    ensureTest("mockWebSocket");
     mockWebSocketConnection = onWebSocketConnected;
 }
 
@@ -483,6 +486,7 @@ export function mockWebSocket(onWebSocketConnected) {
  *  });
  */
 export function mockWorker(onWorkerConnected) {
+    ensureTest("mockWorker");
     mockWorkerConnections.push(onWorkerConnected);
 }
 
@@ -491,6 +495,17 @@ export function mockWorker(onWorkerConnected) {
  */
 export function throttleNetwork(...args) {
     getNetworkDelay = parseNetworkDelay(...args);
+}
+
+/**
+ * @param {typeof mockFetchFn} fetchFn
+ * @param {() => void} callback
+ */
+export async function withFetch(fetchFn, callback) {
+    mockFetchFn = fetchFn;
+    const result = await callback();
+    mockFetchFn = null;
+    return result;
 }
 
 export class MockBlob extends Blob {

--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -12,7 +12,7 @@ import {
 } from "@web/../lib/hoot-dom/helpers/time";
 import { interactor } from "../../hoot-dom/hoot_dom_utils";
 import { MockEventTarget, strictEqual, waitForDocument } from "../hoot_utils";
-import { getRunner } from "../main_runner";
+import { ensureTest, getRunner } from "../main_runner";
 import {
     MockAnimation,
     mockedAnimate,
@@ -597,6 +597,7 @@ export function isPrevented(event) {
  * @param {Record<string, string>} name
  */
 export function mockMatchMedia(values) {
+    ensureTest("mockMatchMedia");
     $assign(mockMediaValues, values);
 
     callMediaQueryChanges($keys(values));
@@ -615,6 +616,7 @@ export function mockPreventDefault(event) {
  * @param {boolean} setTouch
  */
 export function mockTouch(setTouch) {
+    ensureTest("mockTouch");
     const objects = getTouchTargets(getWindow());
     if (setTouch) {
         for (const object of objects) {

--- a/addons/web/static/lib/hoot/tests/mock/network.test.js
+++ b/addons/web/static/lib/hoot/tests/mock/network.test.js
@@ -28,6 +28,20 @@ describe(parseUrl(import.meta.url), () => {
         expect(document.title).toBe("");
     });
 
+    test("fetch with internal URLs works without mocking fetch", async () => {
+        const blob = new Blob([JSON.stringify({ name: "coucou" })], {
+            type: "application/json",
+        });
+        const blobUrl = createObjectURL(blob);
+        const blobResponse = await fetch(blobUrl).then((res) => res.json());
+        const dataResponse = await fetch("data:text/html,<body></body>").then((res) => res.text());
+
+        expect(blobResponse).toEqual({ name: "coucou" });
+        expect(dataResponse).toBe("<body></body>");
+
+        await expect(fetch("http://some.url")).rejects.toThrow(/fetch is not mocked/);
+    });
+
     test("fetch with internal URLs should return default value", async () => {
         mockFetch(expect.step);
 

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -1,4 +1,4 @@
-import { before, mockFetch } from "@odoo/hoot";
+import { before, withFetch } from "@odoo/hoot";
 import { loadBundle } from "@web/core/assets";
 import * as _fields from "./_framework/mock_server/mock_fields";
 import * as _models from "./_framework/mock_server/mock_model";
@@ -163,9 +163,7 @@ export function preloadBundle(bundleName, options) {
         if (once) {
             odoo.loader.preventGlobalDefine = true;
         }
-        mockFetch(globalCachedFetch);
-        await loadBundle(bundleName);
-        mockFetch(null);
+        await withFetch(globalCachedFetch, () => loadBundle(bundleName));
         if (once) {
             odoo.loader.preventGlobalDefine = false;
         }


### PR DESCRIPTION
Before this commit, internal URLs (i.e. "blob:" and "data:") required                                                                                                                     
'fetch' to be mocked to work. This is wierd because these requests are                                                                                                                    
handled directly by the browser and shouldn't require any particular                                                                                                                      
manipulation from the (mocked) server.                                                                                                                                                    
                                                                                                                                                                              
This commit ensures that internal URLs still work without fetch being                                                                                                                     
mocked.    

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
