### PR TITLE
[ADD] core: onchange debugging

### DIFF
--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -285,8 +285,13 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         with Form(copy2) as move_form:  # It is editable in the form
             with self.assertLogs('odoo.tests.form') as cm:
                 move_form.name = 'MyMISC/2016/0001'
-                self.assertTrue(cm.output[0].startswith('WARNING:odoo.tests.form.onchange:'))
-                self.assertIn('The sequence will restart at 1 at the start of every year', cm.output[0])
+                record = next(
+                    record
+                    for record in cm.records
+                    if record.name == 'odoo.tests.form.onchange'
+                    if record.levelname == "WARNING"
+                )
+                self.assertIn('The sequence will restart at 1 at the start of every year', record.args['message'])
 
         copy2.name = False  # Can't modify journal_id if name is set
         copy2.journal_id = self.test_move.journal_id

--- a/odoo/tests/form.py
+++ b/odoo/tests/form.py
@@ -581,6 +581,13 @@ class Form:
         self._env.clear()  # discard cache and pending recomputations
 
         if w := result.get('warning'):
+            _logger.getChild('onchange').runbot(
+                "%r.onchange(..., %r, ...) -> %s(%r)",
+                record,
+                field_names,
+                w.__class__,
+                w,
+            )
             if isinstance(w, collections.abc.Mapping) and w.keys() >= {'title', 'message'}:
                 _logger.getChild('onchange').warning("%(title)s %(message)s", w)
             else:


### PR DESCRIPTION
The branching added in #238705 to try and catch https://runbot.odoo.com/odoo/error/234669 red-handed seems to help not at all: the line numbering in https://runbot.odoo.com/runbot/build/95118641 (in the text logs) indicates that it's running with the branching but it still takes the first branch (so it's receiving some sort of `Mapping` for sure) then fails anyway.
