### PR TITLE
[FIX] account_debit_note: button visible on CN/refund

### DIFF
--- a/addons/account_debit_note/views/account_move_view.xml
+++ b/addons/account_debit_note/views/account_move_view.xml
@@ -19,7 +19,7 @@
             <button name="action_reverse" position="after">
                 <button name="action_debit_note" string='Debit Note'
                     type='object' groups="account.group_account_invoice"
-                    invisible="move_type not in ('out_invoice', 'in_invoice') or state != 'posted'"
+                    invisible="move_type not in ('out_invoice', 'in_invoice', 'out_refund', 'in_refund') or state != 'posted'"
                     data-hotkey="shift+d"/>
             </button>
         </field>


### PR DESCRIPTION
The button for debit note is not visible on credit notes
and refunds.

Since f29c106b57dd6e8ca19ccc2d2479542f202d1c77 the button for debit note
has been moved from action menu to the header of the invoice form, but
the commit makes it only visible for invoices and bills, while it was
also visible for credit notes and refunds before.

The button needs to be also visible for CN/refunds as it is necessary
for many countries, like latam countries

opw-5385273
