### PR TITLE
[FIX] account: Improve line description entry when `sale` is not inst…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -773,6 +773,7 @@ class AccountMove(models.Model):
 
     display_send_button = fields.Boolean(compute='_compute_display_send_button')
     highlight_send_button = fields.Boolean(compute='_compute_highlight_send_button')
+    is_sale_installed = fields.Boolean(compute='_compute_is_sale_installed')
 
     _checked_idx = models.Index("(journal_id) WHERE (checked IS NOT TRUE)")
     _payment_idx = models.Index("(journal_id, state, payment_state, move_type, date)")
@@ -2329,6 +2330,9 @@ class AccountMove(models.Model):
     def _compute_highlight_send_button(self):
         for move in self:
             move.highlight_send_button = not move.is_being_sent and not move.invoice_pdf_report_id
+
+    def _compute_is_sale_installed(self):
+        self.is_sale_installed = 'sale_management' in self.env['ir.module.module']._installed()
 
     @api.depends('line_ids.matched_debit_ids', 'line_ids.matched_credit_ids', 'matched_payment_ids', 'matched_payment_ids.state')
     def _compute_reconciled_payment_ids(self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -957,6 +957,7 @@
                         <field name="show_delivery_date" invisible="1"/>
                         <field name="is_being_sent" invisible="1"/>
                         <field name="show_update_fpos" invisible="1"/>
+                        <field name="is_sale_installed" invisible="1"/> <!-- Needed in the view to trigger the compute for the ProductLabelSectionAndNoteListRender in JS -->
 
                         <div class="oe_title">
                             <span class="o_form_label">
@@ -1174,8 +1175,8 @@
                                                optional="show"
                                                options="{'product_field': 'product_id', 'account_field': 'account_id', 'amount_field': 'price_subtotal'}"
                                                business_domain_compute="parent.move_type in ['out_invoice', 'out_refund', 'out_receipt'] and 'invoice' or parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] and 'bill' or 'general'"/>
-                                        <field name="quantity" optional="show"/>
-                                        <field name="product_uom_id" groups="uom.group_uom" optional="show" width="92px" options="{'no_create': True, 'quantity_field': 'quantity'}" widget="many2one_uom"/>
+                                        <field name="quantity" optional="conditional"/>
+                                        <field name="product_uom_id" groups="uom.group_uom" optional="conditional" width="92px" options="{'no_create': True, 'quantity_field': 'quantity'}" widget="many2one_uom"/>
                                         <!-- /l10n_in_edi.test_edi_json -->
                                         <!-- required for @api.onchange('product_id') -->
                                         <field name="product_uom_id" column_invisible="True"/>


### PR DESCRIPTION
…alled

When the Sale module is not installed (i.e. using only Invoicing or Accounting apps), the Product and Quantity fields are rarely used on invoice lines and can slow down new users who just want to enter a simple description.

This change improves the user experience by making those two columns invisible by default when the `sale` module is not installed.

task-5385721

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
