### PR TITLE
[PERF] hr_timesheet: Avoid OOM on install

### DIFF
--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -47,6 +47,7 @@ up a management by affair.
         'data/hr_timesheet_demo.xml',
     ],
     'installable': True,
+    'pre_init_hook': '_pre_init_hook',
     'post_init_hook': 'create_internal_project',
     'uninstall_hook': '_uninstall_hook',
     'assets': {


### PR DESCRIPTION
Description
-----------
On databases with a large count of existing `account.analytic.line` records, installing modules like `hr_timesheet`, which adds compute stored or related stored fields to this model can trigger a memory error due to the volume of records that need to be recomputed.

This commit creates the columns manually with the correct default value that is inferred from the state and implementation of said fields.

Reference
---------
opw-5234833
opw-5255382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
