### PR TITLE
[PERF] account: speed up _compute_parent_id

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1171,24 +1171,30 @@ class AccountMoveLine(models.Model):
             line.reconciled_lines_excluding_exchange_diff_ids = all_lines - excluded_ids
 
     def _compute_parent_id(self):
+        parent_id_vals_to_lines = defaultdict(list)
         for move, lines in self.grouped('move_id').items():
             if not move:
-                lines.parent_id = False
+                parent_id_vals_to_lines[False].extend(lines._ids)
                 continue
             last_section = False
             last_sub = False
             for line in move.line_ids.sorted('sequence'):
+                value = False
                 if line.display_type == 'line_section':
                     last_section = line
-                    line.parent_id = False
+                    value = False
                     last_sub = False
                 elif line.display_type == 'line_subsection':
-                    line.parent_id = last_section
+                    value = last_section
                     last_sub = line
                 elif line.display_type in {'line_note', 'product'}:
-                    line.parent_id = last_sub or last_section
+                    value = last_sub or last_section
                 else:
-                    line.parent_id = False
+                    value = False
+                parent_id_vals_to_lines[value].append(line.id)
+
+        for val, record_ids in parent_id_vals_to_lines.items():
+            self.browse(record_ids).parent_id = val
 
     @api.depends('move_id.move_type')
     def _compute_no_followup(self):


### PR DESCRIPTION
Before this commit, computing the `parent_id` of `account.move.line` records, involved looping over the `move_lines` grouped by their `move_id` sorted by the `sequence`. The updates on the move_lines are done per line and this involves an individual write operation on each one of them. The cardinality of the set of possible values of the new `parent_id` may involve a lot of values in cases where a big number of lines have a display type of either 'line_section' or 'line_subsection', in most of the cases it is not the case, so a possible performance improvement in the method is to upper bound the number of write operations by the cardinality of the set of possible values instead of a single write operation on each single `move_line`. This can be done by mapping the values to a record set of move lines and updating the move_lines that share the same value.

The benchmark below is done on an invoice that contained **2000** `move.line` records. An individual **write** operation is being done on each one of them.

| Scenario | Time (seconds) |
|-----------|----------------|
| **Before** | **Memory Error** |
| **After**  | **4s** |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
