### PR TITLE
[FIX] hr: remove write access on department for public users

### DIFF
--- a/addons/hr/security/ir.model.access.csv
+++ b/addons/hr/security/ir.model.access.csv
@@ -6,7 +6,7 @@ access_hr_employee_system_user,hr.employee system user,model_hr_employee,base.gr
 access_hr_employee_public_user,hr.employee_public,model_hr_employee_public,base.group_user,1,0,0,0
 access_hr_employee_resource_user,resource.resource.user,resource.model_resource_resource,group_hr_user,1,1,1,1
 access_hr_department_user,hr.department.user,model_hr_department,group_hr_user,1,1,1,1
-access_hr_department_employee,hr.department.employee,model_hr_department,base.group_user,1,1,0,0
+access_hr_department_employee,hr.department.employee,model_hr_department,base.group_user,1,0,0,0
 access_hr_job_user,hr.job user,model_hr_job,group_hr_user,1,1,1,1
 access_hr_departure_wizard,access.hr.departure.wizard,model_hr_departure_wizard,hr.group_hr_user,1,1,1,0
 access_hr_work_location_user,access_hr_work_location_user,model_hr_work_location,base.group_user,1,0,0,0

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -232,6 +232,14 @@ class TestSelfAccessRights(TestHrCommon):
         # Searching user based on employee_id field should not raise bad query error
         self.env['res.users'].with_user(self.richard).search([('employee_id', 'ilike', 'Hubert')])
 
+    # Write hr.department
+    def testWriteDepartmentEmployee(self):
+        with self.assertRaises(AccessError):
+            self.env['hr.department'].with_user(self.richard).create({'name': 'New Dept'})
+        dept = self.env['hr.department'].create({'name': 'New Dept'})
+        with self.assertRaises(AccessError):
+            dept.with_user(self.richard).write({'name': 'Renamed Dept'})
+
     def test_onchange_readable_fields_with_no_access(self):
         """
             The purpose is to test that the onchange logic takes into account `SELF_READABLE_FIELDS`.


### PR DESCRIPTION
**Steps to reproduce:**
- Install Employees app
- Login as public user
- Go to Employees menu
- Press on any employee to open its form view
- Press on the department field
- Try to edit the department configuration

**Issue:**
Public users can edit all the fields on the department configuration, except the Department's manager.

This is should not be the case.

**Solution:**
Remove write access on department for public users.

Task: 5384463