### PR TITLE
[FIX] point_of_sale: prevent error when loaded records are inaccessible

### DIFF
--- a/addons/point_of_sale/models/pos_load_mixin.py
+++ b/addons/point_of_sale/models/pos_load_mixin.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, models
 from odoo.fields import Domain
+from odoo.exceptions import AccessError
 
 
 class PosLoadMixin(models.AbstractModel):
@@ -51,7 +52,15 @@ class PosLoadMixin(models.AbstractModel):
         return records or []
 
     def _unrelevant_records(self, config):
-        return self.filtered(lambda record: not record.active).ids
+        unrelevant_record_ids = []
+        for record in self:
+            try:
+                if not record.active:
+                    unrelevant_record_ids.append(record.id)
+            except AccessError:
+                # If the user has no read access, consider the record as unrelevant
+                unrelevant_record_ids.append(record.id)
+        return unrelevant_record_ids
 
     @api.model
     def _load_pos_data_fields(self, config):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2000,3 +2000,22 @@ class TestPointOfSaleFlow(CommonPosTest):
         loaded_product_ids = [p['id'] for p in data['product.product']]
         self.assertIn(self.product_a.id, loaded_product_ids)
         self.assertIn(self.product_b.id, loaded_product_ids)
+
+    def test_filter_local_data_no_errors(self):
+        new_company = self.env['res.company'].create({
+            'name': 'New Company',
+            'country_id': self.env.company.country_id.id,
+            'currency_id': self.env.company.currency_id.id,
+        })
+        self.pos_config_usd.open_ui()
+        current_session = self.pos_config_usd.current_session_id
+        product = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'available_in_pos': True,
+            'lst_price': 200.0,
+            'company_id': new_company.id,
+        })
+        self.env.clear()
+        data = current_session.with_company(self.env.company).filter_local_data({'product.product': [product.id]})
+        self.assertIn(product.id, data['product.product'])


### PR DESCRIPTION
Before this commit, when reloading the PoS, during the filtering of local data, if some records to be filtered were inaccessible due to record rules, an AccessError was raised.

opw-5394929

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
