### PR TITLE
[FIX] sale_stock: prevent error when validating a picking record

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -158,7 +158,9 @@ class StockPicking(models.Model):
                 so_line_vals['price_unit'] = 0
             # New lines should be added at the bottom of the SO (higher sequence number)
             if not so_line:
-                so_line_vals['sequence'] = max(sale_order.order_line.mapped('sequence')) + len(sale_order_lines_vals) + 1
+                so_line_vals['sequence'] = (
+                    max(sale_order.order_line.mapped('sequence'), default=0) + len(sale_order_lines_vals) + 1
+                )
             sale_order_lines_vals.append(so_line_vals)
 
         if sale_order_lines_vals:


### PR DESCRIPTION
Currently, an error occurs when user validates a picking.

**Steps to Reproduce:**

 - Install the `sale_management` and `sale_stock` modules.
 - Create a `sale order` without `any sale order lines` and `confirm` it.
 - Go to `Inventory > Operations > Deliveries` and create a `picking record by adding a move line` with a `quantity` greater than `zero`.
 - In the `Additional tab`, select the `sale order (the one without order lines)`.
 - Now `validate` this delivery.

**Error:**
`ValueError: max() arg is an empty sequence`

This error occurs because, during validation of the delivery record, the system attempts to `create a sale order line` for the product. If the sale order does not have any `existing order lines`, the system tries to determine the `sequence` from existing sale order lines. Since `no lines exist`, the `sequence list is empty` [1], raising the error.

This commit ensures that when a sale order has no existing order lines, a default sequence value of zero is used.

[1]- https://github.com/odoo/odoo/blob/9e404b52e8c9375a6534a67cfb0fcc0df523402b/addons/sale_stock/models/stock.py#L164

sentry-7089149997


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
