### PR TITLE
[FIX] account_peppol: prevent 9925 registration

### DIFF
--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -33,7 +33,7 @@
                                         <label string="Peppol EAS"
                                                for="account_peppol_eas"
                                                class="col-lg-3 o_light_label"/>
-                                        <field name="account_peppol_eas"/>
+                                        <field name="account_peppol_eas" widget="filterable_selection" options="{'blacklisted_values': ['9925']}"/>
                                     </div>
                                     <div class="row">
                                         <label string="Peppol Endpoint"


### PR DESCRIPTION
Per BOSA requirements, 9925 is no longer necessary to register for any reason, except historic. We therefore prevent any new user from registering with this endpoint

task-5395157
