### PR TITLE
[IMP] stock: make push rule based on move lines

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -239,8 +239,8 @@ class StockRule(models.Model):
             delay_description.append((_('Days to Supply Components'), _('+ %d day(s)', days_to_order)))
         return delays, delay_description
 
-    def _push_prepare_move_copy_values(self, move_to_copy, new_date):
-        new_move_vals = super()._push_prepare_move_copy_values(move_to_copy, new_date)
+    def _push_prepare_move_copy_values(self, move_to_copy):
+        new_move_vals = super()._push_prepare_move_copy_values(move_to_copy)
         new_move_vals['production_group_id'] = move_to_copy.production_group_id.id
         new_move_vals['production_id'] = False
         return new_move_vals

--- a/addons/mrp_subcontracting/models/stock_rule.py
+++ b/addons/mrp_subcontracting/models/stock_rule.py
@@ -7,8 +7,8 @@ from odoo import models
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
-    def _push_prepare_move_copy_values(self, move_to_copy, new_date):
-        new_move_vals = super(StockRule, self)._push_prepare_move_copy_values(move_to_copy, new_date)
+    def _push_prepare_move_copy_values(self, move_to_copy):
+        new_move_vals = super()._push_prepare_move_copy_values(move_to_copy)
         new_move_vals["is_subcontract"] = False
         return new_move_vals
 

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -356,8 +356,8 @@ class StockRule(models.Model):
 
         return domain
 
-    def _push_prepare_move_copy_values(self, move_to_copy, new_date):
-        res = super(StockRule, self)._push_prepare_move_copy_values(move_to_copy, new_date)
+    def _push_prepare_move_copy_values(self, move_to_copy):
+        res = super()._push_prepare_move_copy_values(move_to_copy)
         res['purchase_line_id'] = None
         if self.location_dest_id.usage == "supplier":
             res['purchase_line_id'], res['partner_id'] = move_to_copy._get_purchase_line_and_partner_from_chain()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import itertools
-from ast import literal_eval
 from collections import defaultdict
 from datetime import timedelta
 from operator import itemgetter
@@ -1111,55 +1110,64 @@ Please change the quantity done or the rounding precision in your settings.""",
         return vals_list
 
     def _push_apply(self):
-        new_moves = []
+        move_vals_list = []
+        move_auto = set()
+
+        StockRule = self.env['stock.rule']
+        StockMove = self.env['stock.move']
+
         for move in self:
-            new_move = self.env['stock.move']
-
-            # if the move is a returned move, we don't want to check push rules, as returning a returned move is the only decent way
-            # to receive goods without triggering the push rules again (which would duplicate chained operations)
-            # first priority goes to the preferred routes defined on the move itself (e.g. coming from a SO line)
             warehouse_id = move.warehouse_id or move.picking_id.picking_type_id.warehouse_id
-
-            StockRule = self.env['stock.rule']
-            if move.location_dest_id.company_id not in self.env.companies:
-                StockRule = self.env['stock.rule'].sudo()
-                move = move.with_context(allowed_companies=self.env.user.company_ids.ids)
+            if not move.location_dest_id.company_id:
                 warehouse_id = False
 
-            related_packages = self.env['stock.package'].search_fetch([('id', 'parent_of', move.move_line_ids.result_package_id.ids)], ['package_type_id'])
+            # Multi companies check
+            if move.location_dest_id.company_id not in self.env.companies:
+                StockRule = StockRule.sudo()
+                StockMove = StockMove.sudo()
+                move = move.with_context(allowed_companies=move.env.user.company_ids.ids)
 
-            rule = StockRule._get_push_rule(move.product_id, move.location_dest_id, {
-                'route_ids': move.route_ids | related_packages.package_type_id.route_ids, 'warehouse_id': warehouse_id, 'packaging_uom_id': move.packaging_uom_id,
-            })
+            route_ids = move.route_ids
 
-            excluded_rule_ids = []
-            while (rule and rule.push_domain and not move.filtered_domain(literal_eval(rule.push_domain))):
-                excluded_rule_ids.append(rule.id)
-                rule = StockRule._get_push_rule(move.product_id, move.location_dest_id, {
-                    'route_ids': move.route_ids | related_packages.package_type_id.route_ids, 'warehouse_id': warehouse_id, 'packaging_uom_id': move.packaging_uom_id,
-                    'domain': [('id', 'not in', excluded_rule_ids)],
-                })
+            # Group by exclusion keys and evaluate rules
+            mls_by_rule = defaultdict(lambda: self.env['stock.move.line'])
+            for (location_dest, package), mls in move.move_line_ids.grouped(lambda m: (m.location_dest_id, m.result_package_id)).items():
+                if package:
+                    related_packages = self.env['stock.package'].search_fetch(
+                        [('id', 'parent_of', move.move_line_ids.result_package_id.ids)], ['package_type_id'])
+                    route_ids |= related_packages.package_type_id.route_ids
+                rule = StockRule._get_push_rule(move, location_dest, route_ids, warehouse_id)
+                if rule:
+                    mls_by_rule[rule] |= mls
 
-            # Make sure it is not returning the return
-            if rule and (not move.origin_returned_move_id or move.origin_returned_move_id.location_dest_id.id != rule.location_dest_id.id):
-                new_move = rule._run_push(move) or new_move
-                if new_move:
-                    new_moves.append(new_move)
+            # in case of neg_move push, We apply push rules on moves with -ve quantity without move_lines
+            if not move.move_line_ids:
+                rule = StockRule._get_push_rule(move, move.location_dest_id, route_ids, warehouse_id)
+                if rule:
+                    mls_by_rule[rule] |= self.env['stock.move.line']
 
-            move_to_propagate_ids = set()
-            move_to_mts_ids = set()
-            for m in move.move_dest_ids - new_move:
-                if new_move and move.location_final_id and m.location_id == move.location_final_id:
-                    move_to_propagate_ids.add(m.id)
-                elif not m.location_id._child_of(move.location_dest_id):
-                    move_to_mts_ids.add(m.id)
-            self.env['stock.move'].browse(move_to_mts_ids)._break_mto_link(move)
-            move.move_dest_ids = [Command.unlink(m_id) for m_id in move_to_propagate_ids]
-            new_move.move_dest_ids = [Command.link(m_id) for m_id in move_to_propagate_ids]
+            for rule, mls in mls_by_rule.items():
+                if rule.auto == 'transparent':
+                    mls.location_dest_id = rule.location_dest_id._get_putaway_strategy(mls.product_id) or rule.location_dest_id
+                    move_auto.add(move.id)
+                else:
+                    move_vals = move.copy_data(rule._push_prepare_move_copy_values(move))[0]
+                    move_vals['product_uom_qty'] = sum(mls.mapped('quantity')) if mls else move.product_uom_qty
+                    move_vals_list.append(move_vals)
 
-        new_moves = self.env['stock.move'].concat(*new_moves)
-        new_moves = new_moves.sudo()._action_confirm()
+        moves_auto = StockMove.browse(move_auto)
+        new_moves = StockMove.create(move_vals_list)
+        new_moves.filtered(lambda m: m._should_bypass_reservation()).write({'procure_method': 'make_to_stock'})
 
+        # Recursively apply push rules on auto moves
+        if moves_auto:
+            new_moves |= moves_auto._push_apply()
+
+        # Locations dest has been updated on stock.move.line but the move still have its original dest loc.
+        for move in moves_auto:
+            move.write({'location_dest_id': move.move_line_ids[0].location_dest_id})
+
+        new_moves = new_moves._action_confirm()
         return new_moves
 
     def _merge_moves_fields(self):
@@ -2121,8 +2129,14 @@ Please change the quantity done or the rounding precision in your settings.""",
         moves_to_push = moves_todo.filtered(lambda m: not m._skip_push())
         if moves_to_push:
             moves_to_push._push_apply()
-        for move_dest in moves_todo.move_dest_ids:
-            move_dests_per_company[move_dest.company_id.id] |= move_dest
+
+        for move in moves_todo:
+            for move_dest in move.move_dest_ids:
+                if not move_dest.location_id._child_of(move.location_dest_id) and not move.location_dest_id._child_of(move_dest.location_id):
+                    move_dest._break_mto_link(move)
+                    continue
+                move_dests_per_company[move_dest.company_id.id] |= move_dest
+
         for company_id, move_dests in move_dests_per_company.items():
             move_dests.sudo().with_company(company_id)._action_assign()
 

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+from ast import literal_eval
 from collections import defaultdict, OrderedDict
 from dateutil.relativedelta import relativedelta
 from typing import NamedTuple
@@ -218,61 +219,23 @@ class StockRule(models.Model):
         """
         return fields.Datetime.to_string(move.date + relativedelta(days=self.delay))
 
-    def _run_push(self, move):
-        """ Apply a push rule on a move.
-        If the rule is 'no step added' it will modify the destination location
-        on the move.
-        If the rule is 'manual operation' it will generate a new move in order
-        to complete the section define by the rule.
-        Care this function is not call by method run. It is called explicitely
-        in stock_move.py inside the method _push_apply
-        """
-        self.ensure_one()
-        new_date = self._get_push_new_date(move)
-        if self.auto == 'transparent':
-            old_dest_location = move.location_dest_id
-            move.write({'date': new_date, 'location_dest_id': self.location_dest_id.id})
-            # make sure the location_dest_id is consistent with the move line location dest
-            if move.move_line_ids:
-                move.move_line_ids.location_dest_id = move.location_dest_id._get_putaway_strategy(move.product_id) or move.location_dest_id
-
-            # avoid looping if a push rule is not well configured; otherwise call again push_apply to see if a next step is defined
-            if self.location_dest_id != old_dest_location:
-                # TDE FIXME: should probably be done in the move model IMO
-                return move._push_apply()[:1]
-        else:
-            new_move_vals = self._push_prepare_move_copy_values(move, new_date)
-            new_move = move.sudo().copy(new_move_vals)
-            # when no more push we should reach final destination
-            if new_move._skip_push():
-                new_move.write({'location_dest_id': new_move.location_final_id.id})
-            if new_move._should_bypass_reservation():
-                new_move.write({'procure_method': 'make_to_stock'})
-            if not new_move.location_id.should_bypass_reservation():
-                move.sudo().write({'move_dest_ids': [(4, new_move.id)]})
-            return new_move
-
-    def _push_prepare_move_copy_values(self, move_to_copy, new_date):
+    def _push_prepare_move_copy_values(self, move_to_copy):
         company_id = self.company_id.id
-        copied_quantity = move_to_copy.quantity
+        if not company_id:
+            company_id = self.sudo().warehouse_id and self.sudo().warehouse_id.company_id.id or self.sudo().picking_type_id.warehouse_id.company_id.id
         final_location_id = False
         location_dest_id = self.location_dest_id.id
         if move_to_copy.location_final_id and not move_to_copy.location_dest_id._child_of(move_to_copy.location_final_id):
             final_location_id = move_to_copy.location_final_id.id
         if move_to_copy.location_final_id and move_to_copy.location_final_id._child_of(self.location_dest_id):
             location_dest_id = move_to_copy.location_final_id.id
-        if move_to_copy.uom_id.compare(move_to_copy.product_uom_qty, 0) < 0:
-            copied_quantity = move_to_copy.product_uom_qty
-        if not company_id:
-            company_id = self.sudo().warehouse_id and self.sudo().warehouse_id.company_id.id or self.sudo().picking_type_id.warehouse_id.company_id.id
         new_move_vals = {
-            'product_uom_qty': copied_quantity,
             'origin': move_to_copy.origin or move_to_copy.picking_id.name or "/",
             'location_id': move_to_copy.location_dest_id.id,
             'location_dest_id': location_dest_id,
             'location_final_id': final_location_id,
             'rule_id': self.id,
-            'date': new_date,
+            'date': self._get_push_new_date(move_to_copy),
             'date_deadline': move_to_copy.date_deadline,
             'company_id': company_id,
             'picking_id': False,
@@ -280,6 +243,8 @@ class StockRule(models.Model):
             'propagate_cancel': self.propagate_cancel,
             'warehouse_id': self.warehouse_id.id or move_to_copy.location_dest_id.warehouse_id.id,
             'procure_method': 'make_to_order',
+            'move_orig_ids': [Command.link(move_to_copy.id)],
+            'move_dest_ids': [Command.link(move_dest.id) for move_dest in move_to_copy.move_dest_ids],
         }
         return new_move_vals
 
@@ -660,18 +625,24 @@ class StockRule(models.Model):
         return domain
 
     @api.model
-    def _get_push_rule(self, product_id, location_dest_id, values):
-        """ Find a push rule for the location_dest_id, with a fallback to the parent locations if none could be found.
-        """
-        found_rule = self.env['stock.rule']
+    def _get_push_rule(self, move, location_dest_id, route_ids, warehouse_id, extra_domain=None):
+        """Find a push rule for the location_dest_id, with a fallback to the parent locations if none could be found."""
+        rule = self.env['stock.rule']
         location = location_dest_id
-        while (not found_rule) and location:
+        product_id = move.product_id
+        packaging_uom_id = move.packaging_uom_id
+        while (not rule) and location:
             domain = Domain('location_src_id', '=', location.id) & Domain('action', 'in', ('push', 'pull_push'))
-            if dom := values.get('domain'):
-                domain &= Domain(dom)
-            found_rule = self._search_rule(values.get('route_ids'), values.get('packaging_uom_id'), product_id, values.get('warehouse_id'), domain)
+            if extra_domain:
+                domain &= Domain(extra_domain)
+            rule = self._search_rule(route_ids, packaging_uom_id, product_id, warehouse_id, domain)
+            excluded_rule_ids = []
+            domain &= Domain('id', 'not in', excluded_rule_ids)
+            while rule and rule.push_domain and not move.filtered_domain(literal_eval(rule.push_domain)):
+                excluded_rule_ids.append(rule.id)
+                rule = self._search_rule(route_ids, packaging_uom_id, product_id, warehouse_id, domain)
             location = location.location_id
-        return found_rule
+        return rule
 
     @api.model
     def _get_moves_to_assign_domain(self, company_id):


### PR DESCRIPTION
This PR changes how push rules work. Instead of making push rules work on the move and the move destination location, they now work on the move_lines and the move_lines destination location.

Task-5212472
