### PR TITLE
[FIX] portal: Redirect after confirming address

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -548,7 +548,7 @@ class CustomerPortal(Controller):
                 partner_sudo._onchange_phone_validation()
         elif not self._are_same_addresses(address_values, partner_sudo):
             # If name is not changed then pop it from the address_values, as it affects the bank account holder name
-            if address_values['name'].strip() == partner_sudo.name.strip():
+            if partner_sudo.name and address_values['name'].strip() == partner_sudo.name.strip():
                 address_values.pop('name')
             partner_sudo.write(address_values)  # Keep the same partner if nothing changed.
             if 'phone' in address_values and hasattr(partner_sudo, '_onchange_phone_validation'):

--- a/addons/portal/tests/test_addresses.py
+++ b/addons/portal/tests/test_addresses.py
@@ -308,3 +308,27 @@ class TestPortalAddresses(BaseCommon, HttpCase):
             self.archive_url, params={'partner_id': child_partner.id},
         )
         self.assertFalse(child_partner.active)
+
+    def test_address_update_when_partner_has_no_name(self):
+        """Check that address updates work correctly with name changes."""
+
+        self.user = self.env['res.users'].create({
+            'login': 'test_user',
+            'password': 'test_user',
+            'name': 'Test User',
+            'email': 'test_user@example.com',
+        })
+        self.authenticate(self.user.login, self.user.password)
+        csrf_token = Request.csrf_token(self)
+
+        # Get partner with no name
+        partner = self.env['res.partner'].search([('name', '=', '')])
+        address_values_with_name = {
+            'csrf_token': csrf_token,
+            'verify_address_values': '',
+            'name': 'New Name',
+            'partner_id': partner.id,
+        }
+        res = self._submit_address_values(address_values_with_name)
+        self.assertEqual(res, {'redirectUrl': '/my/addresses'})
+        self.assertEqual(partner.name, 'New Name')


### PR DESCRIPTION
Steps to reproduce:
===================
1. On an event, make sure to:
- Have at least one paying ticket;
- Remove any "name" or "email" type of question.
2. Go to the event website page as a public visitor and buy one ticket.
   Fill in the form and click on "Go to payment".

-> Nothing happens.

Cause:
======
Clicking on "Go to payment" triggers the registration_confirm function:
https://github.com/odoo/odoo/blob/e91c3817574af8bd48a634e3fb0b2f0e08b21ee9/addons/website_event_sale/controllers/main.py#L78

Triggering `_create_or_update_address` for the first time will create
a partner without a `name`:
https://github.com/odoo/odoo/blob/fa137d08669db2f10cf735a2bc1278b3f1b4f5a9/addons/portal/controllers/portal.py#L543

When clicking on the confirm button, it will re-trigger
`_create_or_update_address`. At that moment, `partner_sudo.name` is
`False`, so the confirmation breaks on: `partner_sudo.name.strip()`
because you cannot call `.strip()` on a `False` value.

Solution:
=========
If the name is not set, simply treat it as unchanged and continue.
In the registration form, a name should normally be provided by default.

opw-5357924

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
