### PR TITLE
[FIX] payment_razorpay: prevent error on `Razorpay Key Secret` is not avaliable

### DIFF
--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -248,6 +248,9 @@ class PaymentProvider(models.Model):
         """
         if is_redirect:
             secret = self.razorpay_key_secret
+            if not secret:
+                _logger.warning("Missing key secret; aborting signature calculation.")
+                return None
             signing_string = f'{data["razorpay_order_id"]}|{data["razorpay_payment_id"]}'
             return hmac.new(
                 secret.encode(), msg=signing_string.encode(), digestmod=hashlib.sha256


### PR DESCRIPTION
An error is triggered at line [1] when the code attempts to
encode `secret(self.razorpay_key_secret)`, as the value of
`self.razorpay_key_secret` is `False`.

Error: `AttributeError:'bool' object has no attribute 'encode'`

This issue may occur if the user has not set the `Razorpay Key Secret (razorpay_key_secret)`
 in the Razorpay credentials within the Odoo Razorpay  configuration. See constraint
at [2] `razorpay_key_id` or `razorpay_key_secret` is not required when we have `razorpay_account_id`.

This commit will fix the above issue by early return as `None` when
`secret(razorpay_key_secret)` is `False`.


[1]: https://github.com/odoo/odoo/blob/b0797f7b4b00bea74529a7137df2a293524558ff/addons/payment_razorpay/models/payment_provider.py#L250-L254
[2]: https://github.com/odoo/odoo/blob/b0797f7b4b00bea74529a7137df2a293524558ff/addons/payment_razorpay/models/payment_provider.py#L63-L75


sentry-6767571136
