### PR TITLE
[FIX] point_of_sale: tb with preset with identification and one-click payment

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -73,7 +73,7 @@ export class ProductScreen extends Component {
 
         onWillRender(() => {
             // If its a shared order it can be paid from another POS
-            if (this.currentOrder?.state !== "draft") {
+            if (this.currentOrder?.state !== "draft" && !this.isValidatingOrder) {
                 this.pos.addNewOrder();
             }
         });
@@ -409,7 +409,12 @@ export class ProductScreen extends Component {
     }
 
     async fastValidate(paymentMethod) {
-        await this.pos.validateOrderFast(paymentMethod);
+        try {
+            this.isValidatingOrder = true;
+            await this.pos.validateOrderFast(paymentMethod);
+        } finally {
+            this.isValidatingOrder = false;
+        }
     }
 }
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2278,6 +2278,8 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (preset) {
+            order.setPreset(preset);
+
             if (preset.needsPartner) {
                 const partner = order.partner_id || (await this.selectPartner(order));
                 if (!partner) {
@@ -2291,7 +2293,7 @@ export class PosStore extends WithLazyGetterTrap {
                     }
                 }
             }
-            order.setPreset(preset);
+
             if (preset.identification === "name") {
                 await this.handleSelectNamePreset(order);
             }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1040,15 +1040,21 @@ registry
             [
                 Chrome.startPoS(),
                 Dialog.confirm("Open Register"),
+                PartnerList.searchCustomerValue("Partner Full", true),
+                PartnerList.clickPartner("Partner Full"),
                 ProductScreen.clickDisplayedProduct("Desk Organizer"),
                 ProductScreen.clickFastPaymentButton("Bank"),
                 ReceiptScreen.isShown(),
+                PartnerList.isShown().map(negateStep),
                 ReceiptScreen.clickNextOrder(),
+                PartnerList.searchCustomerValue("Partner Full", true),
+                PartnerList.clickPartner("Partner Full"),
                 ProductScreen.clickDisplayedProduct("Desk Organizer"),
                 ProductScreen.clickPayButton(),
                 PaymentScreen.clickPaymentMethod("Bank"),
                 PaymentScreen.clickValidate(),
                 ReceiptScreen.isShown(),
+                PartnerList.isShown().map(negateStep),
             ].flat(),
     });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -165,3 +165,12 @@ export function scrollBottom() {
         },
     };
 }
+
+export function isShown() {
+    return [
+        {
+            content: "partner list screen is shown",
+            trigger: ".modal .partner-list",
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2848,9 +2848,16 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
 
     def test_fast_payment_validation_from_product_screen_without_automatic_receipt_printing(self):
+        self.preset_delivery = self.env['pos.preset'].create({
+            'name': 'Delivery',
+            'identification': 'address',
+        })
         self.main_pos_config.write({
             'use_fast_payment': True,
+            'use_presets': True,
             'fast_payment_method_ids': [(6, 0, self.bank_payment_method.ids)],
+            'default_preset_id': self.preset_delivery.id,
+            'available_preset_ids': [(6, 0, [self.preset_delivery.id])],
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_fast_payment_validation_from_product_screen_without_automatic_receipt_printing')


### PR DESCRIPTION
steps:
- Configure a default preset as Delivery or Takeout and enable One-click Payment
- Open the POS restaurant.
- Open any table and add a product.
- Click the One-click payment method.

issue:
- Unnecessary dialogs appear on the ReceiptScreen (e.g., customer selection or time-slot selection), followed by traceback.

reason:
- The order is validated on the ProductScreen during One-click Payment and ProductScreen creates new draft order.

fix:
- After this commit, new order will not be created on the ProductScreen with One-click Payment.. 
- If validation fails (e.g., an RPC error), it will redirected back to the previous screen.
- In case of Delivery preset, on discard do not remove Delivery preset.

task-5391389