### PR TITLE
[FIX] point_of_sale: correctly add the scanned product

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1852,7 +1852,7 @@ class PosSession(models.Model):
             ('sale_ok', '=', True),
             ('available_in_pos', '=', True),
         ])
-        if product:
+        if product and product[0].barcode == barcode:
             return {'product.product': product.with_context(product_context).read(product_fields, load=False)}
 
         domain = [('barcode', 'not in', ['', False])]


### PR DESCRIPTION
Before this commit, when GS1 barcode was set in the company settings, scanning an invalid barcode may load a wrong product. For example, if the barcode "0000" was scanned, and it would search for all products that contains "0" in their barcode, and load the first one found.

opw-5394561

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
