### PR TITLE
[FIX] knowledge: no crash on click gif in knowledge article comment

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -176,7 +176,7 @@
 </t>
 
 <t t-name="mail.Composer.extraActions">
-    <div class="me-2" t-attf-class="{{ actionsContainerClass }}">
+    <div class="me-2 o-mail-Composer-extraActions" t-attf-class="{{ actionsContainerClass }}" t-ref="extra-actions">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <ActionList actions="partitionedActions.other" inline="true"/>
         </div>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -38,7 +38,7 @@ export function pickerOnClick(component, action, ev) {
         if (action.sequenceQuick) {
             anchorEl = component.quickActionsRef.el;
         } else {
-            anchorEl = component.moreActionsRef.el ?? action.ref.el;
+            anchorEl = component.moreActionsRef.el ?? component.extraActionsRef.el;
         }
     }
     const previousPicker = component.getActivePicker();
@@ -56,6 +56,7 @@ export function pickerSetup(action, func) {
     component.pickerTargetRef = useRef("picker-target");
     component.quickActionsRef = useRef("quick-actions");
     component.moreActionsRef = useRef("more-actions");
+    component.extraActionsRef = useRef("extra-actions");
     action.ref = useRef(action.id);
     action.picker = func();
 }


### PR DESCRIPTION
Before this commit, opening gif picker in a comment of a knowledge article would lead to crash.

This happens because composer uses chatter visual, and pickers in composer picks either the quick or more node element as anchor of picker, depending on whether the action is in the quick or more action.

In the case of knowledge article, the buttons are placed in extra actions like in chatter. However the picker placement was not taking into account this place, thus it fails to find action placement.

This commit fixes the issue by adding support of extra actions as anchor for composer picker.

Task-5163888