### PR TITLE
[FIX] web: Handle updateRecord errors and revert FullCalendar state.

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -364,12 +364,18 @@ export class CalendarCommonRenderer extends Component {
     }
     onEventDrop(info) {
         this.fc.api.unselect();
-        this.props.model.updateRecord(this.fcEventToRecord(info.event));
+        this.props.model.updateRecord(this.fcEventToRecord(info.event)).catch((e) => {
+            info.revert();
+            throw e;
+        });
         this.ref.el.classList.remove("o_interacting", "o_grabbing");
     }
     onEventResize(info) {
         this.fc.api.unselect();
-        this.props.model.updateRecord(this.fcEventToRecord(info.event));
+        this.props.model.updateRecord(this.fcEventToRecord(info.event)).catch((e) => {
+            info.revert();
+            throw e;
+        });
     }
     fcEventToRecord(event) {
         const { id, allDay, date, start, end } = event;

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -597,9 +597,20 @@ export async function resizeEventToTime(eventId, dateTime) {
     const column = findDateColumn(date);
     const columnRect = queryRect(column);
 
-    await (
-        await drag(resizer)
-    ).drop(row, {
+    if (hasTouch()) {
+        const { drop } = await drag(eventEl, {
+            pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
+        });
+        await waitForSelection();
+        await drop(eventEl);
+        await waitForSelection();
+    }
+
+    const { drop } = await drag(resizer, {
+        pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
+    });
+    await waitForSelection();
+    await drop(row, {
         position: { x: columnRect.x, y: -1 },
         relative: true,
     });


### PR DESCRIPTION
When a drag and drop or resize fails to update the record, the FullCalendar state no longer matches the database.

Per FullCalendar documentation [^1] [^2],
> revert - A function that, if called, reverts the event’s start/end date to the values before the drag. This is useful if an ajax call should fail.

[^1]: https://fullcalendar.io/docs/eventDrop
[^2]: https://fullcalendar.io/docs/eventResize

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
