### PR TITLE
[FIX] mail: apply auto_delete on canceled duplicate mails

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -688,6 +688,9 @@ class MailMail(models.Model):
             try:
                 mail = self.browse(mail_id)
                 if mail.state != 'outgoing':
+                    # Apply auto_delete on duplicated mails as they won't be post-processed
+                    if mail.state == 'cancel' and mail.failure_type == 'mail_dup':
+                        mail.sudo().filtered(lambda m: m.auto_delete).unlink()
                     continue
 
                 # Writing on the mail object may fail (e.g. lock on user) which


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Contact app
- Create two contacts with the same mail
- Add a common tag to each of them
- Go to Email Marketing app
- Create new mailing
- Ensure `keep_archives` is disabled in campaign settings
- Select Contact as Recipient Model
- Create a custom rule on tag to mach both contacts
- Send the mailing out
- Email will be present in the chatter of the second contact

**Issue:**
The `auto_delete` setting of the mail is only applied on `outgoing` mails. As duplicate mail `state` and `failure_type` are set with:
```py
mail_values['state'] = 'cancel'
mail_values['failure_type'] = 'mail_dup'
```
They are ignored by the `_send` loop and won't go though `_postprocess_sent_message` which delete the rest.

**Fix:**
Delete such mails on sending like it is done in the postprocess.

opw-5247192
