### PR TITLE
[FIX] stock_account: handle string to_date input

### DIFF
--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -24,7 +24,7 @@ class StockLot(models.Model):
         """Compute totals of multiple svl related values"""
         company_id = self.env.company
         self.company_currency_id = company_id.currency_id
-        at_date = self.env.context.get('to_date')
+        at_date = fields.Datetime.to_datetime(self.env.context.get('to_date'))
 
         for lot in self:
             if not lot.lot_valuated:


### PR DESCRIPTION
For products using lot valuation and real-time valuation, the Inventory at Date report may fail since the to_date value is provided as a string instead of a date or datetime object. This leads to a comparison error when generating the report.

Steps to reproduce:
- Create a product with lot tracking and real-time valuation, and lot valuated
- Create and receive a purchase order for this product
- Open Inventory > Reports > Inventory at Date
- An error occurs due to a comparison between a string and a date

opw-5362378