### PR TITLE
[FIX] website_sale: ensure one specifications block is shown in accordion mode

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2174,7 +2174,7 @@
                                     />
                                     <div
                                         id="product_attributes_simple"
-                                        t-if="single_value_attributes"
+                                        t-if="single_value_attributes and not is_view_active('website_sale_comparison.accordion_specs_item')"
                                         class="o_wsale_product_details_content_section o_wsale_product_details_content_section_specs mb-4"
                                     >
                                         <table t-attf-class="table table-sm text-muted {{'' if single_value_attributes else 'd-none'}}">


### PR DESCRIPTION
**Steps to produce:**
- Install `sale_management` and `website_sale` with demo data.
- Go to Website > Shop > Open product `Acoustic Bloc Screens`.
- Open the website editor > Click on the Specifications section.
- Set Specifications to `In accordion`.

**Issue:**
Two specification blocks are displayed on the product page:
- The accordion block.
- The simple `product_attributes_simple` block.

**Root cause:**
- In the template [1], the `product_attributes_simple` block is still rendered even when the accordion option is active, leading to duplicate sections.

**Solution:**
- Render the `product_attributes_simple` block only when the accordion option is not active. This ensures that exactly one specifications block is shown.

**Before:**
<img width="568" height="211" alt="before" src="https://github.com/user-attachments/assets/7e6472d4-194f-4e62-b9cb-ece709b29418" />


**After:**
<img width="636" height="126" alt="after" src="https://github.com/user-attachments/assets/40a46111-23d8-43cf-9495-db3e0402906a" />


[1]: https://github.com/odoo/odoo/blob/e91c3817574af8bd48a634e3fb0b2f0e08b21ee9/addons/website_sale/views/templates.xml#L2177

opw-5228938
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
