### PR TITLE
[FIX] website: fix hide_sidebar_header tour

### DIFF
--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -27,7 +27,14 @@ registerWebsitePreviewTour(
             content: "Check that the loading screen has appeared",
             trigger: ":iframe .o_loading_screen",
         },
-        stepUtils.waitIframeIsReady(),
+        {
+            content: "Wait for the loading screen to disappear",
+            trigger: ":iframe:not(:has(.o_loading_screen))",
+        },
+        {
+            content: "Wait for the 'Content Saved' notification",
+            trigger: ".o_notification :contains('Content Saved')",
+        },
         {
             content: "Check that the header changed to 'Sidebar'",
             trigger: ":iframe #wrapwrap>header.o_header_sidebar",


### PR DESCRIPTION
Tour added in this [commit] was previously failing, and the earlier [fix] only reduced the frequency of failures. However, it still occasionally fails due to race conditions of the iframe becoming ready and the moment the builder opens the 'Block' tab after the iframe has been reloaded.
This commit aims to fix it.

[commit]: https://github.com/odoo/odoo/commit/a5455bf
[fix]: https://github.com/odoo/odoo/commit/0a9522792cc0e18a895c0589f34977123d091d1a

runbot-234504
