### PR TITLE
[IMP] web: enable optional wrap mode for ace code editor

### DIFF
--- a/addons/web/static/src/core/code_editor/code_editor.js
+++ b/addons/web/static/src/core/code_editor/code_editor.js
@@ -24,6 +24,7 @@ export class CodeEditor extends Component {
         sessionId: { type: [Number, String], optional: true },
         initialCursorPosition: { type: Object, optional: true },
         showLineNumbers: { type: Boolean, optional: true },
+        lineWrapping: { type: Boolean, optional: true },
     };
     static defaultProps = {
         readonly: false,
@@ -67,6 +68,7 @@ export class CodeEditor extends Component {
                     maxLines: this.props.maxLines,
                     showPrintMargin: false,
                     useWorker: false,
+                    wrap: this.props.lineWrapping,
                 });
                 this.aceEditor.$blockScrolling = true;
 

--- a/addons/web/static/src/views/fields/ace/ace_field.js
+++ b/addons/web/static/src/views/fields/ace/ace_field.js
@@ -14,9 +14,11 @@ export class AceField extends Component {
     static props = {
         ...standardFieldProps,
         mode: { type: String, optional: true },
+        lineWrapping: { type: Boolean, optional: true },
     };
     static defaultProps = {
         mode: "qweb",
+        lineWrapping: false,
     };
     static components = { CodeEditor };
 
@@ -72,10 +74,16 @@ export const aceField = {
             name: "mode",
             type: "string",
         },
+        {
+            name: "lineWrapping",
+            label: "lineWrapping Lines",
+            type: "boolean",
+        },
     ],
     supportedTypes: ["text", "html"],
     extractProps: ({ options }) => ({
         mode: options.mode,
+        lineWrapping: options.lineWrapping,
     }),
 };
 

--- a/addons/web/static/src/views/fields/ace/ace_field.xml
+++ b/addons/web/static/src/views/fields/ace/ace_field.xml
@@ -13,6 +13,7 @@
                 class="'ace-view-editor'"
                 theme="theme"
                 maxLines="200"
+                lineWrapping="props.lineWrapping"
             />
         </div>
     </t>


### PR DESCRIPTION
- Introduce new `lineWrapping` prop in CodeEditor and apply on `wrap` option via Ace session.
- Extend AceField to expose a `lineWrapping` widget option.
- Allow views to enable wrapping using: options="{'lineWrapping': True}".

The ace `wrap` option enables line wrapping, making long lines visible without horizontal scrolling for better readability.

Example:
without `wrap`:
<img width="672" height="76" alt="image" src="https://github.com/user-attachments/assets/f78e517e-003b-41d3-b054-a8427783025e" />

with `wrap` set to true:
<img width="670" height="67" alt="image" src="https://github.com/user-attachments/assets/abccb4b6-a9b3-4da2-9e4d-e53260a21322" />


part of Task-5136867
