### PR TITLE
[FIX] html_editor: prevent button disappearing when animated

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -668,7 +668,7 @@ export class LinkPlugin extends Plugin {
                     link.setAttribute("style", saveCustomStyle);
                 }
                 // Remove the current link (linkInDocument) if it has no content
-                if (cleanZWChars(link.innerText) === "" && !link.querySelector("img")) {
+                if (cleanZWChars(link.textContent) === "" && !link.querySelector("img")) {
                     const [anchorNode, anchorOffset] = rightPos(link);
                     // We force the cursor after the link before removing the link
                     // to ensure we don't lose the selection position.
@@ -768,7 +768,10 @@ export class LinkPlugin extends Plugin {
         if (!selectionData.currentSelectionIsInEditable) {
             const popoverEl = document.querySelector(".o-we-linkpopover");
             const anchorNode = document.getSelection()?.anchorNode;
-            if ((popoverEl && !selectionData.documentSelection) || (anchorNode && isElement(anchorNode) && anchorNode.closest(".o-we-linkpopover"))) {
+            if (
+                (popoverEl && !selectionData.documentSelection) ||
+                (anchorNode && isElement(anchorNode) && anchorNode.closest(".o-we-linkpopover"))
+            ) {
                 return;
             }
             this.linkInDocument = null;

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -384,4 +384,25 @@ describe("button edit", () => {
             '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">X[]</a></p>'
         );
     });
+
+    test("Should not remove invisible button", async () => {
+        const { el } = await setupEditor(
+            '<p><a href="http://test.test/" class="invisible btn btn-primary">a[]</a></p>',
+            {
+                styleContent: `
+                    .invisible {
+                        visibility: hidden;
+                    }
+                `,
+            }
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+
+        await contains(".o-we-linkpopover input.o_we_label_link").fill("b");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="http://test.test/" class="invisible btn btn-primary">ab[]</a></p>'
+        );
+    });
 });


### PR DESCRIPTION
Problem:
When adding an animation to a button and then trying to edit its label, the button disappears.

Cause:
Because of the animation effect, while editing, the button is in its initial `invisible` animation state. In that state, `innerText` always returns an empty string because it checks only the visible content of the element.

Solution:
Use `textContent` instead, which does not depend on element visibility.

Steps to reproduce:
- Open Website.
- Drop any text snippet.
- Add a button.
- Add an animation to the button.
- Edit the button label.
- The button disappears.

opw-5391115

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
