### PR TITLE
[FIX] html_editor: patch classes in footer so xpath of inherited applies

### DIFF
--- a/addons/html_editor/models/ir_ui_view.py
+++ b/addons/html_editor/models/ir_ui_view.py
@@ -312,6 +312,29 @@ class IrUiView(models.Model):
                 else:
                     el.getparent().replace(el, empty)
 
+        # TODO: in master, remove this.
+        # This bit of code patches a view. Patching of this view is necessary
+        # for some xpath in the following views if the view
+        # `website.footer_copyright_company_name` has been COW after:
+        #   - `website.template_footer_mega`
+        #   - `website.template_footer_mega_columns`
+        #   - `website.template_footer_mega_links`
+        # These 4 views inherit from `website.layout`, so we apply the patch
+        # whenever we save one of its children.
+        # The patch consists of adding the class `col-md` to the divs with
+        # `col-sm` in the footer of the view `web.frontend_layout`, which is
+        # the grand-parent of `website.layout`
+        if self.inherit_id and self.inherit_id.key == 'website.layout':
+            ancestor = self.inherit_id.inherit_id.inherit_id
+            arch = etree.fromstring(ancestor.arch.encode('utf-8'))
+            has_change = False
+            for node in arch.xpath("//div[hasclass('o_footer_copyright')]//div[hasclass('col-sm')]"):
+                if 'col-md' not in node.get('class'):
+                    node.set('class', node.get('class') + ' col-md')
+                    has_change = True
+            if has_change:
+                ancestor.with_context(no_cow=True).write({'arch': etree.tostring(arch, encoding='unicode')})
+
         new_arch = self.replace_arch_section(xpath, arch_section)
         old_arch = etree.fromstring(self.arch.encode('utf-8'))
         if not self._are_archs_equal(old_arch, new_arch):


### PR DESCRIPTION
The new footer templates had xpath selectors that were breaking in case the user changed some things in the footer. This is caused by a different order of evaluation after the copy is made to save the customized website view.

This commit patches the view to add the class on which the xpath relies so that it is always present, thus the xpath always apply.

Steps to reproduce:
- Open website builder (on an new db)
- Click on the footer
- Change "Template" to "Mega" (or "Mega Columns", or "Mega Links")
- Click on "Company Name" in the footer, and edit the text
- Save
- Bug: save fails because an xpath does not apply

Commit adding "Mega": f252e096a3c8c432e601f6bae6fc1c11cd92c90b
Commit adding "Mega Columns": aa0e653b5f641c735b4b6e25f80ae5d1d0a6dd94
Commit adding "Mega Links": 97ab0bc41bd3e5bd48b7e35e7d6918017d66004d

task-5181309