### PR TITLE
[FIX] web: no crash if image field with width attrs in list

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -304,8 +304,8 @@ export const imageField = {
         zoomDelay: options.zoom_delay,
         previewImage: options.preview_image,
         acceptedFileExtensions: options.accepted_file_extensions,
-        width: options.size && Boolean(options.size[0]) ? options.size[0] : attrs.width,
-        height: options.size && Boolean(options.size[1]) ? options.size[1] : attrs.height,
+        width: options.size && Boolean(options.size[0]) ? options.size[0] : undefined,
+        height: options.size && Boolean(options.size[1]) ? options.size[1] : undefined,
         reload: "reload" in options ? Boolean(options.reload) : true,
     }),
 };

--- a/addons/web/static/tests/views/fields/image_field.test.js
+++ b/addons/web/static/tests/views/fields/image_field.test.js
@@ -4,6 +4,7 @@ import {
     edit,
     manuallyDispatchProgrammaticEvent,
     queryAll,
+    queryAllProperties,
     queryFirst,
     setInputFiles,
     waitFor,
@@ -17,6 +18,7 @@ import {
     mountView,
     onRpc,
     pagerNext,
+    webModels,
 } from "@web/../tests/web_test_helpers";
 
 import { getOrigin } from "@web/core/utils/urls";
@@ -876,4 +878,25 @@ test("convert image to webp", async () => {
         { message: "image field should not be set" }
     );
     await setFiles(imageFile);
+});
+
+test.tags("desktop");
+test("ImageField with width attribute in list", async () => {
+    const { ResCompany, ResPartner, ResUsers } = webModels;
+    defineModels([ResCompany, ResPartner, ResUsers]);
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+            <list>
+                <field name="document" widget="image" width="30"/>
+                <field name="foo"/>
+            </list>
+        `,
+    });
+
+    expect(".o_data_row").toHaveCount(3);
+    expect(".o_field_widget[name=document] img").toHaveCount(3);
+    expect(queryAllProperties(".o_list_table th[data-name=document]", "offsetWidth")).toEqual([39]);
 });


### PR DESCRIPTION
Before this commit, if one set the `width` attribute on an image field in a list view arch, there was a props validation crash (in debug mode). The `width` attribute is relevant to be set in list view archs as it allows to specify the width of the column. That attribute isn't meant to be used by the image field itself, where the option `size` can be used to specify the size of the image as a pair `[width, height]`.

opw~5392068

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
