### PR TITLE
[FIX] pos_loyalty: fix discount value specific

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -126,6 +126,14 @@ export class PosOrderlineAccounting extends Base {
             .join(" ");
     }
 
+    get basePrice() {
+        const unitPriceWithTaxIncluded = this.unitPrices.taxes_data.reduce(
+            (acc, taxData) => acc + (taxData.price_include ? taxData.tax_amount : 0),
+            this.unitPrices.taxes_data[0]?.base_amount || this.unitPrices.total_excluded
+        );
+        return this.getQuantity() * unitPriceWithTaxIncluded * (1 - this.getDiscount() / 100);
+    }
+
     delete(record, opts = {}) {
         const order = this.order_id;
         const result = super.delete(record, opts);

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -1101,8 +1101,7 @@ patch(PosOrder.prototype, {
                 discountablePerTax[taxKey] = 0;
             }
             discountablePerTax[taxKey] +=
-                line.prices.total_excluded *
-                (remainingAmountPerLine[line.uuid] / line.prices.total_included);
+                line.basePrice * (remainingAmountPerLine[line.uuid] / line.prices.total_included);
         }
         return { discountable, discountablePerTax };
     },

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -720,3 +720,24 @@ registry.category("web_tour.tours").add("test_confirm_coupon_programs_one_by_one
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_promo_code_product_tax_included", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Product Include", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.hasRewardLine("$ 10 on Product Include", "-10.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_promo_code_product_tax_excluded", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.addOrderline("Product Include", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.hasRewardLine("$ 10 on Product Include", "-10.00"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3453,3 +3453,49 @@ class TestUi(TestPointOfSaleHttpCommon):
         with patch.object(pos_order, "confirm_coupon_programs", confirm_coupon_programs_patch):
             self.start_pos_tour("test_confirm_coupon_programs_one_by_one", login="pos_user")
             self.assertEqual(sync_counter['count'], 6)
+
+    def test_specific_reward_product_tax_included_excluded(self):
+        """This test makes sure that the value of a reward applied on a specific product is
+        the same whether the tax is included or excluded in the product price.
+        """
+        tax_01 = self.env['account.tax'].create({
+                "name": "Tax 1",
+                "amount": 10,
+                "price_include_override": "tax_included",
+        })
+
+        product = self.env['product.product'].create({
+            "name": "Product Include",
+            "lst_price": 100,
+            "available_in_pos": True,
+            "taxes_id": [Command.set(tax_01.ids)],
+        })
+
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env["loyalty.program"].create(
+            {
+                "name": "Test Loyalty Program",
+                "program_type": "promotion",
+                "trigger": "with_code",
+                'pos_ok': True,
+                "rule_ids": [
+                    Command.create({"mode": "with_code", "code": "hellopromo"}),
+                ],
+                "reward_ids": [
+                    Command.create({
+                        "reward_type": "discount",
+                        "discount": 10,
+                        "discount_mode": "per_order",
+                        "discount_applicability": "specific",
+                        "required_points": 1,
+                        "discount_product_ids": product.ids,
+                    }),
+                ],
+            }
+        )
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_promo_code_product_tax_included', login="pos_user")
+        tax_01.price_include_override = "tax_excluded"
+        # Discount should be the same even if tax mode is changed
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_promo_code_product_tax_excluded', login="pos_user")


### PR DESCRIPTION
When using a promotion program applied only on specific products with tax included prices, the discount value was incorrect.

Steps to reproduce:
-------------------
* Create a product with a price of 100$ and tax of 10% included
* Create a promotion program with:
  - Apply on: Specific Products (the product created above)
  - Discount Type: $ Fixed Discount
  - Discount Value: 10$
* Open PoS and add the product to the order
* Apply the promotion code
> Observation: The value of the discount is 9.09$ instead of 10$

Why the fix:
------------
When computing the discountable amount for the promotion it would take the amount excluding tax instead of the base price. The base price should be the unit price of the product multiplied by the quantity. As it was before here :
https://github.com/odoo/odoo/blob/8568baa35c9caa4c8cd3b1f5d737e1ecbec76434/addons/point_of_sale/static/src/app/models/pos_order_line.js#L470-L474 https://github.com/odoo/odoo/blob/8568baa35c9caa4c8cd3b1f5d737e1ecbec76434/addons/pos_loyalty/static/src/app/models/pos_order.js#L1112 

opw-5260067