### PR TITLE
[FIX] pos_restaurant: remove unused guest amount display

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.xml
@@ -29,11 +29,6 @@
                     <span class="text-black fs-4 fw-bolder" t-esc="currentOrder?.getCustomerCount() || 0"/>
                 </button>
             </div>
-            <div class="fs-2 text-center">
-            2: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(2))" /> <span class="me-4">/ Guest</span>
-            3: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(3))" /> <span class="me-4">/ Guest</span>
-            4: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(4))" /> <span class="me-4">/ Guest</span>
-            </div>
         </xpath>
     </t>
 


### PR DESCRIPTION
Before this commit, for all of the orders there was the amount per guest displayed in the payment screen.

opw-5394429

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
