### PR TITLE
[FIX] html_builder, website: remove horizontal cursor between cards

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -30,6 +30,7 @@ declare module "plugins" {
     import { builder_actions, BuilderActionsShared } from "@html_builder/core/builder_actions_plugin";
     import { so_content_addition_selector, so_snippet_addition_selector } from "@html_builder/core/dropzone_selector_plugin";
     import { fontCssVariables } from "@html_builder/plugins/font/font_plugin";
+    import { selection_blocker_row_enablers } from "@html_builder/plugins/layout_column_option_plugin";
     import { apply_custom_css_style } from "@html_builder/core/core_builder_action_plugin";
 
     interface SharedMethods {
@@ -109,6 +110,7 @@ declare module "plugins" {
         filter_for_sibling_dropzone_predicates: filter_for_sibling_dropzone_predicates;
         is_draggable_handlers: is_draggable_handlers;
         keep_overlay_options: keep_overlay_options;
+        selection_blocker_row_enablers: selection_blocker_row_enablers,
 
         // Processors
 

--- a/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
@@ -6,6 +6,10 @@ import { withSequence } from "@html_editor/utils/resource";
 import { LayoutColumnOption } from "@html_builder/plugins/layout_column_option";
 import { LAYOUT_COLUMN } from "@html_builder/utils/option_sequence";
 
+/**
+ * @typedef {((blockerRowCandidate: HTMLElement) => boolean)[]} selection_blocker_row_enablers
+ */
+
 class LayoutColumnOptionPlugin extends Plugin {
     static id = "LayoutColumnOption";
     static dependencies = ["clone", "selection"];
@@ -23,6 +27,11 @@ class LayoutColumnOptionPlugin extends Plugin {
         },
         selection_blocker_predicates: (blocker) => {
             if (blocker.nodeType === Node.ELEMENT_NODE && blocker.classList.contains("row")) {
+                for (const enabler of this.getResource("selection_blocker_row_enablers")) {
+                    if (enabler(blocker)) {
+                        return true;
+                    }
+                }
                 return false;
             }
         },

--- a/addons/html_builder/static/src/utils/grid_layout_utils.js
+++ b/addons/html_builder/static/src/utils/grid_layout_utils.js
@@ -111,7 +111,9 @@ export function cleanUpGrid(rowEl, columnEl, dragHelperEl, backgroundGridEl) {
  */
 export function toggleGridMode(containerEl, preserveSelection, mobileBreakpoint) {
     let rowEl = containerEl.querySelector(":scope > .row");
-    const outOfRowEls = [...containerEl.children].filter((el) => !el.classList.contains("row"));
+    const outOfRowEls = [...containerEl.children].filter(
+        (el) => !el.classList.contains("row") && el.dataset.selectionPlaceholder === undefined
+    );
 
     // Keep the text selection.
     const restoreSelection =

--- a/addons/website/static/src/builder/plugins/options/utils.js
+++ b/addons/website/static/src/builder/plugins/options/utils.js
@@ -1,5 +1,17 @@
-export const CARD_PARENT_HANDLERS =
-    ".s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div, .s_company_team_card .row > div, .s_carousel_cards_item";
+export const CARD_PARENT_HANDLERS_ARRAY = [
+    ".s_three_columns .row > div",
+    ".s_comparisons .row > div",
+    ".s_cards_grid .row > div",
+    ".s_cards_soft .row > div",
+    ".s_product_list .row > div",
+    ".s_newsletter_centered .row > div",
+    ".s_company_team_spotlight .row > div",
+    ".s_comparisons_horizontal .row > div",
+    ".s_company_team_grid .row > div",
+    ".s_company_team_card .row > div",
+    ".s_carousel_cards_item",
+];
+export const CARD_PARENT_HANDLERS = CARD_PARENT_HANDLERS_ARRAY.join(", ");
 
 // To remove in master, move it on the Option
 export const ONLY_BG_COLOR_SELECTOR =

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -1,3 +1,4 @@
+import { delay } from "@web/core/utils/concurrency";
 import {
     clickOnSnippet,
     insertSnippet,
@@ -26,6 +27,22 @@ const changeFirstAndSecondColumnsMobileOrder = (snippetRowSelector, snippetName)
         content: "Change the orders of the 1st and 2nd columns",
         trigger: "body .o_overlay_options button[title='Move right']",
         run: "click",
+    },
+    {
+        content: "Wait until scroll starts",
+        trigger: "body",
+        async run() {
+            // Depending on the screen resolution, there might be a scrolling
+            // involved. Ideally, we would want to wait for the scrolling to
+            // start with `body .o_overlay_options:not(:visible)`, but that
+            // would fail the tour if there is no scrolling.
+            // Instead, we wait a few milliseconds to let it start.
+            await delay(10);
+        },
+    },
+    {
+        content: "Wait until scroll ends",
+        trigger: "body .o_overlay_options",
     },
 ];
 


### PR DESCRIPTION
Since [1] when the selection placeholder plugin was introduced, a horizontal cursor is displayed between cards in website, while that area is not supposed to be editable.

This commit adapts card-related (not-)enabled selectors and providers and introduces a resource named `selection_blocker_row_enablers` in the layout column option plugin to make it possible to counter the default behavior that forces any `.row` to never be a selection blocker, making it possible for the horizontal cursor to be used between e.g. a table and the cards.

Steps to reproduce:
- Drop an `s_cards_grid` block
- Put the cursor in a card
- Move the cursor with the arrow keys until you leave the card

=> The cursor was displayed between cards.

[1]: https://github.com/odoo/odoo/commit/edf7f7bb0c62978640c181eccb4934855d5d872d

task-5383957
