### PR TITLE
[FIX] html_editor: avoid traceback when pasting embed video HTML

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -220,7 +220,7 @@ export class VideoSelector extends Component {
 
         const options = {};
         if (this.props.isForBgVideo && URL.canParse(url)) {
-            const parsedUrl = new URL(this.state.urlInput);
+            const parsedUrl = new URL(url);
             const urlParams = parsedUrl.searchParams;
             const startFrom =
                 urlParams.get("start") || urlParams.get("startTime") || urlParams.get("t");


### PR DESCRIPTION
Problem:
A traceback occurs when adding an embedded video in the Website editor.

Cause:
The code uses `urlInput` as the URL source, but when an embed is pasted, `urlInput` contains HTML instead of a direct URL.

Solution:
Parse the `url` instead of using `urlInput` directly.

Steps to reproduce:
- Go to Website.
- Add a slides snippet.
- Change the background to video.
- Paste embedded video HTML.
- A traceback is triggered.

opw-5265390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
