### PR TITLE
[FIX] sale: Use default downpayment account if no product category

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -232,7 +232,8 @@ class ProductTemplate(models.Model):
 
     def _get_product_accounts(self):
         product_accounts = super()._get_product_accounts()
-        product_accounts['downpayment'] = self.categ_id.property_account_downpayment_categ_id
+        product_accounts['downpayment'] = self.categ_id.property_account_downpayment_categ_id \
+            or self.env['account.account'].browse(self.env['product.category'].default_get(['property_account_downpayment_categ_id']).get('property_account_downpayment_categ_id'))
         return product_accounts
 
     ####################################


### PR DESCRIPTION
**Problem:**
When calculating taxes externally (such as Avatax) and a downpayment is made, the line on the invoice will always use the default income account, regardless of the downpayment account set as a company default.

This issue can also happen in the case where products have no category set.

This is inconsistent with the standard behavior of downpayments, which will use the downpayment account set on the product's category instead of the income account (which themselves may come from company defaults).

**Solution:**
If there's no product category set, fall back to the company's default downpayment account.

opw-5171067