### PR TITLE
[FIX] mrp,stock: mark new move line as picked if move was already picked

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -396,7 +396,8 @@ class StockMove(models.Model):
         """
         if self.env.context.get('force_manual_consumption'):
             for vals in vals_list:
-                vals['manual_consumption'] = True
+                if 'quantity' in vals:
+                    vals['manual_consumption'] = True
         mo_id_to_mo = defaultdict(lambda: self.env['mrp.production'])
         product_id_to_product = defaultdict(lambda: self.env['product.product'])
         for values in vals_list:
@@ -444,7 +445,7 @@ class StockMove(models.Model):
                 updated_product_move._action_confirm()
                 move_to_unlink.unlink()
                 self = other_move + updated_product_move
-        if self.env.context.get('force_manual_consumption'):
+        if self.env.context.get('force_manual_consumption') and 'quantity' in vals:
             vals['manual_consumption'] = True
         if 'product_uom_qty' in vals and 'move_line_ids' in vals:
             # first update lines then product_uom_qty as the later will unreserve

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 
+from odoo import Command
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.tests import tagged, Form, HttpCase
 
@@ -300,3 +301,52 @@ class TestManualConsumption(TestMrpCommon):
         self.assertEqual(mo.reservation_state, "assigned")
         mo.move_raw_ids.filtered(lambda m: m.product_id == components[0]).picked = True
         self.assertEqual(mo.reservation_state, "assigned")
+
+    def test_manual_consumption_is_false_if_quantity_was_unchanged(self):
+        """
+        Check that a move's `manual_consumption` field is only set if the
+        quantity of the move line was modified.
+        """
+        product_lot = self.env['product.product'].create({
+            'name': 'Product Lot',
+            'is_storable': True,
+            'tracking': 'lot',
+        })
+        lot_1, lot_2 = self.env['stock.lot'].create([{
+            'name': 'lot_1', 'product_id': product_lot.id,
+        }, {
+            'name': 'lot_2', 'product_id': product_lot.id,
+        }])
+        self.env['stock.quant']._update_available_quantity(product_lot, self.stock_location, 2, lot_id=lot_1)
+        self.env['stock.quant']._update_available_quantity(product_lot, self.stock_location, 2, lot_id=lot_2)
+
+        # Create an MO with one component from lot_1, quantity 2
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product.id,
+            'product_qty': 2,
+            'move_raw_ids': [Command.create({
+                'product_id': product_lot.id,
+                'quantity': 2,
+                'move_line_ids': [Command.create({
+                    'product_id': product_lot.id,
+                    'lot_id': lot_1.id,
+                })],
+            })],
+        })
+
+        # Using the details form, change only the lot of the move line
+        action = mo.move_raw_ids.action_show_details()
+        details_form = Form(mo.move_raw_ids.with_context(action['context']), view=action['view_id'])
+        with details_form.move_line_ids.edit(0) as move_line:
+            move_line.lot_id = lot_2
+        move = details_form.save()
+        # Since quantity was unchanged, `manual_consumption` should not be set
+        self.assertFalse(move.manual_consumption)
+
+        # Use the form again, this time changing the lot and the quantity
+        with details_form.move_line_ids.edit(0) as move_line:
+            move_line.lot_id = lot_1
+            move_line.quantity = 1
+        move = details_form.save()
+        # Quantity was modified, so `manual_consumption` should be set
+        self.assertTrue(move.manual_consumption)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -804,6 +804,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             'res_id': self.id,
             'context': dict(
                 self.env.context,
+                allow_parent_move_picked_reset=True,
             ),
         }
 

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -119,7 +119,7 @@ class StockMoveLine(models.Model):
     @api.depends('state')
     def _compute_picked(self):
         for line in self:
-            if line.move_id.state == 'done':
+            if line.move_id.state == 'done' or (self.env.context.get('allow_parent_move_picked_reset') and line.move_id.picked):
                 line.picked = True
 
     @api.depends('picking_id')

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -7071,3 +7071,46 @@ class StockMove(TransactionCase):
         self.assertEqual(backorder.move_ids.product_uom_qty, 6)
         self.assertEqual(backorder.move_ids.quantity, 6)
         self.assertEqual(backorder.move_ids.state, 'assigned')
+
+    def test_newly_added_move_line_is_picked_if_move_is_picked(self):
+        """
+        After a new move line is added in the "Details" popup of a move,
+        it should be automatically marked as picked if the stock move was
+        earlier marked as picked.
+        """
+        lot_1, lot_2 = self.env['stock.lot'].create([{
+            'name': 'lot_1', 'product_id': self.product_lot.id,
+        }, {
+            'name': 'lot_2', 'product_id': self.product_lot.id,
+        }])
+        for lot_id in [lot_1, lot_2]:
+            self.env['stock.quant']._update_available_quantity(
+                self.product_lot, self.stock_location, 3, lot_id=lot_id
+            )
+        # Create a delivery with one move of 3 products
+        with Form(self.env['stock.picking']) as delivery_form:
+            delivery_form.picking_type_id = self.env.ref('stock.picking_type_out')
+            with delivery_form.move_ids_without_package.new() as move:
+                move.product_id = self.product_lot
+                move.product_uom_qty = 3
+            delivery = delivery_form.save()
+        delivery.action_confirm()
+        # Verify that the stock move line uses lot_1
+        self.assertEqual(delivery.move_ids.move_line_ids.lot_id, lot_1)
+        # Mark the move as picked, which will also mark the move line as picked
+        delivery.move_ids.picked = True
+        self.assertTrue(delivery.move_ids.move_line_ids.picked)
+        # Split the move lines: 2 from lot_1, 1 from lot_2
+        action = delivery.move_ids.action_show_details()
+        with Form(delivery.move_ids.with_context(action['context']), view=action['view_id']) as form:
+            with form.move_line_ids.edit(0) as existing_move_line:
+                existing_move_line.quantity = 2
+            with form.move_line_ids.new() as new_move_line:
+                new_move_line.lot_id = lot_2
+                new_move_line.quantity = 1
+
+        # The move should still be picked
+        self.assertTrue(delivery.move_ids.picked)
+        # All the move lines are also picked
+        for move_line in delivery.move_ids.move_line_ids:
+            self.assertTrue(move_line.picked)


### PR DESCRIPTION
Scenario:
* create a delivery with quantity 3 and mark as TODO
* mark the stock move as picked
* open the "Details" popup and split the stock move line into quantities 1 and 2, e.g. by adding a new package or a new lot
* exit the popup and try to validate the delivery

Behavior before this commit:
* the stock move in the delivery form remains picked
* validation shows a backorder popup, warning of missing quantity

Reason: the newly created stock move line is not picked, but this information is not displayed anywhere, so users are not aware of the cause of this issue

After this commit:
* the stock move is no longer picked after a new move line is added
* users can click the "Picked" checkbox in the delivery form manually, which marks all stock move lines as picked as well
* after this action, delivery validation proceeds without backorders

opw-5345579

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
