### PR TITLE
[FIX] mail: fix subtitles translation

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -212,7 +212,9 @@ class MailRenderMixin(models.AbstractModel):
         # record info
         if 'model_description' not in template_ctx:
             template_ctx['model_description'] = self.env['ir.model']._get(context_record._name).display_name if context_record else False
-        template_ctx.setdefault('subtitles', self.env.context.get('email_notification_subtitles', [record_name]))
+        template_ctx.setdefault('subtitles',
+                                # str(s) resolves the lazy translation
+                                [str(s) for s in self.env.context.get('email_notification_subtitles', [record_name])])
         template_ctx.setdefault('subtitles_highlight_index',
                                 self.env.context.get('email_notification_subtitles_highlight_index', 0))
         # user / environment

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3688,6 +3688,8 @@ class MailThread(models.AbstractModel):
 
         subtype_id = msg_vals['subtype_id'] if 'subtype_id' in msg_vals else message.subtype_id.id
         is_discussion = subtype_id == self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
+        subtitles = record_wlang._resolve_lazy_translations(
+            self.env.context.get('email_notification_subtitles', [record_name]))
 
         return {
             # message
@@ -3699,7 +3701,7 @@ class MailThread(models.AbstractModel):
             'model_description': model_description,
             'record': record_wlang,
             'record_name': record_name,
-            'subtitles': self.env.context.get('email_notification_subtitles', [record_name]),
+            'subtitles': subtitles,
             # user / environment
             'author_user': author_user,  # User who sends the message
             'company': company,
@@ -5127,3 +5129,17 @@ class MailThread(models.AbstractModel):
         if thread.exists() and thread.sudo(False).has_access(mode):
             return thread
         return self.browse()
+
+    # ------------------------------------------------------
+    # OTHER HELPERS
+    # ------------------------------------------------------
+
+    @api.model
+    def _resolve_lazy_translations(self, to_resolve):
+        """Resolve the translation(s) using the language from the context (simple strings are left as is).
+
+        :param list[str|LazyGettext]|str|LazyGettext to_resolve: translation(s) to resolve
+        """
+        if isinstance(to_resolve, list):
+            return [str(v) for v in to_resolve]
+        return str(to_resolve)


### PR DESCRIPTION
With the library "MarkupSafe==3.0.2", the following test fails in test_mail:
- TestMailRenderLayoutTemplateLang .test_template_translation_partner_lang_subtitles
- TestAliasCompany.test_alias_domain_setup

Because the subtitles are not translated as the translation language is not found in the frame stack during the rendering. This is noticed by a warning emitted by the get_lang function: "no translation language detected, skipping translation".

The test have shown that with "MarkupSafe==2.1.5", the method "_get_lang" that searches for a language in the stack frame gets a lot more frames than with "MarkupSafe==3.0.2" which suggests that Markup is removing frames (probably because an optimization in C).

The solution is to evaluate the subtitles earlier.

Task-5401535