### PR TITLE
[FIX] base_import: show errors when a batch import is unsuccessful

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -177,6 +177,9 @@ export class ImportAction extends Component {
         }
 
         if (!isTest && res.ids.length) {
+            if (res.hasError) {
+                return;
+            }
             this.notification.add(_t("%s records successfully imported", res.ids.length), {
                 type: "success",
             });

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -619,6 +619,103 @@ QUnit.module("Base Import Tests", (hooks) => {
         );
     });
 
+    QUnit.test("batched import doesn't exit when a failure occurs", async function (assert) {
+        serverData.actions[2] = {
+            id: 2,
+            name: "Partner List",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            domain: "[]",
+            views: [[false, "list"]],
+        };
+
+        serverData.views = {
+            "partner,false,list": `<tree><field name="name"/></tree>`,
+            "partner,false,search": "<search></search>",
+        };
+
+        registerFakeHTTPService();
+
+        patchWithCleanup(ImportAction.prototype, {
+            get isBatched() {
+                // make sure the UI displays the batched import options
+                return true;
+            },
+        });
+
+        const notificationMock = (message) => {
+            assert.step(message);
+            return () => {};
+        };
+        registry
+            .category("services")
+            .add("notification", makeFakeNotificationService(notificationMock), {
+                force: true,
+            });
+
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => fn(),
+        });
+
+        const steps = [
+            (args) => executeImport(args, true),
+            (args) => executeFailingImport(args[1][0]),
+        ];
+
+        const webClient = await createWebClient({
+            serverData,
+            mockRPC: function (route, args) {
+                switch (route) {
+                    case "/web/dataset/call_kw/partner/get_import_templates":
+                        return Promise.resolve([]);
+
+                    case "/web/dataset/call_kw/base_import.import/parse_preview":
+                        return parsePreview(args.args[1]);
+
+                    case "/web/dataset/call_kw/base_import.import/execute_import":
+                        return steps.shift()(args.args);
+
+                    case "/web/dataset/call_kw/base_import.import/create":
+                        return Promise.resolve(11);
+
+                    case "base_import.import/get_fields":
+                        return Promise.resolve(serverData.models.partner.fields);
+
+                    case "/web/action/load":
+                        assert.step(`/web/action/load id=${args.action_id}`);
+                }
+            },
+        });
+
+        await doAction(webClient, 2);
+        await doAction(webClient, 1);
+
+        assert.verifySteps(["/web/action/load id=2", "/web/action/load id=1"]);
+
+        const file = new File(["fake_file"], "fake_file.xlsx", { type: "text/plain" });
+        await editInput(target, ".o_control_panel_main_buttons .d-none input[type='file']", file);
+        await editInput(target, "input#o_import_batch_limit", 1);
+
+        const importButton = Array.from(
+            target.querySelectorAll(".o_control_panel_main_buttons .d-none button")
+        ).find((e) => e.textContent === "Import");
+        await click(importButton);
+        await nextTick();
+        await nextTick();
+
+        assert.strictEqual(
+            target.querySelector(".alert-danger")?.textContent,
+            "The file contains blocking errors (see below)"
+        );
+
+        assert.strictEqual(
+            target.querySelector(".o_import_report.alert-danger")?.textContent,
+            "Incorrect value"
+        );
+
+        assert.verifySteps([]); // This makes sure that we don't exit the import action
+    });
+
     QUnit.test(
         "Import view: execute import with option 'use first row as headers'",
         async function (assert) {
@@ -1354,7 +1451,8 @@ QUnit.module("Base Import Tests", (hooks) => {
         registerFakeHTTPService();
 
         patchWithCleanup(ImportAction.prototype, {
-            get isBatched() { // Make sure the UI displays the batched import options
+            get isBatched() {
+                // Make sure the UI displays the batched import options
                 return true;
             },
         });


### PR DESCRIPTION
Steps to reproduce
==================

- Go to contact,
- Import the following file

```csv
id,name,active
__import__.res_partner_SV_test_01,Name 1,TRUE
__import__.res_partner_SV_test_02,Name 2,TRUE
__import__.res_partner_SV_test_03,Name 3,TRUE
__import__.res_partner_SV_test_04,Name 4,TRUE
__import__.res_partner_SV_test_05,Name 5,incorrect value
__import__.res_partner_SV_test_06,Name 6,TRUE
__import__.res_partner_SV_test_07,Name 7,TRUE
__import__.res_partner_SV_test_08,Name 8,TRUE
```

- Set the batch size to 4
- Click on the import button

=> Only 4 records have been imported and no error is displayed

Cause of the issue
==================

Errors were only checked in test mode

opw-5242285