### PR TITLE
[FIX] mail: fix reactive issue in firefox caused by array empty slots

### DIFF
--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -131,6 +131,10 @@ export class RecordInternal {
                 this.fieldsSortInNeed.delete(fieldName);
             }
             const sortProxy2 = reactive(recordProxy, function sortObserver() {
+                const value = record[fieldName];
+                if (Array.isArray(value) && value.every((_, i) => !(i in value))) {
+                    return;
+                }
                 self.requestSort(record, fieldName);
             });
             this.fieldsSortProxy2.set(fieldName, sortProxy2);


### PR DESCRIPTION
**Steps to reproduce:**
- (Firefox only)
- Go to any record which uses a chatter (e.g. Contact)
- Send message > Full composer > click the schedule message icon (lower right corner)
- Schedule the message in the future and click send
- You should see now a post in the chatter indicating that the message will be sent
- Now click Send message and repeat the above steps again to schedule a second message
- Whole page will be freezed
- Reloading doesn't help

**Issue:**
Infinite loop in reactive callback on firefox.
The code gets stuck in
```js
for (const callback of [...callbacks]) {
    clearReactivesForCallback(callback);
    callback();
}
```
because of
```js
const sortProxy2 = reactive(recordProxy, function sortObserver() {
    self.requestSort(record, fieldName);
});
this.fieldsSortProxy2.set(fieldName, sortProxy2);
```
which loops over `store._.ADD_QUEUE("sort", record, fieldName);`

(Forcing the `requestSort` only change the infinite loop into a recursion error)

The recomputation seems to be caused by `record[fieldName]` being an array filled with empty slots (previously deleted values). As to why it only happens on firefox, no idea, it's probably related to the design of the tracking on empty slots.

**Fix:**
Avoid reactivity when the value is an array with empty slots. The issue could also happen in other places (e.g. for the `computeProxy2`). Finding a better more reliable/generic fix would be great to avoid the issue on owl level.

related: https://github.com/odoo/odoo/commit/ba77db25c836cb692066cb9487842f7f683beaad

opw-5367371
