### PR TITLE
[FIX] stock: compute container package company_id

### DIFF
--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -165,7 +165,7 @@ class StockPackage(models.Model):
                     package.company_id = quants[0].company_id
             elif package.child_package_ids:
                 package.location_id = package.child_package_ids[0].location_id
-                if all(p.company_id == package.child_package_ids[0] for p in package.child_package_ids):
+                if all(p.company_id == package.child_package_ids[0].company_id for p in package.child_package_ids):
                     package.company_id = package.child_package_ids[0].company_id
 
     @api.depends('child_package_dest_ids')

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -2163,3 +2163,22 @@ class TestPackagePropagation(TestPackingCommon):
         receipt.button_validate()
         in_stock_move = receipt.move_ids.move_dest_ids
         self.assertEqual(in_stock_move.package_ids, receipt.move_ids.package_ids)
+
+    def test_package_info(self):
+        """ Checks that package's location & company are correctly computed, be it in single or multiple layers
+        """
+        pack1, pack2 = self.env['stock.package'].create([
+            {'name': 'Pack1'},
+            {'name': 'Pack2'},
+        ])
+        self.assertFalse((pack1 | pack2).location_id)
+        self.assertFalse((pack1 | pack2).company_id)
+
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1, package_id=pack1)
+        self.assertEqual(pack1.location_id, self.stock_location)
+        self.assertEqual(pack1.company_id, self.stock_location.company_id)
+
+        pack1.parent_package_id = pack2
+        self.assertFalse(pack2.quant_ids)
+        self.assertEqual(pack2.location_id, self.stock_location)
+        self.assertEqual(pack2.company_id, self.stock_location.company_id)


### PR DESCRIPTION
Steps to reproduce:
- Have two packs, A & B
- Put something in pack A
- Put pack A in pack B

Issue:
Despite pack A having both a location & a company set, only the location is set on pack B.

Due to a faulty comparison, we compare package records with company records, which means the `all()` condition will never be true.

Fixes #236413

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
