### PR TITLE
[16.0][FIX] resource: filter global leaves by calendar company

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -504,7 +504,7 @@ class ResourceCalendar(models.Model):
         if domain is None:
             domain = [('time_type', '=', 'leave')]
         if not any_calendar:
-            domain = domain + [('calendar_id', 'in', [False, self.id])]
+            domain = domain + [('calendar_id', 'in', [False, self.id]), '|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)]
         # for the computation, express all datetimes in UTC
         # Public leave don't have a resource_id
         domain = domain + [


### PR DESCRIPTION
When looking for leaves that apply to a specific calendar we include leaves that have no associated calendar, because they apply to all calendars.

In addition, this commit filters such leaves on the company of the requested calendar, otherwise it applies all leaves of all companies.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
