### PR TITLE
[FIX] hr: Fix Versions Timeline Zoom out

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -107,3 +107,11 @@
 .button-on {
     color: $o-success;
 }
+
+.o_field_versions_timeline {
+    overflow-x: auto;
+    > .o_statusbar_status {
+        display: flex;
+        flex-wrap: nowrap;
+    }
+}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
. When you zoom below 100%, the other versions from the version bar disapear, leaving only the active one

Desired behavior after PR is merged:
. When you zoom below 100%, all versions on timeline appears normally

task-5401380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
