### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: fix KeyError when bank has bank_id set

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -168,9 +168,8 @@ class AccountEdiXmlUblTr(models.AbstractModel):
 
     def _get_address_node(self, vals):
         partner = vals['partner']
-        model = vals.get('model', 'res.partner')
-        country = partner['country' if model == 'res.bank' else 'country_id']
-        state = partner['state' if model == 'res.bank' else 'state_id']
+        country = partner['country' if partner._name == 'res.bank' else 'country_id']
+        state = partner['state' if partner._name == 'res.bank' else 'state_id']
 
         return {
             'cbc:StreetName': {'_text': ' '.join(s for s in [partner.street, partner.street2] if s)},


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **Türkiye - Nilvera E-Invoice (l10n_tr_nilvera_einvoice)** modules
* Configure test mode following the [setup guide](https://docs.google.com/document/d/1EUzvTBnSm9-VwIfBsX299MHGXIVys-uijnsJ1fpz7vI/edit?tab=t.0).
* Create a bank account for the main company and fill the **Bank** selector (bank identifier dropdown).
* Create and attempt to send a customer invoice via Nilvera.

**Observed behavior:**
* A server error occurs: `KeyError: 'country_id'` in `l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py` at line 172 while generating `<cac:PayeeFinancialAccount>`.
* The invoice cannot be sent.

**Cause:**
* `_get_address_node()` determines field names using `vals.get('model', 'res.partner')`.
* When the parent class calls `_get_address_node({**vals, 'partner': bank})` with a `res.bank` record, it does **not** pass a `model` parameter.
* The method falls back to `'res.partner'` and attempts to read `country_id` from a `res.bank` record, which instead uses the field `country`.
* This mismatch triggers a `KeyError`.

**Fix:**
* Detect the appropriate field set by checking `partner._name` rather than relying on `vals.get('model')`.
* Use `country` / `state` when the record is `res.bank`.
* Use `country_id` / `state_id` when the record is `res.partner`.

opw-5380246
