### PR TITLE
[FIX] auth_totp: custom domain parameter

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -233,7 +233,7 @@ class ResUsers(models.Model):
     def _totp_enable_search(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        domain = Domain.custom(to_sql=lambda model, alias, query: SQL("%s <> 'false'", SQL.identifier(alias, 'totp_secret')))
+        domain = Domain.custom(to_sql=lambda table: SQL("%s <> 'false'", table.totp_secret))
         if not (self.env.su or self.env.user.has_group('base.group_erp_manager')):
             domain &= Domain('id', '=', self.env.uid)
         return domain


### PR DESCRIPTION
Missed during introduction of SQL aliases. Probably introduced in the meantime by another PR.

runbot-234541


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
