### PR TITLE
[FIX] spreadsheet_dashboard: keep active dashboard when returning via breadcrumb

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -115,8 +115,9 @@ export class SpreadsheetDashboardAction extends Component {
      * @returns {number | undefined}
      */
     getInitialActiveDashboard() {
-        if (this.props.state && this.props.state.activeDashboardId) {
-            return this.props.state.activeDashboardId;
+        const activeDashboardId = this.props.state?.dashboardLoader?.activeDashboardId;
+        if (activeDashboardId) {
+            return activeDashboardId;
         }
         const params = this.props.action.params;
         if (params && params.dashboard_id) {

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -187,6 +187,14 @@ test("Last selected spreadsheet is kept when go back from breadcrumb", async fun
         },
     };
     const serverData = getServerData(spreadsheetData);
+    serverData.models["spreadsheet.dashboard"].records.push({
+        id: 790,
+        name: "Second dashboard",
+        json_data: JSON.stringify(spreadsheetData),
+        spreadsheet_data: JSON.stringify(spreadsheetData),
+        dashboard_group_id: 1,
+    });
+    serverData.models["spreadsheet.dashboard.group"].records[0].published_dashboard_ids.push(790);
     await createSpreadsheetDashboard({ serverData });
     await contains(".o_search_panel li:last-child").click();
     await contains(".o-dashboard-clickable-cell").click();


### PR DESCRIPTION
### Description

After [PR#223171](https://github.com/odoo/odoo/pull/223171/), `useSetupAction` `getLocalState` exports the active dashboard through the loader state (`dashboardLoader.activeDashboardId`). The restore path still read `state.activeDashboardId`, so returning via the breadcrumb reset to the first dashboard. Read the saved loader state to keep the last selected dashboard.

Task: [5391349](https://www.odoo.com/odoo/project/2328/tasks/5391349)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
