### PR TITLE
[FIX] html_editor: fix non-deterministic test fail

### DIFF
--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -83,10 +83,9 @@ test("Replace an image by icon should remove invalid classes", async () => {
     await click("span.fa-envelope-o");
     await animationFrame();
     expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
-    expect("span").toHaveCount(1);
-    expect("span").toHaveClass("fa fa-envelope-o");
-    expect("span").not.toHaveClass("img-fluid");
-    expect("span").not.toHaveClass("w-100");
+    expect("p > span.fa-envelope-o").toHaveCount(1);
+    expect("p > span.fa-envelope-o").not.toHaveClass("img-fluid");
+    expect("p > span.fa-envelope-o").not.toHaveClass("w-100");
 });
 
 test.tags("focus required");


### PR DESCRIPTION
Because of the toolbar being sometimes opened, the test added in odoo#238735 would sometimes failed. This was due to the selector "span" also targetting the elements in the toolbar.

To prevent this test from failing, the selector "span" was updated to be more specific.