### PR TITLE
[FIX] setup: don't start IoT Box service before time sync

### DIFF
--- a/setup/iot_box_builder/overwrite_before_init/etc/systemd/system/odoo.service
+++ b/setup/iot_box_builder/overwrite_before_init/etc/systemd/system/odoo.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Odoo IoT Box service
-After=cups.socket network-online.target NetworkManager.service rc-local.service
-Wants=network-online.target
+After=network-online.target time-sync.target cups.socket NetworkManager.service rc-local.service
+Wants=network-online.target time-sync.target
 StartLimitIntervalSec=0
 
 [Service]


### PR DESCRIPTION
To make the IoT Box more resilient in case of time sync issues, we make the service start after the time sync one.
