### PR TITLE
[IMP] orm: make fetch() compute fields

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -284,7 +284,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
-    @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')
+    @api.depends_context('uid', 'employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')
     def _compute_leaves(self):
         employee = self.env['hr.employee']._get_contextual_employee()
         # This is a workaround to save the date value in context for next triggers
@@ -378,7 +378,8 @@ class HrLeaveType(models.Model):
         if not self.requested_display_name():
             # leave counts is based on employee_id, would be inaccurate if not based on correct employee
             return super()._compute_display_name()
-        for record in self:
+        # use sudo() to get the correct remaining leaves
+        for record in self.sudo():
             name = record.name
             if record.requires_allocation:
                 remaining_time = float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0

--- a/odoo/addons/test_orm/tests/test_performance.py
+++ b/odoo/addons/test_orm/tests/test_performance.py
@@ -166,6 +166,11 @@ class TestPerformance(SavepointCaseWithUserDemo):
             #  on 'value', and none of them are in cache
             records.fetch(['indirect_computed_value'])
 
+            # fetch() has forced the computation of 'indirect_computed_value'
+            for record in records:
+                self.assertIn('value', record._cache)
+                self.assertIn('indirect_computed_value', record._cache)
+
         # Test that new/false records are ignored. We generally make the assumption that
         # new records and real record shouldn't mix together but for the sake of robustness
         # we ignore new/false records in fetch.

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1413,6 +1413,13 @@ class BaseModel(metaclass=MetaModel):
         fetched = self._fetch_query(query, fields_to_fetch)
         if not self.env.su:
             self.env._add_to_access_cache(fetched)
+
+        # force computation of fields
+        for field_name in (field_names or ()):
+            field = self._fields[field_name]
+            if not field.store and any(field._cache_missing_ids(fetched)):
+                fetched.mapped(field_name)
+
         return fetched
 
     #
@@ -2949,12 +2956,12 @@ class BaseModel(metaclass=MetaModel):
     @api.private
     def fetch(self, field_names: Collection[str] | None = None) -> None:
         """ Make sure the given fields are in memory for the records in ``self``,
-        by fetching what is necessary from the database.  Non-stored fields are
-        mostly ignored, except for their stored dependencies. This method should
-        be called to optimize code.
+        by fetching what is necessary from the database.  Non-stored computed
+        fields are computed, and their dependencies are fetched with stored
+        fields. This method should be called to optimize code.
 
-        :param field_names: a collection of field names to fetch, or ``None`` for
-            all accessible fields marked with ``prefetch=True``
+        :param field_names: a collection of field names to fetch or compute, or
+            ``None`` for all accessible fields marked with ``prefetch=True``
         :raise AccessError: if user is not allowed to access requested information
 
         This method is implemented thanks to methods :meth:`_search` and
@@ -2988,6 +2995,12 @@ class BaseModel(metaclass=MetaModel):
         env = self.env
         if not env.su:
             env._add_to_access_cache(fetched)
+
+        # force computation of fields
+        for field_name in (field_names or ()):
+            field = self._fields[field_name]
+            if not field.store and any(field._cache_missing_ids(fetched)):
+                fetched.mapped(field_name)
 
         # possibly raise exception for the records that could not be read
         if not env.su and fetched != self:

--- a/odoo/orm/models_cached.py
+++ b/odoo/orm/models_cached.py
@@ -39,10 +39,8 @@ class CachedModel(Model):
         # each field is mapped to a tuple
         result = {'id': records._ids}
         for fname in fnames:
-            field = self._fields[fname]
-            if field.compute and not field.store:
-                records.mapped(fname)  # fill the cache for computed field
-            result[fname] = tuple(map(field._get_cache(records.env).__getitem__, records.ids))
+            field_cache = self._fields[fname]._get_cache(records.env)
+            result[fname] = tuple(map(field_cache.__getitem__, records.ids))
         return frozendict(result)
 
     def _fetch_field(self, field):


### PR DESCRIPTION
The purpose is that both methods `fetch()` and `search_fetch()` ensure that the fields given as parameter are in cache right after the call.

In particular, one can call `records.fetch(['foo'])` to enforce the computation of field `foo` if necessary.
