### PR TITLE
[IMP] account_peppol: unregister to sender by default

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -229,7 +229,6 @@ class Account_Edi_Proxy_ClientUser(models.Model):
         else:
             journal = (
                 journal
-                or self.company_id.peppol_self_billing_reception_journal_id
                 or self.env['account.journal'].search(
                     [
                         *self.env['account.journal']._check_company_domain(self.company_id),
@@ -493,6 +492,20 @@ class Account_Edi_Proxy_ClientUser(models.Model):
 
         self.company_id._reset_peppol_configuration()
         self.unlink()
+
+    def _peppol_deregister_participant_to_sender(self):
+        self.ensure_one()
+
+        if self.company_id.account_peppol_proxy_state == 'receiver':
+            # fetch all documents and message statuses before unlinking the edi user
+            # so that the invoices are acknowledged
+            self._cron_peppol_get_message_status()
+            self._cron_peppol_get_new_documents()
+            if not modules.module.current_test:
+                self.env.cr.commit()
+
+        self._call_peppol_proxy(endpoint='/api/peppol/1/unregister_to_sender')
+        self.company_id.account_peppol_proxy_state = 'sender'
 
     @api.model
     def _peppol_auto_register_services(self, module):

--- a/addons/account_peppol/models/account_journal.py
+++ b/addons/account_peppol/models/account_journal.py
@@ -20,7 +20,6 @@ class AccountJournal(models.Model):
                 or (
                     j.type == 'purchase'
                     and j.is_self_billing
-                    and j.company_id.peppol_activate_self_billing_sending
                 )
             )
         )).show_refresh_out_einvoices_status_button = True

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -40,7 +40,7 @@ class AccountMove(models.Model):
         # EXTENDS 'account'
         super()._compute_display_send_button()
         for move in self:
-            if move.company_id.peppol_activate_self_billing_sending and move._is_exportable_as_self_invoice():
+            if move._is_exportable_as_self_invoice():
                 move.display_send_button = True
 
     @api.depends('state')

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -23,7 +23,7 @@ class AccountMoveSend(models.AbstractModel):
     @api.model
     def _get_move_constraints(self, move):
         constraints = super()._get_move_constraints(move)
-        if move.company_id.peppol_activate_self_billing_sending and move._is_exportable_as_self_invoice():
+        if move._is_exportable_as_self_invoice():
             constraints.pop('not_sale_document', None)
         return constraints
 

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -98,10 +98,12 @@ class ResCompany(models.Model):
     peppol_metadata = fields.Json(string='Peppol Metadata')
     peppol_metadata_updated_at = fields.Datetime(string='Peppol meta updated at')
 
+    # Deprecated
     peppol_activate_self_billing_sending = fields.Boolean(
         string="Activate self-billing sending",
         help="If activated, you will be able to send vendor bills as self-billed invoices via Peppol.",
     )
+    # Deprecated
     peppol_self_billing_reception_journal_id = fields.Many2one(
         comodel_name='account.journal',
         string='Self-Billing reception journal',

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -38,6 +38,10 @@ class ResConfigSettings(models.TransientModel):
         return registration_action
 
     def button_open_peppol_config_wizard(self):
+        view = self.env.ref('account_peppol.peppol_config_wizard_form').sudo()
+        # TODO remove in master this hack to have the possibility of being only a sender
+        if 'button_peppol_reset_to_sender' not in view.arch_db:
+            view.reset_arch(mode="hard")
         return {
             'type': 'ir.actions.act_window',
             'name': 'Advanced Peppol Configuration',
@@ -64,20 +68,7 @@ class ResConfigSettings(models.TransientModel):
     def button_peppol_register_sender_as_receiver(self):
         """Register the existing user as a receiver."""
         self.ensure_one()
-        self.account_peppol_edi_user._peppol_register_sender_as_receiver()
-        self.account_peppol_edi_user._peppol_get_participant_status()
-        if self.account_peppol_proxy_state == 'smp_registration':
-            return {
-                'type': 'ir.actions.client',
-                'tag': 'display_notification',
-                'params': {
-                    'title': _("Registered to receive documents via Peppol."),
-                    'type': 'success',
-                    'message': _("Your registration on Peppol network should be activated within a day. The updated status will be visible in Settings."),
-                    'next': {'type': 'ir.actions.act_window_close'},
-                }
-            }
-        return True
+        return self.env['peppol.config.wizard'].new().button_peppol_register_sender_as_receiver()
 
     def button_reconnect_this_database(self):
         """Re-establish an out-of-sync connection"""

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -698,8 +698,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
 
     def test_self_billing_sending_constraints(self):
         """Test that self-billing sending constraints are properly handled."""
-        # Test that vendor bills can be sent when self-billing is activated
-        self.env.company.peppol_activate_self_billing_sending = True
         self.valid_partner.invoice_edi_format = 'ubl_bis3'
 
         self_billing_journal = self.env['account.journal'].create({
@@ -733,10 +731,8 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         wizard = self.create_send_and_print(vendor_bill, default=True)
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
 
-        # Test that vendor bills cannot be sent when self-billing is not activated
-        self.env.company.peppol_activate_self_billing_sending = False
-        with self.assertRaisesRegex(UserError, "You can only generate sales documents."):
-            self.create_send_and_print(vendor_bill, default=True)
+        # Test that vendor bills can be sent as soon as the format allows (bis3) and the journal is in self-billing
+        self.create_send_and_print(vendor_bill, default=True)
 
     def test_receive_self_billed_invoice_from_peppol(self):
         """Test receiving a self-billed invoice from Peppol.

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -70,6 +70,10 @@ def _mock_call_peppol_proxy(func, self, endpoint, params=None):
             } for i in params['documents']],
         }
 
+    def _mock_unregister_to_sender(user):
+        user.company_id.account_peppol_proxy_state = 'sender'
+        return True
+
     endpoint = endpoint.rsplit('/', 1)[-1]
     params = params or {}
     return {
@@ -79,6 +83,7 @@ def _mock_call_peppol_proxy(func, self, endpoint, params=None):
         'register_sender_as_receiver': lambda _user: {},
         'update_user': lambda _user: {},
         'cancel_peppol_registration': lambda _user: {},
+        'unregister_to_sender': _mock_unregister_to_sender,
         'migrate_peppol_registration': lambda _user: {'migration_key': 'demo_migration_key'},
         'participant_status': lambda _user: {'peppol_state': 'receiver'},
         'set_webhook': lambda _user: {},

--- a/addons/account_peppol/wizard/peppol_config_wizard.xml
+++ b/addons/account_peppol/wizard/peppol_config_wizard.xml
@@ -22,17 +22,19 @@
                            nolabel="1"
                            required="account_peppol_proxy_state in ('sender', 'smp_registration', 'receiver')"/>
                 </group>
-                <group string="Receive your electronic invoices in Odoo" invisible="account_peppol_proxy_state != 'sender'">
-                    <div class="text-justify text-muted" colspan="2">
-                        Some service support migration keys. If this is your case you can enter your migration key below.
-                        If not, you should de-register from your current service provider and register with Odoo afterward.
-                    </div>
-                    <field name="account_peppol_migration_key"/>
-                </group>
-                <group string="Self Billing" invisible="account_peppol_proxy_state not in ('sender', 'receiver')">
-                    <field name="peppol_activate_self_billing" invisible="account_peppol_proxy_state not in ('sender', 'receiver')"/>
-                    <field name="peppol_self_billing_reception_journal_id" invisible="account_peppol_proxy_state != 'receiver'"/>
-                </group>
+                <div invisible="1"> <!-- Deprecated -->
+                    <group string="Receive your electronic invoices in Odoo" invisible="account_peppol_proxy_state != 'sender'">
+                        <div class="text-justify text-muted" colspan="2">
+                            Some service support migration keys. If this is your case you can enter your migration key below.
+                            If not, you should de-register from your current service provider and register with Odoo afterward.
+                        </div>
+                        <field name="account_peppol_migration_key"/>
+                    </group>
+                    <group string="Self Billing" invisible="account_peppol_proxy_state not in ('sender', 'receiver')">
+                        <field name="peppol_activate_self_billing" invisible="account_peppol_proxy_state not in ('sender', 'receiver')"/>
+                        <field name="peppol_self_billing_reception_journal_id" invisible="account_peppol_proxy_state != 'receiver'"/>
+                    </group>
+                </div>
                 <!-- Note: Deprecated -->
                 <!-- Disabling services can lead to complicance issues and is not necessary -->
                 <!-- since all existing services should just work. -->
@@ -58,6 +60,18 @@
                             type="object"
                             class="btn btn-danger text-nowrap"
                             confirm="This will delete your Peppol registration."/>
+
+                        <button string="Enable reception"
+                                name="button_peppol_register_sender_as_receiver"
+                                type="object"
+                                class="btn-secondary"
+                                invisible="account_peppol_proxy_state != 'sender'"/>
+
+                        <button string="Disable the reception."
+                            name="button_peppol_reset_to_sender"
+                            type="object"
+                            class="btn-secondary"
+                            invisible="account_peppol_proxy_state not in ('smp_registration', 'receiver')"/>
                 </group>
                 <footer>
                     <button string="Save" name="button_sync_form_with_peppol_proxy" type="object"


### PR DESCRIPTION
Remove the use of the config wizard.
Allow unregistering by default to sender instead of unlinking.

task-5395262



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
