### PR TITLE
[FIX] l10n_xx_hr_payroll_account: fix auto install modules not installed

### DIFF
--- a/addons/l10n_fr_hr_holidays/__manifest__.py
+++ b/addons/l10n_fr_hr_holidays/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Human Resources/Time Off',
     'summary': 'Management of leaves for part-time workers in France',
     'depends': ['hr_holidays'],
-    'auto_install': ['hr_holidays'],
+    'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'data': [

--- a/addons/l10n_fr_hr_work_entry_holidays/__manifest__.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/__manifest__.py
@@ -2,13 +2,12 @@
 
 {
     'name': 'France - Work Entries Time Off',
-    'countries': ['fr'],
     'summary': 'Management of leaves for part-time workers in France',
     'depends': [
         'l10n_fr_hr_holidays',
         'hr_work_entry_holidays',
     ],
-    'auto_install': ['hr_work_entry_holidays'],
+    'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Steps to reproduce:
1. Run odoo for a fresh database with -i hr_payroll_account,l10n_xx_hr_payroll (except for us).
2. The corresponding l10n_xx_hr_payroll_account won't be installed.

Cause:
The l10n_xx_hr_payroll_account had 'countries': ['xx'] in their manifest, but there is no company from that country yet. When installing modules, the framework first checks if there can be modules to auto-install as well, but since the demo data with the company of the country does not yet exist, there is no such company. Hence, the module is not installed.

Fix:
Remove all occurrences of 'countries': ['xx'] for modules that are auto-installed and that depend on other modules with countries already defined in their manifest.

Task: 5384292
