### PR TITLE
[FIX] pos_online_payment: sync online payment lines

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -4,7 +4,7 @@ import { serializeDateTime } from "@web/core/l10n/dates";
 
 patch(PaymentScreen.prototype, {
     async addNewPaymentLine(paymentMethod) {
-        if (paymentMethod.is_online_payment && !this.currentOrder.isSynced) {
+        if (paymentMethod.is_online_payment) {
             this.currentOrder.date_order = serializeDateTime(luxon.DateTime.now());
             this.pos.addPendingOrder([this.currentOrder.id]);
             await this.pos.syncAllOrders();

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -78,3 +78,28 @@ registry.category("web_tour.tours").add("test_selected_customer_after_adding_pay
             Dialog.is("Scan to Pay"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_mixed_payments_synced", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Letter Tray", "10"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickNumpad("8"),
+            PaymentScreen.selectedPaymentlineHas("Cash", "8.00"),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.clickPaymentlineDelButton("Online payment", "40.00"),
+            PaymentScreen.clickPaymentline("Cash", "8.00"),
+            PaymentScreen.clickNumpad("9"),
+            PaymentScreen.selectedPaymentlineHas("Cash", "9.00"),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.selectedPaymentlineHas("Online payment", "39.00"),
+            PaymentScreen.clickValidate(),
+            {
+                content: "Check Dialog title",
+                trigger: '.modal .modal-header:contains("Scan to Pay")',
+            }
+        ].flat(),
+});

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -337,6 +337,14 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
         self.assertEqual(order.state, "draft", "The order should still be in draft state.")
         self.assertEqual(len(order.payment_ids), 0, "There should be no payment line in the order.")
 
+    def test_mixed_payments_synced(self):
+        """
+        Tests that when paying with an offline payment method, changing the price to a fraction of the
+        total price. Then paying the rest with an online method, the
+        """
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('test_mixed_payments_synced', login="pos_admin")
+
     @classmethod
     def tearDownClass(cls):
         # Restore company values after the tests


### PR DESCRIPTION
**Steps to reproduce:**
- Allow any online payment method and an offline payment method, like Cash
- Go to PoS, click a product and go to pay for it
- Choose Cash, and change it's value to be less than the product's price
- Click the online payment method then delete the payment line
- Change the Cash value again
- Click the online payment method once again and try to pay
- Error message appears, the values don't match

**Why the fix:**
Currently, the online payment is not synced with the server if the order is already present on the server. This means that adding an online payment method line does not recompute all values related to the order.

In this case, the problematic values are amount_unpaid and amount_paid, which is not what we expect as it was not synced when we added the online payment line. This triggers the error saying that the amount_unpaid does not match the desired value to pay the full price for this order.

We now sync the online payment line regardless of the order state, as we need the values to be updated regardless of if the payment line is online or not.

opw-5177729