### PR TITLE
[FIX] hr_holidays_attendance: prevent traceback when clicking on time off type

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -56,7 +56,8 @@ class HrLeaveType(models.Model):
                             'icon': leave_type.sudo().icon_id.url,
                             'allows_negative': leave_type.allows_negative,
                             'max_allowed_negative': leave_type.max_allowed_negative,
-                            'overtime_deductible': True
+                            'overtime_deductible': True,
+                            'employee_company': employee.company_id.id,
                         },
                         leave_type.requires_allocation,
                         leave_type.id)

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -83,6 +83,8 @@ class TestHolidaysOvertime(TransactionCase):
 
             overtime_leave_data = self.leave_type_no_alloc.get_allocation_data(self.employee)
             self.assertEqual(overtime_leave_data[self.employee][0][1]['virtual_remaining_leaves'], 8.0)
+            # `employee_company` must be present to avoid traceback when opening the Time Off Type
+            self.assertTrue(overtime_leave_data[self.employee][0][1].get('employee_company'))
 
             leave = self.env['hr.leave'].create({
                 'name': 'no overtime',


### PR DESCRIPTION
Steps to reproduce:
--------------------------
1. Install hr_holidays_attendance.
2. Go to Time Off > Dashboard
3. Try to click on "Extra Hours"

Issue:
--------
A traceback occurs:
```python
InvalidDomainError: Invalid domain representation: holiday_status_id,=,5,company_id,=,,user_id,=,2
```

Cause:
---------
After 0aeaa2b (hr_holidays), clicking a time off type sends [employee_company](https://github.com/odoo/odoo/blob/84b137098ee46b1dab679fa8d99dbf368929413d/addons/hr_holidays/models/hr_leave_type.py#L539) in the domain.
https://github.com/odoo/odoo/blob/84b137098ee46b1dab679fa8d99dbf368929413d/addons/hr_holidays/static/src/dashboard/time_off_card.js#L70-L74
However, the hour-based time off type created by `hr_holidays_attendance` does not define
`employee_company`, so the domain contains **undefined,** triggering `InvalidDomainError.`



Solution:
-----------
Add the missing employee_company value in hr_holidays_attendance to resolve the issue.

opw-5358682



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
