### PR TITLE
[FIX] purchase_requisition: fix description,price_unit of same product in pol

### DIFF
--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -631,3 +631,36 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         self.assertEqual(po.partner_id, purchase_requisition.vendor_id, 'The partner should have been set from the purchase requisition')
         self.assertEqual(po.order_line.price_unit, purchase_requisition.line_ids.price_unit, 'The unit price should have been set from the purchase requisition')
         self.assertEqual(po.order_line.taxes_id, purchase_requisition.line_ids.product_id.supplier_taxes_id, 'The blanket order taxes should have been set')
+
+    def test_requisition_multiple_lines_same_product(self):
+        """Creating a PO from a requisition with multiple lines of the same product
+           keeps the correct price and description on each PO line."""
+
+        requisition = self.env['purchase.requisition'].create({
+            'vendor_id': self.res_partner_1.id,
+            'line_ids': [
+                Command.create({
+                    'product_id': self.product_09.id,
+                    'product_qty': 10.0,
+                    'price_unit': 50.0,
+                    'product_description_variants': 'First',
+                }),
+                Command.create({
+                    'product_id': self.product_09.id,
+                    'product_qty': 20.0,
+                    'price_unit': 45.0,
+                    'product_description_variants': 'Second',
+                }),
+            ],
+        })
+        requisition.action_confirm()
+        po = Form(
+            self.env['purchase.order'].with_context(
+                default_requisition_id=requisition.id
+            )
+        ).save()
+        self.assertRecordValues(po.order_line, [
+            {'price_unit': 50.0, 'name': '[E-COM10] Pedal Bin\nFirst'},
+            {'price_unit': 45.0, 'name': '[E-COM10] Pedal Bin\nSecond'}
+        ])
+

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -634,7 +634,8 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
 
     def test_requisition_multiple_lines_same_product(self):
         """Creating a PO from a requisition with multiple lines of the same product
-           keeps the correct price and description on each PO line."""
+           keeps the correct price and description on each PO line and update
+           requisition line qty ordered"""
 
         requisition = self.env['purchase.requisition'].create({
             'vendor_id': self.res_partner_1.id,
@@ -663,4 +664,10 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
             {'price_unit': 50.0, 'name': '[E-COM10] Pedal Bin\nFirst'},
             {'price_unit': 45.0, 'name': '[E-COM10] Pedal Bin\nSecond'}
         ])
-
+        po.order_line[0].product_qty = 10
+        po.order_line[1].product_qty = 20
+        po.button_confirm()
+        self.assertRecordValues(po.requisition_id.line_ids, [
+            {'qty_ordered': 10.0},
+            {'qty_ordered': 20.0}
+        ])


### PR DESCRIPTION
**BUG-1**
---

**Steps to reproduce:**
* Install the *purchase_requisition* module with demo data.
* Navigate to **Purchase → Orders → Purchase Agreements**.
* Create a new purchase agreement.
* Add **two lines for the same product**.
  * Set a **different description** on each line.
  * Set a **different unit price** on each line.
* Confirm the agreement and click **New Quotation**.

**Observed behavior:**
* The generated PO lines display the **same description** and **same unit price**, 
instead of keeping the distinct values set on each agreement line.

**Cause:**
* The matching logic did not track which requisition lines had already been used.
When multiple requisition lines used the same product, both PO lines matched 
the **first** requisition line found, leading to incorrect values for description, price, and `qty_ordered`.

**Fix:**
* Add a `requisition_line_used` set to ensure each requisition line is matched only once.
* This guarantees that each PO line is linked to a *different* requisition line, preserving 
the unique description, price, and quantity per line.
---


`NOTE`- Second bug was introduced while fixing the first one. 
This occurred because we were previously not handling cases where duplicate products appear in the purchase requisition.
* After discussion with CRL, we are considering this as a bug.

---

**BUG-2**
---

**Steps to reproduce:**
* Install the *product_requisition* module with demo data.
* Navigate to **Purchase → Orders → Purchase Agreements**.
* Create a new purchase agreement.
* Add **two lines for the same product**.
  * Set a **different description** on each line.
  * Set a **different unit price** on each line.
* Confirm the agreement and click **New Quotation**.
* Set quantities on both quotation lines and confirm the purchase
order.
* Return to the purchase requisition (agreement).

**Observed behavior:**
* The qty_ordered (Ordered) value is incorrectly calculated and the
sum of quantities is shown on a single requisition line, instead
of being split across matching lines.

**Cause:**
https://github.com/odoo/odoo/blob/b8ef07b191a9b396fa776900a6ad3f83b99e13d0/addons/purchase_requisition/models/purchase_requisition.py#L191

* The matching logic grouped lines only by product_id.
  been used.
* It did not track already allocated requisition lines, so multiple
lines for the same product were merged during computation.

**Fix:**
* Compute ordered quantities by allocating confirmed purchase order
lines to requisition lines using price, description, and UoM-aware
matching, with per-PO allocation safety to avoid double counting.


---

opw-5373617

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
