### PR TITLE
[FIX] stock_account: avoid traceback when account move line has no label

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -138,7 +138,7 @@ class AccountMove(models.Model):
 
                 # Add interim account line.
                 lines_vals_list.append({
-                    'name': line.name[:64],
+                    'name': line.name[:64] if line.name else '',
                     'move_id': move.id,
                     'partner_id': move.commercial_partner_id.id,
                     'product_id': line.product_id.id,
@@ -154,7 +154,7 @@ class AccountMove(models.Model):
 
                 # Add expense account line.
                 lines_vals_list.append({
-                    'name': line.name[:64],
+                    'name': line.name[:64] if line.name else '',
                     'move_id': move.id,
                     'partner_id': move.commercial_partner_id.id,
                     'product_id': line.product_id.id,

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -392,3 +392,24 @@ class TestAccountMove(TestAccountMoveStockCommon):
         })
 
         self.assertEqual(bill.invoice_line_ids.account_id, test_account)
+
+    def test_invoice_with_journal_item_without_label(self):
+        """Test posting an invoice whose invoice lines have no label.
+        The 'name' field is optional on account.move.line and should be
+        handled safely when generating accounting entries.
+        """
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_A.id,
+                    'name': False,
+                }),
+            ],
+        })
+        move.action_post()
+        # name should remain falsy on the invoice line
+        self.assertFalse(move.invoice_line_ids.name)
+        # ensure the invoice is posted successfully
+        self.assertEqual(move.state, 'posted')


### PR DESCRIPTION
Creating an invoice containing journal items without a label triggers a traceback because the code unconditionally slices the 'name' field (line.name[:64]) without ensuring it is not False. Since 'name' is not a required field on account.move.line, it must be safely handled.

This commit ensures that the label is always a string by falling back to an empty string when the value is missing.

Steps to reproduce the bug:
- Create a storable product
- Create an invoice:
    - Add the product to the invoice
    - Set any customer
    - Go to the journal items tab
    - Remove the label of the journal item corresponding to the product
- Try to validate the invoice
- A traceback is raised

opw-5360602
