### PR TITLE
[IMP] web, *: stop interactions when root element is disconnected

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -326,6 +326,9 @@ export class Colibri {
                 { cause: error }
             );
         }
+        if (!this.el.isConnected) {
+            this.core.stopInteractions(this.el);
+        }
     }
 
     destroy() {

--- a/addons/web/static/src/public/utils.js
+++ b/addons/web/static/src/public/utils.js
@@ -1,10 +1,12 @@
 export class PairSet {
     constructor() {
         this.map = new Map(); // map of [1] => Set<[2]>
+        this.keySet = new Set();
     }
     add(elem1, elem2) {
         if (!this.map.has(elem1)) {
             this.map.set(elem1, new Set());
+            this.keySet.add(elem1);
         }
         this.map.get(elem1).add(elem2);
     }
@@ -22,6 +24,7 @@ export class PairSet {
         s.delete(elem2);
         if (!s.size) {
             this.map.delete(elem1);
+            this.keySet.delete(elem1);
         }
     }
 }

--- a/addons/web/static/tests/public/interaction_service.test.js
+++ b/addons/web/static/tests/public/interaction_service.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { queryOne } from "@odoo/hoot-dom";
+import { queryOne, tick } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 
 import { Component, xml } from "@odoo/owl";
@@ -321,5 +321,52 @@ test("does not start interaction in el if not attached", async () => {
     expect(n).toBe(0);
     span.remove();
     await core.startInteractions(span);
+    expect(n).toBe(0);
+});
+
+test("stops interactions if el is removed", async () => {
+    let n = 0;
+    class Test extends Interaction {
+        static selector = ".test";
+        start() {
+            n++;
+        }
+        destroy() {
+            n--;
+        }
+    }
+    class Test2 extends Test {
+        static selector = "span";
+    }
+    class Test3 extends Test {
+        static selector = "p";
+    }
+
+    await startInteraction([Test, Test2, Test3], `<p><span class="test"></span></p>`);
+    expect(n).toBe(3);
+    queryOne("span.test").remove();
+    await tick();
+    expect(n).toBe(1);
+});
+
+test("stops interactions if el is disconnected", async () => {
+    let n = 0;
+    class Test extends Interaction {
+        static selector = ".test";
+        start() {
+            n++;
+        }
+        destroy() {
+            n--;
+        }
+    }
+    class Test2 extends Test {
+        static selector = "span";
+    }
+
+    await startInteraction([Test, Test2], `<p><span class="test"></span></p>`);
+    expect(n).toBe(2);
+    queryOne("p").remove();
+    await tick();
     expect(n).toBe(0);
 });

--- a/addons/website_event/static/src/interactions/modal_attendees_registration.js
+++ b/addons/website_event/static/src/interactions/modal_attendees_registration.js
@@ -95,7 +95,6 @@ export class ModalAttendeesRegistration extends Interaction {
             this.enableRegistrationFormSubmit();
 
             this.el.remove();
-            this.services["public.interactions"].stopInteractions(this.el);
             return;
         }
         if (this.recaptchaToken.token) {


### PR DESCRIPTION
*: website_event

As interactions depend on their root element throughout their lifecycle, once that element is disconnected (either removed directly, or a parent is removed), the interaction should be destroyed.
Until now, this had to be done manually by calling the interaction service.