### PR TITLE
[ADD] pos_partner_autocomplete: link between pos and partner_autocomplete

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'Handle checkouts and payments for shops and restaurants.',
-    'depends': ['resource', 'stock_account', 'barcodes', 'html_editor', 'digest', 'phone_validation', 'partner_autocomplete', 'google_address_autocomplete'],
+    'depends': ['resource', 'stock_account', 'barcodes', 'html_editor', 'digest', 'phone_validation', 'google_address_autocomplete'],
     'uninstall_hook': 'uninstall_hook',
     'data': [
         'security/point_of_sale_security.xml',
@@ -201,7 +201,6 @@
             'web/static/src/webclient/actions/**/*',
             ('remove', 'web/static/src/webclient/actions/reports/report_layouts.scss'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
-            'partner_autocomplete/static/src/**/*',
             'google_address_autocomplete/static/src/**/*',
         ],
         'point_of_sale.base_tests': [

--- a/addons/pos_partner_autocomplete/__manifest__.py
+++ b/addons/pos_partner_autocomplete/__manifest__.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'POS Partner Autocomplete',
+    'category': 'Sales/Point of Sale',
+    'summary': 'Link module between Partner Autocomplete and Point of Sale',
+    'description': """
+This module links Partner Autocomplete with the Point of Sale, allowing partner data to be auto-completed from the POS frontend.
+This module ensures that the Point of Sale remains independent of Partner Autocomplete.
+    """,
+    'depends': ['partner_autocomplete', 'point_of_sale'],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'partner_autocomplete/static/src/**/*',
+        ],
+    },
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}


### PR DESCRIPTION
in this commit:
- Removed dependency of `partner_autocomplete` with `point_of_sale`.
- Add new module linking `partner_autocomplete` with `point_of_sale`.

task-5365585
