### PR TITLE
[IMP] hr: move manager to employee versions

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -223,7 +223,7 @@ class HrEmployee(models.Model):
         groups="hr.group_hr_user"
     )
     # Direct subordinates
-    parent_id = fields.Many2one('hr.employee', 'Manager', tracking=True, index=True,
+    parent_id = fields.Many2one(readonly=False, related='version_id.parent_id', inherited=True, index=True, tracking=True, store=True,
                                 domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]")
     child_ids = fields.One2many('hr.employee', 'parent_id', string='Direct subordinates')
     child_count = fields.Integer('Direct Subordinates Count', compute='_compute_child_count',

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -46,6 +46,7 @@ class HrVersion(models.Model):
         tracking=True,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         index=True)
+    parent_id = fields.Many2one('hr.employee', 'Manager', index=True)
     name = fields.Char(tracking=True)
     display_name = fields.Char(compute='_compute_display_name')
     active = fields.Boolean(default=True, tracking=True)


### PR DESCRIPTION
- Added `parent_id` to `hr.version` to track manager history.
- The manager field on the Employee is now synchronized with the current version

Task: 5380683
