### PR TITLE
[FIX] bus: missed IM status update

### DIFF
--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -51,7 +51,7 @@ export const imStatusService = {
             }
         );
         presence.bus.addEventListener("presence", () => {
-            if (lastSentInactivity >= AWAY_DELAY) {
+            if (!lastSentInactivity || lastSentInactivity >= AWAY_DELAY) {
                 this.updateBusPresence();
             }
             startAwayTimeout();


### PR DESCRIPTION
Before this commit, the user's presence might not be updated after returning from inactivity.

This occurs because the status service only sends an update if the user was away during the previous update. However, this condition doesn't account for cases where the update was never sent.
