### PR TITLE
[FIX] repair: add reference to repair order move

### DIFF
--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -67,7 +67,7 @@ class StockMove(models.Model):
         for move in self:
             if move.repair_id and move.repair_id.name:
                 move.reference = move.repair_id.name
-                moves_with_reference.add(move)
+                moves_with_reference.add(move.id)
         super(StockMove, self - self.env['stock.move'].browse(moves_with_reference))._compute_reference()
 
     def copy_data(self, default=None):

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -646,16 +646,20 @@ class TestRepair(common.TransactionCase):
         repair_order._action_repair_confirm()
         move = repair_order.move_ids[0]
         self.assertEqual(repair_order.name, "PT1/00001")
+        self.assertEqual(move.reference, "PT1/00001")
         self.assertEqual(move.location_id, stock_location_1)
         self.assertEqual(move.quantity, 0.0)
         repair_order.picking_type_id = picking_type_2
         self.assertEqual(repair_order.name, "PT2/00001")
+        self.assertEqual(move.reference, "PT2/00001")
         self.assertEqual(move.location_id, stock_location_2)
         self.assertEqual(move.quantity, 1.0)
         repair_order.picking_type_id = picking_type_1
         self.assertEqual(repair_order.name, "PT1/00002")
+        self.assertEqual(move.reference, "PT1/00002")
         repair_order.picking_type_id = picking_type_1
         self.assertEqual(repair_order.name, "PT1/00002")
+        self.assertEqual(move.reference, "PT1/00002")
 
     def test_repair_components_lots_show_in_invoice(self):
         """


### PR DESCRIPTION
### Steps to reproduce:

- Create and confirm a repair order for a storable product
- Go to Inventory > Reporting > Moves History
#### > The related move line appears without reference

### Issue:

The issue has been introduced with facf4eba6cd0504aae949c23454c6ffa9eaa9c3f which purpose is was to remove the `name` field of the `stock.move` model. However, prior to saas-18.4, the reference of the move relied on its name:
https://github.com/odoo/odoo/blob/404cb10283cbc706eae67dd793ced363273f3602/addons/stock/models/stock_move.py#L325-L328 
To not lose this reference an override of the `_compute_reference` compute method was introduced for repair orders. But it is currently ineffective since `moves_with_reference` is a set of records and not a set of ides which makes it the method call its super method on every records including the repair orders.

opw-5385004

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
