### PR TITLE
[FIX] web, calendar: enhance popover positioning flexibility

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee_expandable.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee_expandable.js
@@ -1,7 +1,6 @@
-import { useState, useEffect } from "@odoo/owl";
-import { registry } from "@web/core/registry";
-import { reposition } from "@web/core/position/utils";
 import { Many2ManyAttendee, many2ManyAttendee } from "@calendar/views/fields/many2many_attendee";
+import { useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
 
 export class Many2ManyAttendeeExpandable extends Many2ManyAttendee {
     static template = "calendar.Many2ManyAttendeeExpandable";
@@ -13,21 +12,6 @@ export class Many2ManyAttendeeExpandable extends Many2ManyAttendee {
         this.acceptedCount = this.props.record.data.accepted_count;
         this.declinedCount = this.props.record.data.declined_count;
         this.uncertainCount = this.attendeesCount - this.acceptedCount - this.declinedCount;
-
-        if (!this.env.isSmall) {
-            useEffect(
-                () => {
-                    const popover = document
-                        .querySelector(".o_field_many2manyattendeeexpandable")
-                        .closest(".o_popover");
-                    const target = document.querySelector(
-                        `.fc-event[data-event-id="${this.props.record.resId}"]`
-                    );
-                    reposition(popover, target, { position: "right", margin: 0 });
-                },
-                () => [this.state.expanded]
-            );
-        }
     }
 
     onExpanderClick() {

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -96,6 +96,7 @@ export class Popover extends Component {
 
         // Positioning props
         fixedPosition: { optional: true, type: Boolean },
+        extendedFlipping: { optional: true, type: Boolean },
         holdOnHover: { optional: true, type: Boolean },
         onPositioned: { optional: true, type: Function },
         position: {
@@ -162,6 +163,7 @@ export class Popover extends Component {
 
     get positioningOptions() {
         return {
+            extendedFlipping: this.props.extendedFlipping,
             margin: this.props.arrow ? 8 : 0,
             onPositioned: (el, solution) => {
                 this.onPositioned(solution);

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -47,6 +47,7 @@ export const popoverService = {
                     closeOnEscape: options.closeOnEscape,
                     component,
                     componentProps: markRaw(props),
+                    extendedFlipping: options.extendedFlipping,
                     ref: options.ref,
                     class: options.popoverClass,
                     animation: options.animation,

--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -27,6 +27,9 @@ import { localization } from "@web/core/l10n/localization";
  *  position of the popper relative to the target
  * @property {boolean} [flip=true]
  *  allow the popper to try a flipped direction when it overflows the container
+ * @property {boolean} [extendedFlipping=false]
+ *  allow the popper to try for all possible flipping directions (including center)
+ *  when it overflows the container
  * @property {boolean} [shrink=false]
  *  reduce the popper's height when it overflows the container
  */
@@ -43,7 +46,15 @@ const DIRECTIONS = { t: "top", r: "right", b: "bottom", l: "left", c: "center" }
 /** @type {{[v: string]: Variant}} */
 const VARIANTS = { s: "start", m: "middle", e: "end", f: "fit" };
 /** @type DirectionFlipOrder */
-const DIRECTION_FLIP_ORDER = { top: "tb", right: "rl", bottom: "bt", left: "lr" };
+const DIRECTION_FLIP_ORDER = { top: "tb", right: "rl", bottom: "bt", left: "lr", center: "c" };
+/** @type DirectionFlipOrder */
+const EXTENDED_DIRECTION_FLIP_ORDER = {
+    top: "tbrlc",
+    right: "rlbtc",
+    bottom: "btrlc",
+    left: "lrbtc",
+    center: "c",
+};
 /** @type VariantFlipOrder */
 const VARIANT_FLIP_ORDER = { start: "se", middle: "m", end: "es", fit: "f" };
 
@@ -99,10 +110,19 @@ export function reverseForRTL(direction, variant = "middle") {
  *                                the containing block of the popper.
  *                                => can be applied to popper.style.(top|left)
  */
-function computePosition(popper, target, { container, flip, margin, position, shrink }) {
+function computePosition(
+    popper,
+    target,
+    { container, extendedFlipping, flip, margin, position, shrink }
+) {
     // Retrieve directions and variants
     const [direction, variant = "middle"] = reverseForRTL(...position.split("-"));
-    const directions = flip ? DIRECTION_FLIP_ORDER[direction] : [direction.at(0)];
+    let directions = [direction.at(0)];
+    if (flip) {
+        directions = extendedFlipping
+            ? EXTENDED_DIRECTION_FLIP_ORDER[direction]
+            : DIRECTION_FLIP_ORDER[direction];
+    }
     const variants = VARIANT_FLIP_ORDER[variant];
 
     // Retrieve container
@@ -172,7 +192,7 @@ function computePosition(popper, target, { container, flip, margin, position, sh
     function getPositioningData(d, v) {
         const [direction, variant] = reverseForRTL(DIRECTIONS[d], VARIANTS[v]);
         const result = { direction, variant };
-        const vertical = ["t", "b"].includes(d);
+        const vertical = ["t", "b", "c"].includes(d);
         const variantPrefix = vertical ? "v" : "h";
         const directionValue = directionsData[d];
         let variantValue = variantsData[variantPrefix + v];
@@ -217,7 +237,7 @@ function computePosition(popper, target, { container, flip, margin, position, sh
 
         // All non zero values of variantOverflow lead to the
         // same malus value since it can be corrected by shifting
-        const malus = Math.abs(directionOverflow) + (variantOverflow && 1);
+        let malus = Math.abs(directionOverflow) + (variantOverflow && 1);
 
         // Apply variant offset
         variantValue -= variantOverflow;
@@ -232,7 +252,13 @@ function computePosition(popper, target, { container, flip, margin, position, sh
         // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
         result.top = positioning.top - popBox.top;
         result.left = positioning.left - popBox.left;
-        if (shrink && malus) {
+        if (d === "c") {
+            // Artificial way to say the center direction is a fallback to every other
+            // once there is a direction overflow since we can always shift the position
+            // in any direction in that case
+            malus = 1.001;
+            result.top -= directionOverflow;
+        } else if (shrink && malus) {
             const minTop = Math.floor(!vertical && v === "s" ? targetBox.top : contBox.top);
             result.top = Math.max(minTop, result.top);
 
@@ -249,15 +275,6 @@ function computePosition(popper, target, { container, flip, margin, position, sh
             result.maxHeight = Math.floor(height);
         }
         return { result, malus };
-    }
-
-    if (direction === "center") {
-        return {
-            top: directionsData[direction[0]] - popBox.top,
-            left: variantsData.vm - popBox.left,
-            direction: DIRECTIONS[direction[0]],
-            variant: "middle",
-        };
     }
 
     // Find best solution

--- a/addons/web/static/src/views/calendar/hooks/calendar_popover_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/calendar_popover_hook.js
@@ -6,7 +6,7 @@ import { useComponent, useExternalListener } from "@odoo/owl";
 export function useCalendarPopover(component) {
     const owner = useComponent();
     let popoverClass = "";
-    const popoverOptions = { onClose: cleanup };
+    const popoverOptions = { extendedFlipping: true, position: "right", onClose: cleanup };
     Object.defineProperty(popoverOptions, "popoverClass", { get: () => popoverClass });
     const popover = usePopover(component, popoverOptions);
     const dialog = useService("dialog");

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -955,9 +955,10 @@ const CONTAINER_STYLE_MAP = {
     w125: { width: "125px" }, // width of popper + 1/2 target
 };
 
-function getRepositionTest(from, to, containerStyleChanges) {
+function getRepositionTest(from, to, containerStyleChanges, extendedFlipping = false) {
     return async () => {
         const TestComp = getTestComponent({
+            extendedFlipping,
             position: from,
             onPositioned: (el, { direction, variant }) => {
                 expect.step(`${direction}-${variant}`);
@@ -1113,6 +1114,87 @@ test(
     getRepositionTest("right-end", "left-end", "right top")
 );
 test("reposition from right-end to right", getRepositionTest("right-end", "left-end", "right"));
+// Reposition with all flipping directions allowed
+test(
+    "extended reposition from top-start to slimfit bottom",
+    getRepositionTest("top-start", "center-start", "slimfit bottom", true)
+);
+test(
+    "extended reposition from top-start to right",
+    getRepositionTest("top-start", "left-start", "right", true)
+);
+test(
+    "extended reposition from top-middle to slimfit bottom",
+    getRepositionTest("top-middle", "center-middle", "slimfit bottom", true)
+);
+test(
+    "extended reposition from top-end to left",
+    getRepositionTest("top-end", "right-end", "left", true)
+);
+test(
+    "extended reposition from top-end to slimfit bottom",
+    getRepositionTest("top-end", "center-end", "slimfit bottom", true)
+);
+test(
+    "extended reposition from left-start to slimfit top",
+    getRepositionTest("left-start", "center-start", "slimfit top", true)
+);
+test(
+    "extended reposition from left-start to bottom",
+    getRepositionTest("left-start", "top-start", "bottom", true)
+);
+test(
+    "extended reposition from left-middle to slimfit bottom",
+    getRepositionTest("left-middle", "center-middle", "slimfit bottom", true)
+);
+test(
+    "extended reposition from left-end to top",
+    getRepositionTest("left-end", "bottom-end", "top", true)
+);
+test(
+    "extended reposition from left-end to slimfit bottom",
+    getRepositionTest("left-end", "center-end", "slimfit bottom", true)
+);
+test(
+    "extended reposition from bottom-start to slimfit top",
+    getRepositionTest("bottom-start", "center-start", "slimfit top", true)
+);
+test(
+    "extended reposition from bottom-start to right",
+    getRepositionTest("bottom-start", "left-start", "right", true)
+);
+test(
+    "extended reposition from bottom-middle to slimfit top",
+    getRepositionTest("bottom-middle", "center-middle", "slimfit top", true)
+);
+test(
+    "extended reposition from bottom-end to left",
+    getRepositionTest("bottom-end", "right-end", "left", true)
+);
+test(
+    "extended reposition from bottom-end to slimfit top",
+    getRepositionTest("bottom-end", "center-end", "slimfit top", true)
+);
+test(
+    "extended reposition from right-start to slimfit top",
+    getRepositionTest("right-start", "center-start", "slimfit top", true)
+);
+test(
+    "extended reposition from right-start to bottom",
+    getRepositionTest("right-start", "top-start", "bottom", true)
+);
+test(
+    "extended reposition from right-middle to slimfit bottom",
+    getRepositionTest("right-middle", "center-middle", "slimfit bottom", true)
+);
+test(
+    "extended reposition from right-end to top",
+    getRepositionTest("right-end", "bottom-end", "top", true)
+);
+test(
+    "extended reposition from right-end to slimfit bottom",
+    getRepositionTest("right-end", "center-end", "slimfit bottom", true)
+);
 
 function getFittingTest(position, styleAttribute) {
     return async () => {


### PR DESCRIPTION
Fixes an issue where the calendar event popover was positioned incorrectly for long events displayed in the day scale.

The fix introduces a new positioning parameter that allows the popover logic to test a wider range of possibilities, including center positioning, which resolves the identified bug case.

Additionally, this commit:
- Restores the default calendar popover position back to 'right', as the previous change (https://github.com/odoo/odoo/pull/236503) did not properly address the root issue.
- Removes an unnecessary useEffect hook from the Many2ManyAttendeeExpandable component.

task-5401647
