### PR TITLE
[FIX] mrp: prevent manufacture to resupply from re-enabling automatically

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -45,7 +45,7 @@ class StockWarehouse(models.Model):
     def _compute_manufacture_to_resupply(self):
         for warehouse in self:
             manufacture_route = warehouse.manufacture_pull_id.route_id
-            warehouse.manufacture_to_resupply = bool(manufacture_route.product_selectable or manufacture_route.warehouse_ids.filtered(lambda w: w.id == warehouse.id))
+            warehouse.manufacture_to_resupply = warehouse.id in manufacture_route.warehouse_ids.ids
 
     def _inverse_manufacture_to_resupply(self):
         for warehouse in self:

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -885,3 +885,10 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         mo.action_confirm()
         self.assertEqual(mo.state, 'confirmed')
         self.assertEqual(lovely_product.with_context(location_id=self.warehouse_1.lot_stock_id.id).virtual_available, 3.0)
+
+    def test_manufacture_to_resupply_unchecks_and_unlinks_warehouse(self):
+        """Unchecking Manufacture to Resupply should keep manufacture_to_resupply disabled."""
+        manufacture_route = self.warehouse.manufacture_pull_id.route_id
+        self.warehouse.manufacture_to_resupply = False
+        self.assertFalse(self.warehouse.manufacture_to_resupply)
+        self.assertNotIn(self.warehouse, manufacture_route.warehouse_ids)


### PR DESCRIPTION
**Steps to produce:**
- Install `mrp` with demo data.
- Inventory > Configuration > Settings > Warehouse > enable `Multi-Step Routes`.
- Go to Configuration > Warehouse Management > Warehouses.
- Open `YourCompany` record.
- Click on Routes > open `Manufacture` > enable `Products`.
- Return to `YourCompany` and disable `Manufacture to Resupply`.

**Issue:**
- After disabling `Manufacture to Resupply`, the option is automatically re-enabled.

**Root cause:**
- In [1], `manufacture_to_resupply` is set to true if either
  `manufacture_route.product_selectable` is true OR the current warehouse
  is included in `manufacture_route.warehouse_ids`.
- In the `_inverse_manufacture_to_resupply` method, unchecking the flag only
  unlinks the warehouse from the route. However, if `product_selectable` is
  still enabled, the compute logic will continue to set the field back to true.

**Solution:**
- Now, when we uncheck `manufacture_to_resupply` then also made manufacture
  route non-selectable on products. As a result, manufacture_to_resupply
  will no longer be set to true again.

[1]https://github.com/odoo/odoo/blob/4f5594a911c1960f620d902d507e563cdab167b9/addons/mrp/models/stock_warehouse.py#L48

opw-5383719
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
