### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: prevent error on generating invoice xml

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -164,7 +164,7 @@ class AccountEdiXmlUblTr(models.AbstractModel):
 
     def _get_address_node(self, vals):
         partner = vals['partner']
-        model = vals.get('model', 'res.partner')
+        model = partner._name
         country = partner['country' if model == 'res.bank' else 'country_id']
         state = partner['state' if model == 'res.bank' else 'state_id']
 

--- a/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_account_move_send
 from . import test_xml_ubl_tr_common
 from . import test_tr_nilvera_mocked_requests

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_account_move_send.py
@@ -1,0 +1,20 @@
+from odoo.tests import tagged
+
+from .test_xml_ubl_tr_common import TestUBLTRCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAccountMoveSend(TestUBLTRCommon):
+
+    def test_send_email_with_recipient_bank(self):
+        """
+        invoice xml generation should work when company has bank account with bank information
+        in order to send email with invoice xml to recipient's bank
+        """
+        bank = self.env['res.bank'].create({
+            'name': 'Test Bank',
+            'bic': 'TESTTRISXXX',
+        })
+        self.company_data['company'].bank_ids.bank_id = bank.id
+
+        self.assertTrue(self._generate_invoice_xml(self.einvoice_partner), "XML generation failed")


### PR DESCRIPTION
For the `Türkiye` localization, sending an invoice by email with a recipient bank causes an error.

Steps to reproduce:
1) Install `accountant` and `l10n_tr_nilvera_einvoice` modules with demo data. 
2) Switch to TR Company.
3) Create a customer with country set to `Türkiye`.
4) Open the TR company contact and on the Accounting page edit an existing bank
   account, add a new bank (e.g., 'Test-Bank'), and set `Send Money` to
   `Trusted`.
5) Create an invoice for the customer, confirm it, and send it by email.

ref video: https://drive.google.com/file/d/1OoUzJ-Dr2uuy4yk9P-CKUS0L6OSgeyJ3/view?usp=sharing

Error:
KeyError: 'country_id'

Root Cause:
When sending the invoice, the system generates the invoice XML. In the method `_get_address_node` (see [1]), there is a special case to determine the correct country for `res.bank`. However, when `vals['partner']` is a `res.bank` record, no `model` is provided in `vals`, so it defaults to `res.partner`. The code then attempts to access `partner['country_id']`, which does not exist on `res.bank`, raising the error.

FIX:
Ensure the `model` is set to `res.bank` when `vals['partner']` is a `res.bank` record, ensuring the correct country value is used.

[1]- https://github.com/odoo/odoo/blob/0190bb7faca1dd5ce38dfdacbb8fa446f06d59a3/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py#L165-L181

opw-5103598
