### PR TITLE
[FIX] point_of_sale: allow exclude multi-attribute variants

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -138,7 +138,7 @@ class PosSession(models.Model):
     def _load_pos_data_models(self, config_id):
         return ['pos.config', 'pos.order', 'pos.order.line', 'pos.pack.operation.lot', 'pos.payment', 'pos.payment.method', 'pos.printer',
                         'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.product', 'product.template', 'product.template.attribute.line', 'product.attribute',
-            'product.attribute.custom.value', 'product.template.attribute.value', 'product.combo', 'product.combo.item', 'product.packaging', 'res.users', 'res.partner',
+            'product.attribute.custom.value', 'product.template.attribute.value', 'product.template.attribute.exclusion', 'product.combo', 'product.combo.item', 'product.packaging', 'res.users', 'res.partner',
             'decimal.precision', 'uom.uom', 'uom.category', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
             'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'ir.ui.view', 'product.tag', 'ir.module.module']
 

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -326,6 +326,21 @@ class ProductTemplateAttributeValue(models.Model):
         return ['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'name', 'is_custom', 'html_color', 'image']
 
 
+class ProductTemplateAttributeExclusion(models.Model):
+    _name = 'product.template.attribute.exclusion'
+    _inherit = ['product.template.attribute.exclusion', 'pos.load.mixin']
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        loaded_product_tmpl_ids = list({p['product_tmpl_id'] for p in data['product.product']['data']})
+        loaded_ptav_ids = list({ptav['id'] for ptav in data['product.template.attribute.value']['data']})
+        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids), ('product_template_attribute_value_id', 'in', loaded_ptav_ids)]
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ['value_ids', 'product_template_attribute_value_id']
+
+
 class ProductPackaging(models.Model):
     _name = 'product.packaging'
     _inherit = ['product.packaging', 'pos.load.mixin']

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -420,6 +420,28 @@ export class PosStore extends Reactive {
                 this.mainProductVariant[products[i].id] = products[nbrProduct - 1];
             }
         }
+
+        this.productAttributesExclusion = this.computeProductAttributesExclusion();
+    }
+
+    computeProductAttributesExclusion() {
+        const exclusions = new Map();
+
+        const addExclusion = (key, value) => {
+            if (!exclusions.has(key)) {
+                exclusions.set(key, new Set());
+            }
+            exclusions.get(key).add(value);
+        };
+
+        for (const exclusion of this.models["product.template.attribute.exclusion"].getAll()) {
+            const ptavId = exclusion.product_template_attribute_value_id.id;
+            for (const { id: valueId } of exclusion.value_ids) {
+                addExclusion(ptavId, valueId);
+                addExclusion(valueId, ptavId);
+            }
+        }
+        return exclusions;
     }
 
     async onDeleteOrder(order) {

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -220,15 +220,16 @@ export class ProductConfiguratorPopup extends Component {
         if (variantAttributeValueIds.length === 0) {
             return false;
         }
-        return this.props.product._isArchivedCombination(variantAttributeValueIds);
+        return this.props.product._isArchivedCombination(
+            variantAttributeValueIds,
+            this.pos.productAttributesExclusion
+        );
     }
     getVariantAttributeValueIds() {
         const attribute_value_ids = [];
         this.state.payload.forEach((att_component) => {
             const { valueIds } = att_component.getValue();
-            if (att_component.attributeLine.attribute_id.create_variant === "always") {
-                attribute_value_ids.push(valueIds);
-            }
+            attribute_value_ids.push(valueIds);
         });
         return attribute_value_ids.flat();
     }

--- a/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
@@ -22,6 +22,13 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             // Click on Configurable Chair product
             ProductScreen.clickDisplayedProduct("Configurable Chair"),
 
+            [
+                {
+                    content: "Check that metal, leather chair variant is disabled",
+                    trigger: `.modal footer button.disabled`,
+                },
+            ],
+
             // Pick Color
             ProductConfigurator.pickColor("Red"),
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -658,6 +658,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         configurable_product = self.env['product.product'].search([('name', '=', 'Configurable Chair'), ('available_in_pos', '=', 'True')], limit=1)
         fabrics_line = configurable_product.attribute_line_ids[2]
         fabrics_line.product_template_value_ids[1].ptav_active = False
+        leather_ptav = fabrics_line.product_template_value_ids[0]
+        metal_ptav = configurable_product.attribute_line_ids[1].product_template_value_ids[0]
+
+        # Create an attribute exclusion for metal, leather chair
+        leather_ptav.exclude_for = [Command.create({
+            'product_tmpl_id': configurable_product.product_tmpl_id.id,
+            'value_ids': [Command.set([metal_ptav.id])],
+        })]
         self.pos_user.write({
             'groups_id': [
                 (4, self.env.ref('stock.group_stock_manager').id),


### PR DESCRIPTION
Step to reproduce:
- for a product A, have 3 attributes, legs , color and extra options (type: multi)
- for a color attribure values (eg red) exclude one option of  'extra options'
- open pos and select this product
- select "red" and excluded option

Observation:
- you are able to select this variant but shouldn't as it is excluded

Fix:
- previously, we do not considered selected attributes for `multi` attributes in `getVariantAttributeValueIds`
- we now compute 'exclusion' for all product once and then use it at runtime, to qualify 
if variant is allowed or not.

opw-5220427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
