### PR TITLE
[IMP] l10n_in: remove unnecessary sudo and fix access rights for TDS/TCS alert

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -453,7 +453,7 @@ class AccountMove(models.Model):
         def _group_by_section_alert(invoice_lines):
             group_by_lines = {}
             for line in invoice_lines:
-                group_key = line.account_id.sudo().l10n_in_tds_tcs_section_id
+                group_key = line.account_id.l10n_in_tds_tcs_section_id
                 if group_key and not line.company_currency_id.is_zero(line.price_total):
                     group_by_lines.setdefault(group_key, [])
                     group_by_lines[group_key].append(line)

--- a/addons/l10n_in/security/ir.model.access.csv
+++ b/addons/l10n_in/security/ir.model.access.csv
@@ -2,6 +2,6 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_port_code_user,port.code.user,model_l10n_in_port_code,base.group_user,1,0,0,0
 access_port_code_account_manager,port.code.user,model_l10n_in_port_code,account.group_account_manager,1,1,1,1
 l10n_in.access_l10n_in_withhold_wizard,access_l10n_in_withhold_wizard,l10n_in.model_l10n_in_withhold_wizard,account.group_account_invoice,1,1,1,1
-access_l10n_in_section_alert_account_readonly,l10n_in.section.alert.account.readonly,model_l10n_in_section_alert,account.group_account_readonly,1,0,0,0
+access_l10n_in_section_alert_account_readonly,l10n_in.section.alert.account.readonly,model_l10n_in_section_alert,base.group_user,1,0,0,0
 access_l10n_in_section_alert_account_manager,l10n_in.section.alert.account.manager,model_l10n_in_section_alert,account.group_account_manager,1,1,1,1
 access_l10n_in_pan_entity,l10n_in.pan.entity,model_l10n_in_pan_entity,base.group_user,1,1,1,1

--- a/addons/l10n_in/tests/common.py
+++ b/addons/l10n_in/tests/common.py
@@ -47,6 +47,8 @@ class L10nInTestInvoicingCommon(AccountTestInvoicingCommon):
             'company_id': cls.default_company.id,
         })
 
+        cls.user_internal = cls._create_new_internal_user()
+
         # === Partners === #
         cls.partner_a.write({
             'name': "Partner Intra State",

--- a/addons/l10n_in/tests/test_tds_tcs_alert.py
+++ b/addons/l10n_in/tests/test_tds_tcs_alert.py
@@ -516,3 +516,10 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
         )
 
         self.assertEqual(move.l10n_in_warning['tds_tcs_threshold_alert']['message'], "It's advisable to collect TCS u/s 206C(1G) Remittance on this transaction.")
+
+    def test_l10n_in_section_alert_access_rights(self):
+        '''
+        Test access rights for l10n_in.section.alert model.
+        '''
+        section_alert = self.env.ref('l10n_in.tds_section_192')
+        section_alert.with_user(self.user_internal).read(['name'])


### PR DESCRIPTION
In version 18, `sudo()` was added as a temporary fix to avoid AccessErrors when invoicing users tried to open invoices. The problem was caused by missing read permissions on the `l10n_in.section.alert` model.

In master, the correct access rights have now been added for invoicing users, so the `sudo()` is no longer needed.

Reference PR - https://github.com/odoo/odoo/pull/236896
