### PR TITLE
[IMP] pos_*: mark order as paid when it is dispatched from urbanpiper

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2658,6 +2658,11 @@ export class PosStore extends WithLazyGetterTrap {
         return makeAwaitable(this.env.services.dialog, ScaleScreen);
     }
 
+    // Used to override inside `pos_blackbox_be` and `pos_urban_piper`
+    async _fetchUrbanpiperOrderCount(order_id) {
+        return;
+    }
+
     selectEmptyOrder() {
         const emptyOrders = this.models["pos.order"].filter(
             (order) =>


### PR DESCRIPTION
Since `pos_urban_piper` module is not in the dependency of `pos_blackbox_be`, we need to add a blank method `_fetchUrbanpiperOrderCount` that will be overriden in both module. It's the same mecanism as what's been used for `_doneOrder`.

task-id: 5261892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
