### PR TITLE
[FIX] mail: mail contains() internal tick only for :value

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -333,7 +333,7 @@ function createFakeDataTransfer(files) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then clicks on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {ContainsOptions} [options] forwarded to `contains`
  * @param {boolean} [options.shiftKey]
  */
@@ -347,7 +347,7 @@ export async function click(selector, options = {}) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then dragenters `files` on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {Object[]} files
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -359,7 +359,7 @@ export async function dragenterFiles(selector, files, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then dragovers `files` on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {Object[]} files
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -371,7 +371,7 @@ export async function dragoverFiles(selector, files, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then drops `files` on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {Object[]} files
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -383,7 +383,7 @@ export async function dropFiles(selector, files, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then inputs `files` on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {Object[]} files
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -395,7 +395,7 @@ export async function inputFiles(selector, files, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then pastes `files` on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {Object[]} files
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -407,7 +407,7 @@ export async function pasteFiles(selector, files, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then focuses on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
 export async function focus(selector, options) {
@@ -418,7 +418,7 @@ export async function focus(selector, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then inserts the given `content`.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {string} content
  * @param {ContainsOptions} [options] forwarded to `contains`
  * @param {boolean} [options.replace=false]
@@ -434,7 +434,7 @@ export async function insertText(selector, content, options = {}) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then sets its `scrollTop` to the given value.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {number|"bottom"} scrollTop
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -446,7 +446,7 @@ export async function scroll(selector, scrollTop, options) {
  * Waits until exactly one element matching the given `selector` is present in
  * `options.target` and then triggers `event` on it.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {(import("@web/../tests/helpers/utils").EventType|[import("@web/../tests/helpers/utils").EventType, EventInit])[]} events
  * @param {ContainsOptions} [options] forwarded to `contains`
  */
@@ -545,7 +545,7 @@ afterEach(() => (hasUsedContainsPositively = false));
 class Contains {
     timeoutCount = 0;
     /**
-     * @param {string} selector
+     * @param {import("@odoo/hoot-dom").Target} selector
      * @param {ContainsOptions} [options={}]
      */
     constructor(selector, options = {}) {
@@ -614,13 +614,14 @@ class Contains {
     setTickTimeout() {
         this.timer = setTimeout(() => {
             this.timeoutCount++;
-            const res = this.runOnce(`Timeout of ${this.timeoutCount * 0.1} seconds`, {
-                crashOnFail: this.timeoutCount > 29,
-            });
+            const res = this.runOnce(
+                `Timeout of ${(this.timeoutCount * this.tickTimeoutDelay) / 1000} seconds`,
+                { crashOnFail: this.timeoutCount >= 3000 / this.tickTimeoutDelay }
+            );
             if (!res) {
                 this.setTickTimeout();
             }
-        }, 100);
+        }, this.tickTimeoutDelay);
     }
 
     /**
@@ -641,6 +642,10 @@ class Contains {
         this.onFocus = () => this.runOnce("after focus");
         this.onScroll = () => this.runOnce("after scroll");
         if (!this.runOnce("immediately")) {
+            const hasValue =
+                this.options.value !== undefined ||
+                (typeof this.selector === "string" && this.selector.includes(":value"));
+            this.tickTimeoutDelay = hasValue ? 500 : 3000;
             this.setTickTimeout();
             this.observer = new MutationObserver((mutations) => {
                 try {
@@ -970,7 +975,7 @@ class Contains {
  * Waits until `count` elements matching the given `selector` are present in
  * `options.target`.
  *
- * @param {string} selector
+ * @param {import("@odoo/hoot-dom").Target} selector
  * @param {ContainsOptions} [options]
  * @returns {Promise}
  */


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/238747

PR above improves execution time of the `@mail` suite by checking selector every 100ms tick, as sometimes the mutation observer fails to see changes and the contains pass after the 3 seconds timeout, thus wasting time. The affected selectors are the ones targeting the `:value` or with param `{ value }`.

However 100ms tick adds significant CPU load, which is a problem as runbot execution time is quite heavily reliant on CPU load. So while this makes `@mail` test suite faster in ideal condition, this worsen execution time in some cases [1].

This commit minimizes the problem by increasing the tick from 100ms to 500ms, and also limit the tick behavior to selectors targeting `:value` or `{ value }`. That way the majority of the time it relies on mutation observer so doesn't worsen CPU load, and only with value that this uses tick system.

[1]: https://runbot.odoo.com/runbot/build/95207707