### PR TITLE
[FIX] mail: fix crash on chat window channel

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -53,7 +53,7 @@ export class ChatWindow extends Component {
         });
         this.ui = useService("ui");
         this.contentRef = useRef("content");
-        this.threadActions = useThreadActions({ thread: () => this.channel.thread });
+        this.threadActions = useThreadActions({ thread: () => this.channel?.thread });
         this.actionsMenuButtonHover = useHover("actionsMenuButton");
         this.parentChannelHover = useHover("parentChannel");
         this.isMobileOS = isMobileOS();


### PR DESCRIPTION
Before this PR, the chat window could crash if it tried to display a deleted channel.
This PR avoids the crash using optional chaining.

task-5404568
