### PR TITLE
[FIX] sale_stock: make test deterministic

### DIFF
--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -119,6 +119,7 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
         for line in new_order.order_line:
             self.assertEqual(line.move_ids[0].date, right_date, "The expected date for the Stock Move is wrong")
 
+    @freeze_time('2025-10-10')
     def test_expected_date_with_storable_product(self):
         ''' This test ensures the expected date is computed based on only goods(consu) products.
         It's avoiding computation for non-goods products.


### PR DESCRIPTION
In the case the test runs a machine not fast enough, by the time we reach either assert, there could be at least a millisecond difference between the two dates.

Now freeze the time to ensure the test doesn't fail depending on its running speed.

runbot-233470

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
