### PR TITLE
[FIX] html_builder: update options' containers when they have been changed

### DIFF
--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -8,9 +8,12 @@ import { useOperation } from "../core/operation_plugin";
 import {
     BaseOptionComponent,
     useApplyVisibility,
+    useDomState,
     useGetItemValue,
     useVisibilityObserver,
 } from "../core/utils";
+import { isRemovable } from "@html_builder/core/remove_plugin";
+import { isClonable } from "@html_builder/core/clone_plugin";
 
 export class OptionsContainer extends BaseOptionComponent {
     static template = "html_builder.OptionsContainer";
@@ -58,6 +61,15 @@ export class OptionsContainer extends BaseOptionComponent {
                 this.props.editingElement
             ),
         });
+
+        this.domState = useDomState((editingElement) => ({
+            isRemovable: isRemovable(editingElement),
+            removeDisabledReason:
+                this.dependencies.builderOptions.getRemoveDisabledReason(editingElement),
+            isClonable: isClonable(editingElement),
+            cloneDisabledReason:
+                this.dependencies.builderOptions.getCloneDisabledReason(editingElement),
+        }));
 
         this.hasGroup = {};
         onWillStart(async () => {

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -37,23 +37,23 @@
                             t-att-title="button.title" t-att-aria-label="button.title"
                             t-on-click="() => button.handler(props.editingElement)"/>
                 </t>
-                <t t-if="props.isClonable || props.cloneDisabledReason">
+                <t t-if="domState.isClonable || domState.cloneDisabledReason">
                     <!-- Disabled buttons do not display their title -->
-                    <span t-att-title="props.cloneDisabledReason" t-att-aria-label="props.cloneDisabledReason">
+                    <span t-att-title="domState.cloneDisabledReason" t-att-aria-label="domState.cloneDisabledReason">
 	                    <button class="fa fa-fw fa-clone oe_snippet_clone o-hb-btn btn btn-success-color-hover"
 	                            title="Duplicate this block"
 	                            aria-label="Duplicate this block"
-                                t-att-disabled="!!props.cloneDisabledReason"
+                                t-att-disabled="!!domState.cloneDisabledReason"
 	                            t-on-click="cloneElement"/>
 	                </span>
                 </t>
-                <t t-if="props.isRemovable || props.removeDisabledReason">
+                <t t-if="domState.isRemovable || domState.removeDisabledReason">
                     <!-- Disabled buttons do not display their title -->
-                    <span t-att-title="props.removeDisabledReason" t-att-aria-label="props.removeDisabledReason">
+                    <span t-att-title="domState.removeDisabledReason" t-att-aria-label="domState.removeDisabledReason">
 	                    <button class="fa fa-fw fa-trash oe_snippet_remove o-hb-btn btn btn-danger-color-hover"
 	                            title="Remove this block"
 	                            aria-label="Remove this block"
-	                            t-att-disabled="!!props.removeDisabledReason"
+	                            t-att-disabled="!!domState.removeDisabledReason"
 	                            t-on-click="removeElement"/>
 	                </span>
                 </t>
@@ -76,7 +76,7 @@
                 <div>You can still access the block options but it might be ineffective.</div>
                 <button type="button" class="btn btn-primary py-2 my-4 border-0" t-on-click="() => this.accessOutdated()">ACCESS OPTIONS ANYWAY</button>
             </div>
-        </t>        
+        </t>
     </div>
 </t>
 


### PR DESCRIPTION
*: website
After the [refactoring of html_builder], containers weren't updated 
all the time properly. They were updated only when the options' length or ids,
respectively, have been changed, which is not the desired behavior. For example,
if `isCloneDisabledReason` changes, we won't be able to see the changes right away.
That's why we moved some options containers' props to the component to use
`useDomState`.

Steps to see the issue:
- Open website and start editing
- Drop a form
- Add a field and click on it
- Change its type to one of the existing fields, e.g. 'Alias Domain'

=> The duplicate button of the builder is not deactivated, while it
should be. The issue exists vice versa too (when we change the type
from an existing field to a custom one).

[refactoring of html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-5391316