### PR TITLE
[FIX] website_sale: restore `s_dynamics_snippets` preview

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1729,3 +1729,7 @@ body.modal-open:has(.js_sale.o_wsale_product_page) {
         opacity: 0;
     }
 }
+
+.o_wsale_alternative_products:not(:has(.s_dynamic_snippet_row)) {
+    display: none;
+}

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -1,11 +1,6 @@
 // class name are dynamically added.
 // If you don't find it with a grep, don't consider it as useless without extra check.
 
-.s_dynamic_snippet_products {
-    &:not(:has(.s_dynamic_snippet_row)) {
-        display: none !important;
-    }
-}
 
 .s_product_product_centered {
     .card {


### PR DESCRIPTION
This PR fixes an issue introduced in Commit[^1] while trying to fix an issue with the alternative products section being displayed even with no alternative products.

In Commit[^1], the rule was set in the snippet file, which worked but was affecting all the places where this snippet is displayed, which made the snippet preview empty.

To ensure this does not happen, we scope the rule to the product page only, ensuring the snippet remains untouched.

[^1]: https://github.com/odoo/odoo/commit/0dfc5a6cfbae808f2dc5c7042bc07180eaa49e9a

task-5404601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
