### PR TITLE
[FIX] website_sale: hide single value attributes in accordion style

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1953,6 +1953,10 @@ $-product-radius-map: (
     }
 }
 
+.oe_website_sale:has(#product_accordion) #product_attributes_simple {
+    display: none;
+}
+
 .o_wsale_products_grid_before_rail .accordion {
     --accordion-btn-icon-width: 1rem;
 }


### PR DESCRIPTION
### Issue:
In this issue, when specification is set to accordion style, single value attributes is still displayed, making single value attributes duplicated.

#### To reproduce:
1- Create a product with a multi-value and a single-value attribute.
2- Using editor on product website page, from style tab, change style of specification to `in accordion`.
3- As you see, single value-attribute is displayed twice. Once in accordion, and one in single-value attributes section.

### Cause:
When `specification` is set to other than `None`, IMHO we need to not display `product_accordion` as single values are already displayed:
https://github.com/odoo/odoo/blob/ea01165d9486572269c44597a1db49b31bf8aba3/addons/website_sale_comparison/views/website_sale_comparison_template.xml#L196-L209

When `specification` is set to `Bottom of Page`, this is already the case using xpath replace:
https://github.com/odoo/odoo/blob/ea01165d9486572269c44597a1db49b31bf8aba3/addons/website_sale_comparison/views/website_sale_comparison_template.xml#L91-L94

However, we cannot do the same in `accordion_specs_item` as it is not inheriting `website_sale.product`.

We can instead fix this using scss style, which also won't require updating views.

opw-5365375

