### PR TITLE
[FIX] discuss: hide combined mic+camera button when only one permission needed

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
@@ -7,7 +7,7 @@
             <small class="text-muted" t-out="permissionNote"/>
             <t t-set-slot="footer">
                 <button class="btn btn-primary px-4" t-on-click="props.media === 'microphone' ? onClickUseMicrophone : onClickUseCamera" t-out="primaryActionText"/>
-                <button class="btn btn-outline-primary px-4" t-if="rtc.cameraPermission !== 'denied'" t-on-click="onClickUseMicAndCamera">Use microphone and camera</button>
+                <button class="btn btn-outline-primary px-4" t-if="rtc.cameraPermission !== 'granted' and rtc.microphonePermission !== 'granted'" t-on-click="onClickUseMicAndCamera">Use microphone and camera</button>
             </t>
         </Dialog>
     </t>

--- a/addons/mail/static/tests/discuss/call/call_permissions.test.js
+++ b/addons/mail/static/tests/discuss/call/call_permissions.test.js
@@ -96,3 +96,23 @@ test("Turn on both microphone and camera from permission dialog", async () => {
     await contains(".o-discuss-CallActionList button[title='Stop camera']");
     await contains(".o-discuss-CallActionList button[title='Mute']");
 });
+
+test("Combined mic+camera button only shown when both permissions not granted", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    mockGetMedia();
+    mockPermissionsPrompt();
+    const env = await start();
+    const rtc = env.services["discuss.rtc"];
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click(".o-discuss-CallActionList button[title='Turn camera on']");
+    await contains(".modal-footer button", { count: 2 });
+    await contains(".modal-footer button", { text: "Use microphone and camera" });
+    await contains(".modal-footer button", { text: "Use Camera" });
+    rtc.cameraPermission = "granted";
+    await click(".modal-footer button", { text: "Use Camera" });
+    await click(".o-discuss-CallActionList button[title='Unmute']");
+    await contains(".modal-footer button");
+    await contains(".modal-footer button", { text: "Use Microphone" });
+});


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
Currently, when requesting microphone permission in video calls, the "Use microphone and camera" button is shown even though only microphone access is needed, or vice-versa. This creates confusion as users see an option to request permissions that aren't relevant to their current action.

**Current behavior before PR:**
----------------------------------------------
- When clicking the microphone button in a video call, the "Use microphone and camera" button is shown if camera permission is not explicitly denied.
- Users see permission options that don't match what they're actually trying to do (e.g., microphone button shows camera options).

**Desired behavior after PR is merged:**
----------------------------------------------
- The "Use microphone and camera" button is only shown when neither camera nor microphone permissions have been granted yet.
- When users click the microphone button, they only see microphone-related options unless they also need camera permissions.
- When users click the camera button, they only see camera-related options unless they also need microphone permissions.
- Permission dialogs are contextual and only show relevant options for the action being performed.

Task-5367786

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr