### PR TITLE
[IMP] mrp: make component replacement faster across boms

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -709,10 +709,7 @@ class MrpBomLine(models.Model):
     tracking = fields.Selection(related='product_id.tracking')
     bom_code = fields.Char(related='bom_id.code')
     bom_type = fields.Selection(related='bom_id.type')
-    bom_product_id = fields.Many2one(related='bom_id.product_id')
     bom_product_tmpl_id = fields.Many2one(related='bom_id.product_tmpl_id')
-    bom_product_qty = fields.Float(related='bom_id.product_qty', string="BoM Quantity")
-    bom_product_uom_id = fields.Many2one(related='bom_id.uom_id', string="BoM Unit")
 
     _bom_qty_zero = models.Constraint(
         'CHECK (product_qty>=0)',
@@ -756,6 +753,17 @@ class MrpBomLine(models.Model):
             if 'product_id' in values and 'uom_id' not in values:
                 values['uom_id'] = self.env['product.product'].browse(values['product_id']).uom_id.id
         return super(MrpBomLine, self).create(vals_list)
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'product_id' in vals:
+            self.bom_id._check_bom_cycle()
+        self.bom_id._set_outdated_bom_in_productions()
+        return res
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_and_update_outdated_bom(self):
+        self.bom_id._set_outdated_bom_in_productions()
 
     def _skip_bom_line(self, product, never_attribute_values=False):
         """ Control if a BoM line should be produced, can be inherited to add custom control.
@@ -806,6 +814,15 @@ class MrpBomLine(models.Model):
             'search_view_id': self.env.ref('product.product_document_search').ids
         }
 
+    def action_open_parent_bom(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'mrp.bom',
+            'res_id': self.bom_id.id,
+            'view_mode': 'form',
+        }
+
     # -------------------------------------------------------------------------
     # CATALOG
     # -------------------------------------------------------------------------
@@ -813,16 +830,6 @@ class MrpBomLine(models.Model):
     def action_add_from_catalog(self):
         bom = self.env['mrp.bom'].browse(self.env.context.get('order_id'))
         return bom.with_context(child_field='bom_line_ids').action_add_from_catalog()
-
-    def action_open_parent_bom(self, *args):
-        return {
-            'res_model': 'mrp.bom',
-            'type': 'ir.actions.act_window',
-            'views': [[False, 'form']],
-            'view_mode': 'form',
-            'res_id': self.bom_id.id,
-            'target': 'current',
-        }
 
     def _get_product_catalog_lines_data(self, default=False, **kwargs):
         if self and not default:

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -80,12 +80,7 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_line_action_used_in_boms")
         action['domain'] = [('product_tmpl_id', '=', self.id)]
-        action['context'] = {
-            'component_variant_count': len(
-                self.product_variant_ids.filtered(lambda variant: variant.bom_line_ids)
-            ),
-            'search_default_bom_active': True,
-        }
+        action['context'] = {'search_default_bom_active': True}
         return action
 
     def _compute_mrp_product_qty(self):
@@ -249,12 +244,7 @@ class ProductProduct(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_line_action_used_in_boms")
         action['domain'] = [('product_id', '=', self.id)]
-        action['context'] = {
-            'component_variant_count': len(
-                self.product_tmpl_id.product_variant_ids.filtered(lambda variant: variant.bom_line_ids)
-            ),
-            'search_default_bom_active': True,
-        }
+        action['context'] = {'search_default_bom_active': True}
         return action
 
     def _compute_mrp_product_qty(self):

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -292,18 +292,13 @@
             <field name="name">mrp.bom.line.view.list</field>
             <field name="model">mrp.bom.line</field>
             <field name="arch" type="xml">
-                <list create="False" delete="False" action="action_open_parent_bom" type="object">
-                    <field name="bom_product_tmpl_id"/>
-                    <field name="bom_code" optional="show"/>
-                    <field name="bom_type"/>
-                    <field name="bom_product_id" groups="product.group_product_variant" optional="hide"/>
-                    <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
-                    <field name="bom_product_qty" string="Quantity" optional="hide"/>
-                    <field name="bom_product_uom_id" string="Unit" groups="uom.group_uom" optional="hide"/>
-                    <field name="product_id" string="Component Variant" column_invisible="context.get('component_variant_count') == 1"/>
-                    <field name="product_qty" string="Component Quantity" optional="hide" width="130px"/>
-                    <field name="uom_id" string="Component Unit" groups="uom.group_uom" optional="hide"/>
-                    <field name="company_id" groups="base.group_multi_company" optional="show"/>
+                <list create="0" multi_edit="1" action="action_open_parent_bom" type="object">
+                    <field name="bom_id" readonly="1" string="Bill of Material"/>
+                    <field name="product_id" string="Component" context="{'default_is_storable': True}"/>
+                    <field name="product_qty"/>
+                    <field name="uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" widget="many2one_uom"/>
+                    <field name="operation_id" readonly="1" optional="hide" groups="mrp.group_mrp_routings"/>
+                    <field name="bom_product_template_attribute_value_ids" readonly="1" optional="hide" groups="product.group_product_variant" widget="many2many_tags"/>
                 </list>
             </field>
         </record>
@@ -314,7 +309,7 @@
             <field name="arch" type="xml">
                 <search string="Search BoM Line">
                     <field name="bom_code" string="Bill of Materials" filter_domain="['|', ('bom_code', 'ilike', self), ('bom_product_tmpl_id', 'ilike', self)]"/>
-                    <field name="bom_product_tmpl_id" string="Product"/>
+                    <field name="product_id" string="Product"/>
                     <filter string="Manufacturing" name="normal" domain="[('bom_type', '=', 'normal')]"/>
                     <filter string="Kit" name="phantom" domain="[('bom_type', '=', 'phantom')]"/>
                     <separator/>
@@ -378,6 +373,22 @@
             <field name="name">Bill of Materials</field>
             <field name="res_model">mrp.bom</field>
             <field name="domain">[]</field> <!-- Force empty -->
+        </record>
+
+        <record id="action_open_bom_lines" model="ir.actions.server">
+            <field name="name">Show BoM Lines</field>
+            <field name="model_id" ref="mrp.model_mrp_bom"/>
+            <field name="binding_model_id" ref="mrp.model_mrp_bom"/>
+            <field name="state">code</field>
+            <field name="code">
+                action = {
+                    'type': 'ir.actions.act_window',
+                    'name': 'BoM Lines',
+                    'res_model': 'mrp.bom.line',
+                    'views': [(env.ref('mrp.mrp_bom_line_view_list').id, 'list')],
+                    'domain': [('bom_id', 'in', env.context.get('active_ids'))],
+                }
+            </field>
         </record>
     </data>
 </odoo>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -12,7 +12,7 @@
             <field name="name">mrp.bom.byproduct.form</field>
             <field name="model">mrp.bom.byproduct</field>
             <field name="arch" type="xml">
-                <form string="Byproduct">
+                <form string="Byproduct" create="0" edit="0">
                     <group>
                         <field name="allowed_operation_ids" invisible="1"/>
                         <field name="company_id"/>
@@ -22,9 +22,9 @@
                             <field name="product_qty"/>
                             <field name="uom_id" groups="uom.group_uom" widget="many2one_uom"/>
                         </div>
-                        <field name="operation_id" groups="mrp.group_mrp_routings" options="{'no_quick_create':True,'no_create_edit':True}"/>
+                        <field name="operation_id" groups="mrp.group_mrp_routings"/>
                         <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
-                        <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
+                        <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" groups="product.group_product_variant"/>
                     </group>
                 </form>
             </field>
@@ -344,10 +344,10 @@
                                 <label for="product_qty" string="Quantity"/>
                                 <div class="o_row">
                                     <field name="product_qty"/>
-                                    <field name="uom_id" options="{'no_open':True,'no_create':True, 'quantity_field': 'product_qty'}" groups="uom.group_uom" widget="many2one_uom"/>
+                                    <field name="uom_id" groups="uom.group_uom" widget="many2one_uom"/>
                                 </div>
                                 <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
-                                <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
+                                <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" groups="product.group_product_variant"/>
                             </group>
                             <group string="Operation">
                                 <field name="company_id" invisible="1"/>


### PR DESCRIPTION
- When `replacing a product` with another, users often need to update all
  related `Bill of Materials` to keep manufacturing data consistent.
  However, the current flow makes this difficult because users cannot
  easily `multi-edit` the underlying `BoM lines` where the `product`
  is actually used.
- This leads to a `time-consuming` and `error-prone` process, where users
  must open each `BoM` individually, search for the `product` manually, and
  update lines one by one.

This improvement introduces a streamlined workflow by allowing users to directly
access and edit all BoM lines referencing a product in one place. This
significantly improves the product-replacement use case by reducing manual work,
avoiding overlooked BoM updates, and ensuring consistency whenever a component
replaced across multiple BoMs.

Previously added list view([here](https://github.com/odoo/odoo/pull/212727)) is being replaced in this task, so removed the
fields that are no longer used in the new list view.

Ent PR https://github.com/odoo/enterprise/pull/105842

task-5365739