### PR TITLE
[FIX] mail: gc outdated sub channel follow up

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -62,6 +62,7 @@ class ChannelMember(models.Model):
               FROM discuss_channel_member member
               JOIN discuss_channel channel
                 ON channel.id = member.channel_id
+               AND channel.parent_channel_id IS NOT NULL
              WHERE (
                        member.unpin_dt IS NULL
                     OR member.last_interest_dt >= member.unpin_dt

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -46,6 +46,12 @@ class TestDiscussSubChannels(HttpCase):
             self_member._mark_as_read(message.id)
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertFalse(self_member.is_pinned)
+        # Ensure regular channels are not impacted.
+        channel = self.env["discuss.channel"].create({"name": "General"})
+        channel.channel_pin(pinned=True)
+        with freeze_time(two_days_later_dt):
+            self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
+            self.assertTrue(channel.channel_member_ids.filtered("is_self").is_pinned)
 
     def test_02_sub_channel_members_sync_with_parent(self):
         parent = self.env["discuss.channel"].create({"name": "General"})


### PR DESCRIPTION
In [1], the `_gc_unpin_outdated_sub_channels` method was updated to avoid unpinning sub-channels multiple times. However, a condition is missing on `parent_channel_id` to restrict this gc to actual sub- channels.

[1]: https://github.com/odoo/odoo/pull/238493

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
