### PR TITLE
[FIX] point_of_sale: total on customer display is always price incl

### DIFF
--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -43,7 +43,12 @@ export class CustomerDisplayPosAdapter {
         this.data = {
             finalized: order.finalized,
             general_customer_note: order.general_customer_note,
-            amount: order.currencyDisplayPrice,
+            amount: order.currencyDisplayPriceIncl,
+            subtotal:
+                order.config_id.iface_tax_included !== "total" &&
+                order.prices.taxDetails.has_tax_groups &&
+                order.currencyDisplayPriceExcl,
+            amountTaxes: order.prices.taxDetails.has_tax_groups && order.currencyAmountTaxes,
             change: order.change && formatCurrency(order.change, order.currency),
             paymentLines: order.payment_ids.map((pl) => this.getPaymentData(pl)),
             lines: order.lines.map((l) => this.getOrderlineData(l)),

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -102,9 +102,19 @@
 
                 <div t-if="order.amount and !order.finalized" class="py-3 px-4 bg-view border-top">
                     <div class="d-flex flex-column justify-content-center gap-1 w-100 w-sm-50 ms-auto">
-                        <div class="row fs-2 fw-bolder">
-                            <div class="col text-end">Total</div>
-                            <div class="col text-end" t-esc="order.amount"/>
+                        <div class="d-flex flex-column gap-1 fw-bolder lh-sm">
+                            <div t-if="order.subtotal" class="row fs-5 text-muted">
+                                <div class="col text-end">Subtotal</div>
+                                <div class="col text-end" t-esc="order.subtotal"/>
+                            </div>
+                            <div t-if="order.amountTaxes" class="row fs-5 text-muted">
+                                <div class="col text-end">Taxes</div>
+                                <div class="col text-end" t-esc="order.amountTaxes"/>
+                            </div>
+                            <div class="row fs-2">
+                                <div class="col text-end">Total</div>
+                                <div class="col text-end" t-esc="order.amount"/>
+                            </div>
                         </div>
                         <div t-foreach="order.paymentLines or []" t-as="line" t-key="line_index" class="row">
                             <div class="col text-end" t-esc="line.name" />

--- a/addons/point_of_sale/static/tests/unit/customer_display/customer_display_adapter.test.js
+++ b/addons/point_of_sale/static/tests/unit/customer_display/customer_display_adapter.test.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@odoo/hoot";
-import { getFilledOrder, setupPosEnv } from "../utils";
+import { getFilledOrder, setupPosEnv, expectFormattedPrice } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
 import { CustomerDisplayPosAdapter } from "@point_of_sale/app/customer_display/customer_display_adapter";
 
@@ -15,4 +15,22 @@ test("getOrderlineData", async () => {
     expect(adapter.data.lines).toHaveLength(2);
     expect(adapter.data.lines[0].isSelected).toBe(false);
     expect(adapter.data.lines[1].isSelected).toBe(true);
+});
+
+test("order amounts summary", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+
+    const adapter = new CustomerDisplayPosAdapter();
+
+    adapter.formatOrderData(order);
+    expectFormattedPrice(adapter.data.amount, "$ 17.85");
+    expectFormattedPrice(adapter.data.amountTaxes, "$ 2.85");
+    expect(adapter.data.subtotal).toBe(false);
+
+    store.config.iface_tax_included = "subtotal";
+    adapter.formatOrderData(order);
+    expectFormattedPrice(adapter.data.amount, "$ 17.85");
+    expectFormattedPrice(adapter.data.amountTaxes, "$ 2.85");
+    expectFormattedPrice(adapter.data.subtotal, "$ 15.00");
 });


### PR DESCRIPTION
Steps to reproduce
------------------
1. In PoS settings, set the "Tax Display" to "Tax-Excluded Price"
2. Enable customer display
3. Open a PoS session, and open the customer display simultaneously
4. Add products, notice that the total in PoS is price included as expected. However, the total in cusromer display is tax excluded, so customer thinks he will be pay less.

Why it happens
----------------
In the refactors done in 9538698f13d5763b4, we mistakenly set the order.amount (i.e. total amount) to follow the config "Tax Display". However, that price should always be tax incl.

In this PR, we now use the `currencyDisplayPriceIncl` getter, instead of the config dependent `currencyDisplayPrice`.

Additional enhancements
-------------------------
In additional to total price, we also display the taxes amount not. And In case of "Tax-Excluded" price config, also display the subtotal (total price excluded). **That follows exactly the UI of the main cart in the products page**.

So now we have
----------------
Tax included: 
<img width="558" height="659" alt="image" src="https://github.com/user-attachments/assets/51415c5c-2234-48dd-a974-572a6b090714" />

Tax excluded: 
<img width="550" height="661" alt="image" src="https://github.com/user-attachments/assets/2c664716-49ab-44eb-bb30-ad42206bc849" />


opw-5401560