### PR TITLE
[FIX] account_peppol: safer server deregistration

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -117,9 +117,6 @@ class AccountEdiProxyClientUser(models.Model):
                 self._renew_token()
                 self.env.cr.commit() # We do not want to lose it if in the _make_request below something goes wrong
                 return self._make_request(url, params)
-            if error_code == 'no_such_user':
-                # This error is also raised if the user didn't exchange data and someone else claimed the edi_identificaiton.
-                self.sudo().active = False
             raise AccountEdiProxyError(error_code, proxy_error['message'] or False)
 
         return response['result']

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -110,29 +110,20 @@ class AccountEdiProxyClientUser(models.Model):
             return
 
         try:
-            with self.env.cr.savepoint():
-                # fetch state from IAP and update user if relevant
-                # _peppol_get_participant_status ignores errors, and here we want to know if it failed
-                # _make_request_peppol won't commit on no_such_user error
-                proxy_user = user._make_request(f"{user._get_server_url_new()}/api/peppol/1/participant_status")
+            # fetch state from IAP and update user if relevant
+            # _peppol_get_participant_status ignores errors, and here we want to know if it failed
+            # _make_request_peppol won't commit on no_such_user error
+            proxy_user = user._make_request(f"{user._get_server_url_new()}/api/peppol/1/participant_status")
 
-                state_map = {
-                    'active': 'active',
-                    'verified': 'pending',
-                    'rejected': 'rejected',
-                    'canceled': 'canceled',
-                    # IAP-side is still draft (needs phone confirmation)
-                    # set to pending to match normal registration flow
-                    'draft': 'pending'
-                }
+            state_map = {'active': 'active', 'verified': 'pending', 'rejected': 'rejected'}
 
-                if proxy_user.get('peppol_state') in state_map:
-                    user.company_id.account_peppol_proxy_state = state_map[proxy_user['peppol_state']]
-                    user.active = True
-                else:
-                    # NOTE: this shouldn't happen, but if it does, we will have refreshed the token
-                    # but as it's an unknown state, there is not much we can do with that information
-                    return
+            if proxy_user.get('peppol_state') in state_map:
+                user.company_id.account_peppol_proxy_state = state_map[proxy_user['peppol_state']]
+                user.active = True
+            else:
+                # NOTE: this shouldn't happen, but if it does, we will have refreshed the token
+                # but as it's an unknown state, there is not much we can do with that information
+                return
         except AccountEdiProxyError as e:
             _logger.info("Tried unsuccessfully to recover EDI proxy user id=%s (%s)", user.id, e)
         else:
@@ -301,15 +292,25 @@ class AccountEdiProxyClientUser(models.Model):
             try:
                 proxy_user = edi_user._make_request(f"{edi_user._get_server_url_new()}/api/peppol/1/participant_status")
             except AccountEdiProxyError as e:
-                _logger.error('Error while updating Peppol participant status: %s', e)
+                if e.code == 'client_gone':
+                    # reset the connection if it was archived/deleted on IAP side
+                    edi_user.sudo().company_id._reset_peppol_configuration()
+                else:
+                    # don't auto-deregister users on any other errors to avoid settings client-side to states
+                    # that are not recoverable without user action if an error on IAP side ever occurs
+                    _logger.error('Error while updating Peppol participant status: %s', e)
                 continue
 
-            state_map = {
+            local_state = {
+                'draft': 'not_registered',
                 'active': 'active',
                 'verified': 'pending',
                 'rejected': 'rejected',
-                'canceled': 'canceled',
-            }
+            }.get(proxy_user.get('peppol_state'))
 
-            if proxy_user['peppol_state'] in state_map:
-                edi_user.company_id.account_peppol_proxy_state = state_map[proxy_user['peppol_state']]
+            if local_state == 'not_registered':
+                edi_user.sudo().company_id._reset_peppol_configuration()
+            elif local_state:
+                edi_user.company_id.account_peppol_proxy_state = local_state
+            else:
+                _logger.warning("Received unknown Peppol state '%s' for EDI proxy user id=%s", proxy_user.get('peppol_state'), edi_user.id)

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -159,6 +159,16 @@ class ResCompany(models.Model):
         if country_code not in PEPPOL_LIST or not phonenumbers.is_valid_number(phone_nbr):
             raise ValidationError(error_message)
 
+    def _reset_peppol_configuration(self):
+        """Reset all peppol configuration fields to their default value, as if not registered"""
+        self.account_peppol_proxy_state = 'not_registered'
+        self.partner_id._compute_peppol_eas()
+        self.partner_id._compute_peppol_endpoint()
+
+        # on 16.0 the constraints on account_edi_proxy_client.user prevent having multiple users of
+        # type 'peppol' for the same company even if they are archived, so we need to unlink them
+        self.account_edi_proxy_client_ids.unlink()
+
     def _check_peppol_endpoint_number(self, warning=False):
         self.ensure_one()
         peppol_dict = PEPPOL_ENDPOINT_WARNINGS if warning else PEPPOL_ENDPOINT_RULES


### PR DESCRIPTION
Reintroduce server-initiated deregistration on `client_gone`, but only for implementations that explicitly handle it. The base proxy client now just raises the error. Peppol opts in by soft-resetting its configuration so users can re-register. See the IAP postmortem for the rationale and incident history. https://github.com/odoo/iap-apps/pull/1317

no-task