### PR TITLE
[FIX] mrp: add warehouse_id to moves created using catalog

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -921,7 +921,7 @@ class MrpProduction(models.Model):
         if 'workorder_ids' in self:
             production_to_replan = self.filtered(lambda p: p.is_planned)
         for move_str in ('move_raw_ids', 'move_finished_ids'):
-            if move_str not in vals or self.state in ['draft', 'cancel', 'done']:
+            if move_str not in vals or self.state in ['cancel', 'done']:
                 continue
             # When adding a move raw/finished, it should have the source location's `warehouse_id`.
             # Before, it was handle by an onchange, now it's forced if not already in vals.

--- a/addons/mrp/static/tests/tours/mrp_product_catalog.js
+++ b/addons/mrp/static/tests/tours/mrp_product_catalog.js
@@ -47,3 +47,34 @@ registry.category("web_tour.tours").add('test_mrp_production_product_catalog', {
             trigger: 'div.o_field_widget:contains("WH/MO/")',
         },
 ]});
+
+registry.category("web_tour.tours").add('test_mrp_multi_step_product_catalog_component_transfer', {
+    steps: () => [
+        {
+            trigger: 'button[name=action_add_from_catalog_raw]',
+            run: "click",
+        },
+        {
+            trigger: '.o_searchview_input',
+            run: 'edit Wooden Leg',
+        },
+        {
+            trigger: '.o_searchview_input',
+            run: 'press Enter',
+        },
+        {
+            trigger: '.o_kanban_record:contains(Wooden Leg)',
+            run: "click",
+        },
+        {
+            trigger: '.o_kanban_record:contains(Wooden Leg)',
+            run: "click",
+        },
+        {
+            trigger: 'button:contains("Back to Production")',
+            run: "click",
+        },
+        {
+            trigger: 'div.o_field_widget:contains("WH/MO/")',
+        },
+]});


### PR DESCRIPTION
Issue
-----
In multi step manufacturing, components added to MO through the catalog don't get transfered to the pre-prod location.

Steps to reproduce
-----
- 2 step manufacturing
- Create 2 products
- Create a MO for the first product
- Open the product catalog
    - Add some qty of the second product
- Go back to the MO & confirm it

> No procurement transfer for the second product from stock to pre-prod

Cause
-----
The move created by the catalog has no `warehouse_id` so in `adjust_procure_method` we don't find any rule which means it gets set to MTS

https://github.com/odoo/odoo/blob/6ecd271ff34313d900a0ad14b1c20679808ba9b8/addons/stock/models/stock_move.py#L2366-L2368

-----
Ticket:
opw-5221418
