### PR TITLE
[FIX] im_livechat: show correspondent country in info panel

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -52,7 +52,8 @@ patch(Thread.prototype, {
     get showCorrespondentCountry() {
         if (this.channel_type === "livechat") {
             return (
-                this.livechat_operator_id?.eq(this.store.self) && Boolean(this.correspondentCountry)
+                this.correspondent?.livechat_member_type === "visitor" &&
+                Boolean(this.correspondentCountry)
             );
         }
         return super.showCorrespondentCountry;

--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
@@ -62,6 +62,7 @@
                         'o-need-help': isBtnActive and btn.status === 'need_help',
                         'o-waiting bg-warning-subtle text-warning': isBtnActive and btn.status === 'waiting',
                     }"
+                    t-att-disabled="!store.has_access_livechat"
                     t-on-click="() => livechatThread.updateLivechatStatus(btn.status)"
                 >
                     <input

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.js
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.js
@@ -15,7 +15,7 @@ import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
  */
 export class ExpertiseTagsAutocomplete extends Component {
     static template = "im_livechat.ExpertiseTagsAutocomplete";
-    static props = ["channel"];
+    static props = ["channel", "disabled?"];
     static components = { TagsList, Many2XAutocomplete };
 
     setup() {

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
@@ -2,11 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.ExpertiseTagsAutocomplete">
         <div
-            class="o-livechat-ExpertiseTagsAutocomplete d-inline-flex o_tags_input o_input flex-wrap gap-1 mb-3"
+            class="o-livechat-ExpertiseTagsAutocomplete d-inline-flex o_tags_input flex-wrap gap-1 mb-3"
+            t-att-class="{'o_input': !props.disabled, 'o-disabled': props.disabled}"
             t-ref="root"
         >
             <TagsList displayText="true" tags="tags"/>
-            <div class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
+            <div t-if="!props.disabled" class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;" >
                 <Many2XAutocomplete
                     placeholder="placeholder"
                     resModel="'im_livechat.expertise'"

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -22,12 +22,12 @@
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Notes</h6>
-                <textarea class="form-control" rows="3" placeholder="Add your notes here..." t-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
+                <textarea class="form-control" t-att-disabled="!store.has_access_livechat"  rows="3" placeholder="Add your notes here..." t-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
             </div>
             <div class="d-flex flex-column bg-inherit gap-1" t-ref="tagsContainer">
                 <h6 class="align-items-baseline pt-3 d-flex">
                     <span class="pt-3 mb-1">Tags</span>
-                    <button class="btn btn-link text-dark opacity-75 opacity-100-hover p-0 ms-1" t-on-click="onClickEditTags"><i class="oi oi-plus"/></button>
+                    <button t-if="store.has_access_livechat" class="btn btn-link text-dark opacity-75 opacity-100-hover p-0 ms-1" t-on-click="onClickEditTags"><i class="oi oi-plus"/></button>
                 </h6>
                 <div t-if="conversationTags.length" class="d-flex flex-wrap flex-grow-1 gap-1">
                     <TagsList displayText="true" tags="conversationTags"/>
@@ -45,7 +45,7 @@
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Expertise</h6>
-                <ExpertiseTagsAutocomplete channel="props.thread"/>
+                <ExpertiseTagsAutocomplete channel="props.thread" disabled="!store.has_access_livechat"/>
             </div>
             <t t-name="extra_infos"/>
             <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -5,8 +5,10 @@ import { LivechatChannelInfoList } from "@im_livechat/core/web/livechat_channel_
 
 registerThreadAction("livechat-info", {
     actionPanelComponent: LivechatChannelInfoList,
-    condition: ({ owner, thread }) =>
-        thread?.channel_type === "livechat" && !owner.isDiscussSidebarChannelActions,
+    condition: ({ owner, store, thread }) =>
+        thread?.channel_type === "livechat" &&
+        store.self_partner?.main_user_id?.share === false &&
+        !owner.isDiscussSidebarChannelActions,
     panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     icon: "fa fa-fw fa-info",
     name: _t("Information"),
@@ -16,8 +18,11 @@ registerThreadAction("livechat-info", {
 });
 registerThreadAction("livechat-status", {
     actionPanelComponent: LivechatChannelInfoList,
-    condition: ({ owner, thread }) =>
-        thread?.channel_type === "livechat" && !thread.livechat_end_dt && !owner.isDiscussContent,
+    condition: ({ owner, store, thread }) =>
+        thread?.channel_type === "livechat" &&
+        store.self_partner?.main_user_id?.share === false &&
+        !thread.livechat_end_dt &&
+        !owner.isDiscussContent,
     dropdown: true,
     dropdownMenuClass: "p-0",
     dropdownTemplate: "im_livechat.LivechatStatusSelection",

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -20,7 +20,7 @@ registerThreadAction("livechat-status", {
     actionPanelComponent: LivechatChannelInfoList,
     condition: ({ owner, store, thread }) =>
         thread?.channel_type === "livechat" &&
-        store.self_partner?.main_user_id?.share === false &&
+        store.has_access_livechat &&
         !thread.livechat_end_dt &&
         !owner.isDiscussContent,
     dropdown: true,

--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -152,8 +152,8 @@ test("open visitor's partner profile if visitor has one", async () => {
     const livechatPartner = pyEnv["res.partner"].create({ name: "Joel Willis" });
     const channel = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: livechatPartner }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ partner_id: livechatPartner, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -7,7 +7,7 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, press, test } from "@odoo/hoot";
+import { describe, press, test, waitFor } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { serializeDate, today } from "@web/core/l10n/dates";
 import { getOrigin } from "@web/core/utils/urls";
@@ -43,6 +43,9 @@ test("livechat note is loaded when opening the channel info list", async () => {
 
 test("editing livechat note is synced between tabs", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], {
+        group_ids: [serverState.groupLivechatId],
+    });
     const userId = pyEnv["res.users"].create({ name: "James" });
     pyEnv["res.partner"].create({
         name: "James",
@@ -161,9 +164,7 @@ test("editing livechat status is synced between tabs", async () => {
 test("Manage expertises from channel info list", async () => {
     const pyEnv = await startServer();
     pyEnv["res.users"].write([serverState.userId], {
-        group_ids: pyEnv["res.groups"]
-            .search_read([["id", "=", serverState.groupLivechatManagerId]])
-            .map(({ id }) => id),
+        group_ids: [serverState.groupLivechatManagerId, serverState.groupLivechatId],
     });
     const userId = pyEnv["res.users"].create({ name: "James" });
     pyEnv["res.partner"].create({ name: "James", user_ids: [userId] });
@@ -212,4 +213,23 @@ test("Can download transcript from channel info panel", async () => {
     await contains(
         `a[href='${getOrigin()}/im_livechat/download_transcript/${channelId}']:text(Download)`
     );
+});
+
+test("Disable actions for non-livechat users", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+        livechat_status: "in_progress",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await waitFor(".o-livechat-LivechatStatusSelection button:text(In progress):disabled");
+    await waitFor(".o-livechat-LivechatStatusSelection button:text(Waiting for customer):disabled");
+    await waitFor(".o-livechat-LivechatStatusSelection button:text(Looking for help):disabled");
+    await waitFor("textarea[placeholder='Add your notes here...']:disabled");
+    await waitFor(".o-livechat-ExpertiseTagsAutocomplete.o-disabled");
 });

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -1,3 +1,4 @@
+import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
 import {
     click,
     contains,
@@ -8,7 +9,6 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, press, test } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
-import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
 import { serializeDate, today } from "@web/core/l10n/dates";
 import { getOrigin } from "@web/core/utils/urls";
 
@@ -94,8 +94,8 @@ test("shows live chat status in discuss sidebar", async () => {
     });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         country_id: countryId,
         channel_type: "livechat",
@@ -129,8 +129,8 @@ test("editing livechat status is synced between tabs", async () => {
     });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         country_id: countryId,
         channel_type: "livechat",

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -49,4 +49,7 @@ export class DiscussChannelMember extends mailModels.DiscussChannelMember {
             });
         }
     }
+    get _to_store_defaults() {
+        return super._to_store_defaults.concat(["livechat_member_type"]);
+    }
 }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
@@ -51,18 +51,21 @@ export class LivechatChannel extends models.ServerModel {
         const MailGuest = this.env["mail.guest"];
         /** @type {import("mock_models").ResUsers} */
         const ResUsers = this.env["res.users"];
-        const agent = operator_info['agent']
+        const agent = operator_info["agent"];
 
         const membersToAdd = [
             Command.create({
-                unpin_dt: "2021-01-01 12:00:00",
                 last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "agent",
                 partner_id: agent.partner_id,
+                unpin_dt: "2021-01-01 12:00:00",
             }),
         ];
         const guest = ResUsers._is_public(this.env.uid) && MailGuest._get_guest_from_context();
         if (guest) {
-            membersToAdd.push(Command.create({ guest_id: guest.id }));
+            membersToAdd.push(
+                Command.create({ guest_id: guest.id, livechat_member_type: "visitor" })
+            );
         }
         let visitorUser;
         if (this.env.user && !ResUsers._is_public(this.env.uid) && this.env.user !== agent) {

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -23,14 +23,14 @@ test("shows language, country and recent page views", async () => {
         website_id,
     });
     const guestId = pyEnv["mail.guest"].create({ name: `Visitor #${visitorId}` });
+    // Do not add agent to the channel to ensure information is properly
+    // displayed, even when the agent is not a member.
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         country_id,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_visitor_id: visitorId,
     });
     await start();

--- a/addons/website_livechat/static/tests/website_livechat_test_helpers.js
+++ b/addons/website_livechat/static/tests/website_livechat_test_helpers.js
@@ -10,8 +10,8 @@ export function defineWebsiteLivechatModels() {
 }
 
 export const websiteLivechatModels = {
-    ...livechatModels,
     ...websiteModels,
+    ...livechatModels,
     WebsiteVisitor,
     DiscussChannel,
 };


### PR DESCRIPTION
Before this PR, the visitor country flag was only shown to the agent who was first assigned to the conversation. In practice, country should always be displayed on the info panel. Users that have the rights to see the conversation should have every information available as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
