### PR TITLE
[IMP] html_editor: automatically run tests in both selection directions

### DIFF
--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -110,12 +110,15 @@ export class LinkPastePlugin extends Plugin {
             cleanZWChars(selection.textContent()) === cleanZWChars(link.innerText) &&
             !this.dependencies.delete.isUnremovable(link)
         ) {
-            this.dependencies.selection.setSelection({
-                anchorNode: link.parentElement,
-                anchorOffset: childNodeIndex(link) + (selection.direction ? 0 : 1),
-                focusNode: link.parentElement,
-                focusOffset: childNodeIndex(link) + (selection.direction ? 1 : 0),
-            });
+            this.dependencies.selection.setSelection(
+                {
+                    anchorNode: link.parentElement,
+                    anchorOffset: childNodeIndex(link) + (selection.direction ? 0 : 1),
+                    focusNode: link.parentElement,
+                    focusOffset: childNodeIndex(link) + (selection.direction ? 1 : 0),
+                },
+                { normalize: false }
+            );
         }
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1015,7 +1015,7 @@ export class TablePlugin extends Plugin {
                 this.selectTableCells(selection);
             }
         } else if (!targetedNodes.every((node) => closestElement(node.parentElement, "table"))) {
-            const endSelectionTable = closestElement(selection.focusNode, "table");
+            const endSelectionTable = closestElement(selection.endContainer, "table");
             const endSelectionTableTds = endSelectionTable && getTableCells(endSelectionTable);
             const targetedTds = new Set(
                 targetedNodes.map((node) => closestElement(node, isTableCell))
@@ -1025,16 +1025,22 @@ export class TablePlugin extends Plugin {
                 // Make sure all the cells are targeted in actual selection
                 // when selecting full table. If not, they will be selected
                 // forcefully and updateSelectionTable will be called again.
-                const targetTd =
-                    selection.direction === DIRECTIONS.RIGHT
-                        ? endSelectionTableTds.pop()
-                        : endSelectionTableTds.shift();
-                this.dependencies.selection.setSelection({
-                    anchorNode: selection.anchorNode,
-                    anchorOffset: selection.anchorOffset,
-                    focusNode: targetTd,
-                    focusOffset: selection.direction === DIRECTIONS.RIGHT ? nodeSize(targetTd) : 0,
-                });
+                const targetTd = endSelectionTableTds.pop();
+                if (selection.direction === DIRECTIONS.RIGHT) {
+                    this.dependencies.selection.setSelection({
+                        anchorNode: selection.anchorNode,
+                        anchorOffset: selection.anchorOffset,
+                        focusNode: targetTd,
+                        focusOffset: nodeSize(targetTd),
+                    });
+                } else {
+                    this.dependencies.selection.setSelection({
+                        anchorNode: targetTd,
+                        anchorOffset: nodeSize(targetTd),
+                        focusNode: selection.focusNode,
+                        focusOffset: selection.focusOffset,
+                    });
+                }
             }
             const targetedTables = new Set(
                 targetedNodes

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1664,7 +1664,7 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should delete part of the text within a paragraph (backward, forward selection)", async () => {
+    test("should delete part of the text within a paragraph", async () => {
         // Forward selection
         await testEditor({
             contentBefore: "<p>ab[cd]ef</p>",
@@ -1672,62 +1672,32 @@ describe("Selection not collapsed", () => {
             contentAfter: "<p>ab[]ef</p>",
         });
     });
-    test("should delete part of the text within a paragraph (backward, backward selection)", async () => {
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>ab]cd[ef</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p>ab[]ef</p>",
-        });
-    });
 
     test("should delete across two paragraphs", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>ab[cd</p><p>ef]gh</p>",
             stepFunction: deleteBackward,
             contentAfter: "<p>ab[]gh</p>",
         });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>ab]cd</p><p>ef[gh</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p>ab[]gh</p>",
-        });
     });
 
-    test("should delete part of the text across two paragraphs (backward, forward selection)", async () => {
+    test("should delete part of the text across two paragraphs", async () => {
         await testEditor({
             contentBefore: "<div>a<p>b[c</p><p>d]e</p>f</div>",
             stepFunction: deleteBackward,
             contentAfter: "<div>a<p>b[]e</p>f</div>",
         });
     });
-    test("should delete part of the text across two paragraphs (backward, backward selection)", async () => {
-        await testEditor({
-            contentBefore: "<div>a<p>b]c</p><p>d[e</p>f</div>",
-            stepFunction: deleteBackward,
-            contentAfter: "<div>a<p>b[]e</p>f</div>",
-        });
-    });
 
     test("should delete all the text in a paragraph", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>[abc]</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>]abc[</p>",
             stepFunction: deleteBackward,
             contentAfter: "<p>[]<br></p>",
         });
     });
 
     test("should delete a complex selection accross format nodes and multiple paragraphs", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p><b>ab[cd</b></p><p><b>ef<br>gh</b>ij<i>kl]</i>mn</p>",
             stepFunction: deleteBackward,
@@ -1738,21 +1708,9 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteBackward,
             contentAfter: "<p><b>ab[]</b><i>l</i>mn</p>",
         });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p><b>ab]cd</b></p><p><b>ef<br>gh</b>ij<i>kl[</i>mn</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p><b>ab[]</b>mn</p>",
-        });
-        await testEditor({
-            contentBefore: "<p><b>ab]cd</b></p><p><b>ef<br>gh</b>ij<i>k[l</i>mn</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p><b>ab[]</b><i>l</i>mn</p>",
-        });
     });
 
-    //
-    test("should delete all contents of a complex DOM with format nodes and multiple paragraphs (backward, forward selection)", async () => {
+    test("should delete all contents of a complex DOM with format nodes and multiple paragraphs", async () => {
         await testEditor({
             contentBefore: "<p><b>[abcd</b></p><p><b>ef<br>gh</b>ij<i>kl</i>mn]</p>",
             stepFunction: deleteBackward,
@@ -1760,31 +1718,15 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should delete all contents of a complex DOM with format nodes and multiple paragraphs (backward, backward selection)", async () => {
-        await testEditor({
-            contentBefore: "<p><b>]abcd</b></p><p><b>ef<br>gh</b>ij<i>kl</i>mn[</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p>[]<br></p>",
-        });
-    });
-
     test("should delete a selection accross a heading1 and a paragraph", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<h1>ab [cd</h1><p>ef]gh</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<h1>ab []gh</h1>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<h1>ab ]cd</h1><p>ef[gh</p>",
             stepFunction: deleteBackward,
             contentAfter: "<h1>ab []gh</h1>",
         });
     });
 
     test("should delete a selection from the beginning of a heading1 with a format to the middle of a paragraph", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<h1><b>[abcd</b></h1><p>ef]gh1</p>",
             stepFunction: deleteBackward,
@@ -1794,17 +1736,6 @@ describe("Selection not collapsed", () => {
             contentBefore: "<h1>[<b>abcd</b></h1><p>ef]gh2</p>",
             stepFunction: deleteBackward,
             contentAfter: "<p>[]gh2</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<h1><b>]abcd</b></h1><p>ef[gh3</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p>[]gh3</p>",
-        });
-        await testEditor({
-            contentBefore: "<h1>]<b>abcd</b></h1><p>ef[gh4</p>",
-            stepFunction: deleteBackward,
-            contentAfter: "<p>[]gh4</p>",
         });
     });
 

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -1259,18 +1259,9 @@ describe("Selection collapsed", () => {
 });
 
 describe("Selection not collapsed", () => {
-    test("should delete part of the text within a paragraph (forward, forward selection)", async () => {
-        // Forward selection
+    test("should delete part of the text within a paragraph", async () => {
         await testEditor({
             contentBefore: "<p>ab[cd]ef</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p>ab[]ef</p>",
-        });
-    });
-    test("should delete part of the text within a paragraph (forward, backward selection)", async () => {
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>ab]cd[ef</p>",
             stepFunction: deleteForward,
             contentAfter: "<p>ab[]ef</p>",
         });
@@ -1284,16 +1275,9 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should delete part of the text across two paragraphs (forward, forward selection)", async () => {
+    test("should delete part of the text across two paragraphs", async () => {
         await testEditor({
             contentBefore: "<div>a<p>b[c</p><p>d]e</p>f</div>",
-            stepFunction: deleteForward,
-            contentAfter: "<div>a<p>b[]e</p>f</div>",
-        });
-    });
-    test("should delete part of the text across two paragraphs (forward, backward selection)", async () => {
-        await testEditor({
-            contentBefore: "<div>a<p>b]c</p><p>d[e</p>f</div>",
             stepFunction: deleteForward,
             contentAfter: "<div>a<p>b[]e</p>f</div>",
         });
@@ -1344,37 +1328,22 @@ describe("Selection not collapsed", () => {
     });
 
     test("should delete across two paragraphs", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>ab[cd</p><p>ef]gh</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p>ab[]gh</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>ab]cd</p><p>ef[gh</p>",
             stepFunction: deleteForward,
             contentAfter: "<p>ab[]gh</p>",
         });
     });
 
     test("should delete all the text in a paragraph", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>[abc]</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>]abc[</p>",
             stepFunction: deleteForward,
             contentAfter: "<p>[]<br></p>",
         });
     });
 
     test("should delete a complex selection accross format nodes and multiple paragraphs", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p><b>ab[cd</b></p><p><b>ef<br>gh</b>ij<i>kl]</i>mn</p>",
             stepFunction: deleteForward,
@@ -1385,20 +1354,9 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteForward,
             contentAfter: "<p><b>ab[]</b><i>l</i>mn</p>",
         });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p><b>ab]cd</b></p><p><b>ef<br>gh</b>ij<i>kl[</i>mn</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p><b>ab[]</b>mn</p>",
-        });
-        await testEditor({
-            contentBefore: "<p><b>ab]cd</b></p><p><b>ef<br>gh</b>ij<i>k[l</i>mn</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p><b>ab[]</b><i>l</i>mn</p>",
-        });
     });
 
-    test("should delete all contents of a complex DOM with format nodes and multiple paragraphs (forward, forward selection)", async () => {
+    test("should delete all contents of a complex DOM with format nodes and multiple paragraphs", async () => {
         await testEditor({
             contentBefore: "<p><b>[abcd</b></p><p><b>ef<br>gh</b>ij<i>kl</i>mn]</p>",
             stepFunction: deleteForward,
@@ -1406,31 +1364,15 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should delete all contents of a complex DOM with format nodes and multiple paragraphs (forward, backward selection)", async () => {
-        await testEditor({
-            contentBefore: "<p><b>]abcd</b></p><p><b>ef<br>gh</b>ij<i>kl</i>mn[</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p>[]<br></p>",
-        });
-    });
-
     test("should delete a selection accross a heading1 and a paragraph", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<h1>ab [cd</h1><p>ef]gh</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<h1>ab []gh</h1>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<h1>ab ]cd</h1><p>ef[gh</p>",
             stepFunction: deleteForward,
             contentAfter: "<h1>ab []gh</h1>",
         });
     });
 
     test("should delete a selection from the beginning of a heading1 with a format to the middle of a paragraph + start of editable", async () => {
-        //Forward selection
         await testEditor({
             contentBefore: "<h1><b>[abcd</b></h1><p>ef]gh1</p>",
             stepFunction: deleteForward,
@@ -1440,17 +1382,6 @@ describe("Selection not collapsed", () => {
             contentBefore: "<h1>[<b>abcd</b></h1><p>ef]gh2</p>",
             stepFunction: deleteForward,
             contentAfter: "<p>[]gh2</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<h1><b>]abcd</b></h1><p>ef[gh3</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p>[]gh3</p>",
-        });
-        await testEditor({
-            contentBefore: "<h1>]<b>abcd</b></h1><p>ef[gh4</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<p>[]gh4</p>",
         });
     });
 
@@ -1468,7 +1399,6 @@ describe("Selection not collapsed", () => {
     });
 
     test("should delete a selection from the beginning of a heading1 to the end of a paragraph", async () => {
-        //Forward selection
         await testEditor({
             contentBefore: "<h1>[abcd</h1><p>ef]</p><h2>1</h2>",
             stepFunction: deleteForward,
@@ -1479,21 +1409,9 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteForward,
             contentAfter: "<h1>[]<br></h1><h2>2</h2>",
         });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<h1>]abcd</h1><p>ef[</p><h2>3</h2>",
-            stepFunction: deleteForward,
-            contentAfter: "<h1>[]<br></h1><h2>3</h2>",
-        });
-        await testEditor({
-            contentBefore: "<h1>]abcd</h1><p>ef[</p><h2>4</h2>",
-            stepFunction: deleteForward,
-            contentAfter: "<h1>[]<br></h1><h2>4</h2>",
-        });
     });
 
     test("should delete a selection from the beginning of a heading1 with a format to the end of a paragraph", async () => {
-        //Forward selection
         await testEditor({
             contentBefore: "<h1><u>[abcd</u></h1><p>ef]</p><h2>1</h2>",
             stepFunction: deleteForward,
@@ -1507,21 +1425,6 @@ describe("Selection not collapsed", () => {
             contentAfterEdit:
                 '<h1 o-we-hint-text="Heading 1" class="o-we-hint"><u data-oe-zws-empty-inline="">[]\u200B</u><br></h1><h2>2</h2>',
             contentAfter: "<h1>[]<br></h1><h2>2</h2>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<h1><u>]abcd</u></h1><p>ef[</p><h2>3</h2>",
-            stepFunction: deleteForward,
-            contentAfterEdit:
-                '<h1 o-we-hint-text="Heading 1" class="o-we-hint"><u data-oe-zws-empty-inline="">[]\u200B</u><br></h1><h2>3</h2>',
-            contentAfter: "<h1>[]<br></h1><h2>3</h2>",
-        });
-        await testEditor({
-            contentBefore: "<h1>]<u>abcd</u></h1><p>ef[</p><h2>4</h2>",
-            stepFunction: deleteForward,
-            contentAfterEdit:
-                '<h1 o-we-hint-text="Heading 1" class="o-we-hint"><u data-oe-zws-empty-inline="">[]\u200B</u><br></h1><h2>4</h2>',
-            contentAfter: "<h1>[]<br></h1><h2>4</h2>",
         });
     });
 

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -273,9 +273,9 @@ test("should make two paragraphs (separated with whitespace) bold, then not bold
             <p>[abc</p>
             <p>def]</p>
         `,
-        stepFunction: async (editor) => {
+        stepFunction: async (editor, { assertContentEquals }) => {
             bold(editor);
-            expect(getContent(editor.editable)).toBe(`
+            assertContentEquals(`
             <p><strong>[abc</strong></p>
             <p><strong>def]</strong></p>
         `);

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -136,9 +136,9 @@ test("should make two paragraphs (separated with whitespace) italic, then not it
             <p>[abc</p>
             <p>def]</p>
         `,
-        stepFunction: async (editor) => {
+        stepFunction: async (editor, { assertContentEquals }) => {
             italic(editor);
-            expect(getContent(editor.editable)).toBe(`
+            assertContentEquals(`
             <p><em>[abc</em></p>
             <p><em>def]</em></p>
         `);

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -3,7 +3,7 @@ import { tick } from "@odoo/hoot-mock";
 import { press } from "@odoo/hoot-dom";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
-import { getContent, setSelection } from "../_helpers/selection";
+import { getContent } from "../_helpers/selection";
 import { s, span } from "../_helpers/tags";
 import {
     insertText,
@@ -33,7 +33,7 @@ test("should make a few characters not strikeThrough", async () => {
 test("should make a few characters strikeThrough then remove style inside", async () => {
     await testEditor({
         contentBefore: `<p>ab[c d]ef</p>`,
-        stepFunction: async (editor) => {
+        stepFunction: async (editor, { setTestSelection }) => {
             strikeThrough(editor);
             const styleSpan = editor.editable.querySelector("s").childNodes[0];
             const selection = {
@@ -42,17 +42,17 @@ test("should make a few characters strikeThrough then remove style inside", asyn
                 focusNode: styleSpan,
                 focusOffset: 2,
             };
-            setSelection(selection);
+            setTestSelection(selection);
             strikeThrough(editor);
         },
         contentAfter: `<p>ab<s>c</s>[ ]<s>d</s>ef</p>`,
     });
 });
 
-test("should make strikeThrough then more then remove", async () => {
+test("should make strikeThrough then more then remove (1)", async () => {
     await testEditor({
         contentBefore: `<p>abc[ ]def</p>`,
-        stepFunction: async (editor) => {
+        stepFunction: async (editor, { setTestSelection }) => {
             strikeThrough(editor);
             const pElem = editor.editable.querySelector("p").childNodes;
             const selection = {
@@ -61,14 +61,17 @@ test("should make strikeThrough then more then remove", async () => {
                 focusNode: pElem[2],
                 focusOffset: 1,
             };
-            setSelection(selection);
+            setTestSelection(selection);
             strikeThrough(editor);
         },
         contentAfter: `<p>ab${s(`[c d]`)}ef</p>`,
     });
+});
+
+test("should make strikeThrough then more then remove (2)", async () => {
     await testEditor({
         contentBefore: `<p>abc[ ]def</p>`,
-        stepFunction: async (editor) => {
+        stepFunction: async (editor, { setTestSelection }) => {
             strikeThrough(editor);
             const pElem = editor.editable.querySelector("p").childNodes;
             const selection = {
@@ -77,7 +80,7 @@ test("should make strikeThrough then more then remove", async () => {
                 focusNode: pElem[2],
                 focusOffset: 1,
             };
-            setSelection(selection);
+            setTestSelection(selection);
             strikeThrough(editor);
             strikeThrough(editor);
         },

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -134,9 +134,9 @@ test("should make two paragraphs (separated with whitespace) underline, then not
             <p>[abc</p>
             <p>def]</p>
         `,
-        stepFunction: async (editor) => {
+        stepFunction: async (editor, { assertContentEquals }) => {
             underline(editor);
-            expect(getContent(editor.editable)).toBe(`
+            assertContentEquals(`
             <p><u>[abc</u></p>
             <p><u>def]</u></p>
         `);

--- a/addons/html_editor/static/tests/insert/line_break.test.js
+++ b/addons/html_editor/static/tests/insert/line_break.test.js
@@ -308,47 +308,24 @@ describe("Selection collapsed", () => {
 
 describe("Selection not collapsed", () => {
     test("should delete the first half of a paragraph, then insert a <br>", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>[ab]cd</p>",
-            stepFunction: insertLineBreak,
-            contentAfter: "<p><br>[]cd</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>]ab[cd</p>",
             stepFunction: insertLineBreak,
             contentAfter: "<p><br>[]cd</p>",
         });
     });
 
     test("should delete part of a paragraph, then insert a <br>", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>a[bc]d</p>",
-            stepFunction: insertLineBreak,
-            contentAfter: "<p>a<br>[]d</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>a]bc[d</p>",
             stepFunction: insertLineBreak,
             contentAfter: "<p>a<br>[]d</p>",
         });
     });
 
     test("should delete the last half of a paragraph, then insert a line break (2 <br>)", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>ab[cd]</p>",
-            stepFunction: insertLineBreak,
-            // the second <br> is needed to make the first one
-            // visible.
-            contentAfter: "<p>ab<br>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>ab]cd[</p>",
             stepFunction: insertLineBreak,
             // the second <br> is needed to make the first one
             // visible.
@@ -357,15 +334,8 @@ describe("Selection not collapsed", () => {
     });
 
     test("should delete all contents of a paragraph, then insert a line break", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>[abcd]</p>",
-            stepFunction: insertLineBreak,
-            contentAfter: "<p><br>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>]abcd[</p>",
             stepFunction: insertLineBreak,
             contentAfter: "<p><br>[]<br></p>",
         });
@@ -373,8 +343,7 @@ describe("Selection not collapsed", () => {
 });
 
 describe("table", () => {
-    test("should remove all contents of an anchor td and insert a line break on forward selection", async () => {
-        // Forward selection
+    test("should remove all contents of an anchor td and insert a line break", async () => {
         await testEditor({
             contentBefore: `
                 <table>
@@ -407,18 +376,19 @@ describe("table", () => {
                         </tr>
                     </tbody>
                 </table>`,
+            testInBothDirections: false,
         });
     });
-    test("should remove all contents of an anchor td and insert a line break on backward selection", async () => {
-        // Backward selection
+
+    test("should remove all contents of an anchor td and insert a line break (reversed selection)", async () => {
         await testEditor({
             contentBefore: `
                 <table>
                     <tbody>
                         <tr>
-                            <td><p>]ab</p></td>
+                            <td><p>]abc</p><p>def</p></td>
                             <td><p>abcd</p></td>
-                            <td><p>abc</p><p>def[</p></td>
+                            <td><p>ab[</p></td>
                         </tr>
                         <tr>
                             <td><p><br></p></td>
@@ -432,7 +402,7 @@ describe("table", () => {
                 <table>
                     <tbody>
                         <tr>
-                            <td><p>ab</p></td>
+                            <td><p>abc</p><p>def</p></td>
                             <td><p>abcd</p></td>
                             <td><p><br>[]<br></p></td>
                         </tr>
@@ -443,6 +413,7 @@ describe("table", () => {
                         </tr>
                     </tbody>
                 </table>`,
+            testInBothDirections: false,
         });
     });
 });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -659,60 +659,32 @@ describe("Selection collapsed", () => {
 
 describe("Selection not collapsed", () => {
     test("should delete the first half of a paragraph, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>[ab]cd</p>",
-            stepFunction: splitBlock,
-            contentAfter: "<p><br></p><p>[]cd</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>]ab[cd</p>",
             stepFunction: splitBlock,
             contentAfter: "<p><br></p><p>[]cd</p>",
         });
     });
 
     test("should delete part of a paragraph, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>a[bc]d</p>",
-            stepFunction: splitBlock,
-            contentAfter: "<p>a</p><p>[]d</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>a]bc[d</p>",
             stepFunction: splitBlock,
             contentAfter: "<p>a</p><p>[]d</p>",
         });
     });
 
     test("should delete the last half of a paragraph, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>ab[cd]</p>",
-            stepFunction: splitBlock,
-            contentAfter: "<p>ab</p><p>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>ab]cd[</p>",
             stepFunction: splitBlock,
             contentAfter: "<p>ab</p><p>[]<br></p>",
         });
     });
 
     test("should delete all contents of a paragraph, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<p>[abcd]</p>",
-            stepFunction: splitBlock,
-            contentAfter: "<p><br></p><p>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<p>]abcd[</p>",
             stepFunction: splitBlock,
             contentAfter: "<p><br></p><p>[]<br></p>",
         });
@@ -730,8 +702,7 @@ describe("Selection not collapsed", () => {
 });
 
 describe("Table", () => {
-    test("should remove all contents of an anchor td and split paragraph on forward selection", async () => {
-        // Forward selection
+    test("should remove all contents of an anchor td and split paragraph", async () => {
         await testEditor({
             contentBefore: `
                 <table>
@@ -764,18 +735,18 @@ describe("Table", () => {
                         </tr>
                     </tbody>
                 </table>`,
+            testInBothDirections: false,
         });
     });
-    test("should remove all contents of an anchor td and split paragraph on backward selection", async () => {
-        // Backward selection
+    test("should remove all contents of an anchor td and split paragraph (reversed selection)", async () => {
         await testEditor({
             contentBefore: `
                 <table>
                     <tbody>
                         <tr>
-                            <td><p>]ab</p></td>
+                            <td><p>]abc</p><p>def</p></td>
                             <td><p>abcd</p></td>
-                            <td><p>abc</p><p>def[</p></td>
+                            <td><p>ab[</p></td>
                         </tr>
                         <tr>
                             <td><p><br></p></td>
@@ -789,7 +760,7 @@ describe("Table", () => {
                 <table>
                     <tbody>
                         <tr>
-                            <td><p>ab</p></td>
+                            <td><p>abc</p><p>def</p></td>
                             <td><p>abcd</p></td>
                             <td><p><br></p><p>[]<br></p></td>
                         </tr>
@@ -800,6 +771,7 @@ describe("Table", () => {
                         </tr>
                     </tbody>
                 </table>`,
+            testInBothDirections: false,
         });
     });
     test("remove selected text and insert paragraph tag within a table cell and enter key is pressed", async () => {

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -87,11 +87,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>[ab]<span class="a">\u200B</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>[ab<span class="a">\u200B</span>c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>[ab<span class="a">]\u200B</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>[ab<span class="a">\u200B</span>c]d</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -100,11 +102,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>a[b]<span class="a">\u200B</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>a[b<span class="a">\u200B</span>c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>a[b<span class="a">]\u200B</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>a[b<span class="a">\u200B</span>c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore:
@@ -112,6 +116,7 @@ describe("Around ZWS", () => {
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter:
                 '<p>a[b<span class="a">\u200B</span></p><p>]<span class="b">\u200B</span></p>',
+            testInBothDirections: false,
         });
     });
 
@@ -120,11 +125,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab[]<span class="a">\u200B</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">[\u200B</span>c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab<span class="a">[]\u200B</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">[\u200B</span>c]d</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -133,11 +140,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab<span class="a">\u200B[]</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b<span class="a">\u200B[</span>cd</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab<span class="a">\u200B</span>[]cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b<span class="a">\u200B[</span>cd</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -146,11 +155,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab<span class="a">\u200B</span>]cd[</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b<span class="a">\u200B</span>cd[</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab<span class="a">\u200B]</span>cd[</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b<span class="a">\u200B</span>cd[</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -159,11 +170,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab<span class="a">\u200B</span>]c[d</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b<span class="a">\u200B</span>c[d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab<span class="a">\u200B]</span>c[d</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b<span class="a">\u200B</span>c[d</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -172,21 +185,25 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab<span class="a">]\u200B[</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">\u200B</span>[c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab<span class="a">]\u200B</span>[cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">\u200B</span>[c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab]<span class="a">\u200B</span>[cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">\u200B</span>[c]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab]<span class="a">\u200B[</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">\u200B</span>[c]d</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -195,11 +212,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab<span class="a">]\u200B</span>c[d</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">\u200B</span>c[]d</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab]<span class="a">\u200B</span>c[d</p>',
             stepFunction: keyPress(["Shift", "ArrowRight"]),
             contentAfter: '<p>ab<span class="a">\u200B</span>c[]d</p>',
+            testInBothDirections: false,
         });
     });
 
@@ -208,21 +227,25 @@ describe("Around ZWS", () => {
             contentBefore: '<p>ab<span class="a">[\u200B]</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b[<span class="a">\u200B</span>cd</p>', // Normalized by the browser
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab<span class="a">[\u200B</span>]cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b[<span class="a">\u200B</span>cd</p>', // Normalized by the browser
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab[<span class="a">\u200B]</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b[<span class="a">\u200B</span>cd</p>', // Normalized by the browser
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>ab[<span class="a">\u200B</span>]cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a]b[<span class="a">\u200B</span>cd</p>', // Normalized by the browser
+            testInBothDirections: false,
         });
     });
 
@@ -231,11 +254,13 @@ describe("Around ZWS", () => {
             contentBefore: '<p>a[b<span class="a">\u200B]</span>cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a[]b<span class="a">\u200B</span>cd</p>',
+            testInBothDirections: false,
         });
         await testEditor({
             contentBefore: '<p>a[b<span class="a">\u200B</span>]cd</p>',
             stepFunction: keyPress(["Shift", "ArrowLeft"]),
             contentAfter: '<p>a[]b<span class="a">\u200B</span>cd</p>',
+            testInBothDirections: false,
         });
     });
 });
@@ -703,6 +728,7 @@ describe("Around contenteditable false elements containing contenteditable true 
                 </div>
                 <p>]mno</p>
             `),
+            testInBothDirections: false,
         });
     });
     test("should select contenteditable false element (ArrowLeft)", async () => {
@@ -730,6 +756,7 @@ describe("Around contenteditable false elements containing contenteditable true 
                 </div>
                 <p>m[no</p>
             `),
+            testInBothDirections: false,
         });
     });
     test("should select contenteditable false element (ArrowUp)", async () => {
@@ -757,6 +784,7 @@ describe("Around contenteditable false elements containing contenteditable true 
                 </div>
                 <p>mno[</p>
             `),
+            testInBothDirections: false,
         });
     });
     test("should select contenteditable false element (ArrowDown)", async () => {
@@ -784,6 +812,7 @@ describe("Around contenteditable false elements containing contenteditable true 
                 </div>
                 <p>]mno</p>
             `),
+            testInBothDirections: false,
         });
     });
 });

--- a/addons/html_editor/static/tests/link/remove.test.js
+++ b/addons/html_editor/static/tests/link/remove.test.js
@@ -322,20 +322,42 @@ describe("range not collapsed", () => {
             await testEditor({
                 contentBefore:
                     '<p>a<a class="oe_unremovable" href="http://test.test">[b</a>c<a href="http://test.test">d</a>e<a class="oe_unremovable" href="http://test.test">f]</a></p>',
-                /** @param {import("@html_editor/plugin").Editor} editor */
                 stepFunction: (editor) => {
-                    const selection = editor.shared.selection.getEditableSelection();
+                    const { anchorNode, focusNode } =
+                        editor.shared.selection.getEditableSelection();
                     // extends selection to contain the feffs
-                    editor.shared.selection.setSelection({
-                        anchorNode: selection.anchorNode.previousSibling,
+                    setSelection({
+                        anchorNode: anchorNode.previousSibling,
                         anchorOffset: 0,
-                        focusNode: selection.focusNode.nextSibling,
+                        focusNode: focusNode.nextSibling,
                         focusOffset: 1,
                     });
                     unlinkByCommand(editor);
                 },
                 contentAfter:
                     '<p>a<a class="oe_unremovable" href="http://test.test">[b</a>cde<a class="oe_unremovable" href="http://test.test">f]</a></p>',
+                testInBothDirections: false,
+            });
+        });
+        test("should not remove unremovable links when fully selected (including feff) with other links (reversed selection)", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p>a<a class="oe_unremovable" href="http://test.test">]b</a>c<a href="http://test.test">d</a>e<a class="oe_unremovable" href="http://test.test">f[</a></p>',
+                stepFunction: (editor) => {
+                    const { anchorNode, focusNode } =
+                        editor.shared.selection.getEditableSelection();
+                    // extends selection to contain the feffs
+                    setSelection({
+                        anchorNode: anchorNode.nextSibling,
+                        anchorOffset: 1,
+                        focusNode: focusNode.previousSibling,
+                        focusOffset: 0,
+                    });
+                    unlinkByCommand(editor);
+                },
+                contentAfter:
+                    '<p>a<a class="oe_unremovable" href="http://test.test">]b</a>cde<a class="oe_unremovable" href="http://test.test">f[</a></p>',
+                testInBothDirections: false,
             });
         });
     });

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -2162,93 +2162,49 @@ describe("Selection not collapsed", () => {
     // with unordered lists and checklists, and vice versae.
     describe("Ordered", () => {
         test("should delete text within a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li>ab[cd]ef</li></ol>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ol><li>ab[]ef</li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li>ab]cd[ef</li></ol>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ol><li>ab[]ef</li></ol>",
             });
         });
 
         test("should delete all the text in a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li>[abc]</li></ol>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ol><li>[]<br></li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li>]abc[</li></ol>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ol><li>[]<br></li></ol>",
             });
         });
 
         test("should delete across two list items", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li>ab[cd</li><li>ef]gh</li></ol>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ol><li>ab[]gh</li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li>ab]cd</li><li>ef[gh</li></ol>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ol><li>ab[]gh</li></ol>",
             });
         });
 
         test("should delete across an unindented list item and an indented list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ol>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ol>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
             });
         });
 
         test("should delete a list", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<p>abc[</p><ol><li><p>def]</p></li></ol>",
-                stepFunction: deleteBackward,
-                contentAfter: "<p>abc[]</p>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<p>abc]</p><ol><li><p>def[</p></li></ol>",
                 stepFunction: deleteBackward,
                 contentAfter: "<p>abc[]</p>",
             });
         });
 
         test("should merge the contents of a list item within a block into a heading, and leave the rest of its list as it is", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore:
                     '<h1>a[b</h1><p>de</p><custom-block style="display: block;"><ol><li>fg</li><li>h]i</li><li>jk</li></ol></custom-block>',
-                stepFunction: deleteBackward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ol><li>jk</li></ol></custom-block>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ol><li>fg</li><li>h[i</li><li>jk</li></ol></custom-block>',
                 stepFunction: deleteBackward,
                 contentAfter:
                     '<h1>a[]i</h1><custom-block style="display: block;"><ol><li>jk</li></ol></custom-block>',
@@ -2265,93 +2221,49 @@ describe("Selection not collapsed", () => {
     });
     describe("Unordered", () => {
         test("should delete text within a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li>ab[cd]ef</li></ul>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ul><li>ab[]ef</li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li>ab]cd[ef</li></ul>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ul><li>ab[]ef</li></ul>",
             });
         });
 
         test("should delete all the text in a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li>[abc]</li></ul>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ul><li>[]<br></li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li>]abc[</li></ul>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ul><li>[]<br></li></ul>",
             });
         });
 
         test("should delete across two list items", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li>ab[cd</li><li>ef]gh</li></ul>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ul><li>ab[]gh</li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li>ab]cd</li><li>ef[gh</li></ul>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ul><li>ab[]gh</li></ul>",
             });
         });
 
         test("should delete across an unindented list item and an indented list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>",
-                stepFunction: deleteBackward,
-                contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>",
                 stepFunction: deleteBackward,
                 contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
             });
         });
 
         test("should delete a list", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<p>abc[</p><ul><li><p>def]</p></li></ul>",
-                stepFunction: deleteBackward,
-                contentAfter: "<p>abc[]</p>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<p>abc]</p><ul><li><p>def[</p></li></ul>",
                 stepFunction: deleteBackward,
                 contentAfter: "<p>abc[]</p>",
             });
         });
 
         test("should merge the contents of a list item within a block into a heading, and leave the rest of its list as it is", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore:
                     '<h1>a[b</h1><p>de</p><custom-block style="display: block;"><ul><li>fg</li><li>h]i</li><li>jk</li></ul></custom-block>',
-                stepFunction: deleteBackward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ul><li>jk</li></ul></custom-block>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ul><li>fg</li><li>h[i</li><li>jk</li></ul></custom-block>',
                 stepFunction: deleteBackward,
                 contentAfter:
                     '<h1>a[]i</h1><custom-block style="display: block;"><ul><li>jk</li></ul></custom-block>',
@@ -2367,37 +2279,22 @@ describe("Selection not collapsed", () => {
     });
     describe("Checklist", () => {
         test("should delete text within a checklist item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li class="o_checked">ab[cd]ef</li></ul>',
-                stepFunction: deleteBackward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]ef</li></ul>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li class="o_checked">ab]cd[ef</li></ul>',
                 stepFunction: deleteBackward,
                 contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]ef</li></ul>',
             });
         });
 
         test("should delete all the text in a checklist item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li class="o_checked">[abc]</li></ul>',
-                stepFunction: deleteBackward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li class="o_checked">]abc[</li></ul>',
                 stepFunction: deleteBackward,
                 contentAfter: '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
             });
         });
 
         describe("should delete across two list items", () => {
-            // Forward selection
             test("should delete across two list items (1)", async () => {
                 await testEditor({
                     contentBefore:
@@ -2414,27 +2311,9 @@ describe("Selection not collapsed", () => {
                     contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
                 });
             });
-            // Backward selection
-            test("should delete across two list items (3)", async () => {
-                await testEditor({
-                    contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="o_checked">ef[gh</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-                });
-            });
-            test("should delete across two list items (4)", async () => {
-                await testEditor({
-                    contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li>ef[gh</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-                });
-            });
         });
 
         describe("should delete across an unindented list item and an indented list item", () => {
-            // Forward selection
             test("should delete across an unindented list item and an indented list item (1)", async () => {
                 await testEditor({
                     contentBefore:
@@ -2456,60 +2335,21 @@ describe("Selection not collapsed", () => {
                     contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
             });
-            // Backward selection
-            test("should delete across an unindented list item and an indented list item (3)", async () => {
-                await testEditor({
-                    contentBefore:
-                        '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-                });
-            });
-            test("should delete across an unindented list item and an indented list item (4)", async () => {
-                await testEditor({
-                    contentBefore:
-                        '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li>ef[gh</li></ul></li></ul>',
-                    stepFunction: deleteBackward,
-                    // The indented list cannot be unchecked while its
-                    // parent is checked: it gets checked automatically
-                    // as a result. So "efgh" gets rendered as checked.
-                    // Given that the parent list item was explicitely
-                    // set as "checked", that status is preserved.
-                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-                });
-            });
         });
 
         test("should delete a checklist", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore:
                     '<p>abc[</p><ul class="o_checklist"><li class="o_checked"><p>def]</p></li></ul>',
                 stepFunction: deleteBackward,
                 contentAfter: "<p>abc[]</p>",
             });
-            // Backward selection
-            await testEditor({
-                contentBefore:
-                    '<p>abc]</p><ul class="o_checklist"><li class="o_checked"><p>def[</p></li></ul>',
-                stepFunction: deleteBackward,
-                contentAfter: "<p>abc[]</p>",
-            });
         });
 
         test("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore:
                     '<h1>a[b</h1><p>de</p><custom-block style="display:block;"><ul class="o_checklist"><li class="o_checked">fg</li><li class="o_checked">h]i</li><li class="o_checked">jk</li></ul></custom-block>',
-                stepFunction: deleteBackward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display:block;"><ul class="o_checklist"><li class="o_checked">jk</li></ul></custom-block>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display:block;"><ul class="o_checklist"><li class="o_checked">fg</li><li class="o_checked">h[i</li><li class="o_checked">jk</li></ul></custom-block>',
                 stepFunction: deleteBackward,
                 contentAfter:
                     '<h1>a[]i</h1><custom-block style="display:block;"><ul class="o_checklist"><li class="o_checked">jk</li></ul></custom-block>',
@@ -2549,50 +2389,26 @@ describe("Selection not collapsed", () => {
     describe("Mixed", () => {
         describe("Ordered to unordered", () => {
             test("should delete across an ordered list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ol><li>ab[cd</li></ol><ul><li>ef]gh</li></ul>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ol><li>ab[]gh</li></ol>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ol><li>ab]cd</li></ol><ul><li>ef[gh</li></ul>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ol><li>ab[]gh</li></ol>",
-                });
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         "<ol><li>ab</li><li>[cd</li></ol><ul><li>ef]</li><li>gh</li></ul>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ol><li>ab</li></ol><ul><li>[]<br></li><li>gh</li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        "<ol><li>ab</li><li>]cd</li></ol><ul><li>ef[</li><li>gh</li></ul>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ol><li>ab</li></ol><ul><li>[]<br></li><li>gh</li></ul>",
-                });
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         "<ol><li>ab</li><li>[cd</li></ol><ul><li>e]f</li><li>gh</li></ul>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ol><li>ab</li></ol><ul><li>[]f</li><li>gh</li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        "<ol><li>ab</li><li>]cd</li></ol><ul><li>e[f</li><li>gh</li></ul>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ol><li>ab</li></ol><ul><li>[]f</li><li>gh</li></ul>",
-                });
             });
 
             test("should delete across an ordered list item and an unordered list item within an ordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ol><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ol>",
                     stepFunction: deleteBackward,
@@ -2603,29 +2419,11 @@ describe("Selection not collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: "<ol><li><p>[]<br></p></li></ol>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ol><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ol>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
-                });
-                await testEditor({
-                    contentBefore: "<ol><li><p>]abcd</p><ul><li>efgh[</li></ul></li></ol>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ol><li><p>[]<br></p></li></ol>",
-                });
             });
 
             test("should delete an ordered list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<p>ab[</p><ul><li>cd</li></ul><ol><li>ef]</li></ol>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<p>ab]</p><ul><li>cd</li></ul><ol><li>ef[</li></ol>",
                     stepFunction: deleteBackward,
                     contentAfter: "<p>ab[]</p>",
                 });
@@ -2633,73 +2431,36 @@ describe("Selection not collapsed", () => {
         });
         describe("Unordered to ordered", () => {
             test("should delete across an unordered list and an ordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ul><li>ab[cd</li></ul><ol><li>ef]gh</li></ol>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ul><li>ab[]gh</li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ul><li>ab]cd</li></ul><ol><li>ef[gh</li></ol>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
-                });
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         "<ul><li>ab</li><li>[cd</li></ul><ol><li>ef]</li><li>gh</li></ol>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ul><li>ab</li></ul><ol><li>[]<br></li><li>gh</li></ol>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        "<ul><li>ab</li><li>]cd</li></ul><ol><li>ef[</li><li>gh</li></ol>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab</li></ul><ol><li>[]<br></li><li>gh</li></ol>",
-                });
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         "<ul><li>ab</li><li>[cd</li></ul><ol><li>e]f</li><li>gh</li></ol>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ul><li>ab</li></ul><ol><li>[]f</li><li>gh</li></ol>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        "<ul><li>ab</li><li>]cd</li></ul><ol><li>e[f</li><li>gh</li></ol>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab</li></ul><ol><li>[]f</li><li>gh</li></ol>",
-                });
             });
 
             test("should delete across an unordered list item and an ordered list item within an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ul><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ul>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ul><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ul>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
             });
 
             test("should delete an ordered list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<p>ab[</p><ol><li>cd</li></ol><ul><li>ef]</li></ul>",
-                    stepFunction: deleteBackward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<p>ab]</p><ol><li>cd</li></ol><ul><li>ef[</li></ul>",
                     stepFunction: deleteBackward,
                     contentAfter: "<p>ab[]</p>",
                 });
@@ -2708,7 +2469,6 @@ describe("Selection not collapsed", () => {
         describe("Checklist to unordered", () => {
             describe("should delete across an checklist list and an unordered list", () => {
                 test("should delete across an checklist list and an unordered list (1)", async () => {
-                    // Forward selection
                     await testEditor({
                         contentBefore:
                             '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li>ef]gh</li></ul>',
@@ -2718,17 +2478,6 @@ describe("Selection not collapsed", () => {
                     });
                 });
                 test("should delete across an checklist list and an unordered list (2)", async () => {
-                    // Backward selection
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li>ef[gh</li></ul>',
-                        stepFunction: deleteBackward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-                    });
-                });
-                test("should delete across an checklist list and an unordered list (3)", async () => {
-                    // Forward selection
                     await testEditor({
                         contentBefore:
                             '<ul class="o_checklist"><li>ab</li><li>[cd</li></ul><ul><li>ef]</li><li>gh</li></ul>',
@@ -2737,18 +2486,7 @@ describe("Selection not collapsed", () => {
                             '<ul class="o_checklist"><li>ab</li></ul><ul><li>[]<br></li><li>gh</li></ul>',
                     });
                 });
-                test("should delete across an checklist list and an unordered list (4)", async () => {
-                    // Backward selection
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li>ab</li><li>]cd</li></ul><ul><li>ef[</li><li>gh</li></ul>',
-                        stepFunction: deleteBackward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li>ab</li></ul><ul><li>[]<br></li><li>gh</li></ul>',
-                    });
-                });
-                test("should delete across an checklist list and an unordered list (5)", async () => {
-                    // Forward selection
+                test("should delete across an checklist list and an unordered list (3)", async () => {
                     await testEditor({
                         contentBefore:
                             '<ul class="o_checklist"><li>ab</li><li>[cd</li></ul><ul><li>e]f</li><li>gh</li></ul>',
@@ -2757,47 +2495,21 @@ describe("Selection not collapsed", () => {
                             '<ul class="o_checklist"><li>ab</li></ul><ul><li>[]f</li><li>gh</li></ul>',
                     });
                 });
-                test("should delete across an checklist list and an unordered list (6)", async () => {
-                    // Backward selection
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li>ab</li><li>]cd</li></ul><ul><li>e[f</li><li>gh</li></ul>',
-                        stepFunction: deleteBackward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li>ab</li></ul><ul><li>[]f</li><li>gh</li></ul>',
-                    });
-                });
             });
 
             test("should delete across an checklist list item and an unordered list item within an checklist list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul class="o_checklist"><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
                     contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul class="o_checklist"><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-                });
             });
 
             test("should delete an checklist list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<p>ab[</p><ul><li>cd</li></ul><ul class="o_checklist"><li class="o_checked">ef]</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<p>ab]</p><ul><li>cd</li></ul><ul class="o_checklist"><li class="o_checked">ef[</li></ul>',
                     stepFunction: deleteBackward,
                     contentAfter: "<p>ab[]</p>",
                 });
@@ -2805,21 +2517,12 @@ describe("Selection not collapsed", () => {
         });
         describe("Unordered to checklist", () => {
             test("should delete across an unordered list and an checklist list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul><li>ab[cd</li></ul><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul>',
                     stepFunction: deleteBackward,
                     contentAfter: "<ul><li>ab[]gh</li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul><li>ab]cd</li></ul><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
-                });
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul><li>ab</li><li>[cd</li></ul><ul class="o_checklist"><li>ef]</li><li>gh</li></ul>',
@@ -2827,15 +2530,6 @@ describe("Selection not collapsed", () => {
                     contentAfter:
                         '<ul><li>ab</li></ul><ul class="o_checklist"><li>[]<br></li><li>gh</li></ul>',
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul><li>ab</li><li>]cd</li></ul><ul class="o_checklist"><li>ef[</li><li>gh</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter:
-                        '<ul><li>ab</li></ul><ul class="o_checklist"><li>[]<br></li><li>gh</li></ul>',
-                });
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul><li>ab</li><li>[cd</li></ul><ul class="o_checklist"><li>e]f</li><li>gh</li></ul>',
@@ -2843,45 +2537,21 @@ describe("Selection not collapsed", () => {
                     contentAfter:
                         '<ul><li>ab</li></ul><ul class="o_checklist"><li>[]f</li><li>gh</li></ul>',
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul><li>ab</li><li>]cd</li></ul><ul class="o_checklist"><li>e[f</li><li>gh</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter:
-                        '<ul><li>ab</li></ul><ul class="o_checklist"><li>[]f</li><li>gh</li></ul>',
-                });
             });
 
             test("should delete across an unordered list item and an checklist list item within an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
                     contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
-                });
             });
 
             test("should delete an checklist list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<p>ab[</p><ul class="o_checklist"><li class="o_checked">cd</li></ul><ul><li>ef]</li></ul>',
-                    stepFunction: deleteBackward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<p>ab]</p><ul class="o_checklist"><li class="o_checked">cd</li></ul><ul><li>ef[</li></ul>',
                     stepFunction: deleteBackward,
                     contentAfter: "<p>ab[]</p>",
                 });

--- a/addons/html_editor/static/tests/list/delete_forward.test.js
+++ b/addons/html_editor/static/tests/list/delete_forward.test.js
@@ -670,93 +670,49 @@ describe("Selection not collapsed", () => {
     // with unordered lists and checklists, and vice versae.
     describe("Ordered", () => {
         test("should delete text within a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li>ab[cd]ef</li></ol>",
-                stepFunction: deleteForward,
-                contentAfter: "<ol><li>ab[]ef</li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li>ab]cd[ef</li></ol>",
                 stepFunction: deleteForward,
                 contentAfter: "<ol><li>ab[]ef</li></ol>",
             });
         });
 
         test("should delete all the text in a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li>[abc]</li></ol>",
-                stepFunction: deleteForward,
-                contentAfter: "<ol><li>[]<br></li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li>]abc[</li></ol>",
                 stepFunction: deleteForward,
                 contentAfter: "<ol><li>[]<br></li></ol>",
             });
         });
 
         test("should delete across two list items", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li>ab[cd</li><li>ef]gh</li></ol>",
-                stepFunction: deleteForward,
-                contentAfter: "<ol><li>ab[]gh</li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li>ab]cd</li><li>ef[gh</li></ol>",
                 stepFunction: deleteForward,
                 contentAfter: "<ol><li>ab[]gh</li></ol>",
             });
         });
 
         test("should delete across an unindented list item and an indented list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ol><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ol>",
-                stepFunction: deleteForward,
-                contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ol><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ol>",
                 stepFunction: deleteForward,
                 contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
             });
         });
 
         test("should delete a list", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<p>abc[</p><ol><li><p>def]</p></li></ol>",
-                stepFunction: deleteForward,
-                contentAfter: "<p>abc[]</p>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<p>abc]</p><ol><li><p>def[</p></li></ol>",
                 stepFunction: deleteForward,
                 contentAfter: "<p>abc[]</p>",
             });
         });
 
         test("should merge the contents of a list item within a block into a heading, and leave the rest of its list as it is", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore:
                     '<h1>a[b</h1><p>de</p><custom-block style="display:block;"><ol><li>fg</li><li>h]i</li><li>jk</li></ol></custom-block>',
-                stepFunction: deleteForward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display:block;"><ol><li>jk</li></ol></custom-block>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display:block;"><ol><li>fg</li><li>h[i</li><li>jk</li></ol></custom-block>',
                 stepFunction: deleteForward,
                 contentAfter:
                     '<h1>a[]i</h1><custom-block style="display:block;"><ol><li>jk</li></ol></custom-block>',
@@ -766,93 +722,49 @@ describe("Selection not collapsed", () => {
 
     describe("Unordered", () => {
         test("should delete text within a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li>ab[cd]ef</li></ul>",
-                stepFunction: deleteForward,
-                contentAfter: "<ul><li>ab[]ef</li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li>ab]cd[ef</li></ul>",
                 stepFunction: deleteForward,
                 contentAfter: "<ul><li>ab[]ef</li></ul>",
             });
         });
 
         test("should delete all the text in a list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li>[abc]</li></ul>",
-                stepFunction: deleteForward,
-                contentAfter: "<ul><li>[]<br></li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li>]abc[</li></ul>",
                 stepFunction: deleteForward,
                 contentAfter: "<ul><li>[]<br></li></ul>",
             });
         });
 
         test("should delete across two list items", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li>ab[cd</li><li>ef]gh</li></ul>",
-                stepFunction: deleteForward,
-                contentAfter: "<ul><li>ab[]gh</li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li>ab]cd</li><li>ef[gh</li></ul>",
                 stepFunction: deleteForward,
                 contentAfter: "<ul><li>ab[]gh</li></ul>",
             });
         });
 
         test("should delete across an unindented list item and an indented list item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<ul><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>",
-                stepFunction: deleteForward,
-                contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<ul><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>",
                 stepFunction: deleteForward,
                 contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
             });
         });
 
         test("should delete a list", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: "<p>abc[</p><ul><li><p>def]</p></li></ul>",
-                stepFunction: deleteForward,
-                contentAfter: "<p>abc[]</p>",
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore: "<p>abc]</p><ul><li><p>def[</p></li></ul>",
                 stepFunction: deleteForward,
                 contentAfter: "<p>abc[]</p>",
             });
         });
 
         test("should merge the contents of a list item within a block into a heading, and leave the rest of its list as it is", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore:
                     '<h1>a[b</h1><p>de</p><custom-block style="display: block;"><ul><li>fg</li><li>h]i</li><li>jk</li></ul></custom-block>',
-                stepFunction: deleteForward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ul><li>jk</li></ul></custom-block>',
-            });
-            // Backward selection
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ul><li>fg</li><li>h[i</li><li>jk</li></ul></custom-block>',
                 stepFunction: deleteForward,
                 contentAfter:
                     '<h1>a[]i</h1><custom-block style="display: block;"><ul><li>jk</li></ul></custom-block>',
@@ -861,7 +773,6 @@ describe("Selection not collapsed", () => {
     });
     describe("Checklist", () => {
         test("should delete text within a checklist item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li class="o_checked">ab[cd]ef</li></ul>',
                 stepFunction: deleteForward,
@@ -872,21 +783,9 @@ describe("Selection not collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: '<ul class="o_checklist"><li>ab[]ef</li></ul>',
             });
-            // Backward selection
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li class="o_checked">ab]cd[ef</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]ef</li></ul>',
-            });
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li>ab]cd[ef</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li>ab[]ef</li></ul>',
-            });
         });
 
         test("should delete all the text in a checklist item", async () => {
-            // Forward selection
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li class="o_checked">[abc]</li></ul>',
                 stepFunction: deleteForward,
@@ -897,21 +796,9 @@ describe("Selection not collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: '<ul class="o_checklist"><li>[]<br></li></ul>',
             });
-            // Backward selection
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li class="o_checked">]abc[</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
-            });
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li>]abc[</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li>[]<br></li></ul>',
-            });
         });
 
         describe("should delete across two list items", () => {});
-        // Forward selection
         test("should delete across two list items (1)", async () => {
             await testEditor({
                 contentBefore:
@@ -943,42 +830,9 @@ describe("Selection not collapsed", () => {
                 contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
             });
         });
-        // Backward selection
-        test("should delete across two list items (5)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="o_checked">ef[gh</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-            });
-        });
-        test("should delete across two list items (6)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li>ab]cd</li><li class="o_checked">ef[gh</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
-            });
-        });
-        test("should delete across two list items (7)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li>ef[gh</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-            });
-        });
-        test("should delete across two list items (8)", async () => {
-            await testEditor({
-                contentBefore: '<ul class="o_checklist"><li>ab]cd</li><li>ef[gh</li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
-            });
-        });
     });
 
     describe("should delete across an unindented list item and an indented list item", () => {
-        // Forward selection
         test("should delete across an unindented list item and an indented list item (1)", async () => {
             await testEditor({
                 contentBefore:
@@ -1009,56 +863,17 @@ describe("Selection not collapsed", () => {
                 contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
-        // Backward selection
-        test("should delete across an unindented list item and an indented list item (4)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
-                stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-            });
-        });
-        test("should delete across an unindented list item and an indented list item (5)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li>ef[gh</li></ul></li></ul>',
-                stepFunction: deleteForward,
-                // The indented list's parent gets rendered as
-                // checked because its only child is checked.
-                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-            });
-        });
-        test("should delete across an unindented list item and an indented list item (6)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
-                stepFunction: deleteForward,
-                // The indented list's parent gets rendered as
-                // checked because its only child is checked. When
-                // we remove that child, the checklist gets
-                // unchecked because it becomes independant again.
-                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-            });
-        });
     });
 
     test("should delete a checklist", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: '<p>abc[</p><ul class="o_checklist"><li><p>def]</p></li></ul>',
-            stepFunction: deleteForward,
-            contentAfter: "<p>abc[]</p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: '<p>abc]</p><ul class="o_checklist"><li><p>def[</p></li></ul>',
             stepFunction: deleteForward,
             contentAfter: "<p>abc[]</p>",
         });
     });
 
     describe("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is", () => {
-        // Forward selection
         test("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is (1)", async () => {
             await testEditor({
                 contentBefore:
@@ -1095,86 +910,28 @@ describe("Selection not collapsed", () => {
                     '<h1>a[]i</h1><custom-block style="display: block;"><ul class="o_checklist"><li>jk</li></ul></custom-block>',
             });
         });
-        // Backward selection
-        test("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is (5)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ul class="o_checklist"><li>fg</li><li class="o_checked">h[i</li><li class="o_checked">jk</li></ul></custom-block>',
-                stepFunction: deleteForward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ul class="o_checklist"><li class="o_checked">jk</li></ul></custom-block>',
-            });
-        });
-        test("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is (6)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ul class="o_checklist"><li>fg</li><li>h[i</li><li class="o_checked">jk</li></ul></custom-block>',
-                stepFunction: deleteForward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ul class="o_checklist"><li class="o_checked">jk</li></ul></custom-block>',
-            });
-        });
-        test("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is (7)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ul class="o_checklist"><li>fg</li><li class="o_checked">h[i</li><li>jk</li></ul></custom-block>',
-                stepFunction: deleteForward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ul class="o_checklist"><li>jk</li></ul></custom-block>',
-            });
-        });
-        test("should merge the contents of a checklist item within a block into a heading, and leave the rest of its list as it is (8)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<h1>a]b</h1><p>de</p><custom-block style="display: block;"><ul class="o_checklist"><li>fg</li><li>h[i</li><li>jk</li></ul></custom-block>',
-                stepFunction: deleteForward,
-                contentAfter:
-                    '<h1>a[]i</h1><custom-block style="display: block;"><ul class="o_checklist"><li>jk</li></ul></custom-block>',
-            });
-        });
     });
     describe("Mixed", () => {
         describe("Ordered to unordered", () => {
             test("should delete across an ordered list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ol><li>ab[cd</li></ol><ul><li>ef]gh</li></ul>",
-                    stepFunction: deleteForward,
-                    contentAfter: "<ol><li>ab[]gh</li></ol>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ol><li>ab]cd</li></ol><ul><li>ef[gh</li></ul>",
                     stepFunction: deleteForward,
                     contentAfter: "<ol><li>ab[]gh</li></ol>",
                 });
             });
 
             test("should delete across an ordered list item and an unordered list item within an ordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ol><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ol>",
-                    stepFunction: deleteForward,
-                    contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ol><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ol>",
                     stepFunction: deleteForward,
                     contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
                 });
             });
 
             test("should delete an ordered list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<p>ab[</p><ul><li>cd</li></ul><ol><li>ef]</li></ol>",
-                    stepFunction: deleteForward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<p>ab]</p><ul><li>cd</li></ul><ol><li>ef[</li></ol>",
                     stepFunction: deleteForward,
                     contentAfter: "<p>ab[]</p>",
                 });
@@ -1182,45 +939,24 @@ describe("Selection not collapsed", () => {
         });
         describe("Unordered to ordered", () => {
             test("should delete across an unordered list and an ordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ul><li>ab[cd</li></ul><ol><li>ef]gh</li></ol>",
-                    stepFunction: deleteForward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ul><li>ab]cd</li></ul><ol><li>ef[gh</li></ol>",
                     stepFunction: deleteForward,
                     contentAfter: "<ul><li>ab[]gh</li></ul>",
                 });
             });
 
             test("should delete across an unordered list item and an ordered list item within an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<ul><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ul>",
-                    stepFunction: deleteForward,
-                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<ul><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ul>",
                     stepFunction: deleteForward,
                     contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
             });
 
             test("should delete an ordered list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore: "<p>ab[</p><ol><li>cd</li></ol><ul><li>ef]</li></ul>",
-                    stepFunction: deleteForward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore: "<p>ab]</p><ol><li>cd</li></ol><ul><li>ef[</li></ul>",
                     stepFunction: deleteForward,
                     contentAfter: "<p>ab[]</p>",
                 });
@@ -1229,7 +965,6 @@ describe("Selection not collapsed", () => {
         describe("Checklist to unordered", () => {
             describe("should delete across an checklist list and an unordered list", () => {
                 test("should delete across an checklist list and an unordered list (1)", async () => {
-                    // Forward selection
                     await testEditor({
                         contentBefore:
                             '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li class="o_checked">ef]gh</li></ul>',
@@ -1241,21 +976,13 @@ describe("Selection not collapsed", () => {
                 test("should delete across an checklist list and an unordered list (2)", async () => {
                     await testEditor({
                         contentBefore:
-                            '<ul class="o_checklist"><li>ab[cd</li></ul><ul><li class="o_checked">ef]gh</li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
-                    });
-                });
-                test("should delete across an checklist list and an unordered list (3)", async () => {
-                    await testEditor({
-                        contentBefore:
                             '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li>ef]gh</li></ul>',
                         stepFunction: deleteForward,
                         contentAfter:
                             '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
                     });
                 });
-                test("should delete across an checklist list and an unordered list (4)", async () => {
+                test("should delete across an checklist list and an unordered list (3)", async () => {
                     await testEditor({
                         contentBefore:
                             '<ul class="o_checklist"><li>ab[cd</li></ul><ul><li>ef]gh</li></ul>',
@@ -1263,45 +990,9 @@ describe("Selection not collapsed", () => {
                         contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
                     });
                 });
-                test("should delete across an checklist list and an unordered list (5)", async () => {
-                    // Backward selection
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li class="o_checked">ef[gh</li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-                    });
-                });
-                test("should delete across an checklist list and an unordered list (6)", async () => {
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li>ab]cd</li></ul><ul><li class="o_checked">ef[gh</li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
-                    });
-                });
-                test("should delete across an checklist list and an unordered list (7)", async () => {
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li>ef[gh</li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
-                    });
-                });
-                test("should delete across an checklist list and an unordered list (8)", async () => {
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li>ab]cd</li></ul><ul><li>ef[gh</li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
-                    });
-                });
             });
 
             describe("should delete across an checklist list item and an unordered list item within an checklist list", () => {
-                // Forward selection
                 test("should delete across an checklist list item and an unordered list item within an checklist list (1)", async () => {
                     await testEditor({
                         contentBefore:
@@ -1318,37 +1009,12 @@ describe("Selection not collapsed", () => {
                         contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                     });
                 });
-                // Backward selection
-                test("should delete across an checklist list item and an unordered list item within an checklist list (3)", async () => {
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li><p>ab]cd</p><ul><li class="o_checked">ef[gh</li></ul></li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-                    });
-                });
-                test("should delete across an checklist list item and an unordered list item within an checklist list (4)", async () => {
-                    await testEditor({
-                        contentBefore:
-                            '<ul class="o_checklist"><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>',
-                        stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
-                    });
-                });
             });
 
             test("should delete an checklist list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<p>ab[</p><ul><li>cd</li></ul><ul class="o_checklist"><li class="o_checked">ef]</li></ul>',
-                    stepFunction: deleteForward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<p>ab]</p><ul><li>cd</li></ul><ul class="o_checklist"><li class="o_checked">ef[</li></ul>',
                     stepFunction: deleteForward,
                     contentAfter: "<p>ab[]</p>",
                 });
@@ -1356,51 +1022,27 @@ describe("Selection not collapsed", () => {
         });
         describe("Unordered to checklist", () => {
             test("should delete across an unordered list and an checklist list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul><li>ab[cd</li></ul><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul>',
                     stepFunction: deleteForward,
                     contentAfter: "<ul><li>ab[]gh</li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul><li>ab]cd</li></ul><ul class="o_checklist"><li>ef[gh</li></ul>',
-                    stepFunction: deleteForward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
-                });
             });
 
             test("should delete across an unordered list item and an checklist list item within an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<ul><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                     stepFunction: deleteForward,
                     contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<ul><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
-                    stepFunction: deleteForward,
-                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
-                });
             });
 
             test("should delete an checklist list and an unordered list", async () => {
-                // Forward selection
                 await testEditor({
                     contentBefore:
                         '<p>ab[</p><ul class="o_checklist"><li class="o_checked">cd</li></ul><ul><li>ef]</li></ul>',
-                    stepFunction: deleteForward,
-                    contentAfter: "<p>ab[]</p>",
-                });
-                // Backward selection
-                await testEditor({
-                    contentBefore:
-                        '<p>ab]</p><ul class="o_checklist"><li class="o_checked">cd</li></ul><ul><li>ef[</li></ul>',
                     stepFunction: deleteForward,
                     contentAfter: "<p>ab[]</p>",
                 });

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -886,78 +886,41 @@ describe("Selection collapsed", () => {
 });
 describe("Selection not collapsed", () => {
     test("should delete part of a list item, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<ul><li>ab[cd]ef</li></ul>",
-            stepFunction: splitBlock,
-            contentAfter: "<ul><li>ab</li><li>[]ef</li></ul>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<ul><li>ab]cd[ef</li></ul>",
             stepFunction: splitBlock,
             contentAfter: "<ul><li>ab</li><li>[]ef</li></ul>",
         });
     });
 
     test("should delete all contents of a list item, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<ul><li>[abc]</li></ul>",
             stepFunction: splitBlock,
             // JW cAfter: '<ul><li><br></li><li>[]<br></li></ul>',
             contentAfter: "<p>[]<br></p>",
         });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<ul><li>]abc[</li></ul>",
-            stepFunction: splitBlock,
-            contentAfter: "<p>[]<br></p>",
-            // JW cAfter: '<ul><li><br></li><li>[]<br></li></ul>',
-        });
     });
 
     test("should delete across two list items, then split what's left", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<ul><li>ab[cd</li><li>ef]gh</li></ul>",
-            stepFunction: splitBlock,
-            contentAfter: "<ul><li>ab</li><li>[]gh</li></ul>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<ul><li>ab]cd</li><li>ef[gh</li></ul>",
             stepFunction: splitBlock,
             contentAfter: "<ul><li>ab</li><li>[]gh</li></ul>",
         });
     });
 
     test("should delete part of a checklist item, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<ul><li>ab[cd]ef</li></ul>",
-            stepFunction: splitBlock,
-            contentAfter: "<ul><li>ab</li><li>[]ef</li></ul>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<ul><li>ab]cd[ef</li></ul>",
             stepFunction: splitBlock,
             contentAfter: "<ul><li>ab</li><li>[]ef</li></ul>",
         });
     });
 
     test("should delete all contents of a checklist item, then split it", async () => {
-        // Forward selection
         await testEditor({
             contentBefore: "<ul><li>[abc]</li></ul>",
-            stepFunction: splitBlock,
-            // JW cAfter: '<ul><li><br></li><li>[]<br></li></ul>',
-            contentAfter: "<p>[]<br></p>",
-        });
-        // Backward selection
-        await testEditor({
-            contentBefore: "<ul><li>]abc[</li></ul>",
             stepFunction: splitBlock,
             // JW cAfter: '<ul><li><br></li><li>[]<br></li></ul>',
             contentAfter: "<p>[]<br></p>",

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -648,30 +648,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a multi-line paragraph into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>]a<br>b<br>c<br>d<br>e[</p>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<ul class="o_checklist"><li>]a</li><li>b</li><li>c</li><li>d</li><li>e[</li></ul>',
-            });
-        });
-
         test("should turn the first few lines of a paragraph into a checklist with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>[a<br>b<br>c]<br>d<br>e</p>",
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<ul class="o_checklist"><li>[a</li><li>b</li><li>c]</li></ul><p>d<br>e</p>',
-            });
-        });
-
-        test("should turn the first few lines of a paragraph into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>]a<br>b<br>c[<br>d<br>e</p>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<ul class="o_checklist"><li>]a</li><li>b</li><li>c[</li></ul><p>d<br>e</p>',
             });
         });
 
@@ -684,30 +666,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn the middle few lines of a paragraph into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>]b<br>c<br>d[<br>e</p>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>a</p><ul class="o_checklist"><li>]b</li><li>c</li><li>d[</li></ul><p>e</p>',
-            });
-        });
-
         test("should turn a last few lines of a paragraph into a checklist with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>a<br>b<br>[c<br>d<br>e]</p>",
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<p>a<br>b</p><ul class="o_checklist"><li>[c</li><li>d</li><li>e]</li></ul>',
-            });
-        });
-
-        test("should turn a last few lines of a paragraph into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>b<br>]c<br>d<br>e[</p>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>a<br>b</p><ul class="o_checklist"><li>]c</li><li>d</li><li>e[</li></ul>',
             });
         });
 
@@ -728,30 +692,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a multi-line heading into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c<br>d<br>e[FG</h1>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>xy</p><ul class="o_checklist"><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e[FG</h1></li></ul>',
-            });
-        });
-
         test("should turn the first few lines of a heading into a checklist with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c]<br>d<br>e</h1>",
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<p>xy</p><ul class="o_checklist"><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c]</h1></li></ul><h1>d<br>e</h1>',
-            });
-        });
-
-        test("should turn the first few lines of a heading into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c[<br>d<br>e</h1>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>xy</p><ul class="o_checklist"><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c[</h1></li></ul><h1>d<br>e</h1>',
             });
         });
 
@@ -764,30 +710,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn the middle few lines of a heading into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>a<br>AB]b<br>c<br>d[EF<br>e</h1>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>xy</p><h1>a</h1><ul class="o_checklist"><li><h1>AB]b</h1></li><li><h1>c</h1></li><li><h1>d[EF</h1></li></ul><h1>e</h1>',
-            });
-        });
-
         test("should turn a last few lines of a heading into a checklist with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>xy</p><h1>a<br>b<br>AB[c<br>d<br>e]EF</h1>",
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<p>xy</p><h1>a<br>b</h1><ul class="o_checklist"><li><h1>AB[c</h1></li><li><h1>d</h1></li><li><h1>e]EF</h1></li></ul>',
-            });
-        });
-
-        test("should turn a last few lines of a heading into a checklist with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>a<br>b<br>AB]c<br>d<br>e[EF</h1>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>xy</p><h1>a<br>b</h1><ul class="o_checklist"><li><h1>AB]c</h1></li><li><h1>d</h1></li><li><h1>e[EF</h1></li></ul>',
             });
         });
 
@@ -808,15 +736,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn four lines over two paragraphs into a checklist with four items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>ab</p><p>c<br>d]e<br>f</p><p>g<br>h[i<br>j</p>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>ab</p><p>c</p><ul class="o_checklist"><li>d]e</li><li>f</li><li>g</li><li>h[i</li></ul><p>j</p>',
-            });
-        });
-
         test("should turn two paragraphs in a div into a checklist with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
@@ -832,15 +751,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<div><p>a</p><ul class="o_checklist"><li>b[c</li><li>d</li><li>e</li><li>f]g</li></ul><p>h</p></div>',
-            });
-        });
-
-        test("should turn four lines over two paragraphs in a div into a checklist with four items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<div><p>a<br>b]c<br>d</p><p>e<br>f[g<br>h</p></div>",
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<div><p>a</p><ul class="o_checklist"><li>b]c</li><li>d</li><li>e</li><li>f[g</li></ul><p>h</p></div>',
             });
         });
 
@@ -878,23 +788,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn two lines of a paragraph and a checklist item into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c[d</li><li>ef</li></ul>',
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c[d</li><li>ef</li></ul>',
-            });
-            await testEditor({
-                contentBefore:
-                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c[d</li><li class="o_checked">ef</li></ul>',
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c[d</li><li class="o_checked">ef</li></ul>',
-            });
-        });
-
         test("should turn two lines of a paragraph and two lines of a checklist item into four list items", async () => {
             // TODO: is this what we want?
             await testEditor({
@@ -910,24 +803,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<p>a</p><ul class="o_checklist"><li>x[b</li><li>y</li><li class="o_checked">c<br>z]d<br>A</li><li class="o_checked">ef</li></ul>',
-            });
-        });
-
-        test("should turn two lines of a paragraph and two lines of a checklist item into four list items (reversed selection)", async () => {
-            // TODO: is this what we want?
-            await testEditor({
-                contentBefore:
-                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c<br>z[d<br>A</li><li>ef</li></ul>',
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c<br>z[d<br>A</li><li>ef</li></ul>',
-            });
-            await testEditor({
-                contentBefore:
-                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c<br>z[d<br>A</li><li class="o_checked">ef</li></ul>',
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c<br>z[d<br>A</li><li class="o_checked">ef</li></ul>',
             });
         });
 
@@ -951,16 +826,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a checklist item and two lines of a paragraph into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d</li></ul><p>e<br>x[f<br>g</p>',
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d</li><li>e</li><li>x[f</li></ul><p>g</p>',
-            });
-        });
-
         test("should turn two lines of a checklist item and two lines of a paragraph into three list items", async () => {
             await testEditor({
                 contentBefore:
@@ -968,16 +833,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d<br>A</li><li>e</li><li>x]f</li></ul><p>g</p>',
-            });
-        });
-
-        test("should turn two lines of a checklist item and two lines of a paragraph into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore:
-                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d<br>A</li></ul><p>e<br>x[f<br>g</p>',
-                stepFunction: toggleCheckList,
-                contentAfter:
-                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d<br>A</li><li>e</li><li>x[f</li></ul><p>g</p>',
             });
         });
 

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -442,27 +442,11 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a multi-line paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>]a<br>b<br>c<br>d<br>e[</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<ol><li>]a</li><li>b</li><li>c</li><li>d</li><li>e[</li></ol>",
-            });
-        });
-
         test("should turn the first few lines of a paragraph into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>[a<br>b<br>c]<br>d<br>e</p>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<ol><li>[a</li><li>b</li><li>c]</li></ol><p>d<br>e</p>",
-            });
-        });
-
-        test("should turn the first few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>]a<br>b<br>c[<br>d<br>e</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<ol><li>]a</li><li>b</li><li>c[</li></ol><p>d<br>e</p>",
             });
         });
 
@@ -474,27 +458,11 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn the middle few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>]b<br>c<br>d[<br>e</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<p>a</p><ol><li>]b</li><li>c</li><li>d[</li></ol><p>e</p>",
-            });
-        });
-
         test("should turn a last few lines of a paragraph into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>a<br>b<br>[c<br>d<br>e]</p>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<p>a<br>b</p><ol><li>[c</li><li>d</li><li>e]</li></ol>",
-            });
-        });
-
-        test("should turn a last few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>b<br>]c<br>d<br>e[</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<p>a<br>b</p><ol><li>]c</li><li>d</li><li>e[</li></ol>",
             });
         });
 
@@ -515,30 +483,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a multi-line heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c<br>d<br>e[FG</h1>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<p>xy</p><ol><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e[FG</h1></li></ol>",
-            });
-        });
-
         test("should turn the first few lines of a heading into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c]<br>d<br>e</h1>",
                 stepFunction: toggleOrderedList,
                 contentAfter:
                     "<p>xy</p><ol><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c]</h1></li></ol><h1>d<br>e</h1>",
-            });
-        });
-
-        test("should turn the first few lines of a heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c[<br>d<br>e</h1>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<p>xy</p><ol><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c[</h1></li></ol><h1>d<br>e</h1>",
             });
         });
 
@@ -551,30 +501,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn the middle few lines of a heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>a<br>AB]b<br>c<br>d[EF<br>e</h1>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<p>xy</p><h1>a</h1><ol><li><h1>AB]b</h1></li><li><h1>c</h1></li><li><h1>d[EF</h1></li></ol><h1>e</h1>",
-            });
-        });
-
         test("should turn a last few lines of a heading into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>xy</p><h1>a<br>b<br>AB[c<br>d<br>e]EF</h1>",
                 stepFunction: toggleOrderedList,
                 contentAfter:
                     "<p>xy</p><h1>a<br>b</h1><ol><li><h1>AB[c</h1></li><li><h1>d</h1></li><li><h1>e]EF</h1></li></ol>",
-            });
-        });
-
-        test("should turn a last few lines of a heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>a<br>b<br>AB]c<br>d<br>e[EF</h1>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<p>xy</p><h1>a<br>b</h1><ol><li><h1>AB]c</h1></li><li><h1>d</h1></li><li><h1>e[EF</h1></li></ol>",
             });
         });
 
@@ -595,15 +527,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn four lines over two paragraphs into a list with four items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>ab</p><p>c<br>d]e<br>f</p><p>g<br>h[i<br>j</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<p>ab</p><p>c</p><ol><li>d]e</li><li>f</li><li>g</li><li>h[i</li></ol><p>j</p>",
-            });
-        });
-
         test("should turn two paragraphs in a div into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
@@ -618,15 +541,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleOrderedList,
                 contentAfter:
                     "<div><p>a</p><ol><li>b[c</li><li>d</li><li>e</li><li>f]g</li></ol><p>h</p></div>",
-            });
-        });
-
-        test("should turn four lines over two paragraphs in a div into a list with four items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<div><p>a<br>b]c<br>d</p><p>e<br>f[g<br>h</p></div>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<div><p>a</p><ol><li>b]c</li><li>d</li><li>e</li><li>f[g</li></ol><p>h</p></div>",
             });
         });
 
@@ -646,14 +560,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn two lines of a paragraph and a list item into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>x]b<br>y</p><ol><li>c[d</li><li>ef</li></ol>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<p>a</p><ol><li>x]b</li><li>y</li><li>c[d</li><li>ef</li></ol>",
-            });
-        });
-
         test("should turn two lines of a paragraph and two lines of a list item into four list items", async () => {
             // TODO: is this what we want?
             await testEditor({
@@ -661,16 +567,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleOrderedList,
                 contentAfter:
                     "<p>a</p><ol><li>x[b</li><li>y</li><li>c<br>z]d<br>A</li><li>ef</li></ol>",
-            });
-        });
-
-        test("should turn two lines of a paragraph and two lines of a list item into four list items (reversed selection)", async () => {
-            // TODO: is this what we want?
-            await testEditor({
-                contentBefore: "<p>a<br>x]b<br>y</p><ol><li>c<br>z[d<br>A</li><li>ef</li></ol>",
-                stepFunction: toggleOrderedList,
-                contentAfter:
-                    "<p>a</p><ol><li>x]b</li><li>y</li><li>c<br>z[d<br>A</li><li>ef</li></ol>",
             });
         });
 
@@ -690,27 +586,11 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<ol><li>ab</li><li>c]d</li></ol><p>e<br>x[f<br>g</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<ol><li>ab</li><li>c]d</li><li>e</li><li>x[f</li></ol><p>g</p>",
-            });
-        });
-
         test("should turn two lines of a list item and two lines of a paragraph into three list items", async () => {
             await testEditor({
                 contentBefore: "<ol><li>ab</li><li>c[d<br>A</li></ol><p>e<br>x]f<br>g</p>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<ol><li>ab</li><li>c[d<br>A</li><li>e</li><li>x]f</li></ol><p>g</p>",
-            });
-        });
-
-        test("should turn two lines of a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<ol><li>ab</li><li>c]d<br>A</li></ol><p>e<br>x[f<br>g</p>",
-                stepFunction: toggleOrderedList,
-                contentAfter: "<ol><li>ab</li><li>c]d<br>A</li><li>e</li><li>x[f</li></ol><p>g</p>",
             });
         });
 

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -502,27 +502,11 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a multi-line paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>]a<br>b<br>c<br>d<br>e[</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<ul><li>]a</li><li>b</li><li>c</li><li>d</li><li>e[</li></ul>",
-            });
-        });
-
         test("should turn the first few lines of a paragraph into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>[a<br>b<br>c]<br>d<br>e</p>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<ul><li>[a</li><li>b</li><li>c]</li></ul><p>d<br>e</p>",
-            });
-        });
-
-        test("should turn the first few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>]a<br>b<br>c[<br>d<br>e</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<ul><li>]a</li><li>b</li><li>c[</li></ul><p>d<br>e</p>",
             });
         });
 
@@ -534,27 +518,11 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn the middle few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>]b<br>c<br>d[<br>e</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<p>a</p><ul><li>]b</li><li>c</li><li>d[</li></ul><p>e</p>",
-            });
-        });
-
         test("should turn a last few lines of a paragraph into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>a<br>b<br>[c<br>d<br>e]</p>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<p>a<br>b</p><ul><li>[c</li><li>d</li><li>e]</li></ul>",
-            });
-        });
-
-        test("should turn a last few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>b<br>]c<br>d<br>e[</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<p>a<br>b</p><ul><li>]c</li><li>d</li><li>e[</li></ul>",
             });
         });
 
@@ -575,30 +543,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a multi-line heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c<br>d<br>e[FG</h1>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<p>xy</p><ul><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e[FG</h1></li></ul>",
-            });
-        });
-
         test("should turn the first few lines of a heading into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c]<br>d<br>e</h1>",
                 stepFunction: toggleUnorderedList,
                 contentAfter:
                     "<p>xy</p><ul><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c]</h1></li></ul><h1>d<br>e</h1>",
-            });
-        });
-
-        test("should turn the first few lines of a heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c[<br>d<br>e</h1>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<p>xy</p><ul><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c[</h1></li></ul><h1>d<br>e</h1>",
             });
         });
 
@@ -611,30 +561,12 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn the middle few lines of a heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>a<br>AB]b<br>c<br>d[EF<br>e</h1>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<p>xy</p><h1>a</h1><ul><li><h1>AB]b</h1></li><li><h1>c</h1></li><li><h1>d[EF</h1></li></ul><h1>e</h1>",
-            });
-        });
-
         test("should turn a last few lines of a heading into a list with multiple items", async () => {
             await testEditor({
                 contentBefore: "<p>xy</p><h1>a<br>b<br>AB[c<br>d<br>e]EF</h1>",
                 stepFunction: toggleUnorderedList,
                 contentAfter:
                     "<p>xy</p><h1>a<br>b</h1><ul><li><h1>AB[c</h1></li><li><h1>d</h1></li><li><h1>e]EF</h1></li></ul>",
-            });
-        });
-
-        test("should turn a last few lines of a heading into a list with multiple items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>xy</p><h1>a<br>b<br>AB]c<br>d<br>e[EF</h1>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<p>xy</p><h1>a<br>b</h1><ul><li><h1>AB]c</h1></li><li><h1>d</h1></li><li><h1>e[EF</h1></li></ul>",
             });
         });
 
@@ -655,15 +587,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn four lines over two paragraphs into a list with four items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>ab</p><p>c<br>d]e<br>f</p><p>g<br>h[i<br>j</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<p>ab</p><p>c</p><ul><li>d]e</li><li>f</li><li>g</li><li>h[i</li></ul><p>j</p>",
-            });
-        });
-
         test("should turn two paragraphs in a div into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
@@ -678,15 +601,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleUnorderedList,
                 contentAfter:
                     "<div><p>a</p><ul><li>b[c</li><li>d</li><li>e</li><li>f]g</li></ul><p>h</p></div>",
-            });
-        });
-
-        test("should turn four lines over two paragraphs in a div into a list with four items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<div><p>a<br>b]c<br>d</p><p>e<br>f[g<br>h</p></div>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<div><p>a</p><ul><li>b]c</li><li>d</li><li>e</li><li>f[g</li></ul><p>h</p></div>",
             });
         });
 
@@ -706,14 +620,6 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn two lines of a paragraph and a list item into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<p>a<br>x]b<br>y</p><ul><li>c[d</li><li>ef</li></ul>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<p>a</p><ul><li>x]b</li><li>y</li><li>c[d</li><li>ef</li></ul>",
-            });
-        });
-
         test("should turn two lines of a paragraph and two lines of a list item into four list items", async () => {
             // TODO: is this what we want?
             await testEditor({
@@ -721,16 +627,6 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleUnorderedList,
                 contentAfter:
                     "<p>a</p><ul><li>x[b</li><li>y</li><li>c<br>z]d<br>A</li><li>ef</li></ul>",
-            });
-        });
-
-        test("should turn two lines of a paragraph and two lines of a list item into four list items (reversed selection)", async () => {
-            // TODO: is this what we want?
-            await testEditor({
-                contentBefore: "<p>a<br>x]b<br>y</p><ul><li>c<br>z[d<br>A</li><li>ef</li></ul>",
-                stepFunction: toggleUnorderedList,
-                contentAfter:
-                    "<p>a</p><ul><li>x]b</li><li>y</li><li>c<br>z[d<br>A</li><li>ef</li></ul>",
             });
         });
 
@@ -750,27 +646,11 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test("should turn a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<ul><li>ab</li><li>c]d</li></ul><p>e<br>x[f<br>g</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<ul><li>ab</li><li>c]d</li><li>e</li><li>x[f</li></ul><p>g</p>",
-            });
-        });
-
         test("should turn two lines of a list item and two lines of a paragraph into three list items", async () => {
             await testEditor({
                 contentBefore: "<ul><li>ab</li><li>c[d<br>A</li></ul><p>e<br>x]f<br>g</p>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<ul><li>ab</li><li>c[d<br>A</li><li>e</li><li>x]f</li></ul><p>g</p>",
-            });
-        });
-
-        test("should turn two lines of a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
-            await testEditor({
-                contentBefore: "<ul><li>ab</li><li>c]d<br>A</li></ul><p>e<br>x[f<br>g</p>",
-                stepFunction: toggleUnorderedList,
-                contentAfter: "<ul><li>ab</li><li>c]d<br>A</li><li>e</li><li>x[f</li></ul><p>g</p>",
             });
         });
 

--- a/addons/html_editor/static/tests/split/split_block_segments.test.js
+++ b/addons/html_editor/static/tests/split/split_block_segments.test.js
@@ -25,27 +25,11 @@ describe("basic", () => {
         });
     });
 
-    test("should isolate multiple lines in a paragraph (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<p>a<br>b<br>]c<br>d[<br>e<br>f</p>`,
-            stepFunction: splitBlockSegments,
-            contentAfter: `<p>a<br>b</p><p>]c</p><p>d[</p><p>e<br>f</p>`,
-        });
-    });
-
     test("should isolate all lines in a paragraph", async () => {
         await testEditor({
             contentBefore: `<p>[a<br>b<br>c<br>d<br>e]</p>`,
             stepFunction: splitBlockSegments,
             contentAfter: `<p>[a</p><p>b</p><p>c</p><p>d</p><p>e]</p>`,
-        });
-    });
-
-    test("should isolate all lines in a paragraph (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<p>]a<br>b<br>c<br>d<br>e[</p>`,
-            stepFunction: splitBlockSegments,
-            contentAfter: `<p>]a</p><p>b</p><p>c</p><p>d</p><p>e[</p>`,
         });
     });
 });
@@ -75,27 +59,11 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate multiple lines in an unbreakable block (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">a<br>b<br>]c<br>d[<br>e<br>f</div>`,
-            stepFunction: splitBlockSegments,
-            contentAfter: `<div class="oe_unbreakable"><p>a<br>b</p><p>]c</p><p>d[</p><p>e<br>f</p></div>`,
-        });
-    });
-
     test("should isolate all lines in an unbreakable block", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b<br>c<br>d<br>e]</div>`,
             stepFunction: splitBlockSegments,
             contentAfter: `<div class="oe_unbreakable"><p>[a</p><p>b</p><p>c</p><p>d</p><p>e]</p></div>`,
-        });
-    });
-
-    test("should isolate all lines in an unbreakable block (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">]a<br>b<br>c<br>d<br>e[</div>`,
-            stepFunction: splitBlockSegments,
-            contentAfter: `<div class="oe_unbreakable"><p>]a</p><p>b</p><p>c</p><p>d</p><p>e[</p></div>`,
         });
     });
 
@@ -215,34 +183,6 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate all lines in an unbreakable block containing blocks (do not wrap said blocks) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: unformat(
-                `<div class="oe_unbreakable">
-                    ]a<br>b
-                    <div>do not wrap</div>
-                    c<br>d<br>e
-                    <div>do not wrap</div>
-                    f<br>g[
-                </div>`
-            ),
-            stepFunction: splitBlockSegments,
-            contentAfter: unformat(
-                `<div class="oe_unbreakable">
-                    <p>]a</p>
-                    <p>b</p>
-                    <div>do not wrap</div>
-                    <p>c</p>
-                    <p>d</p>
-                    <p>e</p>
-                    <div>do not wrap</div>
-                    <p>f</p>
-                    <p>g[</p>
-                </div>`
-            ),
-        });
-    });
-
     test("should not isolate a line in an unbreakable node that doesn't accept paragraph-related elements (inline)", async () => {
         await testEditor({
             contentBefore: `<p>a<br><span class="oe_unbreakable">b<br>[c]<br>d</span><br>e</p>`,
@@ -299,32 +239,6 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate lines in and out of an unbreakable block (at start) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: unformat(
-                `<div class="oe_unbreakable">
-                    a<br>b<br>]c<br>d<br>e
-                </div>
-                <p>
-                    f<br>g<br>h[<br>i<br>j
-                </p>`
-            ),
-            stepFunction: splitBlockSegments,
-            contentAfter: unformat(
-                `<div class="oe_unbreakable">
-                    <p>a<br>b</p>
-                    <p>]c</p>
-                    <p>d</p>
-                    <p>e</p>
-                </div>
-                <p>f</p>
-                <p>g</p>
-                <p>h[</p>
-                <p>i<br>j</p>`
-            ),
-        });
-    });
-
     test("should isolate lines in and out of an unbreakable block (at end)", async () => {
         await testEditor({
             contentBefore: unformat(
@@ -345,32 +259,6 @@ describe("unbreakable", () => {
                     <p>f</p>
                     <p>g</p>
                     <p>h]</p>
-                    <p>i<br>j</p>
-                </div>`
-            ),
-        });
-    });
-
-    test("should isolate lines in and out of an unbreakable block (at end) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: unformat(
-                `<p>
-                    a<br>b<br>]c<br>d<br>e
-                </p>
-                <div class="oe_unbreakable">
-                    f<br>g<br>h[<br>i<br>j
-                </div>`
-            ),
-            stepFunction: splitBlockSegments,
-            contentAfter: unformat(
-                `<p>a<br>b</p>
-                <p>]c</p>
-                <p>d</p>
-                <p>e</p>
-                <div class="oe_unbreakable">
-                    <p>f</p>
-                    <p>g</p>
-                    <p>h[</p>
                     <p>i<br>j</p>
                 </div>`
             ),
@@ -407,42 +295,6 @@ describe("unbreakable", () => {
                     <p>k</p>
                     <p>l</p>
                     <p>m]</p>
-                    <p>n<br>o</p>
-                </div>`
-            ),
-        });
-    });
-
-    test("should isolate lines in and out of an unbreakable block (at start and end) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: unformat(
-                `<div class="oe_unbreakable">
-                    a<br>b<br>]c<br>d<br>e
-                </div>
-                <p>
-                    f<br>g<br>h<br>i<br>j
-                </p>
-                <div class="oe_unbreakable">
-                    k<br>l<br>m[<br>n<br>o
-                </div>`
-            ),
-            stepFunction: splitBlockSegments,
-            contentAfter: unformat(
-                `<div class="oe_unbreakable">
-                    <p>a<br>b</p>
-                    <p>]c</p>
-                    <p>d</p>
-                    <p>e</p>
-                </div>
-                <p>f</p>
-                <p>g</p>
-                <p>h</p>
-                <p>i</p>
-                <p>j</p>
-                <div class="oe_unbreakable">
-                    <p>k</p>
-                    <p>l</p>
-                    <p>m[</p>
                     <p>n<br>o</p>
                 </div>`
             ),

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -126,9 +126,9 @@ describe("select a full table on cross over", () => {
                 contentAfterEdit:
                     '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
-                    '<td class="o_selected_td">ab</td>' +
+                    '<td class="o_selected_td">[ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
-                    '<td class="o_selected_td">e[f</td></tr></tbody></table><p>a]bc</p>',
+                    '<td class="o_selected_td">ef</td></tr></tbody></table><p>a]bc</p>',
             });
         });
 
@@ -366,13 +366,13 @@ describe("select a full table on cross over", () => {
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
-                                <font style="color: aquamarine;">ab</font>
+                                <font style="color: aquamarine;">[ab</font>
                             </td>
                             <td class="o_selected_td">
                                 <font style="color: aquamarine;">cd</font>
                             </td>
                             <td class="o_selected_td">
-                                <font style="color: aquamarine;">e[f</font>
+                                <font style="color: aquamarine;">ef</font>
                             </td>
                         </tr></tbody>
                     </table>

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -36,15 +36,6 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should turn part of a heading 1 into a paragraph (2) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>]<i>a</i>b<br><br>[<br></h1>",
-            stepFunction: setTag("p"),
-            // The third line remains a h1. It wasn't visibly selected.
-            contentAfter: "<p>]<i>a</i>b</p><p><br></p><h1>[<br></h1>",
-        });
-    });
-
     test("should turn a heading 1 into a paragraph (character selected)", async () => {
         await testEditor({
             contentBefore: "<h1>a[b]c</h1>",
@@ -69,14 +60,6 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should turn part of a heading 1 into several paragraphs (characters selected) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
-            stepFunction: setTag("p"),
-            contentAfter: "<h1>a<br>b</h1><p>]c</p><p><br></p><p>d[</p><h1>e<br>f</h1>",
-        });
-    });
-
     test("should turn a heading 1, a paragraph and a heading 2 into three paragraphs", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><p>cd</p><h2>e]f</h2>",
@@ -90,14 +73,6 @@ describe("to paragraph", () => {
             contentBefore: "<h1>a<br>x<br>y[b</h1><p>cd</p><h2>e]f<br>g<br>h</h2>",
             stepFunction: setTag("p"),
             contentAfter: "<h1>a<br>x</h1><p>y[b</p><p>cd</p><p>e]f</p><h2>g<br>h</h2>",
-        });
-    });
-
-    test("should turn part of a heading 1, a paragraph and part of a heading 2 into three paragraphs (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>x<br>y]b</h1><p>cd</p><h2>e[f<br>g<br>h</h2>",
-            stepFunction: setTag("p"),
-            contentAfter: "<h1>a<br>x</h1><p>y]b</p><p>cd</p><p>e[f</p><h2>g<br>h</h2>",
         });
     });
 
@@ -156,15 +131,6 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should not turn a div into a paragraph (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div>]a<br>b[</div>`,
-            stepFunction: setTag("p"),
-            contentAfter: `<div><p>]a</p><p>b[</p></div>`,
-            config: { baseContainers: ["P"] },
-        });
-    });
-
     test("should not turn an unbreakable div into a paragraph", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[ab]</div>`,
@@ -178,14 +144,6 @@ describe("to paragraph", () => {
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("p"),
             contentAfter: `<div class="oe_unbreakable"><p>[a</p><p>b]</p></div>`,
-        });
-    });
-
-    test("should not turn an unbreakable div into a paragraph, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
-            stepFunction: setTag("p"),
-            contentAfter: `<div class="oe_unbreakable"><p>]a</p><p>b[</p></div>`,
         });
     });
 
@@ -221,14 +179,6 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should not add paragraph tag when selection is changed to normal in list with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<ul><li><h1>]ab<br>cd[</h1></li></ul>",
-            stepFunction: setTag("p"),
-            contentAfter: `<ul><li><p>]ab<br>cd[</p></li></ul>`,
-        });
-    });
-
     test("should not add paragraph tag to normal text in list", async () => {
         await testEditor({
             contentBefore: "<ul><li>[abcd]</li></ul>",
@@ -242,14 +192,6 @@ describe("to paragraph", () => {
             contentBefore: "<ul><li>[ab<br>cd]</li></ul>",
             stepFunction: setTag("p"),
             contentAfter: `<ul><li>[ab<br>cd]</li></ul>`,
-        });
-    });
-
-    test("should not add paragraph tag to normal text in list, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<ul><li>]ab<br>cd[</li></ul>",
-            stepFunction: setTag("p"),
-            contentAfter: `<ul><li>]ab<br>cd[</li></ul>`,
         });
     });
 
@@ -278,20 +220,6 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should turn three table cells with heading 1 and line breaks to table cells with paragraphs (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                "<table><tbody><tr><td><h1>a<br>b<br>]c<br>d</h1></td><td><h1>e<br>f</h1></td><td><h1>g<br>h[<br>i<br>j</h1></td></tr></tbody></table>",
-            stepFunction: setTag("p"),
-            // Having selected across several table cells, the custom table
-            // selection is set over the whole cells, which means we transform
-            // every line in them and not just the ones we selected.
-            // The custom table selection is removed in cleanForSave and the selection is collapsed.
-            contentAfter:
-                "<table><tbody><tr><td><p>a</p><p>b</p><p>]c</p><p>d</p></td><td><p>e</p><p>f</p></td><td><p>g</p><p>h[</p><p>i</p><p>j</p></td></tr></tbody></table>",
-        });
-    });
-
     test("should not set the tag of non-editable elements", async () => {
         await testEditor({
             contentBefore:
@@ -308,16 +236,6 @@ describe("to paragraph", () => {
             stepFunction: setTag("p"),
             contentAfter:
                 '<h1>very<br>much</h1><p>[be</p><p>fore</p><h1 contenteditable="false">non<br>editable</h1><p>after]</p><h1>as<br>well</h1>',
-        });
-    });
-
-    test("should not set the tag of non-editable elements, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                '<h1>very<br>much<br>]be<br>fore</h1><h1 contenteditable="false">non<br>editable</h1><h1>after[<br>as<br>well</h1>',
-            stepFunction: setTag("p"),
-            contentAfter:
-                '<h1>very<br>much</h1><p>]be</p><p>fore</p><h1 contenteditable="false">non<br>editable</h1><p>after[</p><h1>as<br>well</h1>',
         });
     });
 
@@ -404,14 +322,6 @@ describe("to heading 1", () => {
         });
     });
 
-    test("should turn part of a paragraph into several heading 1s (characters selected) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<p>a<br>b<br>]c<br><br>d[<br>e<br>f</p>",
-            stepFunction: setTag("h1"),
-            contentAfter: "<p>a<br>b</p><h1>]c</h1><h1><br></h1><h1>d[</h1><p>e<br>f</p>",
-        });
-    });
-
     test.tags("desktop");
     test("should turn the paragraph into a heading 1 (after triple click)", async () => {
         await testEditor({
@@ -495,28 +405,11 @@ describe("to heading 1", () => {
         });
     });
 
-    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<div>]a<br>b[</div>",
-            stepFunction: setTag("h1"),
-            contentAfter: "<div><h1>]a</h1><h1>b[</h1></div>",
-            config: { baseContainers: ["P"] },
-        });
-    });
-
     test("should not turn an unbreakable div into a heading 1, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("h1"),
             contentAfter: `<div class="oe_unbreakable"><h1>[a</h1><h1>b]</h1></div>`,
-        });
-    });
-
-    test("should not turn an unbreakable div into a heading 1, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
-            stepFunction: setTag("h1"),
-            contentAfter: `<div class="oe_unbreakable"><h1>]a</h1><h1>b[</h1></div>`,
         });
     });
 
@@ -542,20 +435,6 @@ describe("to heading 1", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><h1>a</h1><h1>b</h1><h1>[c</h1><h1>d</h1></td><td><h1>e</h1><h1>f</h1></td><td><h1>g</h1><h1>h]</h1><h1>i</h1><h1>j</h1></td></tr></tbody></table>",
-        });
-    });
-
-    test("should turn three table cells with paragraph and line breaks to table cells with heading 1 (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
-            stepFunction: setTag("h1"),
-            // Having selected across several table cells, the custom table
-            // selection is set over the whole cells, which means we transform
-            // every line in them and not just the ones we selected.
-            // The custom table selection is removed in cleanForSave and the selection is collapsed.
-            contentAfter:
-                "<table><tbody><tr><td><h1>a</h1><h1>b</h1><h1>]c</h1><h1>d</h1></td><td><h1>e</h1><h1>f</h1></td><td><h1>g</h1><h1>h[</h1><h1>i</h1><h1>j</h1></td></tr></tbody></table>",
         });
     });
 
@@ -618,14 +497,6 @@ describe("to heading 2", () => {
         });
     });
 
-    test("should turn part of a heading 1 into several heading 2s (characters selected) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
-            stepFunction: setTag("h2"),
-            contentAfter: "<h1>a<br>b</h1><h2>]c</h2><h2><br></h2><h2>d[</h2><h1>e<br>f</h1>",
-        });
-    });
-
     test("should turn a heading 1, a heading 2 and a paragraph into three headings 2", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><h2>cd</h2><p>e]f</p>",
@@ -639,14 +510,6 @@ describe("to heading 2", () => {
             contentBefore: "<h1>a<br>[b</h1><h2>cd</h2><p>e]<br>f</p>",
             stepFunction: setTag("h2"),
             contentAfter: "<h1>a</h1><h2>[b</h2><h2>cd</h2><h2>e]</h2><p>f</p>",
-        });
-    });
-
-    test("should turn parts of a heading 1, a heading 2 and parts of a paragraph into headings 2 (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>]b</h1><h2>cd</h2><p>e[<br>f</p>",
-            stepFunction: setTag("h2"),
-            contentAfter: "<h1>a</h1><h2>]b</h2><h2>cd</h2><h2>e[</h2><p>f</p>",
         });
     });
 
@@ -675,28 +538,11 @@ describe("to heading 2", () => {
         });
     });
 
-    test("should not turn a div into a heading 2 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<div>]a<br>b[</div>",
-            stepFunction: setTag("h2"),
-            contentAfter: "<div><h2>]a</h2><h2>b[</h2></div>",
-            config: { baseContainers: ["P"] },
-        });
-    });
-
     test("should not turn an unbreakable div into a heading 2, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("h2"),
             contentAfter: `<div class="oe_unbreakable"><h2>[a</h2><h2>b]</h2></div>`,
-        });
-    });
-
-    test("should not turn an unbreakable div into a heading 2, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
-            stepFunction: setTag("h2"),
-            contentAfter: `<div class="oe_unbreakable"><h2>]a</h2><h2>b[</h2></div>`,
         });
     });
 
@@ -722,20 +568,6 @@ describe("to heading 2", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><h2>a</h2><h2>b</h2><h2>[c</h2><h2>d</h2></td><td><h2>e</h2><h2>f</h2></td><td><h2>g</h2><h2>h]</h2><h2>i</h2><h2>j</h2></td></tr></tbody></table>",
-        });
-    });
-
-    test("should turn three table cells with paragraph and line breaks to table cells with heading 2 (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
-            stepFunction: setTag("h2"),
-            // Having selected across several table cells, the custom table
-            // selection is set over the whole cells, which means we transform
-            // every line in them and not just the ones we selected.
-            // The custom table selection is removed in cleanForSave and the selection is collapsed.
-            contentAfter:
-                "<table><tbody><tr><td><h2>a</h2><h2>b</h2><h2>]c</h2><h2>d</h2></td><td><h2>e</h2><h2>f</h2></td><td><h2>g</h2><h2>h[</h2><h2>i</h2><h2>j</h2></td></tr></tbody></table>",
         });
     });
 
@@ -798,14 +630,6 @@ describe("to heading 3", () => {
         });
     });
 
-    test("should turn part of a heading 1 into several heading 3s (characters selected) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
-            stepFunction: setTag("h3"),
-            contentAfter: "<h1>a<br>b</h1><h3>]c</h3><h3><br></h3><h3>d[</h3><h1>e<br>f</h1>",
-        });
-    });
-
     test("should turn a heading 1, a paragraph and a heading 2 into three headings 3", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><p>cd</p><h2>e]f</h2>",
@@ -843,28 +667,11 @@ describe("to heading 3", () => {
         });
     });
 
-    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<div>]a<br>b[</div>",
-            stepFunction: setTag("h3"),
-            contentAfter: "<div><h3>]a</h3><h3>b[</h3></div>",
-            config: { baseContainers: ["P"] },
-        });
-    });
-
     test("should not turn an unbreakable div into a heading 3, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("h3"),
             contentAfter: `<div class="oe_unbreakable"><h3>[a</h3><h3>b]</h3></div>`,
-        });
-    });
-
-    test("should not turn an unbreakable div into a heading 3, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
-            stepFunction: setTag("h3"),
-            contentAfter: `<div class="oe_unbreakable"><h3>]a</h3><h3>b[</h3></div>`,
         });
     });
 
@@ -890,20 +697,6 @@ describe("to heading 3", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><h3>a</h3><h3>b</h3><h3>[c</h3><h3>d</h3></td><td><h3>e</h3><h3>f</h3></td><td><h3>g</h3><h3>h]</h3><h3>i</h3><h3>j</h3></td></tr></tbody></table>",
-        });
-    });
-
-    test("should turn three table cells with paragraph and line breaks to table cells with heading 1 (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
-            stepFunction: setTag("h3"),
-            // Having selected across several table cells, the custom table
-            // selection is set over the whole cells, which means we transform
-            // every line in them and not just the ones we selected.
-            // The custom table selection is removed in cleanForSave and the selection is collapsed.
-            contentAfter:
-                "<table><tbody><tr><td><h3>a</h3><h3>b</h3><h3>]c</h3><h3>d</h3></td><td><h3>e</h3><h3>f</h3></td><td><h3>g</h3><h3>h[</h3><h3>i</h3><h3>j</h3></td></tr></tbody></table>",
         });
     });
 
@@ -966,14 +759,6 @@ describe("to pre", () => {
         });
     });
 
-    test("should turn part of a heading 1 into several pres (characters selected) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
-            stepFunction: setTag("pre"),
-            contentAfter: "<h1>a<br>b</h1><pre>]c</pre><pre><br></pre><pre>d[</pre><h1>e<br>f</h1>",
-        });
-    });
-
     test("should turn a heading 1, a pre and a paragraph into three pres", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><pre>cd</pre><p>e]f</p>",
@@ -987,14 +772,6 @@ describe("to pre", () => {
             contentBefore: "<h1>a<br>[b</h1><pre>cd</pre><p>e]<br>f</p>",
             stepFunction: setTag("pre"),
             contentAfter: "<h1>a</h1><pre>[b</pre><pre>cd</pre><pre>e]</pre><p>f</p>",
-        });
-    });
-
-    test("should turn parts of a heading 1, a pre and parts of a paragraph into pres (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>]b</h1><pre>cd</pre><p>e[<br>f</p>",
-            stepFunction: setTag("pre"),
-            contentAfter: "<h1>a</h1><pre>]b</pre><pre>cd</pre><pre>e[</pre><p>f</p>",
         });
     });
 
@@ -1020,20 +797,6 @@ describe("to pre", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><pre>a</pre><pre>b</pre><pre>[c</pre><pre>d</pre></td><td><pre>e</pre><pre>f</pre></td><td><pre>g</pre><pre>h]</pre><pre>i</pre><pre>j</pre></td></tr></tbody></table>",
-        });
-    });
-
-    test("should turn three table cells with paragraph and line breaks to table cells with pre (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
-            stepFunction: setTag("pre"),
-            // Having selected across several table cells, the custom table
-            // selection is set over the whole cells, which means we transform
-            // every line in them and not just the ones we selected.
-            // The custom table selection is removed in cleanForSave and the selection is collapsed.
-            contentAfter:
-                "<table><tbody><tr><td><pre>a</pre><pre>b</pre><pre>]c</pre><pre>d</pre></td><td><pre>e</pre><pre>f</pre></td><td><pre>g</pre><pre>h[</pre><pre>i</pre><pre>j</pre></td></tr></tbody></table>",
         });
     });
 
@@ -1137,15 +900,6 @@ describe("to blockquote", () => {
         });
     });
 
-    test("should turn part of a heading 1 into several blockquotes (characters selected) (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
-            stepFunction: setTag("blockquote"),
-            contentAfter:
-                "<h1>a<br>b</h1><blockquote>]c</blockquote><blockquote><br></blockquote><blockquote>d[</blockquote><h1>e<br>f</h1>",
-        });
-    });
-
     test("should turn a heading 1, a paragraph and a heading 2 into three blockquote", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><p>cd</p><h2>e]f</h2>",
@@ -1184,28 +938,11 @@ describe("to blockquote", () => {
         });
     });
 
-    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: "<div>]a<br>b[</div>",
-            stepFunction: setTag("blockquote"),
-            contentAfter: "<div><blockquote>]a</blockquote><blockquote>b[</blockquote></div>",
-            config: { baseContainers: ["P"] },
-        });
-    });
-
     test("should not turn an unbreakable div into a blockquote, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("blockquote"),
             contentAfter: `<div class="oe_unbreakable"><blockquote>[a</blockquote><blockquote>b]</blockquote></div>`,
-        });
-    });
-
-    test("should not turn an unbreakable div into a blockquote, with line breaks (reversed selection)", async () => {
-        await testEditor({
-            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
-            stepFunction: setTag("blockquote"),
-            contentAfter: `<div class="oe_unbreakable"><blockquote>]a</blockquote><blockquote>b[</blockquote></div>`,
         });
     });
 
@@ -1231,20 +968,6 @@ describe("to blockquote", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><blockquote>a</blockquote><blockquote>b</blockquote><blockquote>[c</blockquote><blockquote>d</blockquote></td><td><blockquote>e</blockquote><blockquote>f</blockquote></td><td><blockquote>g</blockquote><blockquote>h]</blockquote><blockquote>i</blockquote><blockquote>j</blockquote></td></tr></tbody></table>",
-        });
-    });
-
-    test("should turn three table cells with paragraph and line breaks to table cells with blockquotes (reversed selection)", async () => {
-        await testEditor({
-            contentBefore:
-                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
-            stepFunction: setTag("blockquote"),
-            // Having selected across several table cells, the custom table
-            // selection is set over the whole cells, which means we transform
-            // every line in them and not just the ones we selected.
-            // The custom table selection is removed in cleanForSave and the selection is collapsed.
-            contentAfter:
-                "<table><tbody><tr><td><blockquote>a</blockquote><blockquote>b</blockquote><blockquote>]c</blockquote><blockquote>d</blockquote></td><td><blockquote>e</blockquote><blockquote>f</blockquote></td><td><blockquote>g</blockquote><blockquote>h[</blockquote><blockquote>i</blockquote><blockquote>j</blockquote></td></tr></tbody></table>",
         });
     });
 

--- a/addons/html_editor/static/tests/utils/selection.test.js
+++ b/addons/html_editor/static/tests/utils/selection.test.js
@@ -122,6 +122,7 @@ describe("getCursorDirection", () => {
                     DIRECTIONS.RIGHT
                 );
             },
+            testInBothDirections: false,
         });
     });
 
@@ -135,6 +136,7 @@ describe("getCursorDirection", () => {
                     DIRECTIONS.LEFT
                 );
             },
+            testInBothDirections: false,
         });
     });
 


### PR DESCRIPTION
The editor tests with a non-collapsed selection sometimes include a version where the selection direction is reversed (ie, `]...[` instead of `[...]`). There should be no reason to write that manually, and tests should systematically be run in both directions to ensure both work properly.

Adding these tests revealed some issues, addressed here:

1. Link transformation

The tests:

- "should paste and transform plain text content over a link if all of its contents is selected"
- "should paste html content over a link if all of its contents is selected (not collapsed)"
- "should paste html content over a link if all of its contents is selected (not collapsed) (2)"

were failing when reversing the selection direction: link transformation failed when selecting a whole link backwards before pasting.

2. Table selection

The tests:

- "should select some characters and a table"
- "should select a table and some characters"
- "should select some characters, a table, some more characters and another table"
- "should apply a color to some characters and a table"
- "should apply a color to a table and some characters"
- "should apply a color to some characters, a table, some more characters and another table"

were failing when reversing the selection direction: a table wasn't getting fully selected when selecting backwards from a table cell to an element before the table.

Moreover, the reverse case was never handled, namely selecting the whole table when the selection starts in a table cell and ends after the table.

task-5420366


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
