### PR TITLE
[FIX] web_editor: prevent image loss in HTML fields when switching tabs

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -413,9 +413,7 @@ export class HtmlField extends Component {
                 }
                 this.wysiwyg.odooEditor.observerActive('commitChanges');
             }
-            if (status(this) !== 'destroyed') {
-                await this.updateValue();
-            }
+            await this.updateValue();
             if (this.isCurrentlySaving) {
                 this.isCurrentlySaving.resolve();
             }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -3621,8 +3621,8 @@ export class Wysiwyg extends Component {
             let src = attachment.image_src;
             if (!attachment.public) {
                 let accessToken = attachment.access_token;
-                if (!accessToken) {
-                    [accessToken] = await this.orm.call(
+                if (!accessToken && this.env?.model?.orm) {
+                    [accessToken] = await this.env.model.orm.call(
                         'ir.attachment',
                         'generate_access_token',
                         [attachment.id],
@@ -3754,7 +3754,10 @@ export class Wysiwyg extends Component {
                 ...params.kwargs.context,
             };
         }
-        return this.rpc(route, params, {
+        if (!this.env?.model?.rpc) {
+            return;
+        }
+        return this.env.model.rpc(route, params, {
             silent: settings.shadow,
             xhr: settings.xhr,
         });


### PR DESCRIPTION
Problem:
When an image is added to an HTML field inside a form view, switching tabs immediately causes the image to be lost.

Cause:
`useService("rpc")` returns a protected version of the `rpc` method using `_protectMethod`, which becomes a no-op if the component is destroyed. During tab switching, the editor component is destroyed before the async save completes, so the image mutation never reaches the server.

Solution:
During the saving process, we mutate and save the editable clone directly. This avoids relying on the component’s lifecycle and removes the need to check whether the component is still mounted.

Steps to reproduce:
- Go to Sales form view.
- Toggle Studio.
- Add a new tab.
- In that tab, add an HTML field.
- Drag & drop an image into the field.
- Without clicking anywhere else, immediately switch to another tab.
- The image disappears.

task-5262722

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
