### PR TITLE
[IMP] bus: add confirm dialog when enabling bus logging

### DIFF
--- a/addons/bus/static/src/debug/bus_logs_menu_item.js
+++ b/addons/bus/static/src/debug/bus_logs_menu_item.js
@@ -1,5 +1,8 @@
 import { Component, useRef } from "@odoo/owl";
+
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
@@ -11,14 +14,20 @@ export class BusLogsMenuItem extends Component {
     setup() {
         this.busLogsService = useService("bus.logs_service");
         this.downloadButton = useRef("downloadButton");
-    }
-
-    onClickToggle() {
-        this.busLogsService.toggleLogging();
+        this.dialog = useService("dialog");
     }
 
     onClickDownload() {
-        this.env.services.bus_service.downloadLogs();
+        this.dialog.add(ConfirmationDialog, {
+            body: _t(
+                "Bus logs contain confidential information and must only be shared with trusted recipients."
+            ),
+            title: _t("You're about to download the bus logs"),
+            confirm: () => this.env.services.bus_service.downloadLogs(),
+            cancel() {},
+            confirmLabel: _t("Download"),
+            cancelLabel: _t("Discard"),
+        });
     }
 }
 

--- a/addons/bus/static/src/debug/bus_logs_menu_item.xml
+++ b/addons/bus/static/src/debug/bus_logs_menu_item.xml
@@ -4,7 +4,7 @@
         <DropdownItem>
             <div class="d-flex align-items-center justify-content-between" style="padding-left: 12px;">
                 <div class="form-check form-switch">
-                    <label class="form-check-label" t-on-click.prevent.stop="onClickToggle">
+                    <label class="form-check-label" t-on-click.prevent.stop="busLogsService.enabled ? busLogsService.disableLogging : busLogsService.enableLogging">
                         Enable Bus Logging <input class="form-check-input" t-att-checked="busLogsService.enabled" type="checkbox"/>
                     </label>
                 </div>

--- a/addons/bus/static/src/debug/bus_logs_service.js
+++ b/addons/bus/static/src/debug/bus_logs_service.js
@@ -12,12 +12,15 @@ export const busLogsService = {
     start(env, { bus_service, worker_service }) {
         const state = reactive({
             enabled: JSON.parse(localStorage.getItem("bus_log_menu.enabled")),
-            toggleLogging() {
-                state.enabled = !state.enabled;
-                if (bus_service.isActive) {
-                    bus_service.setLoggingEnabled(state.enabled);
-                }
-                localStorage.setItem("bus_log_menu.enabled", state.enabled);
+            enableLogging() {
+                state.enabled = true;
+                bus_service.setLoggingEnabled(true);
+                localStorage.setItem("bus_log_menu.enabled", true);
+            },
+            disableLogging() {
+                state.enabled = false;
+                bus_service.setLoggingEnabled(false);
+                localStorage.setItem("bus_log_menu.enabled", false);
             },
         });
         browser.addEventListener("storage", ({ key, newValue }) => {
@@ -29,8 +32,8 @@ export const busLogsService = {
             bus_service.setLoggingEnabled(state.enabled);
         });
         odoo.busLogging = {
-            stop: () => state.enabled && state.toggleLogging(),
-            start: () => !state.enabled && state.toggleLogging(),
+            stop: () => state.disableLogging(),
+            start: () => state.enableLogging(),
             download: () => bus_service.downloadLogs(),
         };
         if (state.enabled) {

--- a/addons/bus/static/tests/bus_logger.test.js
+++ b/addons/bus/static/tests/bus_logger.test.js
@@ -1,8 +1,13 @@
+import { defineBusModels } from "@bus/../tests/bus_test_helpers";
 import { Logger } from "@bus/workers/bus_worker_utils";
 
-import { after, before, describe, expect, test } from "@odoo/hoot";
+import { after, before, describe, expect, test, waitFor } from "@odoo/hoot";
 import { advanceTime } from "@odoo/hoot-dom";
 
+import { contains, getService, mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { WebClient } from "@web/webclient/webclient";
+
+defineBusModels();
 describe.current.tags("desktop");
 
 before(() => indexedDB.deleteDatabase("test_db"));
@@ -17,4 +22,16 @@ test("logs are saved and garbage-collected after TTL", async () => {
     await advanceTime(Logger.LOG_TTL + 1000);
     expect(await logger.getLogs()).toEqual([]);
     indexedDB.deleteDatabase("test_db");
+});
+
+test("ask for confirmation downloading logs", async () => {
+    odoo.debug = "1";
+    await mountWithCleanup(WebClient);
+    expect(getService("bus.logs_service").enabled).toBe(null);
+    await contains(".o_debug_manager button").click();
+    await contains("button[title='Download logs']").click();
+    await waitFor(".modal-title:text(You're about to download the bus logs)");
+    await waitFor(
+        ".modal-body:text(Bus logs contain confidential information and must only be shared with trusted recipients.)"
+    );
 });


### PR DESCRIPTION
Bus logging contains sensitive information. It wouldn't hurt to add a confirm dialog when downloading the logs to warn the user about it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
