### PR TITLE
[IMP] hr_recruitment_skills: Add matching and missing skills to views

### DIFF
--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -29,6 +29,13 @@
                             <group>
                                 <field name="matching_score" invisible="is_pool_applicant" nolabel="1" widget="skill_match_gauge_field" options="{'max_value': 100}" />
                             </group>
+                            <group>
+                                <!-- empty group to align matching and missing skills below the job position matching widget -->
+                            </group>
+                            <group>
+                                <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            </group>
                         </group>
                     </div>
                 </page>
@@ -86,6 +93,10 @@
             <xpath expr="//list" position="inside">
                 <field name="current_applicant_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide" string="Skills"/>
             </xpath>
+            <field name="priority" position="after">
+                <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
This PR adds the "matching_skill_ids" and "missing_skill_ids" to the list view and the form view of applicants.

task-5139860

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
