### PR TITLE
[FIX] stock: make sure package_m2o only changes its own dialog

### DIFF
--- a/addons/stock/static/src/widgets/stock_package_m2o.js
+++ b/addons/stock/static/src/widgets/stock_package_m2o.js
@@ -10,11 +10,13 @@ import {
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 
+class PackageFormDialog extends FormViewDialog {}
+
 class Many2XStockPackageAutocomplete extends Many2XAutocomplete {
     get createDialog() {
-        const PackageFormDialog = FormViewDialog;
-        PackageFormDialog.defaultProps = {
-            ...PackageFormDialog.defaultProps,
+        const packageFormDialog = PackageFormDialog;
+        packageFormDialog.defaultProps = {
+            ...packageFormDialog.defaultProps,
             onRecordSave: async (record) => {
                 // We need to reload to get the name computed from the backend.
                 const saved = await record.save({ reload: true });
@@ -25,7 +27,7 @@ class Many2XStockPackageAutocomplete extends Many2XAutocomplete {
                 return saved;
             },
         };
-        return PackageFormDialog;
+        return packageFormDialog;
     }
 }
 


### PR DESCRIPTION
Steps to reproduce:
- Enable lots & packages
- Create a tracked product (either lot/serial)
- Try to update its available quantity, it will open the quant view
- Create a new line, add a new lot/serial number and save its form

Issue:
A traceback occurs, saying a package record doesn't exist

In the `Many2XStockPackageAutocomplete`, we add some custom `onRecordSave` to handle creating package records without name, and still use the name given from the python-side.

However, this was done by hijacking `FormViewDialog`, and injected it directly on the class itself, propagating that behavior to unrelated places.

Now limits it to a specificly created Dialog class to avoid overspill.

opw-5326068

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
