### PR TITLE
[FIX] account: fix matching entries in reconciliation in branch

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -514,7 +514,7 @@ class AccountBankStatementLine(models.Model):
 
     def _get_default_amls_matching_domain(self):
         self.ensure_one()
-        all_reconcilable_account_ids = self.env['account.account'].search([
+        all_reconcilable_account_ids = self.env['account.account'].sudo().search([
             ("company_ids", "child_of", self.company_id.root_id.id),
             ('reconcile', '=', True),
         ]).ids


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create a branch company

- Switch to the branch
- Create a Bank journal for the branch
- Create a Sales journal for the branch (You can duplicate the journals from the parent company)
- Make sure that the accounts configured on the journals are linked the branch

- Grant only access to the branch to a user
- Connect with that user
- Create an invoice
- In the bank journal, create a statement line matching the amount of the invoice
- Select the statement line

**Issue:**
In the "Matching Existing Entries" tab, there is no entry.

**Cause:**
When retrieving the accounts required for the domain to fetch these entries, no account can be retrieved because the user doesn't have access to the parent company.

opw-5181909




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
