### PR TITLE
[18.0][FIX] stock: Ensure that "is_storable" is properly computed

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -767,7 +767,7 @@ class ProductTemplate(models.Model):
 
     @api.depends('type')
     def compute_is_storable(self):
-        self.filtered(lambda t: t.type != 'consu' and t.is_storable).is_storable = False
+        self.filtered(lambda t: t.type != 'consu' and t.is_storable).write({"is_storable": False})
 
     @api.depends('is_storable')
     def _compute_show_qty_status_button(self):

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -376,3 +376,19 @@ class TestVirtualAvailable(TestStockCommon):
         self.picking_out.button_validate()
         with self.assertRaises(UserError):
             self.product_3.write({'is_storable': False})
+
+    def test_change_product_product_type(self):
+        """Test that changing the product type directly in a `product.product` record
+        doesn't bypass existing moves check.
+        """
+        self.picking_out.action_confirm()
+        self.picking_out.action_assign()
+
+        # Should not be possible to change the product type when quantities are reserved
+        with self.assertRaises(UserError):
+            self.product_3.write({'type': 'service'})
+
+        # Should not be possible to change the product type when moves are done.
+        self.picking_out.button_validate()
+        with self.assertRaises(UserError):
+            self.product_3.write({'type': 'service'})


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
`compute_is_storable` is called when the `type` value is modified but the `write` function is never called when the value is set using the `is_storable` attribute. Updating `is_storable` using a `write` ensure that an exception is raised when move line exists.

But this fix addresses the symptom, not the underlying issue. So why ? Is it related to the cache or unit test environment ? 

## Current behavior before PR:
In a Unit test, If you convert a consumable and storable product to a service, no exception is raised, even with existing stock moves.
Unlike the previous version of Odoo (<15.0), where an exception was raised when the product type was changed and stock movements existed, detection now occurs if the ‘is_storable’ status is changed. However, this detection is not triggered if the value of ‘is_storable’ is defined by its attribute.

## Desired behavior after PR is merged:
An exception must be raised (like Odoo 14.0)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
