### PR TITLE
[IMP] web: apply base styles to inputs without type attribute

### DIFF
--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -168,6 +168,7 @@ kbd {
 [type="number"],
 [type="email"],
 [type="tel"],
+input:not([type]),
 textarea,
 select {
   width: 100%;


### PR DESCRIPTION
Browsers treat inputs without a type as "text", but the previous CSS selector `[type="text"]` was too strict.
This adds `input:not([type])` to ensure these inputs are styled correctly.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
