### PR TITLE
[FIX] mail: fix error when deleting subthread

### DIFF
--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -149,20 +149,20 @@ export class Store extends Record {
                     RD_QUEUE.delete(record);
                     for (const [localId, names] of record._.uses.data.entries()) {
                         for (const [name2, count] of names.entries()) {
-                            const usingRecord2 =
-                                toRaw(this.recordByLocalId).get(localId) ||
+                            const existingRecordProxyInternal = toRaw(this.recordByLocalId).get(
+                                localId
+                            );
+                            const usingRecord =
+                                (existingRecordProxyInternal &&
+                                    toRaw(existingRecordProxyInternal)?._raw) ||
                                 deletingRecordsByLocalId.get(localId);
-                            if (!usingRecord2) {
+                            if (!usingRecord) {
                                 // record already deleted, clean inverses
                                 record._.uses.data.delete(localId);
                                 continue;
                             }
-                            if (usingRecord2.Model._.fieldsMany.get(name2)) {
-                                for (let c = 0; c < count; c++) {
-                                    usingRecord2[name2].delete(record);
-                                }
-                            } else {
-                                usingRecord2[name2] = undefined;
+                            for (let c = 0; c < count; c++) {
+                                usingRecord[name2].delete(record);
                             }
                         }
                     }


### PR DESCRIPTION
Before this commit, deleting a thread in a group chat could lead to the following crash:

```
Cannot read properties of undefined (reading '_proxy')
```

Steps to reproduce:
- install mail and im_livechat modules
- create a group chat (3 users minimum)
- create a subthread
- delete the subthread

This happens because when deleting the thread of group, there are the following side-effects:
- it deletes relation `parent_channel_id`
- deletion of `parent_channel_id` side-effects to delete subthread again (because deletion in relation may come from parent)
- deletion of subthread triggers deletion of members
- deletion of member deletes subthread.correspondent since this is being used.

While the subthread is being deleted, it's not technically deleted yet, as fields.onDelete() may still need to refer to this record. This is intentional design [1].

However there was a typo in code: code of deletion of record in relation this is being used assumes that the record using it is a proxyInternal, therefore the `proxyInternal[one] = undefined` was expected to work properly. However the deleting records were stored as raw record, and this mistakenly and actually assigned `undefined` instead of clearing the internal record list.

Because of this problem, any `Proxy.get()` on this relational field would trigger the crash above.

We could fix the PR with `_proxy` on deleting record, but to keep code as fast as possible, this commit instead retrieve the raw record in usingRecord instead, and apply the deletion on internal record list on the raw record. This works with reactivity because even when operations are done on raw record, the function `.delete()` and `clear()` on record list have dedicated implementation to properly make writes on `_proxy` thus notifying reactive change as expected.

[1]: https://github.com/odoo/odoo/pull/224912