### PR TITLE
[FIX] html_builder: fix move arrow visibility and hide empty overlay

### DIFF
--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -129,7 +129,7 @@ export class MovePlugin extends Plugin {
             if (previousSiblingEl) {
                 const direction = isVertical ? "up" : reverseButtons ? "right" : "left";
                 const button = {
-                    class: `fa fa-fw fa-angle-${direction}`,
+                    class: `fa fa-fw fw-bolder fa-angle-${direction}`,
                     title: isVertical
                         ? _t("Move up")
                         : this.isEditableRTL
@@ -143,7 +143,7 @@ export class MovePlugin extends Plugin {
             if (nextSiblingEl) {
                 const direction = isVertical ? "down" : reverseButtons ? "left" : "right";
                 const button = {
-                    class: `fa fa-fw fa-angle-${direction}`,
+                    class: `fa fa-fw fw-bolder fa-angle-${direction}`,
                     title: isVertical
                         ? _t("Move down")
                         : this.isEditableRTL

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons.scss
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons.scss
@@ -11,4 +11,8 @@
     button.o_move_handle {
         cursor: move;
     }
+
+    &:empty {
+        display: none;
+    }
 }


### PR DESCRIPTION
Improve visibility of snippet move arrows and hide empty overlay toolbar.

- Bolden the arrows used to move snippets left, right, up, and down so they are more visible.

- Hide the overlay toolbar when it contains no buttons.

Steps to reproduce:

- Click the "Contact Us" button in the header. Previously, the top options overlay appeared even when empty.

- The same issue occurred with "Carousel" snippet.

After this commit, the top options overlay does not appear when it is empty.

task-5353509