### PR TITLE
[FIX] website_sale: product media on form view

### DIFF
--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -198,6 +198,7 @@
                         mode="kanban"
                         add-label="Add Media"
                         nolabel="1"
+                        colspan="2"
                         widget="x2_many_media_viewer"
                         options="{'convert_to_webp': True}"
                     />


### PR DESCRIPTION
After commit e261383a2b5a054c2d59d5330a4599f58ac81ce5, eCommerce Media was renamed and there was an oversight that `colspan=2` was removed.

This commit fixes the view by adding it back.

task-5405413


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
