### PR TITLE
[FIX] hr: Fix restricted access to bank accounts

### DIFF
--- a/addons/hr/views/res_partner_bank_views.xml
+++ b/addons/hr/views/res_partner_bank_views.xml
@@ -10,8 +10,8 @@
                 <label string="Salary Allocation" for="employee_salary_amount" 
                     invisible="not employee_has_multiple_bank_accounts" groups="hr.group_hr_user"/>
                 <div class="d-flex" invisible="not employee_has_multiple_bank_accounts" groups="hr.group_hr_user">
-                    <field name="employee_salary_amount" style="max-width: 200px;"/>
-                    <div invisible="not employee_salary_amount_is_percentage">%</div>
+                    <span><field name="employee_salary_amount" style="max-width: 200px;"/></span>
+                    <span invisible="not employee_salary_amount_is_percentage">%</span>
                     <field name="currency_id" invisible="employee_salary_amount_is_percentage" readonly="True"/>
                 </div>
                 <field name="employee_id" invisible="not employee_id" widget="many2many_avatar_employee"/>

--- a/addons/hr/views/res_partner_bank_views.xml
+++ b/addons/hr/views/res_partner_bank_views.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='allow_out_payment']" position="after">
-                <field name="employee_salary_amount_is_percentage" invisible="1"/>
                 <field name="employee_has_multiple_bank_accounts" invisible="1"/>
                 <label string="Salary Allocation" for="employee_salary_amount" 
                     invisible="not employee_has_multiple_bank_accounts" groups="hr.group_hr_user"/>


### PR DESCRIPTION
The field `employee_salary_amount_is_percentage` is computed, but the computation[^1] relies on `hr_employee.salary_distribution`, a field restricted[^2] to members of `hr.group_hr_user`.

If you try to check a bank account without an hr group, you will get an access error:
```
odoo.exceptions.AccessError: You do not have enough rights to access the field "salary_distribution" on Employee (hr.employee). Please contact your system administrator.

Operation: read
User: 21
Groups: allowed for groups 'Employees / Officer: Manage all employees'
```

This also happens during the mock crawl test of upgrades if the admin lacks the group.

To reproduce in standard:
- Install contacts and hr.
- Use a user without hr permissions.
- Try to create a new bank account.

[^1]:https://github.com/odoo/odoo/blob/57573994313988837d89329d77ab1def63a8cfdd/addons/hr/models/res_partner_bank.py#L26
[^2]:https://github.com/odoo/odoo/blob/57573994313988837d89329d77ab1def63a8cfdd/addons/hr/models/hr_employee.py#L147
---

I've also added another commit to make the percentage symbol stick to the salary amount.
Before:
<img width="366" height="38" alt="image" src="https://github.com/user-attachments/assets/ef890852-50ca-40b1-8c09-07c4aa2d330d" />
After:
<img width="219" height="35" alt="image" src="https://github.com/user-attachments/assets/88e4a6c4-bc3f-483e-97f9-3080c6aa85c9" />
I know the number is not formated correctly but I don't think I can do more just from the view.
