### PR TITLE
[IMP] hr_recruitment{_skills}: modify applicant creation/actions

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -24,7 +24,6 @@ class HrApplicant(models.Model):
     _name = 'hr.applicant'
     _description = "Applicant"
     _order = "priority desc, id desc"
-    _order = "sequence"
     _inherit = [
                'mail.thread.main.attachment',
                'mail.thread.blacklist',

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -4,20 +4,20 @@
         <field name="name">Applicants</field>
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
-            <list string="Applicants" class="o_search_matching_applicant" multi_edit="1" sample="1" decoration-danger="application_status == 'refused'" default_order="stage_id">
+            <list string="Applicants" class="o_search_matching_applicant" multi_edit="1" sample="1" decoration-danger="application_status == 'refused'" default_order="priority DESC">
                 <header>
-                    <button
-                        name="action_job_add_applicants"
-                        string="Create Applications"
-                        invisible="context.get('default_job_id') or not context.get('default_talent_pool_ids')"
-                        type="object"
-                    />
                     <button
                         name="action_talent_pool_add_applicants"
                         string="Add to Pool"
                         type="object"
                         invisible="context.get('default_talent_pool_ids')"
                         groups="hr_recruitment.group_hr_recruitment_user"
+                    />
+                    <button
+                        name="action_job_add_applicants"
+                        string="Apply to Jobs"
+                        invisible="context.get('default_job_id') or not context.get('default_talent_pool_ids')"
+                        type="object"
                     />
                     <button type="object" 
                         name="archive_applicant" 

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -30,12 +30,6 @@
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>View</span>
                                     </h5>
-                                    <div role="menuitem" name="menu_view_applications">
-                                        <a name="%(action_hr_job_applications)d" type="action">Applications</a>
-                                    </div>
-                                    <div role="menuitem">
-                                        <a name="action_open_activities" type="object">Activities</a>
-                                    </div>
                                     <div role="menuitem" name="menu_view_job_posts">
                                         <a name="%(action_hr_job_sources)d" type="action" context="{'default_job_id': id}">Trackers</a>
                                     </div>

--- a/addons/hr_recruitment/wizard/talent_pool_add_applicants.py
+++ b/addons/hr_recruitment/wizard/talent_pool_add_applicants.py
@@ -8,11 +8,6 @@ class TalentPoolAddApplicants(models.TransientModel):
         "hr.applicant",
         string="Applicants",
         required=True,
-        domain=[
-            "|",
-            ("talent_pool_ids", "!=", False),
-            ("is_applicant_in_pool", "=", False),
-        ],
     )
     talent_pool_ids = fields.Many2many("hr.talent.pool", string="Talent Pool")
     categ_ids = fields.Many2many(
@@ -23,7 +18,10 @@ class TalentPoolAddApplicants(models.TransientModel):
     def _add_applicants_to_pool(self):
         talents = self.env["hr.applicant"]
         for applicant in self.applicant_ids:
-            if applicant.talent_pool_ids:
+            if applicant.pool_applicant_id:  # already has a linked talent
+                applicant = applicant.pool_applicant_id
+
+            if applicant.talent_pool_ids:  # is a talent
                 applicant.write(
                     {
                         "talent_pool_ids": [

--- a/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.xml
+++ b/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="hr_recruitment_skills.SearchJobApplicant">
         <DropdownItem onSelected.bind="openMatchingJobApplicants">
-            <i class="fa fa-fw fa-search me-1" aria-hidden="true"></i>Search Matching Applicants
+            <i class="fa fa-fw fa-search me-1" aria-hidden="true"></i>Matching Talents
         </DropdownItem>
     </t>
 </templates>

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -108,6 +108,7 @@
         <field name="arch" type="xml">
             <xpath expr="//list" position="attributes">
                 <attribute name="class" add="o_search_matching_applicant" separator=" "/>
+                <attribute name="default_order">sequence</attribute>
             </xpath>
             <xpath expr="//list" position="inside">
                 <header>
@@ -115,6 +116,18 @@
                 </header>
             </xpath>
             <field name="application_status" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="create_date" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="job_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="stage_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="email_from" position="attributes">
                 <attribute name="optional">hide</attribute>
             </field>
             <field name="priority" position="attributes">
@@ -126,10 +139,16 @@
             <field name="categ_ids" position="attributes">
                 <attribute name="optional">hide</attribute>
             </field>
+            <field name="kanban_state" position="attributes">
+                <attribute name="optional">show</attribute>
+            </field>
             <field name="partner_name" position="after">
                 <xpath expr="//field[@name='matching_score']" position="move"/>
                 <field name="matching_skill_ids" widget="many2many_tags"/>
                 <field name="missing_skill_ids" widget="many2many_tags"/>
+            </field>
+            <field name="recruiter_id" position="after">
+                <xpath expr="//field[@name='kanban_state']" position="move"/>
             </field>
         </field>
     </record>

--- a/addons/hr_recruitment_skills/views/hr_job_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_job_views.xml
@@ -30,6 +30,19 @@
         <field name="binding_model_id" ref="hr_recruitment.model_hr_job"/>
         <field name="binding_view_types">form</field>
         <field name="state">code</field>
-        <field name="code">action = records.action_search_matching_applicants()</field>
+        <field name="code">action = records.with_context({'search_default_talents': 1}).action_search_matching_applicants()</field>
+    </record>
+
+    <record id="view_hr_job_kanban" model="ir.ui.view">
+        <field name="name">hr.job.view.kanban.inherit.hr.recruitment.skills</field>
+        <field name="model">hr.job</field>
+        <field name="inherit_id" ref="hr_recruitment.view_hr_job_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='menu_view_job_posts']" position="before">
+                <div role="menuitem" name="menu_view_matching_applicants">
+                    <a name="action_search_matching_applicants" type="object" context="{'default_job_id': id, 'search_default_talents': True}">Matching Talents</a>
+                </div>
+            </xpath>
+        </field>
     </record>
 </odoo>

--- a/addons/hr_recruitment_survey/views/hr_job_views.xml
+++ b/addons/hr_recruitment_survey/views/hr_job_views.xml
@@ -23,7 +23,7 @@
             <xpath expr="//field[@name='active']" position="after">
                 <field name="survey_id"/>
             </xpath>
-            <xpath expr="//div[@name='menu_view_applications']" position="after">
+            <xpath expr="//div[@name='menu_view_job_posts']" position="after">
                 <div role="menuitem" t-if="record.survey_id.raw_value">
                     <a name="action_test_survey" type="object" title="Display Interview Form">Interviews</a>
                 </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit is part of a 9-part task aiming to improve the user experience of multiple apps related to hr_recruitment.

This commit:
- removes an erroneous domain that causes applicants to not filter properly in the talent pool transient model
- fixes the add applicants to pool duplicating applicants erroneously by checking if the pool applicant already has a corresponding ID before duplicating it
- removes Applications and Activities from the Job '...' button because they were duplications of already existing actions, and adds 'Matching Talents' instead
- modifies the search_matching_applicants function to be able to change the search view depending on if the view is meant for applicants or talents
- modifies the actions of the applicant list view: removes a never shown "Add Applicants " action, renames "Create Applications" to "Apply to Jobs" for consistency, and adds the "Add to Pool" action

task-5212992

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
