### PR TITLE
[FIX] hr: Fix Version Timeline Zoom-out & Zoom-in

### DIFF
--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.scss
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.scss
@@ -1,5 +1,7 @@
 .o_field_statusbar {
     > .o_statusbar_status {
+        width: auto;
+        height: 100%;
         .o_arrow_button_wrapper {
             .o_purple_line {
                 background-color: var(--o-cc1-btn-primary);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
. When you zoom-out below 100%, the other versions from the version bar disappear, leaving only the active one
. Wen zoom-in, a side vertical scrollbar appear

Desired behavior after PR is merged:
. all versions on timeline appears normally without sides scrollbar

task-5401380