### PR TITLE
[FIX] fleet, point_of_sale: Adjust VAT -> tax

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -72,7 +72,7 @@
       </record>
 
       <record id="type_service_service_11" model="fleet.service.type">
-          <field name="name">Rent (Excluding VAT)</field>
+          <field name="name">Rent (Excluding Tax)</field>
           <field name="category">service</field>
       </record>
 
@@ -82,12 +82,12 @@
       </record>
 
       <record id="type_service_service_13" model="fleet.service.type">
-          <field name="name">Total expenses (Excluding VAT)</field>
+          <field name="name">Total expenses (Excluding Tax)</field>
           <field name="category">service</field>
       </record>
 
       <record id="type_service_service_14" model="fleet.service.type">
-          <field name="name">Residual value (Excluding VAT)</field>
+          <field name="name">Residual value (Excluding Tax)</field>
           <field name="category">service</field>
       </record>
 

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -124,7 +124,7 @@ class FleetVehicle(models.Model):
          ('expired', 'Expired'),
          ('closed', 'Closed')
         ], string='Last Contract State', compute='_compute_contract_reminder', required=False)
-    car_value = fields.Float(string="Catalog Value (VAT Incl.)", tracking=True)
+    car_value = fields.Float(string="Catalog Value (Tax Incl.)", tracking=True)
     net_car_value = fields.Float(string="Purchase Value")
     residual_value = fields.Float()
     plan_to_change_car = fields.Boolean(tracking=True)

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -80,7 +80,7 @@
                     <div class="grid gap-2">
                         <label class="fw-bold">Price excl. Tax:</label>
                         <span><t t-esc="env.utils.formatCurrency(props.info.productInfo.all_prices.price_without_tax)"/></span>
-                        <label class="fw-bold">VAT:</label>
+                        <label class="fw-bold">Tax:</label>
                         <span>
                             <t t-esc="props.info.taxAmount"/>
                             (<t t-esc="props.info.taxName"/>)
@@ -106,7 +106,7 @@
                     <div class="grid gap-2">
                         <label class="fw-bold">Total Price excl. Tax:</label>
                         <span t-esc="props.info.orderPriceWithoutTaxCurrency"/>
-                        <label class="fw-bold">Total VAT:</label>
+                        <label class="fw-bold">Total Tax:</label>
                         <span t-esc="props.info.orderTaxTotalCurrency"/>
                         <label class="fw-bold">Total Price incl. Tax:</label>
                         <span t-esc="props.info.orderPriceWithTaxCurrency"/>


### PR DESCRIPTION
In the US and many other countries, the term "VAT" doesn't really exist. Most countries have their own term to refer to a sales tax or other types of taxes and have already adjusted it via translations. Given that we can't create a translation for en_US just to translate VAT -> Tax, we have to swap the few places that refer to taxes as VAT to actually use Tax as it is a more universal term than VAT.

task-5401292
