### PR TITLE
[FIX] base: Change US Vat Label to TIN

### DIFF
--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -117,7 +117,7 @@ class TestAccountPartner(AccountTestInvoicingCommon):
         move.action_post()
         self.partner_a.vat = 'SOMETHING'
         self.partner_b.vat = 'DIFFERENT'
-        with self.assertRaisesRegex(UserError, "different Tax ID"):
+        with self.assertRaisesRegex(UserError, f"different {self.partner_a.vat_label}"):
             self.partner_a.parent_id = self.partner_b
 
     def test_manually_write_partner_id_empty_string_vs_False(self):

--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1502,7 +1502,7 @@
             <field eval="'%(street)s\n%(street2)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s'" name="address_format" />
             <field name="currency_id" ref="USD" />
             <field eval="1" name="phone_code" />
-            <field name="vat_label"/> <!-- Empty to reset on existing DBs-->
+            <field name="vat_label">TIN</field>
         </record>
         <record id="uy" model="res.country">
             <field name="name">Uruguay</field>


### PR DESCRIPTION
In [^1] we reset the US Vat label from EIN to the default of Tax ID as EIN is not the only term for a Tax ID in the US. However, TIN is the parent term that refers to all of the possible values and is more recognized within the country and companies than just Tax ID.

[^1]: 4e124fe89283ecf50a328d405af233b9a3dfc227

task-5400743