### PR TITLE
[FIX] stock_account: correctly calculate avco value with both receipts and manual value adjustments

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -282,7 +282,7 @@ class ProductProduct(models.Model):
             moves_domain &= Domain([
                 ('date', '<=', at_date),
             ])
-        moves_in = self.env['stock.move'].search(moves_domain & Domain(['|', ('is_in', '=', True), ('is_dropship', '=', True)]))
+        moves_in = self.env['stock.move'].search(moves_domain & Domain(['|', ('is_in', '=', True), ('is_dropship', '=', True)]), order='date, id')
         moves_out = self.env['stock.move'].search(moves_domain & Domain(['|', ('is_out', '=', True), ('is_dropship', '=', True)])) if method == "realtime" else self.env['stock.move']
         # TODO convert to company UoM
         product_value_domain = Domain([('product_id', '=', self.id)])

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2370,6 +2370,7 @@ class TestStockValuation(TestStockValuationCommon):
         This test check that the value of this SVL is correct and does result in new_std_price * quantity.
         To do so, we create 2 In moves, which result in a standard price rounded at $5.29, the non-rounded value ≃ 5.2857.
         Then we update the standard price to $7
+        We will then do one more In move to ensure that the most recent value information is used when both sources are present.
         """
         product = self.product_avco
         self._make_in_move(product, 5, unit_cost=5)
@@ -2388,6 +2389,13 @@ class TestStockValuation(TestStockValuationCommon):
         with freeze_time(Datetime.now() + timedelta(minutes=1)):
             product.standard_price = 7
         self.assertEqual(product.total_value, 49)
+
+        with freeze_time(Datetime.now() + timedelta(minutes=2)):
+            move = self._make_in_move(product, 5, unit_cost=5)
+            # We force the sequence here to simulate moves that are not ordered by date
+            move.sequence = -1
+
+        self.assertEqual(product.total_value, 74)  # 49 + (5 * 5) = 74
 
     def test_average_manual_revaluation(self):
         product = self.product_avco


### PR DESCRIPTION
Problem:
When computing avco value of a product whose unit cost has been manually changed, in_moves that occur after the manual value adjustment will be disregarded even if they are more recent. This occurs because PSQL returns the records in heap order when no order is specified.

Solution:
Sort the in_moves by date when computing avco value in order to properly determine whether to prioritize the manual value or the receipt.

Steps to reproduce (Runbot 19):
- Product (AVCO Perpetual)

1. Create a PO for 10 units at $10 each, confirm and receive
2. Navigate to the Stock report, note the Unit Value of $10, and Total Value of $100
3. On the product form, set the Cost to $100
4. Navigate to the Stock report, note the Unit Value of $100, and Total Value of $1000
5. Create a PO for 10 units at $1000 each, confirm and receive
6. Navigate to the Stock report, note the Unit Value is still $100, and the total value has increased to $2000 along with the on hand to 20

opw-5375492
