### PR TITLE
[IMP] account_{edi_ubl_cii,peppol}: add option to exclude product references in PEPPOL invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1001,13 +1001,16 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
         pass
 
     def _add_document_line_item_nodes(self, line_node, vals):
+        invoice = vals.get('invoice')
         product = vals['base_line']['product_id']
 
         line_node['cac:Item'] = {
             'cbc:Description': {'_text': product.description_sale},
             'cbc:Name': {'_text': product.name},
             'cac:SellersItemIdentification': {
-                'cbc:ID': {'_text': product.default_code},
+                'cbc:ID': {
+                    '_text': product.default_code
+                } if not invoice or invoice.peppol_include_product_reference else None,
             },
             'cac:StandardItemIdentification': {
                 'cbc:ID': {

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_hiding_product_code.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_hiding_product_code.xml
@@ -1,0 +1,149 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+    <cbc:ID>INV/2017/00001</cbc:ID>
+    <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+    <cbc:DueDate>2017-01-01</cbc:DueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cac:OrderReference>
+        <cbc:ID>INV/2017/00001</cbc:ID>
+    </cac:OrderReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+                <cbc:CityName>Ramillies</cbc:CityName>
+                <cbc:PostalZone>1367</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+                <cbc:CityName>Ramillies</cbc:CityName>
+                <cbc:PostalZone>1367</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:Delivery>
+        <cac:DeliveryLocation>
+            <cac:Address>
+                <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+                <cbc:CityName>Ramillies</cbc:CityName>
+                <cbc:PostalZone>1367</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:Address>
+        </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
+    </cac:Delivery>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>INV/2017/00001</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>BE15001559627230</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    <cac:PaymentTerms>
+        <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+    </cac:PaymentTerms>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">121.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="EUR">121.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>[P123] product_a</cbc:Description>
+            <cbc:Name>product_a</cbc:Name>
+            <cac:StandardItemIdentification>
+                <cbc:ID schemeID="0160">1234567890123</cbc:ID>
+            </cac:StandardItemIdentification>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">100.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
@@ -171,6 +171,33 @@ class TestUblBis3(AccountTestInvoicingCommon):
         self._generate_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'bis3/test_product_code_and_barcode')
 
+    def test_hiding_product_code(self):
+        self.setup_partner_as_be1(self.env.company.partner_id)
+        self.setup_partner_as_be2(self.partner_a)
+        tax_21 = self.percent_tax(21.0)
+
+        self.product_a.write({
+            'default_code': 'P123',
+            'barcode': '1234567890123',
+        })
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(tax_21.ids)],
+                }),
+            ],
+            'peppol_include_product_reference': False,
+        })
+        invoice.action_post()
+        self._generate_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'bis3/test_hiding_product_code')
+
     def test_financial_account(self):
         self.setup_partner_as_be1(self.env.company.partner_id)
         self.setup_partner_as_be2(self.partner_a)

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -22,6 +22,10 @@ class AccountMove(models.Model):
         string='PEPPOL status',
         copy=False,
     )
+    peppol_include_product_reference = fields.Boolean(
+        string='Include Product Reference',
+        default=True
+    )
 
     def action_send_and_print(self):
         for move in self:

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -18,6 +18,9 @@
                     There was an error while sending this invoice via Peppol.
                 </div>
             </sheet>
+            <xpath expr="//group[@name='sale_info_group']" position="inside">
+                <field name="peppol_include_product_reference"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Introduced a new boolean field to control the inclusion of product references in PEPPOL invoices. Added corresponding logic, tests, and XML changes to support this feature.

Task-5401660

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
