### PR TITLE
[FIX] l10n_es_edi_verifactu_pos: do not allow multi-order invoice consolidation

### DIFF
--- a/addons/l10n_es_edi_verifactu/tests/common.py
+++ b/addons/l10n_es_edi_verifactu/tests/common.py
@@ -192,3 +192,16 @@ class TestL10nEsEdiVerifactuCommon(AccountTestInvoicingCommon):
         invoice.action_post()
 
         return invoice
+
+    def _mock_zeep_registration_operation_single_accept_no_wait(self):
+        # Note: The real result is of type 'odoo.tools.zeep.client.SerialProxy'; here it is a dict
+        zeep_response_dict = json.loads(self._read_file('l10n_es_edi_verifactu/tests/responses/batch_single_accepted_registration.json'))
+        self.env.company.sudo().l10n_es_edi_verifactu_next_batch_time = False  # to not get blocked by the wait time
+
+        def _mock_register_accept(*args, **kwargs):
+            document_id_factura = args[1][0]['RegistroAlta']['IDFactura']
+            response_id_factura = zeep_response_dict['RespuestaLinea'][0]['IDFactura']
+            response_id_factura.update(document_id_factura)
+            return zeep_response_dict
+
+        return self._mock_get_zeep_operation(registration_return_value=_mock_register_accept)

--- a/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
@@ -290,6 +290,8 @@ class PosOrder(models.Model):
         if not self.config_id.l10n_es_edi_verifactu_required:
             return res
 
+        if len(self) > 1:
+            raise UserError(_("With Veri*Factu enabled, POS orders cannot be consolidated into one invoice."))
         res['l10n_es_edi_verifactu_refund_reason'] = self.l10n_es_edi_verifactu_refund_reason
         # There is no reason to create a simplified invoice instead of just creating an order.
         # (Currently "simplified" basically just removes the partner information.)

--- a/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
@@ -244,3 +244,22 @@ class TestL10nEsEdiVerifactuPosOrder(TestL10nEsEdiVerifactuPosCommon):
             'state': 'accepted',
             'errors': False,
         }])
+
+    def test_consolidated_invoice_for_multiple_orders(self):
+        with self.with_pos_session():
+            data = {
+                'is_invoiced': False,
+                'customer': self.partner_b,
+                'pos_order_lines_ui_args': [(self.product, 1.0)],
+                'payments': [(self.bank_pm1, 121.0)],
+            }
+            orders = self.env['pos.order']
+            for _ in range(2):
+                with self._mock_zeep_registration_operation_single_accept_no_wait():
+                    orders |= self._create_order(data)
+
+        wizard = self.env['pos.make.invoice'] \
+            .create({'consolidated_billing': True}) \
+            .with_context({'active_ids': orders.ids})
+        with self.assertRaises(UserError, msg="With Veri*Factu enabled, POS orders cannot be consolidated into one invoice."):
+            wizard.action_create_invoices()


### PR DESCRIPTION
Step to reproduce:
- install `l10n_es_edi_verifactu_pos` and open POS
- finalize 2 order with same customer (do not invoive it)
- close session
- go to pos orders, select both order and try to create consolidated invoice

Traceback:
```
File "/home/odoo/addons/l10n_es_edi_verifactu_pos/models/pos_order.py", line 293, in _prepare_invoice_vals
    res['l10n_es_edi_verifactu_refund_reason'] = self.l10n_es_edi_verifactu_refund_reason
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/odoo/odoo/orm/fields.py", line 1365, in __get__
    record.ensure_one()
```

Cause:
- `_prepare_invoice_vals` is written to accept only one order at time but it can contain multiple orders

Fix:
- we now do not allow invoice consolidation for Veri*Factu
- the consolidation flag has been made invisible so every order now has
to be invoiced individually.

opw-5379577

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
