### PR TITLE
[IMP] hr_attendance: improve overtime ruleset form UI

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -95,7 +95,7 @@ class HrAttendanceOvertimeRule(models.Model):
     )
     sequence = fields.Integer(default=10)
 
-    ruleset_id = fields.Many2one('hr.attendance.overtime.ruleset', required=True, index=True)
+    ruleset_id = fields.Many2one('hr.attendance.overtime.ruleset', required=True, index=True, ondelete="cascade", default=lambda self: self.env.context.get('active_id', None))
     company_id = fields.Many2one(related='ruleset_id.company_id')
 
     paid = fields.Boolean("Pay Extra Hours")

--- a/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import api, fields, models
+from collections import defaultdict
 
 
 class HrAttendanceOvertimeRuleset(models.Model):
@@ -35,10 +36,17 @@ class HrAttendanceOvertimeRuleset(models.Model):
     version_ids = fields.One2many('hr.version', 'ruleset_id')
     versions_count = fields.Integer(compute="_compute_versions_count")
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("name", False):
+                vals['name'] = self.env._("Unnamed Ruleset")
+        return super().create(vals_list)
+
     def _get_current_versions_domain(self):
         today = fields.Date.today()
         return [
-            ("ruleset_id", "in", self.ids),
+            ("date_version", "<=", today),
             ("contract_date_start", "<=", today),
             "|",
                 ("contract_date_end", "=", False),
@@ -51,11 +59,16 @@ class HrAttendanceOvertimeRuleset(models.Model):
             ruleset.rules_count = len(ruleset.rule_ids)
 
     def _compute_versions_count(self):
-        count_by_ruleset = dict(self.env['hr.version']._read_group(
-                domain=self._get_current_versions_domain(),
-                groupby=['ruleset_id'],
-                aggregates=['__count'],
-            ))
+        versions = self.env['hr.version']._read_group(
+            domain=self._get_current_versions_domain(),
+            groupby=['employee_id'],
+            aggregates=['id:recordset'],
+        )
+        count_by_ruleset = defaultdict(int)
+        for employee, recordset in versions:
+            record = recordset.sorted('date_version DESC')[0]
+            if record.ruleset_id in self:
+                count_by_ruleset[record.ruleset_id] += 1
         for ruleset in self:
             ruleset.versions_count = count_by_ruleset.get(ruleset, 0)
 
@@ -75,11 +88,34 @@ class HrAttendanceOvertimeRuleset(models.Model):
 
     def action_show_versions(self):
         self.ensure_one()
+        data = self.env['hr.version']._read_group(
+            domain=self._get_current_versions_domain(),
+            groupby=['employee_id'],
+            aggregates=['id:recordset'],
+        )
+        versions = self.env['hr.version']
+        for employee, recordset in data:
+            record = recordset.sorted('date_version DESC')[0]
+            versions |= record
         action = self.env['ir.actions.act_window']._for_xml_id('hr_attendance.hr_version_list_view')
-        action['domain'] = self._get_current_versions_domain()
-        action['context'] = {'default_ruleset_id': self.id}
+        action['domain'] = [('id', 'in', versions.ids)]
+        action['context'] = {
+            'search_default_ruleset_id': self.id,
+            'default_ruleset_id': self.id,
+        }
         return action
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
         return [dict(vals, name=self.env._("%s (copy)", ruleset.name)) for ruleset, vals in zip(self, vals_list)]
+
+    def action_create_overtime_rule(self):
+        return {
+            'name': self.env._('Create Rule'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.attendance.overtime.rule',
+            'view_mode': 'form',
+            'views': [[False, 'form']],
+            'view_id': self.env.ref('hr_attendance.hr_attendance_overtime_rule_view_form').id,
+            'target': 'new',
+        }

--- a/addons/hr_attendance/models/hr_version.py
+++ b/addons/hr_attendance/models/hr_version.py
@@ -1,6 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
+
 from odoo import api, models, fields
+
+from odoo.addons.hr.models.hr_version import format_date_abbr
 
 
 class HrVersion(models.Model):
@@ -31,6 +35,29 @@ class HrVersion(models.Model):
          default=_default_ruleset_id,
     )
 
+    def write(self, vals):
+        """Track field changes and log them to the employees"""
+        tracked_field_names = {fname for fname in self._track_get_fields() if fname in vals}
+        if tracked_field_names:
+            for version in self:
+                employee = version.employee_id
+                if not employee:
+                    continue
+                employee._track_record(
+                    version, tracked_field_names,
+                )
+                version_sudo = employee.version_id.sudo()
+                start = format_date_abbr(self.env, version_sudo.date_start) if version_sudo.date_start else False
+                end = format_date_abbr(self.env, version_sudo.date_end) if version_sudo.date_end else False
+                if start and end:
+                    msg = self.env._("Modified from %(start)s to %(end)s") % {'start': start, 'end': end}
+                elif start:
+                    msg = self.env._("Modified from %s") % (start)
+                else:
+                    msg = self.env._("Modified")
+                employee._track_set_log_message_for_target(Markup("<b>%s</b>") % msg, version)
+        return super().write(vals)
+
     @api.model
     def _get_versions_by_employee_and_date(self, employee_dates):
         # for `employee_dates` a dict[employee] -> dates
@@ -57,24 +84,3 @@ class HrVersion(models.Model):
                     version_index += 1
                 version_by_employee_and_date[employee][date] = versions[version_index]
         return version_by_employee_and_date
-
-    def action_open_version_selector(self):
-        action = self.env['ir.actions.act_window']._for_xml_id('hr_attendance.hr_version_list_view_add')
-        today = fields.Date.today()
-        action['domain'] = [
-            ("ruleset_id", "=", False),
-            ("contract_date_start", "<=", today),
-            "|",
-            ("contract_date_end", "=", False),
-            ("contract_date_end", ">=", today),
-            ("employee_id", "!=", False),
-        ]
-        action['context'] = {'default_ruleset_id': self.env.context.get('default_ruleset_id', False)}
-        return action
-
-    def action_unassign_ruleset(self):
-        self.ruleset_id = False
-
-    def action_assign_ruleset(self):
-        if ruleset_id := self.env.context.get('default_ruleset_id', False):
-            self.ruleset_id = ruleset_id

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -100,49 +100,53 @@
                     <button name="action_regenerate_overtimes"
                         class="btn"
                         string="Regenerate overtimes"
-                        icon="fa-clock-o"
                         type="object"
-                        groups="hr_attendance.group_hr_attendance_officer"
+                        groups="base.group_no_one,hr_attendance.group_hr_attendance_officer"
                         help="Regenerate overtimes for this ruleset"/>
                 </header>
                 <sheet>
-                    <div class="oe_title">
-                        <label for="name" string="Ruleset Name"/>
-                        <h1><field name="name" placeholder="e.g. Legal Rules"/></h1>
-                    </div>
                     <div class="oe_button_box" name="button_box">
                         <button
                             name="action_show_versions"
                             type="object"
                             class="oe_stat_button"
                             icon="fa-id-card-o"
-                            invisible="not id"
-                            >
-                            <field name="versions_count" widget="statinfo" string="Employees" invisible="not versions_count"/>
-                            <div class="o_field_widget o_stat_info" invisible="versions_count">
-                                <div class="o_field_widget o_stat_info ms-1">
-                                    <span class="o_stat_value">Add</span>
-                                    <span class="o_stat_text">Employees</span>
-                                </div>
-                            </div>
+                            invisible="not id">
+                            <field name="versions_count" widget="statinfo" string="Employees"/>
                         </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name" string="Ruleset Name"/>
+                        <h1><field name="name" placeholder="e.g. Legal Rules" required="id"/></h1>
                     </div>
                     <group>
                         <group>
                             <field name="rate_combination_mode"/>
                         </group>
                         <group>
-                            <field name="country_id" options="{'no_create': True, 'no_open': True}" groups="base.group_multi_company"/>
+                            <field name="country_id" options="{'no_create': True, 'no_open': True}" groups="base.group_multi_company" placeholder="Available in all countries"/>
                         </group>
                     </group>
-                    <group colspan="4">
+                    <group>
                         <field 
-                            name="description" colspan="4"
+                            name="description"
                             placeholder="Provide a description or sources for this ruleset."/>
                     </group>
-                    <notebook colspan="4">
+                    <div class="border rounded-3 d-flex flex-column justify-content-center align-items-center mt-2 flex-1 overflow-hidden" invisible="rule_ids">
+                        <div class="o_view_nocontent" style="position: relative;">
+                            <div class="o_nocontent_help text-center">
+                                <p class="o_view_nocontent_smiling_face">
+                                    No rules on the ruleset yet. Let's create a new one
+                                </p>
+                                <button name="action_create_overtime_rule" type="object"
+                                        class="btn btn-primary"
+                                        string="Create an overtime rule"/>
+                            </div>
+                        </div>
+                    </div>
+                    <notebook colspan="4" invisible="not rule_ids">
                         <page name="overtime_rules" string="Overtime Rules">
-                            <field name="rule_ids" readonly="not id">
+                            <field name="rule_ids">
                                 <list>
                                     <field name="sequence" widget="handle"/>
                                     <field name="name"/>

--- a/addons/hr_attendance/views/hr_version_views.xml
+++ b/addons/hr_attendance/views/hr_version_views.xml
@@ -1,45 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="hr_version_list_view_enhanced_hr_attendance_base" model="ir.ui.view">
+    <record id="hr_attendance_hr_version_list_edit_ruleset" model="ir.ui.view">
         <field name="name">hr.version.list.view.enhanced.hr.attendance.base</field>
         <field name="model">hr.version</field>
-        <field name="inherit_id" ref="hr.hr_version_list_view_enhanced"/>
-        <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <field name="date_version" position="replace"/>
-            <field name="resource_calendar_id" position="replace"/>
-            <field name="job_id" position="after">
-                <field name="resource_calendar_id" optional="show"/>
-            </field>
-        </field>
-    </record>
-
-    <record id="hr_version_list_view_enhanced_hr_attendance_add" model="ir.ui.view">
-        <field name="name">hr.version.list.view.enhanced.hr.attendance.add</field>
-        <field name="model">hr.version</field>
-        <field name="inherit_id" ref="hr_version_list_view_enhanced_hr_attendance_base"/>
-        <field name="mode">primary</field>
-        <field name="arch" type="xml">
-            <xpath expr="//list" position="inside">
-                <header>
-                    <button display="always" name="action_assign_ruleset" type="object" string="Add" class="btn-primary"/>
-                </header>
-            </xpath>
-        </field>
-    </record>
-
-    <record id="hr_version_list_view_enhanced_hr_attendance" model="ir.ui.view">
-        <field name="name">hr.version.list.view.enhanced.hr.attendance</field>
-        <field name="model">hr.version</field>
-        <field name="inherit_id" ref="hr_version_list_view_enhanced_hr_attendance_base"/>
-        <field name="mode">primary</field>
-        <field name="arch" type="xml">
-            <xpath expr="//list" position="inside">
-                <header>
-                    <button display="always" name="action_open_version_selector" type="object" string="Add Employees" class="btn-primary"/>
-                    <button name="action_unassign_ruleset" type="object" string="Remove" class="btn-secondary"/>
-                </header>
-            </xpath>
+            <list multi_edit="1" editable="bottom" create="0" delete="0">
+                <field name="employee_id" readonly="1"/>
+                <field name="job_id" readonly="1"/>
+                <field name="resource_calendar_id" readonly="1"/>
+                <field name="department_id" readonly="1"/>
+                <field name="ruleset_id"/>
+            </list>
         </field>
     </record>
 
@@ -49,8 +20,12 @@
         <field name="inherit_id" ref="hr.hr_version_search_view_enhanced"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <xpath expr="//search/field[@name='company_id']" position="after">
+                <field name="ruleset_id"/>
+            </xpath>
             <xpath expr="//search/group/filter[@name='group_department']" position="before">
                 <filter name="group_resource_calendar" string="Working Hours" domain="[]" context="{'group_by': 'resource_calendar_id'}"/>
+                <filter name="group_ruleset" string="Ruleset" domain="[]" context="{'group_by': 'ruleset_id'}"/>
             </xpath>
         </field>
     </record>
@@ -59,29 +34,13 @@
         <field name="name">Employees</field>
         <field name="res_model">hr.version</field>
         <field name="view_mode">list</field>
-        <field name="view_id" ref="hr_attendance.hr_version_list_view_enhanced_hr_attendance"/>
+        <field name="view_id" ref="hr_attendance.hr_attendance_hr_version_list_edit_ruleset"/>
         <field name="search_view_id" ref="hr_attendance.hr_version_search_view_enhanced_hr_attendance"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Records.
             </p><p>
                 There are no employees assigned to this overtime ruleset.
-            </p>
-        </field>
-    </record>
-    
-    <record id="hr_version_list_view_add" model="ir.actions.act_window">
-        <field name="name">Employees</field>
-        <field name="res_model">hr.version</field>
-        <field name="view_mode">list</field>
-        <field name="target">new</field>
-        <field name="view_id" ref="hr_attendance.hr_version_list_view_enhanced_hr_attendance_add"/>
-        <field name="search_view_id" ref="hr_attendance.hr_version_search_view_enhanced_hr_attendance"/>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                No Records.
-            </p><p>
-                There are no employees without an overtime ruleset.
             </p>
         </field>
     </record>


### PR DESCRIPTION
Before:
- Ruleset Name header didn’t span full width.
- Header block background looked inconsistent.
- “Regenerate overtimes” button always visible and had an unnecessary clock icon.
- Country field lacked placeholder guidance.
- Empty-state message for ruleset rules wasn’t clear.

After:
- Ruleset Name now uses full width for a cleaner layout.
- Removed unused header background.
- “Regenerate overtimes” now only appears in dev mode and without the clock icon.
- Added “Available in all countries” placeholder to country_id.
- Added clearer empty-state message with a button to create the first overtime rule.

Impact:
Improves clarity, visual consistency, and user guidance in the overtime ruleset form.

Task: 5391395