### PR TITLE
[FIX] fields: avoid compuation for field inherited field

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -901,6 +901,8 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
     def _description_sortable(self, env):
         if self.column_type and self.store:  # shortcut
             return True
+        if self.inherited_field and self.inherited_field._description_sortable(env):  # avoid compuation for inherited field
+            return True
 
         model = env[self.model_name]
         query = model._as_query(ordered=False)
@@ -912,6 +914,8 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
 
     def _description_groupable(self, env):
         if self.column_type and self.store:  # shortcut
+            return True
+        if self.inherited_field and self.inherited_field._description_groupable(env):  # avoid compuation for inherited field
             return True
 
         model = env[self.model_name]
@@ -926,6 +930,8 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
     def _description_aggregator(self, env):
         if not self.aggregator or self.column_type and self.store:  # shortcut
             return self.aggregator
+        if self.inherited_field and self.inherited_field._description_aggregator(env):  # avoid compuation for inherited field
+            return self.inherited_field.aggregator
 
         model = env[self.model_name]
         query = model._as_query(ordered=False)


### PR DESCRIPTION
when the ``get_description`` is calling. So, it getting all the information weather it's groupable or not for it [here](https://github.com/odoo/odoo/blob/b48d41086d7ff8ef91c6c43d37d588686d6b921a/odoo/orm/fields.py#L923) and field is from inherited model it trying ``model._read_group_groupby(model._table, groupby, query)`` because those related and non store. As there is no meaning for computation for that because it going groupable because it parent_field is groupable. So, keeping check for that and reduce the computation.

```
   File "/tmp/tmpmagm1mli/migrations/base/tests/test_mock_crawl.py", line 430, in mock_act_window
    views = get_views(
   File "/home/odoo/src/odoo/19.0/addons/mail/models/mail_thread.py", line 463, in get_views
    res = super().get_views(views, options)
   File "/home/odoo/src/enterprise/19.0/web_studio/models/models.py", line 10, in get_views
    result = super().get_views(views, options=options)
   File "/home/odoo/src/enterprise/19.0/web_studio/models/ir_ui_view.py", line 52, in get_views
    return super().get_views(views, options)
   File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_ui_view.py", line 2935, in get_views
    result['models'][model] = {"fields": self.env[model].fields_get(
   File "/home/odoo/src/odoo/19.0/addons/stock/models/product.py", line 521, in fields_get
    res = super().fields_get(allfields, attributes)
   File "/home/odoo/src/enterprise/19.0/web_studio/models/ir_model.py", line 76, in fields_get
    return super().fields_get(allfields, attributes=attributes)
   File "/home/odoo/src/enterprise/19.0/ai_fields/models/models.py", line 47, in fields_get
    res = super().fields_get(allfields, attributes)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3360, in fields_get
    description = field.get_description(self.env, attributes=attributes)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 883, in get_description
    value = value(env)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 930, in _description_groupable
    model._read_group_groupby(model._table, groupby, query)
   File "/home/odoo/src/odoo/19.0/addons/mail/models/mail_activity_mixin.py", line 259, in _read_group_groupby
    return super()._read_group_groupby(alias, groupby_spec, query)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 2064, in _read_group_groupby
    coquery = comodel._search(codomain, bypass_access=field.bypass_search_access)
   File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_attachment.py", line 659, in _search
    records = self.sudo().with_context(active_test=False).search_fetch(
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 1418, in search_fetch
    return self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3914, in _fetch_query
    rows = self.env.execute_query(query.select(*sql_terms))
   File "/home/odoo/src/odoo/19.0/odoo/orm/environments.py", line 534, in execute_query
    self.cr.execute(query)
   File "/home/odoo/src/odoo/19.0/odoo/tests/test_cursor.py", line 79, in execute
    return self._cursor.execute(*args, **kwargs)
   File "/home/odoo/src/odoo/19.0/odoo/sql_db.py", line 426, in execute
    self._obj.execute(query, params)
 psycopg2.DatabaseError: out of memory for query result
```

opw-5260147
upg-3444635

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
