### PR TITLE
[FIX] mass_mailing: wip

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -149,6 +149,7 @@
             'mass_mailing/static/src/scss/mass_mailing.scss',
             'mass_mailing/static/src/scss/mass_mailing_mobile.scss',
             'mass_mailing/static/src/scss/mass_mailing_mobile_preview.scss',
+            'mass_mailing/static/src/js/mass_mailing_import_action.js',
             'mass_mailing/static/src/js/mailing_m2o_filter.js',
             'mass_mailing/static/src/xml/mailing_filter_widget.xml',
             'mass_mailing/static/src/js/tours/**/*',

--- a/addons/mass_mailing/static/src/js/mass_mailing_import_action.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_import_action.js
@@ -1,0 +1,18 @@
+import { registry } from "@web/core/registry";
+import { ImportAction } from "@base_import/import_action/import_action";
+export class MassMailingImportAction extends ImportAction {
+    setup() {
+        super.setup();
+        // this.props.action.params.model is there for retro-compatiblity issues
+        this.resModel = this.props.action.params.model || this.props.action.params.active_model;
+        if (this.resModel) {
+            this.props.updateActionState({ active_model: this.resModel });
+        }
+    }
+
+    onWillStart() {
+        this.model.setResModel(this.resModel);
+        return this.model.init();
+    }
+};
+registry.category("actions").add("action_import_mailing_contacts", MassMailingImportAction);

--- a/addons/mass_mailing/wizard/mailing_contact_import.py
+++ b/addons/mass_mailing/wizard/mailing_contact_import.py
@@ -123,7 +123,7 @@ class MailingContactImport(models.TransientModel):
 
         return {
             'type': 'ir.actions.client',
-            'tag': 'import',
+            'tag': 'action_import_mailing_contacts',
             'name': _('Import Mailing Contacts'),
             'params': {
                 'context': self.env.context,


### PR DESCRIPTION
[FIX] mass_mailing: fix import contact action

Steps to reproduce:
1. Install mass_mailing
2. Mail marketing > mailing lists
3. Click on `import contacts` button of any list
4. Click on `upload a file`
5. Now upload the data file

Issue: 
- The file is imported into the mailing list model instead of the mailing contact model.

Cause: 
- Since commit [1], the import action infers the model from the current action, which results in the wrong model being used.

Solution: 
- Adapts the import action to accept the model as a parameter

opw-5374829
