### PR TITLE
[IMP] account_peppol: add option to exclude product references in PEPPOL invoices

### DIFF
--- a/addons/account_peppol/models/__init__.py
+++ b/addons/account_peppol/models/__init__.py
@@ -7,3 +7,4 @@ from . import account_move_send
 from . import res_company
 from . import res_config_settings
 from . import res_partner
+from . import account_edi_xml_ubl_20

--- a/addons/account_peppol/models/account_edi_xml_ubl_20.py
+++ b/addons/account_peppol/models/account_edi_xml_ubl_20.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class AccountEdiXmlUbl_20(models.AbstractModel):
+    _inherit = 'account.edi.xml.ubl_20'
+
+    def _add_document_line_item_nodes(self, line_node, vals):
+        super()._add_document_line_item_nodes(line_node, vals)
+        invoice = vals.get('invoice')
+        if invoice and invoice.peppol_exclude_product_reference:
+            if line_node.get('cac:Item').get('cac:SellersItemIdentification'):
+                line_node['cac:Item']['cac:SellersItemIdentification'] = None

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -21,6 +21,7 @@ class AccountMove(models.Model):
         string='Peppol status',
         copy=False,
     )
+    peppol_exclude_product_reference = fields.Boolean(string='Exclude Product Reference')
 
     def action_send_and_print(self):
         for move in self:

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -18,6 +18,9 @@
                     There was an error while sending this invoice via Peppol.
                 </div>
             </sheet>
+            <xpath expr="//group[@name='sale_info_group']" position="inside">
+                <field name="peppol_exclude_product_reference"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Introduced a new boolean field to control the exclusion of product references in PEPPOL invoices. Added corresponding logic and XML changes to support this feature.

Task-5401660

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
