### PR TITLE
[FIX] pos_sale_margin: fix margin calculation

### DIFF
--- a/addons/pos_sale_margin/report/sale_report.py
+++ b/addons/pos_sale_margin/report/sale_report.py
@@ -9,5 +9,5 @@ class SaleReport(models.Model):
 
     def _fill_pos_fields(self, additional_fields):
         values = super()._fill_pos_fields(additional_fields)
-        values['margin'] = 'SUM(l.price_subtotal - COALESCE(l.total_cost,0) / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)'
+        values['margin'] = 'SUM((l.price_subtotal - COALESCE(l.total_cost,0)) / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)'
         return values


### PR DESCRIPTION
Step to reproduce:
- create new journal and a pricelist with different currency (here TWD i.e 36.833 * USD)
- set that pricelist and journal in a pos
- have a product with sales (here 1000$) and cost price (300$)
- create pos and finalize the order with that product
- go to sales > reporting > sales > pivot view
- check margin for that order

Observation:
- the margin is calculated wrong due to improper brackets
- current calculation  ( for TWD currency , multiply with currency rate)
sale price - ( cost price / currency rate)
i.e. `1000 * 36.833 - (300* 36.833 / 36.833) = 36833 - 300 = 36533`


Fix:
- fixed the calculation, used brackets
- actual calculation 
- `(1000 * 36.833 - 300 * 36.833) / 36.833 = 1000 - 300 = 700`

Before
<img width="687" height="97" alt="image" src="https://github.com/user-attachments/assets/3a821a5c-eb12-4eae-9465-1702e9d4ac97" />


After
<img width="679" height="110" alt="image" src="https://github.com/user-attachments/assets/d62dbb1d-6839-4099-90b1-6f9a19576721" />


opw-5166714


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
