### PR TITLE
[FIX] lower_logging: support mapping args

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -145,6 +145,16 @@ class DBFormatter(logging.Formatter):
         record.dbname = getattr(threading.current_thread(), 'dbname', '?')
         return logging.Formatter.format(self, record)
 
+    def formatMessage(self, record):
+        if record.munge_traceback:
+            return super().formatMessage(record).replace(
+                'Traceback (most recent call last):',
+                '_Traceback_ (most recent call last):',
+            )
+        else:
+            return super().formatMessage(record)
+
+
 class ColoredFormatter(DBFormatter):
     def format(self, record):
         fg_color, bg_color = LEVEL_COLOR_MAPPING.get(record.levelno, (GREEN, DEFAULT))
@@ -162,6 +172,7 @@ def init_logger():
     def record_factory(*args, **kwargs):
         record = old_factory(*args, **kwargs)
         record.perf_info = ""
+        record.munge_traceback = False
         return record
     logging.setLogRecordFactory(record_factory)
 

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -854,8 +854,8 @@ class lower_logging(logging.Handler):
         if record.levelno > self.max_level:
             record.levelname = f'_{record.levelname}'
             record.levelno = self.to_level
+            record.munge_traceback = True
             self.had_error_log = True
-            record.args = tuple(arg.replace('Traceback (most recent call last):', '_Traceback_ (most recent call last):') if isinstance(arg, str) else arg for arg in record.args)
 
         if logging.getLogger(record.name).isEnabledFor(record.levelno):
             for handler in self.old_handlers:


### PR DESCRIPTION
When `lower_logging` encounters a `LogRecord.args: Mapping`, it fucks up and strips out all the values keeping only the mapping keys (as a tuple), which then breaks when trying to format it in `LogRecord.msg`.

Fix the issue by moving the entire message munging into, appropriately, the formatter: `getMessage` will do the `str.__mod__` call at which point we don't need to deal with the args at all, then `formatMessage` generates the full message line (not including the stack traces from `exc_info` and `stack_info`, those are added in the second half of `Formatter.format`).

https://runbot.odoo.com/odoo/error/234669
