### PR TITLE
[FIX] hr: load demo employee data for the current company

### DIFF
--- a/addons/hr/data/scenarios/hr_scenario.xml
+++ b/addons/hr/data/scenarios/hr_scenario.xml
@@ -80,8 +80,6 @@
             <field name="name">Emma Granger</field>
             <field name="email">granger@mycompany.example.com</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_awa-image.jpg"/>
-            <field name="company_id" ref="base.main_company"/>
-            <field name="company_name">My Company</field>
             <field name="street">260 Broadway</field>
             <field name="city">New York</field>
             <field name="state_id"  model="res.country.state" search="[('code','=','NY')]"/>
@@ -95,8 +93,6 @@
             <field name="name">Michael Williams</field>
             <field name="email">williams@mycompany.example.com</field>
             <field name="image_1920" type="base64" file="hr/static/img/partner_root-image.jpg"/>
-            <field name="company_id" ref="base.main_company"/>
-            <field name="company_name">My Company</field>
             <field name="street">260 RoadStreet</field>
             <field name="city">New York</field>
             <field name="state_id"  model="res.country.state" search="[('code','=','NY')]"/>
@@ -110,8 +106,6 @@
             <field name="name">Simon Jones</field>
             <field name="email">jones@mycompany.example.com</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_qdp-image.png"/>
-            <field name="company_id" ref="base.main_company"/>
-            <field name="company_name">My Company</field>
             <field name="street">260 Broadway</field>
             <field name="city">New York</field>
             <field name="state_id"  model="res.country.state" search="[('code','=','NY')]"/>
@@ -136,7 +130,6 @@
             <field name="department_id" ref="hr.dep_administration"/>
             <field name="job_id" ref="job_ceo"/>
             <field name="job_title">Chief Executive Officer</field>
-            <field name="company_id" ref="base.main_company"/>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_demo')])]"/>
             <field name="image_1920" type="base64" file="hr/static/img/partner_root-image.jpg"/>
             <field name="work_phone">(555)-768-6230</field>
@@ -157,7 +150,6 @@
             <field name="work_email">granger@mycompany.example.com</field>
             <field name="job_id" ref="job_consultant"/>
             <field name="job_title">Consultant</field>
-            <field name="company_id" ref="base.main_company"/>
             <field name="category_ids" eval="[Command.set([ref('employee_category_5'), ref('employee_category_demo')])]"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_awa-image.jpg"/>
             <field name="work_phone">(555)-768-6230</field>
@@ -179,7 +171,6 @@
             <field name="work_email">jones@mycompany.example.com</field>
             <field name="job_id" ref="job_developer"/>
             <field name="job_title">Experienced Developer</field>
-            <field name="company_id" ref="base.main_company"/>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_demo')])]"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_qdp-image.png"/>
             <field name="work_phone">(555)-768-6230</field>


### PR DESCRIPTION
Currently, an error occurs when a user attempts to load demo data for a newly created company in the Appraisal module.

**Steps to Reproduce:**
1. Install `hr_appraisal` without demo data.
2. Create a new company and switch to it.
3. Appraisals > Click "Load sample data".

**Traceback:**
```
AccessError
Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, Sengsourigna Phonkaseumsouk (id=2) doesn't have 'read' access to:
- Employee, Emma Granger (hr.employee: 3, company=TPX Solutions)

Blame the following rules:
- Employee multi-company rule

If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.

This seems to be a multi-company issue; you might be able to access the record by switching to the company: TPX Solutions.

ParseError
while parsing /home/odoo/src/enterprise/18.0/hr_appraisal_skills/demo/scenarios/scenario_appraisal_demo.xml:4, somewhere inside <function model="hr.appraisal" name="_copy_skills_when_confirmed" eval="[ref('hr_appraisal.hr_appraisal_2')]"/>

ValueError
ParseError('while parsing /home/odoo/src/enterprise/18.0/hr_appraisal_skills/demo/scenarios/scenario_appraisal_demo.xml:4, somewhere inside\n<function model="hr.appraisal" name="_copy_skills_when_confirmed" eval="[ref(\'hr_appraisal.hr_appraisal_2\')]"/>') while evaluating 'action = model._load_demo_data()'
```
**Cause:**
The demo data loading process attempts to access employee records without the required permissions. Since the user belongs to a different company, the multi-company security rules prevent reading those employees.

**Fix:**
This commit removes the company assignment from the demo employee records so they are created in the current company instead of the base company.

sentry-7032880299