### PR TITLE
[FIX] hr_skills: prevent error when clicking employee skills pie chart report

### DIFF
--- a/addons/hr_skills/report/hr_employee_skill_history_report_views.xml
+++ b/addons/hr_skills/report/hr_employee_skill_history_report_views.xml
@@ -3,7 +3,7 @@
     <record id="hr_employee_skill_history_report_view_graph" model="ir.ui.view">
         <field name="model">hr.employee.skill.history.report</field>
         <field name="arch" type="xml">
-            <graph js_class="skills_graph" type="line" stacked="0">
+            <graph js_class="skills_graph" type="line" stacked="0" disable_linking="1">
                 <field name="date" interval="day" type="row"/>
                 <field name="skill_id" type="row"/>
                 <field name="level_progress" type="measure"/>


### PR DESCRIPTION
Clicking a record in the Employee Skills pie chart report currently triggers a traceback.

Steps to reproduce the error:
- Install ``hr_skills`` module with demo data
- Open any employee > In Resume tab, Click on TIMELINE
- Switch to Pie chart > click on any record

Traceback:
```py
UndefinedColumn: column hr_employee_skill_history_report.id does not exist
LINE 1: SELECT "hr_employee_skill_history_report"."id" FROM "hr_empl...
```

``hr.employee.skill.history.report`` model is ``_auto=False``,
meaning that no database table is created for this model.
In earlier versions, clicking on the record opens the list view.
In the [commit](https://github.com/odoo/odoo/commit/341fe890d2b7001dab1e3cd65ecb0c3bb4ed327e), list view was removed.
So, now clicking on the record will lead to the above traceback.

[1]: https://github.com/odoo/odoo/commit/341fe890d2b7001dab1e3cd65ecb0c3bb4ed327e

sentry-7099766240

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
