### PR TITLE
[IMP] product: allow hiding upload button in product document kanban

### DIFF
--- a/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.js
+++ b/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.js
@@ -10,6 +10,7 @@ export class ProductDocumentKanbanController extends KanbanController {
         this.formData = {
             'res_model': this.props.context.default_res_model,
             'res_id': this.props.context.default_res_id,
+            'hideUploadButton': this.props.context.hide_upload_button || false,
         };
     }
 }

--- a/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
+++ b/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
@@ -12,6 +12,7 @@
         <button
             type="button"
             name="product_upload_document"
+            t-if="!props.formData.hideUploadButton"
             t-attf-class="btn btn-primary"
             t-on-click.stop.prevent="() => this.uploadFileInputRef.el.click()"
         >


### PR DESCRIPTION
In Enterprise, there are cases where the upload button in the product document kanban needs to be hidden. Previously, the only way to do this was by overriding the entire template, which is fragile and leads to unnecessary duplication of Community code.

Allowing the button visibility to be controlled through context gives Enterprise a clean and maintainable way to hide the button without heavy overrides. This reduces merge conflicts, keeps the Community code stable, and makes the behavior easier to extend in the future.

Task ID: 5358428