### PR TITLE
[IMP] hr_work_entry: Working schedule display based on work entries

### DIFF
--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -69,13 +69,6 @@
                 sequence="5"/>
 
             <menuitem
-                id="menu_resource_calendar_view"
-                action="resource.action_resource_calendar_form"
-                parent="menu_config_employee"
-                name="Working Schedules"
-                sequence="6"/>
-
-            <menuitem
                 id="menu_hr_departure_reason_tree"
                 action="hr_departure_reason_action"
                 parent="menu_config_employee"
@@ -88,6 +81,19 @@
                 parent="menu_config_employee"
                 groups="base.group_no_one"
                 sequence="10"/>
+
+            <menuitem
+                id="menu_config_working_times"
+                name="Working Times"
+                parent="menu_human_resources_configuration"
+                sequence="15"/>
+
+                <menuitem
+                    id="menu_resource_calendar_view"
+                    action="resource.action_resource_calendar_form"
+                    parent="menu_config_working_times"
+                    name="Working Schedules"
+                    sequence="10"/>
 
             <menuitem
                 id="menu_config_recruitment"

--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -1,9 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from datetime import UTC, datetime, time
+from datetime import datetime, time
 from functools import reduce
 from zoneinfo import ZoneInfo
+
+from dateutil.relativedelta import relativedelta
+from dateutil.rrule import DAILY, rrule
 
 from odoo import api, models
 from odoo.fields import Domain
@@ -91,28 +94,162 @@ class ResPartner(models.Model):
 
     @api.model
     def get_working_hours_for_all_attendees(self, attendee_ids, date_from, date_to, everybody=False):
+        timezone = ZoneInfo(self.env.user.tz or "UTC")
+        start_period = datetime.fromisoformat(date_from).replace(hour=0, minute=0, second=0, tzinfo=timezone)
+        stop_period = datetime.fromisoformat(date_to).replace(hour=23, minute=59, second=59, tzinfo=timezone)
 
-        start_period = datetime.fromisoformat(date_from).replace(hour=0, minute=0, second=0, tzinfo=UTC)
-        stop_period = datetime.fromisoformat(date_to).replace(hour=23, minute=59, second=59, tzinfo=UTC)
-
-        schedule_by_partner = self.env['res.partner'].browse(attendee_ids)._get_schedule(start_period, stop_period, everybody)
+        offset = relativedelta(days=1)
+        schedule_by_partner = (
+            self.env["res.partner"]
+            .browse(attendee_ids)
+            ._get_schedule(
+                start_period - offset,  # We use an 1 day offset to capture work entries that start the day before
+                stop_period + offset,  # We use an 1 day offset to capture work entries that span into the day after
+                everybody,
+            )
+        )
         if not schedule_by_partner:
             return []
-        return self._interval_to_business_hours(reduce(Intervals.__and__, schedule_by_partner.values()))
+        return self._interval_to_business_hours(
+            reduce(Intervals.__and__, schedule_by_partner.values()),
+            start_period,
+            stop_period,
+        )
 
-    def _interval_to_business_hours(self, working_intervals):
-        # This is the format expected by the fullcalendar library to do the overlay
-        return [{
-            "daysOfWeek": [(interval[0].weekday() + 1) % 7],
-            "startTime":  interval[0].astimezone(ZoneInfo(self.env.user.tz or 'UTC')).strftime("%H:%M"),
-            "endTime": interval[1].astimezone(ZoneInfo(self.env.user.tz or 'UTC')).strftime("%H:%M"),
-        } for interval in working_intervals] if working_intervals else [{
-            # 7 is used a dummy value to gray the full week
-            # Returning an empty list would leave the week uncolored
-            "daysOfWeek": [7],
-            "startTime":  datetime.today().strftime("00:00"),
-            "endTime": datetime.today().strftime("00:00"),
-        }]
+    @api.model
+    def get_working_days_for_all_attendees(self, attendee_ids, date_from, date_to):
+        timezone = ZoneInfo(self.env.user.tz or "UTC")
+        start_period = datetime.fromisoformat(date_from).replace(hour=0, minute=0, second=0, tzinfo=timezone)
+        stop_period = datetime.fromisoformat(date_to).replace(hour=23, minute=59, second=59, tzinfo=timezone)
+
+        offset = relativedelta(days=1)
+        schedule_by_partner = (
+            self.env["res.partner"]
+            .browse(attendee_ids)
+            ._get_schedule(
+                start_period - offset,  # We use an 1 day offset to capture work entries that start the day before
+                stop_period + offset,  # We use an 1 day offset to capture work entries that span into the day after
+            )
+        )
+        return self._intervals_to_business_days(reduce(Intervals.__and__, schedule_by_partner.values()))
+
+    @api.model
+    def _interval_to_business_hours(self, working_intervals, start_period, stop_period):
+        if not working_intervals:
+            return [self._format_fullcalendar_business_hours()]
+
+        business_hours = []
+        for working_interval in working_intervals:
+            localized_start_datetime = working_interval[0].astimezone(ZoneInfo(self.env.user.tz or "UTC"))
+            localized_end_datetime = working_interval[1].astimezone(ZoneInfo(self.env.user.tz or "UTC"))
+
+            if localized_end_datetime <= start_period or localized_start_datetime >= stop_period:
+                continue
+
+            clamped_start_datetime = max(localized_start_datetime, start_period)
+            clamped_end_datetime = min(localized_end_datetime, stop_period)
+
+            start_date = clamped_start_datetime.date()
+            end_date = clamped_end_datetime.date()
+            if start_date == end_date:
+                business_hours.append(
+                    self._format_fullcalendar_business_hours(
+                        weekday=(clamped_start_datetime.weekday() + 1) % 7,
+                        start_time=clamped_start_datetime.strftime("%H:%M"),
+                        end_time=clamped_end_datetime.strftime("%H:%M"),
+                    ),
+                )
+            else:
+                # Multi-day interval
+                # Handle first day
+                first_day_end = datetime.combine(start_date, time.max, tzinfo=ZoneInfo(self.env.user.tz or "UTC"))
+                if clamped_start_datetime < first_day_end:
+                    business_hours.append(
+                        self._format_fullcalendar_business_hours(
+                            weekday=(clamped_start_datetime.weekday() + 1) % 7,
+                            start_time=clamped_start_datetime.strftime("%H:%M"),
+                            end_time="23:59",
+                        ),
+                    )
+
+                # Handle middle days (if any full days between start and end)
+                if (end_date - start_date).days > 1:
+                    current_day = start_date + relativedelta(days=1)
+                    while current_day < end_date:
+                        business_hours.append(
+                            self._format_fullcalendar_business_hours(
+                                weekday=(current_day.weekday() + 1) % 7,
+                                start_time="00:00",
+                                end_time="23:59",
+                            ),
+                        )
+                        current_day += relativedelta(days=1)
+
+                # Handle last day
+                last_day_start = datetime.combine(end_date, time.min, tzinfo=ZoneInfo(self.env.user.tz or "UTC"))
+                if last_day_start < clamped_end_datetime:
+                    end_time = clamped_end_datetime.strftime("%H:%M")
+                    if end_time != "00:00":
+                        business_hours.append(
+                            self._format_fullcalendar_business_hours(
+                                weekday=(clamped_end_datetime.weekday() + 1) % 7,
+                                start_time="00:00",
+                                end_time=end_time,
+                            ),
+                        )
+
+        return business_hours
+
+    @api.model
+    def _intervals_to_business_days(self, working_intervals):
+        working_days = set()
+        for interval in working_intervals:
+            localized_start_date = interval[0].astimezone(ZoneInfo(self.env.user.tz or "UTC")).date()
+            localized_end_date = interval[1].astimezone(ZoneInfo(self.env.user.tz or "UTC")).date()
+            working_days.add(localized_start_date)
+            if localized_start_date != localized_end_date:
+                middle_day = localized_start_date + relativedelta(days=1)
+                while middle_day <= localized_end_date:
+                    working_days.add(middle_day)
+                    middle_day += relativedelta(days=1)
+
+        return working_days
+
+    @api.model
+    def _format_fullcalendar_business_hours(self, weekday=7, start_time="00:00", end_time="00:00"):
+        """
+        Format business hours values for Fullcalendar so it can grey out unavailable slots in the calendar.
+
+        Fullcalendar is a library that is used by the calendar view. It expects a specifically formatted dictionary for
+        the business hours API option to properly grey out areas where an employee is not available. If an employee has
+        no intervals we return the default values, with weekday=7 as a dummy value to grey out the entire week.
+        Returning nothing would leave the calendar completely uncolored.
+
+        :param int weekday: Day of week (0-6 for Mon-Sun, 7 as dummy to grey entire week). Defaults to 7.
+        :param string start_time: Start time in "HH:MM" format. Defaults to "00:00".
+        :param string end_time: End time in "HH:MM" format. Defaults to "00:00".
+
+        :return: Fullcalendar-business-hours-configuration dict with the keys 'daysOfWeek', 'startTime', and 'endTime'.
+        :rtype: dict
+        """
+        return {
+            "daysOfWeek": [weekday],
+            "startTime": start_time,
+            "endTime": end_time,
+        }
+
+    @api.model
+    def _get_unusual_days(self, attendee_ids, date_from, date_to):
+        timezone = ZoneInfo(self.env.user.tz or "UTC")
+        start_period = datetime.fromisoformat(date_from).replace(hour=0, minute=0, second=0, tzinfo=timezone)
+        stop_period = datetime.fromisoformat(date_to).replace(hour=23, minute=59, second=59, tzinfo=timezone)
+
+        working_days = self.get_working_days_for_all_attendees(attendee_ids, date_from, date_to)
+
+        return {
+            day.strftime("%Y-%m-%d"): (day.date() not in working_days)
+            for day in rrule(DAILY, start_period, until=stop_period)
+        }
 
     def get_worklocation(self, start_date, end_date):
         employee_id = self.env['hr.employee'].search([

--- a/addons/hr_calendar/tests/__init__.py
+++ b/addons/hr_calendar/tests/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_working_days
 from . import test_working_hours
 from . import test_event_interval
 from . import test_hr_employee_location

--- a/addons/hr_calendar/tests/common.py
+++ b/addons/hr_calendar/tests/common.py
@@ -138,7 +138,7 @@ class TestHrContractCalendarCommon(common.TransactionCase):
             },
         ])
         cls.env.user.company_id = cls.company_A
-        cls.calendar_35h, cls.calendar_28h, cls.calendar_35h_night = cls.env['resource.calendar'].create([
+        cls.calendar_35h, cls.calendar_28h, cls.calendar_35h_night, cls.sunday_morning_calendar, cls.sunday_afternoon_calendar = cls.env['resource.calendar'].create([
             {
                 'name': '35h calendar',
                 'hours_per_day': 7.0,
@@ -176,6 +176,18 @@ class TestHrContractCalendarCommon(common.TransactionCase):
                     (0, 0, {'dayofweek': '2', 'hour_from': 15, 'hour_to': 22}),
                     (0, 0, {'dayofweek': '3', 'hour_from': 15, 'hour_to': 22}),
                     (0, 0, {'dayofweek': '4', 'hour_from': 15, 'hour_to': 22}),
+                ],
+            },
+            {
+                "name": "Sunday Morning Calendar",
+                "attendance_ids": [
+                    (0, 0, {"dayofweek": "6", "hour_from": 0, "hour_to": 8}),
+                ],
+            },
+            {
+                "name": "Sunday Afternoon Calendar",
+                "attendance_ids": [
+                    (0, 0, {"dayofweek": "6", "hour_from": 8, "hour_to": 17}),
                 ],
             },
         ])

--- a/addons/hr_calendar/tests/common.py
+++ b/addons/hr_calendar/tests/common.py
@@ -1,123 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime
+
 from odoo.tests import common
-
-
-class TestHrCalendarCommon(common.TransactionCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env.user.tz = 'Europe/Brussels'
-
-        cls.company_A, cls.company_B = cls.env['res.company'].create([
-            {
-                'name': 'Test company A',
-                'tz': "Europe/Brussels",
-            },
-            {
-                'name': 'Test company B',
-                'tz': "Europe/Brussels",
-            },
-        ])
-        cls.env.user.company_id = cls.company_A
-
-        cls.calendar_35h, cls.calendar_28h, cls.calendar_35h_night = cls.env['resource.calendar'].create([
-            {
-                'name': '35h calendar',
-                'hours_per_day': 7.0,
-                'attendance_ids': [
-                    (0, 0, {'dayofweek': '0', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '0', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '1', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '1', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '2', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '2', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '3', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '3', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '4', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '4', 'hour_from': 13, 'hour_to': 16}),
-                ],
-            },
-            {
-                'name': '28h calendar',
-                'attendance_ids': [
-                    (0, 0, {'dayofweek': '1', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '1', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '2', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '2', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '3', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '3', 'hour_from': 13, 'hour_to': 16}),
-                    (0, 0, {'dayofweek': '4', 'hour_from': 8, 'hour_to': 12}),
-                    (0, 0, {'dayofweek': '4', 'hour_from': 13, 'hour_to': 16}),
-                ],
-            },
-            {
-                'name': 'night calendar',
-                'attendance_ids': [
-                    (0, 0, {'dayofweek': '0', 'hour_from': 15, 'hour_to': 22}),
-                    (0, 0, {'dayofweek': '1', 'hour_from': 15, 'hour_to': 22}),
-                    (0, 0, {'dayofweek': '2', 'hour_from': 15, 'hour_to': 22}),
-                    (0, 0, {'dayofweek': '3', 'hour_from': 15, 'hour_to': 22}),
-                    (0, 0, {'dayofweek': '4', 'hour_from': 15, 'hour_to': 21}),
-                    (0, 0, {'dayofweek': '6', 'hour_from': 15, 'hour_to': 16}),
-                ],
-            },
-        ])
-
-        cls.partnerA, cls.partnerB, cls.partnerC, cls.partnerD = cls.env['res.partner'].create([
-            {
-                'name': "Partner A",
-            },
-            {
-                'name': "Partner B",
-            },
-            {
-                'name': "Partner C",
-            },
-            {
-                'name': "Partner D",
-            },
-        ])
-
-        cls.employeeA, cls.employeeA_company_B, cls.employeeB, cls.employeeC, cls.employeeD = cls.env['hr.employee'].create([
-            {
-                'name': "Partner A - Company A - Calendar 35h",
-                'tz': "Europe/Brussels",
-                'resource_calendar_id': cls.calendar_35h.id,
-                'work_contact_id': cls.partnerA.id,
-                'company_id': cls.company_A.id,
-            },
-            {
-                'name': "Partner A - Company B - Calendar 28h",
-                'tz': "Europe/Brussels",
-                'resource_calendar_id': cls.calendar_28h.id,
-                'work_contact_id': cls.partnerA.id,
-                'company_id': cls.company_B.id,
-            },
-            {
-                'name': "Partner B - Calendar 28h",
-                'tz': "Europe/Brussels",
-                'resource_calendar_id': cls.calendar_28h.id,
-                'work_contact_id': cls.partnerB.id,
-                'company_id': cls.company_A.id,
-            },
-            {
-                'name': "Partner C - Calendar 35h night",
-                'tz': "Europe/Brussels",
-                'resource_calendar_id': cls.calendar_35h_night.id,
-                'work_contact_id': cls.partnerC.id,
-                'company_id': cls.company_A.id,
-            },
-            {
-                'name': "Partner D - Calendar 35h No contract",
-                'tz': "Europe/Brussels",
-                'resource_calendar_id': cls.calendar_35h.id,
-                'work_contact_id': cls.partnerD.id,
-                'company_id': cls.company_A.id,
-            },
-        ])
 
 
 class TestHrContractCalendarCommon(common.TransactionCase):
@@ -216,7 +101,7 @@ class TestHrContractCalendarCommon(common.TransactionCase):
             },
         ])
 
-        cls.employeeA, cls.employeeB, cls.employeeB_company_B,\
+        cls.employeeA, cls.employeeA_company_B, cls.employeeB, cls.employeeB_company_B,\
         cls.employeeC, cls.employeeD, cls.employeeE,\
         cls.employeeF, cls.employeeG = cls.env['hr.employee'].create([
             {
@@ -227,6 +112,16 @@ class TestHrContractCalendarCommon(common.TransactionCase):
                 'date_version': datetime(2023, 12, 1),
                 'contract_date_start': datetime(2023, 12, 1),
                 'resource_calendar_id': cls.calendar_35h.id,
+                'wage': 5000.0,
+            },
+            {
+                'name': "Partner A - Company B - Calendar 28h",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerA.id,
+                'company_id': cls.company_B.id,
+                'date_version': datetime(2023, 12, 1),
+                'contract_date_start': datetime(2023, 12, 1),
+                'resource_calendar_id': cls.calendar_28h.id,
                 'wage': 5000.0,
             },
             {

--- a/addons/hr_calendar/tests/test_event_interval.py
+++ b/addons/hr_calendar/tests/test_event_interval.py
@@ -4,11 +4,11 @@ from datetime import datetime, UTC
 from zoneinfo import ZoneInfo
 
 from odoo.tests import tagged
-from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon
+from odoo.addons.hr_calendar.tests.common import TestHrContractCalendarCommon
 
 
 @tagged('event_interval')
-class TestEventInterval(TestHrCalendarCommon):
+class TestEventInterval(TestHrContractCalendarCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/addons/hr_calendar/tests/test_working_days.py
+++ b/addons/hr_calendar/tests/test_working_days.py
@@ -1,0 +1,531 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+
+from odoo.tests import tagged
+
+from odoo.addons.hr_calendar.tests.common import TestHrContractCalendarCommon
+
+
+@tagged("work_days")
+@tagged("at_install", "-post_install")  # LEGACY at_install
+class TestWorkingDaysWithVersion(TestHrContractCalendarCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_working_hours_employee_available_after_contract_start(self):
+        """
+        Assert that an employee with a contract and a fixed schedule is available according to their schedule.
+        """
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_employee_unavailable_before_contract_start(self):
+        """
+        Assert that an employee is not available before their contract starts.
+        """
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id],
+            datetime(2023, 11, 13).isoformat(),
+            datetime(2023, 11, 19).isoformat(),
+        )
+        # Unavailable the whole weekend as they are not working at the company yet.
+        expected_days = {
+            "2023-11-13": True,  # Monday
+            "2023-11-14": True,  # Tuesday
+            "2023-11-15": True,  # Wednesday
+            "2023-11-16": True,  # Thursday
+            "2023-11-17": True,  # Friday
+            "2023-11-18": True,  # Saturday
+            "2023-11-19": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_2_emp_same_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id, self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_2_emp_contract_start(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.contractB.contract_date_start = datetime(2023, 12, 28)
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id, self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # Nothing on monday, tuesday and wednesday due to contractB. (start : thursday 2023/12/28)
+        expected_days = {
+            "2023-12-25": True,  # Monday
+            "2023-12-26": True,  # Tuesday
+            "2023-12-27": True,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_2_emp_contract_stop(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.contractB.date_end = datetime(2023, 12, 28)
+        self.contractB.contract_date_end = datetime(2023, 12, 28)
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id, self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # Nothing on monday due to calendarB.
+        # Nothing on Friday due to contractB (stop : thursday 2023/12/28)
+        expected_days = {
+            "2023-12-25": True,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": True,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_3_emp_different_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id, self.partnerB.id, self.partnerC.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # Nothing on monday due to partnerB's calendar : calendar_2
+        # Nothing before 15:00 due to partnerC's calendar : calendar_3
+        # Nothing on tuesday and wednesday due to contractC. (start : thursday 2023/12/28)
+        expected_days = {
+            "2023-12-25": True,  # Monday
+            "2023-12-26": True,  # Tuesday
+            "2023-12-27": True,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_2_emp_same_calendar_different_timezone(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.contractD.resource_calendar_id = self.calendar_35h
+        self.contractD.tz = "Europe/London"
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id, self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # calendar_35h_london_tz.tz = UTC, calendar_35h.tz = UTC +1
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_split_correctly_with_negative_difference_in_timezones(self):
+        """
+        The working hours of a calendar are localized to the "viewer's"/currently logged in user's timezone.
+        if employee A starts working at 08:00 in the timezone GMT+5 and employee B, working in timezone GMT+1, views the
+        calendar they will see employee A starting at 04:00 as the difference between the two timezones is -4 hours and
+        08:00 + (-4hrs) is 04:00.
+        Additionally if a localization makes the workday of employee A start "yesterday" or ends "tomorrow", the working
+        hours should be split across the "yesterday", "today" and "tomorrow" depending on the scenario.
+        """
+        self.contractD.resource_calendar_id = self.sunday_morning_calendar
+        self.contractD.tz = "Asia/Ashgabat"
+        # "viewer"/self.env.user.tz = "Etc/GMT+1"
+        work_days = self.env["res.partner"]._get_unusual_days(
+            self.partnerD.ids,
+            datetime(2023, 12, 29).isoformat(),  # Friday
+            datetime(2024, 1, 1).isoformat(),  # Monday
+        )
+        # sunday_morning_calendar.tz = GMT+5, viewers_calendar.tz = GMT +1, difference = 4 hours "back in time"
+        expected_days = {
+            "2023-12-29": True,  # Friday
+            "2023-12-30": False,  # Saturday
+            "2023-12-31": False,  # Sunday
+            "2024-01-01": True,  # Monday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_split_working_hours_with_negative_difference_in_timezone_returns_relevant_portion(self):
+        """
+        If a working hours span across two days because of timezone difference then only return the working hours for
+        the requested days.
+        As an example if someone is working from 00:00 to 08:00 in GMT+5 and the working hours are viewed from GMT+1
+        it should show working hours from 20:00 - 23:59 yesterday and 00:00 - 04:00 today. However if the request is
+        to only get working hours for today it should only return 00:00 - 04:00 and not 20:00 - 23:59
+        """
+        self.contractD.resource_calendar_id = self.sunday_morning_calendar
+        self.contractD.tz = "Asia/Ashgabat"
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            self.partnerD.ids,
+            datetime(2023, 12, 30).isoformat(),  # Saturday
+            datetime(2023, 12, 30).isoformat(),  # Saturday
+        )
+        # sunday_morning_calendar.tz = GMT-8, viewers_calendar.tz = GMT +1, difference = 9 hours "forwards in time"
+        expected_days = {
+            "2023-12-30": False,  # Monday
+        }
+        self.assertEqual(work_days, expected_days)
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            self.partnerD.ids,
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+        )
+        # sunday_morning_calendar.tz = GMT-8, viewers_calendar.tz = GMT +1, difference = 9 hours "forwards in time"
+        expected_days = {
+            "2023-12-31": False,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_split_correctly_with_positive_difference_in_timezones(self):
+        """
+        The working hours of a calendar are localized to the "viewer's"/currently logged in user's timezone.
+        If employee A starts working at 08:00 in the timezone GMT-8 and employee B, working in timezone GMT+1, views the
+        calendar they will see employee A starting at 17:00 as the difference between the two timezones is 9 hours and
+        08:00 + 9hrs is 17:00.
+        Additionally if a localization makes the workday of employee A start "yesterday" or ends "tomorrow", the working
+        hours should be split across the "yesterday", "today" and "tomorrow" depending on the scenario.
+        """
+        self.contractD.resource_calendar_id = self.sunday_afternoon_calendar
+        self.contractD.tz = "America/Los_Angeles"
+        # "viewer"/self.env.user.tz = "Etc/GMT+1"
+        work_days = self.env["res.partner"]._get_unusual_days(
+            self.partnerD.ids,
+            datetime(2023, 12, 29).isoformat(),  # Friday
+            datetime(2024, 1, 1).isoformat(),  # Monday
+        )
+        # sunday_afternoon_calendar.tz = GMT-8, viewers_calendar.tz = GMT +1, difference = 9 hours "forwards in time"
+        expected_days = {
+            "2023-12-29": True,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": False,  # Sunday
+            "2024-01-01": False,  # Monday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_split_working_hours_with_positive_difference_in_timezone_returns_relevant_portion(self):
+        """
+        If a working hours span across two days because of timezone difference then only return the working hours for
+        the requested days.
+        As an example if someone is working from 08:00 to 17:00 in GMT-8 and the working hours are viewed from GMT+1
+        it should show working hours from 17:00 - 23:59 yesterday and 00:00 - 02:00 today. However if the request is
+        to only get working hours for today it should only return 17:00 - 23:59 and not 00:00 - 02:00
+        """
+        self.contractD.resource_calendar_id = self.sunday_afternoon_calendar
+        self.contractD.tz = "America/Los_Angeles"
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            self.partnerD.ids,
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+        )
+
+        expected_days = {
+            "2023-12-31": False,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            self.partnerD.ids,
+            datetime(2024, 1, 1).isoformat(),  # Monday
+            datetime(2024, 1, 1).isoformat(),  # Monday
+        )
+
+        expected_days = {
+            "2024-01-01": False,  # Monday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_with_employee_without_contract(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id, self.partnerE.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # Employee E doesn't have a contract
+        expected_days = {
+            "2023-12-25": True,  # Monday
+            "2023-12-26": True,  # Tuesday
+            "2023-12-27": True,  # Wednesday
+            "2023-12-28": True,  # Thursday
+            "2023-12-29": True,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_working_hours_one_employee_with_two_contracts(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        # Contract from november
+        self.env["hr.version"].create(
+            {
+                "date_version": datetime(2023, 11, 1),
+                "contract_date_start": datetime(2023, 11, 1),
+                "contract_date_end": datetime(2023, 11, 30),
+                "name": "Contract november",
+                "resource_calendar_id": self.calendar_35h_night.id,
+                "wage": 5000.0,
+                "employee_id": self.employeeA.id,
+            },
+        )
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerA.id],
+            datetime(2023, 11, 27).isoformat(),
+            datetime(2023, 12, 3).isoformat(),
+        )
+        expected_days = {
+            "2023-11-27": False,  # Monday
+            "2023-11-28": False,  # Tuesday
+            "2023-11-29": False,  # Wednesday
+            "2023-11-30": False,  # Thursday
+            "2023-12-01": False,  # Friday
+            "2023-12-02": True,  # Saturday
+            "2023-12-03": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_multi_companies_2_employees_2_selected_companies(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee B1 company A ---> 28h               [X] A    <- main company
+        employee B2 company A ---> 35h night         [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the union between 28h's and 35h night's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+        self.assertEqual(work_days, expected_days)
+
+    def test_flexible_employee_is_available_in_the_middle_of_a_day(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = 56
+        self.contractD.hours_per_day = 8
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": False,  # Saturday
+            "2023-12-31": False,  # Sunday
+        }
+
+        self.assertEqual(
+            work_days,
+            expected_days,
+        )
+
+    def test_flexible_employee_is_available_in_the_middle_of_day_after_contract_start(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = 56
+        self.contractD.hours_per_day = 8
+        self.contractD.contract_date_start = datetime(2023, 12, 28)
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": True,  # Monday
+            "2023-12-26": True,  # Tuesday
+            "2023-12-27": True,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": False,  # Saturday
+            "2023-12-31": False,  # Sunday
+        }
+
+        self.assertEqual(
+            work_days,
+            expected_days,
+        )
+
+    def test_flexible_employee_is_always_available_until_contract_end(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = 56
+        self.contractD.hours_per_day = 8
+        self.contractD.contract_date_end = datetime(2023, 12, 28)
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": True,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+
+        self.assertEqual(
+            work_days,
+            expected_days,
+        )
+
+    def test_fully_flexible_employee_is_always_available(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = False
+        self.contractD.hours_per_day = False
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": False,  # Saturday
+            "2023-12-31": False,  # Sunday
+        }
+
+        self.assertEqual(
+            work_days,
+            expected_days,
+        )
+
+    def test_fully_flexible_employee_is_always_available_after_contract_start(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = False
+        self.contractD.hours_per_day = False
+        self.contractD.contract_date_start = datetime(2023, 12, 28)
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": True,  # Monday
+            "2023-12-26": True,  # Tuesday
+            "2023-12-27": True,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": False,  # Friday
+            "2023-12-30": False,  # Saturday
+            "2023-12-31": False,  # Sunday
+        }
+
+        self.assertEqual(
+            work_days,
+            expected_days,
+        )
+
+    def test_fully_flexible_employee_is_always_available_until_contract_end(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = False
+        self.contractD.hours_per_day = False
+        self.contractD.contract_date_end = datetime(2023, 12, 28)
+
+        work_days = self.env["res.partner"]._get_unusual_days(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_days = {
+            "2023-12-25": False,  # Monday
+            "2023-12-26": False,  # Tuesday
+            "2023-12-27": False,  # Wednesday
+            "2023-12-28": False,  # Thursday
+            "2023-12-29": True,  # Friday
+            "2023-12-30": True,  # Saturday
+            "2023-12-31": True,  # Sunday
+        }
+
+        self.assertEqual(
+            work_days,
+            expected_days,
+        )

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -3,27 +3,16 @@
 from datetime import datetime, timedelta
 
 from odoo import Command
-from odoo.tests import users, tagged
-from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon, TestHrContractCalendarCommon
-from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests import tagged
+
+from odoo.addons.hr_calendar.tests.common import TestHrContractCalendarCommon
 
 
 @tagged('work_hours')
-class TestWorkingHours(TestHrCalendarCommon):
+class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.user_bxls = mail_new_test_user(
-            cls.env,
-            email='brussels@test.example.com',
-            groups='base.group_user',
-            name='Employee Brussels',
-            notification_type='email',
-            login='user_bxls',
-        )
-        if 'hr.version' in cls.env:
-            cls.skipTest(cls,
-                "hr_contract module is installed. To test these features you need to install test_hr_contract_calendar")
 
     def test_working_hours_2_emp_same_calendar(self):
         self.env.user.company_id = self.company_A
@@ -56,266 +45,6 @@ class TestWorkingHours(TestHrCalendarCommon):
         )
         # Nothing on monday due to partnerB's calendar : calendar_28h
         self.assertEqual(work_hours, [
-            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
-        ])
-
-    def test_working_hours_3_emp_different_calendar(self):
-        self.env.user.company_id = self.company_A
-        self.env.user.company_ids = [self.company_A.id]
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id, self.partnerB.id, self.partnerC.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        # Nothing on monday due to partnerB's calendar : calendar_28h
-        # Nothing before 15:00 due to partnerC's calendar : calendar_35h_night
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [2], 'startTime': '15:00', 'endTime': '16:00'},
-            {'daysOfWeek': [3], 'startTime': '15:00', 'endTime': '16:00'},
-            {'daysOfWeek': [4], 'startTime': '15:00', 'endTime': '16:00'},
-            {'daysOfWeek': [5], 'startTime': '15:00', 'endTime': '16:00'}
-        ])
-
-    def test_working_hours_2_emp_same_calendar_hours_different_timezone(self):
-        self.env.user.company_id = self.company_A
-        self.env.user.company_ids = [self.company_A.id]
-        self.employeeD.resource_calendar_id = self.calendar_35h
-        self.employeeD.tz = 'Europe/London'
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id, self.partnerD.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        # employeeD.tz = UTC +1
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [1], 'startTime': '09:00', 'endTime': '12:00'},
-            {'daysOfWeek': [1], 'startTime': '14:00', 'endTime': '16:00'},
-            {'daysOfWeek': [2], 'startTime': '09:00', 'endTime': '12:00'},
-            {'daysOfWeek': [2], 'startTime': '14:00', 'endTime': '16:00'},
-            {'daysOfWeek': [3], 'startTime': '09:00', 'endTime': '12:00'},
-            {'daysOfWeek': [3], 'startTime': '14:00', 'endTime': '16:00'},
-            {'daysOfWeek': [4], 'startTime': '09:00', 'endTime': '12:00'},
-            {'daysOfWeek': [4], 'startTime': '14:00', 'endTime': '16:00'},
-            {'daysOfWeek': [5], 'startTime': '09:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '14:00', 'endTime': '16:00'},
-        ])
-
-    def test_multi_companies_2_employees_1_selected_company(self):
-        """
-        INPUT:
-        ======
-        Employees                                   Companies
-        employee A company A ---> 35h               [ ] A
-        employee A company B ---> 28h               [X] B
-
-        OUTPUT:
-        =======
-        The schedule will be the 28h's schedule
-        """
-        self.env.user.company_id = self.company_B
-        self.env.user.company_ids = [self.company_B.id]
-
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
-        ])
-
-    def test_multi_companies_2_employees_2_selected_companies(self):
-        """
-        INPUT:
-        ======
-        Employees                                   Companies
-        employee A company A ---> 35h               [X] A    <- main company
-        employee A company B ---> 28h               [X] B
-
-        OUTPUT:
-        =======
-        The schedule will be the 35h's schedule
-        """
-        self.env.user.company_id = self.company_A
-        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
-            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
-        ])
-
-    def test_multi_companies_2_employees_2_selected_companies_union_between_schedules(self):
-        """
-        INPUT:
-        ======
-        Employees                                   Companies
-        employee A company A ---> 35h               [X] A    <- main company
-        employee A company B ---> 35h night         [X] B
-
-        OUTPUT:
-        =======
-        The schedule will be the union between 35h's and 35h night's schedule
-        """
-        self.env.user.company_id = self.company_A
-        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
-
-        self.employeeA_company_B.resource_calendar_id = self.calendar_35h_night
-
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '21:00'},
-            {'daysOfWeek': [0], 'startTime': '15:00', 'endTime': '16:00'},
-        ])
-
-    def test_multi_companies_2_employees_1_partner_1_selected_companies(self):
-        """
-        INPUT:
-        ======
-        Employees                                   Companies
-        employee B1 company A ---> 28h               [X] A    <- main company
-        employee B2 company A ---> 35h night         [ ] B
-
-        OUTPUT:
-        =======
-        The schedule will be the union between 28h's and 35h night's schedule
-        """
-        self.env.user.company_id = self.company_A
-        self.env.user.company_ids = [self.company_A.id]
-
-        self.env['hr.employee'].create({
-            'name': "Partner B2 - Calendar 35h night",
-            'tz': "Europe/Brussels",
-            'resource_calendar_id': self.calendar_35h_night.id,
-            'work_contact_id': self.partnerB.id,
-            'company_id': self.company_A.id,
-        })
-
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerB.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [1], 'startTime': '15:00', 'endTime': '22:00'},
-            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
-            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '21:00'},
-            {'daysOfWeek': [0], 'startTime': '15:00', 'endTime': '16:00'},
-        ])
-
-    def test_work_hours_of_employee_without_time_zone(self):
-        self.env.user.tz = False
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat(),
-        )
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [1], 'startTime': '07:00', 'endTime': '11:00'},
-            {'daysOfWeek': [1], 'startTime': '12:00', 'endTime': '15:00'},
-            {'daysOfWeek': [2], 'startTime': '07:00', 'endTime': '11:00'},
-            {'daysOfWeek': [2], 'startTime': '12:00', 'endTime': '15:00'},
-            {'daysOfWeek': [3], 'startTime': '07:00', 'endTime': '11:00'},
-            {'daysOfWeek': [3], 'startTime': '12:00', 'endTime': '15:00'},
-            {'daysOfWeek': [4], 'startTime': '07:00', 'endTime': '11:00'},
-            {'daysOfWeek': [4], 'startTime': '12:00', 'endTime': '15:00'},
-            {'daysOfWeek': [5], 'startTime': '07:00', 'endTime': '11:00'},
-            {'daysOfWeek': [5], 'startTime': '12:00', 'endTime': '15:00'},
-        ])
-
-    @users('user_bxls')
-    def test_partner_on_leave_with_calendar_leave(self):
-        """Check that resource leaves are correctly reflected in the unavailable_partner_ids field.
-        Overlapping times between the leave time of an employee and the meeting should add the partner
-        to the list of unavailable partners.
-        """
-        test_date = datetime(2022, 2, 14, 7, 0, 0)
-        self.employeeA.user_id = self.user_bxls
-        self.env['calendar.event'].search([('user_id', '=', self.user_bxls.id)]).unlink()
-        self.env['resource.calendar.leaves'].sudo().search([('calendar_id', '=', self.user_bxls.resource_calendar_id.id)]).unlink()
-
-        meeting = self.env['calendar.event'].with_context(company_id=self.company_A.id).create([
-            {
-                'start': test_date,
-                'stop': test_date + timedelta(hours=3),
-                'name': "Event",
-                'attendee_ids': [(0, 0, {'partner_id': self.user_bxls.partner_id.id})],
-            },
-        ])
-        self.assertFalse(meeting.unavailable_partner_ids)
-
-        self.env['resource.calendar.leaves'].sudo().create({
-            'calendar_id': self.user_bxls.resource_calendar_id.id,
-            'date_from': test_date,
-            'date_to': test_date + timedelta(days=1),
-            'name': 'Casual Leave'
-        })
-        meeting.invalidate_recordset()
-        self.assertEqual(meeting.unavailable_partner_ids, self.user_bxls.partner_id)
-
-
-@tagged('work_hours')
-class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-    def test_working_hours_2_emp_same_calendar(self):
-        self.env.user.company_id = self.company_A
-        self.env.user.company_ids = [self.company_A.id]
-
-        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
-            [self.partnerA.id, self.partnerD.id],
-            datetime(2023, 12, 25).isoformat(),
-            datetime(2023, 12, 31).isoformat()
-        )
-        self.assertEqual(work_hours, [
-            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '16:00'},
             {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
             {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
             {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
@@ -591,6 +320,118 @@ class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
             {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
         ])
 
+    def test_multi_companies_2_employees_1_selected_company(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [ ] A
+        employee A company B ---> 28h               [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the 28h's schedule
+        """
+        self.env.user.company_id = self.company_B
+        self.env.user.company_ids = [self.company_B.id]
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [2], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [2], "startTime": "13:00", "endTime": "16:00"},
+            {"daysOfWeek": [3], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [3], "startTime": "13:00", "endTime": "16:00"},
+            {"daysOfWeek": [4], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [4], "startTime": "13:00", "endTime": "16:00"},
+            {"daysOfWeek": [5], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [5], "startTime": "13:00", "endTime": "16:00"},
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+    def test_multi_companies_2_employees_2_selected_companies_union_between_schedules(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [X] A    <- main company
+        employee A company B ---> 35h night         [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the union between 35h's and 35h night's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        self.employeeA_company_B.resource_calendar_id = self.calendar_35h_night
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [1], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [2], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [2], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [3], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [3], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [4], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [4], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [5], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [5], "startTime": "13:00", "endTime": "22:00"},
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+    def test_multi_companies_2_employees_1_partner_1_selected_companies(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee B1 company A ---> 28h               [X] A    <- main company
+        employee B2 company A ---> 35h night         [ ] B
+
+        OUTPUT:
+        =======
+        The schedule will be the union between 28h's and 35h night's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.env["hr.employee"].create({
+            "name": "Partner B2 - Calendar 35h night",
+            "tz": "Europe/Brussels",
+            "work_contact_id": self.partnerB.id,
+            "company_id": self.company_A.id,
+            "date_version": datetime(2023, 12, 1),
+            "contract_date_start": datetime(2023, 12, 1),
+            "resource_calendar_id": self.calendar_35h_night.id,
+            "wage": 5000,
+        })
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "15:00", "endTime": "22:00"},
+            {"daysOfWeek": [2], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [2], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [3], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [3], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [4], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [4], "startTime": "13:00", "endTime": "22:00"},
+            {"daysOfWeek": [5], "startTime": "08:00", "endTime": "12:00"},
+            {"daysOfWeek": [5], "startTime": "13:00", "endTime": "22:00"},
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
     def test_flexible_employee_is_available_in_the_middle_of_a_day(self):
         self.env.user.company_id = self.company_A
         self.contractD.resource_calendar_id = False
@@ -761,3 +602,28 @@ class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
         # Need to read unavailable_partner_ids to force being computed and trigger _get_schedule
         self.assertEqual(event.unavailable_partner_ids.ids, [], "All partners must be available!")
         self.assertEqual(expected_partners.ids, event.partner_ids.ids, "All partners must be invited!")
+
+    def test_partner_on_leave_with_calendar_leave(self):
+        """Check that resource leaves are correctly reflected in the unavailable_partner_ids field.
+        Overlapping times between the leave time of an employee and the meeting should add the partner
+        to the list of unavailable partners.
+        """
+        event_date = datetime(2023, 12, 28, 9, 0, 0)
+        calendar_event = self.env["calendar.event"].create({
+            "name": "Meeting 1",
+            "start": event_date,
+            "stop": event_date + timedelta(hours=2),
+            "partner_ids": [(4, self.partnerD.id)],
+        })
+
+        self.assertFalse(calendar_event.unavailable_partner_ids)
+
+        _leave = self.env["resource.calendar.leaves"].create({
+            "calendar_id": self.calendar_35h.id,
+            "date_from": event_date,
+            "date_to": event_date + timedelta(hours=2),
+            "name": "Casual Leave",
+        })
+
+        calendar_event.invalidate_recordset()
+        self.assertEqual(calendar_event.unavailable_partner_ids, self.partnerD)

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -407,6 +407,118 @@ class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
             {'daysOfWeek': [5], 'startTime': '14:00', 'endTime': '16:00'}
         ])
 
+    def test_working_hours_split_correctly_with_negative_difference_in_timezones(self):
+        """
+        The working hours of a calendar are localized to the "viewer's"/currently logged in user's timezone.
+        if employee A starts working at 08:00 in the timezone GMT+5 and employee B, working in timezone GMT+1, views the
+        calendar they will see employee A starting at 04:00 as the difference between the two timezones is -4 hours and
+        08:00 + (-4hrs) is 04:00.
+        Additionally if a localization makes the workday of employee A start "yesterday" or ends "tomorrow", the working
+        hours should be split across the "yesterday", "today" and "tomorrow" depending on the scenario.
+        """
+        self.contractD.resource_calendar_id = self.sunday_morning_calendar
+        self.contractD.tz = "Asia/Ashgabat"
+        # "viewer"/self.env.user.tz = "Etc/GMT+1"
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            self.partnerD.ids,
+            datetime(2023, 12, 29).isoformat(),  # Friday
+            datetime(2024, 1, 1).isoformat(),  # Monday
+        )
+        # sunday_morning_calendar.tz = GMT+5, viewers_calendar.tz = GMT +1, difference = 4 hours "back in time"
+        expected_hours = [
+            {"daysOfWeek": [6], "startTime": "20:00", "endTime": "23:59"},  # Saturday
+            {"daysOfWeek": [0], "startTime": "00:00", "endTime": "04:00"},  # Sunday
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+    def test_split_working_hours_with_negative_difference_in_timezone_returns_relevant_portion(self):
+        """
+        If a working hours span across two days because of timezone difference then only return the working hours for
+        the requested days.
+        As an example if someone is working from 00:00 to 08:00 in GMT+5 and the working hours are viewed from GMT+1
+        it should show working hours from 20:00 - 23:59 yesterday and 00:00 - 04:00 today. However if the request is
+        to only get working hours for today it should only return 00:00 - 04:00 and not 20:00 - 23:59
+        """
+        self.contractD.resource_calendar_id = self.sunday_morning_calendar
+        self.contractD.tz = "Asia/Ashgabat"
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            self.partnerD.ids,
+            datetime(2023, 12, 30).isoformat(),  # Saturday
+            datetime(2023, 12, 30).isoformat(),  # Saturday
+        )
+        # sunday_morning_calendar.tz = GMT-8, viewers_calendar.tz = GMT +1, difference = 9 hours "forwards in time"
+        expected_hours = [
+            {"daysOfWeek": [6], "startTime": "20:00", "endTime": "23:59"},  # Saturday
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            self.partnerD.ids,
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+        )
+        # sunday_morning_calendar.tz = GMT-8, viewers_calendar.tz = GMT +1, difference = 9 hours "forwards in time"
+        expected_hours = [
+            {"daysOfWeek": [0], "startTime": "00:00", "endTime": "04:00"},  # Sunday
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+    def test_working_hours_split_correctly_with_positive_difference_in_timezones(self):
+        """
+        The working hours of a calendar are localized to the "viewer's"/currently logged in user's timezone.
+        If employee A starts working at 08:00 in the timezone GMT-8 and employee B, working in timezone GMT+1, views the
+        calendar they will see employee A starting at 17:00 as the difference between the two timezones is 9 hours and
+        08:00 + 9hrs is 17:00.
+        Additionally if a localization makes the workday of employee A start "yesterday" or ends "tomorrow", the working
+        hours should be split across the "yesterday", "today" and "tomorrow" depending on the scenario.
+        """
+        self.contractD.resource_calendar_id = self.sunday_afternoon_calendar
+        self.contractD.tz = "America/Los_Angeles"
+        # "viewer"/self.env.user.tz = "Etc/GMT+1"
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            self.partnerD.ids,
+            datetime(2023, 12, 29).isoformat(),  # Friday
+            datetime(2024, 1, 1).isoformat(),  # Monday
+        )
+        # sunday_morning_calendar.tz = GMT-8, viewers_calendar.tz = GMT +1, difference = 9 hours "forwards in time"
+        expected_hours = [
+            {"daysOfWeek": [0], "startTime": "17:00", "endTime": "23:59"},  # Sunday
+            {"daysOfWeek": [1], "startTime": "00:00", "endTime": "02:00"},  # Monday
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+    def test_split_working_hours_with_positive_difference_in_timezone_returns_relevant_portion(self):
+        """
+        If a working hours span across two days because of timezone difference then only return the working hours for
+        the requested days.
+        As an example if someone is working from 08:00 to 17:00 in GMT-8 and the working hours are viewed from GMT+1
+        it should show working hours from 17:00 - 23:59 yesterday and 00:00 - 02:00 today. However if the request is
+        to only get working hours for today it should only return 17:00 - 23:59 and not 00:00 - 02:00
+        """
+        self.contractD.resource_calendar_id = self.sunday_afternoon_calendar
+        self.contractD.tz = "America/Los_Angeles"
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            self.partnerD.ids,
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+            datetime(2023, 12, 31).isoformat(),  # Sunday
+        )
+        expected_hours = [
+            {"daysOfWeek": [0], "startTime": "17:00", "endTime": "23:59"},  # Sunday
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            self.partnerD.ids,
+            datetime(2024, 1, 1).isoformat(),  # Monday
+            datetime(2024, 1, 1).isoformat(),  # Monday
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "00:00", "endTime": "02:00"},  # Monday
+        ]
+        self.assertEqual(work_hours, expected_hours)
+
     def test_working_hours_with_employee_without_contract(self):
         self.env.user.company_id = self.company_A
         self.env.user.company_ids = [self.company_A.id]
@@ -478,6 +590,154 @@ class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
             {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
             {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
         ])
+
+    def test_flexible_employee_is_available_in_the_middle_of_a_day(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = 56
+        self.contractD.hours_per_day = 8
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "08:00", "endTime": "16:00"},  # Monday
+            {"daysOfWeek": [2], "startTime": "08:00", "endTime": "16:00"},  # Tuesday
+            {"daysOfWeek": [3], "startTime": "08:00", "endTime": "16:00"},  # Wednesday
+            {"daysOfWeek": [4], "startTime": "08:00", "endTime": "16:00"},  # Thursday
+            {"daysOfWeek": [5], "startTime": "08:00", "endTime": "16:00"},  # Friday
+            {"daysOfWeek": [6], "startTime": "08:00", "endTime": "16:00"},  # Saturday
+            {"daysOfWeek": [0], "startTime": "08:00", "endTime": "16:00"},  # Sunday
+        ]
+
+        self.assertEqual(
+            work_hours,
+            expected_hours,
+        )
+
+    def test_flexible_employee_is_available_in_the_middle_of_day_after_contract_start(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = 56
+        self.contractD.hours_per_day = 8
+        self.contractD.contract_date_start = datetime(2023, 12, 28)
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [4], "startTime": "08:00", "endTime": "16:00"},  # Thursday
+            {"daysOfWeek": [5], "startTime": "08:00", "endTime": "16:00"},  # Friday
+            {"daysOfWeek": [6], "startTime": "08:00", "endTime": "16:00"},  # Saturday
+            {"daysOfWeek": [0], "startTime": "08:00", "endTime": "16:00"},  # Sunday
+        ]
+
+        self.assertEqual(
+            work_hours,
+            expected_hours,
+        )
+
+    def test_flexible_employee_is_always_available_until_contract_end(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = 56
+        self.contractD.hours_per_day = 8
+        self.contractD.contract_date_end = datetime(2023, 12, 28)
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "08:00", "endTime": "16:00"},  # Monday
+            {"daysOfWeek": [2], "startTime": "08:00", "endTime": "16:00"},  # Tuesday
+            {"daysOfWeek": [3], "startTime": "08:00", "endTime": "16:00"},  # Wednesday
+            {"daysOfWeek": [4], "startTime": "08:00", "endTime": "16:00"},  # Thursday
+        ]
+
+        self.assertEqual(
+            work_hours,
+            expected_hours,
+        )
+
+    def test_fully_flexible_employee_is_always_available(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = False
+        self.contractD.hours_per_day = False
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "00:00", "endTime": "23:59"},  # Monday
+            {"daysOfWeek": [2], "startTime": "00:00", "endTime": "23:59"},  # Tuesday
+            {"daysOfWeek": [3], "startTime": "00:00", "endTime": "23:59"},  # Wednesday
+            {"daysOfWeek": [4], "startTime": "00:00", "endTime": "23:59"},  # Thursday
+            {"daysOfWeek": [5], "startTime": "00:00", "endTime": "23:59"},  # Friday
+            {"daysOfWeek": [6], "startTime": "00:00", "endTime": "23:59"},  # Saturday
+            {"daysOfWeek": [0], "startTime": "00:00", "endTime": "23:59"},  # Sunday
+        ]
+
+        self.assertEqual(
+            work_hours,
+            expected_hours,
+        )
+
+    def test_fully_flexible_employee_is_always_available_after_contract_start(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = False
+        self.contractD.hours_per_day = False
+        self.contractD.contract_date_start = datetime(2023, 12, 28)
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [4], "startTime": "00:00", "endTime": "23:59"},  # Thursday
+            {"daysOfWeek": [5], "startTime": "00:00", "endTime": "23:59"},  # Friday
+            {"daysOfWeek": [6], "startTime": "00:00", "endTime": "23:59"},  # Saturday
+            {"daysOfWeek": [0], "startTime": "00:00", "endTime": "23:59"},  # Sunday
+        ]
+
+        self.assertEqual(
+            work_hours,
+            expected_hours,
+        )
+
+    def test_fully_flexible_employee_is_always_available_until_contract_end(self):
+        self.env.user.company_id = self.company_A
+        self.contractD.resource_calendar_id = False
+        self.contractD.hours_per_week = False
+        self.contractD.hours_per_day = False
+        self.contractD.contract_date_end = datetime(2023, 12, 28)
+
+        work_hours = self.env["res.partner"].get_working_hours_for_all_attendees(
+            [self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        expected_hours = [
+            {"daysOfWeek": [1], "startTime": "00:00", "endTime": "23:59"},  # Monday
+            {"daysOfWeek": [2], "startTime": "00:00", "endTime": "23:59"},  # Tuesday
+            {"daysOfWeek": [3], "startTime": "00:00", "endTime": "23:59"},  # Wednesday
+            {"daysOfWeek": [4], "startTime": "00:00", "endTime": "23:59"},  # Thursday
+        ]
+
+        self.assertEqual(
+            work_hours,
+            expected_hours,
+        )
 
     def test_event_with_flexible_and_default_calendar_employees(self):
         """

--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -23,7 +23,7 @@ You can keep track of time off in different ways by following reports:
 
 A synchronization with an internal agenda (Meetings of the CRM module) is also possible in order to automatically create a meeting when a time off request is accepted by setting up a type of meeting in time off Type.
 """,
-    'depends': ['hr_work_entry', 'calendar', 'resource'],
+    'depends': ['hr_work_entry', 'hr_calendar', 'resource'],
     'data': [
         'data/report_paperformat.xml',
         'data/mail_activity_type_data.xml',

--- a/addons/hr_holidays/tests/test_working_hours.py
+++ b/addons/hr_holidays/tests/test_working_hours.py
@@ -1,23 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, datetime
-from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon
+
+from odoo.addons.hr_calendar.tests.common import TestHrContractCalendarCommon
 
 from odoo.tests import tagged
 
 
 @tagged('work_hours')
-class TestWorkingHours(TestHrCalendarCommon):
+class TestWorkingHours(TestHrContractCalendarCommon):
     """ Test global leaves for a whole company, conflict resolutions """
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # YTI TODO: Those tests seem to be never launched from now.
-        if 'hr.version' in cls.env:
-            cls.skipTest(cls,
-                "hr_contract module is installed. To test these features you need to install hr_holidays_contract"
-            )
 
         cls.work_entry_type = cls.env['hr.work.entry.type'].create({
             'name': 'Unpaid Time Off',
@@ -26,6 +22,7 @@ class TestWorkingHours(TestHrCalendarCommon):
             'leave_validation_type': 'no_validation',
             'request_unit': 'day',
             'unit_of_measure': 'day',
+            'count_as': 'absence',
         })
 
     def test_multi_companies_2_employees_2_selected_companies_holidays(self):

--- a/addons/hr_work_entry/views/menuitems.xml
+++ b/addons/hr_work_entry/views/menuitems.xml
@@ -31,4 +31,11 @@
         action="resource.action_resource_calendar_form"
         parent="menu_hr_work_entry_configuration"
     />
+
+    <!-- Work Entries Configuration in HR/Employees app -->
+    <menuitem
+        id="menu_hr_work_entry_type_view"
+        action="hr_work_entry.hr_work_entry_type_action"
+        parent="hr.menu_config_working_times"
+        sequence="20"/>
 </odoo>

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -229,12 +229,12 @@ class ResourceCalendar(models.Model):
         if not resources_per_tz:
             resources_per_tz = {start_dt.tzinfo: self.env['resource.resource']}
 
-        domain = Domain.AND([
+        attendances_domain = Domain.AND([
             Domain(domain or Domain.TRUE),
             Domain('calendar_id', '=', self.id),
         ])
 
-        attendances = self.env['resource.calendar.attendance'].search(domain)
+        attendances = self.env['resource.calendar.attendance'].search(attendances_domain)
         duration_based_attendances = attendances.filtered('duration_based')
         all_duration_based_attendances = attendances.calendar_id.attendance_ids.filtered('duration_based')
         # Resource specific attendances
@@ -329,14 +329,19 @@ class ResourceCalendar(models.Model):
                 hours_per_day = calendar_data.get('hours_per_day')
                 is_fully_flexible = not calendar and not hours_per_week and not hours_per_day
                 is_flexible = not calendar and (hours_per_week or hours_per_day)
-                if resource and is_fully_flexible:
+                if not domain and resource and is_fully_flexible:
+                    # A domain is only provided in extensions of `_work_intervals_batch` so when a domain is present,
+                    # we should use the standard attendance intervals rather than the flexible employee special handling.
+                    # This prevents a scenario where `_work_intervals_batch` calls this method twice and returns the same
+                    # value, causing the them to cancel out.
+                    #
                     # If the resource is fully flexible, return the whole period from start_dt to end_dt with a dummy attendance
                     hours = (end_dt - start_dt).total_seconds() / 3600
                     dummy_attendance = self.env['resource.calendar.attendance'].new({
                         'duration_hours': hours,
                     })
                     result_per_resource_id[resource.id] = Intervals([(start_datetime, end_datetime, dummy_attendance)], keep_distinct=True)
-                elif resource and is_flexible:
+                elif not domain and resource and is_flexible:
                     # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
                     # until the full time required hours are met. This gives us the most correct approximation when looking at a daily
                     # and weekly range for time offs and overtime calculations and work entry generation

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -446,16 +446,17 @@ export class CalendarModel extends Model {
                 end: data.range.end.plus({ [`${this.scale}s`]: 1 }),
             };
         }
+        const { sections, dynamicFiltersInfo } = await this.loadFilters(data);
+
+        // Load records and dynamic filters only with fresh filters
+        data.filterSections = sections;
+
         if (this.meta.showUnusualDays) {
             unusualDaysProm = this.loadUnusualDays(data).then((unusualDays) => {
                 data.unusualDays = unusualDays;
             });
         }
 
-        const { sections, dynamicFiltersInfo } = await this.loadFilters(data);
-
-        // Load records and dynamic filters only with fresh filters
-        data.filterSections = sections;
         [data.records] = await Promise.all([
             this.loadRecords(data),
             this.meta.canScheduleEvents ? this.fetchEventsToSchedule({ data }) : null,


### PR DESCRIPTION
The calendar now correctly grays out days based on work entry types. Work entries that are considered as absence will grey out a block in the calendar, while others will make the sections white. This was already implemented in l10n_hk_hr_payroll so this commit is just moving this feature into standard.

task-5085284

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
