### PR TITLE
[FIX] modules: adapt for 18.2

### DIFF
--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -77,11 +77,14 @@ def initialize(cr):
                 (id, d, d in (info['auto_install'] or ()))
             )
 
-    # Install recursively all auto-installing modules
     from odoo.tools import config  # noqa: PLC0415
+    if config.get('skip_auto_install'):
+        # even if skip_auto_install is enabled we still want to have base
+        cr.execute("""UPDATE ir_module_module SET state='to install' WHERE name = 'base'""")
+        return
+
+    # Install recursively all auto-installing module
     while True:
-        if config.get('skip_auto_install'):
-            break
         # this selects all the auto_install modules whose auto_install_required
         # deps are marked as to install
         cr.execute("""


### PR DESCRIPTION
Starting in 18.2 the skip-auto-install is not working as in 17.0 because base is not marked as to install another way. The detailed explanation: https://github.com/odoo/odoo/pull/239044#discussion_r2603384580

This commit just makes the logic and code consistent in all versions even if this is not needed in 17.0



