### PR TITLE
[IMP] web: Add \v syntax in odoomark

### DIFF
--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -220,6 +220,7 @@ export function isHtmlEmpty(content = "") {
  *      \`text\` => Put the text in a rounded badge (bg-primary).
  *      \n => Insert a breakline.
  *      \t => Insert 4 spaces.
+ *      \v => Align what follow to right.
  *
  * @param {string|ReturnType<markup>} text
  * @returns {string|ReturnType<markup>} the formatted text
@@ -229,6 +230,18 @@ export function odoomark(text) {
         [/\n/g, () => markup`<br/>`],
         [/\t/g, () => markup`<span style="margin-left: 2em"></span>`],
         [
+            /\v(.*)/g,
+            (_, content) => {
+                /**
+                 * markup: text is a Markup object (either escaped inside htmlReplace or
+                 * flagged safe), `content` is directly coming from this value,
+                 * and the regex doesn't do anything crazy to unescape it.
+                 */
+                content = markup(content);
+                return markup`<span class="float-end ms-3">${content}</span>`;
+            },
+        ],
+        [
             /\*\*(.+?)\*\*/g,
             (_, bold) => {
                 /**
@@ -236,7 +249,7 @@ export function odoomark(text) {
                  * flagged safe), `bold` is directly coming from this value,
                  * and the regex doesn't do anything crazy to unescape it.
                  */
-                markup(bold);
+                bold = markup(bold);
                 return markup`<b>${bold}</b>`;
             },
         ],

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -343,4 +343,8 @@ test("odoomark", () => {
     expect(odoomark("test\ntest2").toString()).toBe("test<br/>test2");
     expect(odoomark("<p>**test**</p>").toString()).toBe("&lt;p&gt;<b>test</b>&lt;/p&gt;");
     expect(odoomark(markup`<p>**test**</p>`).toString()).toBe("<p><b>test</b></p>");
+
+    expect(odoomark("test\vtest2 test2").toString()).toBe(
+        'test<span class="float-end ms-3">test2 test2</span>'
+    );
 });


### PR DESCRIPTION
Now, odoomark can use the syntax \v that will put
a span with a float right for aligning the right part to
the right.

TASK-5386833


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
