### PR TITLE
[FIX] html_editor: fix navigation around stars

### DIFF
--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -35,6 +35,7 @@ export class StarPlugin extends Plugin {
                 commandParams: { length: 5 },
             },
         ],
+        selectors_for_feff_providers: () => ".o_stars",
     };
 
     setup() {
@@ -76,7 +77,7 @@ export class StarPlugin extends Plugin {
 
     addStars({ length }) {
         const stars = Array.from({ length }, () => '<i class="fa fa-star-o"></i>').join("");
-        const html = `\u200B<span contenteditable="false" class="o_stars">${stars}</span>\u200B`;
+        const html = `<span contenteditable="false" class="o_stars">${stars}</span>`;
         this.dependencies.dom.insert(parseHTML(this.document, html));
         this.dependencies.history.addStep();
     }

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -1,7 +1,13 @@
 import { expect, test } from "@odoo/hoot";
 import { click, press } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "./_helpers/editor";
-import { deleteBackward, insertText, splitBlock } from "./_helpers/user_actions";
+import {
+    deleteBackward,
+    deleteForward,
+    insertText,
+    simulateArrowKeyPress,
+    splitBlock,
+} from "./_helpers/user_actions";
 import { getContent } from "./_helpers/selection";
 import { animationFrame } from "@odoo/hoot-mock";
 import { expectElementCount } from "./_helpers/ui_expectations";
@@ -18,7 +24,7 @@ test("add 3 star elements", async () => {
 
     await press("Enter");
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\uFEFF<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF[]</p>`
     );
 });
 
@@ -30,31 +36,31 @@ test("add 5 star elements", async () => {
 
     await press("Enter");
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\uFEFF<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF[]</p>`
     );
 });
 
 test("select star rating", async () => {
     const { el } = await setupEditor(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p><span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>[]</p>`
     );
 
     await click("i.fa-star-o:first");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\uFEFF<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF[]</p>`
     );
 
     await click("i.fa-star-o:last");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\uFEFF<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i></span>\uFEFF[]</p>`
     );
 
     await click("i.fa-star:last");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\uFEFF<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF[]</p>`
     );
 });
 
@@ -64,11 +70,11 @@ test("should insert two empty paragraphs when Enter is pressed twice before the 
     );
     splitBlock(editor);
     expect(getContent(el)).toBe(
-        `<p><br></p><p>[]<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B</p>`
+        `<p><br></p><p>\uFEFF[]<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF\u200B</p>`
     );
     splitBlock(editor);
     expect(getContent(el)).toBe(
-        `<p><br></p><p><br></p><p>[]<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B</p>`
+        `<p><br></p><p><br></p><p>\uFEFF[]<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF\u200B</p>`
     );
 });
 
@@ -78,21 +84,60 @@ test("should insert two empty paragraphs when Enter is pressed twice after the s
     );
     splitBlock(editor);
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        `<p>\u200B\uFEFF<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
     splitBlock(editor);
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span></p><p><br></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        `<p>\u200B\uFEFF<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\uFEFF</p><p><br></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 
 test("should delete star rating elements when delete is pressed twice", async () => {
     await testEditor({
-        contentBefore: `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`,
+        contentBefore: `<p><span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>[]</p>`,
         stepFunction: async (editor) => {
             deleteBackward(editor);
             deleteBackward(editor);
         },
         contentAfter: "<p>[]<br></p>",
     });
+});
+
+test("stars line should be reachable with up/down", async () => {
+    const { el, editor } = await setupEditor("<p>abc[]def</p>");
+    splitBlock(editor);
+    splitBlock(editor);
+    await simulateArrowKeyPress(editor, "ArrowUp");
+    await insertText(editor, "/3star");
+    await animationFrame();
+    await expectElementCount(".o-we-powerbox", 1);
+    await press("Enter");
+
+    const stars = `<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>`;
+    expect(getContent(el)).toBe(`<p>abc</p><p>\uFEFF${stars}\uFEFF[]</p><p>def</p>`);
+
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await simulateArrowKeyPress(editor, "ArrowUp");
+    await simulateArrowKeyPress(editor, "ArrowUp");
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    expect(getContent(el)).toBe(`<p>abc</p><p>\uFEFF${stars}[]\uFEFF</p><p>def</p>`);
+
+    deleteForward(editor);
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    deleteBackward(editor);
+
+    expect(getContent(el)).toBe(`<p>abc[]\uFEFF${stars}\uFEFFdef</p>`);
+
+    splitBlock(editor);
+    await simulateArrowKeyPress(editor, "ArrowRight");
+    splitBlock(editor);
+
+    expect(getContent(el)).toBe(`<p>abc</p><p>\uFEFF${stars}\uFEFF</p><p>[]def</p>`);
+
+    await simulateArrowKeyPress(editor, "ArrowUp");
+    expect(getContent(el)).toBe(`<p>abc</p><p>[]\uFEFF${stars}\uFEFF</p><p>def</p>`);
+
+    await simulateArrowKeyPress(editor, "ArrowUp");
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    expect(getContent(el)).toBe(`<p>abc</p><p>[]\uFEFF${stars}\uFEFF</p><p>def</p>`);
 });


### PR DESCRIPTION
When put on a single line, the `o_stars` blocks are not reachable by up/down keyboard navigation because they lack `FEFF` characters to put the cursor.

This commit fixes this be removing the outdated `200B` characters that were introduced in [1] and making `o_stars` surrounded by `FEFF`.

Steps to reproduce:
- Write two lines of text
- Add a third line between the two by pressing enter at the end of the first one
- Insert stars with `/stars`
- Navigate with up/down arrow
- Notice that the line with the stars is not skipped
- Press Backspace before the stars and before the third line so that everything is on the same line
- Press Enter before and after the stars to put then back in three lines
- Navigate with up/down arrow

=> The line with the stars was skipped

task-5392572
