### PR TITLE
[IMP] web,calendar: improve calendar view usability

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -52,14 +52,20 @@ export class AttendeeCalendarController extends CalendarController {
 
     getQuickCreateFormViewProps(record) {
         const props = super.getQuickCreateFormViewProps(record);
-        const onDialogClosed = () => {
-            this.model.load();
-        };
         return {
             ...props,
             size: "md",
             context: { ...props.context, ...this.props.context },
-            onRecordSaved: () => onDialogClosed(),
+            onRecordSave: async (record) => {
+                if (!record.data.name) {
+                    await record.update({ name: _t("(No Title)") });
+                }
+                const saved = await record.save({ reload: false });
+                if (saved) {
+                    this.model.load();
+                }
+                return saved;
+            },
         };
     }
 

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -333,6 +333,11 @@
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
             <form string="Meetings" class="o_calendar_event_form_quick_create" js_class="calendar_quick_create_form_view">
+                <div class="o_unavailable_attendees_alert alert alert-warning border-0 d-flex flex-wrap m-0 mb-3" role="alert"
+                    invisible="not unavailable_partner_ids or allday">
+                    <span class="me-1">The following attendees are not available at the selected time</span>
+                    <field name="unavailable_partner_ids" widget="many2many_tags"/>
+                </div>
                 <field name="invalid_email_partner_ids" invisible="1"/> <!--used in many2many_attendees widget-->
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
                     <i class="fa fa-fw flex-shrink-0 fa-tag text-600 me-2" title="Booking Name"/>

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -362,17 +362,6 @@
                 }
             }
 
-            .fc-timegrid-event-harness-inset{
-                transition: right .3s, left .3s;
-
-                &:has(.fc-event.o_cw_custom_highlight:not(.fc-dragging)) {
-                    z-index: $zindex-modal !important;
-                    right: 0 !important;
-                    left: 0 !important;
-                    margin-right: 0 !important;
-                }
-            }
-
             // Avoid pointer event on the "Now Indicator" (red line)
             .fc-timegrid-now-indicator-line {
                 pointer-events: none;


### PR DESCRIPTION
1) In Calendar, improving the calendar quick create view by:
- adding a warning when the participants are busy like in the appointment gantt view
- allowing the creation without title to create events faster (defaulting on '(No Title)' name)

2) In every calendar view, removing the on hover animation when hovering a calendar event in the day and week scale as it makes it difficult to access squeezed events on the same timeline.

Task-5407656

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
