### PR TITLE
[IMP] web: ace: qweb: add token for attributes that should not be cha…

### DIFF
--- a/addons/web/static/src/core/code_editor/code_editor.js
+++ b/addons/web/static/src/core/code_editor/code_editor.js
@@ -10,6 +10,7 @@ export class CodeEditor extends Component {
             optional: true,
             validate: (mode) => CodeEditor.MODES.includes(mode),
         },
+        modeOptions: { type: Object, optional: true },
         value: { validate: (v) => typeof v === "string", optional: true },
         readonly: { type: Boolean, optional: true },
         onChange: { type: Function, optional: true },
@@ -154,7 +155,7 @@ export class CodeEditor extends Component {
                     });
                     sessions[sessionId] = session;
                 }
-                session.setMode(mode ? `ace/mode/${mode}` : "");
+                session.setMode(this.aceMode);
                 this.aceEditor.setSession(session);
             },
             () => [this.props.sessionId, this.props.mode, this.props.value]
@@ -178,5 +179,16 @@ export class CodeEditor extends Component {
                 });
             });
         }
+    }
+
+    get aceMode() {
+        const mode = this.props.mode;
+        if (mode) {
+            return {
+                path: `ace/mode/${mode}`,
+                ...(this.props.modeOptions || {}),
+            };
+        }
+        return "";
     }
 }

--- a/addons/web/static/src/core/resizable_panel/resizable_panel.js
+++ b/addons/web/static/src/core/resizable_panel/resizable_panel.js
@@ -47,7 +47,7 @@ function useResizable({
 
     onMounted(() => {
         if (handleRef.el) {
-            resize(initialWidth);
+            resize(Math.max(initialWidth, getMinWidth(props) || 0));
             handleRef.el.addEventListener("mousedown", onMouseDown);
         }
     });

--- a/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.js
+++ b/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.js
@@ -6,6 +6,14 @@ import { IrUiViewCodeEditor } from "@web/core/ir_ui_view_code_editor/code_editor
 export class IrUiViewAceField extends AceField {
     static template = "web.IrUIViewAceField";
     static components = { IrUiViewCodeEditor };
+
+    get invalidLocators() {
+        const { resId, resModel } = this.props.record;
+        if (resModel === "ir.ui.view" && resId) {
+            return this.props.record.data.invalid_locators || undefined;
+        }
+        return undefined; // as if the props was unset
+    }
 }
 
 export const irUiViewAceField = {

--- a/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.xml
+++ b/addons/web/static/src/views/fields/ir_ui_view_ace/ace_field.xml
@@ -6,7 +6,7 @@
                 value="state.initialValue"
                 mode="mode"
                 readonly="props.readonly"
-                record="props.record"
+                invalidLocators="this.invalidLocators"
                 onBlur.bind="commitChanges"
                 onChange.bind="handleChange"
                 class="'ace-view-editor'"


### PR DESCRIPTION
…nged

This commit introduces two things:
- In the mode-qweb ace module that handles qweb XML A feature is added to pass a list of attributes that should not be removed if the parent tag is not removed at the same time.
Behaviors are added to make sure inserting or deleting in or around those readonly attribute do not modify them, at least in a best effort case.
- Options are now passable to the Ace edition mode via the CodeEditor This allows to make the feature described above parametrable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
