### PR TITLE
[FIX] html_builder: stop value commit on all keydown event

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -86,7 +86,7 @@ export class BuilderNumberInput extends Component {
         this.updateUnitVisibility(e.target.value);
     }
 
-    onKeydown(e) {
+    onKeydownArrow(e) {
         this.debouncedCommitValue();
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.xml
@@ -12,7 +12,7 @@
             commit="commit"
             preview="preview"
             clampValue.bind="clampValue"
-            onKeydown.bind="onKeydown"
+            onKeydownArrow.bind="onKeydownArrow"
             onInput.bind="onInput"
             onChange.bind="onChange"
             composable="props.composable"

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input_base.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input_base.js
@@ -4,6 +4,7 @@ export class BuilderNumberInputBase extends BuilderInputBase {
     static template = "html_builder.BuilderNumberInputBase";
     static props = {
         ...super.props,
+        onKeydownArrow: { type: Function, optional: true },
         clampValue: { type: Function, optional: false },
         composable: { type: Boolean, optional: true },
         min: { type: Number, optional: true },
@@ -26,8 +27,8 @@ export class BuilderNumberInputBase extends BuilderInputBase {
             });
             e.target.value = values.join(" ");
             this.props.preview(e.target.value);
+            this.props.onKeydownArrow?.(e);
         }
-        this.props.onKeydown?.(e);
     }
 
     onBeforeInput(e) {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
@@ -213,10 +213,7 @@ test("should syncronize previews", async () => {
 
     // Slider changes are committed automatically after a short delay
     await advanceTime(1200);
-    await expect.verifySteps([
-        "customAction isPreviewing: false",
-        "customAction isPreviewing: false",
-    ]);
+    await expect.verifySteps(["customAction isPreviewing: false"]);
     await expect(".options-container input[type='number']").toHaveProperty("value", 10);
 });
 


### PR DESCRIPTION
Following odoo#232383, there was an issue where the input was always committed on every keydown event. This was due to the onKeydown props behing called even on non arrow inputs.