### PR TITLE
[PERF] pos_loyalty: optimize potential free product qty computation

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -538,25 +538,21 @@ patch(PosStore.prototype, {
                 const considerTheReward =
                     program.applies_on !== "both" || (program.applies_on == "both" && hasLine);
                 if (reward.reward_type === "product" && considerTheReward) {
-                    let hasPotentialQty = true;
-                    let potentialQty;
                     for (const { id } of reward.reward_product_ids) {
                         const product = this.models["product.product"].get(id);
-                        potentialQty = order._computePotentialFreeProductQty(
+                        const potentialQty = order._computePotentialFreeProductQty(
                             reward,
                             product,
                             points
                         );
-                        if (potentialQty <= 0) {
-                            hasPotentialQty = false;
+                        if (potentialQty > 0) {
+                            result.push({
+                                coupon_id: couponProgram.coupon_id,
+                                reward: reward,
+                                potentialQty,
+                            });
+                            break;
                         }
-                    }
-                    if (hasPotentialQty) {
-                        result.push({
-                            coupon_id: couponProgram.coupon_id,
-                            reward: reward,
-                            potentialQty,
-                        });
                     }
                 }
             }


### PR DESCRIPTION
Before this commit, the computation of potential free product quantities looped through all reward products even after finding a valid one. This led to unnecessary calculations and performance degradation, especially when multiple reward products were involved.

opw-5268991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
