### PR TITLE
[IMP] account: add clearer title for rounding methods in settings

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -62,7 +62,8 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting id="rounding_method" company_dependent="1" string="Rounding Method" help="How total tax amount is computed in orders and invoices" title="A rounding per line is advised if your prices are tax-included. That way, the sum of line subtotals equals the total with taxes.">
+                            <setting id="rounding_method" company_dependent="1" string="Rounding Method" help="How total tax amount is computed in orders and invoices" title="- A rounding per tax is advised if your prices are tax-excluded. This minimizes cumulative rounding errors because it totals all unrounded tax amounts first and only rounds the final tax total once.\n
+                                                                                                                                                                               - A rounding per line is advised if your prices are tax-included. That way, the sum of line subtotal equals the total with taxes.">
                                 <field name="tax_calculation_rounding_method" class="o_light_label mt16" widget="radio"/>
                             </setting>
                             <setting id="eu_service" title="If you sell goods and services to customers in a


### PR DESCRIPTION
In the accounting configuration settings, the hover text for the rounding method (title attribute) only showed a description for the "round per line" option, another description was added for the "round per tax" option
task-5367117
