### PR TITLE
[FIX] l10n_sa_edi_pos: propagate potential errors from validation

### DIFF
--- a/addons/l10n_sa_edi_pos/static/src/app/utils/order_payment_validation.js
+++ b/addons/l10n_sa_edi_pos/static/src/app/utils/order_payment_validation.js
@@ -10,7 +10,7 @@ patch(OrderPaymentValidation.prototype, {
         this.dialog = this.pos.env.services.dialog;
     },
     async finalizeValidation() {
-        await super.finalizeValidation(...arguments);
+        const potentialValidationError = await super.finalizeValidation(...arguments);
 
         // note: isSACompany guarantees order.is_to_invoice()
         if (
@@ -39,5 +39,6 @@ patch(OrderPaymentValidation.prototype, {
                 body: message,
             });
         }
+        return potentialValidationError;
     },
 });


### PR DESCRIPTION
This PR is related to https://github.com/odoo/enterprise/pull/101365.

In the above PR, a l10n test fails because an error is not correctly propagated by the method overriding `finalizeValidation`. In fact, the method `OrderPaymentValidation.shouldHideValidationBehindFeedbackScreen` requires the return value of `finalizeValidation` to determine whether an error occurred or not.

https://github.com/odoo/odoo/blob/9e04aadb83d482d05fc2fa66fa3c3bebb6ac1528/addons/point_of_sale/static/src/app/utils/order_payment_validation.js#L96-L99

In the methods overriding `finalizeValidation`, if the return value is not propagated, the potential error is lost and the `shouldHideValidationBehindFeedbackScreen` will attempt to move onto the next screen anyway.

(related to)
opw-5171035