### PR TITLE
[FIX] mail: joining a call from an invitation should open corresponding thread

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_invitation.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.js
@@ -34,6 +34,7 @@ export class CallInvitation extends Component {
     }
 
     joinCall() {
+        this.props.thread.open({ focus: true });
         this.rtc.toggleCall(this.props.thread, {
             audio: this.state.hasMicrophone,
             camera: this.state.hasCamera,

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -7,7 +7,7 @@
                 <div class="o-discuss-CallInvitation-main" t-ref="root">
                     <div class="ms-1 position-relative d-flex justify-content-between p-2">
                         <div class="d-flex align-items-center" style="min-width: 0;">
-                            <div class="o-mail-CallInvitation-avatar flex-shrink-0 cursor-pointer d-flex align-items-center justify-content-center rounded-circle overflow-hidden" t-att-class="{'bg-primary': !inviter}" t-on-click="() => props.thread.open()" t-att-title="avatarTitle">
+                            <div class="o-mail-CallInvitation-avatar flex-shrink-0 cursor-pointer d-flex align-items-center justify-content-center rounded-circle overflow-hidden" t-att-class="{'bg-primary': !inviter}" t-on-click="() => props.thread.open({ focus: true })" t-att-title="avatarTitle">
                                 <img t-if="inviter" class="object-fit-cover h-100 w-100" t-att-src="inviter.avatarUrl" alt="Avatar"/>
                                 <i t-else="" class="fa fa-phone"/>
                             </div>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -13,6 +13,7 @@ import {
     start,
     startServer,
     triggerEvents,
+    triggerHotkey,
     waitStoreFetch,
     dragenterFiles,
     dropFiles,
@@ -1171,4 +1172,49 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
     await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
     await contains(".o-discuss-CallParticipantCard[title='Batman'] video");
     await contains(".o-discuss-CallParticipantCard", { count: 2 }); // card does not get focused in meeting view
+});
+
+test.tags("focus required");
+test("open conversation from call invitation (chat window)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const [memberId] = pyEnv["discuss.channel.member"].search([["channel_id", "=", channelId]]);
+    const rtcSessionId = pyEnv["discuss.channel.rtc.session"].create({
+        channel_member_id: memberId,
+        channel_id: channelId,
+    });
+    pyEnv["discuss.channel.member"].write([memberId], { rtc_inviting_session_id: rtcSessionId });
+    await start();
+    await contains(".o-discuss-CallInvitation");
+    await click(".o-mail-CallInvitation-avatar");
+    await contains(".o-mail-ChatWindow .o-mail-Composer.o-focused");
+    triggerHotkey("Escape");
+    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-discuss-CallInvitation");
+    await click("[title='Join Call']");
+    await contains(".o-mail-ChatWindow .o-mail-Composer.o-focused");
+});
+
+test("open conversation from call invitation (discuss app)", async () => {
+    const pyEnv = await startServer();
+    const channelId1 = pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId2 = pyEnv["discuss.channel"].create({ name: "Test" });
+    const memberId = pyEnv["discuss.channel.member"].search([["channel_id", "=", channelId1]]);
+    const rtcSessionId = pyEnv["discuss.channel.rtc.session"].create({
+        channel_member_id: pyEnv["discuss.channel.member"].create({
+            channel_id: channelId1,
+            partner_id: pyEnv["res.partner"].create({ name: "Armstrong" }),
+        }),
+        channel_id: channelId1,
+    });
+    pyEnv["discuss.channel.member"].write(memberId, { rtc_inviting_session_id: rtcSessionId });
+    await start();
+    await openDiscuss(channelId2);
+    await contains(".o-discuss-CallInvitation");
+    await click(".o-mail-CallInvitation-avatar");
+    await contains(".o-mail-DiscussContent-threadName[title=General]");
+    await click(".o-mail-DiscussSidebarChannel:text('Test')");
+    await contains(".o-discuss-CallInvitation");
+    await click("[title='Join Call']");
+    await contains(".o-mail-DiscussContent-threadName[title=General]");
 });


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Clicking on join call does not open the corresponding thread, 
neither in the discuss app nor in the chat window.

**Steps to Reproduce:**
- Log in with Admin and Demo user
- From the Demo side, open the chat window/discuss app and call Mitchell Admin
- On the Admin Side, click Join the call from the call invitation preview
- Chatwindow/Discuss app does not open the corresponding thread automatically

Additionally, clicking on the `invitation avatar` does not focuses the composer as 
expected in the chat window.

**Desired behavior after PR is merged:**
- Clicking join call now opens the corresponding thread in both discuss and 
chat window, with the composer focused in the `chat window`.
- Clicking the avatar on a call invitation now focuses the composer when opened 
inside a chat window.

task-[5367781](https://www.odoo.com/odoo/project/1519/tasks/5367781)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
