### PR TITLE
[FIX] website: keep image shape colors on animation speed change

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -130,7 +130,7 @@ export class ImageShapeOptionPlugin extends Plugin {
         const getData = (propName) =>
             propName in newDataset ? newDataset[propName] : img.dataset[propName];
         const combinedDataset = { ...img.dataset, ...newDataset };
-        const previousShapeId = this.getDefaultShapeId(img.dataset);
+        const previousShapeId = img.dataset.shape || this.getDefaultShapeId(img.dataset);
         const shapeId = combinedDataset.shape || this.getDefaultShapeId(combinedDataset);
         // todo: should we reset some data if shapeName is not defined?
         if (!shapeId) {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -2,6 +2,7 @@ import {
     addBuilderAction,
     addBuilderOption,
     setupHTMLBuilder,
+    editBuilderRangeValue,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { describe, expect, test } from "@odoo/hoot";
@@ -17,7 +18,6 @@ import {
 import { Deferred } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, models } from "@web/../tests/web_test_helpers";
-import { delay } from "@web/core/utils/concurrency";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 describe.current.tags("desktop");
@@ -220,14 +220,10 @@ describe("default value", () => {
             <div class="test-options-target">10</div>
         `);
         await contains(":iframe .test-options-target").click();
-        const input = queryFirst(".options-container input");
-        input.value = "";
-        input.dispatchEvent(new Event("input"));
-        await delay();
-        input.dispatchEvent(new Event("change"));
-        await delay();
+        await editBuilderRangeValue(".options-container input", "");
+
         expect.verifySteps(["customAction 20", "customAction 20"]);
-        expect(input).toHaveValue("20");
+        expect(".options-container input").toHaveValue("20");
     });
     test("clear BuilderNumberInput without default value", async () => {
         addBuilderAction({

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
@@ -2,14 +2,14 @@ import {
     addBuilderAction,
     addBuilderOption,
     setupHTMLBuilder,
+    editBuilderRangeValue,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { HistoryPlugin } from "@html_editor/core/history_plugin";
 import { expect, test, describe } from "@odoo/hoot";
-import { advanceTime, animationFrame, click, freezeTime, waitFor } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, click, freezeTime } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
-import { delay } from "@web/core/utils/concurrency";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 describe.current.tags("desktop");
@@ -37,13 +37,7 @@ test("should commit changes", async () => {
         <div class="test-options-target">10</div>
     `);
     await contains(":iframe .test-options-target").click();
-
-    const input = await waitFor(".options-container input");
-    input.value = 50;
-    input.dispatchEvent(new Event("input"));
-    await delay();
-    input.dispatchEvent(new Event("change"));
-    await delay();
+    await editBuilderRangeValue(".options-container input", 50);
 
     expect.verifySteps(["customAction 50", "customAction 50"]);
     expect(":iframe .test-options-target").toHaveInnerHTML("50");

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -9,7 +9,7 @@ import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { LocalOverlayContainer } from "@html_editor/local_overlay_container";
 import { Plugin } from "@html_editor/plugin";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
-import { after } from "@odoo/hoot";
+import { after, queryFirst } from "@odoo/hoot";
 import { animationFrame, waitForNone, queryOne, waitFor, advanceTime, tick } from "@odoo/hoot-dom";
 import { Component, onMounted, useRef, useState, useSubEnv, xml } from "@odoo/owl";
 import {
@@ -24,6 +24,7 @@ import { loadBundle } from "@web/core/assets";
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { uniqueId } from "@web/core/utils/functions";
+import { delay } from "@web/core/utils/concurrency";
 
 export function patchWithCleanupImg() {
     const defaultImg =
@@ -528,4 +529,13 @@ export async function setupHTMLBuilderWithDummySnippet(content) {
     };
 
     return await setupHTMLBuilder(content || "", snippetsStructure);
+}
+
+export async function editBuilderRangeValue(selector, newValue) {
+    const input = queryFirst(selector);
+    input.value = newValue;
+    input.dispatchEvent(new Event("input"));
+    await delay();
+    input.dispatchEvent(new Event("change"));
+    await delay();
 }

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -540,3 +540,83 @@ test("Should have the correct active shape in the image shape selector", async (
     await contains("[data-label='Shape'] .dropdown").click();
     expect("[data-action-value='html_builder/geometric/geo_tetris']").toHaveClass("active");
 });
+
+test("Should keep colors when changing speed and vice versa", async () => {
+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<div class="test-options-target">
+            ${testImg}
+        </div>`,
+        {
+            loadIframeBundles: true,
+        }
+    );
+    const editor = getEditor();
+
+    // Select image and apply shape
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
+    await waitSidebarUpdated();
+
+    const imgSelector = ":iframe .test-options-target img";
+    const initialColors = [
+        queryFirst(`[data-label="Colors"] .o_we_color_preview:nth-child(1)`).style.backgroundColor,
+        queryFirst(`[data-label="Colors"] .o_we_color_preview:nth-child(2)`).style.backgroundColor,
+        queryFirst(`[data-label="Colors"] .o_we_color_preview:nth-child(3)`).style.backgroundColor,
+        queryFirst(`[data-label="Colors"] .o_we_color_preview:nth-child(4)`).style.backgroundColor,
+    ];
+    const rangeInput = queryFirst(`[data-action-id="setImageShapeSpeed"] input`);
+
+    // Change speed
+    rangeInput.value = -1;
+    rangeInput.dispatchEvent(new Event("input"));
+    await delay();
+    rangeInput.dispatchEvent(new Event("change"));
+    await delay();
+    await editor.shared.operation.next(() => {});
+
+    // Change first color and verify speed unchanged
+    await contains(`[data-label="Colors"] .o_we_color_preview:nth-child(1)`).click();
+    await contains(`.o_font_color_selector [data-color="o-color-2"]`).click();
+    await waitSidebarUpdated();
+
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(1)`).toHaveStyle({
+        backgroundColor: "rgb(45, 49, 66)",
+    });
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(2)`).toHaveStyle({
+        backgroundColor: initialColors[1],
+    });
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(3)`).toHaveStyle({
+        backgroundColor: initialColors[2],
+    });
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(4)`).toHaveStyle({
+        backgroundColor: initialColors[3],
+    });
+
+    expect(imgSelector).toHaveAttribute("data-shape-animation-speed", "-1");
+
+    // Change speed and verify colors unchanged
+    rangeInput.value = 2;
+    rangeInput.dispatchEvent(new Event("input"));
+    await delay();
+    rangeInput.dispatchEvent(new Event("change"));
+    await delay();
+    await editor.shared.operation.next(() => {});
+
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(1)`).toHaveStyle({
+        backgroundColor: "rgb(45, 49, 66)",
+    });
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(2)`).toHaveStyle({
+        backgroundColor: initialColors[1],
+    });
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(3)`).toHaveStyle({
+        backgroundColor: initialColors[2],
+    });
+    expect(`[data-label="Colors"] .o_we_color_preview:nth-child(4)`).toHaveStyle({
+        backgroundColor: initialColors[3],
+    });
+
+    expect(imgSelector).toHaveAttribute("data-shape-animation-speed", "2");
+});

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst, waitFor } from "@odoo/hoot-dom";
+import { queryFirst, waitFor, setInputRange } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
-import { delay } from "@web/core/utils/concurrency";
 import { testImg } from "./image_test_helpers";
 
 defineWebsiteModels();
@@ -455,14 +454,7 @@ test("Should change the speed of an animated shape", async () => {
 
     const originalSrc = queryFirst(":iframe .test-options-target img").src;
 
-    await waitFor(`[data-action-id="setImageShapeSpeed"]`);
-    const rangeInput = queryFirst(`[data-action-id="setImageShapeSpeed"] input`);
-    rangeInput.value = 2;
-    rangeInput.dispatchEvent(new Event("input"));
-    await delay();
-    rangeInput.dispatchEvent(new Event("change"));
-    await delay();
-
+    await setInputRange(`[data-action-id="setImageShapeSpeed"] input`, 2);
     // ensure the shape action has been applied
     await editor.shared.operation.next(() => {});
 
@@ -567,14 +559,9 @@ test("Should keep colors when changing speed and vice versa", async () => {
         queryFirst(`[data-label="Colors"] .o_we_color_preview:nth-child(3)`).style.backgroundColor,
         queryFirst(`[data-label="Colors"] .o_we_color_preview:nth-child(4)`).style.backgroundColor,
     ];
-    const rangeInput = queryFirst(`[data-action-id="setImageShapeSpeed"] input`);
 
     // Change speed
-    rangeInput.value = -1;
-    rangeInput.dispatchEvent(new Event("input"));
-    await delay();
-    rangeInput.dispatchEvent(new Event("change"));
-    await delay();
+    await setInputRange(`[data-action-id="setImageShapeSpeed"] input`, -1);
     await editor.shared.operation.next(() => {});
 
     // Change first color and verify speed unchanged
@@ -598,11 +585,7 @@ test("Should keep colors when changing speed and vice versa", async () => {
     expect(imgSelector).toHaveAttribute("data-shape-animation-speed", "-1");
 
     // Change speed and verify colors unchanged
-    rangeInput.value = 2;
-    rangeInput.dispatchEvent(new Event("input"));
-    await delay();
-    rangeInput.dispatchEvent(new Event("change"));
-    await delay();
+    await setInputRange(`[data-action-id="setImageShapeSpeed"] input`, 2);
     await editor.shared.operation.next(() => {});
 
     expect(`[data-label="Colors"] .o_we_color_preview:nth-child(1)`).toHaveStyle({

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst, waitFor, setInputRange } from "@odoo/hoot-dom";
+import { queryFirst, setInputRange } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { testImg } from "./image_test_helpers";
@@ -114,8 +114,6 @@ test("Should change the shape color of an image", async () => {
     await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
     await waitSidebarUpdated();
 
-    await waitFor(`[data-label="Colors"] .o_we_color_preview`);
-
     expect(`[data-label="Colors"] .o_we_color_preview`).toHaveCount(4);
 
     expect(`[data-label="Colors"] .o_we_color_preview:nth-child(1)`).toHaveAttribute(
@@ -173,8 +171,6 @@ test("Should change the shape color of an image with a class color", async () =>
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/pattern/pattern_wave_4']").click();
     await waitSidebarUpdated();
-
-    await waitFor(`[data-label="Colors"] .o_we_color_preview`);
 
     expect(`[data-label="Colors"] .o_we_color_preview`).toHaveCount(4);
 
@@ -247,7 +243,6 @@ describe("flip shape axis", () => {
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         await waitSidebarUpdated();
-        await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",
@@ -273,7 +268,6 @@ describe("flip shape axis", () => {
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         await waitSidebarUpdated();
-        await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",
@@ -300,7 +294,6 @@ describe("flip shape axis", () => {
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         await waitSidebarUpdated();
-        await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",
@@ -326,7 +319,6 @@ describe("flip shape axis", () => {
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         await waitSidebarUpdated();
-        await waitFor(`[data-action-id="flipImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",
@@ -355,7 +347,6 @@ describe("rotate shape", () => {
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         // ensure the shape action has been applied
         await waitSidebarUpdated();
-        await waitFor(`[data-action-id="rotateImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",
@@ -380,7 +371,6 @@ describe("rotate shape", () => {
         await contains("[data-label='Shape'] .dropdown").click();
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         await waitSidebarUpdated();
-        await waitFor(`[data-action-id="rotateImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",
@@ -408,8 +398,6 @@ describe("rotate shape", () => {
         await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
         // ensure the shape action has been applied
         await waitSidebarUpdated();
-
-        await waitFor(`[data-action-id="rotateImageShape"]`);
 
         expect(`:iframe .test-options-target img`).toHaveAttribute(
             "data-shape",

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -1,5 +1,4 @@
 import { expect, test } from "@odoo/hoot";
-import { waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { testImg, testImgSrc, testGifImg, testGifImgSrc } from "./image_test_helpers";
@@ -15,7 +14,6 @@ test("the image should show its size", async () => {
     await contains(":iframe .test-options-target img").click();
     await waitSidebarUpdated();
     const selector = `[data-container-title="Image"] [title="Size"]`;
-    await waitFor(selector);
     const size = parseFloat(document.querySelector(selector).innerHTML);
     expectAround(size, 35.6);
 });
@@ -29,7 +27,6 @@ test("the background image should show its size", async () => {
     await contains(":iframe .test-options-target section").click();
     await waitSidebarUpdated();
     const selector = `[data-label="Image"] [title="Size"]`;
-    await waitFor(selector);
     const size = parseFloat(document.querySelector(selector).innerHTML);
     expectAround(size, 35.6);
 });
@@ -48,7 +45,6 @@ test("the GIF image should show its size", async () => {
     await contains(":iframe .test-options-target img").click();
     await waitSidebarUpdated();
     const selector = `[data-container-title="Image"] [title="Size"]`;
-    await waitFor(selector);
     const size = parseFloat(document.querySelector(selector).innerHTML);
     expectAround(size, 325.2);
 });
@@ -62,7 +58,6 @@ test("the GIF background image should show its size", async () => {
     await contains(":iframe .test-options-target section").click();
     await waitSidebarUpdated();
     const selector = `[data-label="Image"] [title="Size"]`;
-    await waitFor(selector);
     const size = parseFloat(document.querySelector(selector).innerHTML);
     expectAround(size, 325.2);
 });

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -11,6 +11,7 @@ import {
     queryOne,
     waitFor,
     waitForNone,
+    setInputRange,
 } from "@odoo/hoot-dom";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import {
@@ -20,7 +21,6 @@ import {
 } from "./website_helpers";
 import { dummyBase64Img } from "@html_builder/../tests/helpers";
 import { testImg } from "./image_test_helpers";
-import { delay } from "@web/core/utils/concurrency";
 import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 
 defineWebsiteModels();
@@ -278,12 +278,7 @@ describe("Image format/optimize", () => {
         const img = await waitFor(":iframe .test-options-target img");
         await contains(":iframe .test-options-target img").click();
         await waitSidebarUpdated();
-        const input = queryFirst('[data-action-id="setImageQuality"] input');
-        input.value = 50;
-        input.dispatchEvent(new Event("input"));
-        await delay();
-        input.dispatchEvent(new Event("change"));
-        await delay();
+        await setInputRange(`[data-action-id="setImageQuality"] input`, 50);
         // ensure the shape action has been applied
         await editor.shared.operation.next(() => {});
 


### PR DESCRIPTION
Before this commit, changing the animation speed would reset the colors applied to the image shape. This was due to the code always considering the shape as new because the current shape id wasn't retrieved.
Therefore, the colors would be reset to the default ones.

Steps to reproduce the issue:
- Drop a snippet with an image
- Click on the image
- Add an image shape. It should be animated.
- Change the image shape color
- Change the image shape animation speed 
=> The image shape color was reset.

task-5375497