### PR TITLE
[FIX] web,mail: remove useState() on usePopover()

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -44,6 +44,7 @@ export class ChatBubble extends Component {
         this.isMobileOS = isMobileOS();
         this.popover = usePopover(ChatBubblePreview, {
             animation: false,
+            onClose: () => (this.state.isPopoverOpen = false),
             position: "left-middle",
             popoverClass:
                 "dropdown-menu bg-view border-0 p-0 overflow-visible o-rounded-bubble mx-1",
@@ -59,11 +60,12 @@ export class ChatBubble extends Component {
             onHover: () => {
                 this.env.bus.trigger("ChatBubble:preview-will-open", this);
                 this.popover.open(this.rootRef.el, { chatWindow: this.props.chatWindow });
+                this.state.isPopoverOpen = true;
             },
             onAway: () => this.popover.close(),
         });
         this.rootRef = useRef("root");
-        this.state = useState({ bouncing: false });
+        this.state = useState({ bouncing: false, isPopoverOpen: false });
         useEffect(
             (importantCounter) => {
                 this.state.bouncing = Boolean(importantCounter);

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <div t-if="props.chatWindow?.channel" class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.channel.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': popover.isOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <div t-if="props.chatWindow?.channel" class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.channel.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': state.isPopoverOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !channel.isUnread or channel.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="channel.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="channel.importantCounter"/>
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>

--- a/addons/mail/static/src/discuss/core/web/channel_member_patch.js
+++ b/addons/mail/static/src/discuss/core/web/channel_member_patch.js
@@ -7,14 +7,16 @@ import { patch } from "@web/core/utils/patch";
 patch(ChannelMember.prototype, {
     setup() {
         super.setup(...arguments);
+        this.state.isAvatarCardOpen = false;
         this.avatarCard = usePopover(AvatarCardPopover, {
             arrow: false,
+            onClose: () => (this.state.isAvatarCardOpen = false),
             popoverClass: "mx-2",
             position: "right-start",
         });
     },
     get attClass() {
-        return { ...super.attClass, "o-active": this.avatarCard.isOpen };
+        return { ...super.attClass, "o-active": this.state.isAvatarCardOpen };
     },
     onClickAvatar(ev) {
         if (!this.canOpenChat) {
@@ -25,6 +27,7 @@ patch(ChannelMember.prototype, {
                 id: this.member.partner_id.main_user_id?.id,
                 channelMember: this.member,
             });
+            this.state.isAvatarCardOpen = true;
         }
     },
 });

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -173,9 +173,11 @@ test("Hover on chat bubble shows chat name + last message preview", async () => 
     setupChatHub({ folded: [marcChannelId, demoChannelId] });
     await start();
     await hover(".o-mail-ChatBubble[name='Marc']");
+    await contains(".o-mail-ChatBubble[name='Marc'].o-active");
     await contains(".o-mail-ChatBubble-preview", { text: "MarcHello!" });
     await leave();
     await contains(".o-mail-ChatBubble-preview", { count: 0 });
+    await contains(".o-mail-ChatBubble[name='Marc']:not(.o-active)");
     await hover(".o-mail-ChatBubble[name='Demo']");
     await contains(".o-mail-ChatBubble-preview", { text: "Demo" });
     await leave();

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -102,8 +102,9 @@ test("chat with member should be opened after clicking on channel member", async
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-discuss-ChannelMember.cursor-pointer", { text: "Demo" });
+    await click(".o-discuss-ChannelMember:has(:text('Demo')).cursor-pointer");
     await contains(".o_avatar_card .o_card_user_infos", { text: "Demo" });
+    await click(".o-discuss-ChannelMember:has(:text('Demo')).o-active");
     await click(".o_avatar_card button", { text: "Send message" });
     await contains(".o-mail-AutoresizeInput[title='Demo']");
 });


### PR DESCRIPTION
Partial revert of https://github.com/odoo/odoo/pull/235132

PR above made an improvement on Discuss UI that relies on `usePopover.isOpen` state. Popover hook was not reactive and this PR makes it reactive so that the template simply relies on `usePopover.isOpen`.

While this change makes sense conceptually, this introduces technical problems: `usePopover` has not designed with reactivity and there's are lots of code using `usePopover` already. Also popover has to integrate with external libs like fullcalendar, so the addition of reactivity layer would trigger more re-renders and actually require more effort to integrate with these libs than with lack of reactivity from the usePopover hook [1].

This commit reverts the change of `useState()` on the `usePopover()` hook, so that the behavior of `usePopover()` is unchanged from how it was designed and business code keeps choice to optionally compensate the reactivity by handling it themselves in a controlled manner.

This commit compensates the lack of reactivity of popover.isOpen in `ChannelMemberList` and `ChatBubble` templates that previously relied on `popover.isOpen`.

[1]: https://github.com/odoo/odoo/pull/234564