### PR TITLE
[IMP] tests: fix post install test execution order

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1523,8 +1523,8 @@ def preload_registries(dbnames):
                     from odoo.tests import loader  # noqa: PLC0415
                     t0 = time.time()
                     t0_sql = sql_db.sql_counter
-                    module_names = (registry.updated_modules if update_module else
-                                    sorted(registry._init_modules))
+                    module_names = sorted(registry.updated_modules if update_module else
+                                    registry._init_modules)
                     _logger.info("Starting post tests")
                     tests_before = registry._assertion_report.testsRun
                     post_install_suite = loader.make_suite(module_names, 'post_install')


### PR DESCRIPTION
For historical reasons, only updated modules are tested when a -u or -i is given. This makes the order change if we install and run test at the same time compared to running tests on a already installed database.

In this specific case, it will make iot test run before databases tests when installing, but after when only running tests, hiding the effect of iot tests on databases tests in some case but not the other.

This commit proposes to always run post install tests in a defined order, regardless of the -i or -u options.