### PR TITLE
[IMP] core: use inner join for required many2one

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1788,7 +1788,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_users"."id"
             FROM "res_users"
-            LEFT JOIN "res_partner" AS "res_users__partner_id" ON
+            JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE "res_users"."active" IS TRUE
             AND ("res_users"."id" IN %s AND "res_users"."partner_id" IN %s)
@@ -1944,7 +1944,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_users"."id"
             FROM "res_users"
-            LEFT JOIN "res_partner" AS "res_users__partner_id" ON
+            JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE "res_users__partner_id"."name" LIKE %s
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
@@ -1956,7 +1956,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_users"."id"
             FROM "res_users"
-            LEFT JOIN "res_partner" AS "res_users__partner_id" ON
+            JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE "res_users__partner_id"."name" LIKE %s
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
@@ -2623,7 +2623,7 @@ class TestMany2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_users"."id"
             FROM "res_users"
-            LEFT JOIN "res_partner" AS "res_users__partner_id" ON ("res_users"."partner_id" = "res_users__partner_id"."id")
+            JOIN "res_partner" AS "res_users__partner_id" ON ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE EXISTS (
                 SELECT 1 FROM "res_groups_users_rel" AS "res_users__group_ids"
                 WHERE "res_users__group_ids"."uid" = "res_users"."id" AND "res_users__group_ids"."gid" IN (

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -1183,7 +1183,7 @@ class TestPrivateReadGroup(common.TransactionCase):
             SELECT "test_read_group_related_inherits__base_id"."name",
                     COUNT(*)
             FROM "test_read_group_related_inherits"
-            LEFT JOIN "test_read_group_related_base" AS "test_read_group_related_inherits__base_id"
+            JOIN "test_read_group_related_base" AS "test_read_group_related_inherits__base_id"
                 ON ("test_read_group_related_inherits"."base_id" = "test_read_group_related_inherits__base_id"."id")
             GROUP BY "test_read_group_related_inherits__base_id"."name"
             ORDER BY "test_read_group_related_inherits__base_id"."name" ASC
@@ -1197,7 +1197,7 @@ class TestPrivateReadGroup(common.TransactionCase):
             SELECT "test_read_group_related_inherits__base_id"."name",
                     SUM("test_read_group_related_inherits__base_id"."value")
             FROM "test_read_group_related_inherits"
-            LEFT JOIN "test_read_group_related_base" AS "test_read_group_related_inherits__base_id"
+            JOIN "test_read_group_related_base" AS "test_read_group_related_inherits__base_id"
                 ON ("test_read_group_related_inherits"."base_id" = "test_read_group_related_inherits__base_id"."id")
             GROUP BY "test_read_group_related_inherits__base_id"."name"
             ORDER BY "test_read_group_related_inherits__base_id"."name" ASC
@@ -1211,7 +1211,7 @@ class TestPrivateReadGroup(common.TransactionCase):
             SELECT "test_read_group_related_inherits__base_id__foo_id"."name",
                     COUNT(*)
             FROM "test_read_group_related_inherits"
-            LEFT JOIN "test_read_group_related_base" AS "test_read_group_related_inherits__base_id"
+            JOIN "test_read_group_related_base" AS "test_read_group_related_inherits__base_id"
                 ON ("test_read_group_related_inherits"."base_id" = "test_read_group_related_inherits__base_id"."id")
             LEFT JOIN "test_read_group_related_foo" AS "test_read_group_related_inherits__base_id__foo_id"
                 ON ("test_read_group_related_inherits__base_id"."foo_id" = "test_read_group_related_inherits__base_id__foo_id"."id")


### PR DESCRIPTION
use INNER JOIN instead of LEFT JOIN for required many2one join to improve query performance.

taskid: 4572107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
