### PR TITLE
[FIX] mail: prevent hover overflow in call menu systray item

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -1,3 +1,8 @@
+.o-discuss-CallMenu {
+    @extend %-main-navbar-entry-base;
+    @extend %-main-navbar-entry-spacing;
+}
+
 .o-discuss-CallMenu-buttonContent {
     max-width: 150px;
     @include o-mail-call-bordered(.7);

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallMenu">
-        <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
+        <div t-if="rtc.channel" class="o-discuss-CallMenu" t-attf-class="{{ className }}" t-ref="root">
+            <button class="user-select-none bg-transparent btn p-0 m-0 border-0" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex btn-group rounded-2 opacity-75 opacity-100-hover" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
                     <div class="o-discuss-CallMenu-channelInfo text-truncate btn btn-group-item border-0 m-0 p-0 d-flex align-items-center o-gap-0_5 ps-1" role="button">
                         <span class="position-relative small bg-transparent">


### PR DESCRIPTION
Before this commit, hovering over the call menu in the systray caused the hover
background to overflow beyond the component’s bounds, resulting in a visually
broken hover effect.

This commit fixes the styling so the hover state remains properly contained
within the call menu element, preventing any overflow.

Before:
<img width="173" height="47" alt="image" src="https://github.com/user-attachments/assets/495a4dfc-9b8c-4296-a89e-653a2b431069" />
<img width="178" height="39" alt="image" src="https://github.com/user-attachments/assets/bd368de8-c861-4f52-9c26-277843710fd3" />

After:
<img width="177" height="44" alt="image" src="https://github.com/user-attachments/assets/de7535dc-0c8f-447f-b17f-36cceab1afff" />
<img width="169" height="43" alt="image" src="https://github.com/user-attachments/assets/9d219f70-fbd0-4145-a441-37a1aa9bedc5" />
