### PR TITLE
[FIX] mail, hr_holidays: correct "back on" indicator position

### DIFF
--- a/addons/hr_holidays/static/src/avatar_card_resource_popover.xml
+++ b/addons/hr_holidays/static/src/avatar_card_resource_popover.xml
@@ -7,7 +7,7 @@
             <!-- Employee is on time off and he is not connected -->
             <i t-if="employee?.hr_icon_display === 'presence_holiday_absent'" class="fa fa-fw fa-plane text-warning me-1" title="On Time Off" role="img" aria-label="On Time Off"/>
         </xpath>
-        <xpath expr="//span[hasclass('o-mail-avatar-card-name')]" position="after">
+        <xpath expr="//div[hasclass('o-mail-avatar-card-name-actions')]" position="after">
             <span t-if="outOfOfficeDateEndText" class="text-warning me-1 small fw-bold" t-esc="outOfOfficeDateEndText"/>
         </xpath>
     </t>


### PR DESCRIPTION
Before this commit, the "back on" indicator in the avatar card resource popover would show up in the same line as the name.
This issue was introduced by [1] which changed the template of the avatar card popover without adapting the ovverride in `hr_holidays`.
This commit fixes the issue by giving a `name` property to the avatar card name element and adapting the override to it.

[1] https://github.com/odoo/odoo/pull/177445


| Before  | After |
| ------------- | ------------- |
| <img width="372" height="156" alt="image" src="https://github.com/user-attachments/assets/3a67473e-b9a5-4877-9086-b8bef33dec16" />  | <img width="372" height="174" alt="image" src="https://github.com/user-attachments/assets/8b0fd954-9aed-4e58-9613-d9faf5dcea98" />  |