### PR TITLE
[IMP] l10n_in: change account type of closing stock

### DIFF
--- a/addons/l10n_in/data/template/account.account-in.csv
+++ b/addons/l10n_in/data/template/account.account-in.csv
@@ -69,7 +69,7 @@
 "p21183","Travelling Expense","21183","expense","","False","",""
 "p2121","Opening Stock","2121","expense","","False","",""
 "p2122","Purchase Stock","2122","expense","","False","",""
-"p2123","Closing Stock","2123","expense","l10n_in.account_tag_closing_stock","False","",""
+"p2123","Closing Stock","2123","expense_direct_cost","l10n_in.account_tag_closing_stock","False","",""
 "p2131","Loss on Sale of Assets","2131","expense","","False","",""
 "p2132","Write Off Expense","2132","expense","","False","",""
 "p213201","Round off Expense","213201","expense","","False","",""


### PR DESCRIPTION
This PR changes the account type of the `closing stock` chart of account from `Expenses` to `Cost of Revenue`

task-5357539

ENT PR: https://github.com/odoo/enterprise/pull/101650