### PR TITLE
[FIX] web: support space key in kanban's quick create record

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -205,10 +205,12 @@ export class KanbanRenderer extends Component {
 
         useHotkey("space", ({ target }) => this.onSpaceKeyPress(target), {
             area: () => this.rootRef.el,
+            isAvailable: () => !this.props.quickCreateState.groupId,
         });
 
         useHotkey("shift+space", ({ target }) => this.onSpaceKeyPress(target, true), {
             area: () => this.rootRef.el,
+            isAvailable: () => !this.props.quickCreateState.groupId,
         });
 
         const arrowsOptions = { area: () => this.rootRef.el, allowRepeat: true };


### PR DESCRIPTION
In kanban's quick create record, the 'Space' key is not 
working on 'Edit' and 'Trash' buttons as earlier versions.

After this commit 'Space' key will work as expected.

Task-5319051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
