### PR TITLE
[IMP] mail: temporarily pin unpinned subchannels in sidebar while viewing

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -203,15 +203,6 @@ class ChannelController(http.Controller):
         store = Store().add(attachments, "_store_attachment_fields")
         return {"store_data": store.get_result(), "count": len(attachments)}
 
-    @http.route("/discuss/channel/join", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
-    def discuss_channel_join(self, channel_id):
-        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
-        if not channel:
-            raise NotFound()
-        channel._find_or_create_member_for_self()
-        return Store().add(channel, "_store_channel_fields").get_result()
-
     @http.route("/discuss/channel/sub_channel/create", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_create(self, parent_channel_id, from_message_id=None, name=None):
         channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -14,7 +14,15 @@ const threadModelPatch = {
          * Inverse of discuss.thread, useful to efficiently check whether this thread is the one
          * currently displayed in discuss app.
          */
-        this.discussAppAsThread = fields.One("DiscussApp", { inverse: "thread" });
+        this.discussAppAsThread = fields.One("DiscussApp", {
+            inverse: "thread",
+            /** @this {import("models").Thread} */
+            onUpdate() {
+                if (!this.discussAppAsThread && this.channel?.parent_channel_id) {
+                    this.channel.isLocallyPinned = false;
+                }
+            },
+        });
     },
     /** Condition for whether the conversation should become present in chat hub on new message */
     get inChathubOnNewMessage() {

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -685,7 +685,7 @@ export class DiscussChannel extends Record {
 
     /** @returns {boolean} true if the channel was opened, false otherwise */
     openChannel() {
-        if (this.self_member_id && !this.self_member_id.is_pinned) {
+        if (this.self_member_id && !this.self_member_id.is_pinned && !this.parent_channel_id) {
             this.self_member_id.is_pinned = true;
             this.pinRpc({ pinned: true });
         }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
@@ -3,7 +3,6 @@ import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { SubChannelPreview } from "@mail/discuss/core/public_web/sub_channel_preview";
 import { useSequential, useVisible } from "@mail/utils/common/hooks";
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
-import { rpc } from "@web/core/network/rpc";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { fuzzyLookup } from "@web/core/utils/search";
 
@@ -51,9 +50,6 @@ export class SubChannelList extends Component {
      * @param {import("models").DiscussChannel} subChannel
      */
     async onClickSubChannel(subChannel) {
-        if (!subChannel.self_member_id) {
-            await rpc("/discuss/channel/join", { channel_id: subChannel.id });
-        }
         subChannel.open({ focus: true });
         this.props.close?.();
     }


### PR DESCRIPTION
Before this PR:
- Opening a subchannel from the thread list automatically joined the user
to the subchannel - if not already a member
- Unpinned subchannels were pinned to sidebar when user opened them

After this PR:
- Opening a subchannel from the thread list no longer joins the user
- Unpinned subchannels are only temporarily repinned while being viewed;
once the user navigates away, they return to their unpinned state.

task-[4207854](https://www.odoo.com/odoo/project/1519/tasks/4207854)