### PR TITLE
[FIX] html_editor: ensure `isBlock` works for nodes with `display: none`

### DIFF
--- a/addons/html_editor/static/src/utils/blocks.js
+++ b/addons/html_editor/static/src/utils/blocks.js
@@ -75,7 +75,9 @@ export function isBlock(node) {
         style = node.ownerDocument.defaultView.getComputedStyle(node);
         computedStyles.set(node, style);
     }
-    if (style.display) {
+    // In case the node has display `none` we don't know what is its display
+    // so we check its tagName in `blockTagNames`
+    if (style.display && style.display !== "none") {
         return !style.display.includes("inline") && style.display !== "contents";
     }
     return blockTagNames.includes(tagName);

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -9,6 +9,7 @@ import {
 } from "@html_editor/utils/dom_info";
 import { describe, expect, test } from "@odoo/hoot";
 import { insertTestHtml } from "../_helpers/editor";
+import { isBlock } from "../../src/utils/blocks";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
@@ -431,6 +432,19 @@ describe("isShrunkBlock", () => {
     test("should not consider a HR as a shrunk block", () => {
         const [hr] = insertTestHtml("<hr>");
         const result = isShrunkBlock(hr);
+        expect(result).toBe(false);
+    });
+});
+
+describe("isBlock on display none elements", () => {
+    test("t element should not be block", () => {
+        const [t] = insertTestHtml(`<t style="display: none"></t>`);
+        const result = isBlock(t);
+        expect(result).toBe(false);
+    });
+    test("span element should not be block", () => {
+        const [span] = insertTestHtml(`<span style="display: none"></span>`);
+        const result = isBlock(span);
         expect(result).toBe(false);
     });
 });


### PR DESCRIPTION
Problem:
When nodes have `display: none` (for example a QWeb `t-else` node
with a false condition), `isBlock` incorrectly fails when checking
them.

Solution:
If a node has `display: none`, fall back to checking its `tagName`
against `blockTagNames`. This ensures consistent behavior regardless
of the node visibility.

Steps to reproduce:
- Open “Appointment: Attendee Invitation”.
- Add a list item to the list in the content.
- Save.
- A QWeb parsing error occurs.

opw-5268806

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
