### PR TITLE
[FIX] point_of_sale: allow product archive if unrelated to point_of_sale

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -311,7 +311,7 @@ class ProductTemplate(models.Model):
         self._check_is_special_product()
 
     def _ensure_unused_in_pos(self):
-        open_pos_sessions = self.env['pos.session'].search([('state', '!=', 'closed')])
+        open_pos_sessions = self.env['pos.session'].sudo().search([('state', '!=', 'closed')])
         used_products = open_pos_sessions.order_ids.filtered(lambda o: o.state == "draft").lines.product_id.product_tmpl_id
         if used_products & self:
             raise UserError(_(
@@ -320,7 +320,7 @@ class ProductTemplate(models.Model):
             ))
 
     def _check_is_special_product(self):
-        special_products = self.env['pos.config']._get_special_products().product_tmpl_id
+        special_products = self.env['pos.config'].sudo()._get_special_products().product_tmpl_id
         for product in self:
             if product in special_products:
                 raise UserError(_("You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."))


### PR DESCRIPTION
### Steps to reproduce:

- With Admin open a pos session
- With an other user without pos access rights archive a product unrelated to pos (e.g. not used in the session)
#### > Access error: You are not allowed to access 'Point of Sale Session' (pos.session) records. This operation is allowed for the following groups: - Point of Sale/User

### Cause of the issue:

Since 985fd5821fe1e8633503d713f1f1c3650bcf0c91 the `action_archive` of products, check that the product is not used by an order of any opened `pos.session` before allowing the user to archive it: https://github.com/odoo/odoo/blob/2011885246f5473ddc16fe5bd17db98ebff712f3/addons/point_of_sale/models/product_product.py#L51-L53 https://github.com/odoo/odoo/blob/2011885246f5473ddc16fe5bd17db98ebff712f3/addons/point_of_sale/models/product_template.py#L313-L320 However, if the user does not have any pos access rights he can not access the pos session to check if the product is used which raises an access error even if the product is un-used.

### Note:

This is notably problematic as it makes it impossible to archive products via the `action_archive` in unrelated stock tests relying on a non-admin user.

opw-stock-tests

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
