### PR TITLE
[FIX] barcodes: barcode reading in Firefox

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { isBrowserChrome, isMobileOS } from "@web/core/browser/feature_detection";
+import { isBrowserChrome, isBrowserFirefox, isMobileOS } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 
@@ -73,6 +73,9 @@ export const barcodeService = {
                 // E.g. when using browser built-in autocomplete on an input.
                 // See https://stackoverflow.com/questions/59534586/google-chrome-fires-keydown-event-when-form-autocomplete
                 return;
+            }
+            if (ev.key === "/" && isBrowserFirefox()) {
+                ev.preventDefault();
             }
             // Ignore 'Shift', 'Escape', 'Backspace', 'Insert', 'Delete', 'Home', 'End', Arrow*, F*, Page*, ...
             // meta is often used for UX purpose (like shortcuts)


### PR DESCRIPTION
In firefox when a '/' keyDown event is trigger is search toolbar of Firefox opens. So we lose the focus and all the folowing chars are lost.

This commit prevents Firefox to open it's search toolbar.

Steps to reproduce:
* Open Odoo in Firefox (Desktop)
* Install barcode app if not already done
* Scan a barcode with a '/' inside => Bug the Firefox search toolbar apears

opw-5380474

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
