### PR TITLE
[FIX] point_of_sale: cust. display compat. stable IoT Box

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -19,11 +19,15 @@ export const CustomerDisplayDataService = {
                                 Accept: "application/json",
                                 "Content-Type": "application/json",
                             },
-                            body: JSON.stringify({ params: {} }),
+                            body: JSON.stringify({
+                                params: {
+                                    action: "get",
+                                },
+                            }),
                         }
                     );
                     const payload = await response.json();
-                    Object.assign(data, payload.result);
+                    Object.assign(data, payload.result?.data || payload.result);
                 } catch (error) {
                     notification.add(
                         _t(


### PR DESCRIPTION
In `saas-18.4` and `19.0` the customer display data service was simplified as we refactored to control IoT displays with actions instead of controllers.

However, to ensure compatibility with v19.1 IoT Boxes, we need to add a request parameter back and to accept both responses: `result: { data: { ... } }` and `result: { ... }`.
