### PR TITLE
[FIX] html_builder: fix BuilderListDialog style

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list_dialog.xml
@@ -3,10 +3,10 @@
 
     <t t-name="html_builder.BuilderListDialog">
         <Dialog contentClass="'o_bl_dialog'" title.translate="Manage Records" size="'lg'">
-            <input type="search" class="form-control" placeholder="Search" t-on-input="onSearch" />
-            <div class="row w-100">
-                <div class="o_left_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap">
-                    <div class="d-flex justify-content-between align-items-center mt-3">
+            <input type="search" class="form-control mb-3" placeholder="Search" t-on-input="onSearch" />
+            <div class="w-100 d-flex flex-row gap-3 ">
+                <div class="o_left_panel w-100 h-100 d-flex flex-column flex-nowrap">
+                    <div class="d-flex justify-content-between align-items-center">
                         <h4 class="m-0">Excluded records</h4>
                         <button class="btn btn-sm btn-link p-0" t-on-click="includeAll">
                             <i class="fa fa-plus me-1" />Include all</button>
@@ -24,8 +24,8 @@
                         </t>
                     </div>
                 </div>
-                <div class="o_right_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap mt-3 mt-md-0">
-                    <div class="d-flex justify-content-between align-items-center mt-3">
+                <div class="o_right_panel w-100 h-100 d-flex flex-column flex-nowrap">
+                    <div class="d-flex justify-content-between align-items-center">
                         <h4 class="m-0">Included records</h4>
                         <button class="btn btn-sm btn-link p-0" t-on-click="excludeAll">
                             <i class="fa fa-minus me-1" />Exclude all</button>


### PR DESCRIPTION
__Behavior before commit:__
The two record lists are not centered in the dialog.

__Fix:__
Remove `row` class which add negative margins and adapt the rest.

__Before:__
<img width="621" height="612" alt="image" src="https://github.com/user-attachments/assets/ebe5b090-5b7e-4421-9450-497d7c17a641" />

__After:__
<img width="615" height="604" alt="image" src="https://github.com/user-attachments/assets/4f6599ad-6979-4592-8ad5-b92a451e7cc2" />
