### PR TITLE
[REF] mail: convert test on thread.model

### DIFF
--- a/addons/hr_holidays/static/src/thread_patch.xml
+++ b/addons/hr_holidays/static/src/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.partner_id?.outOfOfficeDateEndText" class="alert alert-primary mb-0 smaller fw-bolder rounded-0 py-1 shadow-sm" t-esc="props.thread.correspondent.partner_id.outOfOfficeDateEndText" role="alert"/>
+            <div t-if="props.thread.channel and props.thread.correspondent?.partner_id?.outOfOfficeDateEndText" class="alert alert-primary mb-0 smaller fw-bolder rounded-0 py-1 shadow-sm" t-esc="props.thread.correspondent.partner_id.outOfOfficeDateEndText" role="alert"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -821,7 +821,7 @@ export class Composer extends Component {
         const postThread = toRaw(this.thread);
         const post = postThread.post.bind(postThread, value, postData, extraData);
         let message;
-        if (postThread.model === "discuss.channel") {
+        if (postThread.channel) {
             // feature of (optimistic) temp message
             post();
         } else {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -149,7 +149,7 @@
         t-att-disabled="isSendButtonDisabled"
         t-att-aria-label="SEND_TEXT"
     >
-        <t t-if="thread and thread.model !== 'discuss.channel'" t-out="SEND_TEXT"/>
+        <t t-if="thread and !thread.channel" t-out="SEND_TEXT"/>
         <t t-else=""><i class="fa fa-fw fa-lg fa-paper-plane-o"/></t>
     </button>
 </t>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -72,7 +72,7 @@ registerComposerAction("send-message", {
     name: ({ composer, owner }) =>
         composer.message
             ? _t("Save editing")
-            : composer.targetThread?.model === "discuss.channel"
+            : composer.targetThread?.channel
             ? _t("Send")
             : owner.props.type === "note"
             ? _t("Log")

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -48,7 +48,7 @@
                                 <t t-else="" t-out="message.dateSimpleWithDay"/>
                             </small>
                             <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
-                                <t t-if="message.thread.model !== 'discuss.channel'">
+                                <t t-if="!message.thread.channel">
                                     on <a t-if="message.thread.displayName" t-att-href="message.resUrl" t-esc="message.thread.displayName"/><em class="pe-1 text-decoration-line-through" t-else="">Deleted document</em>
                                 </t>
                                 <t t-else="">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -83,7 +83,7 @@ registerMessageAction("reply-to", {
         if (["discuss.channel", "mail.box"].includes(thread.model)) {
             composer.replyToMessage = message;
         }
-        if (thread.model === "discuss.channel") {
+        if (thread.channel) {
             return;
         }
         if (!message.isSelfAuthored && message.model !== "discuss.channel") {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -287,7 +287,7 @@ export class Message extends Record {
     }
 
     get isHighlightedFromMention() {
-        return this.isSelfMentioned && this.thread?.model === "discuss.channel";
+        return this.isSelfMentioned && Boolean(this.thread?.channel);
     }
 
     isSelfAuthored = fields.Attr(false, {
@@ -303,7 +303,7 @@ export class Message extends Record {
     }
 
     get isNotification() {
-        return this.message_type === "notification" && this.thread?.model === "discuss.channel";
+        return this.message_type === "notification" && this.thread?.channel;
     }
 
     get isSubjectSimilarToThreadName() {

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -56,7 +56,7 @@ export class OutOfFocusService {
             .substring(0, PREVIEW_MSG_MAX_SIZE);
         await this.sendNotification({
             message: notificationContent,
-            sound: message.thread?.model === "discuss.channel",
+            sound: Boolean(message.channel_id),
             title: notificationTitle,
             type: "info",
             icon,

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -543,7 +543,7 @@ export class Store extends BaseStore {
         if (role_ids.length) {
             Object.assign(postData, { role_ids });
         }
-        if (thread.model === "discuss.channel" && validMentions?.specialMentions.length) {
+        if (thread.channel && validMentions?.specialMentions.length) {
             postData.special_mentions = validMentions.specialMentions;
         }
         if (attachments.length) {

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -89,14 +89,12 @@ export class SuggestionService {
      */
     async fetchPartnersRoles(term, thread, { abortSignal } = {}) {
         const kwargs = { search: term };
-        if (thread?.model === "discuss.channel") {
+        if (thread?.channel) {
             kwargs.channel_id = thread.id;
         }
         const data = await this.makeOrmCall(
             "res.partner",
-            thread?.model === "discuss.channel"
-                ? "get_mention_suggestions_from_channel"
-                : "get_mention_suggestions",
+            thread?.channel ? "get_mention_suggestions_from_channel" : "get_mention_suggestions",
             [],
             kwargs,
             { abortSignal }

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -303,7 +303,7 @@ export class Thread extends Record {
     }
 
     get hasAttachmentPanel() {
-        return this.model === "discuss.channel";
+        return Boolean(this.channel);
     }
 
     get supportsCustomChannelName() {
@@ -556,7 +556,7 @@ export class Thread extends Record {
     }
 
     getFetchParams() {
-        if (this.model === "discuss.channel") {
+        if (this.channel) {
             return { channel_id: this.id };
         }
         if (this.model === "mail.box") {
@@ -570,7 +570,7 @@ export class Thread extends Record {
     }
 
     getFetchRoute() {
-        if (this.model === "discuss.channel") {
+        if (this.channel) {
             return "/discuss/channel/messages";
         }
         if (this.model === "mail.box" && this.id === "inbox") {

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -57,7 +57,7 @@ patch(Thread.prototype, {
         if (this.eq(this.store.discuss.thread)) {
             router.replaceState({ active_id: undefined });
         }
-        if (this.model === "discuss.channel" && this.self_member_id?.is_pinned !== false) {
+        if (this.channel && this.self_member_id?.is_pinned !== false) {
             await this.store.env.services.orm.silent.call(
                 "discuss.channel",
                 "channel_pin",

--- a/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
@@ -5,7 +5,7 @@ import { patch } from "@web/core/utils/patch";
 /** @type {import("models").Attachment} */
 const attachmentPatch = {
     get isDeletable() {
-        if (this.message && this.thread?.model === "discuss.channel") {
+        if (this.message && this.thread?.channel) {
             return this.message.editable;
         }
         return super.isDeletable;

--- a/addons/mail/static/src/discuss/core/common/partner_compare.js
+++ b/addons/mail/static/src/discuss/core/common/partner_compare.js
@@ -27,7 +27,7 @@ partnerCompareRegistry.add(
 partnerCompareRegistry.add(
     "discuss.members",
     (p1, p2, { thread, context: { memberPartnerIds } }) => {
-        if (thread?.model === "discuss.channel") {
+        if (thread?.channel) {
             const isMember1 = memberPartnerIds.has(p1.id);
             const isMember2 = memberPartnerIds.has(p2.id);
             if (isMember1 && !isMember2) {

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -10,13 +10,13 @@ const commandRegistry = registry.category("discuss.channel_commands");
 const suggestionServicePatch = {
     getSupportedDelimiters(thread, env) {
         const res = super.getSupportedDelimiters(...arguments);
-        return thread?.model === "discuss.channel" ? [...res, ["/", 0]] : res;
+        return thread?.channel ? [...res, ["/", 0]] : res;
     },
     /**
      * @override
      */
     isSuggestionValid(partner, thread) {
-        if (thread?.model === "discuss.channel" && partner.eq(this.store.odoobot)) {
+        if (thread?.channel && partner.eq(this.store.odoobot)) {
             return true;
         }
         return super.isSuggestionValid(...arguments);

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -90,7 +90,7 @@ const threadPatch = {
     /** @override */
     async checkReadAccess() {
         const res = await super.checkReadAccess();
-        if (!res && this.model === "discuss.channel") {
+        if (!res && this.channel) {
             // channel is assumed to be readable if its channel_type is known
             return this.channel.channel_type;
         }
@@ -139,7 +139,7 @@ const threadPatch = {
             }
             return formatList(nameParts);
         }
-        if (this.model === "discuss.channel" && this.name) {
+        if (this.channel && this.name) {
             return this.name;
         }
         return super.displayName;
@@ -246,7 +246,7 @@ const threadPatch = {
     },
     /** @override */
     open(options) {
-        if (this.model === "discuss.channel") {
+        if (this.channel) {
             const res = this.channel.openChannel();
             if (res) {
                 return res;
@@ -259,7 +259,7 @@ const threadPatch = {
     /** @param {string} body */
     async post(body) {
         const textContent = createElementWithContent("div", body).textContent.trim();
-        if (this.model === "discuss.channel" && textContent.startsWith("/")) {
+        if (this.channel && textContent.startsWith("/")) {
             const [firstWord] = textContent.substring(1).split(/\s/);
             const command = commandRegistry.get(firstWord, false);
             if (

--- a/addons/mail/static/src/discuss/core/public_web/messaging_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/messaging_menu_patch.js
@@ -6,7 +6,7 @@ patch(MessagingMenu.prototype, {
     /** @override */
     markAsRead(thread) {
         super.markAsRead(...arguments);
-        if (thread.model === "discuss.channel") {
+        if (thread.channel) {
             thread.markAsRead();
         }
     },

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -36,7 +36,7 @@ export class DiscussCoreWeb {
             }
         });
         this.env.bus.addEventListener("mail.message/delete", ({ detail: { message } }) => {
-            if (message.thread?.model === "discuss.channel") {
+            if (message.channel_id) {
                 // initChannelsUnreadCounter becomes unreliable
                 this.store.channels.fetch();
             }

--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -48,7 +48,7 @@ const StorePatch = {
     },
     onLinkFollowed(fromThread) {
         super.onLinkFollowed(...arguments);
-        if (!this.env.isSmall && fromThread?.model === "discuss.channel") {
+        if (!this.env.isSmall && fromThread?.channel) {
             fromThread.open({ focus: false });
         }
     },

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -35,7 +35,7 @@ patch(Composer.prototype, {
      * @param {boolean} [is_typing=true]
      */
     notifyIsTyping(is_typing = true) {
-        if (this.thread?.model === "discuss.channel" && this.thread.id > 0) {
+        if (this.thread?.channel && this.thread.id > 0) {
             rpc(
                 "/discuss/channel/notify_typing",
                 {
@@ -53,7 +53,7 @@ patch(Composer.prototype, {
     },
     detectTyping() {
         const value = this.props.composer.composerText;
-        if (this.thread?.model === "discuss.channel" && value.startsWith("/")) {
+        if (this.thread?.channel && value.startsWith("/")) {
             const [firstWord] = value.substring(1).split(/\s/);
             const command = commandRegistry.get(firstWord, false);
             if (

--- a/addons/mail/static/src/discuss/voice_message/common/composer_actions_patch.js
+++ b/addons/mail/static/src/discuss/voice_message/common/composer_actions_patch.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 
 registerComposerAction("voice-start", {
     condition: ({ composer, owner }) =>
-        composer.targetThread?.model === "discuss.channel" &&
+        composer.targetThread?.channel &&
         owner.voiceRecorder &&
         !owner.voiceRecorder?.recording &&
         !composer.voiceAttachment,
@@ -15,7 +15,7 @@ registerComposerAction("voice-start", {
 });
 registerComposerAction("voice-stop", {
     condition: ({ composer, owner }) =>
-        composer.targetThread?.model === "discuss.channel" && owner.voiceRecorder?.recording,
+        composer.targetThread?.channel && owner.voiceRecorder?.recording,
     icon: "fa fa-circle text-danger o-mail-VoiceRecorder-dot",
     name: _t("Stop Recording"),
     onSelected: ({ owner }) => owner.voiceRecorder.onClick(),
@@ -38,6 +38,6 @@ registerComposerAction("voice-recording", {
     },
     componentProps: ({ composer, owner }) => ({ composer, state: owner.voiceRecorder }),
     condition: ({ composer, owner }) =>
-        composer.targetThread?.model === "discuss.channel" && owner.voiceRecorder?.recording,
+        composer.targetThread?.channel && owner.voiceRecorder?.recording,
     sequenceQuick: 10,
 });


### PR DESCRIPTION
This commit replaces the pattern `thread.model === "discuss.channel"` by simply test `thread.channel`.
