### PR TITLE
[PERF] website_sale: Batch has_published field on category

### DIFF
--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -291,13 +291,13 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 52  # To increase this number you must ask the permission to al
+        query_count = 51  # To increase this number you must ask the permission to al
         queries = {
             'orm_signaling_registry': 1,
             'website': 2,
             'res_company': 2,
             'product_pricelist': 4,
-            'product_template': 6,
+            'product_template': 5,
             'product_tag': 1,
             'product_public_category': 6,
             'product_product': 1,

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -109,10 +109,15 @@ class ProductPublicCategory(models.Model):
 
     @api.depends('product_tmpl_ids.is_published', 'child_id.has_published_products')
     def _compute_has_published_products(self):
+        grouped_product_templates = self.env['product.template']._read_group(
+            domain=[('public_categ_ids', 'in', self.ids), ('is_published', '=', True)],
+            groupby=['public_categ_ids']
+        )
+        published_category_ids = {group[0].id for group in grouped_product_templates}
         for category in self:
+            has_published = category.id in published_category_ids
             category.has_published_products = (
-                any(p.is_published for p in category.product_tmpl_ids)
-                or any(c.has_published_products for c in category.child_id)
+                has_published or any(c.has_published_products for c in category.child_id)
             )
 
     # === CONSTRAINT METHODS === #


### PR DESCRIPTION
Previously the function was fetching all the product template ids and looping over them for each product template. This triggered the prefetch_ids and prefetch fields for these products which would cause memory issues due to the bloat of the cache from the prefetcher.

The current way is a read_group over the categories and check if category id exists or not.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
