### PR TITLE
[FIX] mail: downgrade to 19.0 with chat hub data should not crash

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -21,7 +21,7 @@ export class ChatHub extends Record {
         const chatHub = super.new(...arguments);
         browser.addEventListener("storage", (ev) => {
             if (ev.key === CHAT_HUB_KEY) {
-                chatHub.load(ev.newValue);
+                chatHub.load(ev.newValue || undefined);
             } else if (ev.key === null) {
                 chatHub.load();
             }
@@ -95,6 +95,14 @@ export class ChatHub extends Record {
     async _load(str) {
         /** @type {{ opened: Object[], folded: Object[] }} */
         const { opened = [], folded = [] } = JSON.parse(str);
+        const hasInvalidData =
+            opened.some((data) => !data.id || !data.model) ||
+            folded.some((data) => !data.id || !data.model);
+        if (hasInvalidData) {
+            opened.length = 0;
+            folded.length = 0;
+            browser.localStorage.removeItem(CHAT_HUB_KEY);
+        }
         const getThread = (data) => this.store.Thread.getOrFetch(data, ["display_name"]);
         const openPromises = opened.map(getThread);
         const foldPromises = folded.map(getThread);


### PR DESCRIPTION
Before this commit, when downgrading from 19.1 to 19.0 with chat hub data from 19.1, i.e. chat windows or bubbles that are open, loading web client would crash with following error:

```
KeyError: 'thread_model'
```

This happens because of mismatch of format of chat hub data in 19.0 and 19.1:

- 19.0 identifies channels with model "discuss.channel" and id
- 19.1 identifies channels with just id

When downgrading from 19.1 to 19.0, it attempts to getOrFetch a thread to server by providing channel id but without passing a model. The getOrFetch of 19.0 looks at thread level, so it cannot guess providing just id means a channel, therefore it crashes due to missing model to provide.

This commit fixes the issue by dropping the chathub local storage data if the format of chathub data in local storage is invalid, i.e. the identifying data of opened / closed should necessarily have id and model. If no model is provided like with downgrade from 19.1 to 19.0, then it drops local storage and assumes no chat window or bubbles is open.

Task-5223650