### PR TITLE
[FIX] html_builder, website: close popup when emptied

### DIFF
--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -94,8 +94,16 @@ export class RemovePlugin extends Plugin {
             childrenEls.length === 1 &&
             childrenEls[0].matches("figcaption");
 
+        // Consider a .s_popup element as empty if it only contains the
+        // .s_popup_close element.
+        const popupModalChildrenEls = [...(el.querySelector(".modal-content")?.children ?? [])];
+        const isEmptyPopup =
+            el.matches(".s_popup") &&
+            popupModalChildrenEls.every((child) => child.matches(".s_popup_close"));
+
         const isEmpty =
             isEmptyFigureEl ||
+            isEmptyPopup ||
             (el.textContent.trim() === "" &&
                 childrenEls.every((el) =>
                     // Consider layout-only elements (like bg-shapes) as empty

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { advanceTime, queryOne, waitFor } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     addPlugin,
@@ -8,7 +8,7 @@ import {
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
 import { Plugin } from "@html_editor/plugin";
-import { insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
+import { insertText, redo, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 
 defineWebsiteModels();
@@ -159,5 +159,58 @@ describe("Popup options: popup in page before edit", () => {
             undo(builder.getEditor())
         );
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
+    });
+
+    test("emptied s_popup are removed and the options are updated correctly", async () => {
+        const editor = builder.getEditor();
+        await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () =>
+            contains(".o_we_invisible_entry .fa-eye-slash").click()
+        );
+        // Sometimes bootstrap.js takes a bit of time to display the popup
+        await waitFor(":iframe .s_popup .modal", { timeout: 1000, visible: true });
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        expect(":iframe .s_popup .modal").toBeVisible();
+
+        await contains(":iframe section p:contains('Popup content')").click();
+        await contains("div[data-container-title='Block'] button.fa-trash").click();
+        expect(":iframe .s_popup").toHaveCount(0);
+        expect("div[data-container-title='Block']").toHaveCount(0);
+
+        expect(editor.shared.history.canUndo()).toBe(true);
+        undo(editor);
+        await animationFrame();
+        expect(":iframe .s_popup").toHaveCount(1);
+        expect("div[data-container-title='Block']").toHaveCount(1);
+
+        expect(editor.shared.history.canRedo()).toBe(true);
+        redo(editor);
+        await animationFrame();
+        expect(":iframe .s_popup").toHaveCount(0);
+        expect("div[data-container-title='Block']").toHaveCount(0);
+
+        // Undo -> Hide popup -> Redo -> Undo -> Popup expected to be visible
+
+        expect(editor.shared.history.canUndo()).toBe(true);
+        undo(editor);
+        await animationFrame();
+        expect(":iframe .s_popup").toHaveCount(1);
+        expect("div[data-container-title='Block']").toHaveCount(1);
+
+        contains(".o_we_invisible_entry .fa-eye").click();
+        await animationFrame();
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
+
+        expect(editor.shared.history.canRedo()).toBe(true);
+        redo(editor);
+        await animationFrame();
+        expect(":iframe .s_popup").toHaveCount(0);
+        expect("div[data-container-title='Block']").toHaveCount(0);
+
+        expect(editor.shared.history.canUndo()).toBe(true);
+        undo(editor);
+        await animationFrame();
+        expect(":iframe .s_popup").toHaveCount(1);
+        expect("div[data-container-title='Block']").toHaveCount(1);
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
     });
 });


### PR DESCRIPTION
**Descripion of the problems**
When the content of a popup is deleted, two problems happen:
1. The popup stays open displaying an empty white rectangle.
2. Options relative to the last removed element are still displayed and produce an error if the user interacts with them.

**How to reproduce**
Drop the snippet `s_popup`, and remove the "Block" element.
Problems: 1. the popup is still open but empty, 2. the "Block" options are still displayed.

**Origin of the problems**
Problem 1 happens simply because nothing takes care of removing empty popups.
Problem 2 happens because `RemovePlugin.removeCurrentTarget` set the `nextTargetEl` without first checking if the element is activable or not. Thus, when removing the last block in a popup, the next target is set to the `.o_we_no_overlay` close button, despite it being not activable. As a result, when `BuilderOptionsPlugin.updateContainers` is called, it does not update containers because the target is not activable. Thus, the "Block" options are still displayed despite the element being removed.

**Fix**
Both problems are fixed by changing `RemovePlugin.isEmptyAndRemovable` such that empty popups are marked as removable.

task-5401692
