### PR TITLE
[FIX] hw_drivers: keep old branch name when update fails

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -165,6 +165,9 @@ def check_git_branch():
                             ['/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh'], check=True
                         )
                 except subprocess.CalledProcessError:
+                    # reset local branch name if update failed, to allow new attempt on next restart
+                    with writable():
+                        subprocess.run(git + ['branch', '-m', local_branch], check=False)
                     _logger.exception("Failed to update the code with git.")
                 finally:
                     odoo_restart()


### PR DESCRIPTION
We used to renamed the Odoo branch name before running the update script in order to get the target branch name easily inside it.

Issue is if for any reason the update fails, when the IoT Box will restart, the branch name will be the target one, so it will assume it's up to date.

Task: 5407662
