### PR TITLE
[IMP] website: s_countdown_snippet

### DIFF
--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -46,7 +46,7 @@ declare module "plugins" {
     import { powerbox_blacklist_selectors, powerbox_categories, powerbox_items, PowerboxShared } from "@html_editor/main/powerbox/powerbox_plugin";
     import { deselect_custom_selected_nodes_processors, TableShared } from "@html_editor/main/table/table_plugin";
     import { shift_tab_overrides, tab_overrides, TabulationShared } from "@html_editor/main/tabulation_plugin";
-    import { can_display_toolbar_predicates, toolbar_groups, toolbar_items, toolbar_namespaces, ToolbarShared } from "@html_editor/main/toolbar/toolbar_plugin";
+    import { can_display_toolbar_predicates, toolbar_groups, toolbar_items, toolbar_namespaces, toolbar_namespace_extra_group_providers, ToolbarShared } from "@html_editor/main/toolbar/toolbar_plugin";
 
     import { CollaborationOdooShared } from "@html_editor/others/collaboration/collaboration_odoo_plugin";
     import { CollaborationShared, on_external_history_step_added_handlers } from "@html_editor/others/collaboration/collaboration_plugin";
@@ -266,6 +266,7 @@ declare module "plugins" {
         system_style_properties: system_style_properties;
         toolbar_groups: toolbar_groups;
         toolbar_items: toolbar_items;
+        toolbar_namespace_extra_group_providers: toolbar_namespace_extra_group_providers;
         toolbar_namespaces: toolbar_namespaces;
         user_commands: user_commands;
     }

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -107,6 +107,14 @@ export const DISABLED_NAMESPACE = "disabled";
  *
  * @typedef {ToolbarGroup[]} toolbar_groups
  * @typedef {ToolbarNamespace[]} toolbar_namespaces
+ *
+ *
+ * @example
+ * toolbar_namespace_extra_group_providers: {
+ *     myNamespace: ["font", "decoration"],
+ * }
+ *
+ * @typedef {{ [namespace: string]: string[] }} toolbar_namespace_extra_group_providers
  */
 
 /**
@@ -310,6 +318,19 @@ export class ToolbarPlugin extends Plugin {
         const buttons = this.getButtons();
         /** @type {ToolbarGroup[]} */
         const groups = this.getResource("toolbar_groups");
+        const extraGroupsPerNamespace = this.getResource("toolbar_namespace_extra_group_providers");
+
+        // Invert { namespace: [groupIds] } → { groupId: [namespaces] }
+        // for efficient lookup when assigning extra namespaces to buttons
+        const extraNamespacesPerGroup = {};
+        for (const mapping of extraGroupsPerNamespace) {
+            for (const [namespace, groupIds] of Object.entries(mapping)) {
+                for (const groupId of groupIds) {
+                    extraNamespacesPerGroup[groupId] ??= [];
+                    extraNamespacesPerGroup[groupId].push(namespace);
+                }
+            }
+        }
 
         return groups.map((group) => ({
             ...omit(group, "namespaces"),
@@ -317,7 +338,10 @@ export class ToolbarPlugin extends Plugin {
                 .filter((button) => button.groupId === group.id)
                 .map((button) => ({
                     ...button,
-                    namespaces: button.namespaces || group.namespaces || ["expanded"],
+                    namespaces: [
+                        ...(button.namespaces || group.namespaces || ["expanded"]),
+                        ...(extraNamespacesPerGroup[group.id] || []),
+                    ],
                 })),
         }));
     }

--- a/addons/html_editor/static/src/scss/bootstrap_overridden.scss
+++ b/addons/html_editor/static/src/scss/bootstrap_overridden.scss
@@ -94,6 +94,6 @@ $o-color-system-initialized: true;
 // "small" font size. Grep: SMALLER_FONT_SIZE_RATIO.
 $small-font-size: if(
     variable-exists('font-size-base'),
-    ($o-small-font-size / $font-size-base) * 1em,
+    ($o-small-font-size / $font-size-base) * 1rem,
     null
 ) !default;

--- a/addons/website/static/src/builder/plugins/options/countdown_option.edit.scss
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.edit.scss
@@ -1,7 +1,7 @@
 // s_countdown preview classes
 .o_savable .s_countdown {
     &.s_countdown_enable_preview {
-        &.hide-countdown .s_countdown_canvas_wrapper, &.hide-countdown .s_countdown_inline_wrapper {
+        &.hide-countdown .s_countdown_wrapper {
             display: none !important;
         }
 

--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -7,13 +7,13 @@
     </BuilderRow>
     <BuilderRow label.translate="At The End">
         <BuilderSelect preview="false" action="'setEndAction'">
-            <BuilderSelectItem actionValue="'nothing'" id="'no_end_action_opt'">Nothing</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'nothing'">Nothing</BuilderSelectItem>
             <BuilderSelectItem actionValue="'redirect'" id="'redirect_end_action_opt'">Redirect</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'message_no_countdown'">Message only</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'message'">Message + Timer</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'message_no_countdown'" id="'message_no_countdown_opt'">Message only</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'message'" id="'message_opt'">Message + Timer</BuilderSelectItem>
         </BuilderSelect>
         <BuilderButton title.translate="The message will be visible once the countdown ends"
-                       t-if="!this.isActiveItem('no_end_action_opt') and !this.isActiveItem('redirect_end_action_opt')"
+                       t-if="this.isActiveItem('message_no_countdown_opt') or this.isActiveItem('message_opt')"
                        action="'previewEndMessage'"
                        preview="false"
                        icon="'fa-eye'"/>
@@ -21,13 +21,6 @@
     <BuilderRow t-if="this.isActiveItem('redirect_end_action_opt')"
                 label.translate="URL">
             <BuilderUrlPicker placeholder.translate="e.g. /my-awesome-page" dataAttributeAction="'redirectUrl'"/>
-    </BuilderRow>
-    <BuilderRow t-if="!this.isActiveItem('text_layout_opt')" label.translate="Size">
-        <BuilderSelect dataAttributeAction="'size'">
-            <BuilderSelectItem dataAttributeActionValue="'80'">Small</BuilderSelectItem>
-            <BuilderSelectItem dataAttributeActionValue="'120'">Medium</BuilderSelectItem>
-            <BuilderSelectItem dataAttributeActionValue="'175'">Large</BuilderSelectItem>
-        </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Display">
         <BuilderSelect dataAttributeAction="'display'">
@@ -37,27 +30,81 @@
         </BuilderSelect>
     </BuilderRow>
 
-    <BuilderRow t-if="!this.isActiveItem('text_layout_opt')" label.translate="Text Color">
-        <BuilderColorPicker dataAttributeAction="'textColor'" enabledTabs="['solid', 'custom']"/>
+    <BuilderRow label.translate="Text Color">
+        <BuilderColorPicker styleAction="'color'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Layout">
-        <BuilderSelect action="'setLayout'">
-            <BuilderSelectItem actionValue="'circle'" id="'circle_layout_opt'">Circle</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'boxes'" id="'boxes_layout_opt'">Boxes</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'clean'">Clean</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'text'" id="'text_layout_opt'">Text Inline</BuilderSelectItem>
+    <BuilderRow label.translate="Layout" action="'selectCountdownTemplate'" applyTo="'.s_countdown_wrapper'">
+        <BuilderSelect>
+            <BuilderSelectItem id="'template_circle_opt'"
+                title.translate="Circle"
+                actionParam="{
+                    view: 'website.s_countdown_circle_template',
+                    templateClass: 'o_template_circle',
+                }">
+                Circle
+            </BuilderSelectItem>
+            <BuilderSelectItem
+                title.translate="Text Inline"
+                actionParam="{
+                    view: 'website.s_countdown_text_inline_template',
+                    templateClass: 'o_template_text_inline',
+                }">
+                Text Inline
+            </BuilderSelectItem>
+            <BuilderSelectItem
+                id="'template_dominoes_opt'"
+                title.translate="Dominoes"
+                actionParam="{
+                    view: 'website.s_countdown_dominoes_template',
+                    templateClass: 'o_template_dominoes',
+                }">
+                Dominoes
+            </BuilderSelectItem>
+            <BuilderSelectItem
+                id="'template_wrapped_numbers_opt'"
+                title.translate="Wrapped Numbers"
+                actionParam="{
+                    view: 'website.s_countdown_wrapped_numbers_template',
+                    templateClass: 'o_template_wrapped_numbers',
+                }">
+                Wrapped Numbers
+            </BuilderSelectItem>
+            <BuilderSelectItem
+                title.translate="Text"
+                actionParam="{
+                    view: 'website.s_countdown_text_template',
+                    templateClass: 'o_template_text',
+                }">
+                Text
+            </BuilderSelectItem>
+            <BuilderSelectItem
+                id="'template_big_numbers_opt'"
+                title.translate="Big Numbers"
+                actionParam="{
+                    view: 'website.s_countdown_big_numbers_template',
+                    templateClass: 'o_template_big_numbers',
+                }">
+                Big Numbers
+            </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
-    <t t-if="this.isActiveItem('circle_layout_opt') or this.isActiveItem('boxes_layout_opt')">
-        <BuilderRow label.translate="Layout Background" level="2">
+    <t t-if="this.isActiveItem('template_circle_opt')">
+        <BuilderRow label.translate="Size" level="2">
+            <BuilderSelect dataAttributeAction="'size'">
+                <BuilderSelectItem dataAttributeActionValue="'80'">Small</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="'120'">Medium</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="'175'">Large</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderRow label.translate="Background" level="2">
             <BuilderSelect dataAttributeAction="'layoutBackground'">
                 <BuilderSelectItem dataAttributeActionValue="'inner'">Inner</BuilderSelectItem>
                 <BuilderSelectItem dataAttributeActionValue="'plain'">Plain</BuilderSelectItem>
                 <BuilderSelectItem dataAttributeActionValue="'none'" id="'no_background_layout_opt'">None</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
-        <BuilderRow label.translate="Layout Background Color"
+        <BuilderRow label.translate="Color"
                     t-if="!this.isActiveItem('no_background_layout_opt')" level="3">
             <BuilderColorPicker dataAttributeAction="'layoutBackgroundColor'" enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
@@ -71,114 +118,50 @@
         </BuilderRow>
 
         <t t-if="!this.isActiveItem('no_progressbar_style_opt')">
-            <BuilderRow label.translate="Progress Bar Weight" level="3">
+            <BuilderRow label.translate="Weight" level="3">
                 <BuilderSelect dataAttributeAction="'progressBarWeight'">
                     <BuilderSelectItem dataAttributeActionValue="'thin'">Thin</BuilderSelectItem>
                     <BuilderSelectItem dataAttributeActionValue="'thick'">Thick</BuilderSelectItem>
                 </BuilderSelect>
             </BuilderRow>
-            <BuilderRow label.translate="Progress Bar Color" level="3">
+            <BuilderRow label.translate="Color" level="3">
                 <BuilderColorPicker dataAttributeAction="'progressBarColor'" enabledTabs="['solid', 'custom']"/>
             </BuilderRow>
         </t>
     </t>
-    <t t-if="this.isActiveItem('text_layout_opt')">
-        <BuilderRow label.translate="Template" level="2">
-            <BuilderSelect id="'countdown_inline_template_opt'" action="'selectCountdownInlineTemplate'" applyTo="'.s_countdown_inline_wrapper'">
-                <BuilderSelectItem
-                    title.translate="Default"
-                    actionParam="{
-                        view: 'website.s_countdown_inline_default_template',
-                        templateClass: 'o_template_default',
-                    }">
-                    Default
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'template_dominoes_opt'"
-                    title.translate="Dominoes"
-                    actionParam="{
-                        view: 'website.s_countdown_inline_dominoes_template',
-                        templateClass: 'o_template_dominoes',
-                    }">
-                    Dominoes
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'template_wrapped_numbers_opt'"
-                    title.translate="Wrapped Numbers"
-                    actionParam="{
-                        view: 'website.s_countdown_inline_wrapped_numbers_template',
-                        templateClass: 'o_template_wrapped_numbers',
-                    }">
-                    Wrapped Numbers
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'template_text_opt'"
-                    title.translate="Text"
-                    actionParam="{
-                        view: 'website.s_countdown_inline_text_template',
-                        templateClass: 'o_template_text',
-                    }">
-                    Text
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'template_big_numbers_opt'"
-                    title.translate="Big Numbers"
-                    actionParam="{
-                        view: 'website.s_countdown_inline_big_numbers_template',
-                        templateClass: 'o_template_big_numbers',
-                    }">
-                    Big Numbers
-                </BuilderSelectItem>
-            </BuilderSelect>
+    <BuilderRow label.translate="Round Corners" applyTo="'.o_count_item_nbs'" t-if="isActiveItem('template_wrapped_numbers_opt')" level="2">
+        <BuilderNumberInput styleAction="'border-radius'" unit="'px'" min="0"/>
+    </BuilderRow>
+    <t t-if="!this.isActiveItem('template_circle_opt')">
+        <BuilderRow label.translate="Color" applyTo="'.o_colored_item'" level="2">
+            <BuilderColorPicker action="'setColorInlineCountdown'" actionParam="'background-color'" enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
-        <BuilderRow label.translate="Round Corners" applyTo="'.o_count_item_nbs'" t-if="isActiveItem('template_wrapped_numbers_opt')" level="3">
-            <BuilderNumberInput styleAction="'border-radius'" unit="'px'" min="0"/>
+        <BuilderRow label.translate="Color" applyTo="'.o_colored_text'" level="2">
+            <BuilderColorPicker action="'setColorInlineCountdown'" actionParam="'color'" enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
-        <BuilderRow label.translate="Color" applyTo="'.s_countdown_inline'" level="2">
-            <BuilderSelect>
-                <BuilderSelectItem id="'color_default_opt'" title.translate="Default" classAction="'o_countdown_default'">Default</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Primary" classAction="'o_countdown_primary'">Primary</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Secondary" classAction="'o_countdown_secondary'">Secondary</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Info" classAction="'o_countdown_info'">Info</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Success" classAction="'o_countdown_success'">Success</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Warning" classAction="'o_countdown_warning'">Warning</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Danger" classAction="'o_countdown_danger'">Danger</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Light" classAction="'o_countdown_light'">Light</BuilderSelectItem>
-                <BuilderSelectItem title.translate="Dark" classAction="'o_countdown_dark'">Dark</BuilderSelectItem>
-            </BuilderSelect>
-        </BuilderRow>
-        <BuilderRow label.translate="Subtle colors" applyTo="'.s_countdown_inline'" level="3">
-            <BuilderCheckbox id="'subtle_colors_opt'" classAction="'o_countdown_subtle'" t-if="!this.isActiveItem('color_default_opt') and !this.isActiveItem('template_text_opt') and !this.isActiveItem('template_big_numbers_opt')"/>
-        </BuilderRow>
-        <BuilderRow label.translate="Label" applyTo="'.s_countdown_inline'" level="2">
+        <BuilderRow label.translate="Label" level="2" applyTo="'.s_countdown_wrapper'">
             <BuilderSelect>
                 <BuilderSelectItem title.translate="Default" classAction="''">Default</BuilderSelectItem>
                 <BuilderSelectItem title.translate="Compact" classAction="'o_label_compact'">Compact</BuilderSelectItem>
                 <BuilderSelectItem title.translate="None" classAction="'o_label_none'">None</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
-        <BuilderRow label.translate="Alignment" level="2">
-            <BuilderButtonGroup applyTo="'.s_countdown_inline_wrapper'">
-                <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="''"/>
-                <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'align-self-center text-center'"/>
-                <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'align-self-end text-end'"/>
-            </BuilderButtonGroup>
-        </BuilderRow>
-        <BuilderRow label.translate="Font Monospace" applyTo="'.s_countdown_inline'" level="2">
-            <BuilderCheckbox
-                id="'font_monospace_opt'"
-                classAction="'o_count_monospace'"
-                t-if="this.isActiveItem('template_dominoes_opt') or this.isActiveItem('template_wrapped_numbers_opt') or this.isActiveItem('template_big_numbers_opt')"
-                />
-        </BuilderRow>
-        <hr class="mx-3"/>
-        <BuilderRow label.translate="Edge Spacing" applyTo="'.s_countdown_inline_wrapper'">
-            <BuilderRange styleAction="'padding'" min="0" max="200" step="1" displayRangeValue="true" unit="'px'"/>
-        </BuilderRow>
-        <BuilderContext applyTo="'.s_countdown_inline_wrapper'">
-            <BorderConfigurator label.translate="Border"/>
-        </BuilderContext>
     </t>
+    <BuilderRow label.translate="Alignment" level="2">
+        <BuilderButtonGroup applyTo="'.s_countdown_wrapper'">
+            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'align-items-start'"/>
+            <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'align-items-center'"/>
+            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'align-items-end'"/>
+        </BuilderButtonGroup>
+    </BuilderRow>
+    <BuilderRow label.translate="Font Monospace" applyTo="'.s_countdown_wrapper'" level="2"
+        t-if="this.isActiveItems(['template_dominoes_opt', 'template_wrapped_numbers_opt', 'template_big_numbers_opt'])">
+        <BuilderCheckbox id="'font_monospace_opt'" dclassAction="'o_count_monospace'"/>
+    </BuilderRow>
+    <hr class="mx-3"/>
+    <BuilderContext applyTo="'.s_countdown_wrapper'">
+        <BorderConfigurator label.translate="Border"/>
+    </BuilderContext>
 </t>
 
 <t t-name="website.s_countdown.end_message">

--- a/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
@@ -4,6 +4,7 @@ import { before, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequenc
 import { getElementsWithOption } from "@html_builder/utils/utils";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { registry } from "@web/core/registry";
 import { renderToElement } from "@web/core/utils/render";
 import { StyleAction } from "@html_builder/core/core_builder_action_plugin";
@@ -36,6 +37,18 @@ class CountdownOptionPlugin extends Plugin {
             for (const countdownEl of countdownEls) {
                 countdownEl.classList.remove("s_countdown_enable_preview");
             }
+        },
+        toolbar_namespace_providers: [
+            withSequence(
+                1,
+                (nodeList, editableSelection) =>
+                    !editableSelection.isCollapsed &&
+                    nodeList.find((node) => closestElement(node, ".s_countdown")) &&
+                    "countdownToolbar"
+            ),
+        ],
+        toolbar_namespace_extra_group_providers: {
+            countdownToolbar: ["font", "decoration"],
         },
         before_insert_processors: (container, block) => {
             if (block.closest(".countdown_metrics")) {

--- a/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
@@ -6,7 +6,9 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 import { renderToElement } from "@web/core/utils/render";
+import { StyleAction } from "@html_builder/core/core_builder_action_plugin";
 import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
+import { SelectTemplateAction } from "../customize_website_plugin";
 
 export class CountdownOption extends BaseOptionComponent {
     static template = "website.CountdownOption";
@@ -26,14 +28,20 @@ class CountdownOptionPlugin extends Plugin {
         builder_actions: {
             SetEndActionAction,
             PreviewEndMessageAction,
-            SetLayoutAction,
-            SelectCountdownInlineTemplateAction,
+            SelectCountdownTemplateAction,
+            SetColorInlineCountdownAction,
         },
         on_cloned_handlers: ({ cloneEl }) => {
             const countdownEls = getElementsWithOption(cloneEl, ".s_countdown");
             for (const countdownEl of countdownEls) {
                 countdownEl.classList.remove("s_countdown_enable_preview");
             }
+        },
+        before_insert_processors: (container, block) => {
+            if (block.closest(".countdown_metrics")) {
+                container.innerHTML = "";
+            }
+            return container;
         },
     };
 }
@@ -86,33 +94,6 @@ export class BaseCountdownAction extends BuilderAction {
         return editingElement.dataset.endAction === value;
     }
 
-    setLayout({ editingElement, value }) {
-        switch (value) {
-            case "circle":
-                editingElement.dataset.progressBarStyle = "disappear";
-                editingElement.dataset.progressBarWeight = "thin";
-                editingElement.dataset.layoutBackground = "none";
-                break;
-            case "boxes":
-                editingElement.dataset.progressBarStyle = "none";
-                editingElement.dataset.layoutBackground = "plain";
-                break;
-            case "clean":
-                editingElement.dataset.progressBarStyle = "none";
-                editingElement.dataset.layoutBackground = "none";
-                break;
-            case "text":
-                editingElement.dataset.progressBarStyle = "none";
-                editingElement.dataset.layoutBackground = "none";
-                break;
-        }
-        editingElement.dataset.layout = value;
-    }
-
-    isLayoutApplied({ editingElement, value }) {
-        return editingElement.dataset.layout === value;
-    }
-
     isEndMessagePreviewed({ editingElement }) {
         return !!editingElement?.classList.contains("s_countdown_enable_preview");
     }
@@ -149,50 +130,42 @@ export class PreviewEndMessageAction extends BaseCountdownAction {
     }
 }
 
-export class SetLayoutAction extends BaseCountdownAction {
-    static id = "setLayout";
-    apply(context) {
-        return this.setLayout(context);
-    }
-    isApplied(context) {
-        return this.isLayoutApplied(context);
-    }
-}
-
-export class SelectCountdownInlineTemplateAction extends BuilderAction {
-    static id = "selectCountdownInlineTemplate";
-    static dependencies = ["builderActions", "edit_interaction"];
-
-    setup() {
-        this.getAction = this.dependencies.builderActions.getAction;
-    }
-
-    async prepare({ actionParam }) {
-        await this.getAction("selectTemplate").prepare({ actionParam: actionParam });
-    }
-
-    isApplied({ editingElement, params: { templateClass } }) {
-        if (templateClass) {
-            return !!editingElement.querySelector(`.${templateClass}`);
-        }
-        return true;
-    }
+export class SelectCountdownTemplateAction extends SelectTemplateAction {
+    static id = "selectCountdownTemplate";
+    static dependencies = [...super.dependencies, "edit_interaction"];
 
     apply(action) {
         this.dependencies.edit_interaction.restartInteractions(
             action.editingElement.closest(".s_countdown")
         );
-        this.getAction("selectTemplate").apply(action);
+        const countdownEl = action.editingElement.closest(".s_countdown");
+        countdownEl.dataset.layoutBackground = "none";
+        if (action.params.view === "website.s_countdown_circle_template") {
+            countdownEl.dataset.progressBarStyle = "disappear";
+            countdownEl.dataset.progressBarWeight = "thin";
+            countdownEl.dataset.layout = "circle";
+        } else {
+            countdownEl.dataset.progressBarStyle = "none";
+            countdownEl.dataset.layoutBackground = "none";
+            countdownEl.dataset.layout = "text";
+        }
+        super.apply(action);
         // Reset the monospace font option if we select a template that doesn't provide it.
-        if (["o_template_default", "o_template_text"].includes(action.params.templateClass)) {
+        if (["o_template_text_inline", "o_template_text"].includes(action.params.templateClass)) {
             action.editingElement
                 .closest(".o_count_monospace")
                 ?.classList.remove("o_count_monospace");
         }
     }
+}
 
-    clean(action) {
-        return this.getAction("selectTemplate").clean(action);
+export class SetColorInlineCountdownAction extends StyleAction {
+    static id = "setColorInlineCountdown";
+
+    apply(context) {
+        super.apply(context);
+        const countdownWrapperEl = context.editingElement.closest(".s_countdown_wrapper");
+        countdownWrapperEl.classList.toggle("o_countdown_no_bg_color", !context.value);
     }
 }
 

--- a/addons/website/static/src/snippets/s_countdown/000.scss
+++ b/addons/website/static/src/snippets/s_countdown/000.scss
@@ -1,5 +1,9 @@
-.s_countdown_inline {
+.s_countdown_wrapper {
     font-variant-numeric: tabular-nums;
+
+    .countdown_metrics {
+        outline: none;
+    }
 
     .o_skeletton {
         display: block;
@@ -13,35 +17,9 @@
         border: $border-width solid $border-color;
     }
 
-    // Defines color classes based on $theme-colors
-    @each $-state, $-value in $theme-colors {
-        &.o_countdown_#{$-state} {
-            .o_colored_item {
-                border-color: $-value;
-                background: $-value;
-                color: color-contrast($-value);
-            }
-
-            &.o_countdown_subtle {
-                .o_colored_item {
-                    border-color: var(--#{$prefix}#{$-state}-border-subtle);
-                    background: var(--#{$prefix}#{$-state}-bg-subtle);
-                    color: var(--#{$prefix}#{$-state}-text-emphasis);
-
-                    a {
-                        color: var(--#{$prefix}#{$-state}-text-emphasis);
-                    }
-                }
-            }
-
-            .o_colored_text {
-                color: $-value;
-            }
-        }
-    }
-
     .o_count_item {
         display: inline-flex;
+        align-items: baseline;
     }
 
     .o_count_item_nbs {
@@ -65,7 +43,13 @@
     &:where(:not(.o_label_compact)) {
         .o_count_inline_text {
             .o_count_item_label {
-                margin-left: map-get($spacers, 1);
+                margin-left: map-get($spacers, 1)/2;
+            }
+            /* Split the margin between the number and the label to prevent
+            accidentally selecting the label when editing numbers with a
+            toolbar. */
+            .o_count_item_nbs {
+                margin-right: map-get($spacers, 1)/2;
             }
         }
     }
@@ -90,7 +74,7 @@
             .o_count_item {
                 // Replace "," separator with ":" when labels are hidden.
                 &:where(:not(:first-of-type)):before {
-                    content: ':\00a0';
+                    content: '\00a0:\00a0';
                 }
 
                 &::after {
@@ -106,7 +90,7 @@
         }
     }
 
-    &.o_countdown_default .o_template_dominoes {
+    &.o_countdown_no_bg_color .o_template_dominoes {
         .o_count_item_nb {
             &:after {
                 position: absolute;
@@ -119,7 +103,7 @@
         }
     }
 
-    &:not(.o_countdown_default) .o_template_dominoes {
+    &:not(.o_countdown_no_bg_color) .o_template_dominoes {
         .o_count_item_nb {
             // Simulates the horizontal line in the middle of the domino.
             clip-path: polygon(0 0, 100% 0, 100% calc(50% - 0.5px), 0 calc(50% - 0.5px), 0 calc(50% + 0.5px), 100% calc(50% + 0.5px), 100% 100%, 0 100%);
@@ -128,13 +112,16 @@
 
     .o_template_wrapped_numbers {
         .o_count_item_nbs {
-            width: map-get($spacers, 5);
+            min-width: map-get($spacers, 5);
+            width: 3em;
             aspect-ratio: 1 / 1;
+            display: inline-flex;
         }
 
         .o_count_separator {
             display: flex;
-            height: map-get($spacers, 5);
+            min-height: map-get($spacers, 5);
+            height: 3em;
         }
     }
 }

--- a/addons/website/static/src/snippets/s_countdown/countdown.edit.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.edit.js
@@ -1,17 +1,64 @@
-import { Countdown } from "./countdown";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { registry } from "@web/core/registry";
+import { Countdown } from "./countdown";
 
 const CountdownEdit = (I) =>
     class extends I {
+        dynamicContent = {
+            ...super.dynamicContent,
+            _root: {
+                // users should be able to change the countdown metrics only
+                // with the toolbar, no other changes are allowed
+                "t-on-keydown": this.preventEvent,
+                "t-on-paste": this.preventEvent,
+                "t-on-cut": this.preventEvent,
+                "t-on-dragstart": this.preventEvent,
+            },
+        };
         setup() {
-            super.setup();
             this.websiteEditService = this.services.website_edit;
+            this.renderedTimes = 0;
+            super.setup();
             this.websiteEditService.callShared("builderOverlay", "refreshOverlays");
         }
         get shouldHideCountdown() {
             return false;
         }
+        render() {
+            // first render's modifications are ignored by the history, because
+            // they happened in the setup of the interaction, we need to render
+            // once more so the countdown's state has been added to the history
+            // so if a user undoes/redoes stuff, it won't be broken.
+            super.render();
+            this.renderedTimes += 1;
+            if (this.renderedTimes == 2) {
+                // stop the render in the edit mode, so users can modify the
+                // countdown using the toolbar
+                clearInterval(this.setInterval);
+            }
+        }
         handleEndCountdownAction() {}
+        getConfigurationSnapshot() {
+            let snapshot = super.getConfigurationSnapshot();
+            // should restart the interaction if the color has changed
+            // so canvas' text color is updated
+            if (this.el.querySelector(".o_template_circle")) {
+                snapshot = JSON.parse(snapshot) || {};
+                snapshot.style = { ...snapshot.style, color: this.textColor };
+                snapshot = JSON.stringify(snapshot);
+            }
+            return snapshot;
+        }
+        preventEvent(ev) {
+            const targetedNodes = this.websiteEditService.callShared(
+                "selection",
+                "getTargetedNodes"
+            );
+            if (targetedNodes.some((node) => closestElement(node, ".countdown_metrics"))) {
+                ev.preventDefault();
+                ev.stopPropagation();
+            }
+        }
     };
 
 registry.category("public.interactions.edit").add("website.countdown", {

--- a/addons/website/static/src/snippets/s_countdown/countdown.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.js
@@ -7,9 +7,9 @@ import { isCSSColor } from "@web/core/utils/colors";
 import { verifyHttpsUrl } from "@website/utils/misc";
 
 export class Countdown extends Interaction {
-    static selector = ".s_countdown";
+    static selector = ".s_countdown[data-vxml='001']";
     dynamicContent = {
-        ".s_countdown_canvas_wrapper": {
+        ".s_countdown_wrapper": {
             "t-att-class": () => ({
                 "d-flex": true,
                 "justify-content-center": true,
@@ -21,7 +21,8 @@ export class Countdown extends Interaction {
         // Remove SVG previews (used to simulated canvas)
         this.el.querySelectorAll("svg").forEach((el) => el.parentNode.remove());
 
-        this.wrapperEl = this.el.querySelector(".s_countdown_canvas_wrapper");
+        this.wrapperEl = this.el.querySelector(".s_countdown_wrapper");
+        this.circleCountdownEl = this.el.querySelector(".o_template_circle");
         this.hereBeforeTimerEnds = false;
         this.endAction = this.el.dataset.endAction;
         this.endTime = parseInt(this.el.dataset.endTime);
@@ -48,24 +49,17 @@ export class Countdown extends Interaction {
 
         this.layoutBackgroundColor = this.ensureCSSColor(this.el.dataset.layoutBackgroundColor);
         this.progressBarColor = this.ensureCSSColor(this.el.dataset.progressBarColor);
-        this.textColor = this.ensureCSSColor(this.el.dataset.textColor);
 
         this.onlyOneUnit = this.display === "d";
         this.width = this.size;
-        if (this.layout === "boxes") {
-            this.width /= 1.75;
-        }
         this.initTimeDiff();
 
         this.render();
-
         this.setInterval = setInterval(this.render.bind(this), 1000);
     }
 
     destroy() {
-        // The optional chaining is required because the queried element may not
-        // exist anymore if the interaction target has just been deleted
-        this.el.querySelector(".s_countdown_canvas_wrapper")?.classList.remove("d-none");
+        this.wrapperEl?.classList.remove("d-none");
         clearInterval(this.setInterval);
         window.removeEventListener("resize", this.onResize);
     }
@@ -81,6 +75,10 @@ export class Countdown extends Interaction {
             return color;
         }
         return getCSSVariableValue(color, getHtmlStyle(document)) || this.defaultColor;
+    }
+
+    get textColor() {
+        return this.ensureCSSColor(getComputedStyle(this.el).color);
     }
 
     /**
@@ -134,8 +132,11 @@ export class Countdown extends Interaction {
         const delta = this.getDelta();
         this.timeDiff = [];
         if (this.isUnitVisible("d") && !(this.onlyOneUnit && delta < 86400)) {
-            const divEl = this.createCanvasWrapper();
-            this.insert(divEl, this.wrapperEl);
+            // Only create canvas elements if we are using the circle layout
+            const divEl = this.layout === "circle" ? this.createCanvasWrapper() : null;
+            if (divEl) {
+                this.insert(divEl, this.circleCountdownEl);
+            }
             this.timeDiff.push({
                 canvas: divEl,
                 // There is no logical number of unit (total) on which day units
@@ -146,8 +147,10 @@ export class Countdown extends Interaction {
             });
         }
         if (this.isUnitVisible("h") || (this.onlyOneUnit && delta < 86400 && delta > 3600)) {
-            const divEl = this.createCanvasWrapper();
-            this.insert(divEl, this.wrapperEl);
+            const divEl = this.layout === "circle" ? this.createCanvasWrapper() : null;
+            if (divEl) {
+                this.insert(divEl, this.circleCountdownEl);
+            }
             this.timeDiff.push({
                 canvas: divEl,
                 total: 24,
@@ -156,8 +159,10 @@ export class Countdown extends Interaction {
             });
         }
         if (this.isUnitVisible("m") || (this.onlyOneUnit && delta < 3600 && delta > 60)) {
-            const divEl = this.createCanvasWrapper();
-            this.insert(divEl, this.wrapperEl);
+            const divEl = this.layout === "circle" ? this.createCanvasWrapper() : null;
+            if (divEl) {
+                this.insert(divEl, this.circleCountdownEl);
+            }
             this.timeDiff.push({
                 canvas: divEl,
                 total: 60,
@@ -166,20 +171,15 @@ export class Countdown extends Interaction {
             });
         }
         if (this.isUnitVisible("s") || (this.onlyOneUnit && delta < 60)) {
-            const divEl = this.createCanvasWrapper();
-            this.insert(divEl, this.wrapperEl);
+            const divEl = this.layout === "circle" ? this.createCanvasWrapper() : null;
+            if (divEl) {
+                this.insert(divEl, this.circleCountdownEl);
+            }
             this.timeDiff.push({
                 canvas: divEl,
                 total: 60,
                 label: _t("Seconds"),
                 nbSeconds: 1,
-            });
-        }
-        if (this.layout === "text") {
-            this.timeDiff.forEach((metric) => {
-                if (metric.label) {
-                    metric.label = this.wrapFirstLetter(metric.label);
-                }
             });
         }
     }
@@ -225,17 +225,18 @@ export class Countdown extends Interaction {
      */
     render() {
         if (this.onlyOneUnit && this.getDelta() < this.timeDiff[0].nbSeconds) {
-            this.el.querySelector(".s_countdown_canvas_flex").remove();
+            // In circle mode, we remove the canvas flex wrapper.
+            // In text mode, the structure is different, but onlyOneUnit isn't usually combined with complex text templates in the same way.
+            if (this.layout !== "text") {
+                this.el.querySelector(".s_countdown_canvas_flex").remove();
+            }
             this.initTimeDiff();
         }
         this.updateTimediff();
 
-        this.el
-            .querySelector(".s_countdown_inline_wrapper")
-            ?.classList.toggle("d-none", this.layout !== "text" || this.shouldHideCountdown);
-        this.el
-            .querySelector(".s_countdown_canvas_wrapper")
-            ?.classList.toggle("d-none", this.layout === "text");
+        // We toggle the wrapper visibility if the countdown is finished.
+        this.wrapperEl?.classList.toggle("d-none", this.shouldHideCountdown);
+
         if (this.layout === "text") {
             this.countItemEls = this.el.querySelectorAll(".o_count_item");
             this.countItemNbsEls = this.el.querySelectorAll(".o_count_item_nbs");
@@ -255,14 +256,29 @@ export class Countdown extends Interaction {
                 // If the selected template have inner element, wrap each number in each of them
                 if (this.countItemNbEls.length > 0) {
                     metric.nb.split("").forEach((number, i) => {
-                        this.countItemNbsEls[index].querySelectorAll("span")[i].textContent =
-                            number;
+                        // Numbers can be wrapped inside of some elements(font, span, etc)
+                        // if a user modified it before. To preserve the style we should get
+                        // the deepest node
+                        const countItemNbEl = getDeepestChild(
+                            this.countItemNbsEls[index].querySelectorAll("span")[i]
+                        );
+                        countItemNbEl.textContent = number;
                     });
                 } else {
-                    this.countItemNbsEls[index].textContent = String(metric.nb).padStart(2, "0");
+                    const countItemNbsEl = getDeepestChild(this.countItemNbsEls[index]);
+                    countItemNbsEl.textContent = String(metric.nb).padStart(2, "0");
                 }
-                const fragmentEl = document.createRange().createContextualFragment(metric.label);
-                this.countItemLabelEls[index].replaceChildren(fragmentEl);
+                const labelEl = this.countItemLabelEls[index];
+                const firstLetterEl = getDeepestChild(labelEl.querySelector(".o_first_letter"));
+                const otherLettersEl = getDeepestChild(labelEl.querySelector(".o_other_letters"));
+                if (firstLetterEl && otherLettersEl) {
+                    firstLetterEl.textContent = metric.label[0];
+                    otherLettersEl.textContent = metric.label.slice(1);
+                } else {
+                    if (labelEl.textContent !== metric.label) {
+                        labelEl.textContent = metric.label;
+                    }
+                }
                 this.countItemEls[index].classList.remove("d-none");
             }
         } else {
@@ -291,7 +307,6 @@ export class Countdown extends Interaction {
                 if (this.progressBarStyle !== "none") {
                     this.drawProgressBar(ctx, val.nb, val.total, this.progressBarWeight === "thin");
                 }
-                val.canvas.classList.toggle("mx-1", this.layout === "boxes");
             }
         }
 
@@ -337,21 +352,6 @@ export class Countdown extends Interaction {
             canvas.height / dpr / 2 + nbSize / 1.5,
             this.width
         );
-
-        if (
-            this.layout === "boxes" &&
-            this.layoutBackground !== "none" &&
-            this.progressBarStyle === "none"
-        ) {
-            let barWidth = this.size / (this.progressBarWeight === "thin" ? 31 : 10);
-            if (full) {
-                barWidth = 0;
-            }
-            ctx.beginPath();
-            ctx.moveTo(barWidth, this.size / 2);
-            ctx.lineTo(this.width - barWidth, this.size / 2);
-            ctx.stroke();
-        }
     }
 
     /**
@@ -370,23 +370,6 @@ export class Countdown extends Interaction {
             }
             ctx.arc(this.size / 2, this.size / 2, rayon, 0, Math.PI * 2);
             ctx.fill();
-        } else if (this.layout === "boxes") {
-            let barWidth = this.size / (this.progressBarWeight === "thin" ? 31 : 10);
-            if (full) {
-                barWidth = 0;
-            }
-
-            ctx.fillStyle = this.layoutBackgroundColor;
-            ctx.rect(barWidth, barWidth, this.width - barWidth * 2, this.size - barWidth * 2);
-            ctx.fill();
-
-            const gradient = ctx.createLinearGradient(0, this.width, 0, 0);
-            gradient.addColorStop(0, "#ffffff24");
-            gradient.addColorStop(1, this.layoutBackgroundColor);
-            ctx.fillStyle = gradient;
-            ctx.rect(barWidth, barWidth, this.width - barWidth * 2, this.size - barWidth * 2);
-            ctx.fill();
-            ctx.canvas.style.borderRadius = "8px";
         }
     }
 
@@ -409,48 +392,6 @@ export class Countdown extends Interaction {
                 Math.PI * 2 * (nbUnit / totalUnit) + Math.PI / -2
             );
             ctx.stroke();
-        } else if (this.layout === "boxes") {
-            ctx.lineWidth *= 2;
-            let pc = (nbUnit / totalUnit) * 100;
-
-            // Lines: Top(x1,y1,x2,y2) Right(x1,y1,x2,y2) Bottom(x1,y1,x2,y2) Left(x1,y1,x2,y2)
-            const linesCoordFuncs = [
-                (linePc) => [
-                    0 + ctx.lineWidth / 2,
-                    0,
-                    ((this.width - ctx.lineWidth / 2) * linePc) / 25 + ctx.lineWidth / 2,
-                    0,
-                ],
-                (linePc) => [
-                    this.width,
-                    0 + ctx.lineWidth / 2,
-                    this.width,
-                    ((this.size - ctx.lineWidth / 2) * linePc) / 25 + ctx.lineWidth / 2,
-                ],
-                (linePc) => [
-                    this.width -
-                        ((this.width - ctx.lineWidth / 2) * linePc) / 25 -
-                        ctx.lineWidth / 2,
-                    this.size,
-                    this.width - ctx.lineWidth / 2,
-                    this.size,
-                ],
-                (linePc) => [
-                    0,
-                    this.size - ((this.size - ctx.lineWidth / 2) * linePc) / 25 - ctx.lineWidth / 2,
-                    0,
-                    this.size - ctx.lineWidth / 2,
-                ],
-            ];
-            while (pc > 0 && linesCoordFuncs.length) {
-                const linePc = Math.min(pc, 25);
-                const lineCoord = linesCoordFuncs.shift()(linePc);
-                ctx.beginPath();
-                ctx.moveTo(lineCoord[0], lineCoord[1]);
-                ctx.lineTo(lineCoord[2], lineCoord[3]);
-                ctx.stroke();
-                pc -= linePc;
-            }
         }
     }
 
@@ -466,26 +407,31 @@ export class Countdown extends Interaction {
             ctx.beginPath();
             ctx.arc(this.size / 2, this.size / 2, this.size / 2 - this.size / 20, 0, Math.PI * 2);
             ctx.stroke();
-        } else if (this.layout === "boxes") {
-            ctx.lineWidth *= 2;
-
-            // Lines: Top(x1,y1,x2,y2) Right(x1,y1,x2,y2) Bottom(x1,y1,x2,y2) Left(x1,y1,x2,y2)
-            const points = [
-                [0 + ctx.lineWidth / 2, 0, this.width, 0],
-                [this.width, 0 + ctx.lineWidth / 2, this.width, this.size],
-                [0, this.size, this.width - ctx.lineWidth / 2, this.size],
-                [0, 0, 0, this.size - ctx.lineWidth / 2],
-            ];
-            while (points.length) {
-                const point = points.shift();
-                ctx.beginPath();
-                ctx.moveTo(point[0], point[1]);
-                ctx.lineTo(point[2], point[3]);
-                ctx.stroke();
-            }
         }
         ctx.globalAlpha = 1;
     }
+}
+
+/**
+ * Returns the deepest descendant by following firstElementChild.
+ * At each level of traversal, all sibling nodes (including text nodes)
+ * of the next firstElementChild are removed, so the returned element
+ * is the remaining child at every level of the chain.
+ *
+ * @param {Element} node - Starting element.
+ * @returns {Element} The last element in the firstElementChild chain,
+ * or the same node if it has no element children.
+ */
+function getDeepestChild(node) {
+    while (node.firstElementChild) {
+        [...node.childNodes].forEach((child) => {
+            if (child !== node.firstElementChild) {
+                child.remove();
+            }
+        });
+        node = node.firstElementChild;
+    }
+    return node;
 }
 
 registry.category("public.interactions").add("website.countdown", Countdown);

--- a/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
@@ -23,13 +23,11 @@ const getTemplate = function (options = { endAction: "nothing", endTime: "987654
             data-text-color="o-color-1"
             data-layout-background-color="400"
             data-progress-bar-color="o-color-1"
-            data-end-time="${options.endTime}">
+            data-end-time="${options.endTime}"
+            data-vxml="001">
                 <div class="container">
-                    <div class="s_countdown_canvas_wrapper"
-                    style="
-                        display: flex;
-                        justify-content: center;
-                        align-items: center;">
+                    <div class="s_countdown_wrapper">
+                        <div class="o_template_circle d-inline-flex gap-1">
                     </div>
                 </div>
                 ${["message", "message_no_countdown"].includes(options.endAction) ? endMessage : ""}

--- a/addons/website/static/tests/interactions/snippets/countdown.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.test.js
@@ -25,13 +25,11 @@ const getTemplate = function (options = { endAction: "nothing", endTime: "987654
             data-text-color="o-color-1"
             data-layout-background-color="400"
             data-progress-bar-color="o-color-1"
-            data-end-time="${options.endTime}">
+            data-end-time="${options.endTime}"
+            data-vxml="001">
                 <div class="container">
-                    <div class="s_countdown_canvas_wrapper"
-                    style="
-                        display: flex;
-                        justify-content: center;
-                        align-items: center;">
+                    <div class="s_countdown_wrapper">
+                        <div class="o_template_circle d-inline-flex gap-1">
                     </div>
                 </div>
                 ${["message", "message_no_countdown"].includes(options.endAction) ? endMessage : ""}
@@ -159,7 +157,7 @@ test("countdown is stopped correctly", async () => {
     await advanceTime(0);
     expect(queryAll(".s_countdown_canvas_flex")).toHaveLength(4);
     core.stopInteractions();
-    expect(queryOne(".s_countdown_canvas_wrapper")).not.toBe(null);
+    expect(queryOne(".s_countdown_wrapper")).not.toBe(null);
     expect(queryAll(".s_countdown_canvas_flex")).toHaveLength(0);
     expect(queryAll(".s_countdown_end_message")).toHaveLength(0);
     expect(queryAll(".s_countdown_text_wrapper")).toHaveLength(0);
@@ -176,13 +174,11 @@ test("Countdown snippet exists, when the colors are not defined", async () => {
             data-progress-bar-style="surrounded"
             data-progress-bar-weight="thin"
             id="countdown-section"
-            data-end-time="1749351790.469224">
+            data-end-time="1749351790.469224"
+            data-vxml="001">
                 <div class="container">
-                    <div class="s_countdown_canvas_wrapper"
-                    style="
-                        display: flex;
-                        justify-content: center;
-                        align-items: center;">
+                    <div class="s_countdown_wrapper">
+                        <div class="o_template_circle d-inline-flex gap-1">
                     </div>
                 </div>
             </section>`;

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -47,7 +47,7 @@ registerWebsitePreviewTour(
         ...changeOptionInPopover("Countdown", "At The End", "Message only"),
         {
             content: "Check that the countdown is not displayed",
-            trigger: ":iframe .s_countdown:has(.s_countdown_canvas_wrapper:not(:visible))",
+            trigger: ":iframe .s_countdown:has(.s_countdown_wrapper:not(:visible))",
         },
         {
             content: "Check that the message is still displayed",

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -2,59 +2,60 @@
 <odoo>
 
 <template id="s_countdown" name="Countdown">
-    <section class="s_countdown pt48 pb48"
-        data-display="dhms" data-end-action="nothing" data-size="175"
+    <section class="s_countdown pt48 pb48 text-o-color-1"
+        data-display="dhms" data-end-action="nothing" data-size="120"
         t-att-data-end-time="60 * round(datetime.datetime.now().timestamp() / 60) + 228300"
         data-layout="circle" data-layout-background="none"
         data-progress-bar-style="surrounded" data-progress-bar-weight="thin"
-        data-text-color="o-color-1" data-layout-background-color="400" data-progress-bar-color="o-color-1">
+        color="var(--o-color-1)" data-layout-background-color="400" data-progress-bar-color="o-color-1" data-vxml="001">
         <div class="container">
-            <div class="s_countdown_canvas_wrapper text-center d-flex justify-content-center">
-                <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 175px;">
-                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="175" height="175" class="w-100" viewBox="0 0 175 175"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="43.75px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="87.5" text-anchor="middle" dominant-baseline="central">2</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14.583333333333334px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="116.66666666666667" text-anchor="middle" dominant-baseline="central">Days</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 166.25 87.5 A 78.75 78.75 0 1 1 166.24996062500327 87.42125001312495" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 87.5 8.75 A 78.75 78.75 0 0 1 146.0226550063448 34.80596474923991" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
-                </div>
-                <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 175px;">
-                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="175" height="175" class="w-100" viewBox="0 0 175 175"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="43.75px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="87.5" text-anchor="middle" dominant-baseline="central">16</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14.583333333333334px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="116.66666666666667" text-anchor="middle" dominant-baseline="central">Hours</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 166.25 87.5 A 78.75 78.75 0 1 1 166.24996062500327 87.42125001312495" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 87.5 8.75 A 78.75 78.75 0 1 1 19.30049945197547 126.87500000000003" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
-                </div>
-                <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 175px;">
-                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="175" height="175" class="w-100" viewBox="0 0 175 175"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="43.75px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="87.5" text-anchor="middle" dominant-baseline="central">30</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14.583333333333334px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="116.66666666666667" text-anchor="middle" dominant-baseline="central">Minutes</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 166.25 87.5 A 78.75 78.75 0 1 1 166.24996062500327 87.42125001312495" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 87.5 8.75 A 78.75 78.75 0 0 1 87.5 166.25" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
-                </div>
-                <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 175px;">
-                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="175" height="175" class="w-100" viewBox="0 0 175 175"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="43.75px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="87.5" text-anchor="middle" dominant-baseline="central">45</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14.583333333333334px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="116.66666666666667" text-anchor="middle" dominant-baseline="central">Seconds</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 166.25 87.5 A 78.75 78.75 0 1 1 166.24996062500327 87.42125001312495" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 87.5 8.75 A 78.75 78.75 0 1 1 8.75 87.50000000000001" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
-                </div>
-            </div>
-            <div class="s_countdown_inline d-flex flex-column align-items-start o_countdown_default">
-                <div class="s_countdown_inline_wrapper d-none">
-                    <t t-call="website.s_countdown_inline_default_template"/>
-                </div>
+            <div class="s_countdown_wrapper o_countdown_no_bg_color d-flex flex-column align-items-start">
+                <t t-call="website.s_countdown_circle_template"/>
             </div>
         </div>
     </section>
 </template>
 
-<template id="s_countdown_inline_default_template" groups="base.group_user">
-    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
-    <div class="o_template_default o_count_inline_text o_colored_item alert mb-0">
-        <p>
-            <i class="fa fa-clock-o"/> Sale ends in
-            <span class="o_not_editable oe_unremovable" contenteditable="false">
-                <t t-foreach="metrics" t-as="metric">
-                    <span class="o_count_item">
-                        <span class="o_count_item_nbs d-inline-flex fw-bold"/>
-                        <span class="o_count_item_label fw-bold">
-                            <span class="o_skeletton rounded bg-200 ps-5"/>
-                        </span>
-                    </span>
-                </t>
-            </span>
-        </p>
+<template id="s_countdown_circle_template" groups="base.group_user">
+    <div class="o_template_circle d-inline-flex gap-1">
+        <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 120px;">
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="120" class="w-100" viewBox="0 0 120 120"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="30px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="60" text-anchor="middle" dominant-baseline="central">2</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="82" text-anchor="middle" dominant-baseline="central">Days</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 114 60 A 54 54 0 1 1 113.99995714285649 59.94085714285714" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 60 6 A 54 54 0 0 1 100.10774057369516 23.860518514235936" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
+        </div>
+        <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 120px;">
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="120" class="w-100" viewBox="0 0 120 120"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="30px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="60" text-anchor="middle" dominant-baseline="central">16</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="82" text-anchor="middle" dominant-baseline="central">Hours</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 114 60 A 54 54 0 1 1 113.99995714285649 59.94085714285714" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 60 6 A 54 54 0 1 1 13.234155309494916 87" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
+        </div>
+        <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 120px;">
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="120" class="w-100" viewBox="0 0 120 120"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="30px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="60" text-anchor="middle" dominant-baseline="central">30</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="82" text-anchor="middle" dominant-baseline="central">Minutes</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 114 60 A 54 54 0 1 1 113.99995714285649 59.94085714285714" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 60 6 A 54 54 0 0 1 60 114" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
+        </div>
+        <div class="s_countdown_canvas_flex" style="width: 25%; max-width: 120px;">
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="120" class="w-100" viewBox="0 0 120 120"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="30px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="60" text-anchor="middle" dominant-baseline="central">45</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14px" font-style="normal" font-weight="normal" text-decoration="normal" x="60" y="82" text-anchor="middle" dominant-baseline="central">Seconds</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 114 60 A 54 54 0 1 1 113.99995714285649 59.94085714285714" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 60 6 A 54 54 0 1 1 6 60.00000000000001" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
+        </div>
     </div>
 </template>
 
-<template id="s_countdown_inline_dominoes_template" groups="base.group_user">
+<template id="s_countdown_text_inline_template" groups="base.group_user">
+    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
+    <div class="o_template_text_inline o_count_inline_text o_colored_item alert mb-0">
+        <div>
+            <span>
+                <i class="fa fa-clock-o"/> Sale ends in
+            </span>
+            <div class="oe_unremovable d-inline-flex countdown_metrics">
+                <t t-foreach="metrics" t-as="metric">
+                    <span class="o_count_item">
+                        <span class="o_count_item_nbs d-inline-flex fw-bold"/>
+                        <span class="o_count_item_label fw-bold"><span class="o_first_letter"/><span class="o_other_letters"/></span>
+                    </span>
+                </t>
+            </div>
+        </div>
+    </div>
+</template>
+
+<template id="s_countdown_dominoes_template" groups="base.group_user">
     <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
     <div class="o_template_dominoes">
-        <div class="o_not_editable oe_unremovable d-flex gap-1" contenteditable="false">
+        <div class="oe_unremovable countdown_metrics d-flex gap-1">
             <t t-foreach="metrics" t-as="metric">
                 <span class="o_count_item d-flex gap-1">
                     <span class="d-flex flex-column align-items-center">
@@ -62,7 +63,7 @@
                             <span class="o_count_item_nb o_colored_item position-relative rounded py-1 px-2 fs-4 fw-bold"/>
                             <span class="o_count_item_nb o_colored_item position-relative rounded py-1 px-2 fs-4 fw-bold"/>
                         </span>
-                        <span class="o_count_item_label small"/>
+                        <span class="o_count_item_label small"><span class="o_first_letter"/><span class="o_other_letters"/></span>
                     </span>
                 </span>
                 <span t-if="metric_last == false" class="o_count_separator mt-1 fs-4">:</span>
@@ -71,15 +72,15 @@
     </div>
 </template>
 
-<template id="s_countdown_inline_wrapped_numbers_template" groups="base.group_user">
+<template id="s_countdown_wrapped_numbers_template" groups="base.group_user">
     <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
     <div class="o_template_wrapped_numbers">
-        <div class="o_not_editable oe_unremovable d-inline-flex gap-1" contenteditable="false">
+        <div class="oe_unremovable countdown_metrics d-inline-flex gap-1">
             <t t-foreach="metrics" t-as="metric">
                 <span class="o_count_item d-flex gap-1">
                     <span class="d-flex flex-column align-items-center">
                         <span class="o_count_item_nbs o_colored_item d-flex justify-content-center align-items-center rounded p-2"/>
-                        <span class="o_count_item_label small"/>
+                        <span class="o_count_item_label small"><span class="o_first_letter"/><span class="o_other_letters"/></span>
                     </span>
                 </span>
                 <span t-if="metric_last == false" class="o_count_separator align-items-center">:</span>
@@ -88,32 +89,34 @@
     </div>
 </template>
 
-<template id="s_countdown_inline_text_template" groups="base.group_user">
+<template id="s_countdown_text_template" groups="base.group_user">
     <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
     <div class="o_template_text o_count_inline_text">
-        <p>
-            <i class="fa fa-clock-o"/> Sale ends in
-            <span class="o_not_editable oe_unremovable" contenteditable="false">
+        <div>
+            <span>
+                <i class="fa fa-clock-o"/> Sale ends in
+            </span>
+            <div class="oe_unremovable d-inline-flex countdown_metrics">
                 <t t-foreach="metrics" t-as="metric">
                     <span class="o_count_item o_colored_text">
                         <span class="o_count_item_nbs d-inline-flex fw-bold"/>
-                        <span class="o_count_item_label fw-bold"/>
+                        <span class="o_count_item_label fw-bold"><span class="o_first_letter"/><span class="o_other_letters"/></span>
                     </span>
                 </t>
-            </span>
-        </p>
+            </div>
+        </div>
     </div>
 </template>
 
-<template id="s_countdown_inline_big_numbers_template" groups="base.group_user">
+<template id="s_countdown_big_numbers_template" groups="base.group_user">
     <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
     <div class="o_template_big_numbers">
-        <div class="o_not_editable oe_unremovable d-inline-flex gap-1" contenteditable="false">
+        <div class="oe_unremovable countdown_metrics d-inline-flex gap-1">
             <t t-foreach="metrics" t-as="metric">
                 <span class="o_count_item d-flex gap-1">
                     <span class="d-flex flex-column align-items-center">
                         <span class="o_count_item_nbs o_colored_text fs-3 fw-bold"/>
-                        <span class="o_count_item_label small"/>
+                        <span class="o_count_item_label small"><span class="o_first_letter"/><span class="o_other_letters"/></span>
                     </span>
                 </span>
                 <span t-if="metric_last == false" class="o_count_separator fs-3 fw-bold">:</span>


### PR DESCRIPTION
[IMP] website: merge countdown snippet layout and template options

Following [commit], we'd like to improve the countdown snippet.
Key changes:
1. Merge Layout and Template into a single layout option with the
following layouts:
 - Circle
 - Text Inline
 - Dominoes (replaces Boxes)
 - Wrapped Numbers
 - Text
 - Big Numbers (replaces Clean)
2. Add Font Size Control for both Date and Indications elements
3. Remove Edge Spacing
4. Convert Circle layout to Text Inline format: display the countdown
on the left with reduced size.
5. Retain Circle-specific options plus all Text Inline options when
possible.

[commit]: https://github.com//odoo/odoo/commit/74a9e5bb734708497456ed2bc91465f95505b2d7

task-5242156

---
[FIX] html_editor: use rem instead of em for $small-font-size

Change `$small-font-size` from using `em` to `rem` units to align it
with the rest of the font sizes in the codebase, which all use `rem`.

Because `em` is relative to the parent element's font size, applying
the `o_small-fs` class (which uses `$small-font-size`) on an element
with a base font size of "14" could result in a rendered font size
bigger than a sibling element using an explicit "16" `rem`-based font
size class, even though 14 must be smaller than 16. This leads to
inconsistent and counterintuitive sizing behavior where a "smaller"
font size appears larger than expected.

---
[IMP] html_editor, website: add toolbar group namespace extension system

Introduce `toolbar_namespace_extra_group_providers` resource to allow
new namespaces to reuse existing toolbar groups without manually
redefining all buttons.

Useful when a plugin wants to opt existing groups (defined elsewhere)
into a new namespace without modifying their original definitions.

E.g., `{ countdownToolbar: ["font", "decoration"] }` automatically
includes font and decoration groups in the countdownToolbar namespace.

This commit uses it for the first time in the countdown plugin to use
`font` and `decoration` toolbar groups with countdownToolbar namespace.