### PR TITLE
[IMP] payroll: fix double holiday

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -633,6 +633,20 @@ class HrVersion(models.Model):
             for tz, versions in version_per_tz.items()
         }
 
+    def _get_days_per_week(self):
+        self.ensure_one()
+        if self.resource_calendar_id:
+            return self.resource_calendar_id._get_days_per_week()
+        return 5
+
+    def _get_hours_per_week(self):
+        self.ensure_one()
+        if self.resource_calendar_id:
+            return self.resource_calendar_id._get_hours_per_week()
+        elif self.is_flexible:
+            return self.hours_per_week
+        return self.company_id.resource_calendar_id._get_hours_per_week()
+
     def action_open_version(self):
         self.ensure_one()
 

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -707,10 +707,10 @@
     </record>
 
     <record id="l10n_be_work_entry_type_simple_holiday_pay_variable_salary" model="hr.work.entry.type">
-        <field name="name">Simple Holiday Pay - Variable Salary</field>
+        <field name="name">Fictitious Variable Salary</field>
         <field name="code">LEAVE1731</field>
         <field name="color">3</field>
-        <field name="display_code">SHP</field>
+        <field name="display_code">FVS</field>
         <field name="country_id" ref="base.be"/>
         <field name="count_as">absence</field>
     </record>


### PR DESCRIPTION
This commit is part of a PR that refactors the belgian double holiday pay for the CP 200.
The following changes have been made:
- Split the basic line into 4 lines to improve clarity on how things get computed
- Add the computation for the simple holiday pay on variable salary
- Refactor the recovery mechanism by simplifying it. The wizard is removed and the amount automatically computed on the payslip

This commit adds two helper methods on the hr.version model and adapts a work entry type.

task-5068001

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
