### PR TITLE
[FIX] html_editor: specify toolbar for code blocks

### DIFF
--- a/addons/html_editor/static/src/main/font/code_plugin.js
+++ b/addons/html_editor/static/src/main/font/code_plugin.js
@@ -1,0 +1,49 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class CodePlugin extends Plugin {
+    static id = "code";
+    /** @type {import("plugins").EditorResources} */
+    resources = {
+        toolbar_namespace_providers: [
+            (targetedNodes, editableSelection) => {
+                if (editableSelection.isCollapsed) {
+                    return;
+                }
+                if (
+                    targetedNodes.length &&
+                    targetedNodes.every(
+                        // All nodes should be inside a <pre>
+                        (node) => node.closest?.("pre") || node.parentElement.closest("pre")
+                    )
+                ) {
+                    return "codecompact";
+                }
+            },
+        ],
+        toolbar_groups: [
+            {
+                isPatch: true,
+                id: "font",
+                getNamespaces: (button) => {
+                    if ("font-family" === button.id) {
+                        return [];
+                    }
+                    return ["codecompact", "codeexpanded"];
+                },
+            },
+            {
+                isPatch: true,
+                id: "decoration",
+                getNamespaces: (button) => {
+                    if (["forecolor", "backcolor", "remove_format"].includes(button.id)) {
+                        return [];
+                    }
+                    return ["codecompact", "codeexpanded"];
+                },
+            },
+            { isPatch: true, id: "link", namespaces: ["codecompact", "codeexpanded"] },
+            { isPatch: true, id: "expand_toolbar", namespaces: ["codecompact"] },
+            { isPatch: true, id: "ai", namespaces: ["codeexpanded"] },
+        ],
+    };
+}

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -440,13 +440,15 @@ export class FontPlugin extends Plugin {
                 targetOffset,
                 blockToSplit: closestBlockNode,
             });
-            const isPreBlock = beforeElement.nodeName === "PRE";
+            const isPreBlock = beforeElement === undefined || beforeElement.nodeName === "PRE";
             const baseContainer = isPreBlock
                 ? this.dependencies.baseContainer.createBaseContainer()
                 : afterElement;
             if (isPreBlock) {
-                baseContainer.replaceChildren(...afterElement.childNodes);
-                afterElement.replaceWith(baseContainer);
+                if (afterElement) {
+                    baseContainer.replaceChildren(...afterElement.childNodes);
+                    afterElement.replaceWith(baseContainer);
+                }
             } else {
                 beforeElement.remove();
                 closestPre.after(afterElement);

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
@@ -3,7 +3,31 @@
     <!-- syntax highlighting template -->
     <t t-name="html_editor.EmbeddedSyntaxHighlighting">
         <CodeToolbar target="state.host" currentLanguage="embeddedState.languageId"
-            getContent="() => this.textarea.value" onLanguageChange="onLanguageChange.bind(this)"/>
+            getContent="this.getContent.bind(this)" onLanguageChange="onLanguageChange.bind(this)"/>
+        <t t-if="this.embeddedState.languageId === 'plaintext'">
+            <EmbeddedSyntaxPlainInput
+                host="this.props.host"
+                embeddedState="this.embeddedState"
+                onFocus="props.onTextareaFocus" 
+            />
+        </t>
+        <t t-else="">
+            <EmbeddedSyntaxHighlightingInput
+                host="this.props.host"
+                embeddedState="this.embeddedState"
+                onTextareaFocus="props.onTextareaFocus" 
+            />
+        </t>
+    </t>
+    
+    <t t-name="html_editor.EmbeddedSyntaxPlainInput">
+        <pre data-oe-protected="false" t-ref="pre" contenteditable="true"
+            t-on-focus="props.onFocus"
+            t-on-input="onInput"
+        />
+    </t>
+
+    <t t-name="html_editor.EmbeddedSyntaxHighlightingInput">
         <pre t-ref="pre"/>
         <textarea t-ref="textarea" class="o_prism_source" contenteditable="true"
             t-on-input="onInput"

--- a/addons/html_editor/static/src/others/embedded_components/core/syntax_highlighting/readonly_syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/syntax_highlighting/readonly_syntax_highlighting.js
@@ -23,7 +23,12 @@ export class ReadonlySyntaxHighlightingComponent extends Component {
             const owlRoot = [...(this.props.host.children || [])].find(
                 (child) => child.nodeName === "OWL-ROOT"
             );
-            highlightPre(owlRoot || this.props.host, this.props.value, this.props.languageId);
+            const pre = owlRoot || this.props.host;
+            if (this.props.languageId === "plaintext") {
+                pre.innerHTML = this.props.value;
+                return;
+            }
+            highlightPre(pre, this.props.value, this.props.languageId);
         });
     }
 }
@@ -34,6 +39,9 @@ export const readonlySyntaxHighlightingEmbedding = {
     getProps: (host) => ({
         host,
         languageId: host.dataset.languageId || DEFAULT_LANGUAGE_ID,
-        value: getPreValue(host),
+        value:
+            (host.dataset.languageId || DEFAULT_LANGUAGE_ID) === "plaintext"
+                ? host.innerText
+                : getPreValue(host),
     }),
 };

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -29,6 +29,7 @@ export class SyntaxHighlightingPlugin extends Plugin {
             }
         },
         system_attributes: "data-syntax-highlighting-autofocus",
+        powerbox_blacklist_selectors: "[data-embedded-props*='plaintext'] pre",
 
         /** Handlers */
         mount_component_handlers: this.setupNewCodeBlock.bind(this),

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -30,6 +30,7 @@ export class SyntaxHighlightingPlugin extends Plugin {
         },
         system_attributes: "data-syntax-highlighting-autofocus",
         powerbox_blacklist_selectors: "[data-embedded-props*='plaintext'] pre",
+        shorthand_blacklist_selectors: "[data-embedded-props*='plaintext'] pre",
 
         /** Handlers */
         mount_component_handlers: this.setupNewCodeBlock.bind(this),

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -20,6 +20,7 @@ import { UserCommandPlugin } from "./core/user_command_plugin";
 import { AlignPlugin } from "./main/align/align_plugin";
 import { BannerPlugin } from "./main/banner_plugin";
 import { ChatGPTTranslatePlugin } from "./main/chatgpt/chatgpt_translate_plugin";
+import { CodePlugin } from "./main/font/code_plugin";
 import { ColumnPlugin } from "./main/column_plugin";
 import { EmojiPlugin } from "./main/emoji_plugin";
 import { ColorPlugin } from "./main/font/color_plugin";
@@ -147,6 +148,7 @@ export const MAIN_PLUGINS = [
     TableResizePlugin,
     PlaceholderPlugin,
     SelectionPlaceholderPlugin,
+    CodePlugin,
 ];
 
 export const COLLABORATION_PLUGINS = [

--- a/addons/html_editor/static/tests/_helpers/toolbar.js
+++ b/addons/html_editor/static/tests/_helpers/toolbar.js
@@ -1,7 +1,7 @@
 import { waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 
-export async function expandToolbar() {
+export async function expandToolbar(namespace = "expanded") {
     await contains(".o-we-toolbar .btn[name='expand_toolbar'").click();
-    await waitFor(".o-we-toolbar[data-namespace='expanded']");
+    await waitFor(`.o-we-toolbar[data-namespace='${namespace}']`);
 }

--- a/addons/html_editor/static/tests/format/code.test.js
+++ b/addons/html_editor/static/tests/format/code.test.js
@@ -1,0 +1,18 @@
+import { waitFor } from "@odoo/hoot-dom";
+import { setupEditor } from "../_helpers/editor";
+import { expect, test } from "@odoo/hoot";
+import { expandToolbar } from "../_helpers/toolbar";
+
+test("should have toolbar within code block", async () => {
+    await setupEditor(`<pre>ab[cde]fg</pre>`);
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='font']").toHaveCount(1);
+    expect(".btn[name='bold']").toHaveCount(1);
+    expect(".btn[name='link']").toHaveCount(1);
+    expect(".btn[name='translate']").toHaveCount(0);
+    await expandToolbar("codeexpanded");
+    expect(".btn[name='font']").toHaveCount(1);
+    expect(".btn[name='bold']").toHaveCount(1);
+    expect(".btn[name='link']").toHaveCount(1);
+    expect(".btn[name='translate']").toHaveCount(1);
+});

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1,7 +1,8 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
 import { getContent } from "./_helpers/selection";
 import { animationFrame, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
-import { insertText, splitBlock } from "./_helpers/user_actions";
+import { expandToolbar } from "./_helpers/toolbar";
+import { insertText, simulateArrowKeyPress, splitBlock } from "./_helpers/user_actions";
 import {
     compareHighlightedContent,
     highlightedPre,
@@ -1133,4 +1134,23 @@ test("can write in a highlighted code block within a nested list", async () => {
             <p>b</p>`
         ),
     });
+});
+
+test("should have toolbar within plaintext /code block, but not other syntaxes", async () => {
+    const { editor } = await setupEditor(`<div>[]</div>`);
+    await insertText(editor, "/code");
+    await press("Enter");
+    await insertText(editor, "let a = 1;");
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    await simulateArrowKeyPress(editor, ["Shift", "ArrowLeft"]); // "1" is selected
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='font']").toHaveCount(1);
+    expect(".btn[name='bold']").toHaveCount(1);
+    expect(".btn[name='link']").toHaveCount(1);
+    expect(".btn[name='translate']").toHaveCount(0);
+    await expandToolbar("codeexpanded");
+    expect(".btn[name='font']").toHaveCount(1);
+    expect(".btn[name='bold']").toHaveCount(1);
+    expect(".btn[name='link']").toHaveCount(1);
+    expect(".btn[name='translate']").toHaveCount(1);
 });


### PR DESCRIPTION
The toolbar is not displayed when the selection is inside a code block.

This commit defines the content of the toolbar for selections inside such blocks:
- Font type & size
- Bold, italic, underscore, strikethrough
- Link
- Extended: translate

task-5241467
