### PR TITLE
[IMP] account: include journal name in allowed journal error messages

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1236,7 +1236,7 @@ class AccountMoveLine(models.Model):
                 raise UserError(_('The account selected on your journal entry forces to provide a secondary currency. You should remove the secondary currency on the account.'))
 
             if account.allowed_journal_ids and journal not in account.allowed_journal_ids:
-                raise UserError(_('You cannot use this account (%s) in this journal, check the field \'Allowed Journals\' on the related account.', account.display_name))
+                raise UserError(_('You cannot use this account (%(account)s) in journal "%(journal)s", check the field \'Allowed Journals\' on the related account.', account=account.display_name, journal=journal.display_name))
 
             if account in (journal.default_account_id, journal.suspense_account_id):
                 continue
@@ -1244,8 +1244,8 @@ class AccountMoveLine(models.Model):
             is_account_control_ok = not journal.account_control_ids or account in journal.account_control_ids
 
             if not is_account_control_ok:
-                raise UserError(_("You cannot use this account (%s) in this journal, check the section 'Control-Access' under "
-                                  "tab 'Advanced Settings' on the related journal.", account.display_name))
+                raise UserError(_('You cannot use this account (%(account)s) in journal "%(journal)s", check the section \'Control-Access\' under '
+                                  'tab \'Advanced Settings\' on the related journal.', account=account.display_name, journal=journal.display_name))
 
     @api.constrains('account_id', 'tax_ids', 'tax_line_id', 'reconciled')
     def _check_off_balance(self):


### PR DESCRIPTION
## Description

When an account has restricted `allowed_journal_ids` and is used in a journal entry that uses a different journal (e.g., during deferred entry generation), the error message now shows which journal is actually causing the issue.

**Before:** 
> You cannot use this account (613292 Expense) in this journal, check the field 'Allowed Journals' on the related account.

**After:** 
> You cannot use this account (613292 Expense) in journal "Miscellaneous Operations", check the field 'Allowed Journals' on the related account.

## Problem

When posting a vendor bill with deferred expense dates, Odoo generates deferred entries in a different journal (e.g., "Miscellaneous Operations"). If the expense account has `allowed_journal_ids` restricted to only "Vendor Bills", the constraint fails.

The current error message says "in this journal" which is confusing because:
1. The user is looking at a Vendor Bill (journal = "Vendor Bills")
2. The actual failure happens in the deferred entries journal ("Miscellaneous Operations")
3. The user has no idea deferred entries are being created in a different journal

## Solution

Include the actual journal name in both error messages in `_check_constrains_account_id_journal_id()`:
- Line 1239: allowed_journal_ids constraint
- Line 1247: account_control_ids constraint

This makes it immediately clear which journal is causing the issue, helping users understand and fix the problem faster.