### PR TITLE
[FIX] point_of_sale: prevent traceback with sequence prefix

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -540,7 +540,13 @@ class PosOrder(models.Model):
         return super().create(vals_list)
 
     def _update_sequence_number(self, session, values):
-        values['sequence_number'] = session.config_id.order_seq_id._next()  # Some localization needs orders to have a sequence number
+        # Some localization needs orders to have a sequence number
+        values['sequence_number'] = (
+            session.config_id.order_seq_id
+            ._next()
+            .removeprefix(session.config_id.order_seq_id.prefix or '')
+            .removesuffix(session.config_id.order_seq_id.suffix or '')
+        )
 
     @api.model
     def _complete_values_from_session(self, session, values):
@@ -661,7 +667,9 @@ class PosOrder(models.Model):
             return _('%(refunded_order)s REFUND', refunded_order=self.refunded_order_id.name)
         else:
             last_reference_part = self.get_reference_last_part()
-            return f"{session.config_id.name} - {last_reference_part}"
+            prefix = session.config_id.order_seq_id.prefix or session.config_id.name
+            suffix = f" - {session.config_id.order_seq_id.suffix}" if session.config_id.order_seq_id.suffix else ''
+            return f"{prefix} - {last_reference_part}{suffix}"
 
     def get_reference_last_part(self):
         return self.pos_reference.split('-')[-1]

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2065,3 +2065,38 @@ class TestPointOfSaleFlow(CommonPosTest):
         self.env.clear()
         data = current_session.with_company(self.env.company).filter_local_data({'product.product': [product.id]})
         self.assertIn(product.id, data['product.product'])
+
+    def test_string_sequence_number(self):
+        self.pos_config_usd.open_ui()
+        current_session = self.pos_config_usd.current_session_id
+        current_session.config_id.order_seq_id.prefix = '/AA'
+        current_session.config_id.order_seq_id.suffix = '1.B'
+        product_order = {
+            'amount_paid': 750,
+            'amount_tax': 0,
+            'amount_return': 0,
+            'amount_total': 750,
+            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+            'lines': [[0, 0, {
+                'price_unit': 750.0,
+                'product_id': self.product.id,
+                'price_subtotal': 750.0,
+                'price_subtotal_incl': 750.0,
+                'tax_ids': [[6, False, []]],
+                'qty': 1,
+            }]],
+            'name': 'Order 12345-123-1234',
+            'partner_id': False,
+            'session_id': current_session.id,
+            'payment_ids': [[0, 0, {
+                'amount': 750,
+                'name': fields.Datetime.now(),
+                'payment_method_id': self.bank_payment_method.id
+            }]],
+            'uuid': '12345-123-1234',
+            'user_id': self.env.uid,
+            'to_invoice': False}
+
+        self.env['pos.order'].sync_from_ui([product_order])
+        order = self.env['pos.order'].search([])
+        self.assertEqual(order.name, f"/AA - {order.pos_reference.split('-')[-1]} - 1.B")


### PR DESCRIPTION
**Steps to reproduce:**
- Go to the sequence interface, and chose the config number 1 for a pos.order
- In the prefix field, enter something with characters that are not numbers
- Go to a PoS with config number 1 active and make a purchase
- A traceback appears saying that we can't convert the sequence to an Integer

**Why the fix:**
Having a custom prefix with letters used to work, but in version 19, we now store the sequence_number with the prefix, which can be composed of characters which can not be stored in an Integer field such as sequence_number.

To prevent this error, we remove the prefix and the suffix (which has the same issue) from the sequence_number before storing it. We then add the prefix and the suffix back when computing the order's name, so that it's consistant with the prefix and the suffix the user chose.

This is the way the order's name was computed before version 19.0, which saw the prefix and suffix disappear from the order's name.

opw-5386575