### PR TITLE
[FIX] account: traceback on journal currency change

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -390,7 +390,7 @@ class AccountJournal(models.Model):
                 existing_method_lines = journal.inbound_payment_method_line_ids
                 default_methods = journal._default_inbound_payment_methods()
                 for pay_method in default_methods:
-                    payment_account = existing_method_lines.filtered(lambda m: m.payment_method_id == pay_method).payment_account_id
+                    payment_account = existing_method_lines.filtered(lambda m: m.payment_method_id == pay_method)[:1].payment_account_id
                     pay_method_line_ids_commands += [
                         Command.create({
                             'name': pay_method.name,
@@ -412,7 +412,7 @@ class AccountJournal(models.Model):
                 existing_method_lines = journal.outbound_payment_method_line_ids
                 default_methods = journal._default_outbound_payment_methods()
                 for pay_method in default_methods:
-                    payment_account = existing_method_lines.filtered(lambda m: m.payment_method_id == pay_method).payment_account_id
+                    payment_account = existing_method_lines.filtered(lambda m: m.payment_method_id == pay_method)[:1].payment_account_id
                     pay_method_line_ids_commands += [
                         Command.create({
                             'name': pay_method.name,

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -454,7 +454,7 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
         outbound_method_lines = bank_journal.outbound_payment_method_line_ids
         outbound_method_lines_names = outbound_method_lines.mapped('name')
         outbound_method_lines[0].payment_account_id = outstanding_payment_account
-        new_outbound_payment_line = outbound_method_lines[0].copy({'payment_account_id': outstanding_payment_account.id})
+        new_outbound_payment_line = outbound_method_lines[0].copy({'payment_account_id': self.company_data['default_account_deferred_expense'].id})
         bank_journal.outbound_payment_method_line_ids = [Command.link(new_outbound_payment_line.id)]
 
         # Set currency_id to trigger the compute of {in,out}bound_payment_method_line_ids


### PR DESCRIPTION
036530a8983e485ac1ad0b9444a6aba01caabc07 introduced a bug, because it
can happen to have 2 (or more) payment method lines from the same payment method.
If these PML have differents payment accounts, we get a singleton error.

Steps:

- On Bank journal, add a new outbound payment method line, which use the
  same payment method as the first default one (it should be 'Manual')
- Set two different payment account for each line
- Then change the currency of the journal
-> Traceback (singleton error)

opw-5384042
