### PR TITLE
[FIX] tools: Don't remove whitespace when transpiling unnamed import

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -522,3 +522,24 @@ return __exports;
 """
 
         self.assertEqual(result, expected_result)
+
+    def test_14_unnamed_import(self):
+        input_content = """
+// first line
+
+import "@test_assetsbundle/some_file";
+"""
+
+        result = transpile_javascript("/test_assetsbundle/static/src/a.js", input_content)
+        expected_result = """odoo.define('@test_assetsbundle/a', ['@test_assetsbundle/some_file'], function (require) {
+'use strict';
+let __exports = {};
+
+// first line
+
+require("@test_assetsbundle/some_file");
+
+return __exports;
+});
+"""
+        self.assertEqual(result, expected_result)

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -621,7 +621,7 @@ def convert_unnamed_relative_import(content):
         // after
         require("some/path")
     """
-    repl = r"require(\g<path>)"
+    repl = r"\g<space>require(\g<path>)"
     return IMPORT_UNNAMED_RELATIVE_RE.sub(repl, content)
 
 


### PR DESCRIPTION
Steps to reproduce
==================

- Create a js file with a blank line followed by an unnamed import

```js
import { mailModels } from "@mail/../tests/mail_test_helpers";

import "@account_accountant/components/bank_reconciliation/list_view/list_view_many2one_multi_edit";
import "@account_accountant/components/bank_reconciliation/list_view/list";
debugger;
```

- Open the devtools

=> The debugger will be off by one line

Cause of the issue
==================

When remplacing unnamed imports by a require statement, the leading whitespace was not preserved.

Solution
========

We add back the captured space. This is done for every other replacement.