### PR TITLE
[FIX] point_of_sale: correctly redirect to splitting order after payment

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
@@ -39,7 +39,7 @@ export class FeedbackScreen extends Component {
                     } finally {
                         this.state.loading = false;
                         this.timeout = setTimeout(() => {
-                            this.pos.orderDone(this.currentOrder);
+                            this.goNext();
                         }, 5000);
                     }
                 };
@@ -77,6 +77,10 @@ export class FeedbackScreen extends Component {
             return;
         }
         clearTimeout(this.timeout);
+        this.goNext();
+    }
+
+    goNext() {
         this.pos.orderDone(this.currentOrder);
     }
 }

--- a/addons/pos_restaurant/static/src/app/screens/feedback_screen/feedback_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/feedback_screen/feedback_screen.js
@@ -1,0 +1,12 @@
+import { FeedbackScreen } from "@point_of_sale/app/screens/feedback_screen/feedback_screen";
+import { patch } from "@web/core/utils/patch";
+
+patch(FeedbackScreen.prototype, {
+    goNext() {
+        if (this.pos.isContinueSplitting(this.currentOrder)) {
+            this.pos.continueSplitting(this.currentOrder);
+        } else {
+            super.goNext();
+        }
+    },
+});

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -3,25 +3,9 @@ import { patch } from "@web/core/utils/patch";
 
 patch(ReceiptScreen.prototype, {
     continueSplitting() {
-        const originalOrderUuid = this.currentOrder.uiState.splittedOrderUuid;
-        this.currentOrder.uiState.screen_data.value = "";
-        this.pos.selectedOrderUuid = originalOrderUuid;
-        const nextOrderScreen = this.pos.getOrder().getCurrentScreenData().name;
-        this.pos.navigate(nextOrderScreen || "ProductScreen", {
-            orderUuid: originalOrderUuid,
-        });
+        return this.pos.continueSplitting(this.currentOrder);
     },
     isContinueSplitting() {
-        if (this.pos.config.module_pos_restaurant && !this.pos.selectedTable) {
-            const splittedOrder = this.currentOrder.originalSplittedOrder;
-
-            if (!splittedOrder) {
-                return false;
-            }
-
-            return !splittedOrder.finalized;
-        } else {
-            return false;
-        }
+        return this.pos.isContinueSplitting(this.currentOrder);
     },
 });

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -1048,7 +1048,28 @@ patch(PosStore.prototype, {
             customer_count: order.getCustomerCount(),
         };
     },
+    continueSplitting(order) {
+        const originalOrderUuid = order.uiState.splittedOrderUuid;
+        order.uiState.screen_data.value = "";
+        this.selectedOrderUuid = originalOrderUuid;
+        const nextOrderScreen = this.getOrder().getCurrentScreenData().name;
+        this.navigate(nextOrderScreen || "ProductScreen", {
+            orderUuid: originalOrderUuid,
+        });
+    },
+    isContinueSplitting(order) {
+        if (this.config.module_pos_restaurant && !this.selectedTable) {
+            const splittedOrder = order.originalSplittedOrder;
 
+            if (!splittedOrder) {
+                return false;
+            }
+
+            return !splittedOrder.finalized;
+        } else {
+            return false;
+        }
+    },
     async validateOrderFast(paymentMethod) {
         const currentOrder = this.getOrder();
         if (!currentOrder) {


### PR DESCRIPTION
Ensure FeedbackScreen uses a unified `goNext()` flow and restore the splitting workflow when `Automatic receipt printing` + `Skip preview screen` are enabled. 
Paying part of a splitted orders now correctly return to the splitting screen instead of the floor plan by delegating the logic to `pos.continueSplitting()` / `pos.isContinueSplitting()` (shared with ReceiptScreen).

task-id: 5405595



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
