### PR TITLE
[FIX] point_of_sale : synchronize orders via button

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -109,7 +109,7 @@ export class PosOrder extends Base {
     }
 
     get isUnsyncedPaid() {
-        return this.finalized && typeof this.id === "string";
+        return this.finalized && typeof this.id === "string" && this.lines.length > 0;
     }
 
     get originalSplittedOrder() {

--- a/addons/point_of_sale/static/src/app/navbar/navbar.scss
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.scss
@@ -48,3 +48,9 @@
 .o-dropdown--menu .dropdown-item.focus {
     background-color: $o-gray-200;
 }
+
+.pending-orders {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+}

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -23,10 +23,11 @@
                     <button class="btn btn-light btn-lg lh-lg" t-if="isBarcodeScannerSupported() and pos.mainScreen.component.name == 'ProductScreen'" t-on-click="onClickScan">
                         <i class="fa fa-fw fa-lg fa-barcode" /><span t-if="this.pos.scanning" class="ms-1">Stop</span>
                     </button>
-                    <div t-if="this.pos.data.network.offline or this.pos.data.network.loading" class="oe_status btn btn-light btn-lg lh-lg h-100 pe-none" t-on-click="onSyncNotificationClick">
-                        <span t-if="this.pos.data.network.unsyncData.length > 0" t-esc="this.pos.data.network.unsyncData.length" /> 
-                        <div t-if="this.pos.data.network.offline" class="fa fa-fw fa-chain-broken text-danger"/>
-                        <div t-else="" class="fa fa-fw fa-spin fa-circle-o-notch text-warning"/>
+                    <div t-if="this.pos.data.network.offline or this.pos.data.network.loading or this.pos.unsyncedOrderCount > 0" class="oe_status pending-orders btn btn-light btn-lg lh-lg h-100" t-on-click="onSyncNotificationClick">
+                        <span t-if="this.pos.unsyncedOrderCount > 0" t-esc="this.pos.unsyncedOrderCount"/>
+                        <div t-if="this.pos.data.network.loading" class="fa fa-fw fa-spin fa-circle-o-notch text-warning"/>
+                        <div t-elif="this.pos.unsyncedOrderCount > 0" class="oe_status_unsync fa fa-fw fa-chain-broken text-danger"/>
+                        <div t-else="" class="oe_status_unsync fa fa-fw fa-rss text-danger"/>
                     </div>
                     <!-- No need to show the cashier name on small screens -->
                     <CashierName t-if="!ui.isSmall"/>

--- a/addons/point_of_sale/static/src/app/navbar/sync_popup/sync_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/sync_popup/sync_popup.js
@@ -16,17 +16,20 @@ export class SyncPopup extends Component {
         this.pos = usePos();
         this.dialog = useService("dialog");
     }
-    getCount(data) {
-        return data.values ? 1 : data.args.length;
+    trySync(orderId) {
+        const orderToSync = this.pos.models["pos.order"]
+            .filter((order) => order.id == orderId)
+            .filter(Boolean);
+        this.pos.syncAllOrders({ orders: orderToSync });
     }
-    delete(uuid) {
+    delete(orderId) {
         this.dialog.add(ConfirmationDialog, {
             title: _t("Delete pending record?"),
             body: _t(
                 "Please note that this operation will result in the loss of any data not saved on the server."
             ),
             confirm: () => {
-                this.pos.data.deleteUnsyncData(uuid);
+                this.pos.removePendingOrder(orderId);
             },
         });
     }

--- a/addons/point_of_sale/static/src/app/navbar/sync_popup/sync_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/sync_popup/sync_popup.xml
@@ -2,38 +2,48 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.SyncPopup">
-        <Dialog class="'p-0'">
+        <Dialog contentClass="'p-0'">
             <t t-set-slot="header">
-                <h4 class="modal-title">Records to synchronize</h4>
-                <div class="total-orders fw-bolder">
-                    Total <t t-esc="pos.data.network.unsyncData.length"/>
+                <div>
+                    <h3 class="modal-title">Records to synchronize</h3>
+                    <div class="total-orders">
+                        <div class="total-orders fw-bolder">
+                            Total <t t-esc="this.pos.unsyncedOrderCount"/>
+                        </div>
+                    </div>
                 </div>
             </t>
             <div class="payment-methods-overview overflow-auto">
                 <div class="w-100">
-                    <t t-foreach="this.pos.data.network.unsyncData" t-as="data" t-key="data_index">
-                        <div class="d-flex align-item-center border rounded mb-1">
-                            <div class="col wide p-2 d-flex flex-column">
-                                <span class="fw-bolder">Model</span>
-                                <span t-esc="data.args[0].model"/>
+                    <t t-set="pendingOrderLists" t-value="this.pos.getPendingOrder()"/>
+
+                    <t t-foreach="pendingOrderLists" t-as="category" t-key="category_index">
+                        <t t-foreach="pendingOrderLists[category]" t-as="order" t-key="order_index">
+                            <div t-if="order.state == 'paid' or order.state == 'done' or order.finalized" class="d-flex align-item-center border rounded mb-1">
+                                <div class="col wide p-2 d-flex flex-column">
+                                    <span class="fw-bolder">Status</span>
+                                    <span t-if="category_index == 0">Deleted</span>
+                                    <span t-elif="category_index == 1">Created</span>
+                                    <span t-else="">Updated</span>
+                                </div>
+                                <div class="col wide p-2 d-flex flex-column">
+                                    <span class="fw-bolder">Name</span>
+                                    <span t-esc="order.name"/>
+                                </div>
+                                <div class="col wide p-2 d-flex flex-column">
+                                    <span class="fw-bolder">Date</span>
+                                    <span t-esc="order.date_order"/>
+                                </div>
+                                <div class="col wide p-2 d-flex flex-column">
+                                    <span class="fw-bolder">Retry</span>
+                                    <i class="fa fa-refresh cursor-pointer" aria-hidden="true" t-on-click="() => this.trySync(order.id)"></i>
+                                </div>
+                                <div class="col p-2 d-flex flex-column">
+                                    <span class="fw-bolder">Delete</span>
+                                    <i class="fa fa-trash cursor-pointer" aria-hidden="true" t-on-click="() => this.delete(order.id)"></i>
+                                </div>
                             </div>
-                            <div class="col wide p-2 d-flex flex-column">
-                                <span class="fw-bolder">Date</span>
-                                <span t-esc="data.date.toFormat('dd/MM/yyyy HH:mm:ss')"/>
-                            </div>
-                            <div class="col wide p-2 d-flex flex-column">
-                                <span class="fw-bolder">Count</span>
-                                <span t-esc="this.getCount(data.args[0])"/>
-                            </div>
-                            <div class="col wide p-2 d-flex flex-column">
-                                <span class="fw-bolder">Retry</span>
-                                <span t-esc="data.try"/>
-                            </div>
-                            <div class="col p-2 d-flex flex-column">
-                                <span class="fw-bolder">Delete</span>
-                                <i class="fa fa-trash cursor-pointer" aria-hidden="true" t-on-click="() => this.delete(data.uuid)"></i>
-                            </div>
-                        </div>
+                        </t>
                     </t>
                 </div>
             </div>

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -61,7 +61,7 @@ export function endTour() {
 }
 export function isSyncStatusConnected() {
     return {
-        trigger: negate(".oe_status", ".pos-rightheader .status-buttons"),
+        trigger: negate(".oe_status_unsync", ".pos-rightheader .status-buttons"),
     };
 }
 export function clickPlanButton() {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -368,4 +368,22 @@ patch(PosStore.prototype, {
     get showSaveOrderButton() {
         return super.showSaveOrderButton && !this.config.module_pos_restaurant;
     },
+
+    //@override
+    get unsyncedOrderCount() {
+        if (!this.config.module_pos_restaurant) {
+            return super.unsyncedOrderCount;
+        }
+        const pendingIds = new Set([...this.pendingOrder.create, ...this.pendingOrder.write]);
+
+        const unsyncedCount = this.models["pos.order"]
+            .filter(
+                (order) =>
+                    pendingIds.has(order.id) &&
+                    (order.state === "paid" || order.state === "done" || order.finalized)
+            )
+            .filter(Boolean).length;
+
+        return unsyncedCount + this.pendingOrder.delete.size;
+    },
 });


### PR DESCRIPTION
The pending orders indicator never display the unsynchronized orders when the device is online, even if some exist. When offline, the number of pending orders isn't displayed because of the array `network.unsyncData` never populated.

The following changes were introduced:
 * The unsynchronized order count is now consistently displayed if superior to 0, regardless of the device's online status.
 * The pending orders icon can now be used to force a synchronization of all pending orders.
 * A synchronization check is added prior to showing the session close popup to guarantee session resume data is up-to-date.

[opw-5352388](https://www.odoo.com/odoo/project/49/tasks/5352388)