### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: add pagination for fetching

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -1,4 +1,5 @@
 import uuid
+from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 from urllib.parse import quote, urlencode, urlparse
 
@@ -205,27 +206,75 @@ class AccountMove(models.Model):
                     else:
                         invoice.message_post(body=_("The invoice status couldn't be retrieved from Nilvera."))
 
+    def _get_nilvera_last_fetch_date(self, invoice_channel):
+        """
+        Fetches the last fetched date for Nilvera e-invoice synchronization specific to the
+        current company. If no value exists, it sets a default date of one month prior to
+        the current date, stores it, and returns it.
+        """
+        # A config param is used to be able to store the date in stable. One for einvoice and one for earchive.
+        # Should be removed in master and replaced with two date fields on the company.
+        param_key = f"l10n_tr_nilvera_{invoice_channel}.last_fetched_date.{self.env.company.id}"
+        last_fetched_date = self.env['ir.config_parameter'].sudo().get_param(param_key)
+        if not last_fetched_date:
+            last_fetched_date = (fields.Date.today() - relativedelta(months=1)).strftime("%Y-%m-%d")
+            self.env['ir.config_parameter'].sudo().set_param(param_key, last_fetched_date)
+        return last_fetched_date
+
     def _l10n_tr_nilvera_get_documents(self, invoice_channel="einvoice", document_category="Purchase", journal_type="in_invoice"):
         with _get_nilvera_client(self.env.company) as client:
-            response = client.request("GET", f"/{invoice_channel}/{quote(document_category)}", params={"StatusCode": ["succeed"]})
-            if not response.get('Content'):
+            endpoint = f"/{invoice_channel}/{quote(document_category)}"
+            start_date = self._get_nilvera_last_fetch_date(invoice_channel)
+            end_date = fields.Datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+            page = 1
+
+            # We filter documents by their CreatedDate on Nilvera, which represents when the document was created on
+            # their platform. This ensures we always fetch the most recently uploaded documents, regardless of their
+            # actual invoicing date (which might be much older).
+            # The sorting allows us to resume from the last successfully fetched document in case an error interrupts
+            # the batch fetching process.
+            params = {
+                'StatusCode': ['succeed'],
+                'StartDate': start_date,
+                'EndDate': end_date,
+                'DateFilterType': 'CreatedDate',
+                'SortColumn': 'CreationDateTime',
+                'SortType': 'ASC',
+            }
+            response = client.request("GET", endpoint, params={**params, "Page": page})
+            total_pages = response.get("TotalPages")
+            if not total_pages:
                 return
 
-            journal = self._l10n_tr_get_nilvera_invoice_journal(journal_type)
-            response_document_uuids = [content.get('UUID') for content in response.get('Content')]
-            existing_document_uuids = self.env['account.move'].search([
-                ('l10n_tr_nilvera_uuid', 'in', response_document_uuids),
-            ]).mapped('l10n_tr_nilvera_uuid')
             moves = self.env['account.move']
+            journal = self._l10n_tr_get_nilvera_invoice_journal(journal_type)
+            date_param_key = f"l10n_tr_nilvera_{invoice_channel}.last_fetched_date.{self.env.company.id}"
+            while page <= total_pages:
+                # Reuse first response, fetch subsequent pages.
+                if page > 1:
+                    response = client.request("GET", endpoint, params={**params, "Page": page})
 
-            for document_uuid in response_document_uuids:
-                # Skip invoices that have already been downloaded.
-                if document_uuid in existing_document_uuids:
-                    continue
-                move = self._l10n_tr_nilvera_get_invoice_from_uuid(client, journal, document_uuid, document_category, invoice_channel)
-                self._l10n_tr_nilvera_add_pdf_to_invoice(client, move, document_uuid, document_category, invoice_channel)
-                moves |= move
-                self.env.cr.commit()
+                uuid_to_created_date = {
+                    content.get('UUID'): content.get('CreatedDate')
+                    for content in response.get('Content')
+                }
+                existing_document_uuids = {
+                    rec['l10n_tr_nilvera_uuid'] for rec in self.env['account.move'].search_read(
+                        [('l10n_tr_nilvera_uuid', 'in', list(uuid_to_created_date))],
+                        ['l10n_tr_nilvera_uuid'],
+                    )
+                }
+                for document_uuid, created_date in uuid_to_created_date.items():
+                    # Skip invoices that have already been downloaded.
+                    if document_uuid in existing_document_uuids:
+                        continue
+                    move = self._l10n_tr_nilvera_get_invoice_from_uuid(client, journal, document_uuid, document_category, invoice_channel)
+                    self._l10n_tr_nilvera_add_pdf_to_invoice(client, move, document_uuid, document_category, invoice_channel)
+                    moves |= move
+                    # Update the last fetched date.
+                    self.env['ir.config_parameter'].sudo().set_param(date_param_key, created_date)
+                    self.env.cr.commit()
+                page += 1
             journal._notify_einvoices_received(moves)
 
     def _l10n_tr_get_nilvera_invoice_journal(self, journal_type):


### PR DESCRIPTION
Nilvera returns documents in pages of 30 items and, when no date range is provided, only returns documents created within the last week.
As a result, _l10n_tr_nilvera_get_documents only processed the first page of recent documents.

This commit introduces a full pagination and incremental-fetching mechanism:
- Provide explicit StartDate and EndDate parameters.
- Store the last successfully fetched CreatedDate per company in an ir.config_parameter to allow resuming after interruptions.
- Fetch pages in ascending CreationDateTime order.

This ensures all documents are fetched, in order, without duplication and without reprocessing previously downloaded data.

task-5186428