### PR TITLE
[IMP] mail: improve discuss sidebar category title style

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.scss
@@ -23,6 +23,12 @@
         .o-mail-DiscussSidebarCategory-actions {
             visibility: hidden;
         }
+        .o-mail-DiscussSidebarCategory-title {
+            color: $text-muted;
+        }
+        &:has(.o-mail-DiscussSidebarCategory-chevronCompact) .o-mail-DiscussSidebarCategory-toggler {
+            color: $text-muted !important;
+        }
     }
 
 }
@@ -34,7 +40,7 @@
 }
 
 .o-mail-DiscussSidebarCategory-chevronCompact {
-    left: - map-get($spacers, 1)/2;
+    left: map-get($spacers, 1)/2;
 }
 
 .o-mail-DiscussSidebarCategory-toggler {
@@ -42,6 +48,6 @@
         font-size: .65rem;
     }
     &:not(.o-compact) {
-        line-height: 2.35; // so that same height as actions, so folding doesn't resize
+        line-height: 2; // so that same height as actions, so folding doesn't resize
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
@@ -14,21 +14,21 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.main">
-        <div class="o-mail-DiscussSidebarCategory position-relative d-flex align-items-center rounded opacity-trigger-hover ps-1" t-att-class="{ 'mx-2 my-1 position-relative': store.discuss.isSidebarCompact, 'mt-1 ms-4 me-2 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
+        <div class="o-mail-DiscussSidebarCategory position-relative d-flex align-items-center rounded opacity-trigger-hover" t-att-class="{ 'mx-2 my-1 ps-1 position-relative': store.discuss.isSidebarCompact, 'mt-1 mx-2 o-ps-1_5 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start" t-att-class="{ 'align-items-baseline o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
-                    <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xsmaller o-mt-0_5" t-att-class="{
+                    <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller o-mt-0_5" t-att-class="{
                         'oi oi-chevron-down': category.is_open,
                         'oi oi-chevron-right': !category.is_open,
                     }"/>
                     <span class="rounded p-1"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
-                    <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50 o-mt-0_5"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller fa-fw position-absolute ms-n3 align-self-center o-mt-0_5" t-att-class="category.is_open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                     <span class="o-mail-DiscussSidebarCategory-title text-break smaller d-flex align-items-center" t-att-class="{ 'fs-bold': category.open }">
                         <t name="titleText" t-esc="category.name"/>
                     </span>
+                    <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50 ps-1"/></span>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa-fw align-self-center ps-1" t-att-class="category.is_open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 </t>
             </button>
             <t t-if="actions.length and !store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCategory.actions"/>


### PR DESCRIPTION
This PR makes the following changes:

1. mute category color when not mouse-hovering
2. reduce height of category item
3. move chevron on right on name rather than left

Motivation for changes:

1. better contrast of category and items, making it easier to visually see difference between category and channel items.
2. category vertical footprint is reduced and also looks better when folded.
3. chevron on right allows to align text, and also new position feels more natural with the translate animation on mouse-hover

Task-5410962

Before / After (white theme)
<img width="302" height="578" alt="Screenshot 2025-12-10 at 18 36 34" src="https://github.com/user-attachments/assets/da5cd355-cf3d-4880-b68d-c34197725344" /> <img width="302" height="579" alt="Screenshot 2025-12-10 at 18 36 46" src="https://github.com/user-attachments/assets/73634547-8fca-4f39-83ff-8813be851544" />



Before / After (dark theme)
<img width="301" height="573" alt="Screenshot 2025-12-10 at 18 26 18" src="https://github.com/user-attachments/assets/fa4eb637-8e06-469c-b9f9-2e62cedd981f" /> <img width="305" height="577" alt="Screenshot 2025-12-10 at 18 33 00" src="https://github.com/user-attachments/assets/08d58c14-81d6-43f3-9d1d-ecbf46d86c79" />
