### PR TITLE
[FIX] stock: prevent KeyError for packaging_qty_ordered in delivery slip

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -954,6 +954,8 @@ class StockMoveLine(models.Model):
                 aggregated_move_lines[line_key] = {
                     **aggregated_properties,
                     'quantity': False,
+                    'packaging_quantity': 0,
+                    'packaging_qty_ordered': 0,
                     'qty_ordered': qty_ordered,
                     'product': empty_move.product_id,
                 }

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -282,14 +282,12 @@
                 </t>
             </td>
             <td class="text-end" name="move_line_aggregated_quantity">
-                <t t-if="aggregated_lines[line]['quantity']">
-                    <span t-out="format_number(aggregated_lines[line]['quantity'])"/>
-                    <span t-out="aggregated_lines[line]['product_uom'].name"/>
-                    <t t-if="aggregated_lines[line]['packaging_uom_id'] != aggregated_lines[line]['product_uom']" groups="uom.group_uom">
-                        <br/>
-                        <span class="text-muted" t-out="aggregated_lines[line]['packaging_quantity']">1.00</span>
-                        <span class="text-muted" t-out="aggregated_lines[line]['packaging_uom_id'].name">Pack of 6</span>
-                    </t>
+                <span t-out="format_number(aggregated_lines[line]['quantity'])"/>
+                <span t-out="aggregated_lines[line]['product_uom'].name"/>
+                <t t-if="aggregated_lines[line]['packaging_uom_id'] != aggregated_lines[line]['product_uom']" groups="uom.group_uom">
+                    <br/>
+                    <span class="text-muted" t-out="aggregated_lines[line]['packaging_quantity']">1.00</span>
+                    <span class="text-muted" t-out="aggregated_lines[line]['packaging_uom_id'].name">Pack of 6</span>
                 </t>
             </td>
         </tr>

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6630,3 +6630,56 @@ class TestStockMove(TestStockCommon):
         self.assertEqual(picking.move_line_ids.lot_id, lot2)
         picking.button_validate()
         self.assertEqual(picking.move_ids.lot_ids, lot2)
+
+    def test_delivery_slip_aggregated_lines_with_canceled_move_and_packaging(self):
+        """
+        Ensure that the delivery slip report correctly aggregates product quantities
+        when a picking contains both a completed move and a canceled move that uses
+        packaging units.
+        - two products are ordered in packaging (e.g., 1 pack of 6)
+        - the picking is split, causing one move to be fulfilled and the other canceled
+        - the canceled move still contributes packaging information (ordered quantity)
+        The report must not crash and must return consistent aggregated values.
+        """
+        pack_of_6 = self.env.ref('uom.product_uom_pack_6')
+        # upodate the quantity of product A
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 6)
+        picking = self.env['stock.picking'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.productA.id,
+                    'product_uom_qty': 1,
+                    'product_uom': pack_of_6.id,
+                    'location_id': self.stock_location.id,
+                    'location_dest_id': self.customer_location.id,
+                }),
+                Command.create({
+                    'product_id': self.productB.id,
+                    'product_uom_qty': 1,
+                    'product_uom': pack_of_6.id,
+                    'location_id': self.stock_location.id,
+                    'location_dest_id': self.customer_location.id,
+                }),
+            ],
+        })
+        picking.action_confirm()
+        self.assertEqual(picking.move_ids.mapped('quantity'), [1.0, 0])
+        picking.action_split_transfer()
+        backorder = picking.backorder_ids
+        backorder.action_cancel()
+        picking.button_validate()
+        self.assertEqual(backorder.state, 'cancel')
+        self.assertEqual(picking.state, 'done')
+        aggregate_values = picking.move_line_ids._get_aggregated_product_quantities()
+        self.assertEqual(len(aggregate_values), 2)
+        aggregate_val_1 = aggregate_values[f'{self.productA.id}_{self.productA.name}__{pack_of_6.id}_{pack_of_6.id}']
+        aggregate_val_2 = aggregate_values[f'{self.productB.id}_{self.productB.name}__{pack_of_6.id}_{pack_of_6.id}']
+        self.assertEqual(aggregate_val_1['qty_ordered'], 1.0)
+        self.assertEqual(aggregate_val_1['quantity'], 1.0)
+        self.assertEqual(aggregate_val_1['packaging_qty_ordered'], 1.0)
+        self.assertEqual(aggregate_val_2['qty_ordered'], 1.0)
+        self.assertEqual(aggregate_val_2['quantity'], 0)
+        self.assertEqual(aggregate_val_2['packaging_qty_ordered'], 0.0)


### PR DESCRIPTION
Steps to reproduce:
- Create a Sale Order with two products:
    - P1 -> 1 pack of 6
    - P2 -> 1 pack of 6

- Confirm the SO to generate the picking
- Set qty_done of product P1 to 1 pack and P2 to 0 pack
- Split the picking into two pickings
- Validate the picking containing P1 and cancel the one containing P2
- Try to Open the delivery slip from P1 picking → KeyError:

Problem:
raise QWebError(qweb_error_info) from error
odoo.addons.base.models.ir_qweb.QWebError: Error while rendering the template:
 KeyError: 'packaging_qty_ordered'
 Template: stock.stock_report_delivery_aggregated_move_lines

The KeyError occurs because _get_aggregated_product_quantities() builds
aggregation in two steps: first for move lines in the initial picking,
then for moves from the backorder pickings, especially empty/canceled moves.
In this second pass, the code sets quantity and
qty_ordered, but does not set packaging_qty_ordered. This makes the
aggregated entry incomplete, and the QWeb report crashes when accessing
this missing key.

Before the change in xml:
<img width="1919" height="648" alt="2025-12-11_17-08" src="https://github.com/user-attachments/assets/d2f709af-7f63-4ea7-b615-5ce23291c45d" />

after:
<img width="1919" height="697" alt="2025-12-11_17-07" src="https://github.com/user-attachments/assets/49d8406f-d64a-412e-9fdf-fa24fce46276" />

opw-5365832