### PR TITLE
[FIX] mrp_subcontracting{_purchase}: handle a chain of multiple subcontract returns

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -347,6 +347,11 @@ class StockMove(models.Model):
         subcontracting_location = self.picking_id.partner_id.with_company(self.company_id).property_stock_subcontractor
         return (
                 not self.is_subcontract
-                and self.origin_returned_move_id.is_subcontract
+                and self._is_previous_move_subcontract()
                 and self.location_dest_id.id == subcontracting_location.id
         )
+
+    def _is_previous_move_subcontract(self):
+        if not self.group_id:
+            return False
+        return any(move.is_subcontract and move.product_id == self.product_id for move in self.group_id.stock_move_ids)


### PR DESCRIPTION
Problem: If a customer ends up returning their subcontracted products and then creates a second return to receive the products again the received quantity on the purchase order line updates correctly. However, if they return the second receipt, then it increases the received quantity on the purchase order line instead of decreasing it.

Purpose: This will allow a customer to process a chain of returns for subcontracted products while keeping the received quantity correct.

I have removed the check for origin_returned_move_id because of the
return for an exchange workflow in Odoo 18.0. This field does not get
set because the exchange moves should be independent of their origin moves.

Steps to Reproduce on Runbot:
1. Create a purchase order for a subcontracted product.
2. Validate the receipt on the purchase order.
3. Return the receipt and validate it.
4. Create a return of the previous return and receive the products again.
5. Create a return of the return from the previous step and validate it.
6. Observe the received quantity on the purchase order line increased instead of decreasing after step 5.

opw-4839366

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
