### PR TITLE
Handle missing payment_stripe module gracefully

### DIFF
--- a/addons/payment/models/res_country.py
+++ b/addons/payment/models/res_country.py
@@ -1,7 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-import odoo.addons.payment_stripe as stripe  # prevent circular import error with payment_stripe
+try:
+    import odoo.addons.payment_stripe as stripe  # prevent circular import error with payment_stripe
+except ModuleNotFoundError:
+    stripe = None
 
 
 class ResCountry(models.Model):
@@ -12,6 +15,9 @@ class ResCountry(models.Model):
     @api.depends('code')
     def _compute_is_stripe_supported_country(self):
         for country in self:
-            country.is_stripe_supported_country = stripe.const.COUNTRY_MAPPING.get(
-                country.code, country.code
-            ) in stripe.const.SUPPORTED_COUNTRIES
+            country.is_stripe_supported_country = (
+                stripe is not None
+                and stripe.const.COUNTRY_MAPPING.get(
+                    country.code, country.code
+                ) in stripe.const.SUPPORTED_COUNTRIES
+            )

--- a/doc/cla/individual/merlinz01.md
+++ b/doc/cla/individual/merlinz01.md
@@ -1,0 +1,11 @@
+United States, 2025-12-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Merlin Zimmerman 158784988+merlinz01@users.noreply.github.com https://github.com/merlinz01


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The `payment` module does not declare a dependency on the `payment_stripe` module but the code implicitly depends on it. This makes a problem in optimized deployments where the `payment_stripe` module is not included.

Current behavior before PR:

Optimized Odoo deployments without `payment_stripe` fail to start because of a `ModuleNotFoundError`.

Desired behavior after PR is merged:

If the module is not available, the import error is silently ignored and the `is_stripe_supported_country` calculation returns `False`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
