### PR TITLE
[FIX] stock_account: prevent infinite recursion in FIFO valuation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -230,7 +230,10 @@ class ProductProduct(models.Model):
         valued_qty = last_in._get_valued_qty()
         if not valued_qty:
             return self.standard_price
-        return last_in._get_value(at_date=date) / valued_qty
+        # Pass current standard_price as fallback to prevent infinite recursion.
+        # Without this, _get_value_from_std_price would call _get_standard_price_at_date
+        # again, creating an infinite loop when no other valuation source is available.
+        return last_in._get_value(at_date=date, forced_std_price=self.standard_price) / valued_qty
 
     def _get_value_from_lots(self):
         lots = self.env['stock.lot'].search([


### PR DESCRIPTION
When calculating the standard price at a specific date for FIFO products, _get_standard_price_at_date calls last_in._get_value(at_date=date) to get the value of the last incoming move. If this move doesn't have a value from invoices, quotations, or other sources, _get_value_from_std_price is called, which in turn calls _get_standard_price_at_date again, creating an infinite recursion loop.

This happens when:
- Products have stock moves without proper cost/price information
- No invoices or quotations are linked to the moves
- The product's standard_price is zero or not set

The fix passes the current standard_price as a fallback (forced_std_price) when calling _get_value. This ensures that if no other valuation source is available, the current standard_price is used instead of recursively calling _get_standard_price_at_date.

Traceback pattern before fix:
_get_standard_price_at_date -> _get_value -> _get_value_data -> _get_value_from_std_price -> _get_standard_price_at_date -> (infinite loop)

closes odoo/odoo #239564

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
