### PR TITLE
[FIX] sale_purchase,stock_dropshipping: avoid duplicate activities on PO

### DIFF
--- a/addons/sale_purchase/models/sale_order.py
+++ b/addons/sale_purchase/models/sale_order.py
@@ -60,7 +60,11 @@ class SaleOrder(models.Model):
         """
         purchase_to_notify_map = {}  # map PO -> recordset of SOL as {purchase.order: set(sale.orde.liner)}
 
-        purchase_order_lines = self.env['purchase.order.line'].search([('sale_line_id', 'in', self.mapped('order_line').ids), ('state', '!=', 'cancel')])
+        purchase_order_lines = self.env['purchase.order.line'].search([
+            ('sale_line_id', 'in', self.mapped('order_line').ids),
+            ('state', '!=', 'cancel'),
+            ('product_id.service_to_purchase', '=', True),
+        ])
         for purchase_line in purchase_order_lines:
             purchase_to_notify_map.setdefault(purchase_line.order_id, self.env['sale.order.line'])
             purchase_to_notify_map[purchase_line.order_id] |= purchase_line.sale_line_id

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -587,3 +587,23 @@ class TestDropshipPostInstall(common.TransactionCase):
         return_picking.button_validate()
         self.assertEqual(sale_order.order_line.qty_delivered, 0)
         self.assertEqual(purchase_order.order_line.qty_received, 0)
+
+    def test_so_cancel_creates_one_activity_on_po(self):
+        """
+        Create Sale order with dropshipping product, confirm it, confirm the generated
+        purchase order, then cancel the sale order. This should create an activity on the
+        purchase order.
+        """
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': self.dropship_product.id,
+            })],
+        })
+        sale_order.action_confirm()
+        purchase_order = self.env['purchase.order'].search([
+            ('origin', '=', sale_order.name)
+        ], limit=1)
+        purchase_order.button_confirm()
+        sale_order._action_cancel()
+        self.assertEqual(len(purchase_order.activity_ids), 1)


### PR DESCRIPTION
**Steps to Reproduce**

* Install `sale_management`, `purchase`, and `stock` with demo data.
* In Inventory → Settings, enable `Dropshipping`.
* Create a product: 
     * Set a vendor under the Purchase tab. 
     * Set routes to `Dropshipping` and `Buy`
* Create and confirm a sale order for this product.
* Confirm the generated purchase order.
* Cancel the originating sale order.
* Go back to the linked purchase order.

**Observed behavior**

* Two activities are created on the purchase order when the sale order is cancelled.

**Cause**

* Both templates — `exception_on_so` (from sale_stock) and
`exception_purchase_on_sale_cancellation` (from sale_purchase) 
are triggered during sale order cancellation.

* Each module overrides `_action_cancel` and triggers its corresponding exception template.

* When both modules are installed, both templates run.

https://github.com/odoo/odoo/blob/98da30375a5ae50a77d848b838781aa7247bd362/addons/sale_purchase/models/sale_order.py#L26-L32

https://github.com/odoo/odoo/blob/98da30375a5ae50a77d848b838781aa7247bd362/addons/sale_stock/models/sale_order.py#L206-L208

* The template `exception_purchase_on_sale_cancellation` should only be triggered
when the PO originates from an SO and the product is a service, but
the domain lacks the required product-type condition.

**Fix**

* Add the missing condition to ensure that `exception_purchase_on_sale_cancellation`
is not triggered for dropshipped products, preventing duplicate activities.

---
`NOTE` - This issue is resolved from version 19.0 in this [commit](https://github.com/odoo/odoo/pull/212679/changes/ede2898278220a3ba4d8910ef268fe59f1587c72)

---
opw-5153488

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
