### PR TITLE
[FIX] hr_attendance: prevent deletion of default overtime rules

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -451,3 +451,19 @@ class HrAttendanceOvertimeRule(models.Model):
                     )
                     continue
                 rule.information_display = timing_types[rule.timing_type]
+
+    @api.ondelete(at_uninstall=False)
+    def _check_default_overtime_rules_on_unlink(self):
+        xml_ids = [
+            'hr_attendance.hr_attendance_overtime_employee_schedule_rule',
+            'hr_attendance.hr_attendance_overtime_non_working_days_rule',
+        ]
+        for xml_id in xml_ids:
+            rule = self.env.ref(xml_id, raise_if_not_found=False)
+            if rule and rule in self:
+                raise ValidationError(
+                    self.env._(
+                        "You cannot delete the overtime rule '%s' because it is a part of default overtime ruleset.\nArchive the Ruleset instead.",
+                        rule.name,
+                    )
+                )


### PR DESCRIPTION
Currently, an error occurs when user tries to upgrade `hr_attendance` module while the overtime rules from default ruleset are missing.

Steps to replicate:
- Install `hr_work_entry_attendance`.
- Open `Attendance > Configuration > Overtime Rulesets`.
- Open the default ruleset and delete all the Overtime rules.
- Upgrade `hr_attendance`.

Error:
```
ParseError: while parsing /home/odoo/src/odoo/19.0/addons/hr_attendance/data/hr_attendance_overtime_rule_data.xml:4, somewhere inside
<record id=hr_attendance_overtime_employee_schedule_rule model=hr.attendance.overtime.rule>
            <field name=name>Employee Schedule Rule</field>
            <field name=base_off>quantity</field>
            <field name=timing_type>schedule</field>
            <field name=expected_hours_from_contract eval=True/>
            <field name=paid eval=True/>
            <field name=ruleset_id ref=hr_attendance_default_ruleset/>
        </record>

CheckViolation: new row for relation hr_attendance_overtime_rule violates check constraint hr_attendance_overtime_rule_if_paid_work_entry_type_defined
DETAIL:  Failing row contains (1, null, 10, 1, 1, 1, Employee Schedule Rule, quantity, schedule, day, null, t, t, 2025-12-10 08:40:10.431738, 2025-12-10 08:40:10.431738, 0, 24, null, 1, null, null, null, null).
```

Cause:
- As the record was deleted, it would be created back during the module upgrade. But because only `hr_attendance` was upgraded the record will be created without `work_entry_type_id` [1] (because it exists in the module `hr_work_entry_attendance`) that will cause the checkviolation through the [constraint].

Solution:
- Prevent the deletion of rules in the default ruleset as if the user deletes the ruleset, it completely defeats the purpose of this [PR].

[1]: https://github.com/odoo/odoo/blob/f42a41610d8dbe1906ea4dd45f49d10adefc94ae/addons/hr_attendance/data/hr_attendance_overtime_rule_data.xml#L4-L21

[constraint]: https://github.com/odoo/enterprise/blob/d9c864a5a55dd45f6fed794a809a5aefe26e7699/hr_work_entry_attendance/models/hr_attendance_overtime_rule.py#L24-L27

[PR]: https://github.com/odoo/enterprise/pull/95421

sentry-7098419330
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
