### PR TITLE
[FIX] html_editor: hide toolbar for collapsed selection after an image

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -107,10 +107,7 @@ export class ImagePlugin extends Plugin {
             (targetedNodes) => {
                 if (
                     targetedNodes.length &&
-                    targetedNodes.every(
-                        // All nodes should be images or its ancestors
-                        (node) => node.nodeName === "IMG" || node.querySelector?.("img")
-                    )
+                    targetedNodes.every((node) => node.nodeName === "IMG")
                 ) {
                     return this.toolbarNamespace;
                 }

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -491,7 +491,7 @@ test("Can delete an image", async () => {
 test("Deleting an image that is alone inside `p` should set selection at start of `p`", async () => {
     const { el } = await setupEditor(`<p><img>[]</p>`);
     await click("img");
-    await waitFor(".o-we-toolbar");
+    await waitFor('.o-we-toolbar[data-namespace="image"');
     expect("button[name='image_delete']").toHaveCount(1);
     await click("button[name='image_delete']");
     await animationFrame();
@@ -504,7 +504,7 @@ test("Deleting an image that is alone inside `p` should set selection at start o
 test("Deleting an image that is the only content inside a <p> tag should place the selection at the start of the <p>", async () => {
     const { el } = await setupEditor(`<p>abc<img>[]</p>`);
     await click("img");
-    await waitFor(".o-we-toolbar");
+    await waitFor('.o-we-toolbar[data-namespace="image"');
     expect("button[name='image_delete']").toHaveCount(1);
     await click("button[name='image_delete']");
     await animationFrame();

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1232,6 +1232,13 @@ test("toolbar should open with image namespace the selection spans an image and 
     expect(queryAll(".o-we-toolbar .btn-group[name='decoration']").length).toBe(0);
 });
 
+test.tags("desktop");
+test("toolbar should not be visible for collapsed selection after image", async () => {
+    await setupEditor(`<p><img class="img-fluid" src="/web/static/img/logo.png">[]</p>`);
+    await animationFrame();
+    await expectElementCount(".o-we-toolbar", 0);
+});
+
 test("plugins can create buttons with text in toolbar", async () => {
     class TestPlugin extends Plugin {
         static id = "TestPlugin";


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

The toolbar was shown when the cursor (collapsed selection) was positioned after an image.

Desired behavior after PR is merged:

A collapsed selection placed after an image no longer displays the toolbar.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
