### PR TITLE
[FIX] hr_work_entry: make country filter functional in work entries

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -37,7 +37,7 @@ class HrWorkEntry(models.Model):
         default=lambda self: self.env.company)
     conflict = fields.Boolean('Conflicts', compute='_compute_conflict', store=True)  # Used to show conflicting work entries first
     department_id = fields.Many2one('hr.department', related='employee_id.department_id', store=True)
-    country_id = fields.Many2one('res.country', related='employee_id.company_id.country_id')
+    country_id = fields.Many2one('res.country', related='employee_id.company_id.country_id', search='_search_country_id')
 
     # There is no way for _error_checking() to detect conflicts in work
     # entries that have been introduced in concurrent transactions, because of the transaction
@@ -247,6 +247,9 @@ class HrWorkEntry(models.Model):
                 # New work entries are handled in the create method,
                 # no need to reload work entries.
                 work_entries.exists()._check_if_error()
+
+    def _search_country_id(self, operator, value):
+        return [('employee_id.company_id.partner_id.country_id', operator, value)]
 
 
 class HrWorkEntryType(models.Model):


### PR DESCRIPTION
Issue:
The country_id related field on work entries was not stored, causing domain filters and search on this field to fail and triggering client-side errors.

Fix:
Use search parameter on field to write function so field can be used safely in search domains and filters.

Impact:
Country-based filtering now works correctly without triggering module loader errors.

Task: 5406904
