### PR TITLE
[FIX] purchase_stock: make catalog search options translatable

### DIFF
--- a/addons/purchase_stock/static/src/product_catalog/search/search_panel.js
+++ b/addons/purchase_stock/static/src/product_catalog/search/search_panel.js
@@ -9,15 +9,15 @@ export class PurchaseSuggestCatalogSearchPanel extends AccountProductCatalogSear
     static template = "purchase_stock.ProductCatalogSearchPanel";
     static components = { TimePeriodSelectionField };
     static basedOnOptions = [
-        ["actual_demand", "Forecasted"],
-        ["one_week", "Last 7 days"],
-        ["30_days", "Last 30 days"],
-        ["three_months", "Last 3 months"],
-        ["one_year", "Last 12 months"],
-        ["last_year", "Same month last year"],
-        ["last_year_m_plus_1", "Next month last year"],
-        ["last_year_m_plus_2", "After next month last year"],
-        ["last_year_quarter", "Last year quarter"],
+        ["actual_demand", _t("Forecasted")],
+        ["one_week", _t("Last 7 days")],
+        ["30_days", _t("Last 30 days")],
+        ["three_months", _t("Last 3 months")],
+        ["one_year", _t("Last 12 months")],
+        ["last_year", _t("Same month last year")],
+        ["last_year_m_plus_1", _t("Next month last year")],
+        ["last_year_m_plus_2", _t("After next month last year")],
+        ["last_year_quarter", _t("Last year quarter")],
     ];
 
     setup() {


### PR DESCRIPTION
When adding the search options in the catalog view[^1], the labels were not made translatable. This commit wraps the labels with the _t function to ensure they can be translated into different languages.

[^1]: https://github.com/odoo/odoo/commit/96dc626f8d489817c944420178c22dba5c916799