### PR TITLE
[FIX] pos_{loyalty, sale_loyalty}: customer loading while applying code

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -239,9 +239,9 @@ patch(PosStore.prototype, {
             (rule) =>
                 rule.mode === "with_code" && (rule.promo_barcode === code || rule.code === code)
         );
-        const partnerId = await this.data.call("loyalty.card", "get_loyalty_card_partner_by_code", [
-            code,
-        ]);
+        const partnerId = (
+            await this.data.call("loyalty.card", "get_loyalty_card_partner_by_code", [code])
+        )?.[0];
         let claimableRewards = null;
         let coupon = null;
         // If the code belongs to a loyalty card we just set the partner
@@ -252,6 +252,7 @@ patch(PosStore.prototype, {
 
             const partner = this.models["res.partner"].get(partnerId);
             order.setPartner(partner);
+            await this.updateRewards();
         } else if (rule) {
             const date_order = DateTime.fromSQL(order.date_order);
             if (

--- a/addons/pos_sale_loyalty/static/tests/tours/pos_sale_loyalty_tour.js
+++ b/addons/pos_sale_loyalty/static/tests/tours/pos_sale_loyalty_tour.js
@@ -4,6 +4,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as PosSale from "@pos_sale/../tests/tours/utils/pos_sale_utils";
+import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosSaleLoyaltyTour1", {
@@ -27,5 +28,19 @@ registry.category("web_tour.tours").add("test_pos_sale_loyalty_ignored_in_pos", 
             Dialog.confirm("Open Register"),
             PosSale.settleNthOrder(1),
             ProductScreen.totalAmountIs(90),
+        ].flat(),
+});
+registry.category("web_tour.tours").add("test_sale_order_loyalty_card_can_be_used_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            PosLoyalty.enterCode("LOYALTY123"),
+            ProductScreen.customerIsSelected("partner_a"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });


### PR DESCRIPTION
Steps:
------------
- Install pos_sale_loyalty.
- Create a loyalty program of type loyalty, available for both Sales and POS.
- Create a sale order with simultaneous customer creation and confirm it.
- Open POS and enter code of the loyalty card generated from the sale order.

Issue:
------------
- A traceback occurs with: Error: Invalid ids list.

Cause:
------------
- A list of partner IDs was passed, where a single partner ID was expected.

Fix:
------------
- Extract and pass the correct partner ID instead of the full partner ID list.

Task-5388341
