### PR TITLE
[FIX] account: Fix order of lines in _split_base_lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3360,16 +3360,15 @@ class AccountTax(models.Model):
         new_tax_details_list = self._split_tax_details(base_line, company, target_factors)
 
         # Split 'base_line'.
-        new_base_lines = []
-        for (_index, factor), new_tax_details, target_factor in zip(factors, new_tax_details_list, target_factors):
+        new_base_lines = [None] * len(factors)
+        for (index, factor), new_tax_details, target_factor in zip(factors, new_tax_details_list, target_factors):
             kwargs = {
                 'price_unit': factor * base_line['price_unit'],
                 'tax_details': new_tax_details,
             }
             if populate_function:
                 populate_function(base_line, target_factor, kwargs)
-            new_base_line = self._prepare_base_line_for_taxes_computation(base_line, **kwargs)
-            new_base_lines.append(new_base_line)
+            new_base_lines[index] = self._prepare_base_line_for_taxes_computation(base_line, **kwargs)
         return new_base_lines
 
     @api.model

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -1864,8 +1864,9 @@ export const accountTaxHelpers = {
         const new_tax_details_list = this.split_tax_details(base_line, company, target_factors);
 
         // Split 'base_line'.
-        const new_base_lines = [];
+        const new_base_lines = factors.map((x) => null);
         for (let i = 0; i < factors.length; i++) {
+            const index = factors[i][0];
             const factor = factors[i][1];
             const new_tax_details = new_tax_details_list[i];
             const target_factor = target_factors[i];
@@ -1879,8 +1880,7 @@ export const accountTaxHelpers = {
                 populate_function(base_line, target_factor, kwargs);
             }
 
-            const new_base_line = this.prepare_base_line_for_taxes_computation(base_line, kwargs);
-            new_base_lines.push(new_base_line);
+            new_base_lines[index] = this.prepare_base_line_for_taxes_computation(base_line, kwargs);
         }
         return new_base_lines;
     },


### PR DESCRIPTION
The factors are sorted so zipping them with base_lines won't
assign the factor to the correct base_line. We need to use the
index in it instead to reorder them as previously.

Before this commit, in Mexico, when having lines with price_unit set as
l1=326.4, l2=24.0, l3=172.8, l4=691.2 and a negative line of 1149.6, this
last line was distributed accross the positive lines.
However, the negative amount of l4 was wrongly assigned to l1 making this line
negative at the end because of the reordering of lines in _split_base_lines.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
