### PR TITLE
[FIX] base_import: import action: allow to specify model in params

### DIFF
--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -27,11 +27,11 @@ export class ImportRecords extends Component {
     //---------------------------------------------------------------------
 
     importRecords() {
-        const { context } = this.env.searchModel;
+        const { context, resModel } = this.env.searchModel;
         this.action.doAction({
             type: "ir.actions.client",
             tag: "import",
-            params: { context },
+            params: { active_model: resModel, context },
         });
     }
 }

--- a/addons/base_import/static/tests/import_action.test.js
+++ b/addons/base_import/static/tests/import_action.test.js
@@ -1,5 +1,12 @@
 import { before, describe, expect, test } from "@odoo/hoot";
-import { animationFrame, drag, queryOne, setInputFiles, waitFor } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    drag,
+    queryOne,
+    runAllTimers,
+    setInputFiles,
+    waitFor,
+} from "@odoo/hoot-dom";
 import { useEffect } from "@odoo/owl";
 import {
     contains,
@@ -731,7 +738,7 @@ describe("Import view", () => {
             },
         });
 
-        redirect("/odoo/action-2")
+        redirect("/odoo/action-2");
         await mountWebClient();
         onRpc("base_import.import", "parse_preview", ({ route }) => {
             expect.step(route);
@@ -1470,7 +1477,7 @@ describe("Import view", () => {
 
     test("date format should be converted to strftime", async () => {
         let parseCount = 0;
-        redirect("/odoo/action-2")
+        redirect("/odoo/action-2");
         await mountWebClient();
         onRpc("base_import.import", "parse_preview", async ({ args }) => {
             parseCount++;
@@ -1509,6 +1516,46 @@ describe("Import view", () => {
         }
         expect.verifySteps(["parse_preview", "parse_preview", "execute_import"]);
         await waitFor(".o_list_view");
+    });
+
+    test("active_model in params is the main model", async () => {
+        class Team extends models.Model {
+            name = fields.Char();
+            _records = [];
+        }
+        defineModels([Team]);
+
+        const templateURL = "/myTemplateURL.xlsx";
+        onRpc("team", "get_import_templates", ({ route }) => {
+            expect.step(route);
+            return [{ label: "Some Import Template", template: templateURL }];
+        });
+        onRpc("base_import.import", "create", ({ route }) => expect.step(route));
+
+        await mountWebClient();
+        await getService("action").doAction({
+            name: "Import Teams",
+            tag: "import",
+            type: "ir.actions.client",
+            params: {
+                active_model: "team",
+            },
+        });
+
+        expect(".o_import_action").toHaveCount(1);
+        expect(".o_nocontent_help .btn-outline-primary").toHaveText("Some Import Template");
+        expect(".o_nocontent_help .btn-outline-primary").toHaveProperty(
+            "href",
+            "https://www.hoot.test" + templateURL
+        );
+        expect(".o_control_panel button:visible").toHaveCount(2);
+        expect.verifySteps([
+            "/web/dataset/call_kw/team/get_import_templates",
+            "/web/dataset/call_kw/base_import.import/create",
+        ]);
+
+        await runAllTimers(); // wait for router pushState
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo/import?active_model=team");
     });
 });
 


### PR DESCRIPTION
This commit allows adding an `active_model` to the parameters of
the `import` action. With that param, it is now possible to
execute the import action to import records for another model than
the current one.

There were two usecases in the codebase:
- in the Mailing Lists kanban view ("Import Contacts" button on cards)
- in Inventory > Operations > Master Production Schedule: there's
    an "Import records" item in the search menu

Before this commit, those two usecases didn't work either because
it was importing data of the wrong model (mailing list case) or
because the current action was a client action, i.e. with no res
model (inventory case).

This commit is a partial revert of https://github.com/odoo/odoo/pull/222793

task~5367920
