### PR TITLE
[IMP] web: list: alt click to open/fold all groups

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -288,7 +288,8 @@ export class DynamicGroupList extends DynamicList {
     }
 
     _createGroupDatapoint(data) {
-        return new this.model.constructor.Group(this.model, this.config.groups[data.value], data);
+        const config = this.config.groups[data.value];
+        return new this.model.constructor.Group(this.model, config, data, { parent: this });
     }
 
     async _deleteGroups(groups) {
@@ -360,6 +361,34 @@ export class DynamicGroupList extends DynamicList {
             group.list._selectDomain(value);
         }
         super._selectDomain(value);
+    }
+
+    /**
+     * Opens or folds all groups.
+     *
+     * @param {boolean} [fold=false] true to fold all groups, false to open them
+     * @returns {Promise}
+     */
+    _toggleAllGroups(fold = false) {
+        if (fold) {
+            this.groups.forEach((group) => {
+                if (!group.isFolded) {
+                    group.toggle();
+                }
+            });
+        } else {
+            const nextGroupConfig = Object.fromEntries(
+                Object.entries(this.config.groups).map(([groupId, groupConfig]) => [
+                    groupId,
+                    Object.assign({}, groupConfig, { isFolded: fold }),
+                ])
+            );
+            return this.model._updateConfig(
+                this.config,
+                { groups: nextGroupConfig },
+                { commit: this._setData.bind(this) }
+            );
+        }
     }
 
     async _toggleSelection() {

--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -12,9 +12,10 @@ export class Group extends DataPoint {
     /**
      * @param {import("./relational_model").Config} config
      */
-    setup(config, data) {
+    setup(config, data, { parent }) {
         super.setup(...arguments);
         this.groupByField = this.fields[config.groupByFieldName];
+        this._parent = parent;
         this.range = data.range;
         this._rawValue = data.rawValue;
         /** @type {number} */
@@ -92,15 +93,21 @@ export class Group extends DataPoint {
     }
 
     async toggle() {
-        if (this.config.isFolded) {
+        if (this.isFolded) {
             await this.list.load();
         }
         this._useGroupCountForList();
-        this.model._updateConfig(
-            this.config,
-            { isFolded: !this.config.isFolded },
-            { reload: false }
-        );
+        this.model._updateConfig(this.config, { isFolded: !this.isFolded }, { reload: false });
+    }
+
+    /**
+     * Toggles this group and all its siblings: opens all if this one is folded
+     * and folds all if this one is open.
+     *
+     * @returns {Promise}
+     */
+    async toggleAll() {
+        return this._parent._toggleAllGroups(!this.isFolded);
     }
 
     // -------------------------------------------------------------------------

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -199,7 +199,10 @@ export class ListRenderer extends Component {
         this.multiCurrencyPopover = usePopover(MultiCurrencyPopover, {
             position: "right",
         });
-        this.state = useState({ showGroupInput: false });
+        this.state = useState({
+            showGroupInput: false,
+            altKeyMode: false,
+        });
         this.currencyRates = null;
         onWillStart(async () => {
             const needsCurrencyRates = this.props.archInfo.columns.some((column) => {
@@ -279,9 +282,11 @@ export class ListRenderer extends Component {
         }));
 
         useExternalListener(window, "keydown", (ev) => {
+            this.state.altKeyMode = ev.altKey;
             this.shiftKeyMode = ev.shiftKey;
         });
         useExternalListener(window, "keyup", (ev) => {
+            this.state.altKeyMode = ev.altKey;
             this.shiftKeyMode = ev.shiftKey;
             const hotkey = getActiveHotkey(ev);
             if (hotkey === "shift") {
@@ -2022,7 +2027,11 @@ export class ListRenderer extends Component {
     async onGroupHeaderClicked(_ev, group) {
         const left = await this.props.list.leaveEditMode();
         if (left) {
-            this.toggleGroup(group);
+            if (this.state.altKeyMode) {
+                group.toggleAll();
+            } else {
+                this.toggleGroup(group);
+            }
         }
     }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -324,6 +324,19 @@
             .o_group_caret {
                 margin-inline-start: calc(var(--o-list-group-level, 0) * #{map-get($spacers, 4)});
             }
+
+            &.o_multi_group_expand_available {
+                background-color: rgba(0, 0, 0, 0.1);
+                &:hover {
+                    background-color: rgba(0, 0, 0, 0.5);
+                    .o_multi_group_expand_tooltip {
+                        display: block !important;
+                        transform: translate(-50%, -50%);
+                        background: white;
+                        color: black;
+                    }
+                }
+            }
         }
         tbody + tbody {
             border-top: none; // Override bootstrap for grouped list views

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -204,7 +204,7 @@
     </t>
 
     <t t-name="web.ListRenderer.GroupRow">
-        <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer {{ canResequenceRows and group_index > 0 ? 'o_row_draggable' : '' }}"
+        <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer {{ canResequenceRows and group_index > 0 ? 'o_row_draggable' : '' }} {{state.altKeyMode ? 'o_multi_group_expand_available' : ''}}"
             t-att-data-group-id="group.id"
             t-on-click="(ev) => this.onGroupHeaderClicked(ev, group)"
         >
@@ -212,6 +212,10 @@
                 tabindex="-1"
                 t-attf-class="o_group_name fs-6 fw-bold {{!group.isFolded ? 'text-black' : 'text-body'}}"
                 t-att-colspan="getGroupNameCellColSpan(group)">
+                <div t-if="state.altKeyMode" class="o_multi_group_expand_tooltip d-none position-absolute rounded-3 p-1 start-50 top-50 fw-normal">
+                    <t t-if="group.isFolded">Click to expand all groups</t>
+                    <t t-else="">Click to collapse all groups</t>
+                </div>
                 <div class="d-flex align-items-center">
                     <span t-attf-class="o_group_caret fa fa-fw {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }} me-1"
                         t-attf-style="--o-list-group-level: {{getGroupLevel(group)}}"/>

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -8130,6 +8130,81 @@ test(`groupby node with subfields, and onchange`, async () => {
 });
 
 test.tags("desktop");
+test(`alt click to toggle multiple groups (1 level of groupby)`, async () => {
+    stepAllNetworkCalls();
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list><field name="foo"/><field name="int_field"/></list>`,
+        groupBy: ["m2o"],
+    });
+
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_read_group",
+        "has_group",
+    ]);
+
+    expect(".o_group_header").toHaveCount(2);
+    expect(".o_data_row").toHaveCount(0);
+
+    await keyDown("alt");
+    await animationFrame();
+    expect(".o_group_header").toHaveClass("o_multi_group_expand_available");
+    expect(`.o_multi_group_expand_available`).toHaveCount(2);
+    await contains(".o_group_header").click();
+    expect(".o_data_row").toHaveCount(4);
+    expect.verifySteps(["web_read_group"]);
+
+    await contains(".o_group_header").click();
+    expect(".o_data_row").toHaveCount(0);
+    expect.verifySteps([]);
+});
+
+test.tags("desktop");
+test(`alt click to toggle multiple groups (2 levels of groupby)`, async () => {
+    stepAllNetworkCalls();
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list><field name="foo"/><field name="int_field"/></list>`,
+        groupBy: ["m2o", "int_field"],
+    });
+
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_read_group",
+        "has_group",
+    ]);
+
+    expect(".o_group_header").toHaveCount(2);
+    expect(".o_group_header.o_group_open").toHaveCount(0);
+    expect(".o_data_row").toHaveCount(0);
+
+    await keyDown("alt");
+    await animationFrame();
+    expect(".o_group_header").toHaveClass("o_multi_group_expand_available");
+    expect(`.o_multi_group_expand_available`).toHaveCount(2);
+    await contains(".o_group_header").click();
+    expect(".o_group_header").toHaveCount(6);
+    expect(".o_group_header.o_group_open").toHaveCount(2);
+    expect(".o_data_row").toHaveCount(0);
+    expect.verifySteps(["web_read_group"]);
+
+    await contains(".o_group_header:eq(1)").click();
+    expect(".o_group_header").toHaveCount(6);
+    expect(".o_group_header.o_group_open").toHaveCount(5);
+    expect(".o_data_row").toHaveCount(3);
+    expect.verifySteps(["web_read_group"]);
+});
+
+test.tags("desktop");
 test(`list view, editable, without data`, async () => {
     Foo._records = [];
     Foo._fields.date = fields.Date({ default: "2017-02-10" });


### PR DESCRIPTION
It is now possible, in list view, to open or fold all groups by
pressing the ALT key and then clicking on the header of a group:
if that group was folded (resp. open), the group and its sibblings
are opened (resp. folded).

Note: the group openining isn't recursive: we only open the groups
of the next level.

task~5351106