### PR TITLE
[FIX] html_builder: fix layout of options with select and button group

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.scss
@@ -48,6 +48,20 @@
     }
 }
 
+// The following code handles the case where a select and a group of buttons are
+// on the same row. In this situation, we want to show as much of the buttons’
+// text as possible. (For Animation: "onScroll" or Layout: "Column")
+.hb-row-content {
+    &:has(.o-hb-button-group) > .o-hb-select-wrapper {
+        flex: 1 0 auto;
+        max-width: 50%;
+    }
+
+    &:has(.o-hb-select-wrapper) > .o-hb-button-group .o-hb-btn {
+        min-width: 6ch;
+    }
+}
+
 // Image format badge.
 .o-hb-select-toggle.dropdown-toggle, .o-hb-select-dropdown-item {
     > div > .badge {


### PR DESCRIPTION
Fix animation options layout when a select and a button group share the same row. Ensure the select text remains visible and the buttons show their full labels (e.g. for "onScroll").

| Before  | After |
| ------------- | ------------- |
| <img width="290" height="39" alt="image" src="https://github.com/user-attachments/assets/4fb367fe-77f0-4038-ac2c-c0d856aeba8f" />  | <img width="288" height="40" alt="image" src="https://github.com/user-attachments/assets/99402e23-4144-42bf-81b1-7ddec0c35cfe" />  |

| Before  | After |
| ------------- | ------------- |
| <img width="290" height="36" alt="image" src="https://github.com/user-attachments/assets/39f1a6d0-3ba5-4c80-b452-5c5ba03cee2d" /> | <img width="289" height="39" alt="image" src="https://github.com/user-attachments/assets/482f84cc-7600-4510-91d7-1d6ad9d63937" /> |

task-5353509