### PR TITLE
[FIX] purchase: Fixed valueError for uom

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -157,7 +157,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends('product_uom_id', 'price_unit')
     def _compute_price_unit_product_uom(self):
         for line in self:
-            line.price_unit_product_uom = line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
+            line.price_unit_product_uom = not line.display_type and line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_received', 'product_uom_qty', 'order_id.state')
     def _compute_qty_invoiced(self):


### PR DESCRIPTION
Some purchase lines are of type note or section.
For those lines, the UoM is null,
So when the system tries to compute the unit price Using the product UoM, we get a ValueError
due to the missing UoM.
To prevent this, we need to add a condition
in the compute method so that it only processes
lines where display_type is False.

```
  File "/home/odoo/src/odoo/19.0/addons/purchase/models/purchase_order_line.py", line 160, in _compute_price_unit_product_uom
    line.price_unit_product_uom = line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
   File "/home/odoo/src/odoo/19.0/addons/uom/models/uom_uom.py", line 195, in _compute_price
    self.ensure_one()
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5934, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
 ValueError: Expected singleton: uom.uom()

```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
