### PR TITLE
[PERF] website: cache snippets without image src in tests

### DIFF
--- a/addons/website/static/tests/builder/snippets_getter.hoot.js
+++ b/addons/website/static/tests/builder/snippets_getter.hoot.js
@@ -15,15 +15,14 @@ function removeImageSrc(xmlString) {
 }
 
 let websiteSnippetsPromise;
-export const getWebsiteSnippets = async () => {
+export const getWebsiteSnippets = () => {
     if (!websiteSnippetsPromise) {
         websiteSnippetsPromise = unmockedOrm(
             "ir.ui.view",
             "render_public_asset",
             ["website.snippets"],
             {}
-        );
+        ).then((snippets) => removeImageSrc(snippets.trim()));
     }
-    const str = await websiteSnippetsPromise;
-    return removeImageSrc(str.trim());
+    return websiteSnippetsPromise;
 };


### PR DESCRIPTION
__Behavior before commit:__
`getWebsiteSnippets` is called *at least* twice per website Hoot test.
- [When opening the sidebar][1]
- [When `render_public_asset` is called][2]

Although the orm result is cached using `websiteSnippetsPromise`, it still calls `removeImageSrc` everytime. But inside `removeImageSrc`, this line takes around 50 ms to execute:
```js
new DOMParser().parseFromString(xmlString, "text/html")
```
Therefore wasting at least 100 ms per test.

__Fix:__
Make the promise encompass the result of `removeImageSrc` so that it is called only once at the beginning of the test suite.

[1]: https://github.com/odoo/odoo/blob/2dc9529af127ed4b2d451059b6ab9c83778c7814/addons/website/static/tests/builder/website_helpers.js#L281
[2]: https://github.com/odoo/odoo/blob/2dc9529af127ed4b2d451059b6ab9c83778c7814/addons/website/static/tests/builder/website_helpers.js#L51

task-5269391