### PR TITLE
[IMP] hr_recruitment: Sync fields between talent and applicants.

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -52,7 +52,7 @@ class HrApplicant(models.Model):
     active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.", index=True)
 
     partner_id = fields.Many2one('res.partner', "Contact", copy=False, index='btree_not_null')
-    partner_name = fields.Char("Applicant's Name")
+    partner_name = fields.Char("Applicant's Name", tracking=True)
     email_from = fields.Char(
         string="Email",
         size=128,
@@ -60,6 +60,7 @@ class HrApplicant(models.Model):
         inverse='_inverse_partner_email',
         copy=True,
         store=True,
+        tracking=True,
         index='trigram',
     )
     email_normalized = fields.Char(index='trigram')  # inherited via mail.thread.blacklist
@@ -70,13 +71,14 @@ class HrApplicant(models.Model):
         inverse='_inverse_partner_email',
         copy=True,
         store=True,
+        tracking=True,
         index='btree_not_null',
     )
     partner_phone_sanitized = fields.Char(
         string="Sanitized Phone Number", compute='_compute_partner_phone_sanitized', store=True, index='btree_not_null'
     )
-    linkedin_profile = fields.Char('LinkedIn Profile', index='btree_not_null')
-    type_id = fields.Many2one('hr.recruitment.degree', "Degree")
+    linkedin_profile = fields.Char('LinkedIn Profile', tracking=True, index='btree_not_null')
+    type_id = fields.Many2one('hr.recruitment.degree', "Degree", tracking=True)
     availability = fields.Date("Availability", help="The date at which the applicant will be available to start working", tracking=True)
     color = fields.Integer("Color Index", default=0)
     employee_id = fields.Many2one('hr.employee', string="Employee", help="Employee linked to the applicant.", copy=False, index='btree_not_null')
@@ -92,7 +94,7 @@ class HrApplicant(models.Model):
                                group_expand='_read_group_stage_ids')
     last_stage_id = fields.Many2one('hr.recruitment.stage', "Last Stage",
                                     help="Stage of the applicant before being in the current stage. Used for lost cases analysis.")
-    categ_ids = fields.Many2many('hr.applicant.category', string="Tags")
+    categ_ids = fields.Many2many('hr.applicant.category', string="Tags", tracking=True)
     currency_id = fields.Many2one('res.currency', string='Currency', related='company_id.currency_id')
     company_id = fields.Many2one('res.company', "Company", compute='_compute_company', store=True, readonly=False, tracking=True)
     recruiter_id = fields.Many2one('hr.employee', "Recruiter", compute='_compute_recruiter', domain=_recruiter_domain, check_company=True,
@@ -152,6 +154,7 @@ class HrApplicant(models.Model):
     refuse_date = fields.Datetime('Refuse Date')
     talent_pool_ids = fields.Many2many(comodel_name="hr.talent.pool", string="Talent Pools")
     pool_applicant_id = fields.Many2one("hr.applicant", index='btree_not_null')
+    linked_applicant_ids = fields.One2many('hr.applicant', 'pool_applicant_id', 'Applications')
     is_pool_applicant = fields.Boolean(compute="_compute_is_pool")
     is_applicant_in_pool = fields.Boolean(
         compute="_compute_is_applicant_in_pool", search="_search_is_applicant_in_pool"
@@ -670,6 +673,10 @@ class HrApplicant(models.Model):
                 )
         return applicants
 
+    @api.model
+    def _get_sync_fields(self):
+        return ('partner_name', 'email_from', 'partner_phone', 'linkedin_profile', 'categ_ids', 'type_id', 'availability')
+
     def write(self, vals):
         # recruiter change: update date_open
         if vals.get('recruiter_id'):
@@ -693,16 +700,9 @@ class HrApplicant(models.Model):
             vals['date_last_stage_update'] = fields.Datetime.now()
         res = super().write(vals)
 
-        for applicant in self:
-            if applicant.pool_applicant_id and applicant != applicant.pool_applicant_id and (not applicant.is_pool_applicant):
-                if 'email_from' in vals:
-                    applicant.pool_applicant_id.email_from = vals['email_from']
-                if 'partner_phone' in vals:
-                    applicant.pool_applicant_id.partner_phone = vals['partner_phone']
-                if 'linkedin_profile' in vals:
-                    applicant.pool_applicant_id.linkedin_profile = vals['linkedin_profile']
-                if 'type_id' in vals:
-                    applicant.pool_applicant_id.type_id = vals['type_id']
+        if not self.env.context.get('fields_synced', False):
+            sync_fields_in_vals = {field: vals[field] for field in self._get_sync_fields() if field in vals}
+            (self.pool_applicant_id.linked_applicant_ids - self).with_context(fields_synced=True).write(sync_fields_in_vals)
 
         if 'interviewer_ids' in vals:
             interviewers_to_clean = old_interviewers - self.interviewer_ids

--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -2,7 +2,7 @@
 
 from ast import literal_eval
 
-from odoo import fields, models, Command, api
+from odoo import Command, api, fields, models
 
 
 class HrApplicant(models.Model):
@@ -91,29 +91,30 @@ class HrApplicant(models.Model):
         ]
         return vals
 
-    def _map_applicant_skill_ids_to_talent_skill_ids(self, vals):
+    def _map_applicant_skill_ids_to_other_applicant_skill_ids(self, other_applicant, vals):
         """
         The applicant_skills_ids contains a list of ORM tuples i.e (command, record ID, {values})
         The challenge lies in the uniqueness of the record ID in this tuple. Each skill (e.g., 'arabic')
         has a distinct ID per applicant, i.e arabic in applicant 1 will have a different id from arabic in
         applicant 2. This means the content of applicant_skills_ids is unique for each record and attempting
         to pass it directly (e.g., applicant.pool_applicant_id.write(vals)) won't yield results so we must
-        update each tuple to have the correct command and record ID for the talent pool applicant
+        update each tuple to have the correct command and record ID for the other applicant
 
+        :param other_applicant: the other @hr.applicant the skill_ids will be mapped to
         :param vals: list of CREATE, WRITE or UNLINK commands with skill_ids relevant to the applicant
-        :return: list of CREATE, WRITE or UNLINK commands with skill_ids relevant to the pool_applicant
+        :return: list of CREATE, WRITE or UNLINK commands with skill_ids relevant to the other applicant
         """
         applicant_skills = {a.id: a.skill_id.id for a in self.applicant_skill_ids}
         applicant_skills_type = {a.id: a.skill_type_id.id for a in self.applicant_skill_ids}
-        talent_skills = {a.skill_id.id: a.id for a in self.pool_applicant_id.applicant_skill_ids}
+        other_applicant_skills = {a.skill_id.id: a.id for a in other_applicant.applicant_skill_ids}
         mapped_commands = []
         for command in vals.get("applicant_skill_ids"):
             command_number = command[0]
             record_id = command[1]
             if command_number == Command.UPDATE:
                 values = command[2]
-                if applicant_skills[record_id] in talent_skills:
-                    mapped_command = Command.update(talent_skills[applicant_skills[record_id]], values)
+                if applicant_skills[record_id] in other_applicant_skills:
+                    mapped_command = Command.update(other_applicant_skills[applicant_skills[record_id]], values)
                     mapped_commands.append(mapped_command)
                 else:
                     mapped_command = Command.create(
@@ -125,8 +126,8 @@ class HrApplicant(models.Model):
                     )
                     mapped_commands.append(mapped_command)
             elif command_number == Command.DELETE:
-                if applicant_skills[record_id] in talent_skills:
-                    mapped_command = Command.delete(talent_skills[applicant_skills[record_id]])
+                if applicant_skills[record_id] in other_applicant_skills:
+                    mapped_command = Command.delete(other_applicant_skills[applicant_skills[record_id]])
                     mapped_commands.append(mapped_command)
             else:
                 mapped_commands.append(command)
@@ -158,9 +159,12 @@ class HrApplicant(models.Model):
             original_vals = vals.copy()
             original_vals["applicant_skill_ids"] = skills
             vals["applicant_skill_ids"] = self.env["hr.applicant.skill"]._get_transformed_commands(skills, self)
-            for applicant in self:
-                # Modify the skill values for the talent if it exists
-                if applicant.pool_applicant_id and (not applicant.is_pool_applicant):
-                    mapped_skills = applicant._map_applicant_skill_ids_to_talent_skill_ids(original_vals)
-                    applicant.pool_applicant_id.write({"applicant_skill_ids": mapped_skills})
+            if not self.env.context.get('skills_synced'):
+                for pool_applicant, current_applicants in self.grouped('pool_applicant_id').items():
+                    # Modify the skill values for the remaining applicants in the talent pool
+                    source_applicant = current_applicants[0]
+                    other_applicants = pool_applicant.linked_applicant_ids - current_applicants
+                    for applicant in other_applicants:
+                        mapped_skills = source_applicant._map_applicant_skill_ids_to_other_applicant_skill_ids(applicant, original_vals)
+                        applicant.with_context(skills_synced=True).write({"applicant_skill_ids": mapped_skills})
         return super().write(vals)

--- a/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
+++ b/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
@@ -12,7 +12,12 @@ class TestRecruitmentSkills(TransactionCase):
         super().setUpClass()
 
         cls.t_talent_pool = cls.env["hr.talent.pool"].create({"name": "Test Talent Pool"})
-        cls.t_job = cls.env["hr.job"].create({"name": "Test Job"})
+        cls.t_job_1, cls.t_job_2 = cls.env["hr.job"].create(
+            [
+                {"name": "Test Job 1"},
+                {"name": "Test Job 2"},
+            ]
+        )
         cls.t_skill_type = cls.env["hr.skill.type"].create({"name": "Skills for tests"})
         cls.t_skill_level_1, cls.t_skill_level_2, cls.t_skill_level_3 = cls.env["hr.skill.level"].create(
             [
@@ -30,9 +35,41 @@ class TestRecruitmentSkills(TransactionCase):
         cls.t_applicant = cls.env["hr.applicant"].create(
             {
                 "partner_name": "Test Applicant",
-                "job_id": cls.t_job.id,
+                "job_id": cls.t_job_1.id,
             }
         )
+
+        def get_applicant_skills(cls, applicant):
+            return [
+                {
+                    "id": skill.skill_id,
+                    "level": skill.skill_level_id,
+                    "type": skill.skill_type_id,
+                }
+                for skill in applicant.applicant_skill_ids
+            ]
+        cls.get_applicant_skills = get_applicant_skills
+
+        def get_applicant_skill(cls, applicant):
+            assert len(applicant.applicant_skill_ids) == 1
+            return cls.get_applicant_skills(applicant)[0]
+        cls.get_applicant_skill = get_applicant_skill
+
+        def create_talent(cls, applicant, talent_pool):
+            return (
+                cls.env["talent.pool.add.applicants"]
+                .create({"applicant_ids": applicant, "talent_pool_ids": talent_pool})
+                ._add_applicants_to_pool()
+            )
+        cls.create_talent = create_talent
+
+        def create_applicant_from_talent(cls, talent, job):
+            return (
+                cls.env["job.add.applicants"]
+                .create({"applicant_ids": talent, "job_ids": job})
+                ._add_applicants_to_job()
+            )
+        cls.create_applicant_from_talent = create_applicant_from_talent
 
     def test_add_a_skill_to_applicant(self):
         """
@@ -46,11 +83,7 @@ class TestRecruitmentSkills(TransactionCase):
         app_form.save()
 
         expected_skill = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
+        app_skill = self.get_applicant_skill(self.t_applicant)
 
         self.assertTrue(self.t_applicant.applicant_skill_ids, "The applicant should have a skill")
         self.assertEqual(expected_skill, app_skill, "The applicant should have the test skill")
@@ -82,7 +115,7 @@ class TestRecruitmentSkills(TransactionCase):
         # Create a fresh applicant never added to any pool
         new_applicant = self.env["hr.applicant"].create({
             "partner_name": "New Applicant Access Test",
-            "job_id": self.t_job.id,
+            "job_id": self.t_job_1.id,
         })
 
         # Create a restricted user with Recruitment access only
@@ -103,329 +136,123 @@ class TestRecruitmentSkills(TransactionCase):
         talent_pool_applicants = self.t_talent_pool.talent_ids
         self.assertEqual(len(talent_pool_applicants), 1)
 
-    def test_one_skill_is_copied_from_applicant_to_talent(self):
+    def test_one_skill_is_copied_from_applicant_to_talent_and_linked_applicants(self):
         """
-        Assert that a skill is copied from the applicant to the talent when the talent is created
+        Assert that a skill is copied from the applicant to the talent and linked applicants when they are created.
         """
-        app_form = Form(self.t_applicant)
-        with app_form.current_applicant_skill_ids.new() as skill:
+        app_1_form = Form(self.t_applicant)
+        with app_1_form.current_applicant_skill_ids.new() as skill:
             skill.skill_type_id = self.t_skill_type
             skill.skill_id = self.t_skill_1
             skill.skill_level_id = self.t_skill_level_1
-        app_form.save()
+        app_1_form.save()
 
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
+        app_2 = self.create_applicant_from_talent(talent, self.t_job_2)
 
         expected = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
-        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${talent_skill}")
-        self.assertEqual(app_skill, talent_skill, "The skill from the applicant should have been copied to the talent")
+        talent_skill = self.get_applicant_skill(talent)
+        app_1_skill = self.get_applicant_skill(self.t_applicant)
+        app_2_skill = self.get_applicant_skill(app_2)
+        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${expected} instead of {talent_skill}")
+        self.assertEqual(expected, app_2_skill, f"The linked applicant should have the following skill: ${expected} instead of {app_1_skill}")
+        self.assertEqual(app_1_skill, talent_skill, "The skill from the applicant should have been copied to the talent")
 
-    def test_multi_skill_is_copied_from_applicant_to_talent(self):
+    def test_multi_skill_is_copied_from_applicant_to_talent_and_linked_applicants(self):
         """
-        Assert that multiple skills are copied from the applicant to the talent when the talent is created
+        Assert that multiple skills are copied from the applicant to the talent and linked applicants when they are created.
         """
         skills = [self.t_skill_1, self.t_skill_2]
-        app_form = Form(self.t_applicant)
+        app_1_form = Form(self.t_applicant)
         for skill in skills:
-            with app_form.current_applicant_skill_ids.new() as new_skill:
+            with app_1_form.current_applicant_skill_ids.new() as new_skill:
                 new_skill.skill_type_id = self.t_skill_type
                 new_skill.skill_id = skill
                 new_skill.skill_level_id = self.t_skill_level_1
-        app_form.save()
+        app_1_form.save()
 
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
+        app_2 = self.create_applicant_from_talent(talent, self.t_job_2)
 
         expected = [
             {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type},
             {"id": self.t_skill_2, "level": self.t_skill_level_1, "type": self.t_skill_type},
         ]
-        talent_skill = [
-            {
-                "id": skill.skill_id,
-                "level": skill.skill_level_id,
-                "type": skill.skill_type_id,
-            }
-            for skill in talent.applicant_skill_ids
-        ]
-        app_skill = [
-            {
-                "id": skill.skill_id,
-                "level": skill.skill_level_id,
-                "type": skill.skill_type_id,
-            }
-            for skill in self.t_applicant.applicant_skill_ids
-        ]
-        self.assertCountEqual(expected, talent_skill, f"The talent should have the following skills: ${talent_skill}")
+        talent_skill = self.get_applicant_skills(talent)
+        app_1_skill = self.get_applicant_skills(self.t_applicant)
+        app_2_skill = self.get_applicant_skills(app_2)
+        self.assertCountEqual(expected, talent_skill, f"The talent should have the following skills: ${expected} instead of {talent_skill}")
+        self.assertCountEqual(expected, app_2_skill, f"The linked applicant should have the following skills: ${expected} instead of {app_2_skill}")
         self.assertCountEqual(
-            app_skill, talent_skill, "The skills from the applicant should have been copied to the talent"
+            app_1_skill, talent_skill, "The skills from the applicant should have been copied to the talent"
         )
 
-    def test_add_skill_to_applicant_with_talent_without_skill(self):
+    def test_update_skill_on_applicant_with_talent_and_linked_applicants(self):
         """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is added on an applicant, the same skill is also added or updated on the talent.
-        In this test the skill does not exist on the talent prior to adding it to the applicant.
+        Assert that when a skill is updated on an applicant, the same skill is also updated on the talent and linked applicants.
         """
-        app_form = Form(self.t_applicant)
-
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
-
-        with app_form.current_applicant_skill_ids.new() as skill:
+        app_1_form = Form(self.t_applicant)
+        with app_1_form.current_applicant_skill_ids.new() as skill:
             skill.skill_type_id = self.t_skill_type
             skill.skill_id = self.t_skill_1
             skill.skill_level_id = self.t_skill_level_1
+        app_1_form.save()
 
-        app_form.save()
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
+        app_2 = self.create_applicant_from_talent(talent, self.t_job_2)
 
-        expected = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
-        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${talent_skill}")
-        self.assertEqual(
-            app_skill,
-            talent_skill,
-            "After adding a skill to the applicant, the talent and the applicant should have the same skill",
-        )
-
-    def test_add_skill_to_applicant_with_talent_with_skill(self):
-        """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is added on an applicant, the same skill is also added or updated on the talent.
-        In this test the skill exists on the talent prior to adding it to the applicant.
-        """
-        app_form = Form(self.t_applicant)
-
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
-        with Form(talent) as talent_form:
-            with talent_form.current_applicant_skill_ids.new() as skill:
-                skill.skill_type_id = self.t_skill_type
-                skill.skill_id = self.t_skill_1
-                skill.skill_level_id = self.t_skill_level_1
-
-        with app_form.current_applicant_skill_ids.new() as skill:
-            skill.skill_type_id = self.t_skill_type
-            skill.skill_id = self.t_skill_1
-            skill.skill_level_id = self.t_skill_level_1
-
-        app_form.save()
-
-        expected = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
-        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${talent_skill}")
-        self.assertEqual(
-            app_skill,
-            talent_skill,
-            "After adding a skill to the applicant that already existed on the talent, the talent and the applicant should have the same skill",
-        )
-
-    def test_update_skill_on_applicant_with_talent_without_skill(self):
-        """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is updated on an applicant, the same skill is also added or updated on the talent.
-        In this test the skill does not exist on the talent prior to updating it to the applicant.
-        """
-        app_form = Form(self.t_applicant)
-        with app_form.current_applicant_skill_ids.new() as skill:
-            skill.skill_type_id = self.t_skill_type
-            skill.skill_id = self.t_skill_1
-            skill.skill_level_id = self.t_skill_level_1
-        app_form.save()
-
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
-        with Form(talent) as talent_form:
-            talent_form.current_applicant_skill_ids.remove(0)
-
-        with app_form.current_applicant_skill_ids.edit(0) as skill:
+        with app_1_form.current_applicant_skill_ids.edit(0) as skill:
             skill.skill_type_id = self.t_skill_type
             skill.skill_id = self.t_skill_1
             skill.skill_level_id = self.t_skill_level_2
-        app_form.save()
+        app_1_form.save()
 
         expected = {"id": self.t_skill_1, "level": self.t_skill_level_2, "type": self.t_skill_type}
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
-        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${talent_skill}")
+        talent_skill = self.get_applicant_skill(talent)
+        app_1_skill = self.get_applicant_skill(self.t_applicant)
+        app_2_skill = self.get_applicant_skill(app_2)
+        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${expected} instead of {talent_skill}")
+        self.assertEqual(expected, app_2_skill, f"The linked applicant should have the following skill: ${expected} instead of {app_2_skill}")
         self.assertEqual(
-            app_skill,
-            talent_skill,
-            "After updating a skill on the applicant, the talent and the applicant should have the same skill",
-        )
-
-    def test_update_skill_on_applicant_with_talent_with_skill(self):
-        """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is updated on an applicant, the same skill is also added or updated on the talent.
-        In this test the skill exists on the talent prior to updating it to the applicant.
-        """
-        app_form = Form(self.t_applicant)
-        with app_form.current_applicant_skill_ids.new() as skill:
-            skill.skill_type_id = self.t_skill_type
-            skill.skill_id = self.t_skill_1
-            skill.skill_level_id = self.t_skill_level_1
-        app_form.save()
-
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
-
-        with app_form.current_applicant_skill_ids.edit(0) as skill:
-            skill.skill_type_id = self.t_skill_type
-            skill.skill_id = self.t_skill_1
-            skill.skill_level_id = self.t_skill_level_2
-        app_form.save()
-
-        expected = {"id": self.t_skill_1, "level": self.t_skill_level_2, "type": self.t_skill_type}
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
-        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: ${talent_skill}")
-        self.assertEqual(
-            app_skill,
+            app_1_skill,
             talent_skill,
             "After updating a skill on the applicant that already existed on the talent, the talent and the applicant should have the same skill",
         )
 
-    def test_delete_skill_on_applicant_with_talent_without_skill(self):
+    def test_delete_skill_on_applicant_with_talent_and_linked_applicants(self):
         """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is deleted on an applicant, the same skill is also deleted on the talent.
-        In this test the skill does not exist on the talent prior to deleting it on the applicant.
+        This test ensures that when a skill is deleted on an applicant,
+        the same skill is also deleted on the talent and linked applicants.
         """
-        app_form = Form(self.t_applicant)
-        with app_form.current_applicant_skill_ids.new() as skill:
+        app_1_form = Form(self.t_applicant)
+        with app_1_form.current_applicant_skill_ids.new() as skill:
             skill.skill_type_id = self.t_skill_type
             skill.skill_id = self.t_skill_1
             skill.skill_level_id = self.t_skill_level_1
-        app_form.save()
+        app_1_form.save()
 
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
-        with Form(talent) as talent_form:
-            talent_form.current_applicant_skill_ids.remove(0)
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
+        app_2 = self.create_applicant_from_talent(talent, self.t_job_2)
 
-        app_form.current_applicant_skill_ids.remove(0)
+        app_1_form.current_applicant_skill_ids.remove(0)
 
-        app_form.save()
-
-        self.assertFalse(self.t_applicant.applicant_skill_ids, "The applicant should not have any skills")
-        self.assertFalse(
-            talent.applicant_skill_ids,
-            "The talent should not have any skills",
-        )
-
-    def test_delete_skill_on_applicant_with_talent_with_skill(self):
-        """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is deleted on an applicant, the same skill is also deleted on the talent.
-        In this test the skill exists on the talent prior to deleting it on the applicant.
-        """
-        app_form = Form(self.t_applicant)
-        with app_form.current_applicant_skill_ids.new() as skill:
-            skill.skill_type_id = self.t_skill_type
-            skill.skill_id = self.t_skill_1
-            skill.skill_level_id = self.t_skill_level_1
-        app_form.save()
-
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
-
-        app_form.current_applicant_skill_ids.remove(0)
-
-        app_form.save()
+        app_1_form.save()
 
         self.assertFalse(self.t_applicant.applicant_skill_ids, "The applicant should not have any skills")
         self.assertFalse(
             talent.applicant_skill_ids,
             "The talent should not have any skills after removing the skill from the applicant",
         )
-
-    def test_adding_a_skill_on_a_talent_does_not_affect_applicants(self):
-        """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is added on a talent, the linked applicants are unaffected.
-        """
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
+        self.assertFalse(
+            app_2.applicant_skill_ids,
+            "The linked applicant should not have any skills after removing the skill from the applicant",
         )
+
+    def test_adding_a_skill_on_a_talent_adds_skill_on_applicants(self):
+        """
+        This test ensures that when a skill is added on a talent, it is added to the linked applicants as well.
+        """
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
         talent_form = Form(talent)
         with talent_form.current_applicant_skill_ids.new() as skill:
             skill.skill_type_id = self.t_skill_type
@@ -433,23 +260,18 @@ class TestRecruitmentSkills(TransactionCase):
             skill.skill_level_id = self.t_skill_level_1
         talent_form.save()
 
-        expected_talent = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
+        expected = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
 
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
+        talent_skill = self.get_applicant_skill(talent)
+        app_skill = self.get_applicant_skill(self.t_applicant)
 
-        self.assertFalse(self.t_applicant.applicant_skill_ids, "The applicant should not have any skills")
-        self.assertEqual(expected_talent, talent_skill, f"The talent should have the following skill: {talent_skill}")
+        self.assertEqual(expected, talent_skill, f"The talent should have the following skill: {expected} instead of {talent_skill}")
+        self.assertEqual(app_skill, talent_skill, "Adding a skill on a talent should add the skill on its linked applicants as well")
         return
 
-    def test_updating_a_skill_on_a_talent_does_not_affect_applicants(self):
+    def test_updating_a_skill_on_a_talent_updates_applicants(self):
         """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is updated on a talent, the linked applicants are unaffected.
+        This test ensures that when a skill is updated on a talent, the skill is updated for linked applicants as well.
         """
         app_form = Form(self.t_applicant)
         with app_form.current_applicant_skill_ids.new() as skill:
@@ -458,11 +280,7 @@ class TestRecruitmentSkills(TransactionCase):
             skill.skill_level_id = self.t_skill_level_1
         app_form.save()
 
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
         talent_form = Form(talent)
         with talent_form.current_applicant_skill_ids.edit(0) as skill:
             skill.skill_type_id = self.t_skill_type
@@ -470,28 +288,17 @@ class TestRecruitmentSkills(TransactionCase):
             skill.skill_level_id = self.t_skill_level_2
         talent_form.save()
 
-        expected_app = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
-        expected_talent = {"id": self.t_skill_1, "level": self.t_skill_level_2, "type": self.t_skill_type}
+        expected = {"id": self.t_skill_1, "level": self.t_skill_level_2, "type": self.t_skill_type}
 
-        talent_skill = {
-            "id": talent.applicant_skill_ids.skill_id,
-            "level": talent.applicant_skill_ids.skill_level_id,
-            "type": talent.applicant_skill_ids.skill_type_id,
-        }
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
+        talent_skill = self.get_applicant_skill(talent)
+        app_skill = self.get_applicant_skill(self.t_applicant)
 
-        self.assertEqual(expected_app, app_skill, "The skill on the applicant should not have changed")
-        self.assertEqual(expected_talent, talent_skill, "The skill on the talent should have updated")
+        self.assertEqual(expected, talent_skill, "The skill on the talent should have updated")
+        self.assertEqual(expected, app_skill, "The skill on the applicant should have updated")
 
-    def test_removing_a_skill_on_a_talent_does_not_affect_applicants(self):
+    def test_removing_a_skill_on_a_talent_removes_it_from_applicants(self):
         """
-        Verify one-way skill synchronization between an applicant its linked talent.
-
-        This test ensures that when a skill is deleted on a talent, the linked applicants are unaffected.
+        This test ensures that when a skill is deleted on a talent, it is also removed for linked applicants as well.
         """
         app_form = Form(self.t_applicant)
         with app_form.current_applicant_skill_ids.new() as skill:
@@ -500,23 +307,12 @@ class TestRecruitmentSkills(TransactionCase):
             skill.skill_level_id = self.t_skill_level_1
         app_form.save()
 
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
         with Form(talent) as talent_form:
             talent_form.current_applicant_skill_ids.remove(0)
 
-        expected_app = {"id": self.t_skill_1, "level": self.t_skill_level_1, "type": self.t_skill_type}
-        app_skill = {
-            "id": self.t_applicant.applicant_skill_ids.skill_id,
-            "level": self.t_applicant.applicant_skill_ids.skill_level_id,
-            "type": self.t_applicant.applicant_skill_ids.skill_type_id,
-        }
-
-        self.assertEqual(expected_app, app_skill, f"The applicant should have the expected skill: {expected_app}")
         self.assertFalse(talent.applicant_skill_ids, "The talent should not have any skills")
+        self.assertFalse(self.t_applicant.applicant_skill_ids, "The applicant should not have any skills")
 
     def test_move_applicant_to_matching_job(self):
         """
@@ -589,7 +385,7 @@ class TestRecruitmentSkills(TransactionCase):
             groups='base.group_user,hr_recruitment.group_hr_recruitment_interviewer',
             name='Recruitment Interviewer', email='itw@example.com')
 
-        self.t_job.expected_degree = self.env['hr.recruitment.degree'].create({
+        self.t_job_1.expected_degree = self.env['hr.recruitment.degree'].create({
             'name': 'Master',
             'score': 0.5,
         })
@@ -604,11 +400,7 @@ class TestRecruitmentSkills(TransactionCase):
         Verify that when an applicant is created from a talent pool applicant, the new applicant
         has the same skills as the talent and the talent retains all its skills.
         """
-        talent = (
-            self.env["talent.pool.add.applicants"]
-            .create({"applicant_ids": self.t_applicant, "talent_pool_ids": self.t_talent_pool})
-            ._add_applicants_to_pool()
-        )
+        talent = self.create_talent(self.t_applicant, self.t_talent_pool)
         talent_form = Form(talent)
         with talent_form.current_applicant_skill_ids.new() as skill:
             skill.skill_type_id = self.t_skill_type
@@ -616,12 +408,7 @@ class TestRecruitmentSkills(TransactionCase):
             skill.skill_level_id = self.t_skill_level_1
         talent_form.save()
 
-        test_job = self.env["hr.job"].create({"name": "Test Job"})
-        applicant = (
-            self.env["job.add.applicants"]
-            .create({"applicant_ids": talent.ids, "job_ids": test_job})
-            ._add_applicants_to_job()
-        )
+        applicant = self.create_applicant_from_talent(talent, self.t_job_1)
 
         self.assertEqual(applicant.applicant_skill_ids.skill_type_id, self.t_skill_type)
         self.assertEqual(applicant.applicant_skill_ids.skill_level_id, self.t_skill_level_1)


### PR DESCRIPTION
This commit improves the synchronization between talent and applicant by replacing the existing 1 way sync from applicant to talent to a sync between all `hr.applicant`s in the same pool.

task-5184168
