### PR TITLE
[FIX] l10n_fr_hr_holidays: remove country from manifest

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -106,7 +106,7 @@ class HrLeave(models.Model):
                 else:
                     leave.l10n_fr_date_to_changed = False
 
-    def _get_durations(self, check_leave_type=True, resource_calendar=None):
+    def _get_durations(self, check_leave_type=True, resource_calendar=None, additional_domain=[]):
         """
         In french time off laws, if an employee has a part time contract, when taking time off
         before one of his off day (compared to the company's calendar) it should also count the time


### PR DESCRIPTION
Country is removed from l10n_fr_hr_holidays since l10n_fr has country declared in its manifest.

task-5408245

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
