### PR TITLE
[FIX] website_sale: fix filmstrip's "Style" option alignment

### DIFF
--- a/addons/website_sale/static/src/website_builder/website_sale.editor.scss
+++ b/addons/website_sale/static/src/website_builder/website_sale.editor.scss
@@ -14,8 +14,8 @@
 }
 
 .options-container:has(.o_wsale_products_list_page_options) {
-    div[data-label="Style"].hb-row-sublevel-1:after {
-        height: calc(#{$o-hb-row-min-height} * 0.5);
+    div[data-label="Style"].hb-row-sublevel-1 .hb-row-label::after {
+        height: $o-hb-row-min-height * 1.5;
     }
 }
 


### PR DESCRIPTION
This commit fixes the alignment between the "L" shape and the label of the "Style" sub option for the top categories (Filmstrip)

task-5222688

| Before | After |
|--------|--------|
| <img width="284" height="118" alt="Screenshot 2025-12-11 at 11 10 14" src="https://github.com/user-attachments/assets/82fba2bf-b605-4c75-a667-357b7f8fc08d" /> | <img width="283" height="116" alt="Screenshot 2025-12-11 at 11 09 08" src="https://github.com/user-attachments/assets/6ce63f2e-27e5-4881-8032-f4a0e9133ef5" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
