### PR TITLE
[FIX] web, *: enhance popover positioning flexibility

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee_expandable.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee_expandable.js
@@ -1,7 +1,6 @@
-import { useState, useEffect } from "@odoo/owl";
-import { registry } from "@web/core/registry";
-import { reposition } from "@web/core/position/utils";
 import { Many2ManyAttendee, many2ManyAttendee } from "@calendar/views/fields/many2many_attendee";
+import { useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
 
 export class Many2ManyAttendeeExpandable extends Many2ManyAttendee {
     static template = "calendar.Many2ManyAttendeeExpandable";
@@ -13,21 +12,6 @@ export class Many2ManyAttendeeExpandable extends Many2ManyAttendee {
         this.acceptedCount = this.props.record.data.accepted_count;
         this.declinedCount = this.props.record.data.declined_count;
         this.uncertainCount = this.attendeesCount - this.acceptedCount - this.declinedCount;
-
-        if (!this.env.isSmall) {
-            useEffect(
-                () => {
-                    const popover = document
-                        .querySelector(".o_field_many2manyattendeeexpandable")
-                        .closest(".o_popover");
-                    const target = document.querySelector(
-                        `.fc-event[data-event-id="${this.props.record.resId}"]`
-                    );
-                    reposition(popover, target, { position: "right", margin: 0 });
-                },
-                () => [this.state.expanded]
-            );
-        }
     }
 
     get visibleItemsLimit() {

--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -10,6 +10,7 @@ import {
 } from "@odoo/owl";
 import { OVERLAY_SYMBOL } from "@web/core/overlay/overlay_container";
 import { usePosition } from "@web/core/position/position_hook";
+import { getIFrame } from "@web/core/position/utils";
 import { useActiveElement } from "@web/core/ui/ui_service";
 
 export class EditorOverlay extends Component {
@@ -180,27 +181,28 @@ export class EditorOverlay extends Component {
         if (!scrollContainer) {
             return true;
         }
+        const canFlip = this.props.positionOptions?.flip ?? true;
         const scrollContainerRect = scrollContainer.getBoundingClientRect();
-        const top = Math.max(scrollContainerRect.top, 0);
-        const bottom = top + scrollContainerRect.height;
+        let top = Math.max(scrollContainerRect.top, 0);
+        let bottom = top + Math.min(scrollContainerRect.height, window.innerHeight);
+        if (canFlip) {
+            // Don't show the overlay when the selection is out of the screen
+            const target = this.props.target || this.getSelectionTarget();
+            if (target.ownerDocument !== window.top.document) {
+                const iframe = getIFrame(overlayElement, target);
+                const iframeRect = iframe.getBoundingClientRect();
+                top -= iframeRect.top;
+                bottom -= iframeRect.top;
+            }
+            const targetRect = target.getBoundingClientRect();
+            return targetRect.bottom >= top && targetRect.top < bottom;
+        }
         const overflowsTop = solution.top < top;
         const overflowsBottom = solution.top + overlayElement.offsetHeight > bottom;
-        const canFlip = this.props.positionOptions?.flip ?? true;
-        if (overflowsTop) {
-            if (overflowsBottom) {
-                // Overlay is bigger than the cointainer. Hiding it would make
+        if (overflowsTop || overflowsBottom) {
+            if (overflowsTop && overflowsBottom) {
+                // Overlay is bigger than the container. Hiding it would make
                 // it always invisible.
-                return true;
-            }
-            if (solution.direction === "top" && canFlip) {
-                // Scrolling down will make overlay eventually flip and no longer overflow
-                return true;
-            }
-            return false;
-        }
-        if (overflowsBottom) {
-            if (solution.direction === "bottom" && canFlip) {
-                // Scrolling up will make overlay eventually flip and no longer overflow
                 return true;
             }
             return false;

--- a/addons/html_editor/static/tests/table/table_drag_drop.test.js
+++ b/addons/html_editor/static/tests/table/table_drag_drop.test.js
@@ -477,7 +477,7 @@ test("undo/redo should work correctly after dragging and dropping a row", async 
     const { el, editor } = await setupEditor(
         unformat(`
             <p><br></p>
-            <table class="table table-bordered o_table">
+            <table class="table table-bordered o_table m-4">
                 <tbody>
                     <tr><td class="a">[]1</td></tr>
                     <tr><td class="b">2</td></tr>
@@ -517,14 +517,14 @@ test("undo/redo should work correctly after dragging and dropping a row", async 
     expect(getContent(el)).toBe(
         unformat(`
             <p><br></p>
-            <table class="table table-bordered o_table">
+            <table class="table table-bordered o_table m-4">
                 <tbody>
                     <tr><td class="b">2</td></tr>
                     <tr class=""><td class="c">3</td></tr>
                     <tr><td class="a">[]1</td></tr>
                 </tbody>
             </table>
-            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+            <p data-selection-placeholder="" style="margin: -13px 0px 12px;"><br></p>
         `)
     );
     // Undo the drag and drop
@@ -532,14 +532,14 @@ test("undo/redo should work correctly after dragging and dropping a row", async 
     expect(getContent(el)).toBe(
         unformat(`
             <p><br></p>
-            <table class="table table-bordered o_table">
+            <table class="table table-bordered o_table m-4">
                 <tbody>
                     <tr><td class="a">[]1</td></tr>
                     <tr><td class="b">2</td></tr>
                     <tr><td class="c">3</td></tr>
                 </tbody>
             </table>
-            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+            <p data-selection-placeholder="" style="margin: -13px 0px 12px;"><br></p>
         `)
     );
     // Redo the drag and drop
@@ -547,14 +547,14 @@ test("undo/redo should work correctly after dragging and dropping a row", async 
     expect(getContent(el)).toBe(
         unformat(`
             <p><br></p>
-            <table class="table table-bordered o_table">
+            <table class="table table-bordered o_table m-4">
                 <tbody>
                     <tr><td class="b">2</td></tr>
                     <tr><td class="c">3</td></tr>
                     <tr><td class="a">[]1</td></tr>
                 </tbody>
             </table>
-            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+            <p data-selection-placeholder="" style="margin: -13px 0px 12px;"><br></p>
         `)
     );
 });

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1889,7 +1889,7 @@ test("dropdown menu should not overflow scroll container", async () => {
     expect(top(toolbar)).toBeGreaterThan(bottom(range));
 
     // Scroll down to make the toolbar overflow the scroll container
-    scrollStep = top(toolbar) - top(scrollableElement);
+    scrollStep = top(toolbar);
     scrollableElement.scrollTop += scrollStep;
     await animationFrame();
     await advanceTime(200);
@@ -1915,7 +1915,7 @@ test("dropdown menu should not overflow scroll container", async () => {
     const fontSelector = queryOne(".o_font_selector_menu");
 
     // Scroll down to make the toolbar overflow the scroll container
-    scrollStep = top(toolbar) - top(scrollableElement);
+    scrollStep = top(toolbar);
     scrollableElement.scrollTop += scrollStep;
     await animationFrame();
 

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -166,6 +166,7 @@ export class Dropdown extends Component {
                 return getPosition();
             },
             ref: this.menuRef,
+            shrink: true,
             setActiveElement: false,
         };
         if (this.isBottomSheet) {

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -96,6 +96,7 @@ export class Popover extends Component {
 
         // Positioning props
         fixedPosition: { optional: true, type: Boolean },
+        shrink: { optional: true, type: Boolean },
         holdOnHover: { optional: true, type: Boolean },
         onPositioned: { optional: true, type: Function },
         position: {
@@ -168,7 +169,7 @@ export class Popover extends Component {
                 this.props.onPositioned?.(el, solution);
             },
             position: this.props.position,
-            shrink: true,
+            shrink: this.props.shrink,
         };
     }
 

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -47,6 +47,7 @@ export const popoverService = {
                     closeOnEscape: options.closeOnEscape,
                     component,
                     componentProps: markRaw(props),
+                    shrink: options.shrink,
                     ref: options.ref,
                     class: options.popoverClass,
                     animation: options.animation,

--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -55,7 +55,10 @@ export function usePosition(refName, getTarget, options = {}) {
         }
         const repositionOptions = omit(options, "onPositioned");
         const solution = reposition(ref.el, targetEl, repositionOptions);
-        options.position = `${solution.direction}-${solution.variant}`; // memorize last position
+        // Don't memorize center position because it's a fallback that we don't want to keep if possible
+        if (solution.direction !== "center") {
+            options.position = `${solution.direction}-${solution.variant}`; // memorize last position
+        }
         options.onPositioned?.(ref.el, solution);
     };
 

--- a/addons/web/static/src/views/calendar/hooks/calendar_popover_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/calendar_popover_hook.js
@@ -6,7 +6,7 @@ import { useComponent, useExternalListener } from "@odoo/owl";
 export function useCalendarPopover(component) {
     const owner = useComponent();
     let popoverClass = "";
-    const popoverOptions = { onClose: cleanup };
+    const popoverOptions = { position: "right", onClose: cleanup };
     Object.defineProperty(popoverOptions, "popoverClass", { get: () => popoverClass });
     const popover = usePopover(component, popoverOptions);
     const dialog = useService("dialog");

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -361,7 +361,7 @@ test("popover with arrow and onPositioned", async () => {
 
     expect.verifySteps(["onPositioned (from override)", "onPositioned (from props)"]);
     expect(".o_popover").toHaveClass("o_popover popover mw-100 bs-popover-auto");
-    expect(".o_popover").toHaveAttribute("data-popper-placement", "bottom");
+    expect(".o_popover").toHaveAttribute("data-popper-placement", "center");
     expect(".o_popover > .popover-arrow").toHaveClass("position-absolute z-n1");
 });
 

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -476,11 +476,11 @@ test("iframe: popper is outside, target and container inside", async () => {
     const { top: iframeTop, left: iframeLeft } = iframe.getBoundingClientRect();
     const targetBox = popperTarget.getBoundingClientRect();
     const popperBox = onPositionedArgs.el.getBoundingClientRect();
-    const expectedTop = iframeTop + targetBox.top;
+    const expectedTop = iframeTop + targetBox.top - popperBox.height;
     const expectedLeft =
         iframeLeft + targetBox.left + popperTarget.offsetWidth / 2 - popperBox.width / 2;
 
-    expect(popperBox.bottom).toBe(expectedTop);
+    expect(popperBox.top).toBe(expectedTop);
     expect(popperBox.top).toBe(onPositionedArgs.solution.top);
 
     expect(popperBox.left).toBe(expectedLeft);
@@ -974,45 +974,44 @@ function getRepositionTest(from, to, containerStyleChanges) {
     };
 }
 
-// -----------------------------------------------------------------------------
 test("reposition from top-start to top", getRepositionTest("top-start", "bottom-start", "top"));
 test(
     "reposition from top-start to top right",
-    getRepositionTest("top-start", "bottom-end", "top right")
+    getRepositionTest("top-start", "bottom-start", "top right")
 );
 test(
     "reposition from top-start to slimfit bottom",
-    getRepositionTest("top-start", "top-start", "slimfit bottom")
+    getRepositionTest("top-start", "center-middle", "slimfit bottom")
 );
-test("reposition from top-start to right", getRepositionTest("top-start", "top-end", "right"));
+test("reposition from top-start to right", getRepositionTest("top-start", "top-start", "right"));
 // -----------------------------------------------------------------------------
 test("reposition from top-middle to top", getRepositionTest("top-middle", "bottom-middle", "top"));
 test(
     "reposition from top-middle to slimfit bottom",
-    getRepositionTest("top-middle", "top-middle", "slimfit bottom")
+    getRepositionTest("top-middle", "center-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
-test(
-    "reposition from top-end to top left",
-    getRepositionTest("top-end", "bottom-start", "top left")
-);
+test("reposition from top-end to top left", getRepositionTest("top-end", "bottom-end", "top left"));
 test("reposition from top-end to top", getRepositionTest("top-end", "bottom-end", "top"));
-test("reposition from top-end to left", getRepositionTest("top-end", "top-start", "left"));
+test("reposition from top-end to left", getRepositionTest("top-end", "top-end", "left"));
 test(
     "reposition from top-end to slimfit bottom",
-    getRepositionTest("top-end", "top-end", "slimfit bottom")
+    getRepositionTest("top-end", "center-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
 test("reposition from left-start to left", getRepositionTest("left-start", "right-start", "left"));
 test(
     "reposition from left-start to left bottom",
-    getRepositionTest("left-start", "right-end", "left bottom")
+    getRepositionTest("left-start", "right-start", "left bottom")
 );
 test(
     "reposition from left-start to slimfit top",
-    getRepositionTest("left-start", "left-start", "slimfit top")
+    getRepositionTest("left-start", "center-middle", "slimfit top")
 );
-test("reposition from left-start to bottom", getRepositionTest("left-start", "left-end", "bottom"));
+test(
+    "reposition from left-start to bottom",
+    getRepositionTest("left-start", "left-start", "bottom")
+);
 // -----------------------------------------------------------------------------
 test(
     "reposition from left-middle to left",
@@ -1020,27 +1019,27 @@ test(
 );
 test(
     "reposition from left-middle to slimfit bottom",
-    getRepositionTest("left-middle", "left-middle", "slimfit bottom")
+    getRepositionTest("left-middle", "center-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
 test(
     "reposition from left-end to left top",
-    getRepositionTest("left-end", "right-start", "left top")
+    getRepositionTest("left-end", "right-end", "left top")
 );
 test("reposition from left-end to left", getRepositionTest("left-end", "right-end", "left"));
-test("reposition from left-end to top", getRepositionTest("left-end", "left-start", "top"));
+test("reposition from left-end to top", getRepositionTest("left-end", "left-end", "top"));
 test(
     "reposition from left-end to slimfit bottom",
-    getRepositionTest("left-end", "left-end", "slimfit bottom")
+    getRepositionTest("left-end", "center-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
 test(
     "reposition from bottom-start to slimfit top",
-    getRepositionTest("bottom-start", "bottom-start", "slimfit top")
+    getRepositionTest("bottom-start", "center-middle", "slimfit top")
 );
 test(
     "reposition from bottom-start to right",
-    getRepositionTest("bottom-start", "bottom-end", "right")
+    getRepositionTest("bottom-start", "bottom-start", "right")
 );
 test(
     "reposition from bottom-start to bottom",
@@ -1048,36 +1047,36 @@ test(
 );
 test(
     "reposition from bottom-start to bottom right",
-    getRepositionTest("bottom-start", "top-end", "bottom right")
+    getRepositionTest("bottom-start", "top-start", "bottom right")
 );
 // -----------------------------------------------------------------------------
 test(
     "reposition from bottom-middle to slimfit top",
-    getRepositionTest("bottom-middle", "bottom-middle", "slimfit top")
+    getRepositionTest("bottom-middle", "center-middle", "slimfit top")
 );
 test(
     "reposition from bottom-middle to bottom",
     getRepositionTest("bottom-middle", "top-middle", "bottom")
 );
 // -----------------------------------------------------------------------------
-test("reposition from bottom-end to left", getRepositionTest("bottom-end", "bottom-start", "left"));
+test("reposition from bottom-end to left", getRepositionTest("bottom-end", "bottom-end", "left"));
 test(
     "reposition from bottom-end to slimfit top",
-    getRepositionTest("bottom-end", "bottom-end", "slimfit top")
+    getRepositionTest("bottom-end", "center-middle", "slimfit top")
 );
 test(
     "reposition from bottom-end to bottom left",
-    getRepositionTest("bottom-end", "top-start", "bottom left")
+    getRepositionTest("bottom-end", "top-end", "bottom left")
 );
 test("reposition from bottom-end to bottom", getRepositionTest("bottom-end", "top-end", "bottom"));
 // -----------------------------------------------------------------------------
 test(
     "reposition from right-start to slimfit top",
-    getRepositionTest("right-start", "right-start", "slimfit top")
+    getRepositionTest("right-start", "center-middle", "slimfit top")
 );
 test(
     "reposition from right-start to bottom",
-    getRepositionTest("right-start", "right-end", "bottom")
+    getRepositionTest("right-start", "right-start", "bottom")
 );
 test(
     "reposition from right-start to right",
@@ -1085,26 +1084,26 @@ test(
 );
 test(
     "reposition from right-start to right bottom",
-    getRepositionTest("right-start", "left-end", "right bottom")
+    getRepositionTest("right-start", "left-start", "right bottom")
 );
 // -----------------------------------------------------------------------------
 test(
     "reposition from right-middle to slimfit bottom",
-    getRepositionTest("right-middle", "right-middle", "slimfit bottom")
+    getRepositionTest("right-middle", "center-middle", "slimfit bottom")
 );
 test(
     "reposition from right-middle to right",
     getRepositionTest("right-middle", "left-middle", "right")
 );
 // -----------------------------------------------------------------------------
-test("reposition from right-end to top", getRepositionTest("right-end", "right-start", "top"));
+test("reposition from right-end to top", getRepositionTest("right-end", "right-end", "top"));
 test(
     "reposition from right-end to slimfit bottom",
-    getRepositionTest("right-end", "right-end", "slimfit bottom")
+    getRepositionTest("right-end", "center-middle", "slimfit bottom")
 );
 test(
     "reposition from right-end to right top",
-    getRepositionTest("right-end", "left-start", "right top")
+    getRepositionTest("right-end", "left-end", "right top")
 );
 test("reposition from right-end to right", getRepositionTest("right-end", "left-end", "right"));
 


### PR DESCRIPTION
*: calendar, html_editor

Fixes an issue where the calendar event popover was positioned incorrectly for long events displayed in the day scale.

The fix updates the general positioning logic to test a wider range of placement possibilities, including center positioning. This applies to any positioned element that can be flipped but is not shrinkable.
Consequently, the `shrink` behavior is moved from the popover default to an optional parameter (currently enabled only for dropdowns), ensuring that calendar popovers maintain their size while finding a valid position.

Additionally, this commit:

- Restores the default calendar popover position back to 'right', as the previous change (https://github.com/odoo/odoo/pull/236503) did not properly address the root issue.
- Removes an unnecessary useEffect hook from the Many2ManyAttendeeExpandable component.
- Removes the concept of variant flipping because variant shifting was making it pointless.
- Adjusts rules that hide html_editor overlays when they overflow: this should now only apply to non flippable overlays and when the selection is out of the view port.

task-5401647
