### PR TITLE
[FIX] pos_restaurant: freeze datetime test takeaway preset

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -640,9 +640,11 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
 registry.category("web_tour.tours").add("test_open_register_with_preset_takeaway", {
     steps: () =>
         [
+            Chrome.freezeDateTime(1749981600000), // June 15, 2025 - 10:00
             Chrome.startPoS(),
             FloorScreen.isShown(),
             FloorScreen.clickTable("5"),
+            Chrome.presetTimingSlotHourNotExists("09:00"),
             Chrome.selectPresetTimingSlotHour("12:20"),
             Chrome.presetTimingSlotIs("12:20"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),


### PR DESCRIPTION
Runbot Error: [#234842](https://runbot.odoo.com/odoo/runbot.build.error/234842) 

When running the test `test_open_register_with_preset_takeaway` in `pos_restaurant`, the test was failing if executed after 12:20. We now freeze the datetime at June 15, 2025 - 10:00 to ensure that the preset timing slot **12:20** is always in the future.

This was a forgotten change during the forward-port. 
Forward: [odoo/239126](https://github.com/odoo/odoo/pull/239126) 
Task: [#5365003](https://www.odoo.com/odoo/project/1737/tasks/5365003)