### PR TITLE
[FIX] website: Search suggestions hidden in grid layout snippets

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -52,6 +52,12 @@
                 }
             }
         }
+
+        // Override the grid item z-index if it has an open dropdown, so
+        // its content is always visible.
+        &.o_grid_item:has(.dropdown-menu.show, .o_dropdown_menu.show) {
+            z-index: $zindex-dropdown !important;
+        }
     }
 }
 


### PR DESCRIPTION
Steps to reproduce:
===================
-  Add a product categories block with a search bar in the inner content of the block, like "s_product_list".
- Drag a "Search" snippet inside of the block in top of products categories
- Change the layout to "Grid" & Save.
- Type in the search bar to trigger autocomplete suggestions. -> The suggestions appear behind the product categories and are not visible.

Cause:
======
When a searchbar snippet is placed inside a section using grid mode, the autocomplete dropdown was hidden behind sibling grid items. This occurred because the grid layout applies inline z-index to each column (via `_placeColumns` `in grid_layout_utils.js` (See [1])), creating stacking contexts that trapped the dropdown.
So once you change to grid mode layout `_toggleGridMode` function will be triggered which will call  `_placeColumns` that will assign z-index; (See [2])

Solution:
=========
Override the inline z-index on grid items containing a searchbar

[1]: https://github.com/odoo/odoo/blob/d4411c27b469e5dcc526b5b1f8ea4498f2b08567/addons/web_editor/static/src/js/common/grid_layout_utils.js#L225

[2]: https://github.com/odoo/odoo/blob/d4411c27b469e5dcc526b5b1f8ea4498f2b08567/addons/web_editor/static/src/js/common/grid_layout_utils.js#L138

opw-5392011

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
