### PR TITLE
[IMP] mail:  switching activity type should not remove summary

### DIFF
--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -25,7 +25,7 @@ class MailActivityType(models.Model):
         ]
 
     name = fields.Char('Name', required=True, translate=True)
-    summary = fields.Char('Default Summary', translate=True)
+    summary = fields.Char('Default Summary', translate=True, compute="_compute_summary", store=True, readonly=False)
     sequence = fields.Integer('Sequence', default=10)
     active = fields.Boolean(default=True)
     create_uid = fields.Many2one('res.users', index=True)
@@ -79,6 +79,11 @@ class MailActivityType(models.Model):
     initial_res_model = fields.Selection(selection=_get_model_selection, string='Initial model', compute="_compute_initial_res_model", store=False,
             help='Technical field to keep track of the model at the start of editing to support UX related behaviour')
     res_model_change = fields.Boolean(string="Model has change", default=False, store=False)
+
+    @api.depends('name')
+    def _compute_summary(self):
+        for record in self.filtered(lambda x: not x.summary):
+            record.summary = record.name
 
     @api.constrains('res_model')
     def _check_activity_type_res_model(self):

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -158,6 +158,7 @@
                     <group>
                         <field name="activity_type_id" required="1" widget="selection_badge_icons" options="{'related_icon_field': 'icon'}" nolabel="1"/>
                         <field name="summary" placeholder="e.g. Discuss Proposal" class="fs-3 pb-2"/>
+                        <field name="is_summary_edited" invisible="1"/>
                         <group>
                             <field name="date_deadline"/>
                         </group>

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -50,6 +50,7 @@
                             </group>
                             <group>
                                 <field name="date_deadline" string="Due Date"/>
+                                <field name="is_summary_edited" invisible="1"/>
                                 <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -302,15 +302,15 @@ class TestActivityFlow(TestActivityCommon):
             # they must be set using defaults, see `action_feedback_schedule_next`
             ActivityForm.activity_type_id = call_activity_type
             # activity summary should be empty
-            self.assertEqual(ActivityForm.summary, "TodoSummary", "Did not erase if void on type")
+            self.assertEqual(ActivityForm.summary, False, "Summary will set to false")
 
             ActivityForm.activity_type_id = email_activity_type
             # activity summary should be replaced with email's default summary
             self.assertEqual(ActivityForm.summary, email_activity_type.summary)
 
             ActivityForm.activity_type_id = call_activity_type
-            # activity summary remains unchanged from change of activity type as call activity doesn't have default summary
-            self.assertEqual(ActivityForm.summary, email_activity_type.summary)
+            # activity summary will be changed as call type activity have the summary set to it's name by default.
+            self.assertEqual(ActivityForm.summary, call_activity_type.summary)
 
     def test_activity_type_unlink(self):
         """ Removing type should allocate activities to Todo """


### PR DESCRIPTION
Earlier, when a user switches the activity_type, the summary was changed to the default summary set on the type. This behaviour feels annoying when users have written some custom summary, and it gets lost while switching types.

This commit improves the behaviour, and now the default summary will be the name of the type and while scheduling the activity, if the user adds some custom summary, that will be preserved even when switching the type.

Task-5269655