### PR TITLE
[IMP] l10n_in_pos: hide hsn summary when no hsn items are available

### DIFF
--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -11,6 +11,7 @@
     'data': [
         'views/pos_order_line_views.xml',
         'views/pos_payment_method_views.xml',
+        'views/report_invoice.xml',
         'views/res_config_settings_views.xml',
         'data/pos_bill_data.xml',
     ],

--- a/addons/l10n_in_pos/views/report_invoice.xml
+++ b/addons/l10n_in_pos/views/report_invoice.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="l10n_in_pos.report_invoice_document" inherit_id="l10n_in.l10n_in_report_invoice_document_inherit">
+        <xpath expr="//div[@name='l10n_in_hsn_summary']" position="attributes">
+            <attribute name="t-if">len(hsn_summary['items'])</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
### Before this commit:
- The HSN Summary section was displayed on the invoice even when no HSN items were present.
- This caused an empty or misleading HSN Summary block to appear in the invoice report.

### After this commit:
- The HSN Summary section is now displayed only when HSN items are available.

Task - 5391976