### PR TITLE
[FIX] account: prevent setting zero and negative values for fiscal year date

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -226,7 +226,7 @@ class ResCompany(models.Model):
                 year = datetime.now().year
 
             max_day = calendar.monthrange(year, int(rec.fiscalyear_last_month))[1]
-            if rec.fiscalyear_last_day > max_day:
+            if rec.fiscalyear_last_day <= 0 or rec.fiscalyear_last_day > max_day:
                 raise ValidationError(_("Invalid fiscal year last day"))
 
     @api.depends('fiscal_position_ids.foreign_vat')

--- a/addons/account/tests/test_settings.py
+++ b/addons/account/tests/test_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
 
@@ -116,3 +116,13 @@ class TestSettings(AccountTestInvoicingCommon):
             user_env['res.company'].browse(company_b.id).write({
                 'currency_id': self.env.ref('base.EUR').id,
             })
+
+    def test_set_fiscalyear_last_day_less_than_or_equal_zero(self):
+        """Test that ensure that fiscalyear_last_day raises ValidationError when set
+           to Zero or a negative value."""
+        company = self.company_data['company']
+        with self.assertRaises(ValidationError):
+            company.fiscalyear_last_day = -1
+
+        with self.assertRaises(ValidationError):
+            company.fiscalyear_last_day = 0


### PR DESCRIPTION
Currently, an error exists that allows users to set negative values for fiscal year date.

**Steps to Reproduce:**

 - Install the `account_accountant` module.
 - Go to `Settings` > `Fiscal Periods` and set a negative value for `Last Day`.

**Cause:**

 - The field is related to the company's fiscalyear_last_day[1].
 - When the user enters a negative value, that invalid value is written
   directly to the company's fiscal year last day [2].
 - Writing a negative day to the company's fiscal year configuration is
   incorrect and should not be allowed.

**Fix:**
 - This commit ensures that when a user enters a negative or zero value for
   the fiscal year date, a validation is raised instead.

[1]: https://github.com/odoo/enterprise/blob/99642bdf62f8b1c653dfefdbdcd0e9258cc9e307/account_accountant/models/res_config_settings.py#L10

[2]: https://github.com/odoo/enterprise/blob/99642bdf62f8b1c653dfefdbdcd0e9258cc9e307/account_accountant/models/res_config_settings.py#L104-L111

sentry-7102968735


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
