### PR TITLE
[FIX] base_vat: add TH VAT number validation

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -76,6 +76,7 @@ _ref_vat = {
     'si': 'SI12345679',
     'sk': 'SK2022749619',
     'sm': 'SM24165',
+    'th': '1234545678781',
     'tr': _('17291716060 (NIN) or 1729171602 (VKN)'),
     'uy': _("Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"),
     've': 'V-12345678-1, V123456781, V-12.345.678-1',
@@ -793,6 +794,10 @@ class ResPartner(models.Model):
             return False
 
         return True
+
+    def check_vat_th(self, vat):
+        check_func = stdnum.util.get_cc_module('th', 'tin').is_valid
+        return check_func(vat)
 
     def check_vat_de(self, vat):
         is_valid_vat = stdnum.util.get_cc_module("de", "vat").is_valid

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -148,6 +148,19 @@ class TestStructure(TransactionCase):
         with self.assertRaisesRegex(ValidationError, msg):
             test_partner.write({'vat': '0123457890-11134'})
 
+    def test_vat_th(self):
+        test_partner = self.env["res.partner"].create({
+            "name": "TH Company",
+            "country_id": self.env.ref("base.th").id,
+        })
+
+        for tin in ['1234545678781', '1-2345-45678-78-1', '0-99-4-000-61772-1']:
+            test_partner.vat = tin
+
+        for tin in ['1234545678782', '1-2345-45678-78-2', '0-99-4-000-61772-2', 'X-99-4-000-61772-1']:
+            with self.assertRaises(ValidationError):
+                test_partner.vat = tin
+
     def test_vat_do(self):
         test_partner = self.env["res.partner"].create({"name": "DO Company", "country_id": self.env.ref("base.do").id})
         # Valid do vat


### PR DESCRIPTION
This PR adds a validation method check_vat_th() to verify Thai VAT numbers.
In Thailand, a VAT number must consist of exactly 13 numeric digits.

For partners with country set to Thailand, the system will only allow VAT numbers that are exactly 13 digits long.

Total credits go to: [Saran440](https://github.com/Saran440) `<saranl@ecosoft.co.th>`
(See PR: https://github.com/odoo/odoo/pull/239164)

Enterprise PR: odoo/enterprise#101905