### PR TITLE
[IMP] portal: enable grid css on portal

### DIFF
--- a/addons/portal/static/src/scss/bootstrap_overridden.scss
+++ b/addons/portal/static/src/scss/bootstrap_overridden.scss
@@ -16,6 +16,9 @@ $gray-300: #dee2e6 !default;
 
 $light: #eeeeee !default;
 
+// Enable CSS grid
+$enable-cssgrid: true !default;
+
 // Body
 //
 // Settings for the `<body>` element.


### PR DESCRIPTION
Before this commit, CSS Grid was not enabled on the portal. Since the redesign of the appointment frontend, CSS Grid is now required on the portal too.

task-5160208


Requires:
- https://github.com/odoo/enterprise/pull/101785
- https://github.com/odoo/upgrade/pull/9049




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
