### PR TITLE
[FIX] l10n_din5008_purchase: add date_planned to DIN5008 Purchase Order report

### DIFF
--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -81,6 +81,10 @@
                     <td>Order Deadline:</td>
                     <td><t t-out="o.date_order" t-options="{'widget': 'date'}"/></td>
                 </tr>
+                <tr t-if="o.date_planned">
+                    <td>Expected Arrival:</td>
+                    <td><t t-out="o.date_planned" t-options="{'widget': 'date'}"/></td>
+                </tr>
                 <tr t-if="o.incoterm_id">
                     <td>Incoterm:</td>
                     <td><t t-out="o.incoterm_id.code"/></td>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install l10n_din5008 and purchase modules.
2. Switch the Document Layout template to DIN 5008.
3. Create or open an existing Purchase Order.
4. Print the Purchase Order report.

**Issue:**
The Expected Arrival Date does not appear on the DIN 5008 Purchase Order report. Both functional experts and PO (CHKL) confirmed that the Expected Arrival Date should appear by default on the Purchase Order report in DIN 5008.

**Cause:**
The date_planned (Expected Arrival) field was introduced in standard Purchase
 Order report in v18.0, but DIN 5008 report template was not updated accordingly

**Fix:**
Add the Expected Arrival information to the DIN 5008 Purchase Order template.

Before:
<img width="606" height="162" alt="image" src="https://github.com/user-attachments/assets/e11f5b1f-5898-4ec9-a4f2-087db5dfeced" />

After:
<img width="605" height="147" alt="image" src="https://github.com/user-attachments/assets/57419d00-50c9-4508-9bfc-307c0a54dc67" />


**opw-5376176**