### PR TITLE
[FIX] survey: fix traceback and copy button

### DIFF
--- a/addons/survey/static/src/interactions/survey_session_manage.js
+++ b/addons/survey/static/src/interactions/survey_session_manage.js
@@ -116,7 +116,10 @@ export class SurveySessionManage extends Interaction {
                 delay: 0,
             }
         );
-        this.registerCleanup(() => this.copyBtnTooltip?.dispose());
+        this.registerCleanup(() => {
+            this.copyBtnPopover?.dispose();
+            this.copyBtnTooltip?.dispose();
+        });
         // Attendees count & navigation label
         this.sessionAttendeesCountText = "";
         this.sessionNavigationNextLabel = "";
@@ -172,18 +175,19 @@ export class SurveySessionManage extends Interaction {
         const copyBtnTooltipHideDelay = 800;
         this.copyBtnTooltip?.dispose();
         delete this.copyBtnTooltip;
-        const copyBtnPopover = window.Popover.getOrCreateInstance(ev.currentTarget, {
+        this.copyBtnPopover = window.Popover.getOrCreateInstance(ev.currentTarget, {
             content: _t("Copied!"),
             trigger: "manual",
             placement: "right",
             container: "body",
             offset: "0, 3",
         });
-        this.registerCleanup(() => copyBtnPopover.dispose());
-        await this.waitFor(browser.navigator.clipboard.writeText(ev.target.textContent));
+        await this.waitFor(
+            browser.navigator.clipboard.writeText(ev.currentTarget.innerText.trim())
+        );
         this.protectSyncAfterAsync(() => {
-            copyBtnPopover.show();
-            this.waitForTimeout(() => copyBtnPopover.hide(), copyBtnTooltipHideDelay);
+            this.copyBtnPopover.show();
+            this.waitForTimeout(() => this.copyBtnPopover.hide(), copyBtnTooltipHideDelay);
         })();
     }
 


### PR DESCRIPTION
Issue 1:
Steps to reproduce
===============
1. Go to the survey.
2. Create a live session for any survey.
3. On the session screen, click the copy button after the url. ------> Popover will show `Copied!` but nothing is copied.

Issue 2:
Steps to reproduce
================
1, 2: same as issue 1.
3. Click the copy button 2,3 times.
4. Click the button start survey. ------> TypeError: Cannot read properties of null (reading 'closest')

Technical
========
Issue 1: The event listener callback `onCopySessionLink` was using `event.target.textContent` to insert into clipboard of the browser. As the event.target is icon with no text content, the empty string is _copied_.

Issue 2: At each click of the copy button, we register cleanup to dispose the _same_ instance of `window.Popover` component. Therefore more than one click will register the cleanup each time. While cleaning, the second cleanup will actually dispose the already disposed instance raising an error at this [line] because the instance has `this._element` null.

This commit makes the `onCopySessionLink` to copy the text of the element with the url and makes sure the cleanup is registered only once.

[line]: https://github.com/odoo/odoo/blob/058212e12b5079eba870bde9775fe98f27928935/addons/web/static/lib/bootstrap/js/dist/tooltip.js#L173

Task-5347197r
