### PR TITLE
[FIX] website: add selection attribute in get_authorized_field

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -55,7 +55,7 @@ class IrModel(models.Model):
         model = self.env[model_name]
         fields_get = model.fields_get(attributes=[
             'required', 'domain', 'readonly', 'type', 'relation',
-            'definition_record', 'definition_record_field', 'string',
+            'definition_record', 'definition_record_field', 'string', 'selection',
         ])
 
         for val in model._inherits.values():


### PR DESCRIPTION
[FIX] website: add selection attribute in get_authorized_fields

In the commit [1], a list of attributes was introduced in the
`fields_get` of `get_authorized_fields` and selection was forgotten in
that list.

Steps to reproduce:
- Drop a form block
- Set action : Create a customer (you need to have website_sale installed)
- Add a field
- Set that field type to Language
- Traceback occurs

[1]: https://github.com/odoo/odoo/commit/bfae7140d3951bec93fb7f2e49018649045edd40

task-5410833