### PR TITLE
[FIX] website: Fix website logout UI

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -110,7 +110,7 @@
                     <i class="fa fa-fw fa-th me-1 small text-primary-emphasis"/> Apps
                 </a>
                 <div id="o_logout_divider" class="dropdown-divider"/>
-                <form method="POST" action="/web/session/logout" role="menuitem" class="dropdown-item p-0">
+                <form method="POST" action="/web/session/logout?redirect=/" role="menuitem" class="dropdown-item p-0">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <button id="o_logout" type="submit" class="btn w-100 ps-3 text-start">
                         <i class="fa fa-fw fa-sign-out small text-primary-emphasis"/> Logout


### PR DESCRIPTION
Problem
---------
When Portal and Website are installed, a user that is in the Website app and tries to logout from the website iframe (not from the menubar) will get disconnected correctly.

However, only the iframe gets redirected; not the whole page. This leaves the user in an interesting stage where he is disconnected but still seem connected when looking at the menubar.

Solution
---------
Instead of using a form in the XML, we use a custom JS tool that will correctly redirect the user depeding on whether or not there is an iframe.

task-5262619

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
