### PR TITLE
[FIX] html_editor: clear local overlays on Editor destroy

### DIFF
--- a/addons/html_editor/static/src/main/local_overlay_plugin.js
+++ b/addons/html_editor/static/src/main/local_overlay_plugin.js
@@ -34,4 +34,9 @@ export class LocalOverlayPlugin extends Plugin {
         }
         return container;
     }
+
+    destroy() {
+        this.localOverlayContainer?.replaceChildren();
+        super.destroy();
+    }
 }

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -107,6 +107,16 @@ describe("visibility", () => {
 });
 
 describe.tags("desktop");
+describe("cleanup", () => {
+    test("power buttons overlay is removed when editor is destroyed", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        expect("[data-oe-local-overlay-id='oe-power-buttons-overlay']").toHaveCount(1);
+        editor.destroy();
+        expect("[data-oe-local-overlay-id='oe-power-buttons-overlay']").toHaveCount(0);
+    });
+});
+
+describe.tags("desktop");
 describe("buttons", () => {
     test("should create a numbered list using power buttons", async () => {
         const { el } = await setupEditor("<p>[]<br></p>");


### PR DESCRIPTION
This commit ensures that local overlays are correctly removed when the
Editor and `LocalOverlayPlugin` are destroyed.

Steps to reproduce (observable after 18.4):
- Go on website
- Enter edit mode
- Save
- Repeat entering edit mode and saving
- Inspect the DOM: oe-local-overlay elements keep accumulating, only one
  is non-empty

The bug is only observable after 18.4, after the website refactoring,
but the root cause has been present since 18.0, so we fix it there in
case there are other use cases.

task-5380409