### PR TITLE
[IMP] website: translate search result names in search bar

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -37,6 +37,11 @@ class WebsitePage(models.Model):
     # for how long a cache entry is considered valid (in seconds)
     _CACHE_DURATION = 3600
 
+    name = fields.Char(
+        string="Page Name",
+        compute='_compute_name', inverse='_inverse_name', store=True,
+        translate=True,
+    )
     url = fields.Char('Page URL', required=True)
     view_id = fields.Many2one('ir.ui.view', string='View', required=True, index=True, ondelete="cascade")
 
@@ -57,6 +62,15 @@ class WebsitePage(models.Model):
     # don't use mixin website_id but use website_id on ir.ui.view instead
     website_id = fields.Many2one(related='view_id.website_id', store=True, readonly=False, ondelete='cascade')
     arch = fields.Text(related='view_id.arch', readonly=False, depends_context=('website_id',))
+
+    @api.depends('view_id.name')
+    def _compute_name(self):
+        for page in self.with_context(lang='en_US'):
+            page.name = page.view_id.name
+
+    def _inverse_name(self):
+        for page in self.with_context(lang='en_US'):
+            page.view_id.name = page.name
 
     @api.constrains('parent_id')
     def _compute_parent_ids(self):


### PR DESCRIPTION
When using the website search bar on a multilingual site, the names of matched webpages were always displayed in the default language instead of the active language.

This commit adds the `name` field as a translatable field to the relevant model so that search results are shown in the active language.

Steps to reproduce:
1. Configure a multilingual website (e.g., English and French with English as the default language).
2. Switch the website language to French.
3. Use the search bar and search for “Contact us”.
4. Notice that the result shows the webpage name in English instead of French.

**Task:** [5063002](https://www.odoo.com/odoo/project/974/tasks/5063002)
