### PR TITLE
[FIX] account_peppol: Remove the auto-assigned Peppol sending method

### DIFF
--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 from datetime import timedelta
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 from odoo.addons.account.models.company import PEPPOL_LIST
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
@@ -9,6 +9,14 @@ from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import A
 
 class AccountMoveSend(models.AbstractModel):
     _inherit = 'account.move.send'
+
+    @api.model
+    def _get_default_sending_method(self, move) -> str:
+        # EXTENDS 'account'
+        preferred_method = move.commercial_partner_id.with_company(move.company_id).invoice_sending_method
+        if not preferred_method and self._is_applicable_to_move('peppol', move):
+            return 'peppol'
+        return super()._get_default_sending_method(move)
 
     # -------------------------------------------------------------------------
     # ALERTS

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -267,9 +267,6 @@ class ResPartner(models.Model):
             self_partner.peppol_eas,
             self_partner._get_peppol_edi_format(),
         )
-        if new_value == 'valid' and not self_partner.invoice_sending_method:
-            self_partner.invoice_sending_method = 'peppol'
-
         if (
                 new_value != 'valid'
                 and self_partner.peppol_eas in ('0208', '9925')

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -439,7 +439,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
             'invoice_edi_format': 'ubl_bis3',
-            'invoice_sending_method': 'peppol',
         }])
         # but not valid for company 2
         new_partner.with_company(company_2).invoice_edi_format = 'nlcius'
@@ -448,7 +447,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
             'invoice_edi_format': 'nlcius',
-            'invoice_sending_method': 'peppol',
         }])
         move_1 = self.create_move(new_partner)
         move_2 = self.create_move(new_partner)
@@ -460,8 +458,8 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         self.assertEqual((move_1 + move_2 + move_3).mapped('is_being_sent'), [True, True, True])
         # the cron is run asynchronously and should be agnostic from the current self.env.company
         self.env.ref('account.ir_cron_account_move_send').with_company(company_2).method_direct_trigger()
-        # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should fail to send
-        self.assertEqual((move_1 + move_2 + move_3).mapped('peppol_move_state'), ['processing', 'processing', 'error'])
+        # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should not be sent by Peppol
+        self.assertEqual((move_1 + move_2 + move_3).mapped('peppol_move_state'), ['processing', 'processing', False])
 
     def test_available_peppol_sending_methods(self):
         company_us = self.setup_other_company()['company']  # not a valid Peppol country

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -94,8 +94,6 @@ def _mock_button_verify_partner_endpoint(func, self, *args, **kwargs):
     state = _mock_get_peppol_verification_state(func, self, endpoint, eas, edi_format)
     self.with_company(company).peppol_verification_state = state
     self._log_verification_state_update(company, old_value, state)
-    if state == 'valid':
-        self.with_company(company).invoice_sending_method = 'peppol'
 
 
 def _mock_get_peppol_verification_state(func, self, *args, **kwargs):


### PR DESCRIPTION
We previously remove the automatic assignment of this value when sent through the Send & Print.
But we forgot to remove this automatic assignment when the "Verify" button was clicked.

task-none (feedback from PO)
