### PR TITLE
[FIX] website, html_editor: b64 background image

### DIFF
--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -80,6 +80,27 @@ export class CustomizeWebsitePlugin extends Plugin {
         save_handlers: this.onSave.bind(this),
     };
 
+    setup() {
+        // Some websites since 18.4 could have a base64 body backgrounds,
+        // this resolve them to an existing attachment URL.
+        this.normalizeBodyBackgroundImage();
+    }
+
+    async normalizeBodyBackgroundImage() {
+        const bodyImage = this.getWebsiteVariableValue("body-image");
+        if (!bodyImage?.startsWith("data:image/")) {
+            return;
+        }
+        const attachment = await rpc("/html_editor/attachment/find_existing_or_add_from_data", {
+            data: bodyImage,
+        });
+        if (attachment?.image_src && !this.isDestroyed) {
+            await this.customizeWebsiteVariables({
+                "body-image": `'${attachment.image_src}'`,
+            });
+        }
+    }
+
     async onSave() {
         if (this.viewsToEnableOnSave.size || this.viewsToDisableOnSave.size) {
             await rpc("/website/theme_customize_data", {
@@ -505,8 +526,14 @@ export class CustomizeBodyBgTypeAction extends BuilderAction {
             });
         } else {
             const imageEl = historyImageSrc || (await getAction("replaceBgImage").load({ el }));
-            if (imageEl) {
-                imageSrc = imageEl.src;
+            if (imageEl && imageEl !== NO_IMAGE_SELECTION) {
+                if (typeof imageEl === "string") {
+                    imageSrc = imageEl;
+                } else {
+                    imageSrc = imageEl.dataset?.originalSrc || imageEl.getAttribute("src") || "";
+                }
+            }
+            if (imageSrc) {
                 await this.dependencies.customizeWebsite.customizeWebsiteVariables({
                     "body-image-type": `'${value}'`,
                     "body-image": `'${imageSrc}'`,


### PR DESCRIPTION
Since saas-18.4, body background images are saved as base64 in `body-image` instead of an URL. This affects the performance of the website.

To reproduce:
- Install Website
- Open the website builder
- go on the theme tab
- website > background > choose an image
- In the CSS file or in the style tab of the dev tools > `body-image` value is a base64 image

To fix:
Instead of directly giving the image source as the `body-image` value, we should give the `originalSrc` of the image element. 

To retro fix databases that would maybe have base64 backgrounds, a `normalizeBodyBackgroundImage` have been added to replace them with the correct URL.
This function activates when the user opens the website builder. 