### PR TITLE
[IMP] repair: simplify repair orders

### DIFF
--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -29,6 +29,7 @@ The following topics are covered by this module:
         'views/stock_lot_views.xml',
         'views/stock_picking_views.xml',
         'views/stock_warehouse_views.xml',
+        'views/account_move_views.xml',
         'report/repair_reports.xml',
         'report/repair_templates_repair_order.xml',
         'data/repair_data.xml',

--- a/addons/repair/models/__init__.py
+++ b/addons/repair/models/__init__.py
@@ -10,3 +10,4 @@ from . import stock_lot
 from . import product
 from . import sale_order
 from . import stock_warehouse
+from . import account_move

--- a/addons/repair/models/account_move.py
+++ b/addons/repair/models/account_move.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _name = 'account.move'
+    _inherit = 'account.move'
+
+    repair_order_id = fields.Many2one('repair.order', string='Repair Order', index='btree_not_null', copy=False)
+
+    def action_show_repair(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'repair.order',
+            'views': [[False, 'form']],
+            'res_id': self.repair_order_id.id,
+        }
+
+    def button_draft(self):
+        draft_invoices = self.repair_order_id.invoice_ids.filtered(lambda move: move.state == 'draft')
+        if draft_invoices:
+            raise UserError(self.env._('You can only have one invoice linked to a repair order.'))
+        super().button_draft()

--- a/addons/repair/views/account_move_views.xml
+++ b/addons/repair/views/account_move_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_move_form_inherit_repair" model="ir.ui.view">
+        <field name="name">view.account.move.form.inherit.repair</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_show_repair"
+                    string="Repair Order"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-wrench"
+                    invisible="not repair_order_id"
+                    groups="stock.group_stock_user"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -70,13 +70,12 @@
                <header>
                    <button name="action_validate" invisible="state != 'draft'" type="object" string="Confirm Repair" class="oe_highlight" data-hotkey="v"/>
                    <button name="action_repair_start" invisible="state != 'confirmed'" type="object" string="Start Repair" class="oe_highlight" data-hotkey="q"/>
-                   <button name="action_repair_end" invisible="state != 'under_repair' or not has_uncomplete_moves" type="object" string="End Repair" class="oe_highlight" data-hotkey="x" confirm="For some of the parts, there is a difference between the initial demand and the actual quantity that was used. Are you sure you want to confirm ?"/>
-                   <button name="action_repair_end" invisible="state != 'under_repair' or has_uncomplete_moves" type="object" string="End Repair" class="oe_highlight" data-hotkey="x"/>
+                   <button name="action_repair_end" invisible="state != 'under_repair'" type="object" string="End Repair" class="oe_highlight" data-hotkey="x"/>
                    <button name="action_assign" invisible="not reserve_visible" string="Check availability" type="object"/>
-                   <button name="action_unreserve" type="object" string="Unreserve" invisible="not unreserve_visible" data-hotkey="w"/>
-                   <button name="action_create_sale_order" type="object" string="Create Quotation" invisible="not partner_id or (state == 'cancel' or sale_order_id)"/>
-                   <button name="action_repair_cancel" string="Cancel Repair" type="object" invisible="state in ('done', 'cancel')" data-hotkey="l"/>
+                   <button name="action_create_sale_order" type="object" string="Quote" invisible="not can_create_sale_or_invoice"/>
+                   <button name="action_create_invoice" type="object" string="Invoice" invisible="not can_create_sale_or_invoice"/>
                    <button name="action_repair_cancel_draft" invisible="state != 'cancel'" string="Set to Draft" type="object" data-hotkey="z"/>
+                   <button name="action_repair_cancel" string="Cancel" type="object" invisible="state in ('done', 'cancel')" data-hotkey="l"/>
                    <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,under_repair,done"/>
                </header>
                <sheet string="Repairs order">
@@ -91,6 +90,13 @@
                             </div>
                         </button>
                         <button name="%(action_repair_move_lines)d" type="action" string="Product Moves" class="oe_stat_button" icon="fa-exchange" invisible="state not in ['done', 'cancel']"/>
+                        <button name="action_view_invoice"
+                            type="object"
+                            icon="fa-pencil-square-o"
+                            class="oe_stat_button"
+                            invisible="not invoice_count">
+                            <field name="invoice_count" widget="statinfo" string="Invoices"/>
+                        </button>
                     </div>
                     <div class="oe_title">
                         <label class="o_form_label" for="name"/>
@@ -144,7 +150,6 @@
                                 </control>
                                 <field name="company_id" column_invisible="True"/>
                                 <field name="state" column_invisible="True"/>
-                                <field name="repair_line_type" required="1"/>
                                 <field name="picking_type_id" column_invisible="True"/>
                                 <field name="location_id" column_invisible="True"/>
                                 <field name="location_dest_id" column_invisible="True"/>
@@ -162,12 +167,12 @@
                                 <field name="description_picking" string="Description" optional="hide"/>
                                 <field name="date" optional="hide"/>
                                 <field name="date_deadline" optional="hide"/>
+                                <field name="repair_line_type" required="1"/>
                                 <field name="product_uom_qty" string="Demand" readonly="state in ('done', 'cancel')"/>
                                 <field name="forecast_expected_date" column_invisible="True"/>
                                 <field name="product_qty" readonly="1" column_invisible="True"/>
-                                <field name="quantity" string="Quantity" readonly="not product_id"/>
+                                <field name="quantity" string="Reserved" readonly="not product_id" optional="hide"/>
                                 <field name="uom_id" readonly="state != 'draft' and not additional" options="{'no_open': True, 'no_create': True}" widget="many2one_uom"/>
-                                <field name="picked" string="Picked" optional='hide'/>
                                 <field name="lot_ids" widget="many2many_tags"
                                     groups="stock.group_production_lot"
                                     invisible="not show_details_visible or has_tracking != 'serial'"
@@ -376,6 +381,17 @@
                 Create a new tag
               </p>
             </field>
+        </record>
+
+        <record id="action_unreserve" model="ir.actions.server">
+            <field name="name">Unreserve</field>
+            <field name="model_id" ref="repair.model_repair_order"/>
+            <field name="binding_model_id" ref="repair.model_repair_order"/>
+            <field name="binding_view_types">form</field>
+            <field name="state">code</field>
+            <field name="code">
+            if records:
+                records.action_unreserve()</field>
         </record>
 
         <menuitem id="menu_repair_order" groups="stock.group_stock_user" name="Repairs" sequence="165"


### PR DESCRIPTION
This commit simplifies the repair order process by:
- Adding an option to directly invoice the customer instead
of creating a quotation then confirming sale order then
finally creating an invoice.
- Linking the invoice directly to repair order and vice versa by
smart buttons.
- Setting invoice lines' price to 0 if repair is under warranty and
vice versa only for a draft invoice.
- Simplify consumption; when ending a repair, if reserved amount is
less than demand, consumption will be forced.
- If all invoices are cancelled, the user will be able to either create a
new quotation (if there are none already) or a new invoice.
- If the user decides to set a cancelled invoice to draft, after creating
a new invoice (so 2 draft invoices are linked to the repair),
only the last one will be considered.
- Some UI changes.

Task: 5226748



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
