### PR TITLE
[CLN] html_builder, website, *: use Promise.withResolvers()

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
@@ -2,7 +2,6 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { ImageTransformation } from "@html_editor/main/media/image_transformation";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { Deferred } from "@web/core/utils/concurrency";
 
 export class ImageTransformOptionPlugin extends Plugin {
     static id = "imageTransformOption";
@@ -27,7 +26,7 @@ class TransformImageAction extends BuilderAction {
     }) {
         if (!isImageTransformationOpen()) {
             let changed = false;
-            const deferredTillMounted = new Deferred();
+            const deferredTillMounted = Promise.withResolvers();
             registry.category("main_components").add("ImageTransformation", {
                 Component: ImageTransformation,
                 props: {
@@ -49,7 +48,7 @@ class TransformImageAction extends BuilderAction {
                     },
                 },
             });
-            await deferredTillMounted;
+            await deferredTillMounted.promise;
         }
     }
 }

--- a/addons/html_builder/static/tests/block_tab/snippet_content.test.js
+++ b/addons/html_builder/static/tests/block_tab/snippet_content.test.js
@@ -6,15 +6,7 @@ import {
 import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin";
 import { Operation } from "@html_builder/core/operation";
 import { describe, expect, test } from "@odoo/hoot";
-import {
-    animationFrame,
-    click,
-    Deferred,
-    queryAll,
-    queryAllTexts,
-    queryOne,
-    waitFor,
-} from "@odoo/hoot-dom";
+import { animationFrame, click, queryAll, queryAllTexts, queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { loadBundle } from "@web/core/assets";
 
@@ -140,7 +132,7 @@ test("A snippet should appear disabled if there is nowhere to drop it", async ()
 
 test.tags("desktop");
 test("click just after drop is redispatched in next operation", async () => {
-    const nextDef = new Deferred();
+    const nextDef = Promise.withResolvers();
     patchWithCleanup(Operation.prototype, {
         next(fn, ...args) {
             const originalFn = fn;
@@ -192,7 +184,7 @@ test("click just after drop is redispatched in next operation", async () => {
     await waitFor(":iframe .o_loading_screen");
     await click(":iframe", { position: { x: 200, y: 50 }, relative: true });
     expect.verifySteps(["next"]); // On click
-    await nextDef;
+    await nextDef.promise;
     expect.verifySteps(["updateContainers"]); // End of drop, on addStep()
     await animationFrame();
     expect.verifySteps(["onClick", "next", "updateContainers"]); // On click redispatched

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_button.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_button.test.js
@@ -7,7 +7,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, click, Deferred, hover, runAllTimers } from "@odoo/hoot-dom";
+import { animationFrame, click, hover, runAllTimers } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
@@ -800,7 +800,7 @@ test("do not load when an operation is cleaned", async () => {
 });
 
 test("click on BuilderButton with async action", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";
@@ -808,7 +808,7 @@ test("click on BuilderButton with async action", async () => {
                 return editingElement.classList.contains("applied");
             }
             async apply({ editingElement }) {
-                await def;
+                await def.promise;
                 editingElement.classList.add("applied");
             }
         },

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -7,7 +7,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { before, describe, expect, test } from "@odoo/hoot";
-import { animationFrame, click, Deferred, hover, press, tick, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, click, hover, press, tick, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
@@ -127,7 +127,7 @@ test("apply custom action", async () => {
 });
 
 test("apply custom async action", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";
@@ -135,7 +135,7 @@ test("apply custom async action", async () => {
                 return "";
             }
             async apply({ editingElement }) {
-                await def;
+                await def.promise;
                 editingElement.classList.add("applied");
             }
         },

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2many.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2many.test.js
@@ -5,7 +5,7 @@ import {
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-mock";
+import { animationFrame } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, fields, models, onRpc } from "@web/../tests/web_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
@@ -84,8 +84,8 @@ test("many2many: find tag, select tag, unselect tag", async () => {
 });
 
 test("many2many: async load", async () => {
-    const defWillLoad = new Deferred();
-    const defDidApply = new Deferred();
+    const defWillLoad = Promise.withResolvers();
+    const defDidApply = Promise.withResolvers();
     onRpc("test", "name_search", () => [
         [1, "First"],
         [2, "Second"],
@@ -96,7 +96,7 @@ test("many2many: async load", async () => {
             static id = "testAction";
             async load({ value }) {
                 expect.step("load");
-                await defWillLoad;
+                await defWillLoad.promise;
                 return value;
             }
             apply({ editingElement, value }) {
@@ -130,7 +130,7 @@ test("many2many: async load", async () => {
     expect.verifySteps(["load"]);
     expect(editableContent).toHaveInnerHTML(`<div class="test-options-target">b</div>`);
     defWillLoad.resolve();
-    await defDidApply;
+    await defDidApply.promise;
     expect(editableContent).toHaveInnerHTML(
         `<div class="test-options-target" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}]">b</div>`
     );

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
@@ -6,7 +6,7 @@ import {
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent, useGetItemValue } from "@html_builder/core/utils";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-mock";
+import { animationFrame } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, fields, models, onRpc } from "@web/../tests/web_test_helpers";
 
@@ -24,8 +24,8 @@ describe.current.tags("desktop");
 defineModels([Test]);
 
 test("many2one: async load", async () => {
-    const defWillLoad = new Deferred();
-    const defDidApply = new Deferred();
+    const defWillLoad = Promise.withResolvers();
+    const defDidApply = Promise.withResolvers();
     onRpc("test", "name_search", () => [
         [1, "First"],
         [2, "Second"],
@@ -39,7 +39,7 @@ test("many2one: async load", async () => {
             }
             async load({ value }) {
                 expect.step("load");
-                await defWillLoad;
+                await defWillLoad.promise;
                 return value;
             }
             apply({ editingElement, value }) {
@@ -73,7 +73,7 @@ test("many2one: async load", async () => {
     expect.verifySteps(["load"]);
     expect(editableContent).toHaveInnerHTML(`<div class="test-options-target">b</div>`);
     defWillLoad.resolve();
-    await defDidApply;
+    await defDidApply.promise;
     expect(editableContent).toHaveInnerHTML(
         `<div class="test-options-target" data-test="{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}">b</div>`
     );

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -15,7 +15,6 @@ import {
     press,
     queryFirst,
 } from "@odoo/hoot-dom";
-import { Deferred } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, models } from "@web/../tests/web_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
@@ -108,7 +107,7 @@ test("input with classAction and styleAction", async () => {
 });
 
 test("input kept on async action", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";
@@ -116,7 +115,7 @@ test("input kept on async action", async () => {
                 return editingElement.dataset.test;
             }
             async apply({ editingElement, value }) {
-                await def;
+                await def.promise;
                 editingElement.dataset.test = value;
             }
         },

--- a/addons/html_builder/static/tests/img.test.js
+++ b/addons/html_builder/static/tests/img.test.js
@@ -2,7 +2,7 @@ import { Image } from "@html_builder/core/img";
 import { ImgGroup } from "@html_builder/core/img_group";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { expect, test, describe } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-dom";
 import { Component, xml } from "@odoo/owl";
 import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
@@ -11,13 +11,13 @@ describe.current.tags("desktop");
 defineMailModels(); // meh
 test("ImgGroup's inner Image components should not be blocked before src load", async () => {
     const defs = {
-        img1: new Deferred(),
-        img2: new Deferred(),
-        img3: new Deferred(),
+        img1: Promise.withResolvers(),
+        img2: Promise.withResolvers(),
+        img3: Promise.withResolvers(),
     };
     patchWithCleanup(Image.prototype, {
         loadImage() {
-            const def = defs[this.props.class];
+            const { promise: def } = defs[this.props.class];
             return Promise.all([super.loadImage(), def]);
         },
     });

--- a/addons/html_builder/static/tests/operation.test.js
+++ b/addons/html_builder/static/tests/operation.test.js
@@ -8,7 +8,7 @@ import { Operation } from "@html_builder/core/operation";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { HistoryPlugin } from "@html_editor/core/history_plugin";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { advanceTime, Deferred, delay, hover, press, tick } from "@odoo/hoot-dom";
+import { advanceTime, delay, hover, press, tick } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
@@ -87,12 +87,12 @@ test("handle 3 concurrent cancellable operations (without delay)", async () => {
 
 describe("Block editable", () => {
     test("Doing an operation should block the editable during its execution", async () => {
-        const customActionDef = new Deferred();
+        const customActionDef = Promise.withResolvers();
         addBuilderAction({
             customAction: class extends BuilderAction {
                 static id = "customAction";
                 load() {
-                    return customActionDef;
+                    return customActionDef.promise;
                 }
                 apply({ editingElement }) {
                     editingElement.classList.add("custom-action");

--- a/addons/html_builder/static/tests/utils.test.js
+++ b/addons/html_builder/static/tests/utils.test.js
@@ -6,7 +6,7 @@ import {
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred, delay } from "@odoo/hoot-dom";
+import { animationFrame, delay } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
@@ -71,7 +71,7 @@ describe("waitSidebarUpdated", () => {
                 }
                 async apply({ editingElement, value }) {
                     await delay(delayAmount);
-                    await deferred;
+                    await deferred.promise;
                     editingElement.dataset.value = value;
                 }
             },
@@ -86,7 +86,7 @@ describe("waitSidebarUpdated", () => {
                 super.setup();
                 this.state = useDomState(async (el) => {
                     await delay(delayAmount);
-                    await deferred;
+                    await deferred.promise;
                     return { value: el.dataset.value };
                 });
             }
@@ -112,7 +112,7 @@ describe("waitSidebarUpdated", () => {
                 super.setup();
                 this.state = useDomState(async (el) => {
                     await delay(delayAmount);
-                    await deferred;
+                    await deferred.promise;
                     return { value: el.dataset.value, showOther: el.dataset.value === "c" };
                 });
             }
@@ -122,7 +122,7 @@ describe("waitSidebarUpdated", () => {
             `<div class="test" data-value="a">a</div>`
         );
 
-        deferred = new Deferred();
+        deferred = Promise.withResolvers();
         await contains(":iframe div.test").click();
         expect(".test-value-parent").toHaveCount(0);
         deferred.resolve();
@@ -130,7 +130,7 @@ describe("waitSidebarUpdated", () => {
         await waitSidebarUpdated();
         expect(".test-value-parent").toHaveText("a");
 
-        deferred = new Deferred();
+        deferred = Promise.withResolvers();
         await contains(".test-button-1 button").click();
         expect(".test-value-parent").toHaveText("a");
         expect(".test-button-3").toHaveCount(0);
@@ -140,7 +140,7 @@ describe("waitSidebarUpdated", () => {
         expect(".test-value-parent").toHaveText("b");
         expect(".test-value-sub").toHaveCount(0);
 
-        deferred = new Deferred();
+        deferred = Promise.withResolvers();
         await contains(".test-button-2 button").click();
         expect(".test-value-parent").toHaveText("b");
         expect(".test-value-sub").toHaveCount(0);

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -7,7 +7,6 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { isColorGradient, isCSSColor } from "@web/core/utils/colors";
-import { Deferred } from "@web/core/utils/concurrency";
 import { debounce } from "@web/core/utils/timing";
 import { withSequence } from "@html_editor/utils/resource";
 import { BuilderAction } from "@html_builder/core/builder_action";
@@ -435,7 +434,7 @@ export class AddLanguageAction extends BuilderAction {
         this.preview = false;
     }
     async apply() {
-        const def = new Deferred();
+        const def = Promise.withResolvers();
         // Retrieve the website id to check by default the website checkbox in
         // the dialog box 'action_view_base_language_install'
         const websiteId = this.services.website.currentWebsite.id;
@@ -466,7 +465,7 @@ export class AddLanguageAction extends BuilderAction {
                         // dialog has been cancelled
                         onClose: (closeParams) => def.resolve(!!closeParams?.noReload),
                     });
-                    return await def;
+                    return await def.promise;
                 },
             })
         );
@@ -682,7 +681,7 @@ export class WebsiteConfigAction extends BuilderAction {
      * @returns {Promise} deferred function
      */
     async _customizeThemeData(isViewData, shouldReset, toEnable, toDisable) {
-        const def = new Deferred();
+        const def = Promise.withResolvers();
         this.dependencies.customizeWebsite.getPendingThemeRequests().push({
             isViewData,
             shouldReset,
@@ -728,7 +727,7 @@ export class WebsiteConfigAction extends BuilderAction {
                     .catch(() => Promise.all(defs.map((def) => def.reject())));
             }
         }, 0);
-        return def;
+        return def.promise;
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -3,7 +3,6 @@ import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "@html_editor/plugin";
 import { GoogleMapsApiKeyDialog } from "./google_maps_api_key_dialog";
 import { GoogleMapsOption } from "./google_maps_option";
-import { Deferred } from "@web/core/utils/concurrency";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
 /**
@@ -88,10 +87,10 @@ export class GoogleMapsOptionPlugin extends Plugin {
 
     async onSnippetDropped({ snippetEl }) {
         if (snippetEl.matches(".s_google_map")) {
-            const deferredInit = new Deferred();
+            const deferredInit = Promise.withResolvers();
             this.recentlyDroppedSnippetDeferredInit.set(snippetEl, deferredInit);
             this.dependencies.edit_interaction.restartInteractions(snippetEl);
-            const initSuccess = await deferredInit;
+            const initSuccess = await deferredInit.promise;
             this.recentlyDroppedSnippetDeferredInit.delete(snippetEl);
             if (!initSuccess) {
                 return true; // cancel

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -19,7 +19,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ResizablePanel } from "@web/core/resizable_panel/resizable_panel";
 import { RPCError } from "@web/core/network/rpc";
-import { Deferred } from "@web/core/utils/concurrency";
 import { uniqueId } from "@web/core/utils/functions";
 import { useChildRef, useService, useBus } from "@web/core/utils/hooks";
 import { effect } from "@web/core/utils/reactive";
@@ -163,7 +162,7 @@ export class WebsiteBuilderClientAction extends Component {
                 fn();
             }
         });
-        this.publicRootReady = new Deferred();
+        this.publicRootReady = Promise.withResolvers();
         this.setIframeLoaded();
         this.addSystrayItems();
         onWillDestroy(() => {
@@ -287,7 +286,7 @@ export class WebsiteBuilderClientAction extends Component {
 
         // Wait for navigation to complete if currently navigating
         if (this.isNavigatingToAnotherPage) {
-            await this.isNavigatingToAnotherPage;
+            await this.isNavigatingToAnotherPage.promise;
         }
 
         await this.loadIframeAndBundles(true);
@@ -307,7 +306,7 @@ export class WebsiteBuilderClientAction extends Component {
     async loadIframeAndBundles(isEditing) {
         await this.iframeLoaded;
         if (isEditing) {
-            await this.publicRootReady;
+            await this.publicRootReady.promise;
             await this.loadAssetsEditBundle();
         }
     }
@@ -470,7 +469,7 @@ export class WebsiteBuilderClientAction extends Component {
                     // This scenario triggers a navigation inside the iframe.
                     this.websiteService.websiteRootInstance = undefined;
 
-                    this.isNavigatingToAnotherPage = new Deferred();
+                    this.isNavigatingToAnotherPage = Promise.withResolvers();
                 }
             }
         });
@@ -600,7 +599,7 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     preparePublicRootReady() {
-        const deferred = new Deferred();
+        const deferred = Promise.withResolvers();
         this.publicRootReady = deferred;
         this.websiteContent.el.contentWindow.addEventListener(
             "PUBLIC-ROOT-READY",

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -1,14 +1,6 @@
 import { xml } from "@odoo/owl";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import {
-    advanceTime,
-    animationFrame,
-    click,
-    Deferred,
-    press,
-    queryOne,
-    waitFor,
-} from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
 import { Plugin } from "@html_editor/plugin";
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
@@ -99,11 +91,11 @@ test("getRecordInfo retrieves the info from the #wrap element", async () => {
 });
 
 test("elements within iframe can't be clicked while the builder is being set up", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     patchWithCleanup(WebsiteBuilderClientAction.prototype, {
         async loadIframeAndBundles(isEditing) {
             super.loadIframeAndBundles(isEditing);
-            await def;
+            await def.promise;
         },
     });
     await setupWebsiteBuilder(

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -15,7 +15,7 @@ import {
     getSnippetView,
 } from "@html_builder/../tests/helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { animationFrame, Deferred, queryText, tick, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, queryText, tick, waitFor } from "@odoo/hoot-dom";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
@@ -343,12 +343,12 @@ test("applying option container button should wait for actions in progress", asy
         }
     }
     addPlugin(TestPlugin);
-    const customActionDef = new Deferred();
+    const customActionDef = Promise.withResolvers();
     addActionOption({
         customAction: class extends BuilderAction {
             static id = "customAction";
             load() {
-                return customActionDef;
+                return customActionDef.promise;
             }
             apply({ editingElement }) {
                 editingElement.classList.add("customAction");

--- a/addons/website/static/tests/builder/options/grid_column_option.test.js
+++ b/addons/website/static/tests/builder/options/grid_column_option.test.js
@@ -1,13 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import {
-    animationFrame,
-    click,
-    Deferred,
-    edit,
-    queryAll,
-    queryFirst,
-    waitFor,
-} from "@odoo/hoot-dom";
+import { animationFrame, click, edit, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -22,12 +14,12 @@ test("Using the Padding option should display a padding preview", async () => {
     await waitFor("[data-label='Padding'] input");
     await click(queryAll("[data-label='Padding'] input")[0]);
     await edit(20);
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     expect(queryFirst(":iframe .s_banner .o_grid_item")).toHaveClass("o_we_padding_highlight");
     queryFirst(":iframe .s_banner .o_grid_item").addEventListener("animationend", () => {
         def.resolve();
     });
-    await def;
+    await def.promise;
     await animationFrame();
     expect(queryFirst(":iframe .s_banner .o_grid_item")).not.toHaveClass("o_we_padding_highlight");
 });

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -2,7 +2,7 @@ import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
 import { advanceTime, animationFrame, expect, test } from "@odoo/hoot";
-import { Deferred, tick, waitFor } from "@odoo/hoot-dom";
+import { tick, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
@@ -265,12 +265,12 @@ test("Applying an overlay button action should wait for the actions in progress"
         }
     }
     addPlugin(TestPlugin);
-    const customActionDef = new Deferred();
+    const customActionDef = Promise.withResolvers();
     addActionOption({
         customAction: class extends BuilderAction {
             static id = "customAction";
             load() {
-                return customActionDef;
+                return customActionDef.promise;
             }
             apply({ editingElement }) {
                 editingElement.classList.add("customAction");

--- a/addons/website/static/tests/builder/theme_tab/palette.test.js
+++ b/addons/website/static/tests/builder/theme_tab/palette.test.js
@@ -4,7 +4,6 @@ import {
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
 import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
-import { Deferred } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -16,7 +15,7 @@ test("theme tab: warning on palette change", async () => {
         }
     }
     defineModels([WebsiteAssets]);
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     onRpc("/website/theme_customize_bundle_reload", async (request) => {
         expect.step("asset reload");
         def.resolve();
@@ -41,7 +40,7 @@ test("theme tab: warning on palette change", async () => {
     await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
     expect(".o_dialog").toHaveCount(1);
     await contains(".o_dialog .btn-primary").click();
-    await def;
+    await def.promise;
     expect.verifySteps([
         `/website/static/src/scss/options/user_values.scss {"color-palettes-name":"'default-light-1'"}`,
         "asset reload",
@@ -56,7 +55,7 @@ test("theme tab: no warning on palette change", async () => {
         }
     }
     defineModels([WebsiteAssets]);
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     onRpc("/website/theme_customize_bundle_reload", async (request) => {
         expect.step("asset reload");
         def.resolve();
@@ -69,7 +68,7 @@ test("theme tab: no warning on palette change", async () => {
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();
     await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
-    await def;
+    await def.promise;
     expect(".o_dialog").toHaveCount(0);
     expect.verifySteps([
         `/website/static/src/scss/options/user_values.scss {"color-palettes-name":"'default-light-1'"}`,

--- a/addons/website/static/tests/builder/website_builder/customize_website.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import {
     contains,
@@ -20,12 +20,12 @@ import { renderToString } from "@web/core/utils/render";
 defineWebsiteModels();
 
 test("BuilderButton with action “websiteConfig” are correctly displayed", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     onRpc("/website/theme_customize_data_get", async (request) => {
         const { params } = await request.json();
         expect.step("theme_customize_data_get");
         expect(params.keys).toEqual(["test_template_1", "test_template_2"]);
-        await def;
+        await def.promise;
         return ["test_template_2"];
     });
     addOption({
@@ -116,12 +116,12 @@ test("click on BuilderSelectItem with action “websiteConfig”", async () => {
 });
 
 test("use isActiveItem base on BuilderButton with 'websiteConfig'", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     onRpc("/website/theme_customize_data_get", async (request) => {
         const { params } = await request.json();
         expect.step("theme_customize_data_get");
         expect(params.keys).toEqual(["test_template_1"]);
-        await def;
+        await def.promise;
         return ["test_template_1"];
     });
     addOption({
@@ -143,12 +143,12 @@ test("use isActiveItem base on BuilderButton with 'websiteConfig'", async () => 
 });
 
 test("use isActiveItem base on BuilderCheckbox with 'websiteConfig'", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     onRpc("/website/theme_customize_data_get", async (request) => {
         const { params } = await request.json();
         expect.step("theme_customize_data_get");
         expect(params.keys).toEqual(["test_template_1"]);
-        await def;
+        await def.promise;
         return ["test_template_1"];
     });
     addOption({

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
 import {
@@ -19,7 +19,7 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     }
     defineModels([WebsiteAssets]);
 
-    let def = new Deferred();
+    let def = Promise.withResolvers();
     onRpc("/website/theme_customize_bundle_reload", async (request) => {
         expect.step("asset reload");
         def.resolve();
@@ -53,7 +53,7 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await contains("button.o_we_color_preview").click();
     await contains("button[data-color='o_cc4'").click();
     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles
-    await def;
+    await def.promise;
     expect.verifySteps([
         "set preset",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":4}',
@@ -61,14 +61,14 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         "asset reload",
     ]);
 
-    def = new Deferred();
+    def = Promise.withResolvers();
     // Setting solid color does not impact preset
     expect.step("set solid color");
     await contains("button.o_we_color_preview").click();
     await contains("button.custom-tab").click();
     await contains("button[data-color='400']").click();
     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles
-    await def;
+    await def.promise;
     expect.verifySteps([
         "set solid color",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"#CED4DA"}',
@@ -76,14 +76,14 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         "asset reload",
     ]);
 
-    def = new Deferred();
+    def = Promise.withResolvers();
     // Setting preset does not impact solid color
     expect.step("set preset on solid color");
     await contains("button.o_we_color_preview").click();
     await contains("button.theme-tab").click();
     await contains("button[data-color='o_cc3'").click();
     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles
-    await def;
+    await def.promise;
     expect.verifySteps([
         "set preset on solid color",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":3}',
@@ -91,14 +91,14 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         "asset reload",
     ]);
 
-    def = new Deferred();
+    def = Promise.withResolvers();
     // Setting gradient does not impact preset
     expect.step("set gradient");
     await contains("button.o_we_color_preview").click();
     await contains("button.gradient-tab").click();
     await contains("button.o_gradient_color_button").click();
     // Should wait for 3 ticks (debounced): customizeWebsiteColors, customizeWebsiteVariables, reloadBundles
-    await def;
+    await def.promise;
     expect.verifySteps([
         "set gradient",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL"}',
@@ -106,14 +106,14 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         "asset reload",
     ]);
 
-    def = new Deferred();
+    def = Promise.withResolvers();
     // Setting preset does not impact gradient
     expect.step("set preset on gradient");
     await contains("button.o_we_color_preview").click();
     await contains("button.theme-tab").click();
     await contains("button[data-color='o_cc4'").click();
     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles
-    await def;
+    await def.promise;
     expect.verifySteps([
         "set preset on gradient",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":4}',
@@ -121,13 +121,13 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         "asset reload",
     ]);
 
-    def = new Deferred();
+    def = Promise.withResolvers();
     // Clear clears everything
     expect.step("reset");
     await contains("button.o_we_color_preview").click();
     await contains(".o_font_color_selector .fa-trash").click();
     // Should wait for 3 ticks (debounced): customizeWebsiteColors, customizeWebsiteVariables, reloadBundles
-    await def;
+    await def.promise;
     expect.verifySteps([
         "reset",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":"NULL"}',

--- a/addons/website/static/tests/interactions/image_lazy_loading.test.js
+++ b/addons/website/static/tests/interactions/image_lazy_loading.test.js
@@ -1,7 +1,7 @@
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
-import { Deferred, queryOne, tick } from "@odoo/hoot-dom";
+import { queryOne, tick } from "@odoo/hoot-dom";
 
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { ImageLazyLoading } from "@website/interactions/image_lazy_loading";
@@ -12,10 +12,10 @@ setupInteractionWhiteList("website.image_lazy_loading");
 describe.current.tags("interaction_dev");
 
 test("images lazy loading removes height then restores it", async () => {
-    const def = new Deferred();
+    const def = Promise.withResolvers();
     patchWithCleanup(ImageLazyLoading.prototype, {
         async willStart() {
-            await def;
+            await def.promise;
         },
     });
     const { core } = await startInteractions(

--- a/addons/website/static/tests/interactions/listing_layout.test.js
+++ b/addons/website/static/tests/interactions/listing_layout.test.js
@@ -2,7 +2,6 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { click, microTick, queryOne } from "@odoo/hoot-dom";
-import { Deferred } from "@odoo/hoot-mock";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -11,7 +10,7 @@ setupInteractionWhiteList("website.listing_layout");
 describe.current.tags("interaction_dev");
 
 test("listing_layout toggle to list mode", async () => {
-    const deferred = new Deferred();
+    const deferred = Promise.withResolvers();
     await startInteractions(`
         <div class="container o_website_listing_layout">
             <section>
@@ -56,12 +55,12 @@ test("listing_layout toggle to list mode", async () => {
         "px-2",
         "col-xs-12",
     ]);
-    await deferred;
+    await deferred.promise;
     expect.verifySteps(["rpc"]);
 });
 
 test("listing_layout toggle to grid mode", async () => {
-    const deferred = new Deferred();
+    const deferred = Promise.withResolvers();
     await startInteractions(`
         <div class="container o_website_listing_layout">
             <section>
@@ -106,6 +105,6 @@ test("listing_layout toggle to grid mode", async () => {
         "px-2",
         "col-xs-12",
     ]);
-    await deferred;
+    await deferred.promise;
     expect.verifySteps(["rpc"]);
 });

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -2,7 +2,7 @@ import { setupInteractionWhiteList, startInteractions } from "@web/../tests/publ
 
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, clear, click, fill, queryOne, setInputFiles } from "@odoo/hoot-dom";
-import { advanceTime, Deferred } from "@odoo/hoot-mock";
+import { advanceTime } from "@odoo/hoot-mock";
 
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 
@@ -409,14 +409,14 @@ test("(rpc) form checks conditions", async () => {
     await advanceTime(400); // Debounce delay.
 
     let rpcCheck = false;
-    const rpcDone = new Deferred();
+    const rpcDone = Promise.withResolvers();
     onRpc("/website/form/mail.mail", async (args) => {
         rpcCheck = true;
         rpcDone.resolve();
         return {};
     });
     await click("a.s_website_form_send");
-    await rpcDone;
+    await rpcDone.promise;
     expect(rpcCheck).toBe(true);
 });
 

--- a/addons/website_forum/static/tests/interactions/website_forum_spam.test.js
+++ b/addons/website_forum/static/tests/interactions/website_forum_spam.test.js
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { advanceTime, click, edit, fill, queryAll, tick } from "@odoo/hoot-dom";
-import { Deferred } from "@odoo/hoot-mock";
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -38,9 +37,9 @@ test("spamIds returns empty array if dataset is empty", async () => {
 test("keep last spam input search", async () => {
     await startInteractions(template({ spamIds: true }));
 
-    const def = new Deferred();
-    def.then(() => expect.step("rpc"));
-    onRpc("forum.post", "search_read", async () => await def);
+    const def = Promise.withResolvers();
+    def.promise.then(() => expect.step("rpc"));
+    onRpc("forum.post", "search_read", async () => await def.promise);
     await click("#spamSearch");
     await fill("coucou");
     await advanceTime(201); // debounced


### PR DESCRIPTION
*: website_forum

Commit [1] deprecated `Deferred` to promote the native
`Promise.withResolvers()`. As a polyfill is available for older browsers
on the frontend, we can safely remove uses of `Deferred` everywhere in
the html_builder / website.

[1]: https://github.com/odoo/odoo/commit/2067b860d2168ff581434f21b49355af92d09780