### PR TITLE
[FIX] base_automation: keep to compute values in pre-filter

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -619,9 +619,20 @@ class BaseAutomation(models.Model):
                 # automations while evaluating their precondition
                 records = records.with_context(__action_feedback=True)
             domain = safe_eval.safe_eval(self_sudo.filter_pre_domain, self._get_eval_context())
-            return records.sudo().filtered_domain(domain).with_env(records.env)
-        else:
-            return records
+            # keep computed fields depending on the currently changed field
+            # as-is so they are recomputed after the value is set
+            # see `test_computation_sequence`
+            changed_fields = self.env.context.get('changed_fields', ())
+            to_compute = {
+                dep: comp
+                for f in changed_fields
+                for dep in self.env.registry.get_dependent_fields(f)
+                if (comp := self.env.records_to_compute(dep))
+            }
+            records = records.with_context(changed_fields=()).sudo().filtered_domain(domain).sudo(records.env.su)
+            for dep, comp in to_compute.items():
+                self.env.add_to_compute(dep, comp)
+        return records
 
     def _filter_post(self, records, feedback=False):
         return self._filter_post_export_domain(records, feedback)[0]
@@ -789,7 +800,9 @@ class BaseAutomation(models.Model):
                     _compute_field_value.origin(self, field)
                     return True
                 # check preconditions on records
-                pre = {a: a._filter_pre(records) for a in automations}
+                # changed fields are all fields computed by the function
+                changed_fields = [f for f in records._fields.values() if f.compute == field.compute]
+                pre = {a: a.with_context(changed_fields=changed_fields)._filter_pre(records) for a in automations}
                 # read old values before the update
                 old_values = {
                     record.id: {fname: record[fname] for fname in stored_fnames}

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -109,6 +109,10 @@ class Task(models.Model):
         compute='_compute_project_id', recursive=True, store=True, readonly=False,
     )
     state = fields.Boolean(tracking=True)
+    allocated_hours = fields.Float()
+    trigger_hours = fields.Float("Save time to trigger effective hours")
+    remaining_hours = fields.Float("Time Remaining", compute='_compute_remaining_hours', store=True, readonly=True, help="Number of allocated hours minus the number of hours spent.")
+    effective_hours = fields.Float("Time Spent", compute='_compute_effective_hours', compute_sudo=True, store=True)
 
     @api.depends('parent_id.project_id')
     def _compute_project_id(self):
@@ -120,6 +124,19 @@ class Task(models.Model):
         if 'state' in changes:
             return {'state': (self.env.ref("test_base_automation.test_tracking_template"), {})}
         return {}
+
+    @api.depends('trigger_hours')
+    def _compute_effective_hours(self):
+        for task in self:
+            task.effective_hours = task.trigger_hours
+
+    @api.depends('effective_hours')
+    def _compute_remaining_hours(self):
+        for task in self:
+            if not task.allocated_hours:
+                task.remaining_hours = 0.0
+            else:
+                task.remaining_hours = task.allocated_hours - task.effective_hours
 
 
 class Stage(models.Model):

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -978,6 +978,31 @@ class TestCompute(common.TransactionCase):
         r.parent_id = company2
         self.assertEqual(r.display_name, 'Awiclo, Bob')
 
+    def test_computation_sequence(self):
+        """ This test ensure sequential computation is done and all fields are correctly set
+        when a filter_pre_domain trigger computation of one of the chain element
+        """
+        project = self.env['test_base_automation.project'].create({})
+        task = self.env['test_base_automation.task'].create({
+            'project_id': project.id,
+            'allocated_hours': 100,
+        })
+
+        # this action is executed every time a task is modified
+        create_automation(
+            self,
+            model_id=self.env.ref('test_base_automation.model_test_base_automation_task').id,
+            trigger='on_create_or_write',
+            filter_pre_domain="[('remaining_hours', '>', 0)]",
+            _actions={'state': 'code'},  # no-op action
+        )
+
+        task.trigger_hours = 5
+        self.assertRecordValues(task, [{
+            'effective_hours': 5,
+            'remaining_hours': 95,
+        }])
+
     def test_recursion(self):
         project = self.env['test_base_automation.project'].create({})
 


### PR DESCRIPTION
This PR is a cherry-pick of: https://github.com/odoo/odoo/pull/236323

When a pre-filter condition of an automation flushes fields, we must ensure that their recomputation is still scheduled afterwards For example, if a rule pre-filters on field B (which depends on A), computing A should not clear the compute flag of B

### Issue:
In some automation rules, computed fields must be processed in a specific order (e.g., `effective_hours` -> `remaining_hours`)
However, if `remaining_hours` is referenced in the automation `Before Update Domain`, its compute flag may be incorrectly cleared, preventing the proper recomputation chain

This results in inconsistent behavior, such as delays in activities being created when timesheets exceed allocated time

### Cause:
The automation engine flushes fields referenced in the `Before Update Domain`, but does not restore their compute flags afterward Thus dependent fields are not recomputed as expected

### Steps to reproduce:
1. Enable Debug Mode
2. Create an Automation Rule
-- Name: Time Exceeded
-- Model: Task
-- Trigger: On Save
-- Before Update Domain: [("remaining_hours", ">=", 0)]
-- Apply on: [("remaining_hours", "<", 0)]
4. Create a Project with Timesheets
5. Create a Task inside the Project
6. Set Allocated Time to 10h
7. Use the Start button to record 11h (No activity appears in chatter)
8. Do the same again (Activity appears only after the second exceed) Before the fix, there is always a delay because the recomputation chain is broken

### Tickets:
18.0: opw-4409744
17.0: opw-5237430