### PR TITLE
[FIX] sale: prevent invoice_origin from being copied via Invoices smart button

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1235,7 +1235,6 @@ class SaleOrder(models.Model):
                 'default_partner_id': self.partner_id.id,
                 'default_partner_shipping_id': self.partner_shipping_id.id,
                 'default_invoice_payment_term_id': self.payment_term_id.id or self.partner_id.property_payment_term_id.id or self.env['account.move'].default_get(['invoice_payment_term_id']).get('invoice_payment_term_id'),
-                'default_invoice_origin': self.name,
             })
         action['context'] = context
         return action


### PR DESCRIPTION
### Issue:
When opening an invoice from a Sale Order and duplicating it, the Source Document (invoice_origin) was also copied As a result, both the original and duplicated invoice showed the same Sale Order in the Source Document field

### Cause:
The `action_view_invoice` method adds `default_invoice_origin` in the context, causing the `copy` function to set `invoice_origin` The field invoice_origin was already set with copy=False in this PR: https://github.com/odoo/odoo/pull/236656

The default context was introduced in PR: https://github.com/odoo/odoo/pull/34561

### Steps to reproduce:
- Create a sales order (SO)
- Create and confirm an invoice from the SO
- Click on the `Invoices` smart button to access the invoice  (SO is visible at the top)
- Duplicate and confirm the invoice (The SO is not linked)
- Go to the invoices list view and make the `Source Document` visible
- Observe that both invoices show the same SO as their `Source Document`

opw-5360172