### PR TITLE
[IMP] tools: optimize translation import query

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1509,15 +1509,20 @@ class TranslationImporter:
                                 translations.update({k: v for k, v in translation_dictionary[term_en].items() if v != term_en})
                                 translation_dictionary[term_en] = translations
 
+                        changed_values = {}
                         for lang in langs:
                             # translate and confirm model_terms translations
-                            values[lang] = field.translate(lambda term: translation_dictionary.get(term, {}).get(lang), _value_en)
-                            values.pop(f'_{lang}', None)
-                        params.extend((id_, Json(values)))
+                            new_val = field.translate(lambda term: translation_dictionary.get(term, {}).get(lang), _value_en)
+                            if values.get(lang, None) != new_val:
+                                changed_values[lang] = new_val
+                            if f'_{lang}' in values:
+                                changed_values[f'_{lang}'] = None
+                        if changed_values:
+                            params.extend((id_, Json(changed_values)))
                     if params:
                         env.cr.execute(f"""
                             UPDATE "{model_table}" AS m
-                            SET "{field_name}" =  t.value
+                            SET "{field_name}" = jsonb_strip_nulls("{field_name}" || t.value)
                             FROM (
                                 VALUES {', '.join(['(%s, %s::jsonb)'] * (len(params) // 2))}
                             ) AS t(id, value)


### PR DESCRIPTION
Before this commit, when importing the translations with the TranslationImporter object, the save method was building one big query per model, with each JSON object containing all the languages.

On our server, where 36 languages are installed, this leads to big JSON objects, especially for some large mail templates. Recently, we even got MemoryErrors because of the soft memory limit being hit. The query was about 250MB long.

In the function, we already have the current values, so it's easy to compare them to the new values, and only consider these in the query. Furthermore, there is no need to add the languages that aren't being updated.

With this commit, we are building a slightly more complicated query, but it will receive much less data when the translations are updated frequently, as unchanged values will be ignored.

Task-id: none