### PR TITLE
[FIX] html_editor,mail*: various fixes and minor imps

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -9,10 +9,9 @@ import { closestBlock } from "@html_editor/utils/blocks";
 import { isEmptyBlock, isParagraphRelatedElement } from "../utils/dom_info";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
-function isAvailable(selection) {
-    return (
-        isHtmlContentSupported(selection) &&
-        !closestElement(selection.anchorNode, ".o_editor_banner")
+function checkCommandAvailablePredicates(selection) {
+    return this.getResource("banner_command_available_predicates").every((predicateFn) =>
+        predicateFn(selection)
     );
 }
 
@@ -34,7 +33,7 @@ export class BannerPlugin extends Plugin {
                 title: _t("Banner Info"),
                 description: _t("Insert an info banner"),
                 icon: "fa-info-circle",
-                isAvailable,
+                isAvailable: checkCommandAvailablePredicates.bind(this),
                 run: () => {
                     this.insertBanner(_t("Banner Info"), "💡", "info");
                 },
@@ -44,7 +43,7 @@ export class BannerPlugin extends Plugin {
                 title: _t("Banner Success"),
                 description: _t("Insert a success banner"),
                 icon: "fa-check-circle",
-                isAvailable,
+                isAvailable: checkCommandAvailablePredicates.bind(this),
                 run: () => {
                     this.insertBanner(_t("Banner Success"), "✅", "success");
                 },
@@ -54,7 +53,7 @@ export class BannerPlugin extends Plugin {
                 title: _t("Banner Warning"),
                 description: _t("Insert a warning banner"),
                 icon: "fa-exclamation-triangle",
-                isAvailable,
+                isAvailable: checkCommandAvailablePredicates.bind(this),
                 run: () => {
                     this.insertBanner(_t("Banner Warning"), "⚠️", "warning");
                 },
@@ -64,7 +63,7 @@ export class BannerPlugin extends Plugin {
                 title: _t("Banner Danger"),
                 description: _t("Insert a danger banner"),
                 icon: "fa-exclamation-circle",
-                isAvailable,
+                isAvailable: checkCommandAvailablePredicates.bind(this),
                 run: () => {
                     this.insertBanner(_t("Banner Danger"), "❌", "danger");
                 },
@@ -74,7 +73,7 @@ export class BannerPlugin extends Plugin {
                 title: _t("Monospace"),
                 description: _t("Insert a monospace banner"),
                 icon: "fa-laptop",
-                isAvailable,
+                isAvailable: checkCommandAvailablePredicates.bind(this),
                 run: () => {
                     this.insertBanner(
                         _t("Monospace Banner"),
@@ -85,6 +84,9 @@ export class BannerPlugin extends Plugin {
                 },
             },
         ],
+        banner_command_available_predicates: (selection) =>
+            isHtmlContentSupported(selection) &&
+            !closestElement(selection.anchorNode, ".o_editor_banner"),
         powerbox_categories: withSequence(20, { id: "banner", name: _t("Banner") }),
         powerbox_items: [
             {

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -723,8 +723,10 @@ class MailMessage(models.Model):
                             attachment.generate_access_token()
                             attachments = values.setdefault('attachment_ids', [])
                             attachments.append((4, attachment.id))
-                            data_to_url[key] = ['/web/image/%s?access_token=%s' % (attachment.id, attachment.access_token), name]
-                    return '%s%s alt="%s"' % (data_to_url[key][0], match.group(3), data_to_url[key][1])
+                            data_to_url[key] = ['/web/image/%s?access_token=%s' % (attachment.id, attachment.access_token), name, attachment.id]
+                    # data-attachment-id helps identify image attachments that are already inserted in the body
+                    # this is notably used to avoid displaying them twice in the chatter
+                    return f'{data_to_url[key][0]}{match.group(3)} alt="{data_to_url[key][1]}" data-attachment-id="{data_to_url[key][2]}"'
                 values['body'] = _image_dataurl.sub(base64_to_boundary, values['body'] or '')
 
             # delegate creation of tracking after the create as sudo to avoid access rights issues

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -13,6 +13,8 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
 
+import { attClassObjectToString } from "@mail/utils/common/format";
+
 class Actions extends Component {
     static components = { Dropdown, DropdownItem };
     static props = ["actions"];
@@ -35,6 +37,9 @@ export class AttachmentList extends Component {
     static components = { Actions, Gif };
     static props = ["attachments", "unlinkAttachment", "messageSearch?"];
     static template = "mail.AttachmentList";
+
+    // make this available for class evaluation in the template
+    attClassObjectToString = attClassObjectToString;
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -1,9 +1,9 @@
 .o-mail-AttachmentContainer {
-    &.o-inMessage.o-isImage {
+    &.o-inMessage.o-isImage:not(.o-inChatter) {
         min-width: 13em;
         min-height: 10em;
     }
-    &:not(.o-inMessage.o-isImage) {
+    &:not(.o-inMessage.o-isImage),&.o-inChatter.o-inMessage.o-isImage {
         width: 13em;
         height: 10em;
     }

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -15,6 +15,7 @@
                      t-att-title="attachment.name ? attachment.name : undefined"
                      t-att-class="{
                         'o-inMessage': env.inMessage,
+                        'o-inChatter': env.inChatter,
                         'o-isImage': attachment.isImage,
                         'o-isUploading opacity-25': attachment.uploading,
                         'o-viewable': attachment.isViewable,
@@ -30,12 +31,23 @@
                         src="getImageUrl(attachment)"
                         paused="attachment.gifPaused"
                         alt="attachment.name"
-                        class="'o-mail-AttachmentImage img img-fluid w-100 rounded-3 ' + (env.inMessage ? 'object-fit-contain o-inMessage' : 'object-fit-cover')"
+                        class="attClassObjectToString({
+                            'o-mail-AttachmentImage img img-fluid w-100 rounded-3': true,
+                            'o-inMessage': env.inMessage,
+                            'o-inChatter object-fit-scale': env.inChatter,
+                            'object-fit-contain': !env.inChatter and env.inMessage,
+                            'object-fit-cover': !env.inChatter and !env.inMessage,
+                        })"
                     />
                     <img
                         t-elif="attachment.isImage"
                         class="o-mail-AttachmentImage img img-fluid w-100 rounded-3"
-                        t-att-class="{ 'object-fit-contain o-inMessage': env.inMessage, 'object-fit-cover': !env.inMessage }"
+                        t-att-class="{
+                            'o-inMessage': env.inMessage,
+                            'o-inChatter object-fit-scale': env.inChatter,
+                            'object-fit-contain': !env.inChatter and env.inMessage,
+                            'object-fit-cover': !env.inChatter and !env.inMessage,
+                        }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"
                         t-on-load="onImageLoaded"

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -33,13 +33,7 @@ import {
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import {
-    createElementWithContent,
-    htmlJoin,
-    isHtmlEmpty,
-    isMarkup,
-    setElementContent,
-} from "@web/core/utils/html";
+import { htmlJoin, isHtmlEmpty, isMarkup, setElementContent } from "@web/core/utils/html";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { isEmail } from "@web/core/utils/strings";
 import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
@@ -615,18 +609,7 @@ export class Composer extends Component {
             // Reset signature when recovering an empty body.
             composer.emailAddSignature = true;
         }
-        let signature = this.thread.effectiveSelf.main_user_id?.signature;
-        if (signature) {
-            const divElement = document.createElement("div");
-            divElement.setAttribute("data-o-mail-quote", "1");
-            divElement.append(
-                document.createElement("br"),
-                document.createTextNode("-- "),
-                document.createElement("br"),
-                ...createElementWithContent("div", signature).childNodes
-            );
-            signature = markup(divElement.outerHTML);
-        }
+        const signature = this.thread.effectiveSelf.main_user_id?.getSignatureBlock();
         default_body = this.formatDefaultBodyForFullComposer(
             default_body,
             this.props.composer.emailAddSignature ? signature : ""

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -131,8 +131,8 @@
                                 </div>
                                 <div class="position-relative">
                                     <AttachmentList
-                                        t-if="message.attachment_ids.length > 0"
-                                        attachments="message.attachment_ids.map((a) => a)"
+                                        t-if="message.extra_body_attachment_ids.length > 0"
+                                        attachments="message.extra_body_attachment_ids"
                                         unlinkAttachment.bind="onClickAttachmentUnlink"
                                         messageSearch="props.messageSearch"/>
                                 </div>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -142,7 +142,7 @@ registerMessageAction("edit", {
         message.enterEditMode(thread);
         owner.optionsDropdown?.close();
     },
-    sequence: ({ message }) => (message.isSelfAuthored ? 20 : 55),
+    sequence: ({ message }) => (message.isSelfAuthored ? 20 : 115),
 });
 registerMessageAction("delete", {
     condition: ({ message }) => message.editable,

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -74,6 +74,17 @@ export class Message extends Record {
             );
         },
     });
+    /** attachments not already clearly visible in the body, unlike inlined images */
+    extra_body_attachment_ids = fields.Attr("ir.attachment", {
+        compute() {
+            const parsedBody = createDocumentFragmentFromContent(this.body);
+            const inlinedImageAttachmentIds = [
+                ...parsedBody.querySelectorAll("img[data-attachment-id]"),
+            ].map((img) => parseInt(img.dataset.attachmentId));
+
+            return this.attachment_ids.filter((a) => !inlinedImageAttachmentIds.includes(a.id));
+        },
+    });
     hasLink = fields.Attr(false, {
         compute() {
             if (this.isBodyEmpty) {

--- a/addons/mail/static/src/core/common/res_users_model.js
+++ b/addons/mail/static/src/core/common/res_users_model.js
@@ -1,3 +1,5 @@
+import { markup } from "@odoo/owl";
+import { createElementWithContent } from "@web/core/utils/html";
 import { fields, Record } from "@mail/core/common/record";
 
 export class ResUsers extends Record {
@@ -30,6 +32,24 @@ export class ResUsers extends Record {
     share;
     /** @type {ReturnType<import("@odoo/owl").markup>|string|undefined} */
     signature = fields.Html(undefined);
+
+    /**
+     * Get the signature with its typical layout when inserted in html
+     */
+    getSignatureBlock() {
+        if (!this.signature) {
+            return "";
+        }
+        const divElement = document.createElement("div");
+        divElement.setAttribute("data-o-mail-quote", "1");
+        divElement.append(
+            document.createElement("br"),
+            document.createTextNode("-- "),
+            document.createElement("br"),
+            ...createElementWithContent("div", this.signature).childNodes
+        );
+        return markup(divElement.outerHTML);
+    }
 }
 
 ResUsers.register();

--- a/addons/mail/static/src/core/web/message_actions_patch.js
+++ b/addons/mail/static/src/core/web/message_actions_patch.js
@@ -50,11 +50,13 @@ registerMessageAction("reply-all", {
             email,
             message,
             name: name || email,
+            signature: thread.effectiveSelf.main_user_id?.getSignatureBlock(),
         });
         const context = {
             default_body: body,
             default_composition_mode: "comment",
             default_composition_comment_option: "reply_all",
+            default_email_add_signature: false,
             default_partner_ids: recipientIds,
         };
         messageActionOpenFullComposer(_t("Reply All"), context, owner);
@@ -65,7 +67,7 @@ registerMessageAction("forward", {
     condition: ({ message, thread }) => message.canForward(thread),
     icon: "fa fa-share",
     name: _t("Forward"),
-    onSelected: async ({ message, owner, store }) => {
+    onSelected: async ({ message, owner, store, thread }) => {
         const emailFrom = message.author_id?.email || message.email_from;
         const [name, email] = parseEmail(emailFrom);
         const datetime = _t("%(date)s at %(time)s", {
@@ -78,6 +80,7 @@ registerMessageAction("forward", {
             email,
             message,
             name: name || email,
+            signature: thread.effectiveSelf.main_user_id?.getSignatureBlock(),
         });
         const attachmentIds = message.attachment_ids.map((a) => a.id);
         const newAttachmentIds = await store.env.services.orm.call(
@@ -93,6 +96,7 @@ registerMessageAction("forward", {
             default_body: body,
             default_composition_mode: "comment",
             default_composition_comment_option: "forward",
+            default_email_add_signature: false,
         };
         messageActionOpenFullComposer(_t("Forward Message"), context, owner);
     },

--- a/addons/mail/static/src/core/web/message_actions_patch.js
+++ b/addons/mail/static/src/core/web/message_actions_patch.js
@@ -39,7 +39,7 @@ registerMessageAction("reply-all", {
         });
         const recipientIds = recipients.map((r) => r.id);
         const emailFrom = message.author_id?.email || message.email_from;
-        const [name, email] = parseEmail(emailFrom);
+        const [name, email] = emailFrom ? parseEmail(emailFrom) : ["", ""];
         const datetime = _t("%(date)s at %(time)s", {
             date: message.datetime.toFormat("ccc, MMM d, yyyy"),
             time: message.datetime.toFormat("hh:mm a"),
@@ -69,7 +69,7 @@ registerMessageAction("forward", {
     name: _t("Forward"),
     onSelected: async ({ message, owner, store, thread }) => {
         const emailFrom = message.author_id?.email || message.email_from;
-        const [name, email] = parseEmail(emailFrom);
+        const [name, email] = emailFrom ? parseEmail(emailFrom) : ["", ""];
         const datetime = _t("%(date)s at %(time)s", {
             date: message.datetime.toFormat("ccc, MMM d, yyyy"),
             time: message.datetime.toFormat("hh:mm a"),

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -56,7 +56,7 @@
 
     <t t-name="mail.Message.bodyInReply">
         <div><br/></div>
-        <div class="o_mail_reply_container">
+        <div class="o_mail_reply_container" data-o-mail-quote="1">
             <div class="o_mail_reply_content">
                 <div>
                     <span>On <t t-esc="date"/> <t t-esc="name"/> <a t-att-href="'mailto:' + email" target="_blank">&lt;<t t-esc="email"/>&gt;</a>wrote</span>

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -46,6 +46,12 @@
             <span>Subject: <t t-esc="message.subject || message.default_subject"/></span>
         </div>
         <t t-out="body"/>
+        <div t-if="signature" data-o-mail-quote="1">
+            <br/>
+            <t t-call="html_editor.Signature">
+                <t t-set="signatureClass" t-value="'o-signature-container'"/>
+            </t>
+        </div>
     </t>
 
     <t t-name="mail.Message.bodyInReply">
@@ -57,6 +63,12 @@
                 </div>
                 <blockquote t-out="body"/>
             </div>
+        </div>
+        <div t-if="signature" data-o-mail-quote="1">
+            <br/>
+            <t t-call="html_editor.Signature">
+                <t t-set="signatureClass" t-value="'o-signature-container'"/>
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/content_expandable_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/content_expandable_plugin.js
@@ -52,7 +52,7 @@ export class ContentExpandablePlugin extends Plugin {
             this.dependencies.protectedNode.setProtectingNode(subEl, false);
             subEl.classList.add("d-none");
         }
-        const mailQuoteElement = this.editable.querySelectorAll('*[data-o-mail-quote="1"]');
+        const mailQuoteElement = ele.querySelectorAll('*[data-o-mail-quote="1"]');
         for (const element of mailQuoteElement) {
             element.removeAttribute("data-o-mail-quote");
             element.removeAttribute("style");

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/disable_banner_commands_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/disable_banner_commands_plugin.js
@@ -1,0 +1,9 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class DisableBannerCommandsPlugin extends Plugin {
+    static id = "disable_banner_commands";
+    static dependencies = ["banner"];
+    resources = {
+        banner_command_available_predicates: () => false,
+    };
+}

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -5,6 +5,7 @@ import { useBus } from "@web/core/utils/hooks";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
 import { MentionPlugin } from "./mention_plugin";
 import { ContentExpandablePlugin } from "./content_expandable_plugin";
+import { DisableBannerCommandsPlugin } from "./disable_banner_commands_plugin";
 import { fillEmpty } from "@html_editor/utils/dom";
 import { markup } from "@odoo/owl";
 
@@ -39,7 +40,7 @@ export class HtmlComposerMessageField extends HtmlMailField {
 
     getConfig() {
         const config = super.getConfig(...arguments);
-        config.Plugins = [...config.Plugins, MentionPlugin];
+        config.Plugins = config.Plugins.concat([DisableBannerCommandsPlugin, MentionPlugin]);
         if (this.props.record.data.composition_comment_option === "reply_all") {
             config.Plugins.push(ContentExpandablePlugin);
         }

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -40,7 +40,10 @@ export class HtmlComposerMessageField extends HtmlMailField {
 
     getConfig() {
         const config = super.getConfig(...arguments);
-        config.Plugins = config.Plugins.concat([DisableBannerCommandsPlugin, MentionPlugin]);
+        config.Plugins = config.Plugins.filter((plugin) => !["video"].includes(plugin.id)).concat([
+            DisableBannerCommandsPlugin,
+            MentionPlugin,
+        ]);
         if (this.props.record.data.composition_comment_option === "reply_all") {
             config.Plugins.push(ContentExpandablePlugin);
         }

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
@@ -25,6 +25,12 @@
             .note-editable {
                 padding-left: 0;
                 padding-right: 0;
+                
+                &:not(.o_field_highlight) {
+                    &:hover, &:focus {
+                        --o-input-border-color: transparent;
+                    }
+                }
             }
         }
     }

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -160,6 +160,49 @@ class TestMailComposerForm(TestMailComposer):
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('employee')
+    def test_composer_template_change_recipients_update(self):
+        """Check that recipients only change when coming or going to a template with specific recipients."""
+        self.mail_template.write({
+            'email_to': self.partner_private.email_formatted,
+            'partner_to': False,
+            'use_default_to': False,
+        })
+        specific_recipient_template = self.mail_template
+        specific_recipient_template_copy = specific_recipient_template.copy(default={
+            'email_to': False,
+            'partner_to': f'{self.partner_private_2.id}',
+        })
+        default_recipient_template = specific_recipient_template.copy(default={
+            'email_to': False, 'partner_to': False, 'use_default_to': True,
+        })
+        default_recipient_template_copy = default_recipient_template.copy()
+        test_record = self.test_record.with_env(self.env)
+        default_recipient = test_record
+        self.assertTrue(default_recipient, self.env.registry['res.partner'])
+
+        cases = [
+            (self.partner_classic, False, specific_recipient_template, self.partner_private, 'No template -> Specific recipients'),
+            (self.partner_classic, specific_recipient_template, specific_recipient_template_copy, self.partner_private_2, 'Specific recipients -> Specific recipients'),
+            (self.partner_classic, specific_recipient_template_copy, default_recipient_template, self.partner_classic, 'Specific recipients -> Default recipients'),
+            (None, default_recipient_template, default_recipient_template_copy, default_recipient, 'Default recipients -> Default recipients'),
+            (self.partner_classic, default_recipient_template, default_recipient_template_copy, self.partner_classic, 'Default recipients -> Default recipients'),
+            (self.partner_classic, default_recipient_template_copy, specific_recipient_template, self.partner_private, 'Default recipients -> Specific recipients'),
+            (None, specific_recipient_template, False, False, 'Specific recipients -> No template'),
+            (None, default_recipient_template, False, False, 'Default recipients -> No template'),
+        ]
+        for previous_partners, previous_template, new_template, expected_partners, case_name in cases:
+            with self.subTest(case=case_name):
+                composer_form = Form(self.env['mail.compose.message'].with_context({
+                    'default_model': test_record._name,
+                    'default_res_ids': test_record.ids,
+                    'default_template_id': previous_template and previous_template.id,
+                } | ({'default_partner_ids': previous_partners.ids} if previous_partners is not None else {})
+                ))
+                composer_form.template_id = new_template or self.env['mail.template']
+                self.assertEqual(sorted(composer_form.partner_ids.ids), sorted(expected_partners.ids if expected_partners else []))
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    @users('employee')
     def test_composer_template_recipients_private(self):
         """ Test usage of a private partner in composer, coming from template
         value """

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -511,8 +511,13 @@ class MailComposeMessage(models.TransientModel):
         When not having a template, recipients may come from the parent in
         comment mode, to be sure to notify the same people. """
         for composer in self:
-            if (composer.template_id and composer.composition_mode == 'comment'
-                and not composer.composition_batch):
+            template = composer.template_id
+            # Use template in comment mode only if there are no partners yet or if the template specifies different ones
+            # as suggested recipients should normally not change and we don't want to re-add them every time
+            if (template and composer.composition_mode == 'comment'
+                and not composer.composition_batch
+                and (not template.use_default_to or not composer.partner_ids)
+            ):
                 res_ids = composer._evaluate_res_ids() or [0]
                 rendered_values = composer._generate_template_for_composer(
                     res_ids,

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -323,10 +323,11 @@ class TestMessageValues(MailCommon):
             'body': 'taratata <img src="data:image/png;base64,iV/+OkI=" width="2"> <img src="data:image/png;base64,iV/+OkI=" width="2">',
         })
         self.assertEqual(len(msg.attachment_ids), 1)
+        attachment = msg.attachment_ids[0]
         self.assertEqual(
             msg.body,
-            '<p>taratata <img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" width="2"> '
-            '<img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" width="2"></p>'.format(attachment=msg.attachment_ids[0])
+            f'<p>taratata <img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" data-attachment-id="{attachment.id}" width="2"> '
+            f'<img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" data-attachment-id="{attachment.id}" width="2"></p>'
         )
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.models')

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -256,7 +256,12 @@ registry.category("web_tour.tours").add("course_review_modification_by_admin", {
         {
             trigger:
                 "#chatterRoot:shadow .o-mail-Message:contains(Non admin user review) .o_website_rating_static[title='3 stars on 5']",
-            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Edit']",
+            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Expand']"
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains(Non admin user review) .o_website_rating_static[title='3 stars on 5']",
+            run: "hover && click #chatterRoot:shadow button[name='edit']",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer-input",


### PR DESCRIPTION
Backport of fixes added in odoo/odoo#238694

- banners don't work in emails because of inline conversion, and we don't need them
- video elements and iframes are also not supported, hence we can remove the plugin entirely
- the highlight inside the composer is redundant with the footer separator
- "edit" should not be a quick option for admins on other users' messages, instead reply is more appropriate
- signatures should be shown when composing replies and forwards as well
- images already embedded into the body of a message don't need to be shown as attachments as well
- images shown in the composer don't need to be big and legible by default, users can click on them as needed
- when the author has no email and there is no email from (log not on a fresh db for example), replying should be possible
- recipients should not be recomputed in the composer unless the user selected a template using specific recipients. This avoids picking a bunch of specific recipients only to lose them when picking a template.
- when sending a reply immediately without touching the body, the reply content should still be quoted

task-5013894
