### PR TITLE
[IMP] mail: reduce opacity of borders in discuss app in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -84,7 +84,7 @@ export class ChatWindow extends Component {
     get attClass() {
         return {
             "w-100 h-100 o-mobile": this.ui.isSmall,
-            "o-rounded-bubble border border-dark mb-2": !this.ui.isSmall,
+            "o-rounded-bubble border border-dark o-border-opacity-15 mb-2": !this.ui.isSmall,
         };
     }
 

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -6,7 +6,6 @@
         z-index: $zindex-sticky - 2 !important;
     }
     &:not(.o-mobile) {
-        --border-opacity: .15;
         height: Min(95vh, $o-mail-ChatWindow-width * 15 / 9)
     }
     outline: none;

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -10,7 +10,7 @@
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 border-bottom border-secondary" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 border-bottom border-dark o-border-opacity-15" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
             <t t-if="hasActionsMenu">
                 <div class="d-flex text-truncate bg-inherit">
                     <Dropdown position="ui.isSmall ? 'bottom-end' : 'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="store.discussDropdownMenuClass(this)">

--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -1,9 +1,6 @@
 .o-mail-Composer {
     --mail-Composer-bg: #{mix($gray-100, $o-view-background-color)};
-}
-
-.o-mail-Composer-bg {
-    --border-opacity: 0.25;
+    --mail-Composer-focusedOpacity: .5;
 }
 
 .o-mail-Composer-actions {

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -195,9 +195,10 @@
 }
 
 .o-mail-Composer-inputContainer {
+    --border-color: #{rgba($dark, .15)};
 
     &:has(textarea:focus) {
-        --border-color: #{rgba($o-component-active-border, .65)};
+        --border-color: #{rgba($o-component-active-border, var(--mail-Composer-focusedOpacity, .65))};
     }
 
     &:has(.o-mail-Composer-html:focus) {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -21,6 +21,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     background-color: $body-bg !important;
 }
 
+.o-border-opacity-15 {
+    --border-opacity: 0.15;
+}
+
 .o-border-opacity-25 {
     --border-opacity: 0.25;
 }

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app.xml
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Discuss">
-    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall, 'border-top border-secondary': !ui.isSmall }" t-att-data-active="store.discuss.isActive" t-ref="root">
+    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall, 'border-top border-dark o-border-opacity-15': !ui.isSmall }" t-att-data-active="store.discuss.isActive" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <DiscussContent t-if="!ui.isSmall" thread="props.thread"/>
         <MessagingMenu t-if="ui.isSmall"/>

--- a/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.DiscussSidebar">
         <div class="o-mail-DiscussSidebar-resizablePanelContainer h-100 d-flex">
             <ResizablePanel handleSide="'end'" initialWidth="store.discuss.isSidebarCompact ? store.discuss.COMPACT_SIDEBAR_WIDTH : store.discuss.INSPECTOR_WIDTH" minWidth="60" onResize.bind="onResize">
-                <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+                <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-dark o-border-opacity-15 z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
                     <DiscussSearch class="{
                         'position-sticky top-0 z-2 o-mail-discussSidebarBgColor': true,
                         'pt-2 o-pb-0_5 o-mb-0_5': !store.inPublicPage and store.discuss.isSidebarCompact,

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DiscussContent">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
     <div class="o-mail-DiscussContent d-flex flex-column h-100 w-100 overflow-auto o-scrollbar-thin" t-ref="root">
-        <div class="o-mail-DiscussContent-header py-1 ps-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary gap-1 z-1 flex-grow-0" t-ref="header">
+        <div class="o-mail-DiscussContent-header py-1 ps-3 d-flex flex-shrink-0 align-items-center border-bottom border-dark o-border-opacity-15 gap-1 z-1 flex-grow-0" t-ref="header">
             <t t-if="thread">
                 <div t-if="showThreadAvatar" class="o-mail-DiscussContent-threadAvatar position-relative align-self-center align-items-center bg-inherit">
                     <img class="rounded-2 object-fit-cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
@@ -71,7 +71,7 @@
                             <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent"/></t>
                             <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                         </div>
-                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0" t-att-class="{ 'w-100': ui.isSmall }">
+                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-dark o-border-opacity-15 flex-shrink-0" t-att-class="{ 'w-100': ui.isSmall }">
                             <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                         </div>
                     </t>

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -6,7 +6,7 @@
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
                     <Call hasOverlay="false" isPip="props.isPip"/>
                 </div>
-                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0 rounded-2" t-att-class="{ 'w-100': ui.isSmall }">
+                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-dark o-border-opacity-15 flex-shrink-0 rounded-2" t-att-class="{ 'w-100': ui.isSmall }">
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                 </div>
             </div>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-DiscussSidebarChannel {
+    --o-mail-DiscussSidebar-borderOpacity: .65;
+}
+
 .o-mail-DiscussSidebarChannel-container {
     --mail-DiscussSidebarChannel-borderOpacity: .125;
     ---mail-DiscussSidebarChannel-borderedBgColor: #{mix($gray-100, $gray-200, 75%)};

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.scss
@@ -19,7 +19,7 @@
     
         &:hover, &:active, &:focus-visible, &.o-showingActions {
             --border-opacity: 1;
-            --border-color: #{$o-action};
+            --border-color: #{rgba($o-action, var(--o-mail-DiscussSidebar-borderOpacity, 1))};
         }
     }
 }


### PR DESCRIPTION
The border in discuss app in dark theme was too distracting with its too light color.

This happens because border-secondary has still a strong presence in dark theme, when in white theme this is reduced appropriately.

This commit improves by using `border-dark o-border-opacity-15` instead of `border-secondary`, which makes it almost visually unchanged in white theme but in dark theme this reduces border visible to a similar ratio than the white theme counterpart.

Before / After (dark theme)
<img width="1275" height="870" alt="dark-before" src="https://github.com/user-attachments/assets/70f49fcb-28c9-4e6c-9991-87458edce5bb" />
<img width="1275" height="870" alt="dark-after" src="https://github.com/user-attachments/assets/5dc43d74-9a27-411e-91ee-c6d21d843062" />

Before / After (white theme)
<img width="1275" height="870" alt="white-before" src="https://github.com/user-attachments/assets/884aba63-6e99-4bd0-b6d3-682c5adf1004" />
<img width="1275" height="870" alt="white-after" src="https://github.com/user-attachments/assets/30fc5e04-473a-423a-8bd0-96887142ab07" />