### PR TITLE
[FIX] stock: restore 'No Package' tag

### DIFF
--- a/addons/stock/static/src/widgets/stock_package_m2m.js
+++ b/addons/stock/static/src/widgets/stock_package_m2m.js
@@ -15,9 +15,11 @@ export class Many2ManyPackageTagsField extends Many2ManyTagsField {
         const tags = super.tags;
         if (this.hasNoneTag) {
             tags.push({
-                ...this.getTagProps(this.props.record.data[this.props.name].records.at(-1)),
                 id: "datapoint_None",
-                text: _t("No Package"),
+                props: {
+                    ...this.getTagProps(this.props.record.data[this.props.name].records.at(-1)),
+                    text: _t("No Package"),
+                },
             });
         }
         return tags;


### PR DESCRIPTION
Steps to reproduce:
- Enable packages
- Create a transfer, add a move with some quantity
- Split the quantity into two move lines, assign a destination package to one move line & save

Issue:
Instead of having a tag on the move saying 'No Package', instead we have an empty tag.

The structure of the tags have been changed in [1], just need to adapt to the new structure.

[1] 58e9fbf651473dc39214d7faabdfb06606ce92d0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
