### PR TITLE
[FIX] account{_edi_ubl_cii, _peppol}: Attachment fix

### DIFF
--- a/addons/account/static/src/components/mail_attachments/mail_attachments.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.js
@@ -22,7 +22,11 @@ export class MailAttachments extends Component {
     }
 
     getValue(){
-        const attachments = this.props.record.data[this.props.name] || [];
+        return this.props.record.data[this.props.name] || [];
+    }
+
+    getRenderedValue() {
+        const attachments = JSON.parse(JSON.stringify(this.getValue()));
         const attachmentsNotSupported = this.props.record.data.attachments_not_supported || {};
         for (const attachment of attachments) {
             if (attachment.id && attachment.id in attachmentsNotSupported) {
@@ -42,7 +46,7 @@ export class MailAttachments extends Component {
 
     get iconsSupported() {
         // Technical getter to display icons in view
-        return this.getValue().some(attachment => !!attachment.tooltip);
+        return this.getRenderedValue().some(attachment => !!attachment.tooltip);
     }
 
     onFileUploaded(files) {

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.xml
@@ -51,7 +51,7 @@
     </t>
 
     <t t-name="account.mail_attachments">
-        <t t-set="data" t-value="getValue()"/>
+        <t t-set="data" t-value="getRenderedValue()"/>
 
         <div t-attf-class="oe_fileupload" aria-atomic="true">
             <div class="o_attachments">

--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -95,6 +95,8 @@ class AccountMoveSend(models.AbstractModel):
 
     @api.model
     def _get_ubl_available_attachments(self, mail_attachments_widget, invoice_edi_format):
+        if not invoice_edi_format or not mail_attachments_widget:
+            return self.env['ir.attachment'], self.env['ir.attachment']
         attachment_ids = [values['id'] for values in mail_attachments_widget if values.get('manual')]
         attachments = self.env['ir.attachment'].browse(attachment_ids)
 

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -220,7 +220,7 @@ class AccountMoveSend(models.AbstractModel):
                     invoice.peppol_message_uuid = message['message_uuid']
                     invoice.peppol_move_state = 'processing'
                     attachments_linked, attachments_not_linked = self._get_ubl_available_attachments(
-                        invoice_data['mail_attachments_widget'],
+                        invoice_data.get('mail_attachments_widget', []),
                         invoice_data['invoice_edi_format']
                     )
                     if attachments_not_linked:


### PR DESCRIPTION
[FIX] account{_edi_ubl_cii, _peppol}: Attachment fix

2 scenarios fixed in this commit :

1:
When a user invoice_edi_format is not 'ubl_bis3' the attachment button is not displayed and the key doesn't exists in the invoice_data. This causes traceback when trying to access the key.

2:
When a user send and print an invoice, with 'email' and 'peppol' as sending_methods, warnings will be displayed next to attachments not supported by peppol.
But if the user uncheck 'peppol', warnings will stay while no sending method requires them anymore.

See odoo/odoo#234339