### PR TITLE
[FIX] {sale_}stock: double name on unvalidated delivery slip

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock_report.py
+++ b/addons/sale_stock/tests/test_sale_stock_report.py
@@ -284,6 +284,40 @@ class TestSaleStockInvoices(TestSaleCommon):
         text = html2plaintext(html)
         self.assertRegex(text, r'Product By Lot\n4.00Units\nLOT0001', "There should be a line that specifies 4 x LOT0001")
 
+    def test_picking_description(self):
+        """
+        Verify that for a no-variant product, the product name is not included as the first element in the picking description,
+        as this avoids repeating the name on the delivery slip.
+        """
+
+        product_attr = self.env['product.attribute'].create({'name': 'Color', 'create_variant': 'no_variant'})
+        product_attrv1, product_attrv2 = self.env['product.attribute.value'].create([
+            {'name': 'Value1', 'attribute_id': product_attr.id},
+            {'name': 'Value2', 'attribute_id': product_attr.id},
+        ])
+        product_template_no_variant = self.env['product.template'].create({
+            'name': 'product name',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': product_attr.id,
+                    'value_ids': [Command.set([product_attrv1.id, product_attrv2.id])],
+                })]
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({'name': product_template_no_variant.name,
+                'product_id': product_template_no_variant.product_variant_id.id,
+                'product_uom_qty': 4,
+                'product_no_variant_attribute_value_ids': product_template_no_variant.product_variant_id.attribute_line_ids.product_template_value_ids
+                }),
+            ],
+        })
+        so.action_confirm()
+        picking = so.picking_ids[0]
+        picking_description = picking.move_ids._get_report_description_picking()
+        self.assertEqual(picking_description, 'Color: Value1\nColor: Value2')
+
     def test_backorder_and_several_invoices(self):
         """
         Suppose the lots are printed on the invoices.

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2254,6 +2254,13 @@ Please change the quantity done or the rounding precision of your unit of measur
         else:
             return []
 
+    def _get_report_description_picking(self):
+        self.ensure_one()
+        description = self.description_picking or ""
+        if description.startswith(self.product_id.display_name):
+            description = description.removeprefix(self.product_id.display_name).strip()
+        return description
+
     def _set_quantity_done_prepare_vals(self, qty):
         def _move_qty(qty):
             return self.product_id.uom_id._compute_quantity(qty, self.product_uom, round=False)

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -71,8 +71,8 @@
                             <tr t-foreach="lines" t-as="move">
                                 <td>
                                     <span t-field="move.product_id">Customizable Desk</span>
-                                    <p t-if="move.description_picking and move.description_picking != move.product_id.name and move.description_picking != move.product_id.display_name">
-                                        <span t-field="move.description_picking">Description on transfer</span>
+                                    <p t-if="move.description_picking and move.description_picking != move.product_id.name and move._get_report_description_picking()">
+                                        <span t-out="move._get_report_description_picking()">Description on transfer</span>
                                     </p>
                                 </td>
                                 <td class="o_td_quantity text-end">
@@ -176,8 +176,8 @@
                                 <tr t-foreach="backorders.mapped('move_ids').filtered(lambda x: x.product_uom_qty)" t-as="bo_line">
                                     <td class="w-auto">
                                         <span t-field="bo_line.product_id">Office Chair</span>
-                                        <p t-if="bo_line.description_picking and bo_line.description_picking != bo_line.product_id.name and bo_line.description_picking != bo_line.product_id.display_name">
-                                            <span t-field="bo_line.description_picking">Description on transfer</span>
+                                        <p t-if="bo_line.description_picking and bo_line.description_picking != bo_line.product_id.name and bo_line._get_report_description_picking()">
+                                            <span t-out="bo_line._get_report_description_picking()">Description on transfer</span>
                                         </p>
                                     </td>
                                     <td/>


### PR DESCRIPTION
When creating a delivery slip, if the product sold has variant of type never and have a description, the name will be repeated.

### Steps to reproduce:

* Create a product A with variants of type never
* Create a sales order with two product A and confirm it
* Go on the delivery (don't validate it) and create a delivery slip
-> Issue, the name of the product appears twice.
* Reduce the quantity of product delivered to one
* Confirm and create a backorder
* Print the deliveryslip
-> Issue, the name of the product appears twice in the backorder section

### Observation:

When confirming the SO:
It creates the procurement values, where the product_description_variants are obtained from _get_sale_order_line_multiline_description_variants. In our case, we will have several elements regarding the variant:
https://github.com/odoo/odoo/blob/3e5aabf66a19d406fa49c9ff2f6e4db6d5ba124a/addons/sale_stock/models/sale_order_line.py#L300
This information is added to the picking_description (for which the fallback value is the product name):
https://github.com/odoo/odoo/blob/626d06734991bcd3b94a6c9454317f311164e9dc/addons/stock/models/stock_rule.py#L339-L340
When printing the delivery_slip, it uses description_picking (and attempts to filter out the name):
https://github.com/odoo/odoo/blob/842025976ab65e92551366def88cdd243549e5ee/addons/stock/report/report_deliveryslip.xml#L74
However, in our case, since the variant information is included, it will not be filtered out because the value is no longer just the name.

The same issue is present here :
https://github.com/odoo/odoo/blob/e99e07f2f22b0987468c45d3d7da287cdf703588/addons/stock/report/report_deliveryslip.xml#L179-L180

opw-5153222