### PR TITLE
[FIX] l10n_ar_stock: date format cai expiration date

### DIFF
--- a/addons/l10n_ar_stock/views/report_delivery_guide.xml
+++ b/addons/l10n_ar_stock/views/report_delivery_guide.xml
@@ -59,7 +59,7 @@
                                 CAI: <t t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
                             </div>
                             <div name="cai_expiration_date">
-                                CAI Expiration Date: <t t-out="o.l10n_ar_cai_data['cai_expiration_date']"/>
+                                CAI Expiration Date: <t t-out="o.l10n_ar_cai_data['cai_expiration_date']" t-options='{"widget": "date"}'/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
The CAI expiration date is not well formated in the delivery guide
report.

opw-5004345
