### PR TITLE
[IMP] iot_drivers: cleanup community compatibility

### DIFF
--- a/addons/iot_drivers/controllers/proxy.py
+++ b/addons/iot_drivers/controllers/proxy.py
@@ -1,19 +1,10 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+# TODO: remove this file when v19.0 is deprecated (/hw_proxy/hello still used in v19.0)
 
 from odoo import http
 from odoo.addons.iot_drivers.tools import route
-
-proxy_drivers = {}
 
 
 class ProxyController(http.Controller):
     @route.iot_route('/hw_proxy/hello', type='http', cors='*')
     def hello(self):
         return "ping"
-
-    @route.iot_route('/hw_proxy/status_json', type='jsonrpc', cors='*')
-    def status_json(self):
-        return {
-            driver: instance.get_status()
-            for driver, instance in proxy_drivers.items()
-        }

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -10,12 +10,9 @@ import logging
 import netifaces as ni
 import time
 
-from odoo import http
 from odoo.addons.iot_drivers.connection_manager import connection_manager
-from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import EscposNotAvailableError, PrinterDriverBase
-from odoo.addons.iot_drivers.main import iot_devices
-from odoo.addons.iot_drivers.tools import helpers, route, system, wifi
+from odoo.addons.iot_drivers.tools import helpers, system, wifi
 from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
@@ -293,20 +290,3 @@ class PrinterDriver(PrinterDriverBase):
             _logger.exception('IPP error occurred while fetching CUPS jobs')
             self.job_ids.remove(job_id)
             self._recent_action_ids.pop(self.job_action_ids.pop(job_id, None), None)
-
-
-class PrinterController(http.Controller):
-
-    @route.iot_route('/hw_proxy/default_printer_action', type='jsonrpc', cors='*')
-    def default_printer_action(self, data):
-        printer = next((d for d in iot_devices if iot_devices[d].device_type == 'printer' and iot_devices[d].device_connection == 'direct'), None)
-        if printer:
-            try:
-                iot_devices[printer].action(data)
-                return True
-            except Exception:  # noqa: BLE001
-                return False
-        return False
-
-
-proxy_drivers['printer'] = PrinterDriver

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -10,7 +10,6 @@ import win32print
 import pywintypes
 import ghostscript
 
-from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import EscposNotAvailableError, PrinterDriverBase
 from odoo.addons.iot_drivers.tools import system
 from odoo.tools.mimetypes import guess_mimetype
@@ -186,6 +185,3 @@ class PrinterDriver(PrinterDriverBase):
                 _logger.exception('Win32 error occurred while querying print job')
             self.job_ids.remove(job_id)
             self._recent_action_ids.pop(self.job_action_ids.pop(job_id, None), None)
-
-
-proxy_drivers['printer'] = PrinterDriver

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -11,7 +11,6 @@ import re
 import time
 
 from odoo.addons.iot_drivers.driver import Driver
-from odoo.addons.iot_drivers.main import iot_devices
 from odoo.addons.iot_drivers.event_manager import event_manager
 
 _logger = logging.getLogger(__name__)
@@ -76,15 +75,6 @@ class PrinterDriverBase(Driver, ABC):
             'status': self.print_status,
             '': self._action_default,
         })
-
-    @classmethod
-    def get_status(cls):
-        status = 'connected' if any(
-            iot_devices[d].device_type == "printer"
-            and iot_devices[d].device_connection == 'direct'
-            for d in iot_devices
-        ) else 'disconnected'
-        return {'status': status, 'messages': ''}
 
     def send_status(self, status, message=None, action_unique_id=None):
         """Sends a status update event for the printer.


### PR DESCRIPTION
As we moved the whole IoT logic in enterprise, we can now remove all controllers that were only meant to allow using the IoT Box without the IoT app.

see odoo/enterprise#105375