### PR TITLE
[FIX] sale_stock: link sale procurement group to delivery moves

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -100,16 +100,13 @@ class StockPicking(models.Model):
     def _set_sale_id(self):
         if self.group_id:
             self.group_id.sale_id = self.sale_id
-        else:
-            if self.sale_id:
-                vals = {
-                    'sale_id': self.sale_id.id,
-                    'name': self.sale_id.name,
-                }
-            else:
-                vals = {}
-
+        elif self.sale_id:
+            vals = {
+                'sale_id': self.sale_id.id,
+                'name': self.sale_id.name,
+            }
             pg = self.env['procurement.group'].create(vals)
+            self.move_ids.group_id = pg
             self.group_id = pg
 
     def _auto_init(self):


### PR DESCRIPTION
### Steps to reproduce:

- Create a picking with a move for any product 
#### Issue 1: > A procurement group is created and linked to the transfer
- Add a second move on the picking and save 
#### Issue 2: > The procurement group of the picking is lost

### Cause of the issue:

The `_set_sale_id` set method creates a procurment group and links it to the picking no matter if the `sale_id` is set or not. https://github.com/odoo/odoo/blob/842025976ab65e92551366def88cdd243549e5ee/addons/sale_stock/models/stock.py#L90-L93 https://github.com/odoo/odoo/blob/842025976ab65e92551366def88cdd243549e5ee/addons/sale_stock/models/stock.py#L100-L113

opw-5386424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
