### PR TITLE
[FIX] html_editor: properly compute padding inline start

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -1239,7 +1239,7 @@ export class ListPlugin extends Plugin {
                 const markerWidth = parseFloat(this.window.getComputedStyle(li, "::marker").width);
                 return isNaN(markerWidth) ? 0 : markerWidth;
             })
-            .reduce(Math.max);
+            .reduce((accumulator, currentValue) => Math.max(accumulator, currentValue));
         // For `UL` with large font size the marker width is so big that more padding is needed.
         const largestMarkerPadding = Math.round(largestMarker) * (list.nodeName === "UL" ? 2 : 1);
 


### PR DESCRIPTION
Since commit [1], the padding inline start value is wrong whenever the number of items in the list is greater than the largest marker width in the list. This is because calling `.reduce(Math.max)` on the list of widths means `Math.max` receives one plus the index of the item as third argument instead of just the widths it means to compare.

As an interesting side note, this would have returned `NaN` if `reduce` had been called on an actual array rather than an iterator, because then `Math.max` would have received the array itself as fourth argument. Here, there is no array so there is no fourth argument, and `Math.max` receives only numbers as it expects, and returns a wrong value.

[1]: https://github.com/odoo/odoo/commit/9b0c411f94ed1e090d4adbaf785cd852bbe5469e

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
