### PR TITLE
[FIX] account, l10n_it_edi: only invoices attachments must be detached

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5511,13 +5511,17 @@ class AccountMove(models.Model):
         """
         return ['invoice_pdf_report_file']
 
+    def _get_condition_to_detach(self):
+        return self.is_sale_document()
+
     def _detach_attachments(self):
         """
         Called by button_draft to detach specific attachments for the current journal entries to allow regeneration.
         """
-        files_to_detach = self.sudo().env['ir.attachment'].search([
+        moves = self.filtered(lambda move: move._get_condition_to_detach())
+        files_to_detach = self.env['ir.attachment'].sudo().search([
             ('res_model', '=', 'account.move'),
-            ('res_id', 'in', self.ids),
+            ('res_id', 'in', moves.ids),
             ('res_field', 'in', self._get_fields_to_detach()),
         ])
         if files_to_detach:

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5607,13 +5607,17 @@ class AccountMove(models.Model):
         """
         return ['invoice_pdf_report_file']
 
+    def _should_detach_attachments(self):
+        return self.is_sale_document()
+
     def _detach_attachments(self):
         """
         Called by button_draft to detach specific attachments for the current journal entries to allow regeneration.
         """
-        files_to_detach = self.sudo().env['ir.attachment'].search([
+        moves = self.filtered(lambda move: move._should_detach_attachments())
+        files_to_detach = self.env['ir.attachment'].sudo().search([
             ('res_model', '=', 'account.move'),
-            ('res_id', 'in', self.ids),
+            ('res_id', 'in', moves.ids),
             ('res_field', 'in', self._get_fields_to_detach()),
         ])
         if files_to_detach:

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -195,6 +195,10 @@ class AccountMove(models.Model):
         fields_list.append('l10n_it_edi_attachment_file')
         return fields_list
 
+    def _get_condition_to_detach(self):
+        # EXTENDS account
+        return self.l10n_it_edi_is_self_invoice or super()._get_condition_to_detach()
+
     # -------------------------------------------------------------------------
     # Business actions
     # -------------------------------------------------------------------------

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -215,6 +215,10 @@ class AccountMove(models.Model):
         fields_list.append('l10n_it_edi_attachment_file')
         return fields_list
 
+    def _should_detach_attachments(self):
+        # EXTENDS account
+        return self.l10n_it_edi_is_self_invoice or super()._should_detach_attachments()
+
     # -------------------------------------------------------------------------
     # Business actions
     # -------------------------------------------------------------------------

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
 from unittest.mock import patch
 
+from odoo import Command
 from odoo.tests import tagged
 from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
@@ -303,3 +305,89 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
         invoice.action_post()
         self.generate_l10n_it_edi_send_attachments(invoice)
         self.assertTrue(invoice.l10n_it_edi_attachment_id)
+
+    def test_detach_invoice(self):
+        # Prepare an invoice
+        invoice = self.init_invoice(self.italian_partner_a)
+        self.italian_partner_a.with_company(invoice.company_id).invoice_edi_format = 'it_edi_xml'
+
+        def _get_default_extra_edis(self, move):
+            return {}
+
+        # Fake sending to the EDI and reset to draft
+        with patch(
+            'odoo.addons.account.models.account_move_send.AccountMoveSend._get_default_extra_edis',
+            _get_default_extra_edis
+        ):
+            self.env['account.move.send']._generate_and_send_invoices(invoice)
+        attachment_name = invoice.l10n_it_edi_attachment_id.name
+        invoice.button_draft()
+
+        self.assertNotEqual(invoice.l10n_it_edi_attachment_id.name, attachment_name)
+        self.assertTrue('detached' in invoice.l10n_it_edi_attachment_id.name.lower())
+
+    def test_detach_bill_fails(self):
+        # Fake an exported bill by manually attaching its export
+        values = {
+            'invoice_date': '2022-03-24',
+            'invoice_date_due': '2022-03-24',
+            'partner_id': self.italian_partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': "Product A",
+                    'price_unit': 800.40,
+                    'tax_ids': [(6, 0, self.default_tax.ids)],
+                })
+            ],
+        }
+        bill = self.env['account.move'].with_company(self.company).create({'move_type': 'in_invoice', **values})
+
+        # Post it, add an attachment, revert to draft
+        bill.action_post()
+        bill.l10n_it_edi_attachment_file = base64.b64encode(bill._l10n_it_edi_render_xml())
+        attachment_name = bill.l10n_it_edi_attachment_id.name
+        bill.button_draft()
+
+        self.assertEqual(bill.l10n_it_edi_attachment_id.name, attachment_name)
+        self.assertFalse('detached' in bill.l10n_it_edi_attachment_id.name.lower())
+
+    def test_detach_reverse_charged_bill(self):
+        # Create a reverse charged tax
+        purchase_rc_tax = self.env['account.tax'].with_company(self.company).create({
+            'name': 'Tax 4% (Goods) Reverse Charge',
+            'amount': 4.0,
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'invoice_repartition_line_ids': self.repartition_lines(
+                self.RepartitionLine(100, 'base', ('+03', '+vj9')),
+                self.RepartitionLine(100, 'tax', ('+5v',)),
+                self.RepartitionLine(-100, 'tax', ('-4v',))),
+            'refund_repartition_line_ids': self.repartition_lines(
+                self.RepartitionLine(100, 'base', ('-03', '-vj9')),
+                self.RepartitionLine(100, 'tax', False),
+                self.RepartitionLine(-100, 'tax', False)),
+        })
+
+        # Create a reverse charged bill
+        bill = self.env['account.move'].with_company(self.company).create({
+            'move_type': 'in_invoice',
+            'invoice_date': '2022-03-24',
+            'invoice_date_due': '2022-03-24',
+            'partner_id': self.american_partner.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': "Product A",
+                    'price_unit': 800.40,
+                    'tax_ids': [Command.set(purchase_rc_tax.ids)],
+                })
+            ],
+        })
+
+        # Post it, add an attachment, revert to draft
+        bill.action_post()
+        bill.l10n_it_edi_attachment_file = base64.b64encode(bill._l10n_it_edi_render_xml())
+        attachment_name = bill.l10n_it_edi_attachment_id.name
+        bill.button_draft()
+
+        self.assertNotEqual(bill.l10n_it_edi_attachment_id.name, attachment_name)
+        self.assertTrue('detached' in bill.l10n_it_edi_attachment_id.name.lower())


### PR DESCRIPTION
The feature introduced in odoo/enterprise#78429 allows users to detach attachments from moves, primarily to facilitate the regeneration and re-sending of outgoing XMLs (e.g., sales invoices) without needing to delete the original attachment.

However, detaching should not apply to incoming XML attachments on bills that originate from EDI import, as these attachments are the received source document and are never regenerated by the system. Detaching them inadvertently prevents their inclusion in bulk XML exports.

An exception exists for Italy: businesses need to send Tax Integration XMLs back to the SdI. In this specific case, detaching the Tax Integration XML is appropriate and ensures the bulk export finds the latest, correct attachment.

Ticket [link](https://www.odoo.com/odoo/project.task/5062132)
opw-5062132