### PR TITLE
[FIX] website: reload page list after duplicating page

### DIFF
--- a/addons/website/static/src/components/views/page_list.js
+++ b/addons/website/static/src/components/views/page_list.js
@@ -63,6 +63,8 @@ export class PageListController extends PageControllerMixin(listView.Controller)
                     pageId: 0, // Ignored but mandatory
                     pageIds: resIds,
                     onDuplicate: () => {
+                        const websiteId = this.state.activeWebsite.id;
+                        this.env.searchModel.notifyWebsiteChange(websiteId);
                         this.model.load();
                     },
                 });


### PR DESCRIPTION
Steps to reproduce:
- Go in website page list
- Select a page
- Click on actions -> duplicate
- Select a name
- New page doesn't appear in the list, you need to reload to be able to see it

task-5412167

https://github.com/odoo/odoo/issues/225299