### PR TITLE
[REM] crm_livechat: remove "create lead & forward" step

### DIFF
--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -1,9 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from ast import literal_eval
-
 from odoo import _, models, fields
-from odoo.fields import Domain
 from odoo.tools import html2plaintext
 
 
@@ -11,20 +8,13 @@ class ChatbotScriptStep(models.Model):
     _inherit = 'chatbot.script.step'
 
     step_type = fields.Selection(
-        selection_add=[
-            ("create_lead", "Create Lead"),
-            ("create_lead_and_forward", "Create Lead & Forward"),
-        ],
-        ondelete={"create_lead": "cascade", "create_lead_and_forward": "cascade"},
+        selection_add=[("create_lead", "Create Lead")],
+        ondelete={"create_lead": "cascade"},
     )
     crm_team_id = fields.Many2one(
         'crm.team', string='Sales Team', ondelete='set null', index="btree_not_null",
         help="Used in combination with 'create_lead' step type in order to automatically "
              "assign the created lead/opportunity to the defined team")
-
-    def _compute_is_forward_operator(self):
-        super()._compute_is_forward_operator()
-        self.filtered(lambda s: s.step_type == "create_lead_and_forward").is_forward_operator = True
 
     def _chatbot_crm_prepare_lead_values(self, discuss_channel, description):
         name = self.env._("%s's New Lead", self.chatbot_script_id.title)
@@ -49,8 +39,6 @@ class ChatbotScriptStep(models.Model):
 
     def _process_step(self, discuss_channel):
         self.ensure_one()
-        if self.step_type == "create_lead_and_forward":
-            return self._process_step_create_lead_and_forward(discuss_channel)
         posted_message = super()._process_step(discuss_channel)
         if self.step_type == 'create_lead':
             self._process_step_create_lead(discuss_channel)
@@ -80,48 +68,3 @@ class ChatbotScriptStep(models.Model):
         new_leads = self.env["crm.lead"].create(create_values)
         new_leads._assign_userless_lead_in_team(_('livechat discussion'))
         return new_leads
-
-    def _process_step_create_lead_and_forward(self, discuss_channel):
-        lead = self._process_step_create_lead(discuss_channel)
-        teams = lead.team_id
-        if not teams:
-            possible_teams = self.env["crm.team"].search(
-                Domain("assignment_optout", "=", False) & (
-                    Domain("use_leads", "=", True) | Domain("use_opportunities", "=", True)
-                ),
-            )
-            teams = possible_teams.filtered(
-                lambda team: team.assignment_max
-                and lead.filtered_domain(literal_eval(team.assignment_domain or "[]"))
-            )
-        if self.env.user.partner_id.company_id:
-            teams = teams.filtered(
-                lambda team: not team.company_id
-                or team.company_id == self.env.user.partner_id.company_id
-            )
-        assignable_user_ids = [
-            member.user_id.id
-            for member in teams.crm_team_member_ids
-            if not member.assignment_optout
-            and member._get_assignment_quota() > 0
-            and lead.filtered_domain(literal_eval(member.assignment_domain or "[]"))
-        ]
-        previous_operator = discuss_channel.livechat_operator_id
-        users = self.env["res.users"]
-        if discuss_channel.livechat_channel_id:
-            # sudo: im_livechat.channel - getting available operators is acceptable
-            users = discuss_channel.livechat_channel_id.sudo()._get_available_operators_by_livechat_channel(
-                self.env["res.users"].browse(assignable_user_ids)
-            )[discuss_channel.livechat_channel_id]
-        message = discuss_channel._forward_human_operator(self, users=users)
-        if previous_operator != discuss_channel.livechat_operator_id:
-            user = next(user for user in users if user.partner_id == discuss_channel.livechat_operator_id)
-            lead.user_id = user
-            lead.team_id = next(team for team in teams if user in team.crm_team_member_ids.user_id)
-            msg = self.env._("Created a new lead: %s", lead._get_html_link())
-            user._bus_send_transient_message(discuss_channel, msg)
-            # Call flush_recordset() now (as sudo), otherwise flush_all() is called at the end of
-            # the request with a non-sudo env, which fails (as public user) to compute some crm.lead
-            # fields having dependencies on assigned user_id.
-            lead.flush_recordset()
-        return message

--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -17,69 +17,6 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         self.assertEqual(created_lead.team_id, self.sale_team)
         self.assertEqual(created_lead.type, 'opportunity')
 
-    def test_chatbot_create_lead_and_forward_public_user(self):
-        """Test create_lead_and_forward properly creates a lead, assigns it to an available sales
-        team member, and forwards the discussion to that member."""
-        self.step_create_lead.sudo().step_type = "create_lead_and_forward"
-        discuss_channel = self._play_session_with_lead()
-        not_available_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertEqual(not_available_lead.name, "Testing Bot's New Lead")
-        self.assertEqual(not_available_lead.email_from, "test2@example.com")
-        self.assertEqual(not_available_lead.phone, "123456")
-        self.assertEqual(not_available_lead.team_id, self.sale_team)
-        self.assertEqual(not_available_lead.type, "opportunity")
-        chatbot_partner = self.chatbot_script.operator_partner_id
-        # sales team member is not available
-        self.assertFalse(not_available_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        # sales team member is available
-        self.env["mail.presence"]._update_presence(self.user_employee)
-        discuss_channel = self._play_session_with_lead()
-        assigned_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertEqual(assigned_lead.user_id, self.user_employee)
-        self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
-        # sales team member quota is reached (lead already assigned before)
-        discuss_channel = self._play_session_with_lead()
-        quota_reached_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(quota_reached_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        assigned_lead.unlink()
-        # sales team member opt out
-        self.sale_team.crm_team_member_ids.assignment_optout = True
-        discuss_channel = self._play_session_with_lead()
-        optout_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(optout_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        self.sale_team.crm_team_member_ids.assignment_optout = False
-        # sales team member invalid domain (probability of lead is 5.39)
-        self.sale_team.crm_team_member_ids.assignment_domain = "[('probability', '>=', 20)]"
-        discuss_channel = self._play_session_with_lead()
-        non_matching_domain_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(non_matching_domain_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        self.sale_team.crm_team_member_ids.assignment_domain = False
-        # auto-assign team
-        self.step_create_lead.crm_team_id = False
-        discuss_channel = self._play_session_with_lead()
-        auto_team_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertEqual(auto_team_lead.user_id, self.user_employee)
-        self.assertEqual(auto_team_lead.team_id, self.sale_team)
-        self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
-        auto_team_lead.unlink()
-        # sales team opt out
-        self.sale_team.assignment_optout = True
-        discuss_channel = self._play_session_with_lead()
-        team_optout_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(team_optout_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-        self.sale_team.assignment_optout = False
-        # sales team invalid domain (probability of lead is 5.39)
-        self.sale_team.assignment_domain = "[('probability', '>=', 20)]"
-        discuss_channel = self._play_session_with_lead()
-        team_non_matching_domain_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-        self.assertFalse(team_non_matching_domain_lead.user_id)
-        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
-
     def test_chatbot_create_lead_portal_user(self):
         self.authenticate(self.user_portal.login, self.user_portal.login)
         self.step_create_lead.write({'crm_team_id': self.sale_team_with_lead})
@@ -126,45 +63,6 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         # lead has no company if no company on partner and team
         partner.company_id = False
         team.company_id = False
-        self.assertFalse(play_script_and_get_created_lead().company_id)
-
-    def test_chatbot_create_lead_and_forward_company(self):
-        self.step_create_lead.sudo().step_type = "create_lead_and_forward"
-        self.user_portal.write({"company_ids": self.company_2.ids, "company_id": self.company_2.id})
-        self.user_employee.write({"company_ids": self.company_3.ids, "company_id": self.company_3.id})
-        self.user_employee.partner_id.company_id = self.company_3
-        teams = self.sale_team_with_lead + self.sale_team
-        partner = self.user_portal.partner_id
-        self.authenticate(self.user_portal.login, self.user_portal.login)
-
-        def play_script_and_get_created_lead():
-            self.env["crm.lead"].search([]).unlink()
-            self._play_session_with_lead()
-            return self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
-
-        # lead has company of partner and no team if no company matching
-        partner.company_id = self.company_2
-        teams.company_id = self.company_3
-        lead = play_script_and_get_created_lead()
-        self.assertEqual(lead.company_id, self.company_2)
-        self.assertFalse(lead.team_id)
-        # lead has common company of partner and team if both are matching
-        self.user_employee.write({"company_ids": self.company_2.ids, "company_id": self.company_2.id})
-        self.user_employee.partner_id.company_id = self.company_2
-        partner.company_id = self.company_2
-        teams.company_id = self.company_2
-        self.assertEqual(play_script_and_get_created_lead().company_id, self.company_2)
-        # lead has team company if partner has no company
-        partner.company_id = False
-        teams.company_id = self.company_2
-        self.assertEqual(play_script_and_get_created_lead().company_id, self.company_2)
-        # lead has partner company if team has no company
-        partner.company_id = self.company_2
-        teams.company_id = False
-        self.assertEqual(play_script_and_get_created_lead().company_id, self.company_2)
-        # lead has no company if no company on partner and team
-        partner.company_id = False
-        teams.company_id = False
         self.assertFalse(play_script_and_get_created_lead().company_id)
 
     def _play_session_with_lead(self):

--- a/addons/crm_livechat/views/chatbot_script_step_views.xml
+++ b/addons/crm_livechat/views/chatbot_script_step_views.xml
@@ -9,7 +9,7 @@
             <field name="step_type" position="after">
                 <field
                     name="crm_team_id"
-                    invisible="step_type not in ['create_lead', 'create_lead_and_forward']"
+                    invisible="step_type != 'create_lead'"
                     options="{'no_open': True}"
                 />
             </field>

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -46,7 +46,7 @@ class LivechatChatbotScriptController(http.Controller):
         # sudo: chatbot.script.step - visitor can access current step of the script
         if current_step := discuss_channel.sudo().chatbot_current_step_id:
             if (
-                current_step.is_forward_operator
+                current_step.step_type == "forward_operator"
                 and discuss_channel.livechat_operator_id
                 != current_step.chatbot_script_id.operator_partner_id
             ):
@@ -86,7 +86,7 @@ class LivechatChatbotScriptController(http.Controller):
                 **chatbot_next_step,
                 "id": (next_step.id, posted_message.id),
                 "isLast": next_step._is_last_step(discuss_channel),
-                "operatorFound": next_step.is_forward_operator
+                "operatorFound": next_step.step_type == "forward_operator"
                 and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,
             },
         )

--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -49,7 +49,7 @@ class ChatbotScript(models.Model):
         for script in self:
             script.livechat_channel_count = mapped_channels.get(script.id, 0)
 
-    @api.depends("script_step_ids.is_forward_operator", "script_step_ids.step_type" )
+    @api.depends("script_step_ids.step_type")
     def _compute_first_step_warning(self):
         for script in self:
             allowed_first_step_types = [
@@ -60,7 +60,7 @@ class ChatbotScript(models.Model):
                 'free_input_multi',
             ]
             welcome_steps = script.script_step_ids and script._get_welcome_steps()
-            if welcome_steps and welcome_steps[-1].is_forward_operator:
+            if welcome_steps and welcome_steps[-1].step_type == "forward_operator":
                 script.first_step_warning = 'first_step_operator'
             elif welcome_steps and welcome_steps[-1].step_type not in allowed_first_step_types:
                 script.first_step_warning = 'first_step_invalid'

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -39,7 +39,6 @@ class ChatbotScriptStep(models.Model):
         copy=False,  # copied manually, see chatbot.script#copy
         string='Only If', help='Show this step only if all of these answers have been selected.')
     # forward-operator specifics
-    is_forward_operator = fields.Boolean(compute="_compute_is_forward_operator")
     is_forward_operator_child = fields.Boolean(compute='_compute_is_forward_operator_child')
     operator_expertise_ids = fields.Many2many(
         "im_livechat.expertise",
@@ -65,14 +64,8 @@ class ChatbotScriptStep(models.Model):
             if update_command:
                 step.triggering_answer_ids = update_command
 
-    @api.depends("step_type")
-    def _compute_is_forward_operator(self):
-        for step in self:
-            step.is_forward_operator = step.step_type == "forward_operator"
-
     @api.depends(
         "chatbot_script_id.script_step_ids.answer_ids",
-        "chatbot_script_id.script_step_ids.is_forward_operator",
         "chatbot_script_id.script_step_ids.sequence",
         "chatbot_script_id.script_step_ids.step_type",
         "chatbot_script_id.script_step_ids.triggering_answer_ids",
@@ -83,7 +76,7 @@ class ChatbotScriptStep(models.Model):
         parent_steps_by_chatbot = {}
         for chatbot in self.chatbot_script_id:
             parent_steps_by_chatbot[chatbot.id] = chatbot.script_step_ids.filtered(
-                lambda step: step.is_forward_operator or step.step_type == "question_selection"
+                lambda step: step.step_type in ["forward_operator", "question_selection"]
             ).sorted(lambda s: s.sequence, reverse=True)
         for step in self:
             parent_steps = parent_steps_by_chatbot[step.chatbot_script_id.id].filtered(
@@ -92,9 +85,9 @@ class ChatbotScriptStep(models.Model):
             parent = step
             while True:
                 parent = parent._get_parent_step(parent_steps)
-                if not parent or parent.is_forward_operator:
+                if not parent or parent.step_type == "forward_operator":
                     break
-            step.is_forward_operator_child = parent and parent.is_forward_operator
+            step.is_forward_operator_child = parent and parent.step_type == "forward_operator"
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -474,7 +474,7 @@ class DiscussChannel(models.Model):
             current_step_sudo = channel.chatbot_current_step_id.sudo().with_context(lang=lang)
             chatbot_script = current_step_sudo.chatbot_script_id
             step_message = self.env["chatbot.message"]
-            if not current_step_sudo.is_forward_operator:
+            if current_step_sudo.step_type != "forward_operator":
                 step_message = channel.sudo().chatbot_message_ids.filtered(
                     lambda m: m.script_step_id == current_step_sudo
                     and m.mail_message_id.author_id == chatbot_script.operator_partner_id
@@ -482,7 +482,7 @@ class DiscussChannel(models.Model):
             current_step = {
                 "scriptStep": current_step_sudo.id,
                 "message": step_message.mail_message_id.id,
-                "operatorFound": current_step_sudo.is_forward_operator
+                "operatorFound": current_step_sudo.step_type == "forward_operator"
                 and channel.livechat_operator_id != chatbot_script.operator_partner_id,
             }
             store.add(current_step_sudo, "_store_script_step_fields")

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -48,7 +48,8 @@ class MailMessage(models.Model):
                         res.one("scriptStep", ["message", "step_type"], value=step)
                         res.attr(
                             "operatorFound",
-                            step.is_forward_operator and channel.livechat_operator_id != chatbot,
+                            step.step_type == "forward_operator" and
+                            channel.livechat_operator_id != chatbot,
                         )
                         if answer := chatbot_message.user_script_answer_id:
                             res.attr("selectedAnswer", {"id": answer.id, "label": answer.name})

--- a/addons/im_livechat/views/chatbot_script_step_views.xml
+++ b/addons/im_livechat/views/chatbot_script_step_views.xml
@@ -10,7 +10,7 @@
                 <div class="alert alert-info text-center mb-0" role="alert" invisible="not is_forward_operator_child">
                     <span>Reminder: This step will only be played if no operator is available.</span>
                 </div>
-                <div class="alert alert-info text-center mb-0" role="alert" invisible="not is_forward_operator">
+                <div class="alert alert-info text-center mb-0" role="alert" invisible="step_type != 'forward_operator'">
                     <span>Tip: Plan further steps for the Bot in case no operator is available.</span>
                 </div>
                 <sheet>
@@ -18,7 +18,7 @@
                         <group>
                             <field name="sequence" invisible="1"/>
                             <field name="message" placeholder="e.g. 'How can I help you?'"
-                                required="not is_forward_operator"/>
+                                required="step_type != 'forward_operator'"/>
                             <field name="chatbot_script_id" invisible="1"/>
                             <field name="step_type"/>
                             <field name="operator_expertise_ids" widget="many2many_tags" options="{'on_tag_click': 'open_form'}" invisible="step_type != 'forward_operator'"/>


### PR DESCRIPTION
upgrade PR: https://github.com/odoo/upgrade/pull/9129

This commit removes the "Create Lead & Forward" chatbot step.

The current implementation is considered unintuitive - the process of selecting the salesperson as operator is unclear and can lead to customers not being connected to the support line.

task-5137022