### PR TITLE
[FIX] point_of_sale: fix recompute prices on canceled orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -16,6 +16,9 @@ export class PosOrderAccounting extends Base {
     }
 
     triggerRecomputeAllPrices() {
+        if (!this._prices) {
+            return;
+        }
         this._prices.original = this._constructPriceData();
         this._prices.unit = this._constructPriceData({ baseLineOpts: { quantity: 1 } });
     }


### PR DESCRIPTION
- When using POS on multiple devices and when an order was canceled from an other device, the order prices computation was leading to a traceback.
- Now we ensure that the prices data is initialized before triggering a recompute of all prices.

task-id: 5411637




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
