### PR TITLE
[FIX] point_of_sale: add `canPrintReceipt` on feedback screens

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
@@ -119,6 +119,10 @@ export class FeedbackScreen extends Component {
         return true;
     }
 
+    get canPrintReceipt() {
+        return true;
+    }
+
     get canEditPayment() {
         return !this.pos.config.iface_print_auto && this.currentOrder.nb_print === 0;
     }

--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.xml
@@ -9,7 +9,7 @@
                 </div>
             </div>
             <div t-if="!ui.isSmall" class="desktop-format w-75 d-flex gap-3 flex-row align-items-center justify-content-around p-2">
-                <button t-att-disabled="state.loading || currentOrder.state == 'draft'" class="print-ticket-button button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.clickPrint()"><i class="fa fa-print" role="img" aria-label="Print" title="Print"></i> Print</button>
+                <button t-if="canPrintReceipt" t-att-disabled="state.loading || currentOrder.state == 'draft'" class="print-ticket-button button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.clickPrint()"><i class="fa fa-print" role="img" aria-label="Print" title="Print"></i> Print</button>
                 <button t-if="canSendReceipt" t-att-disabled="state.loading || currentOrder.state == 'draft'" class="send-receipt button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.clickSend()"><i class="fa fa-paper-plane" role="img" aria-label="Send" title="Send"></i> Send Receipt</button>
                 <button t-if="canEditPayment" t-att-disabled="state.loading" class="button btn btn-secondary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3 edit-order-payment" t-on-click.stop="() => this.clickEditPayment()"><i class="fa fa-pencil-square-o" role="img" aria-label="Edit" title="Edit"></i> Edit</button>
                 <button t-att-disabled="state.loading" class="validation button btn btn-primary btn-lg lh-lg text-truncate flex-basis-25 py-3 rounded-3" t-on-click.stop="() => this.onClick(true)">


### PR DESCRIPTION
Add a method `canPrintReceipt` on feedback screens to indicate if the button do print must be displayed.

task-id: 5410921


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
