### PR TITLE
[FIX] mrp: make planning test more robust

### DIFF
--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime, timedelta
+from pytz import timezone
 
 from odoo import exceptions, Command, fields
 from odoo.api import UserError
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
+from odoo.addons.resource.models.utils import make_aware
 from odoo.tests.common import HttpCase, tagged, freeze_time
 from odoo.tools import float_compare, float_round, float_repr
 
@@ -880,17 +883,38 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(report_values['lines']['operations_time'], 30.0)
         self.assertEqual(report_values['lines']['producible_qty'], 0)
 
-        # The planning is limited to 700 days and the calendar is 40h/week
-        # So the 700 days limit is equivalent to 700 / 7 * 40 = 4000 hours
-        # With 4000 hours, we can plan 16000 pickaxes.
+        # The planning is limited to 700 days, fill the entire planning and keep 15 minutes
+        # available, so that we can still plan a single operation.
+        calendar = workcenter.resource_calendar_id
+        date_to = fields.Datetime.today() + timedelta(days=699)
+
+        # get_available_intervals, retrieve the last attendance of the day
+        date_start, revert = make_aware(date_to)
+        work_intervals = calendar._work_intervals_batch(
+            date_start,
+            date_start + timedelta(days=1),
+            resources=workcenter.resource_id,
+            tz=timezone(calendar.tz),
+        )[workcenter.resource_id.id]
+        end_of_day = datetime.combine(
+            date_to,
+            revert(max(i[1] for i in work_intervals)).time(),
+        )
 
         # Populate the workcenter's planning
-        mo_form = Form(self.env['mrp.production'])
-        mo_form.bom_id = bom_pickaxe
-        mo_form.product_qty = 16000 - 1  # Keep 1 slot available
-        mo = mo_form.save()
-        mo.action_confirm()
-        mo.button_plan()
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Game update',
+            'date_from': fields.Date.today(),
+            'date_to': end_of_day - timedelta(minutes=15),
+            'resource_id': workcenter.resource_id.id,
+            'time_type': 'other',
+        })
+
+        # Check that we still have on available slot of 15 minutes
+        self.assertEqual(
+            workcenter._get_first_available_slot(date_to, 15),
+            (end_of_day - timedelta(minutes=15), end_of_day),
+        )
 
         # 1 quantity should still work
         report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_pickaxe.id, searchQty=1, searchVariant=False)


### PR DESCRIPTION
Before this commit:
Introduced in https://github.com/odoo/odoo/commit/d06dcfbca96273b540c87252b9188603879ac1b4, the test was failing on runbot in some cases. The issue is deterministic, but requires a specific set of modules installed to fail.

After this commit:
Use a more robust approach in the test, by creating the leave manually instead of computing the number of operations needed.

runbot-234638