### PR TITLE
[IMP] account: backport multiple embed files peppol 17.0

### DIFF
--- a/addons/account/static/src/components/mail_attachments/mail_attachments.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.js
@@ -23,12 +23,28 @@ export class MailAttachments extends Component {
         return this.props.record.data[this.props.name] || [];
     }
 
+    getRenderedValue() {
+        const attachments = JSON.parse(JSON.stringify(this.getValue()));
+        const attachmentsNotSupported = this.props.record.data.attachments_not_supported || {};
+        for (const attachment of attachments) {
+            if (attachment.id && attachment.id in attachmentsNotSupported) {
+                attachment.tooltip = attachmentsNotSupported[attachment.id];
+            }
+        }
+        return attachments;
+    }
+
     getUrl(attachmentId) {
         return `/web/content/${attachmentId}?download=true`
     }
 
     getExtension(file) {
         return file.name.replace(/^.*\./, "");
+    }
+
+    get iconsSupported() {
+        // Technical getter to display icons in view
+        return this.getRenderedValue().some(attachment => !!attachment.tooltip);
     }
 
     onFileUploaded(files) {

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.xml
@@ -36,10 +36,22 @@
         </xpath>
         <!-- Remove the mimetype on the second line. -->
         <xpath expr="//div[hasclass('caption', 'small')]" position="replace"/>
+        <!-- Set float left to add an icon on the right. -->
+        <xpath expr="//div[@name='attachment']" position="attributes">
+            <attribute name="t-attf-class"
+                       add="d-flex flex-row align-items-center gap-1 w-100 {{ iconsSupported ? 'float-start' : '' }}"
+                       separator=" "/>
+        </xpath>
+        <!-- Add Icon on the right of the Attachment -->
+        <xpath expr="//div[@name='attachment']" position="inside">
+            <div class="float-start" t-if="file.tooltip">
+                <i class="fa fa-fw o_button_icon fa-warning" t-att-data-tooltip="file.tooltip"></i>
+            </div>
+        </xpath>
     </t>
 
     <t t-name="account.mail_attachments">
-        <t t-set="data" t-value="getValue()"/>
+        <t t-set="data" t-value="getRenderedValue()"/>
 
         <div t-attf-class="oe_fileupload" aria-atomic="true">
             <div class="o_attachments">

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -77,6 +77,12 @@ class AccountMoveSend(models.TransientModel):
         store=True,
         readonly=False,
     )
+    # Technical field to display or not the attachment button
+    display_attachments_widget = fields.Boolean(
+        compute='_compute_display_attachments_widget',
+    )
+    # Technical field to display or not a warning icon besides attachments not supported
+    attachments_not_supported = fields.Json(compute='_compute_attachments_not_supported')
 
     @api.model
     def default_get(self, fields_list):
@@ -241,6 +247,10 @@ class AccountMoveSend(models.TransientModel):
             for attachment in mail_template.attachment_ids
         ]
 
+    def _get_invoice_edi_format(self):
+        # To extends
+        return False
+
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
@@ -331,6 +341,16 @@ class AccountMoveSend(models.TransientModel):
                 )
             else:
                 wizard.mail_attachments_widget = []
+
+    @api.depends('checkbox_send_mail')
+    def _compute_display_attachments_widget(self):
+        for wizard in self:
+            wizard.display_attachments_widget = wizard.checkbox_send_mail
+
+    @api.depends('display_attachments_widget', 'mail_attachments_widget')
+    def _compute_attachments_not_supported(self):
+        for wizard in self:
+            wizard.attachments_not_supported = {}
 
     @api.model
     def _format_error_text(self, error):

--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -17,6 +17,8 @@
                 <field name="send_mail_warning_message" invisible="1"/>
                 <field name="display_mail_composer" invisible="1"/>
                 <field name="mail_lang" invisible="1"/>
+                <field name="display_attachments_widget" invisible="1"/>
+                <field name="attachments_not_supported" invisible="1"/>
 
                 <div class="m-0" name="warnings">
                     <field name="send_mail_warning_message" class="o_field_html" widget="actionable_errors"/>
@@ -66,13 +68,6 @@
                            options="{'style-inline': true}"
                            invisible="not display_mail_composer"/>
                     <group>
-                        <group invisible="not display_mail_composer">
-                            <field name="mail_attachments_widget"
-                                   widget="mail_attachments"
-                                   string="Attach a file"
-                                   nolabel="1"
-                                   colspan="2"/>
-                        </group>
                         <group>
                             <field name="mail_template_id"
                                    required="mode == 'invoice_multi'"
@@ -81,6 +76,13 @@
                         </group>
                     </group>
                 </div>
+
+                <field name="mail_attachments_widget"
+                       widget="mail_attachments"
+                       string="Attach a file"
+                       nolabel="1"
+                       colspan="2"
+                       invisible="not display_attachments_widget"/>
 
                 <footer>
                     <button string="Send &amp; Print"

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -95,6 +95,18 @@ EAS_MAPPING = {
     'VA': {'9953': 'vat'},
 }
 
+# -------------------------------------------------------------------------
+# SUPPORTED FILE TYPES FOR IMPORT
+# -------------------------------------------------------------------------
+SUPPORTED_FILE_TYPES = {
+    'application/pdf': '.pdf',
+    'application/vnd.oasis.opendocument.spreadsheet': '.ods',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+    'image/jpeg': '.jpeg',
+    'image/png': '.png',
+    'text/csv': '.csv',
+}
+
 
 class AccountEdiCommon(models.AbstractModel):
     _name = "account.edi.common"
@@ -321,34 +333,35 @@ class AccountEdiCommon(models.AbstractModel):
         with invoice._get_edi_creation() as invoice:
             self._correct_invoice_tax_amount(tree, invoice)
 
-        # === Import the embedded PDF in the xml if some are found ===
-
+        # === Import the embedded documents in the xml if some are found ===
         attachments = self.env['ir.attachment']
         additional_docs = tree.findall('./{*}AdditionalDocumentReference')
         for document in additional_docs:
             attachment_name = document.find('{*}ID')
             attachment_data = document.find('{*}Attachment/{*}EmbeddedDocumentBinaryObject')
-            if attachment_name is not None \
-                    and attachment_data is not None \
-                    and attachment_data.attrib.get('mimeCode') == 'application/pdf':
+            if attachment_name is not None and attachment_data is not None:
+                mimetype = attachment_data.attrib.get('mimeCode')
+                if not (extension := SUPPORTED_FILE_TYPES.get(mimetype)):
+                    continue
                 text = attachment_data.text
                 # Normalize the name of the file : some e-fff emitters put the full path of the file
                 # (Windows or Linux style) and/or the name of the xml instead of the pdf.
-                # Get only the filename with a pdf extension.
-                name = (attachment_name.text or 'invoice').split('\\')[-1].split('/')[-1].split('.')[0] + '.pdf'
+                # Get only the filename with the right extension.
+                name = (attachment_name.text or 'invoice').split('\\')[-1].split('/')[-1].split('.')[0] + extension
                 attachment = self.env['ir.attachment'].create({
                     'name': name,
                     'res_id': invoice.id,
                     'res_model': 'account.move',
                     'datas': text + '=' * (len(text) % 3),  # Fix incorrect padding
                     'type': 'binary',
-                    'mimetype': 'application/pdf',
+                    'mimetype': mimetype,
                 })
                 # Upon receiving an email (containing an xml) with a configured alias to create invoice, the xml is
                 # set as the main_attachment. To be rendered in the form view, the pdf should be the main_attachment.
                 if invoice.message_main_attachment_id and \
                         invoice.message_main_attachment_id.name.endswith('.xml') and \
-                        'pdf' not in invoice.message_main_attachment_id.mimetype:
+                        'pdf' not in invoice.message_main_attachment_id.mimetype and \
+                        mimetype == 'application/pdf':
                     invoice.message_main_attachment_id = attachment
                 attachments |= attachment
         if attachments:

--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -7,6 +7,7 @@ from lxml import etree
 from xml.sax.saxutils import escape, quoteattr
 
 from odoo import _, api, fields, models, tools, SUPERUSER_ID
+from odoo.addons.account_edi_ubl_cii.models.account_edi_common import SUPPORTED_FILE_TYPES
 from odoo.tools import cleanup_xml_node
 from odoo.tools.pdf import OdooPdfFileReader, OdooPdfFileWriter
 
@@ -42,6 +43,11 @@ class AccountMoveSend(models.TransientModel):
             'checkbox_ubl_cii_xml': False,
             **values,
         }
+
+    def _get_invoice_edi_format(self):
+        # EXTENDS 'account'
+        self.ensure_one()
+        return self.move_ids.partner_id.commercial_partner_id.ubl_cii_format
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
@@ -93,6 +99,21 @@ class AccountMoveSend(models.TransientModel):
                                         "Please check those in their Accounting tab. "
                                         "Otherwise, the generated files will be incomplete.", names)
 
+    def _compute_attachments_not_supported(self):
+        # EXTENDS 'account'
+        super()._compute_attachments_not_supported()
+        for wizard in self:
+            if wizard.mode == 'invoice_single' and wizard.checkbox_ubl_cii_xml:
+                edi_format = wizard._get_invoice_edi_format()
+                _attachments_to_embed, attachments_not_supported = wizard._get_ubl_available_attachments(
+                    wizard.mail_attachments_widget,
+                    edi_format,
+                )
+                wizard.attachments_not_supported = {
+                    attachment.id: _("Unsupported file type via %s", edi_format)
+                    for attachment in attachments_not_supported
+                }
+
     # -------------------------------------------------------------------------
     # ATTACHMENTS
     # -------------------------------------------------------------------------
@@ -120,6 +141,28 @@ class AccountMoveSend(models.TransientModel):
             })
 
         return results
+
+    @api.depends('checkbox_ubl_cii_xml')
+    def _compute_display_attachments_widget(self):
+        # EXTENDS 'account'
+        super()._compute_display_attachments_widget()
+        for wizard in self:
+            if not wizard.display_attachments_widget and wizard.mode == 'invoice_single':
+                wizard.display_attachments_widget = wizard.checkbox_ubl_cii_xml and wizard._get_invoice_edi_format() == 'ubl_bis3'
+
+    @api.model
+    def _get_ubl_available_attachments(self, mail_attachments_widget, invoice_edi_format):
+        self.ensure_one()
+        if not invoice_edi_format or not mail_attachments_widget:
+            return self.env['ir.attachment'], self.env['ir.attachment']
+        attachment_ids = [values['id'] for values in mail_attachments_widget if values.get('manual')]
+        attachments = self.env['ir.attachment'].browse(attachment_ids)
+
+        if invoice_edi_format != 'ubl_bis3':
+            return self.env['ir.attachment'], attachments
+
+        accepted_attachments = attachments.filtered(lambda attachment: attachment.mimetype in SUPPORTED_FILE_TYPES)
+        return accepted_attachments, attachments - accepted_attachments
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
@@ -226,9 +269,8 @@ class AccountMoveSend(models.TransientModel):
             return
 
         xmlns_move_type = 'Invoice' if invoice.move_type == 'out_invoice' else 'CreditNote'
-        pdf_values = invoice_data.get('pdf_attachment_values') or invoice_data['proforma_pdf_attachment_values']
-        filename = pdf_values['name']
-        content = pdf_values['raw']
+        anchor_index = tree.index(anchor_elements[0])
+        pdf_values = invoice.invoice_pdf_report_id or invoice_data.get('pdf_attachment_values') or invoice_data['proforma_pdf_attachment_values']
 
         doc_type_node = ""
         edi_model = invoice_data["ubl_cii_xml_options"]["builder"]
@@ -236,25 +278,45 @@ class AccountMoveSend(models.TransientModel):
         if doc_type_code_vals['value']:
             doc_type_code_attrs = " ".join(f'{name}="{value}"' for name, value in doc_type_code_vals['attrs'].items())
             doc_type_node = f"<cbc:DocumentTypeCode {doc_type_code_attrs}>{doc_type_code_vals['value']}</cbc:DocumentTypeCode>"
-        to_inject = f'''
-            <cac:AdditionalDocumentReference
-                xmlns="urn:oasis:names:specification:ubl:schema:xsd:{xmlns_move_type}-2"
-                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
-                <cbc:ID>{escape(filename)}</cbc:ID>
-                {doc_type_node}
-                <cac:Attachment>
-                    <cbc:EmbeddedDocumentBinaryObject
-                        mimeCode="application/pdf"
-                        filename={quoteattr(filename)}>
-                        {base64.b64encode(content).decode()}
-                    </cbc:EmbeddedDocumentBinaryObject>
-                </cac:Attachment>
-            </cac:AdditionalDocumentReference>
-        '''
 
-        anchor_index = tree.index(anchor_elements[0])
-        tree.insert(anchor_index, etree.fromstring(to_inject))
+        attachments_to_embed = [
+            {
+                'filename': attachment.name,
+                'raw': attachment.raw,
+                'mimetype': attachment.mimetype,
+            }
+            for attachment in self._get_ubl_available_attachments(
+                invoice_data['mail_attachments_widget'],
+                invoice.partner_id.commercial_partner_id.ubl_cii_format,
+            )[0]
+        ] if invoice_data.get('mail_attachments_widget') else []
+        attachments_to_embed.append({
+            'filename': pdf_values['name'],
+            'raw': pdf_values['raw'],
+            'mimetype': pdf_values['mimetype'],
+            'xmlns': f'xmlns="urn:oasis:names:specification:ubl:schema:xsd:{xmlns_move_type}-2"',
+            'document_type_node': doc_type_node,
+        })
+
+        for attachment_values in attachments_to_embed:
+            to_inject = f'''
+                <cac:AdditionalDocumentReference
+                    {attachment_values.get("xmlns", "")}
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                    <cbc:ID>{escape(attachment_values["filename"])}</cbc:ID>
+                    {attachment_values.get("document_type_node", "")}
+                    <cac:Attachment>
+                        <cbc:EmbeddedDocumentBinaryObject
+                            mimeCode={quoteattr(attachment_values["mimetype"])}
+                            filename={quoteattr(attachment_values['filename'])}>
+                            {base64.b64encode(attachment_values['raw']).decode()}
+                        </cbc:EmbeddedDocumentBinaryObject>
+                    </cac:Attachment>
+                </cac:AdditionalDocumentReference>
+            '''
+            tree.insert(anchor_index, etree.fromstring(to_inject))
+
         invoice_data['ubl_cii_xml_attachment_values']['raw'] = etree.tostring(
             cleanup_xml_node(tree), xml_declaration=True, encoding='UTF-8'
         )

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -184,6 +184,9 @@ class AccountMoveSend(models.TransientModel):
                     invoice_data['error'] = _('Please verify partner configuration in partner settings.')
                     continue
 
+                if len(xml_file) > 64000000:
+                    invoice_data['error'] = _("Invoice %s is too big to send via peppol (64MB limit)", invoice.name)
+
                 receiver_identification = f"{partner.peppol_eas}:{partner.peppol_endpoint}"
                 params['documents'].append({
                     'filename': filename,
@@ -216,13 +219,32 @@ class AccountMoveSend(models.TransientModel):
             else:
                 # the response only contains message uuids,
                 # so we have to rely on the order to connect peppol messages to account.move
-                invoices = self.env['account.move']
+                attachments_linked_message = _("The invoice has been sent to the Peppol Access Point. The following attachments were sent with the XML:")
+                attachments_not_linked_message = _("Some attachments could not be sent with the XML:")
                 for message, (invoice, invoice_data) in zip(response['messages'], invoices_data_peppol.items()):
                     invoice.peppol_message_uuid = message['message_uuid']
                     invoice.peppol_move_state = 'processing'
-                    invoices |= invoice
-                log_message = _('The document has been sent to the Peppol Access Point for processing')
-                invoices._message_log_batch(bodies=dict((invoice.id, log_message) for invoice in invoices))
+                    attachments_linked, attachments_not_linked = self._get_ubl_available_attachments(
+                        invoice_data.get('mail_attachments_widget', []),
+                        invoice.partner_id.commercial_partner_id.ubl_cii_format,
+                    )
+                    if attachments_not_linked:
+                        invoice._message_log(body=attachments_not_linked_message, attachment_ids=attachments_not_linked.mapped('id'))
+
+                    base_attachments = [
+                        (invoice_data[key]['name'], invoice_data[key]['raw'])
+                        for key in ['pdf_attachment_values', 'ubl_cii_xml_attachment_values']
+                        if invoice_data.get(key)
+                    ]
+                    attachments_embedded = [
+                        (attachment.name, attachment.raw)
+                        for attachment in attachments_linked
+                    ] + base_attachments
+
+                    invoice.with_context(no_new_invoice=True).message_post(
+                        body=attachments_linked_message,
+                        attachments=attachments_embedded,
+                    )
 
         if self._can_commit():
             self._cr.commit()

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
@@ -27,7 +27,7 @@
 
 <t t-name="Many2ManyBinaryField.attachment_preview">
     <t t-set="editable" t-value="!props.readonly"/>
-    <div t-attf-class="o_attachment o_attachment_many2many #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
+    <div name="attachment" t-attf-class="o_attachment o_attachment_many2many #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
         <div class="o_attachment_wrap">
             <t t-set="ext" t-value="getExtension(file)"/>
             <t t-set="url" t-value="getUrl(file.id)"/>


### PR DESCRIPTION
[IMP] account: multiple embed files peppol

Backport of 4170f0e889b8aa0557b1ae4e456f053407570832

This commit allows user to send multiple attachments through peppol. The attachments will be embedded into the xml under the <AdditionalDocumentReference> tag

task-5103539

closes odoo/odoo#234339


