### PR TITLE
[FIX] base: Not translated content

### DIFF
--- a/odoo/addons/base/models/res_groups_privilege.py
+++ b/odoo/addons/base/models/res_groups_privilege.py
@@ -7,8 +7,8 @@ class ResGroupsPrivilege(models.Model):
     _order = 'sequence, name, id'
 
     name = fields.Char(string='Name', required=True, translate=True)
-    description = fields.Text(string='Description')
-    placeholder = fields.Char(string='Placeholder', default="No", help="Text that is displayed as placeholder in the selection field of the user form.")
+    description = fields.Text(string='Description', translate=True)
+    placeholder = fields.Char(string='Placeholder', default="No", help="Text that is displayed as placeholder in the selection field of the user form.", translate=True)
     sequence = fields.Integer(string='Sequence', default=100)
     category_id = fields.Many2one('ir.module.category', string='Category', index=True)
     group_ids = fields.One2many('res.groups', 'privilege_id', string='Groups')


### PR DESCRIPTION
The value of these fields are not translated, because a mising "translate=True" attzribute. The placeholder is very visible on the User Rights form (you need to be in debug mode) if you view Odoo other than english.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
