### PR TITLE
[FIX] web: Missing text from translation

### DIFF
--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -32,13 +32,14 @@ class ShortcutsFooterComponent extends Component {
 }
 
 function shortCutsItem(env) {
+    const label = _t("Shortcuts");
     return {
         type: "item",
         id: "shortcuts",
         hide: env.isSmall,
         description: markup`
             <div class="d-flex align-items-center justify-content-between p-0 w-100">
-                <span>${_t("Shortcuts")}</span>
+                <span>${label}</span>
                 <span class="fw-bold">${isMacOS() ? "CMD" : "CTRL"}+K</span>
             </div>`,
         callback: () => {


### PR DESCRIPTION
The "Shortcuts" menu item was not translatable in the User Menu. It is missing from the .POT file, so i refactor it into a dedicated variable.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
