### PR TITLE
[FIX] sale_management: restore product prices after unsetting optional lines

### DIFF
--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
@@ -131,13 +131,16 @@ patch(SaleOrderLineListRenderer.prototype, {
             is_optional: setOptional,
         }))];
 
+        const proms = [];
         for (const sectionRecord of getSectionRecords(this.props.list, record)) {
             let changes = {};
 
             if (!sectionRecord.data.display_type) {
-                changes = setOptional
-                    ? { product_uom_qty: 0, price_total: 0, price_subtotal: 0 }
-                    : { product_uom_qty: sectionRecord.data.product_uom_qty || 1 };
+                if (setOptional) {
+                    changes = { product_uom_qty: 0, price_total: 0, price_subtotal: 0 }
+                } else {
+                    proms.push(sectionRecord._update({ product_uom_qty: sectionRecord.data.product_uom_qty || 1 }));
+                }
             } else if (this.isSubSection(sectionRecord)) {
                 changes = setOptional && {
                     collapse_composition: false,
@@ -156,6 +159,7 @@ patch(SaleOrderLineListRenderer.prototype, {
         }
 
         await this.props.list.applyCommands(commands, { sort: true });
+        await Promise.all(proms);
     },
 
     /**


### PR DESCRIPTION
**Steps to produce:**
- Install the `Sales` module.
- Create a Sales Order.
- Add a section and some products under it.
- In the section menu (three dots), click Set Optional.
- Again, open the section menu and click Unset Optional.

**Issue:**
- After unsetting the optional, the product amounts remain `0`.

**Root cause:**
- At[1], when setting options, both quantity and price are reset to `0`.
- When unsetting optional, only the quantity is restored, leaving the price at `0`.

**Solution:**
- When unsetting optional, explicitly trigger the onchange on the field `product_uom_qty` using `.update()`.

[1]https://github.com/odoo/odoo/blob/27cd0a3fea1b47a85a4f3d397b052bbec08e182b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js#L138-L140

Before:
<img width="1198" height="476" alt="image" src="https://github.com/user-attachments/assets/01dee1d6-2870-4222-8a6c-724fbfff8da1" />

After:
<img width="1214" height="453" alt="image" src="https://github.com/user-attachments/assets/63ed4eb4-27cf-4b15-a957-c28a46a3ca42" />

opw-5368488
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
