### PR TITLE
[FIX] l10n_in_sale: correct fiscal partner determination on Sale Order

### DIFF
--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -10,53 +10,66 @@ class SaleOrder(models.Model):
     l10n_in_reseller_partner_id = fields.Many2one('res.partner',
         string='Reseller', domain="[('vat', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]", readonly=False)
 
-    @api.depends('partner_id', 'partner_shipping_id')
+    @api.depends('partner_invoice_id')
     def _compute_fiscal_position_id(self):
 
-        def _get_fiscal_state(order, foreign_state):
+        def _get_partner_fiscal(order):
+            order = order.with_company(order.company_id)
+            return (
+                order.partner_shipping_id.property_account_position_id
+                or order.partner_invoice_id.property_account_position_id
+                or order.partner_id.property_account_position_id
+            )
+
+        def _get_fiscal_state(order):
             """
             Maps each order to its corresponding fiscal state based on its type,
             fiscal conditions, and the state of the associated partner or company.
             """
 
-            if (
-                order.country_code != 'IN'
-                # Partner's FP takes precedence through super
-                or order.partner_shipping_id.property_account_position_id
-                or order.partner_id.property_account_position_id
-            ):
-                return False
-            elif order.partner_shipping_id.l10n_in_gst_treatment == 'special_economic_zone':
+            partner_to_consider = order.partner_invoice_id or order.partner_id
+            if partner_to_consider.l10n_in_gst_treatment == 'special_economic_zone':
                 # Special Economic Zone
-                return foreign_state
+                return sez_state
 
             # Computing Place of Supply for particular order
             partner = (
-                order.partner_id.commercial_partner_id == order.partner_shipping_id.commercial_partner_id
+                partner_to_consider.commercial_partner_id == order.partner_shipping_id.commercial_partner_id
                 and order.partner_shipping_id
-                or order.partner_id
+                or partner_to_consider
             )
             if partner.country_id and partner.country_id.code != 'IN':
                 return foreign_state
-            partner_state = partner.state_id or order.partner_id.commercial_partner_id.state_id or order.company_id.state_id
+            partner_state = partner.state_id or partner_to_consider.commercial_partner_id.state_id or order.company_id.state_id
             country_code = partner_state.country_id.code or order.country_code
             return partner_state if country_code == 'IN' else foreign_state
 
+        # Handle non-Indian orders using standard logic
         FiscalPosition = self.env['account.fiscal.position']
-        foreign_state = self.env['res.country.state'].search([('code', '!=', 'IN')], limit=1)
-        for state_id, orders in self.grouped(lambda order: _get_fiscal_state(order, foreign_state)).items():
-            if state_id:
-                virtual_partner = self.env['res.partner'].new({
-                    'state_id': state_id.id,
-                    'country_id': state_id.country_id.id,
-                })
-                # Group orders by company to avoid multi-company conflicts
-                for company_id, company_orders in orders.grouped('company_id').items():
-                    company_orders.fiscal_position_id = FiscalPosition.with_company(
-                        company_id.id
-                    )._get_fiscal_position(virtual_partner)
-            else:
-                super(SaleOrder, orders)._compute_fiscal_position_id()
+        non_in_orders = self.filtered(lambda o: o.country_code != 'IN')
+        super(SaleOrder, non_in_orders)._compute_fiscal_position_id()
+
+        in_orders = self - non_in_orders
+        orders_group_by_fp = in_orders.grouped(_get_partner_fiscal)
+        orders_without_fiscal = orders_group_by_fp.pop(FiscalPosition, False)
+        for fiscal_position, orders in orders_group_by_fp.items():
+            orders.fiscal_position_id = fiscal_position
+
+        if not orders_without_fiscal:
+            return
+
+        foreign_state = self.env['res.country.state'].search([('country_id.code', '!=', 'IN')], limit=1)
+        sez_state = self.env.ref('l10n_in.state_in_oc', raise_if_not_found=False)
+        for state, orders in orders_without_fiscal.grouped(_get_fiscal_state).items():
+            virtual_partner = self.env['res.partner'].new({
+                'state_id': state.id,
+                'country_id': state.country_id.id,
+            })
+            # Group orders by company to avoid multi-company conflicts
+            for company, company_orders in orders.grouped('company_id').items():
+                company_orders.fiscal_position_id = FiscalPosition.with_company(
+                    company.id
+                )._get_fiscal_position(virtual_partner)
 
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()

--- a/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
+++ b/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
@@ -79,7 +79,7 @@ class TestSaleFiscal(L10nInTestInvoicingCommon):
 
             self.assertEqual(
                 sale_order.fiscal_position_id,
-                template.ref('fiscal_position_in_export_sez_in')
+                template.ref('fiscal_position_in_sez')
             )
 
         # Sub-test: Manual Partner Fiscal Check
@@ -93,6 +93,35 @@ class TestSaleFiscal(L10nInTestInvoicingCommon):
                 fpos_ref='fiscal_position_in_export_sez_in',
                 partner=self.partner_a.id,
             )
+
+    def test_l10n_in_sale_invoice_fiscal_position(self):
+        """Ensure the fiscal position is correctly compute from the sale order to the invoice."""
+        self.env.company = self.default_company
+
+        # Create a sale order with an intra-state fiscal position
+        sale_order = self._assert_order_fiscal_position(
+            fpos_ref='fiscal_position_in_intra_state',
+            partner=self.partner_a.id,
+            post=False,
+        )
+
+        # Change the `invoice_partner` to an inter-state and verify the updated fiscal position
+        sale_order.write({'partner_invoice_id': self.partner_b.id})
+        self.assertEqual(
+            sale_order.fiscal_position_id,
+            self.env['account.chart.template'].ref('fiscal_position_in_inter_state')
+        )
+
+        # Confirm SO and create invoice
+        sale_order.action_confirm()
+        invoice = sale_order._create_invoices()
+
+        # Force FP recompute on invoice by re-applying partner
+        invoice.write({'partner_id': self.partner_b.id})
+        self.assertEqual(
+            invoice.fiscal_position_id,
+            sale_order.fiscal_position_id,
+        )
 
     def test_foreign_partner_without_state_fiscal_position(self):
         """ Verify foreign partner without state gets export fiscal position """


### PR DESCRIPTION
## Before this commit
Fiscal position on Sale Orders was computed based on `partner_id` and `partner_shipping_id`. However, during invoice creation from a Sale Order, We uses `partner_invoice_id` as the invoice’s `partner_id`. This mismatch caused fiscal inconsistencies between the Sale Order and the generated Invoice in certain edge cases.

## After this commit
Fiscal position is now computed using `partner_invoice_id` to ensure that both the Sale Order and its Invoice use the same fiscal partner reference. This aligns fiscal determination across documents and avoids inconsistencies in scenarios where the invoice partner differs from the order’s main or shipping partner.

opw-5367523

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
