### PR TITLE
[FIX] account: prevent error when opening the tax return

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -338,7 +338,7 @@ class ResCompany(models.Model):
                 year = datetime.now().year
 
             max_day = calendar.monthrange(year, int(rec.fiscalyear_last_month))[1]
-            if rec.fiscalyear_last_day > max_day:
+            if rec.fiscalyear_last_day <= 0 or rec.fiscalyear_last_day > max_day:
                 raise ValidationError(_("Invalid fiscal year last day"))
 
     def _compute_force_restrictive_audit_trail(self):

--- a/addons/account/tests/test_company_branch.py
+++ b/addons/account/tests/test_company_branch.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from odoo import Command, fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged, Form
 
 
@@ -306,3 +306,9 @@ class TestCompanyBranch(AccountTestInvoicingCommon):
             user_env['res.company'].browse(company_b.id).write({
                 'currency_id': self.env.ref('base.EUR').id,
             })
+
+    def test_set_fiscalyear_last_day_to_negative_value(self):
+        """Test that ensure that fiscalyear_last_day raises ValidationError when set
+           to negative value."""
+        with self.assertRaises(ValidationError):
+            self.root_company.fiscalyear_last_day = -1


### PR DESCRIPTION
Currently, an error occurs when user tries to open the Tax Return view.

**Steps to Reproduce:**
 - Install the `Accounting` module.
 - Go to `Tax Returns` and set the `Fiscal Year End Day to negative value`, then click `Apply`.

**Error:**
`ValueError: day is out of range for month.`

**Cause:**

 - The field is related to the `company's fiscalyear_last_day` [1].
 - When the user enters a `negative value`, that invalid value is written directly to the `company's fiscal year last day`[2] .
 - When the user opens the `Tax Returns`, it going to compute the `fiscal year dates` [4]. Since the day value is negative, it raises error [5] because the day is out of range for the month.

**Fix:**
- This commit ensures that a validation error is raised when a user enters zero or negative fiscal year date.
- In 18.3, setting the value to 0 falls back to the previously defined company value [2].
- In 19.0, however, the value 0 is incorrectly saved on the company [3], causing an error.
- This fix restores the correct behavior and resolves the issue in 19.0 as well.

[1]: https://github.com/odoo/odoo/blob/27cd0a3fea1b47a85a4f3d397b052bbec08e182b/addons/account/wizard/setup_wizards.py#L17-L18

[2]: https://github.com/odoo/odoo/blob/45ca03fcb77febf4f373fe35f0242720e88cb85b/addons/account/wizard/setup_wizards.py#L49

[3]: https://github.com/odoo/odoo/blob/27cd0a3fea1b47a85a4f3d397b052bbec08e182b/addons/account/wizard/setup_wizards.py#L54-L56

[4]: https://github.com/odoo/enterprise/blob/99642bdf62f8b1c653dfefdbdcd0e9258cc9e307/account_accountant/models/res_company.py#L174-L175

[5]: https://github.com/odoo/odoo/blob/27cd0a3fea1b47a85a4f3d397b052bbec08e182b/odoo/tools/date_utils.py#L242

sentry-7102968735



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
