### PR TITLE
[IMP] l10n_es_{pos,edi_verifactu}: multiple changes in spain localition

### DIFF
--- a/addons/l10n_es_edi_verifactu/views/account_move_views.xml
+++ b/addons/l10n_es_edi_verifactu/views/account_move_views.xml
@@ -79,13 +79,6 @@
                         <field class="d-inline-block" name="l10n_es_edi_verifactu_warning"/>
                     </div>
                 </xpath>
-                <xpath expr="//button[@name='button_cancel']" position="after">
-                    <button name="l10n_es_edi_verifactu_button_cancel"
-                            string="Request Veri*Factu Cancellation"
-                            type="object"
-                            groups="account.group_account_invoice"
-                            invisible="not l10n_es_edi_verifactu_show_cancel_button"/>
-                </xpath>
                 <xpath expr="//notebook" position="inside">
                     <page
                         id="verifactu_tab"
@@ -123,6 +116,18 @@
                         </group>
                     </page>
                 </xpath>
+            </field>
+        </record>
+
+        <record model="ir.actions.server" id="action_l10n_es_edi_verifactu_button_cancel">
+            <field name="name">Request Veri*Factu Cancellation</field>
+            <field name="model_id" ref="l10n_es_edi_verifactu.model_account_move"/>
+            <field name="group_ids" eval="[Command.link(ref('account.group_account_invoice'))]"/>
+            <field name="binding_model_id" ref="l10n_es_edi_verifactu.model_account_move" />
+            <field name="state">code</field>
+            <field name="binding_view_types">form</field>
+            <field name="code">
+                record.l10n_es_edi_verifactu_button_cancel()
             </field>
         </record>
     </data>

--- a/addons/l10n_es_edi_verifactu/views/res_config_settings_views.xml
+++ b/addons/l10n_es_edi_verifactu/views/res_config_settings_views.xml
@@ -20,6 +20,12 @@
                                         Manage certificates
                                     </button>
                                 </div>
+                                <div class="o_row">
+                                    <a class="oe_link fw-bold" target="_blank" href="https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/spain.html#veri-factu">
+                                        <i class="o_button_icon oi oi-fw oi oi-arrow-right"/>
+                                        Access Declaración Responsable
+                                    </a>
+                                </div>
                                 <div class="o_row mt16">
                                     <label for="l10n_es_edi_verifactu_test_environment" class="o_light_label"
                                            string="Test Environment"/>


### PR DESCRIPTION
SPECIFICATION
- Add the way to access the 'Declaración Responsable' documentation.
- Make the Veri*Factu Cancellation Request harder to find.

TECHNICAL DETAILS
- In this commit, providing the direct URL for the 'Declaración Responsable'
  documentation in the settings.
- Changing the 'Request Veri*factu Cancellation' button position from the header
  of the form view to the Server Actions menu.

Related PR: https://github.com/odoo/upgrade/pull/9064

Task-5354717