### PR TITLE
[FIX] mail: device selection overflow

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -9,7 +9,7 @@
         >
             <button
                 t-if="isPermissionGranted(props.kind)"
-                class="o-mail-DeviceSelect-button btn cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret"
+                class="o-mail-DeviceSelect-button btn cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret overflow-hidden"
                 t-att-data-kind="props.kind"
                 t-attf-class="{{ props.roundedType === 'pill' ? 'rounded-pill' : 'rounded' }}"
              >


### PR DESCRIPTION
**Steps to reproduce:**
Go to Discuss > Configuration > Voice & Video
Click 'Permission Needed' next to the 'Microphone' label 
Grant microphone permission and select any device

**Current behavior before PR:**
A horizontal scrollbar appeared at the bottom due to overflowing content in the device selection dropdown.

**Desired behavior after PR is merged:**
The button containing the device selection now prevents overflow, eliminating the horizontal scrollbar.

task-5413169


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
