### PR TITLE
[FIX] point_of_sale: fix traceback with ship later

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.js
@@ -2,6 +2,8 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { _t } from "@web/core/l10n/translation";
 import { Component, onMounted, useState } from "@odoo/owl";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { useService } from "@web/core/utils/hooks";
 const { DateTime } = luxon;
 
 export class DatePickerPopup extends Component {
@@ -9,6 +11,7 @@ export class DatePickerPopup extends Component {
     static components = { Dialog, DateTimeInput };
     static props = {
         title: { type: String, optional: true },
+        defaultValue: { type: DateTime, optional: true },
         confirmLabel: { type: String, optional: true },
         getPayload: Function,
         close: Function,
@@ -20,9 +23,8 @@ export class DatePickerPopup extends Component {
 
     setup() {
         super.setup();
-        this.state = useState({
-            shippingDate: DateTime.now(),
-        });
+        this.dialog = useService("dialog");
+        this.state = useState({ shippingDate: this.props.defaultValue ?? DateTime.now() });
         onMounted(() => {
             const input = document.querySelector(".shipping-date-selector input");
             if (input) {
@@ -33,11 +35,19 @@ export class DatePickerPopup extends Component {
         });
     }
     onDateChange(date) {
-        this.state.shippingDate = date;
+        const today = DateTime.now().startOf("day");
+        if (date && date < today) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Validation Error"),
+                body: _t("Selected date cannot be in the past."),
+            });
+            this.state.shippingDate = today;
+        } else {
+            this.state.shippingDate = date;
+        }
     }
     confirm() {
-        const selected = this.state.shippingDate.toISODate();
-        this.props.getPayload(selected);
+        this.props.getPayload(this.state.shippingDate);
         this.props.close();
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.xml
@@ -3,9 +3,6 @@
     <t t-name="point_of_sale.DatePickerPopup">
         <Dialog title="props.title" size="'sm'">
             <div class="mb-3 w-100 d-flex flex-column flex-sm-row align-items-center">
-                <span class="me-3 fs-5 text-center text-sm-start" style="white-space: nowrap;">
-                    Select Date:
-                </span>
                 <div class="flex-grow-1 w-100 shipping-date-selector">
                     <DateTimeInput
                         type="'date'"

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -288,16 +288,13 @@ export class PaymentScreen extends Component {
         return this.pos.currency.round(tip);
     }
     async toggleShippingDatePicker() {
-        if (!this.currentOrder.shipping_date) {
-            this.dialog.add(DatePickerPopup, {
-                title: _t("Select the shipping date"),
-                getPayload: (shippingDate) => {
-                    this.currentOrder.shipping_date = shippingDate;
-                },
-            });
-        } else {
-            this.currentOrder.shipping_date = false;
-        }
+        this.dialog.add(DatePickerPopup, {
+            title: _t("Select the shipping date"),
+            defaultValue: this.currentOrder.shipping_date,
+            getPayload: (shippingDate) => {
+                this.currentOrder.shipping_date = shippingDate;
+            },
+        });
     }
     deletePaymentLine(uuid) {
         const line = this.paymentLines.find((line) => line.uuid === uuid);

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -292,16 +292,13 @@ export class PaymentScreen extends Component {
         return this.pos.currency.round(tip);
     }
     async toggleShippingDatePicker() {
-        if (!this.currentOrder.shipping_date) {
-            this.dialog.add(DatePickerPopup, {
-                title: _t("Select the shipping date"),
-                getPayload: (shippingDate) => {
-                    this.currentOrder.shipping_date = shippingDate;
-                },
-            });
-        } else {
-            this.currentOrder.shipping_date = false;
-        }
+        this.dialog.add(DatePickerPopup, {
+            title: _t("Select the shipping date"),
+            defaultValue: this.currentOrder.shipping_date,
+            getPayload: (shippingDate) => {
+                this.currentOrder.shipping_date = shippingDate;
+            },
+        });
     }
     deletePaymentLine(uuid) {
         const line = this.paymentLines.find((line) => line.uuid === uuid);

--- a/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
@@ -6,6 +6,9 @@ import { registry } from "@web/core/registry";
 import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 
+const { DateTime } = luxon;
+const nextYear = DateTime.now().year + 1;
+
 registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
     steps: () =>
         [
@@ -15,47 +18,37 @@ registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
             ProductScreen.addOrderline("Whiteboard Pen", "1"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
-            {
-                content: "click ship later button",
-                trigger: ".button:contains('Ship Later')",
-                run: "click",
-            },
-            {
-                content: "pick a date",
-                trigger: ".modal-body .o_datetime_input",
-                run: () => {
-                    const input = document.querySelector(".modal-body .o_datetime_input");
-                    const nextYear = new Date().getFullYear() + 1;
-                    input.value = `${nextYear}-05-30`;
-                    input.dispatchEvent(new Event("input", { bubbles: true }));
-                    input.dispatchEvent(new Event("change", { bubbles: true }));
-                },
-            },
-            {
-                content: "click confirm button",
-                trigger: ".btn:contains('Confirm')",
-                run: "click",
-            },
-            {
-                content: "Assert shipping date was set",
-                trigger: ".payment-buttons .d-flex .btn span",
-                run: () => {
-                    const spans = [
-                        ...document.querySelectorAll(".payment-buttons .d-flex .btn span"),
-                    ];
-                    const nextYear = new Date().getFullYear() + 1;
-                    const expectedDate = `5/30/${nextYear}`;
-                    if (!spans.some((span) => span.innerText === expectedDate)) {
-                        throw new Error("Expected shipping date is not set");
-                    }
-                },
-            },
+            setShipLaterDate(""),
+            setShipLaterDate(`${nextYear}-05-30`),
             PaymentScreen.clickValidate(),
             Dialog.confirm(),
-            PartnerList.clickPartner("Partner Test with Address"),
+            PartnerList.clickPartner("Partner Full"),
             FeedbackScreen.isShown(),
             FeedbackScreen.checkTicketData({
                 is_shipping_date: true,
             }),
         ].flat(),
 });
+
+const setShipLaterDate = (date) => [
+    {
+        content: "click ship later button",
+        trigger: ".button:contains('Ship Later')",
+        run: "click",
+    },
+    {
+        content: "pick a date",
+        trigger: ".modal-body .o_datetime_input",
+        run: () => {
+            const input = document.querySelector(".modal-body .o_datetime_input");
+            input.value = date;
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+            input.dispatchEvent(new Event("change", { bubbles: true }));
+        },
+    },
+    {
+        content: "click confirm button",
+        trigger: ".btn:contains('Confirm')",
+        run: "click",
+    },
+];

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -300,18 +300,6 @@ test("isCustomerRequired", async () => {
     expect(order.isCustomerRequired).toBe(false);
 });
 
-test("setShippingDate and getShippingDate with Luxon", async () => {
-    const store = await setupPosEnv();
-    const order = store.addNewOrder();
-
-    const testDate = "2019-03-11";
-    order.shipping_date = testDate;
-
-    expect(order.shipping_date.toISODate()).toBe(testDate);
-    order.shipping_date = null;
-    expect(order.shipping_date).toBeEmpty();
-});
-
 test("[get prices] check prices and taxes", async () => {
     const store = await setupPosEnv();
     const order = await getFilledOrder(store);

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -299,18 +299,6 @@ test("isCustomerRequired", async () => {
     expect(order.isCustomerRequired).toBe(false);
 });
 
-test("setShippingDate and getShippingDate with Luxon", async () => {
-    const store = await setupPosEnv();
-    const order = store.addNewOrder();
-
-    const testDate = "2019-03-11";
-    order.shipping_date = testDate;
-
-    expect(order.shipping_date.toISODate()).toBe(testDate);
-    order.shipping_date = null;
-    expect(order.shipping_date).toBeEmpty();
-});
-
 test("[get prices] check prices and taxes", async () => {
     const store = await setupPosEnv();
     const order = await getFilledOrder(store);

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3125,13 +3125,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertNotIn(product_uom_three.id, loaded_product_uoms, f"Product UOM {product_uom_three} shouldn't be loaded as its product {product_three} is not included in the results")
 
     def test_pos_order_shipping_date(self):
-        self.env['res.partner'].create({
-            'name': 'Partner Test with Address',
-            'street': 'test street',
-            'zip': '1234',
-            'city': 'test city',
-            'country_id': self.env.ref('base.us').id
-        })
         self.main_pos_config.write({'ship_later': True})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
@@ -3139,6 +3132,9 @@ class TestUi(TestPointOfSaleHttpCommon):
             "test_pos_order_shipping_date",
             login="pos_user",
         )
+        next_year = date.today().year + 1
+        pos_order = self.env['pos.order'].search([('partner_id', '=', self.partner_full.id)], limit=1)
+        self.assertEqual(pos_order.shipping_date, date(next_year, 5, 30))
 
     def test_fast_payment_validation_from_product_screen_without_automatic_receipt_printing(self):
         self.preset_delivery = self.env['pos.preset'].create({

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3088,13 +3088,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertNotIn(product_uom_three.id, loaded_product_uoms, f"Product UOM {product_uom_three} shouldn't be loaded as its product {product_three} is not included in the results")
 
     def test_pos_order_shipping_date(self):
-        self.env['res.partner'].create({
-            'name': 'Partner Test with Address',
-            'street': 'test street',
-            'zip': '1234',
-            'city': 'test city',
-            'country_id': self.env.ref('base.us').id
-        })
         self.main_pos_config.write({'ship_later': True})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
@@ -3102,6 +3095,9 @@ class TestUi(TestPointOfSaleHttpCommon):
             "test_pos_order_shipping_date",
             login="pos_user",
         )
+        next_year = date.today().year + 1
+        pos_order = self.env['pos.order'].search([('partner_id', '=', self.partner_full.id)], limit=1)
+        self.assertEqual(pos_order.shipping_date, date(next_year, 5, 30))
 
     def test_fast_payment_validation_from_product_screen_without_automatic_receipt_printing(self):
         self.preset_delivery = self.env['pos.preset'].create({


### PR DESCRIPTION
Steps:
=
- Enable Allow Ship Later in POS configuration.
- Open POS and add any product.
- Proceed to the Payment screen.
- Click Ship Later, clear the date field, and confirm

Issue:
=
- A traceback occurs: `TypeError: this.state.shippingDate.toISODate is not a function`

Reason:
=
- Here, shippingDate is a Luxon DateTime object when provided. when cleared, it becomes null, so converting it to ISO format is casung the error.

Fix:
=
- Removed unnecessary conversion using `.toISODate()`.
- Removed unnecessary hoot test.
- Added validation on shippingDate to prevent selecting a past date.

task-5406969

