### PR TITLE
[12.0][FIX] base: Replaced mail.channel recordset on message_post call in channel_invite

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -758,7 +758,7 @@ class Channel(models.Model):
                     }
                 else:
                     notification = _('<div class="o_mail_notification">joined <a href="#" class="o_channel_redirect" data-oe-id="%s">#%s</a></div>') % (channel.id, channel.name,)
-                self.message_post(body=notification, message_type="notification", subtype="mail.mt_comment", author_id=partner.id)
+                channel.message_post(body=notification, message_type="notification", subtype="mail.mt_comment", author_id=partner.id)
 
         # broadcast the channel header to the added partner
         self._broadcast(partner_ids)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The message_post method uses an ensure_one method on the provided recordset, to insure only one record is passed. However, within the context of channel_invite, self can be a recordset of multiple mail.channel records, since it loops through the different channels contained within it.

As such, when subscribing a user to several channels at once using the channel_invite method, the message_post instruction raises an exception, since we call it using self rather than channel. To avoid this, we simply call message_post on the channel of any current loop.


Current behavior before PR:

Using `channel_invite` on a recordset with multiple `mail.channel` records raises an exception from the `message_post` method.

Desired behavior after PR is merged: 

Using `channel_invite` on a recordset with multiple `mail.channel` records to no longer raise an exception from the `message_post` method.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
