### PR TITLE
[FIX] l10n_my_edi_extended: set classification code for downpayment lines

### DIFF
--- a/addons/l10n_my_edi_extended/models/account_move_line.py
+++ b/addons/l10n_my_edi_extended/models/account_move_line.py
@@ -30,4 +30,8 @@ class AccountMoveLine(models.Model):
         for line in self:
             # We don't want to automatically update it on invoices that were sent to MyInvois
             if not line.move_id.l10n_my_edi_external_uuid:
-                line.l10n_my_edi_classification_code = line.product_id.product_tmpl_id.l10n_my_edi_classification_code or line.l10n_my_edi_classification_code
+                # There is no product in case of downpayments, so we need to manually set the class code
+                if 'is_downpayment' in line and line.is_downpayment:
+                    line.l10n_my_edi_classification_code = "022"
+                else:
+                    line.l10n_my_edi_classification_code = line.product_id.product_tmpl_id.l10n_my_edi_classification_code or line.l10n_my_edi_classification_code


### PR DESCRIPTION
Ensure downpayment lines are assigned a fixed classification code ("022"), while other lines retain their product-based classification.

Task-5356913

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
