### PR TITLE
[FIX] point_of_sale: send order to customer display

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -51,8 +51,8 @@ export class Chrome extends Component {
         onWillStart(this.pos._loadFonts);
         onMounted(this.props.disableLoader);
         effect(
-            batched(() => {
-                this.onPosChanges(arguments);
+            batched((pos) => {
+                this.onPosChanges(pos);
             }),
             [this.pos]
         );


### PR DESCRIPTION
Step to reproduce:
-Open customer display
-Add products
=> The customer display doesn't update

Fix:
Replaced arguments with an explicit pos parameter to ensure the correct POS instance is forwarded.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
