### PR TITLE
[IMP] l10n_my_edi: improve MyInvois tab visibility and fix MyInvois section alignment

### DIFF
--- a/addons/l10n_my_edi/views/account_move_view.xml
+++ b/addons/l10n_my_edi/views/account_move_view.xml
@@ -21,7 +21,7 @@
             </xpath>
             <!-- There are quite a few fields, and with other modules adding some too it would be too messy to not put them in a tab. -->
             <xpath expr="//notebook" position="inside">
-                <page string="MyInvois" invisible="country_code != 'MY'">
+                <page string="MyInvois" invisible="country_code != 'MY' or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')">
                     <group>
                         <group>
                             <!-- Only displayed if the invoice contains a tax of type Exempt -->

--- a/addons/l10n_my_edi/views/res_partner_view.xml
+++ b/addons/l10n_my_edi/views/res_partner_view.xml
@@ -10,18 +10,16 @@
                 <field name="l10n_my_edi_display_tin_warning" invisible="1"/>
                 <!-- Foreigner with a tax number registered in Malaysia could be customer of an e-invoice. -->
                 <group name="l10n_my_edi" string="MyInvois Information" invisible="'MY' not in fiscal_country_codes">
-                    <group colspan="2">
-                        <label for="l10n_my_identification_type" string="Identification"/>
-                        <div class="d-flex gap-2">
-                            <field name="l10n_my_identification_type"  readonly="parent_id"/>
-                            <span class="d-flex gap-2 w-100">
-                                <field name="l10n_my_identification_number" placeholder="202001234568"  readonly="parent_id"/>
-                                <button class="oe_link oe_inline p-0" type="object" name="action_validate_tin" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state or parent_id">Validate</button>
-                                <span class="text-success fa fa-check" title="Validation Successful" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state != 'valid'"/>
-                                <span class="text-danger fa fa-close" title="Validation Failed" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state != 'invalid'"/>
-                            </span>
-                        </div>
-                    </group>
+                    <label for="l10n_my_identification_type" string="Identification"/>
+                    <div class="d-flex gap-2">
+                        <field name="l10n_my_identification_type"  readonly="parent_id"/>
+                        <span class="d-flex gap-2 w-100">
+                            <field name="l10n_my_identification_number" placeholder="202001234568"  readonly="parent_id"/>
+                            <button class="oe_link oe_inline p-0" type="object" name="action_validate_tin" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state or parent_id">Validate</button>
+                            <span class="text-success fa fa-check" title="Validation Successful" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state != 'valid'"/>
+                            <span class="text-danger fa fa-close" title="Validation Failed" invisible="not l10n_my_edi_display_tin_warning or l10n_my_tin_validation_state != 'invalid'"/>
+                        </span>
+                    </div>
                 </group>
             </group>
         </field>

--- a/addons/l10n_my_edi_extended/views/res_partner_view.xml
+++ b/addons/l10n_my_edi_extended/views/res_partner_view.xml
@@ -5,7 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="l10n_my_edi.view_partner_form_inherit_l10n_my_myinvois"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='l10n_my_edi']/group" position="inside">
+            <xpath expr="//group[@name='l10n_my_edi']" position="inside">
                 <field name="l10n_my_edi_industrial_classification" readonly="parent_id"/>
                 <field name="l10n_my_edi_malaysian_tin" placeholder="EI00000000020" readonly="parent_id"/>
             </xpath>


### PR DESCRIPTION
This commit:
- Fixes alignment of the `MYINVOIS INFORMATION` section on the partner form.
- Hides the `MyInvois` tab on journal entries where journal type is neither `sale` nor `purchase`.

task-5356808
