### PR TITLE
[FIX] mrp_account: fix mo/wo state concern 2nd part

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -105,7 +105,7 @@ class MrpProduction(models.Model):
             for line in account_move.line_ids[:-1]:
                 workorders[line.account_id].time_ids.write({'account_move_line_id': line.id})
 
-    def _post_inventory(self, cancel_backorder=False):
-        res = super()._post_inventory(cancel_backorder=cancel_backorder)
-        self.filtered(lambda mo: not mo.reservation_state and mo.state == 'done')._post_labour()
+    def button_mark_done(self):
+        res = super().button_mark_done()
+        self.filtered(lambda mo: mo.state == 'done' and not mo.reservation_state)._post_labour()
         return res


### PR DESCRIPTION
Previous fix was not sufficient (https://github.com/odoo/odoo/pull/238832)
In some cases, evaluating state and reservation_state within _post_inventory's override in mrp_account leads to incorrect workorders state.
By evaluating them at end of button_mark_done, the workorders states are correct.

task: 5247116

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
