### PR TITLE
[FIX] point_of_sale: closing balance count with rescue sessions

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -570,7 +570,7 @@ class PosSession(models.Model):
         cash_in_count = 0
         cash_out_count = 0
         cash_in_out_list = []
-        last_session = self.search([('config_id', '=', self.config_id.id), ('id', '!=', self.id)], limit=1)
+        last_session = self.search([('config_id', '=', self.config_id.id), ('id', '<', self.id)], limit=1)
         for cash_move in self.sudo().statement_line_ids.sorted('create_date'):
             if cash_move.amount > 0:
                 cash_in_count += 1


### PR DESCRIPTION
Before this commit, when calculating the end balance during closing a POS session, if a new rescue session was created after opening the current session, the closing balance calculation would incorrectly consider the rescue session as the last session. This led to an inaccurate closing balance as the opening balance of the rescue session is always zero.

opw-5222527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
