### PR TITLE
[IMP] website_*: make unpublished badge consistent

### DIFF
--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -108,8 +108,12 @@ body {
         display: none;
     }
 }
-[data-publish='off'] > *:not(.css_options) {
-    opacity: 0.5;
+[data-publish='off'] {
+    &:where(:not(:hover)) > *:not(.o_unpublished_badge),
+    &:where(:hover) .o_unpublished_badge {
+        pointer-events: none;
+        opacity: 0.5;
+    }
 }
 
 .js_publish_management > .js_publish_btn.btn-success {

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2785,6 +2785,21 @@
     </div>
 </template>
 
+<template id="website.unpublished_badge" name="Unpublished Badge">
+    <t t-set="badge_offset" t-value="badge_offset or '2'"/>
+    <t t-if="not badge_position == 'static' and not badge_classes">
+        <t t-if="badge_position == 'left'" t-set="badge_classes" t-valuef="position-absolute start-0 top-0 z-1 mt-{{badge_offset}} ms-{{badge_offset}}"/>
+        <t t-else="" t-set="badge_classes" t-valuef="position-absolute end-0 top-0 z-1 mt-{{badge_offset}} me-{{badge_offset}}"/>
+    </t>
+    <t t-set="unpublished_label">Unpublished</t>
+    <small
+        t-attf-class="o_unpublished_badge badge bg-black-75 shadow-sm {{badge_classes}}"
+        t-att-title="is_minimal_badge and unpublished_label or ''"
+    >
+        <i t-attf-class="fa fa-ban {{not is_minimal_badge and 'me-2' or ''}}" aria-hidden="true"/><t t-if="not is_minimal_badge"><t t-out="unpublished_label"/></t>
+    </small>
+</template>
+
 <template id="pager" name="Pager" inherit_id="portal.pager">
 </template>
 

--- a/addons/website_event/static/src/scss/event_templates_common.scss
+++ b/addons/website_event/static/src/scss/event_templates_common.scss
@@ -38,11 +38,6 @@ $o-wevent-color: $body-color;
      */
 
     .o_wevent_online {
-        // unpublished badge: put opacity to distinguish form other badges
-        .o_wevent_online_badge_unpublished{
-            opacity: 0.4;
-        }
-
         .o_wesession_list_item {
             margin: map-get($spacers, 2) 0;
         }

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -318,8 +318,9 @@
     <!-- View -->
     <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size}">
         <t t-set="event_tag_ids" t-value="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)"/>
-        <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
-            <article t-attf-class="h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
+        <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset position-relative" t-att-data-publish="event.website_published and 'on' or 'off'">
+            <t t-if="not event.website_published" t-call="website.unpublished_badge" badge_position="'left'" groups="base.group_user"/>
+            <article t-attf-class="position-relative h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
                 <div t-attf-class="h-100 #{opt_events_list_columns and 'd-flex flex-wrap flex-column' or 'row mx-0'}">
                     <!-- Header -->
                     <header t-attf-class="card-header overflow-hidden bg-secondary p-0 border-0 rounded-0 #{opt_events_list_columns and 'col-12' or 'col-4 col-lg-3'} #{(not opt_events_list_cards) and 'shadow-sm'}">
@@ -365,10 +366,6 @@
                                 <small t-if="event.publish_on" class="o_wevent_scheduled  position-absolute bottom-0 px-3 py-2 w-100 text-bg-warning">
                                     Scheduled for <span t-field="event.with_context(tz=event.date_tz).publish_on" />
                                 </small>
-                                <!-- Unpublished -->
-                                <small t-elif="not event.website_published" class="o_wevent_unpublished position-absolute bottom-0 px-3 py-2 w-100 text-bg-danger">
-                                    <i class="fa fa-ban me-2"/>Unpublished
-                                </small>
                             </t>
                         </div>
                     </header>
@@ -386,7 +383,7 @@
                                 </t>
                             </div>
                             <!-- Title -->
-                            <h2 t-attf-class="card-title my-2 h5 #{not event.website_published and 'text-danger'} #{not opt_events_list_columns and not event.event_registrations_open and 'text-muted'}">
+                            <h2 t-attf-class="card-title my-2 h5 #{not opt_events_list_columns and not event.event_registrations_open and 'text-muted'}">
                                 <span t-field="event.name" itemprop="name"/>
                             </h2>
                             <div t-if="not opt_events_list_columns" class="d-inline-flex flex-wrap gap-3">

--- a/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
@@ -31,17 +31,6 @@
             padding: 0.75rem 1rem;
         }
 
-        .o_wesponsor_card_header_badge {
-            position: absolute;
-            bottom: 0;
-            width: 100%;
-            padding: 0.25rem 1.25rem;
-            text-align: right;
-        }
-        &.o_wesponsor_card_unpublished {
-            opacity: 0.8;
-        }
-
         .o_wesponsor_bg_image {
             background-size: contain;
             background-repeat: no-repeat;

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -239,16 +239,14 @@
 <!-- ============================================================ -->
 
 <template id="exhibitor_card" name="Exhibitor Card">
-    <article class="o_wesponsor_card card h-100">
+    <article class="o_wesponsor_card card h-100" t-att-data-publish="sponsor.website_published and 'on' or 'off'">
+        <t t-if="not sponsor.website_published" t-call="website.unpublished_badge" badge_position="'left'"/>
         <div class="row g-0 h-100" t-att-data-publish="sponsor.website_published and 'on' or 'off'">
             <t t-set="sponsor_image_url" t-value="sponsor.website_image_url"/>
             <header t-att-class="'overflow-hidden col-12 %s' % ('bg-secondary' if not sponsor_image_url else '')">
                 <div class="d-block h-100 w-100">
                     <div t-if="sponsor_image_url" class="card-img-top position-static o_wesponsor_bg_image"
                         t-attf-style="padding-top: 50%; background-image: url(#{sponsor_image_url});">
-                        <small t-if="not sponsor.is_published" class="o_wesponsor_card_header_badge bg-danger">
-                            <i class="fa fa-ban me-2"/>Unpublished
-                        </small>
                         <img class="position-absolute me-3 mt-3"
                             style="right: 0; top: 0; max-height: 20px;"
                             t-if="sponsor.partner_id.country_id"
@@ -257,9 +255,6 @@
                     </div>
                     <div t-else="" class="o_wesponsor_gradient card-img-top"
                         style="padding-top: 50%">
-                        <small t-if="not sponsor.is_published" class="o_wesponsor_card_header_badge bg-danger">
-                            <i class="fa fa-ban me-2"/>Unpublished
-                        </small>
                     </div>
                 </div>
             </header>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -147,6 +147,7 @@
                     <a class="d-flex flex-wrap flex-md-nowrap text-decoration-none text-reset"
                         t-att-href="sponsor_other.website_absolute_url"
                         t-att-data-publish="sponsor_other.website_published and 'on' or 'off'">
+                        <t t-if="not sponsor_other.website_published" t-call="website.unpublished_badge" is_minimal_badge="True"/>
                         <div class="d-flex flex-column align-items-center">
                             <img t-if="sponsor_other.partner_id.country_id"
                             class="o_wesponsor_aside_logo mb-1"
@@ -163,9 +164,6 @@
                                 <span class="d-inline-block text-truncate" t-out="sponsor_other.name"/>
                             </span>
                             <small class="opacity-75" t-out="sponsor_other.subtitle"/>
-                            <div class="d-inline-block float-end" t-if="not sponsor_other.website_published">
-                                <small class="badge text-bg-danger">Unpublished</small>
-                            </div>
                         </div>
                     </a>
                 </li>

--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -15,10 +15,11 @@
                                 <i class="fa fa-globe me-2"/><a t-att-href="sponsor.url" t-field="sponsor.url" class="text-truncate"/>
                             </div>
                         </t>
-                        <a class="o_wevent_sponsor o_wevent_sponsor_card h-100 rounded text-decoration-none" tabindex="0" role="button"
+                        <a class="o_wevent_sponsor o_wevent_sponsor_card h-100 rounded text-decoration-none position-relative" tabindex="0" role="button"
                             t-att-data-publish="'on' if sponsor.website_published else 'off'"
                             t-att-data-bs-content="popover_content"
                             data-bs-html="true" data-bs-trigger="focus" data-bs-toggle="popover" data-bs-placement="bottom">
+                            <t t-if="not sponsor.website_published" t-call="website.unpublished_badge" is_minimal_badge="True"/>
                             <t t-call="website_event_exhibitor.event_sponsor_thumb_details"/>
                         </a>
                     </t>
@@ -36,8 +37,6 @@
     </div>
     <span t-if="sponsor.sudo().sponsor_type_id.display_ribbon_style and sponsor.sudo().sponsor_type_id.display_ribbon_style != 'no_ribbon'"
             t-field="sponsor.sudo().sponsor_type_id" t-attf-class="o_ribbon d-block w-100 ribbon_#{sponsor.sudo().sponsor_type_id.display_ribbon_style}"/>
-    <span t-if="not sponsor.website_published"
-        class="d-flex justify-content-center badge text-bg-danger o_wevent_online_badge_unpublished">Unpublished</span>
 </template>
 
 </odoo>

--- a/addons/website_event_track/static/src/scss/event_track_templates.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates.scss
@@ -151,12 +151,6 @@
                 > div {
                     padding: 0.3em;
                 }
-                // For unpublished tracks, opacity is already reduced
-                [data-publish='off'] .o_weagenda_track_badges > .o_wevent_online_badge_unpublished {
-                    opacity: unset;
-                }
-
-
             }
         }
     }

--- a/addons/website_event_track/static/src/scss/event_track_templates_online.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates_online.scss
@@ -9,24 +9,6 @@
         opacity: 0.8;
     }
 
-    /*
-     * MAIN PAGE: LIST
-     */
-
-    // Track card
-    .o_wesession_track_card {
-        .o_wesession_track_card_header_badge {
-            position: absolute;
-            bottom: 0;
-            width: 100%;
-            padding: $card-spacer-y $card-spacer-x;
-            text-align: right;
-        }
-
-        &.o_wesession_track_card_unpublished {
-            opacity: 0.8;
-        }
-    }
 
     /*
      * TRACK PAGE: VIEW

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -175,6 +175,7 @@
 
 <template id="agenda_main_track" name="Track Agenda: Track">
     <div class="d-flex flex-column h-100" t-att-data-publish="track.website_published and 'on' or 'off'">
+        <t t-if="not track.website_published and is_event_user" t-call="website.unpublished_badge" badge_classes="'mx-auto'"/>
         <div class="o_we_agenda_card d-flex flex-column h-100">
             <div class="o_we_agenda_card_content position-relative d-flex flex-column justify-content-center my-1">
                 <div class="o_we_agenda_card_title mb-1">
@@ -206,9 +207,6 @@
                     <small t-if="track.is_track_live and not track.is_track_done and track.website_published"
                         class="mx-1 badge text-bg-danger rounded-1">Live
                     </small>
-                    <small t-if="not track.website_published and is_event_user"
-                        title="Unpublished"
-                        class="ms-1 mt-1 mt-md-0 badge text-bg-danger o_wevent_online_badge_unpublished">Unpublished</small>
                     <span t-if="option_track_wishlist and (track.is_track_upcoming or track.is_reminder_on or (not track.date and not track.event_id.is_finished))">
                         <t t-call="website_event_track.track_widget_reminder"
                             reminder_light="False"

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -291,13 +291,10 @@
 </template>
 
 <template id="track_card" name="Track Card">
-    <article t-att-class="'card o_wesession_track_card h-100 %s' % ('o_wesession_track_card_unpublished' if (not track.website_published and is_event_user) else '')">
+    <article class="card h-100" t-att-data-publish="track.website_published and 'on' or 'off'">
+        <t t-if="not track.website_published" t-call="website.unpublished_badge"/>
         <div class="h-100 row g-0">
             <header class="overflow-hidden bg-secondary col-12">
-                <small t-if="not track.website_published and is_event_user" class="o_wesession_track_card_header_badge bg-danger">
-                    <i class="fa fa-ban me-2"/>Unpublished
-                </small>
-
                 <div t-if="track.website_image_url" class="card-img-top"
                     t-attf-style="padding-top: 50%; background-image: url(#{track.website_image_url}); background-size: cover; background-position:center">
                     <span t-if="option_track_wishlist and (track.is_track_upcoming or track.is_reminder_on or (not track.date and not track.event_id.is_finished))" class="position-absolute h3 mt-2 me-2 text-white" style="right: 0; top: 0;">
@@ -353,7 +350,10 @@
 </template>
 
 <template id="track_list_item" name="Track List Item">
-    <div class="row p-3 g-0">
+    <div class="row p-3 g-0 position-relative" t-att-data-publish="track.website_published and 'on' or 'off'">
+        <div class="col-12 o_unpublished_badge">
+            <t t-if="not track.website_published and is_event_user" t-call="website.unpublished_badge"/>
+        </div>
         <div class="col-12 d-flex justify-content-between">
             <!-- Hour: Live > Remaining > Hour: desktop only -->
             <div class="d-flex align-items-center gap-1 flex-wrap">
@@ -386,9 +386,6 @@
         <!-- Main column: name, speaker -->
         <div class="col-12">
             <span class="o_wesession_list_item_title fw-bold" t-field="track.name"/>
-            <span t-if="not track.website_published and is_event_user" class="alert alert-danger px-2 py-1 align-top small">
-                Unpublished
-            </span>
         </div>
 
         <div class="col-12 d-flex justify-content-between align-items-end">

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -227,12 +227,11 @@
 </template>
 
 <template id="event_track_aside_other_track">
+    <t t-if="not track_other.website_published and user_event_manager" t-call="website.unpublished_badge"/>
     <span t-out="track_other.name" class="fw-bold"/>
     <div class="d-flex flex-column flex-lg-row flex-wrap justify-content-between align-items-start mt-1">
         <small class="opacity-75" t-out="track_other.partner_name"/>
         <div class="d-inline-block o_wesession_track_aside_info text-truncate">
-            <small t-if="not track_other.website_published and user_event_manager"
-                class="badge text-bg-danger">Unpublished</small>
             <small t-if="track_other.is_track_live and not track_other.is_track_done"
                 class="badge text-bg-danger">Live</small>
             <small t-elif="track_other.is_track_done"

--- a/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
+++ b/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
@@ -16,10 +16,6 @@
                 box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.1), 0 2px 2px 0 rgba(0, 0, 0, 0.05);
             }
         }
-
-        .o_jobs_unpublished {
-            opacity: .6;
-        }
     }
 
     .o_website_hr_recruitment_job_description {

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -45,15 +45,15 @@
                                 </div>
                             </t>
                             <div t-foreach="jobs" t-as="job" class="col-lg mb32">
-                                <div t-attf-class="card #{not job.website_published and 'o_jobs_unpublished'}">
+                                <div class="card" t-att-data-publish="job.website_published and 'on' or 'off'">
+                                    <t t-if="not job.website_published" t-call="website.unpublished_badge" badge_offset="'4'"/>
                                     <a t-attf-href="/jobs/#{ slug(job) }"
-                                            t-attf-class="text-decoration-none text-reset"
+                                            class="text-decoration-none text-reset"
                                             draggable="false">
                                         <div class="card-body p-4">
                                             <div class="mt0 d-flex justify-content-between align-items-center">
                                                 <h3 t-field="job.name"/>
                                                 <span t-if="job.publish_on" class="badge pagination text-bg-warning mb8">scheduled</span>
-                                                <span t-elif="not job.website_published" class="badge pagination text-bg-danger mb8">unpublished</span>
                                             </div>
                                             <h5 t-if="job.no_of_recruitment >= 1" class="text-reset">
                                                 <span t-field="job.no_of_recruitment"/>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -486,7 +486,6 @@
                     <img class="position-absolute" t-attf-src="/website_profile/static/src/img/rank_#{user_index + 1}.svg" alt="User rank" style="bottom: 0; right: -10px"/>
                 </div>
                 <h3 class="mt-2 mb-0" t-out="user['name']"></h3>
-                <span class="badge text-bg-danger fw-normal" t-if="not user['website_published']">Unpublished</span>
                 <strong class="text-muted" t-out="user['rank']"/>
                 <div class="h3 my-2" t-if="user['karma_gain']">
                     <span t-attf-class="badge #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
@@ -523,9 +522,6 @@
                     <t t-else="">All time </t>
                 </span>
             </t>
-        </td>
-        <td class="align-middle fw-bold text-end text-nowrap">
-            <span t-if="not user['website_published']" class="badge text-bg-danger fw-normal m-1">Unpublished</span>
         </td>
         <td class="align-middle fw-bold text-end text-nowrap">
             <b t-out="user['karma']"/> <span class="text-muted small fw-bold">XP</span>

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -178,6 +178,10 @@
         font-size: var(--o-wsale-card-info-font-size, var(--o-wsale-card-info-responsive-font-size, #{unquote("clamp(12px, calc(0.5rem + 3.3cqw), 1.2rem)")}));
     }
 
+    .o_unpublished_badge {
+        font-size: .875rem;
+    }
+
     // 'o_wsale_product_information' flex order map
     // ------------------------------------------------------------------------
     //  - 2: 'o_wsale_attribute_previewer' default

--- a/addons/website_sale/templates/product_tile_templates.xml
+++ b/addons/website_sale/templates/product_tile_templates.xml
@@ -44,6 +44,7 @@
         t-att-data-publish="product.website_published and 'on' or 'off'"
         t-att-aria-label="product.name"
     >
+        <t t-if="not product.website_published" t-call="website.unpublished_badge" badge_position="'left'"/>
         <div t-attf-class="oe_product_image position-relative flex-grow-0 overflow-hidden">
             <!-- Fetch Images Data -->
             <t
@@ -130,15 +131,6 @@
                                     t-out="'('+combination_name+')'"
                                 />
                             </t>
-                        </a>
-                        <a
-                            t-if="not product.website_published"
-                            role="button"
-                            t-att-href="product_href"
-                            class="btn btn-sm btn-danger"
-                            title="This product is unpublished."
-                        >
-                            Unpublished
                         </a>
                     </h2>
                     <!-- Description -->

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -177,12 +177,6 @@ $line-height-truncate: 1.5em;
     }
 }
 
-// Courses Card
-// **************************************************
-.o_wslides_course_card.o_wslides_course_unpublished {
-    opacity: 0.5;
-}
-
 // New course page
 // **************************************************
 

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -600,6 +600,7 @@
         </div>
 
         <div class="d-flex flex-row o_not_editable align-items-center">
+            <t t-if="not slide.website_published" t-call="website.unpublished_badge" badge_position="'static'"/>
             <a name="o_wslides_list_slide_add_quizz" t-if="channel.can_upload and not slide.question_ids" t-attf-href="/slides/slide/#{slug(slide)}?quiz_quick_create" aria-label="Add quiz">
                 <span class="badge text-bg-primary badge-hide fw-normal m-1">Add Quiz</span>
             </a>
@@ -616,7 +617,6 @@
                 <i t-attf-class="fa fa-fw #{'fa-check' if channel_progress[slide.id].get('completed') else 'fa-flag'}"/>
                 <t t-out="channel_progress[slide.id].get('quiz_karma_won', 0) if channel_progress[slide.id].get('completed') else channel_progress[slide.id].get('quiz_karma_gain', 0)"/> xp
             </span>
-            <span class="badge text-bg-danger fw-normal m-1" t-if="not slide.website_published">Unpublished</span>
         </div>
 
         <div t-if="channel.is_member or channel.can_publish" class="pt-2 pb-2 border-start ms-2 me-2 ps-2 d-flex flex-row align-items-center o_wslides_slides_list_slide_controls o_not_editable">
@@ -837,9 +837,10 @@
 </template>
 
 <template id='lesson_card' name="Lesson Card">
-    <div class="card w-100 o_wslides_lesson_card mb-4">
+    <div class="card w-100 o_wslides_lesson_card mb-4" t-att-data-publish="slide.website_published and 'on' or 'off'">
         <t t-if="slide.is_new_slide and not channel_progress[slide.id].get('completed')" t-call="website_slides.course_card_information"/>
         <t t-set="can_access" t-value="not invite_preview and (slide.is_preview or channel.is_member or channel.can_publish)"/>
+        <t t-if="not slide.is_published and channel.can_publish" t-call="website.unpublished_badge"/>
         <a t-if="can_access" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-title="slide.name" style="height:150px">
             <div t-field="slide.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image h-100"/>
         </a>
@@ -853,7 +854,6 @@
             <span t-else="" class="card-title h5 o_wslides_desc_truncate_2 text-muted" t-out="slide.name"/>
             <div class="text-muted o_wslides_desc_truncate_2 mb-2" t-if="slide.is_preview or (not slide.is_published and user.has_group('website_slides.group_website_slides_officer'))">
                 <span t-if="slide.is_preview" class="badge text-bg-info">Preview</span>
-                <span t-if="not slide.is_published and channel.can_publish" class="badge text-bg-danger">Unpublished</span>
             </div>
             <div class="card-text mb-auto">
                 <div class="o_wslides_desc_truncate_3 fw-light oe_no_empty" t-field="slide.description"/>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -33,9 +33,9 @@
             </div>
             <div t-foreach="channels_my[:5]" t-as="channel">
                 <div class="row">
-                    <div class="col-5 d-flex align-items-center my-2">
+                    <div class="col-5 d-flex align-items-center gap-1 my-2">
+                        <t t-if="not channel.website_published" t-call="website.unpublished_badge" badge_position="'static'" is_minimal_badge="True"/>
                         <a t-attf-href="/slides/#{slug(channel)}" t-out="channel.name"/>
-                        <span t-if="not channel.is_published" class="badge text-bg-danger ms-1">Unpublished</span>
                     </div>
                     <div class="col-5 d-flex justify-content-between align-items-center">
                         <div t-if="channel.completed" class="badge rounded-pill text-bg-success pull-right">
@@ -337,7 +337,8 @@
 </template>
 
 <template id='course_card' name="Course Card">
-    <a t-attf-href="/slides/#{slug(channel)}" t-title="channel.name" t-attf-class="card o_wslides_course_card w-100 h-100 text-decoration-none #{'o_wslides_course_unpublished' if not channel.is_published else ''}">
+    <a t-attf-href="/slides/#{slug(channel)}" t-title="channel.name" class="card w-100 h-100 text-decoration-none" t-att-data-publish="channel.website_published and 'on' or 'off'">
+        <t t-if="not channel.website_published" t-call="website.unpublished_badge"/>
         <t t-set="channel_frontend_tags" t-value="channel.tag_ids.filtered(lambda tag: tag.color)"/>
         <div>
             <div t-field="channel.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image ratio ratio-16x9"/>
@@ -345,7 +346,6 @@
         </div>
         <div class="card-body">
             <h3 class="o_line_clamp card-title h6" t-field="channel.name"/>
-            <span t-if="not channel.is_published" class="badge text-bg-danger">Unpublished</span>
             <div class="card-text d-flex flex-column flex-grow-1 mt-1">
                 <div class="o_line_clamp small" t-field="channel.description_short"/>
                 <div t-if="channel_frontend_tags" class="small o_wslides_desc_truncate_2_badges">


### PR DESCRIPTION
*: website,website_event,website_event_exhibitor,website_event_track,website_hr_recruitment,website_profile,website_sale, website_slides

Currently we have multiple design when an entry is unpublished, using different badges and visual tips.

The goal is to ensure a consistent design accross the website modules, using the same badge and de-emphasizing the card when it's displayed on a card like layout.

task-5136516

Related: https://github.com/odoo/enterprise/pull/102013

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
