### PR TITLE
[FIX] sale_stock: avoid duplicated product name in picking description

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -29,6 +29,8 @@ class StockMove(models.Model):
         for move in self:
             if move.sale_line_id and not move.description_picking_manual:
                 sale_line_id = move.sale_line_id.with_context(lang=move.sale_line_id.order_id.partner_id.lang)
+                if move.description_picking == move.product_id.display_name:
+                    move.description_picking = ''
                 move.description_picking = (sale_line_id._get_sale_order_line_multiline_description_variants() + '\n' + move.description_picking).strip()
 
     def _action_synch_order(self):

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2332,6 +2332,44 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         so.action_confirm()
         self.assertEqual(so.picking_ids.move_ids.description_picking, 'No variant: extra\nDeliver with care')
 
+    def test_move_description_uses_custom_attribute_values(self):
+        """
+        Check that the move description of prodcut variants uses
+        the custom attribute values as expected.
+        """
+        self.env['res.lang']._activate_lang('fr_FR')
+        product = self.new_product
+        product.with_context(lang='fr_FR').name = "French Sofa"
+        self.partner_b.lang = 'fr_FR'
+        attribute_line = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.product_template_sofa.id,
+            'attribute_id': self.no_variant_attribute.id,
+            'value_ids': [
+                Command.set([self.no_variant_attribute.value_ids[0].id])
+            ],
+        })
+        order_line_vals = {
+            'product_id': product.id,
+            'product_custom_attribute_value_ids': [
+                Command.create({
+                    'custom_product_template_attribute_value_id':
+                        attribute_line.product_template_value_ids.id,
+                    'custom_value': 'Best',
+                })
+            ]
+        }
+        sale_orders = self.env['sale.order'].create([
+            {
+                'partner_id': partner.id,
+                'order_line': [Command.create(order_line_vals)],
+            } for partner in [self.partner_a, self.partner_b]
+        ])
+        sale_orders.action_confirm()
+        self.assertEqual(
+            sale_orders.picking_ids.move_ids.mapped('description_picking'),
+            ['No variant: extra: Best', 'No variant: extra: Best\nFrench Sofa']
+        )
+
     def test_multicompany_transit_with_one_company_for_user(self):
         """ Check that the inter-company transit location is created when
         user has only one allowed company. """


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **stock** and **sale_management** modules.
* Go to *Inventory > Configuration > Attributes* and create a new
  attribute.
  * Set *Variant Creation Mode* to *Never*.
  * Add a single attribute value and enable *Free text* on it.
* Create a product using this attribute and select the value for which
  *free text* is enabled.
* Create a Sale Order for this product.
  * Open the sale order line pop-up and enter custom text in the *Text* field.
* Confirm the sale order.
* Open the generated Delivery Order.

**Observed behavior:**
The product name appears **twice** in the stock move description.
The same duplication appears in the **Delivery Slip** PDF report.

**Cause:**
https://github.com/odoo/odoo/blob/452800a9fd56539c04bed5dcf4525afb9b8ad28e/addons/sale_stock/models/stock.py#L31-L32
In `_compute_description_picking`, the description is built as description + variant description.
Since Odoo already uses the product name as the base description and avoids rendering
it twice only when the name equals the description, concatenating the variant description
breaks this logic and results in the product name being repeated.

---

<details>
    <summary>Click here to see the results:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/2f76fcc9-c71d-4c3d-a80a-06391e5d863c" />
    After:
   <img src="https://github.com/user-attachments/assets/78eb7905-8ce6-42b9-aed3-ac1452b74dc1"/>

</details>

---

opw-5382353

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
