### PR TITLE
[IMP] event: allow multiple entries for tickets

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -238,6 +238,7 @@ class EventMail(models.Model):
             ("mail_registration_ids", "not in", self.env["event.mail.registration"]._search(
                 [('scheduler_id', 'in', self.ids)]
             )),
+            ('mail_notrack', '!=', True),
         ]
         if context_registrations:
             new_attendee_domain += [

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.fields import Domain
 from odoo.tools import email_normalize, format_date, formataddr
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 _logger = logging.getLogger(__name__)
 
 
@@ -78,6 +78,9 @@ class EventRegistration(models.Model):
              'Registered: registrations considered taken by a client\n'
              'Attended: registrations for which the attendee attended the event\n'
              'Cancelled: registrations cancelled manually')
+    remaining_entries = fields.Integer(string="Remaining Entries", compute="_compute_remaining_entries", tracking=True)
+    ticket_entry_limit = fields.Integer(string="Initial Entry Limit", related="event_ticket_id.entry_limit", tracking=True)
+    main_registration_id = fields.Many2one('event.registration', string='Main Registration', ondelete='restrict')
     # questions
     registration_answer_ids = fields.One2many('event.registration.answer', 'registration_id', string='Attendee Answers')
     registration_answer_choice_ids = fields.One2many('event.registration.answer', 'registration_id', string='Attendee Selection Answers',
@@ -86,6 +89,7 @@ class EventRegistration(models.Model):
     mail_registration_ids = fields.One2many(
         'event.mail.registration', 'registration_id',
         string="Scheduler Emails", readonly=True)
+    mail_notrack = fields.Boolean()
     # properties
     registration_properties = fields.Properties(
         'Properties', definition='event_id.registration_properties_definition', copy=True)
@@ -191,6 +195,19 @@ class EventRegistration(models.Model):
         for registration in self:
             registration.event_end_date = registration.event_slot_id.end_datetime or registration.event_id.date_end
 
+    @api.depends("ticket_entry_limit")
+    def _compute_remaining_entries(self):
+        sub_registrations = dict(self.env['event.registration']._read_group(
+            domain=[('main_registration_id', 'in', self.ids), ('state', '=', 'done')],
+            groupby=['main_registration_id'],
+            aggregates=['__count']
+        ))
+        for registration in self:
+            if registration.ticket_entry_limit > 1 and not registration.main_registration_id and registration.state != 'done':
+                registration.remaining_entries = max(0, (registration.ticket_entry_limit - sub_registrations.get(registration, 0)))
+            else:
+                registration.remaining_entries = 0
+
     @api.model
     def _search_event_end_date(self, operator, value):
         return Domain.OR([
@@ -249,7 +266,7 @@ class EventRegistration(models.Model):
             if event_id and attendee.event_id.id != event_id:
                 status = 'need_manual_confirmation'
             else:
-                attendee.action_set_done()
+                attendee.with_context(mail_notrack=True).action_attend_event()
                 status = 'confirmed_registration'
         else:
             status = 'already_registered'
@@ -311,6 +328,48 @@ class EventRegistration(models.Model):
 
     def action_confirm(self):
         self.write({'state': 'open'})
+
+    def cancel_last_attendance(self):
+        """ Cancel the last attendance of registration to increase times it can be scanned by one
+        or make it open again if there was no remaining entries.
+
+        :raises: UserError if one of the registrations is a sub-registrations, this method is meant to be used only on main registrations. """
+        if any(self.mapped("main_registration_id")):
+            raise UserError("You cannot cancel the last attendance of this registration.")
+        last_attendance_registrations = self.filtered(lambda r: r.remaining_entries == 0)
+        other_registrations = self.filtered(lambda r: r.remaining_entries > 0)
+        last_attendance_registrations.write({'state': 'open'})
+        #Find for each registration the last created sub-registration to cancel it
+        last_sub_registrations = self.env['event.registration']._read_group(
+            domain=[('main_registration_id', 'in', other_registrations.ids), ('state', '=', 'done')],
+            groupby=['main_registration_id'],
+            aggregates=['id:max']
+        )
+        self.env['event.registration'].browse(
+            [reg_id for main_reg, reg_id in last_sub_registrations]
+        ).action_cancel()
+
+    def action_attend_event(self):
+        for record in self:
+            if record.remaining_entries > 1:
+                new_record_fields = {
+                    'main_registration_id': record.id,
+                }
+                if self.env.context.get('mail_notrack'):
+                    new_record_fields['mail_notrack'] = True
+                new_registration = record.copy(new_record_fields)
+                new_registration.action_set_done()
+                sub_registration_link = new_registration._get_html_link(title=f"{new_registration.name}")
+                record._message_log(
+                    body=_(
+                        "New attendance by this attendee created at %(attendance_datetime)s, see %(attendance_link)s",
+                        attendance_datetime=fields.Datetime.to_string(new_registration.create_date),
+                        attendance_link=sub_registration_link
+                    ),
+                    message_type='notification',
+                )
+            else:
+                record.action_set_done()
 
     def action_set_done(self):
         """ Close Registration """
@@ -465,4 +524,6 @@ class EventRegistration(models.Model):
             'badge_format': self.event_id.badge_format,
             'date_closed_formatted': format_date(env=self.env, value=self.date_closed, date_format='short') if self.date_closed else False,
             'is_date_closed_today': is_date_closed_today,
+            'remaining_entries': max(0, self.remaining_entries - 1),  # Anticipates the validation of the ticket to display the right amount
+            'ticket_entry_limit': self.ticket_entry_limit,
         }

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -37,6 +37,10 @@ class EventEventTicket(models.Model):
         string='Is Available', compute='_compute_sale_available', compute_sudo=True,
         help='Whether it is possible to sell these tickets')
     registration_ids = fields.One2many('event.registration', 'event_ticket_id', string='Registrations')
+    entry_limit = fields.Integer(default=0, string="Entry Limit",
+        help="Enable multi-entry tickets\n"
+        "- Set to 0 or 1 to disable.\n"
+        "- Enter 2 or more to define the maximum number of allowed entries.")
     # seats
     seats_reserved = fields.Integer(string='Reserved Seats', compute='_compute_seats', store=False)
     seats_available = fields.Integer(string='Available Seats', compute='_compute_seats', store=False)
@@ -48,6 +52,11 @@ class EventEventTicket(models.Model):
         'Sold Out', compute='_compute_is_sold_out', help='Whether seats are not available for this ticket.')
     # reports
     color = fields.Char('Color', default="#875A7B")
+
+    _entry_limit_positive = models.Constraint(
+        'CHECK(entry_limit >= 0)',
+        'The Entry Limit of an event ticket cannot be lower than 0.',
+    )
 
     @api.depends('end_sale_datetime', 'event_id.date_tz')
     def _compute_is_expired(self):

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.js
@@ -44,12 +44,7 @@ export class EventRegistrationSummaryDialog extends Component {
         return this.registrationStatus.value === "need_manual_confirmation";
     }
 
-    async onRegistrationConfirm() {
-        if (this.registrationStatus.value !== "confirmed_registration") {
-            this.button.enabled = false
-            await this.orm.call("event.registration", "action_set_done", [this.registration.id]).catch(() => this.button.enabled = true);
-            this.registrationStatus.value = "confirmed_registration";
-        }
+    async onRegistrationClose() {
         this.props.close();
         if (this.props.model) {
             this.props.model.load();
@@ -61,7 +56,7 @@ export class EventRegistrationSummaryDialog extends Component {
 
     async undoRegistration() {
         if (["confirmed_registration", "already_registered"].includes(this.registrationStatus.value)) {
-            await this.orm.call("event.registration", "action_confirm", [this.registration.id]);
+            await this.orm.call("event.registration", "cancel_last_attendance", [this.registration.id]);
         } else if (this.registrationStatus.value == "unconfirmed_registration") {
             await this.orm.call("event.registration", "action_set_draft", [this.registration.id]);
         }

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -14,7 +14,7 @@
                         </button>
                     </div>
                     <div t-else="" class="alert alert-warning d-flex justify-content-center" role="alert">
-                        <i class="fa fa-exclamation-circle me-2 align-self-center ms-0 ms-sm-5"/>
+                        <i class="fa fa-exclamation-circle me-2 align-self-center"/>
                         <t t-if="this.registrationStatus.value === 'need_manual_confirmation'">
                             <span>This ticket is for another event!<br/>
                             Confirm attendance?</span>
@@ -30,10 +30,11 @@
                                 <span>Ticket was first scanned on <t t-out="this.registration.date_closed_formatted"/></span>
                             </t>
                             <t t-else="">
-                                <span>Ticket already scanned!</span>
+                                <span style="font-size:16px">This Card/Ticket is currently unavailable.<br/>
+                                    The offer may have expired or you may have reached the maximum number of entries allowed.</span>
                             </t>
                         </t>
-                        <button type="button" class="btn btn-link ms-3 ms-sm-5" t-on-click="this.undoRegistration">
+                        <button type="button" t-if="this.registrationStatus.value != 'already_registered'" class="btn btn-link ms-3 ms-sm-5" t-on-click="this.undoRegistration">
                             Undo
                         </button>
                     </div>
@@ -53,6 +54,7 @@
                         <tr><td>Event</td><td><t t-out="this.registration.event_display_name"/></td></tr>
                         <tr t-if="this.registration.slot_name"><td>Slot</td><td><t t-out="this.registration.slot_name"/></td></tr>
                         <tr t-if="this.registration.ticket_name"><td>Ticket Type</td><td><t t-out="this.registration.ticket_name"/></td></tr>
+                        <tr t-if="this.registration.ticket_entry_limit"><td>Remaining Entries</td><td><t t-out="this.registration.remaining_entries"/></td></tr>
                         <tr t-if="this.registration.registration_answers &amp;&amp; this.registration.registration_answers.length > 0">
                             <td class="d-flex">Answers</td>
                             <td>
@@ -67,9 +69,9 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button t-att-disabled="!this.button.enabled" t-custom-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Continue</button>
+                <button t-att-disabled="!this.button.enabled" t-custom-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onRegistrationClose()">Close</button>
                 <button id="print_button" class="btn btn-primary" t-on-click="() => this.onRegistrationPrintPdf()">Print</button>
-                <button class="btn btn-secondary" t-on-click="() => this.onRegistrationView()">Edit</button>
+                <button class="btn btn-secondary" t-on-click="() => this.onRegistrationView()">Edit Ticket</button>
             </t>
         </Dialog>
     </t>

--- a/addons/event/static/src/views/event_registration_kanban_controller.js
+++ b/addons/event/static/src/views/event_registration_kanban_controller.js
@@ -27,7 +27,8 @@ export class EventRegistrationKanbanController extends KanbanController {
                 {
                     model: this.model,
                     registration: result
-                }
+                },
+                { onClose: () => this.model.load() }
             );
         } else {
             return super.openRecord(record);

--- a/addons/event/static/src/views/event_registration_list_controller.js
+++ b/addons/event/static/src/views/event_registration_list_controller.js
@@ -27,7 +27,8 @@ export class EventRegistrationListController extends ListController {
                 {
                     model: this.model,
                     registration: result
-                }
+                },
+                { onClose: () => this.model.load() }
             );
         } else {
             return super.openRecord(record);

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -907,6 +907,36 @@ class TestEventRegistrationData(TestEventInternalsCommon):
         self.assertEqual(new_reg.email, contact.email)
         self.assertEqual(new_reg.phone, contact.phone)
 
+    @users('user_eventmanager')
+    def test_registration_remaining_entries(self):
+        """ Test initial remaining entries of a registration and the computation of that field based on attendances """
+        multi_entry_event = self.env['event.event'].create({
+            'name': 'Multi Entry Event Test',
+            'date_begin': FieldsDatetime.to_string(datetime.today() - timedelta(days=1)),
+            'date_end': FieldsDatetime.to_string(datetime.today() + timedelta(days=1)),
+        })
+        multi_entry_event_ticket = self.env['event.event.ticket'].create({
+            'name': 'Multi Entry Event Ticket Test',
+            'event_id': multi_entry_event.id,
+            'entry_limit': 3,
+        })
+        multi_entry_registration = self.env['event.registration'].create({
+            'name': 'Multi Entry Registration Test',
+            'event_id': multi_entry_event.id,
+            'event_ticket_id': multi_entry_event_ticket.id,
+        })
+        self.assertEqual(multi_entry_registration.remaining_entries, multi_entry_event_ticket.entry_limit)
+        multi_entry_registration.action_attend_event()
+        multi_entry_registration._compute_remaining_entries()
+        self.assertEqual(multi_entry_registration.remaining_entries, multi_entry_event_ticket.entry_limit - 1)
+        self.assertEqual(multi_entry_registration.state, 'open')
+        multi_entry_registration.action_attend_event()
+        multi_entry_registration._compute_remaining_entries()
+        multi_entry_registration.action_attend_event()
+        multi_entry_registration._compute_remaining_entries()
+        self.assertEqual(multi_entry_registration.remaining_entries, 0)
+        self.assertEqual(multi_entry_registration.state, 'done')
+
 
 @tagged('event_registration', 'phone_number')
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -28,7 +28,7 @@
                 <field name="message_needaction" column_invisible="True"/>
                 <button name="action_confirm" string="Registered" type="object" icon="fa-check"
                         invisible="not active or state != 'draft'"/>
-                <button name="action_set_done" string="Mark as Attending" type="object" icon="fa-level-down"
+                <button name="action_attend_event" string="Mark as Attending" type="object" icon="fa-level-down"
                         invisible="not active or state != 'open'"/>
                 <button name="action_cancel" string="Cancel" type="object"
                         class="o_btn_cancel_registration" icon="fa-times"
@@ -49,7 +49,7 @@
                             invisible="not active or state != 'open' and state != 'done'"/>
                     <button name="action_confirm" string="Registered" type="object" class="oe_highlight"
                             invisible="not active or state != 'draft'"/>
-                    <button name="action_set_done" string="Attended" type="object" class="oe_highlight"
+                    <button name="action_attend_event" string="Attended" type="object" class="oe_highlight"
                             invisible="not active or state != 'open'"/>
                     <button name="action_cancel" string="Cancel Registration" type="object"
                             invisible="not active or state == 'cancel'"/>
@@ -80,6 +80,10 @@
                             <field name="partner_id"/>
                             <field name="create_date" string="Registration Date" groups="base.group_no_one"/>
                             <field name="date_closed" groups="base.group_no_one"/>
+                        </group>
+                        <group string="Transaction" name="transaction" invisible="ticket_entry_limit  &lt; 2">
+                            <field name="remaining_entries" invisible="ticket_entry_limit &lt; 2 or main_registration_id"/>
+                            <field name="main_registration_id" readonly="true" invisible="not main_registration_id"/>
                         </group>
                         <group string="Marketing" name="utm_link" groups="base.group_no_one">
                             <field name="utm_campaign_id"/>
@@ -216,6 +220,8 @@
                 <filter string="Registered" name="confirmed" domain="[('state', '=', 'open')]"/>
                 <filter string="Attended" name="attended" domain="[('state', '=', 'done')]"/>
                 <separator/>
+                <filter string="Main Registration" name="main_registration" domain="[('main_registration_id', '=', False)]"/>
+                <separator/>
                 <filter string="Registration Date" name="filter_create_date" date="create_date"/>
                 <filter string="Event Start Date" name="filter_event_begin_date" date="event_begin_date"/>
                 <filter string="Attended Date" name="filter_date_closed" date="date_closed"/>
@@ -239,6 +245,7 @@
                     <filter string="Slot" name="group_by_event_slot_id" context="{'group_by': 'event_slot_id'}"/>
                     <filter string="Ticket Type" name ="group_event_ticket_id" domain="[]" context="{'group_by': 'event_ticket_id'}"/>
                     <filter string="Status" name="status" domain="[]" context="{'group_by':'state'}"/>
+                    <filter string="Main Registration" name="group_by_main_registration" domain="[]" context="{'group_by':'main_registration_id'}"/>
                     <filter string="Registration Date" name="group_by_create_date_week" domain="[]" context="{'group_by': 'create_date:week'}"
                             invisible="context.get('registration_view_hide_group_by_create_date_week')"/>
                     <filter string="Registration Date" name="group_by_create_date_day" domain="[]" context="{'group_by': 'create_date:day'}"

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -74,7 +74,8 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="description" optional="hide"/>
-                <field name="start_sale_datetime" optional="hide"/>
+                <field name="entry_limit" optional="hide"/>
+                <field name="start_sale_datetime" optional="show"/>
                 <field name="end_sale_datetime" optional="show"/>
                 <field name="seats_max" sum="Total" width="120px" string="Maximum" column_invisible="context.get('is_event_multi_slots')"/>
                 <field name="seats_max" sum="Total" width="120px" string="Maximum per slot" column_invisible="not context.get('is_event_multi_slots')"/>

--- a/addons/event_product/views/event_registration_views.xml
+++ b/addons/event_product/views/event_registration_views.xml
@@ -37,9 +37,6 @@
                 <widget name="web_ribbon" title="Not Sold" bg_color="text-bg-info"
                     invisible="not sale_status or sale_status in ('sold', 'free') or not id"/>
             </xpath>
-             <group name="utm_link" position="before">
-                <group string="Transaction" name="transaction" groups="base.group_no_one" />
-            </group>
         </field>
     </record>
 

--- a/addons/event_sale/views/event_registration_views.xml
+++ b/addons/event_sale/views/event_registration_views.xml
@@ -27,6 +27,9 @@
                         </div>
                 </button>
             </xpath>
+            <group name="transaction" position="attributes">
+                <attribute name="invisible">False</attribute>
+            </group>
             <group name="transaction" position="inside">
                 <field name="sale_order_id"/>
                 <field name="sale_order_line_id" readonly="1" invisible="not sale_order_id"/>

--- a/addons/pos_event/views/event_registration_views.xml
+++ b/addons/pos_event/views/event_registration_views.xml
@@ -15,6 +15,9 @@
                         </div>
                 </button>
             </xpath>
+            <group name="transaction" position="attributes">
+                <attribute name="invisible">False</attribute>
+            </group>
             <group name="transaction" position="inside">
                 <field name="pos_order_id" invisible="not pos_order_id" />
             </group>


### PR DESCRIPTION
This PR adds multi-entry on the event registration model, meaning that one bought ticket could be used multiple times to enter an event.

Current behavior before PR:

There are only single use tickets.

Desired behavior after PR is merged:

The registration should be ongoing as long as there is remaining entries if there is multiple entries allowed on the ticket used by the registration, and is usable to enter the event.
Single use ticket are not affected by those changes and their behavior is the same as before.

Task-5373441
