### PR TITLE
[FIX] mail: load default template body in full composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -590,6 +590,7 @@ export class Composer extends Component {
             default_res_ids: [this.thread.id],
             default_subtype_xmlid: this.props.type === "note" ? "mail.mt_note" : "mail.mt_comment",
             mail_post_autofollow: this.thread.hasWriteAccess,
+            body_contains_signature_only: !body || body.trim().length === 0,
         };
         const action = {
             name: this.props.type === "note" ? _t("Log note") : _t("Compose Email"),

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -53,8 +53,9 @@ class MailComposer(models.TransientModel):
         may have to give a huge list of IDs that won't fit into res_ids field.
         """
         # support subtype xmlid, like ``message_post``, when easier than using ``ref``
+        composer = self
         if self.env.context.get('default_subtype_xmlid'):
-            self = self.with_context(
+            composer = composer.with_context(
                 default_subtype_id=self.env['ir.model.data']._xmlid_to_res_id(
                     self.env.context['default_subtype_xmlid']
                 )
@@ -62,8 +63,17 @@ class MailComposer(models.TransientModel):
         # deprecated record context management
         if 'default_res_id' in self.env.context:
             raise ValueError(_("Deprecated usage of 'default_res_id', should use 'default_res_ids'."))
+        if (
+            'body' in fields_list
+            and self.env.context.get('default_body')
+            and self.env.context.get('body_contains_signature_only')
+            and super().default_get(['template_id']).get('template_id')
+        ):
+            ctx = dict(composer.env.context)
+            ctx.pop('default_body', None)
+            composer = composer.with_context(ctx)
 
-        result = super().default_get(fields_list)
+        result = super(MailComposer, composer).default_get(fields_list)
 
         # when being in new mode, create_uid is not granted -> ACLs issue may arise
         if 'create_uid' in fields_list and 'create_uid' not in result:

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -276,6 +276,33 @@ class TestComposerForm(TestMailComposer):
         self.assertFalse(composer_form.subtype_is_log)
 
     @users('employee')
+    def test_mail_composer_comment_wtpl_signature_only(self):
+        """Signature-only body loads user default template; otherwise keeps signature."""
+        composer_form = Form(self.env['mail.compose.message'].with_context(
+            self._get_web_context(
+                self.test_record,
+                add_web=True,
+                default_body='<p data-o-mail-quote="1">--<br data-o-mail-quote="1"/>Signature</p>',
+                body_contains_signature_only=True,
+            )
+        ))
+        self.assertEqual(composer_form.body, '<p data-o-mail-quote="1">--<br data-o-mail-quote="1"/>Signature</p>')
+
+        # Now with user default template
+        self.env['ir.default'].sudo().set(
+            'mail.compose.message', 'template_id', self.template.id
+        )
+        composer_form = Form(self.env['mail.compose.message'].with_context(
+            self._get_web_context(
+                self.test_record,
+                add_web=True,
+                default_body='<p data-o-mail-quote="1">--<br data-o-mail-quote="1"/>Signature</p>',
+                body_contains_signature_only=True,
+            )
+        ))
+        self.assertEqual(composer_form.body, f'<p>TemplateBody {self.test_record.name}</p>')
+
+    @users('employee')
     def test_mail_composer_comment_wtpl_batch(self):
         """ Batch mode of composer in comment mode. """
         composer_form = Form(self.env['mail.compose.message'].with_context(


### PR DESCRIPTION
**Issue:**
- When opening the full composer from the chatter, the body of the default email
template is not loaded. Only the subject line from the template appears,
while the body remains empty or contains only the user's signature.

**Steps to reproduce:**
1. Install `contact`
2. Open any contact form.
3. In the chatter, click 'Send message' and then expand button
4. Write a something in body, then save this as a new template.
5. Set this new template as the default (using Debug Mode > Set Default Values).
6. Click 'Send message' in the chatter,
7. Click the 'Full composer' (expand) button without typing anything.

**Observed behavior:**
- The full composer opens with the correct subject from the default template,
but the body is empty.

**Cause:**
- The `onClickFullComposer` method always passes a `default_body` value
in the context to the mail.compose.message wizard. Even if the chatter input is empty

**Solution:**
- Forward isBodyEmpty in the context from onClickFullComposer.
If the user typed content, do nothing. If the body is empty and a default template is available,
allow the backend to apply the default template by removing default_body.

opw-5405056