### PR TITLE
[FIX] point_of_sale: test_07_product_combo record deleted

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1071,7 +1071,7 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_07_product_combo(self):
         self.env['decimal.precision'].search([('name', '=', 'Product Price')]).digits = 4
         setup_product_combo_items(self)
-        combo_product_sofa = self.env["product.product"].create(
+        combo_product_sofa = self.env["product.template"].create(
             {
                 "name": "Combo product Sofa",
                 "is_storable": True,
@@ -1094,7 +1094,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         product_attribute_size = self.env['product.template.attribute.line'].create({
-            'product_tmpl_id': combo_product_sofa.product_tmpl_id.id,
+            'product_tmpl_id': combo_product_sofa.id,
             'attribute_id': sofa_size_attribute.id,
             'value_ids': [(6, 0, [sofa_size_M.id, sofa_size_L.id])],
 
@@ -1106,11 +1106,11 @@ class TestUi(TestPointOfSaleHttpCommon):
                 "name": "Chairs Combo",
                 "combo_item_ids": [
                     Command.create({
-                        "product_id": combo_product_sofa.product_tmpl_id.product_variant_ids[0].id,
+                        "product_id": combo_product_sofa.product_variant_ids[0].id,
                         "extra_price": 5,
                     }),
                     Command.create({
-                        "product_id": combo_product_sofa.product_tmpl_id.product_variant_ids[1].id,
+                        "product_id": combo_product_sofa.product_variant_ids[1].id,
                         "extra_price": 10,
                     }),
                 ],


### PR DESCRIPTION
The test `test_07_product_combo` with no demo data raised a traceback because a product record was being accessed after it had been implicitly deleted.

The issue occurred because the product was initially created via `product.product` instead of `product.template` in the test setup: https://github.com/odoo/odoo/blob/6cc757147aebfe98db95ce6aafccdddc8483a5c6/addons/point_of_sale/tests/test_frontend.py#L1074 The link to the record was broken during the test execution, leading to the access error.

runbot-234758
