### PR TITLE
[FIX] pos_sale: fix price unit for groupable UoM on LOT tracked products

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -187,6 +187,7 @@ patch(PosStore.prototype, {
                 converted_line.lot_names.length > 0 &&
                 useLoadedLots
             ) {
+                const priceUnit = newLine.price_unit;
                 newLine.delete();
                 let total_lot_quantity = 0;
                 for (const lot of converted_line.lot_names) {
@@ -206,6 +207,7 @@ patch(PosStore.prototype, {
                             ...newLineValues,
                         });
                         splitted_line.set_quantity(lot_remaining_quantity, true);
+                        splitted_line.set_unit_price(priceUnit);
                         splitted_line.set_discount(line.discount);
                         splitted_line.setPackLotLines({
                             modifiedPackLotLines: [],

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -595,3 +595,13 @@ registry.category("web_tour.tours").add("test_ecommerce_unpaid_order_is_shown_in
             PosSale.checkOrdersListNotEmpty(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_settle_groupable_lot_total_amount", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1, { loadSN: true }),
+            Order.hasTotal("12.00"),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1993,3 +1993,70 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.env['pos.order'].sync_from_ui([pos_order])
         self.assertEqual(len(sale_order.order_line), 3)
         self.assertEqual(sale_order.order_line[2].qty_invoiced, 1)
+
+    def test_settle_groupable_lot_total_amount(self):
+        uom_category = self.env['uom.category'].create({
+            'name': 'Non groupable',
+            'is_pos_groupable': True,
+        })
+
+        groupable_uom_unit = self.env['uom.uom'].create({
+            'name': 'Groupable Unit',
+            'category_id': uom_category.id,
+            'uom_type': 'reference',
+        })
+
+        groupable_uom_dozens = self.env['uom.uom'].create({
+            'name': 'Groupable Dozens',
+            'category_id': uom_category.id,
+            'factor_inv': 12,
+            'uom_type': 'bigger',
+        })
+
+        self.product = self.env['product.product'].create({
+            'name': 'Product',
+            'available_in_pos': True,
+            'is_storable': True,
+            'lst_price': 1.0,
+            'taxes_id': False,
+            'categ_id': self.product_category.id,
+            'tracking': 'lot',
+            'uom_id': groupable_uom_unit.id,
+            'uom_po_id': groupable_uom_unit.id,
+        })
+
+        self.warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+
+        self.shelf = self.env['stock.location'].create({
+            'name': 'Shelf 1',
+            'usage': 'internal',
+            'location_id': self.warehouse.lot_stock_id.id,
+        })
+
+        quants = self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product.id,
+            'inventory_quantity': 10_000,
+            'location_id': self.shelf.id,
+            'lot_id': self.env['stock.lot'].create({
+                'name': '1001',
+                'product_id': self.product.id,
+                'location_id': self.shelf.id,
+            }).id,
+        })
+
+        quants.action_apply_inventory()
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': self.product.id,
+                'name': self.product.name,
+                'product_uom_qty': 1,
+                'product_uom': groupable_uom_dozens.id,
+                'price_unit': 12.0,
+            })],
+        })
+
+        sale_order.action_confirm()
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_settle_groupable_lot_total_amount', login="accountman")


### PR DESCRIPTION
Steps to reproduce
------------------
1. Make a product tracked by 'LOT' and having a groupable in pos UoM
2. Make a SO with that product, choosing another UoM from the same category (if we chose Kg in first step, choose gram here, etc)
3. Settle the order in PoS.

We observe that the order's total amount is totally off, we explain why below.

Why it's happening
------------------
The `lot_remaining_quantity` is quantity after converting to the original UoM (that of step 1, not that of step 2). We are using that quantity for lines having products tracked by 'LOT' and a groupable UoM; however, we are keeping price unit as if we are using the quantity before conversion, i.e. the quantity in the UoM of step 2. That creates a mismatch between the UoM and thus we miscalculte the total price.

The fix
-------
When using the converted quantity, also use the converted price unit.

opw-5144326