### PR TITLE
[IMP] orm: domain 'access' operator

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -274,6 +274,13 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
+    <record id="base_user_account_move_line_rule" model="ir.rule">
+        <field name="name">Normal User Account Move Line</field>
+        <field name="model_id" ref="account.model_account_move_line"/>
+        <field name="domain_force">[('move_id', 'access', 'read')]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
     <!-- Some modules (i.e. sale) restrict the access for some users
     We want the invoice group to still have all access on all moves.-->
     <record id="account_move_rule_group_invoice" model="ir.rule">

--- a/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
+++ b/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
@@ -52,13 +52,7 @@
     <record model="ir.rule" id="stock_move_line_subcontractor_rule">
         <field name="name">Stock Move Lines Subcontractor</field>
         <field name="model_id" ref="model_stock_move_line"/>
-        <field name="domain_force">[
-        '|', 
-            '|',
-                ('move_id.production_id.subcontractor_id', '=', user.partner_id.commercial_partner_id.id),
-                ('move_id.move_orig_ids.production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids),
-            ('move_id.raw_material_production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids),
-        ]</field>
+        <field name="domain_force">[('move_id', 'access', 'read')]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -84,11 +84,5 @@
         <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
         <field name="domain_force">[('pos_order_ids', '!=', False)]</field>
     </record>
-    <record id="rule_invoice_line_pos_user" model="ir.rule">
-        <field name="name">Invoice Line POS User</field>
-        <field name="model_id" ref="account.model_account_move_line"/>
-        <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
-        <field name="domain_force">[('move_id.pos_order_ids', '!=', False)]</field>
-    </record>
     </data>
 </odoo>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -85,11 +85,7 @@
         <field name="perm_unlink" eval="False"/>
         <field name="domain_force">[
             '|',
-                '&amp;',
-                    ('project_id', '!=', False),
-                    '|',
-                        ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
-                        ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('project_id', 'access', 'read'),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
                     # to subscribe check access to the record, follower is not enough at creation
@@ -150,11 +146,7 @@
         <field name="perm_read" eval="False"/>
         <field name="domain_force">[
             '|',
-                '&amp;',
-                    ('project_id', '!=', False),
-                    '|',
-                        ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
-                        ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('project_id', 'access', 'read'),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
                     # to subscribe check access to the record, follower is not enough at creation
@@ -166,11 +158,11 @@
     <record id="ir_rule_private_task" model="ir.rule">
         <field name="name">Project: See private tasks</field>
         <field name="model_id" ref="project.model_project_task"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
-            '|', '|', ('project_id', '!=', False),
-                      ('parent_id', '!=', False),
-                 ('user_ids', 'in', user.id),
+            ('project_id', 'access', 'read'),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -60,23 +60,17 @@
         <field name="perm_create" eval="0"/>
     </record>
 
-    <record id="purchase_user_account_move_line_rule" model="ir.rule">
-        <field name="name">Purchase User Journal Item</field>
-        <field name="model_id" ref="account.model_account_move_line"/>
-        <field name="domain_force">[('move_id.move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
-        <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
-    </record>
     <record id="purchase_user_account_move_rule" model="ir.rule">
         <field name="name">Purchase User Journal Entry</field>
         <field name="model_id" ref="account.model_account_move"/>
         <field name="domain_force">[('move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
     </record>
-    <record id="portal_purchase_order_line_rule" model="ir.rule">
-        <field name="name">Portal Purchase Order Lines</field>
+    <record id="purchase_order_line_rule" model="ir.rule">
+        <field name="name">Purchase Order Lines</field>
         <field name="model_id" ref="purchase.model_purchase_order_line"/>
-        <field name="domain_force">[('order_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
-        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="domain_force">[('order_id','access','read')]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
 
     <record id="purchase_order_report_comp_rule" model="ir.rule">

--- a/addons/sale/security/ir_rules.xml
+++ b/addons/sale/security/ir_rules.xml
@@ -35,7 +35,7 @@
     <record id="sale_order_line_rule_portal" model="ir.rule">
         <field name="name">Portal Sales Orders Line</field>
         <field name="model_id" ref="sale.model_sale_order_line"/>
-        <field name="domain_force">[('order_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('order_id', 'access', 'read')]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
@@ -126,20 +126,6 @@
         <field name="name">All Invoices</field>
         <field name="model_id" ref="model_account_move"/>
         <field name="domain_force">[('move_type', 'in', ('out_invoice', 'out_refund'))]</field>
-        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
-    </record>
-
-    <record id="account_invoice_line_rule_see_personal" model="ir.rule">
-        <field name="name">Personal Invoice Lines</field>
-        <field name="model_id" ref="model_account_move_line"/>
-        <field name="domain_force">[('move_id.move_type', 'in', ('out_invoice', 'out_refund')), '|', ('move_id.invoice_user_id', '=', user.id), ('move_id.invoice_user_id', '=', False)]</field>
-        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
-    </record>
-
-    <record id="account_invoice_line_rule_see_all" model="ir.rule">
-        <field name="name">All Invoice Lines</field>
-        <field name="model_id" ref="model_account_move_line"/>
-        <field name="domain_force">[('move_id.move_type', 'in', ('out_invoice', 'out_refund'))]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -789,6 +789,95 @@ class TestDomainOptimize(TransactionCase):
             Domain('id', 'in', OrderedSet([categ_child.id, categ.id])),
         )
 
+    def test_condition_optimize_access(self):
+        model = self.env['test_orm.mixed']
+        records = model.create([
+            {'number': 11},
+            {'number': 22},
+            {'number': 23, 'currency_id': self.env.ref('base.USD').id},
+        ])
+        user_group = self.ref('base.group_user')
+        elevated_group = self.ref('base.group_allow_export')
+        internal_user, elevated_user, portal_user = self.env['res.users'].create([{
+            'name': 'test internal user',
+            'login': 'test_user',
+            'group_ids': [(6, 0, [user_group])],
+        }, {
+            'name': 'test elevated user',
+            'login': 'test_user_more',
+            'group_ids': [(6, 0, [user_group, elevated_group])],
+        }, {
+            'name': 'test poral user',
+            'login': 'test_portal',
+            'group_ids': [(6, 0, [self.ref('base.group_portal')])],
+        }])
+        self.env['ir.model.access'].create({
+            'name': "read",
+            'model_id': self.env['ir.model']._get_id('res.currency'),
+            'group_id': user_group,
+            'perm_write': True,
+        })
+        rules = self.env['ir.rule'].search([('model_id.name', 'in', [model._name, 'res.currency'])])
+        rules.unlink()
+        rules.create([{
+            'model_id': self.env['ir.model']._get_id(model._name),
+            'groups': [user_group],
+            'domain_force': str([('number', '>', 20)]),
+        }, {
+            'model_id': self.env['ir.model']._get_id(model._name),
+            'groups': [elevated_group],
+            'domain_force': str([]),
+        }, {
+            'model_id': self.env['ir.model']._get_id('res.currency'),
+            'groups': [user_group],
+            'domain_force': str([('name', '=', 'EUR')]),
+            'perm_read': False,
+        }, {
+            'model_id': self.env['ir.model']._get_id('res.currency'),
+            'groups': [elevated_group],
+            'domain_force': str([('name', 'in', ['EUR', 'USD'])]),
+            'perm_read': False,
+        }])
+
+        for user in (internal_user, elevated_user, portal_user):
+            for su in (False, True):
+                with self.subTest("", user=user.display_name, su=su):
+                    env = self.env(user=user, su=su)
+                    self._test_condition_optimize_access(records.with_env(env))
+
+    def _test_condition_optimize_access(self, records):
+        model = records.browse()
+        domain = Domain('id', 'access', 'read')
+        self.assertEqual(domain.optimize(model), domain)
+        domain_custom = domain.optimize_dynamic(model)
+        self.assertEqual(records.filtered_domain(domain_custom), records.sudo(False)._filtered_access('read'))
+
+        domain_full = domain_custom.optimize_full(model)
+        if model.sudo(False).has_access('read'):
+            access_rule = model.env['ir.rule'].sudo(False)._compute_domain(model._name, 'read').optimize_full(model)
+        else:
+            access_rule = Domain.FALSE
+        self.assertEqual(domain_full, access_rule)
+
+        domain = Domain('currency_id', 'access', 'write')
+        self.assertLessEqual(records.filtered_domain(domain), records.sudo().filtered('currency_id'), "Cannot return records without a currency")
+
+        domain_full = domain.optimize_full(model)
+        currency_model = model.env['res.currency']
+        if currency_model.sudo(False).has_access('write'):
+            access_rule = model.env['ir.rule'].sudo(False)._compute_domain(currency_model._name, 'write')
+            access_rule = Domain('currency_id', 'any!', access_rule)
+            access_rule = access_rule.optimize_full(model)
+        else:
+            access_rule = Domain.FALSE
+        self.assertEqual(domain_full, access_rule)
+
+        with self.assertRaises(ValueError):
+            Domain('number', 'access', 'read').optimize_dynamic(model)
+        with self.assertRaises(AssertionError):
+            assert not model.sudo(False).env.su, 'Just raise an assert for super-user'
+            Domain('currency_id', 'access', 'blabla').optimize_dynamic(model)
+
     def test_not_optimize(self):
         # optimizations are tested with nary
         self.assertEqual(

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1885,6 +1885,45 @@ def _operator_parent_of_domain(comodel: BaseModel, parent):
     return parent_ids
 
 
+@operator_optimization(['access'], level=OptimizationLevel.DYNAMIC_VALUES)
+def _operator_access_rule_domain(condition, model):
+    operation = condition.value
+    field = condition._field(model)
+    if condition.field_expr != field.name:
+        condition._raise("The 'access' operator does not work for properties")
+
+    if field.name == 'id':
+        comodel = model
+    elif field.type == 'many2one' and field.comodel_name:
+        comodel = model.env[field.comodel_name]
+    else:
+        condition._raise("The 'access' operator works only for many2one and 'id' fields")
+        assert False, "no return above"  # for pylint
+
+    comodel = comodel.sudo(False)
+    access_domain = comodel._access_domain(operation)
+    if access_domain.is_false():
+        # no access to the comodel for any record
+        return Domain.FALSE
+    if access_domain.is_true() or comodel.env.su:
+        # access to all or edge-case for super user
+        return Domain.TRUE
+
+    def filtered_access(record):
+        if field.name == 'id':
+            return record.sudo(False).has_access(operation)
+        return (
+            record.has_access('read')
+            and (corecord := field.__get__(record.sudo()))
+            and corecord.sudo(False).has_access(operation)
+        )
+
+    def optimize_sql(custom, model):
+        return DomainCondition(field.name, 'any!', access_domain)
+
+    return DomainCustom(filtered=filtered_access, optimize_func=optimize_sql)
+
+
 @operator_optimization(['any', 'not any'], level=OptimizationLevel.FULL)
 def _optimize_any_with_rights(condition, model):
     if model.env.su or condition._field(model).bypass_search_access:


### PR DESCRIPTION
Bring record rules from another model.

`[('order_id', 'access', 'read')]` would be true if on the current model, the user can read the related order. Usually, an order line would be readable when the user has access to the order.

The 'access' operator gets the domain for filtering records and injects them into the domain. This allows to avoid repeating the same security domains if we need access to related records.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
