### PR TITLE
[FIX] point_of_sale: disallow only taxes update when product in cart

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -118,7 +118,7 @@
             <t t-set-slot="footer">
                 <div class="d-flex flex-row gap-2 w-100">
                     <button class="btn btn-primary btn-lg lh-lg w-50" t-on-click="props.close">Close</button>
-                    <button t-if="allowProductEdition" t-att-disabled="this.pos.orderContainsProduct(this.props.productTemplate)" class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="editProduct">Edit</button>
+                    <button t-if="allowProductEdition" class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="editProduct">Edit</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2254,6 +2254,7 @@ export class PosStore extends WithLazyGetterTrap {
      * @param {import("@point_of_sale/app/models/product_product").ProductProduct?} product leave undefined to create a new product
      */
     async editProduct(product) {
+        const orderContainsProduct = product && this.orderContainsProduct(product);
         this.action.doAction(
             product
                 ? "point_of_sale.product_template_action_edit_pos"
@@ -2270,6 +2271,9 @@ export class PosStore extends WithLazyGetterTrap {
                             type: "ir.actions.act_window_close",
                         });
                     },
+                },
+                additionalContext: {
+                    taxes_readonly: orderContainsProduct,
                 },
             }
         );

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -840,8 +840,10 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
                 ),
             ]),
             ProductScreen.longPressProduct("Test Frontend Product Edited"),
-            // Edit button should be disabled (cause we cannot edit a product which is in the cart)
-            Dialog.footerBtnIsDisabled("Edit"),
+            Dialog.confirm("Edit", ".btn-secondary"),
+            Dialog.is({ title: "Edit Product" }),
+            // Product 'taxes_id' field should be reaonly (cause already in the cart)
+            ProductScreen.ensureTaxesInputIsReadonly(),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -944,6 +944,13 @@ function productInputSteps(name, barcode, list_price) {
     ];
 }
 
+export function ensureTaxesInputIsReadonly() {
+    return {
+        content: "Taxes field should be readonly.",
+        trigger: 'div[name="taxes_id"].o_readonly_modifier',
+    };
+}
+
 export function createProductFromFrontend(name, barcode, list_price, category) {
     return [
         ...productInputSteps(name, barcode, list_price),

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -207,6 +207,7 @@
                             <label for="taxes_id"/>
                             <div name="tax_info" class="o_row">
                                 <field name="taxes_id" widget="many2many_tags"
+                                    readonly="context.get('taxes_readonly', False)"
                                     context="{'search_default_sale': 1}"
                                     options="{'create': false, 'create_edit': false}"/>
                                 <field name="tax_string"/>


### PR DESCRIPTION
- When a product is already in the cart, prevent updating its taxes from the frontend product edit popup. This avoids inconsistencies between the product taxes and the taxes applied to the order line.
- Now we can still edit other fields of the product.

task-id: 4943650


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
