### PR TITLE
[FIX] stock_account: use the right type of date

### DIFF
--- a/addons/stock_account/static/src/stock_valuation/controller.js
+++ b/addons/stock_account/static/src/stock_valuation/controller.js
@@ -1,6 +1,6 @@
 import { reactive } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { serializeDate } from "@web/core/l10n/dates";
+import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 const { DateTime } = luxon;
 
 
@@ -70,7 +70,7 @@ export class StockValuationReportController {
 
     async setDate(date) {
         this.state.date = date;
-        this.dateAsString = serializeDate(date);
+        this.dateAsString = serializeDateTime(date);
         await this.loadReportData();
     }
 


### PR DESCRIPTION
Before #239595, dateAsString was a stringified version of a datetime. However the fix mistakenly used `serializeDate()` instead of `serializeDateTime()`, losing precision.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
