### PR TITLE
[IMP] l10n_ro_edi_stock: Prevent carrier validation for demo data

### DIFF
--- a/addons/l10n_ro/models/template_ro.py
+++ b/addons/l10n_ro/models/template_ro.py
@@ -13,6 +13,7 @@ class AccountChartTemplate(models.AbstractModel):
             'property_account_payable_id': 'pcg_4011',
             'property_account_expense_categ_id': 'ro_pcg_expense',
             'property_account_income_categ_id': 'ro_pcg_sale',
+            'property_stock_valuation_account_id': 'pcg_301',
             'code_digits': '6',
             'use_storno_accounting': True,
         }

--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -409,7 +409,11 @@ class Picking(models.Model):
         # EXTENDS 'stock'
 
         # Validate the carrier first because it cannot be changed after the super call
-        self._l10n_ro_edi_stock_validate_carrier()
+        # validation should not be blocking demo data or unit tests of other modules
+        # an example is l10n_ro_saft_stock that creates pickings in demo data which cannot
+        # have a carrier_id because the module does not depends on stock_delivery
+        if not self.env.context.get('demo_mode', False):
+            self._l10n_ro_edi_stock_validate_carrier()
 
         return super().button_validate()
 


### PR DESCRIPTION
This commit ensures that stock picking carrier validation for Romanian EDI does not block demo data installation.

task-3748978




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
