### PR TITLE
[FIX] hw_drivers: ensure threads are `deamon`s

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -14,10 +14,9 @@ _logger = logging.getLogger(__name__)
 
 
 class ConnectionManager(Thread):
-    daemon = True
 
     def __init__(self):
-        super().__init__()
+        super().__init__(daemon=True)
         self.pairing_code = False
         self.pairing_uuid = False
         self.pairing_code_expired = False

--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -14,11 +14,10 @@ _logger = logging.getLogger(__name__)
 class Driver(Thread):
     """Hook to register the driver into the drivers list"""
     connection_type = ''
-    daemon = True
     priority = 0
 
     def __init__(self, identifier, device):
-        super().__init__()
+        super().__init__(daemon=True)
         self.dev = device
         self.device_identifier = identifier
         self.device_name = ''

--- a/addons/hw_drivers/interface.py
+++ b/addons/hw_drivers/interface.py
@@ -14,10 +14,9 @@ class Interface(Thread):
     _loop_delay = 3  # Delay (in seconds) between calls to get_devices or 0 if it should be called only once
     connection_type = ''
     allow_unsupported = False
-    daemon = True
 
     def __init__(self):
-        super().__init__()
+        super().__init__(daemon=True)
         self._detected_devices = set()
         self.drivers = sorted([d for d in drivers if d.connection_type == self.connection_type], key=lambda d: d.priority, reverse=True)
 

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -23,11 +23,10 @@ unsupported_devices = {}
 
 
 class Manager(Thread):
-    daemon = True
     ws_channel = ""
 
     def __init__(self):
-        super().__init__()
+        super().__init__(daemon=True)
         self.hostname = helpers.get_hostname()
         self.mac_address = helpers.get_mac_address()
         self.domain = self._get_domain()

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -46,7 +46,7 @@ class IoTRestart(Thread):
     Thread to restart odoo server in IoT Box when we must return a answer before
     """
     def __init__(self, delay):
-        Thread.__init__(self)
+        super().__init__(daemon=True)
         self.delay = delay
 
     def run(self):

--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -116,7 +116,7 @@ class WebsocketClient(Thread):
         url_parsed = urllib.parse.urlsplit(server_url)
         scheme = url_parsed.scheme.replace("http", "ws", 1)
         self.url = urllib.parse.urlunsplit((scheme, url_parsed.netloc, 'websocket', '', ''))
-        super().__init__()
+        super().__init__(daemon=True)
 
     def run(self):
         self.ws = websocket.WebSocketApp(self.url,


### PR DESCRIPTION
To ensure all threads are killed when we restart the Odoo service on the IoT Box, we need to ensure they all have the `daemon=True`.

Some already had the property set, but in the sub class attributes, so it was not properly taken into account.

Task: 5410736