### PR TITLE
[REF] html_(builder|editor): a couple of minor refactorings

### DIFF
--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -35,12 +35,12 @@ export class BuilderContentEditablePlugin extends Plugin {
 
     getContentEditableEls(rootEl) {
         const editableSelector = this.getResource("content_editable_selectors").join(",");
-        return [...selectElements(rootEl, editableSelector)];
+        return selectElements(rootEl, editableSelector);
     }
 
     getContentNotEditableEls(rootEl) {
         const notEditableSelector = this.getResource("content_not_editable_selectors").join(",");
-        return [...selectElements(rootEl, notEditableSelector)];
+        return selectElements(rootEl, notEditableSelector);
     }
 
     isValidContentEditable(contentEditableEl) {

--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -1,6 +1,7 @@
 import { omit } from "@web/core/utils/objects";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 /**
  * @typedef { Object } DisableSnippetsShared
@@ -55,7 +56,7 @@ export class DisableSnippetsPlugin extends Plugin {
         const checkSanitize = (el, snippetEl) => {
             let forbidSanitize = false;
             // Check if the snippet is sanitized/contains such snippets.
-            for (const el of [snippetEl, ...snippetEl.querySelectorAll("[data-snippet")]) {
+            for (const el of selectElements(snippetEl, "[data-snippet")) {
                 const snippet = this.snippetModel.getOriginalSnippet(el.dataset.snippet);
                 if (snippet && snippet.forbidSanitize) {
                     forbidSanitize = snippet.forbidSanitize;

--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -7,6 +7,7 @@ import { clamp } from "@web/core/utils/numbers";
 import { rowSize } from "@html_builder/utils/grid_layout_utils";
 import { isEditable, isVisible } from "@html_builder/utils/utils";
 import { DragAndDropMoveHandle } from "./drag_and_drop_move_handle";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 /**
  * @typedef {{
@@ -101,7 +102,7 @@ export class DragAndDropPlugin extends Plugin {
     }
 
     cleanForSave({ root }) {
-        [root, ...root.querySelectorAll(".o_draggable")].forEach((el) => {
+        selectElements(root, ".o_draggable").forEach((el) => {
             el.classList.remove("o_draggable");
         });
     }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -1,7 +1,7 @@
 import { isVisible } from "@html_builder/utils/utils";
 import { Plugin } from "@html_editor/plugin";
 import { isElement } from "@html_editor/utils/dom_info";
-import { closestElement } from "@html_editor/utils/dom_traversal";
+import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
 import { _t } from "@web/core/l10n/translation";
 
 /** @typedef {import("plugins").CSSSelector} CSSSelector */
@@ -171,7 +171,7 @@ export class DropZonePlugin extends Plugin {
         // Prevent dropping sanitized elements in sanitized zones.
         let forbidSanitize = false;
         // Check if the element is sanitized or if it contains such elements.
-        for (const el of [snippetEl, ...snippetEl.querySelectorAll("[data-snippet")]) {
+        for (const el of selectElements(snippetEl, "[data-snippet")) {
             const snippet = this.snippetModel.getOriginalSnippet(el.dataset.snippet);
             if (snippet && snippet.forbidSanitize) {
                 forbidSanitize = snippet.forbidSanitize;

--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { unremovableNodePredicates as deletePluginPredicates } from "@html_editor/core/delete_plugin";
 import { isUnremovableQWebElement as qwebPluginPredicate } from "@html_editor/others/qweb_plugin";
 import { isEditable } from "@html_builder/utils/utils";
-import { closestElement } from "@html_editor/utils/dom_traversal";
+import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
 
 /** @typedef {import("plugins").CSSSelector} CSSSelector */
 
@@ -141,7 +141,7 @@ export class RemovePlugin extends Plugin {
         }
 
         // Remove tooltips.
-        [toRemoveEl, ...toRemoveEl.querySelectorAll("*")].forEach((el) => {
+        selectElements(toRemoveEl, "*").forEach((el) => {
             const tooltip = Tooltip.getInstance(el);
             if (tooltip) {
                 tooltip.dispose();

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -78,7 +78,7 @@ export class SetupEditorPlugin extends Plugin {
             savableEl.classList.remove("o_savable");
         }
 
-        [root, ...root.querySelectorAll("[data-editor-message]")].forEach((el) => {
+        selectElements(root, "[data-editor-message]").forEach((el) => {
             el.removeAttribute("data-editor-message");
             el.removeAttribute("data-editor-message-default");
         });
@@ -93,6 +93,6 @@ export class SetupEditorPlugin extends Plugin {
      */
     getSavableAreas(rootEl) {
         const editableEl = rootEl || this.editable;
-        return [...selectElements(editableEl, ".o_savable")];
+        return selectElements(editableEl, ".o_savable");
     }
 }

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { InputConfirmationDialog } from "./input_confirmation_dialog";
 import { fuzzyLookup } from "@web/core/utils/search";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 export class SnippetViewer extends Component {
     static template = "html_builder.SnippetViewer";
@@ -100,8 +101,7 @@ export class SnippetViewer extends Component {
         }
         const getClasses = (snippet) => {
             const classes = new Set();
-            const elements = [snippet.content, ...snippet.content.querySelectorAll("*")];
-            for (const el of elements) {
+            for (const el of selectElements(snippet.content, "*")) {
                 for (const className of el.classList) {
                     if (className.startsWith("s_")) {
                         classes.add(className);

--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -65,9 +65,7 @@ export class ContentEditablePlugin extends Plugin {
 
     cleanForSave({ root }) {
         const toRemoveSelector = this.getResource("contenteditable_to_remove_selector").join(",");
-        const contenteditableEls = toRemoveSelector
-            ? [...selectElements(root, toRemoveSelector)]
-            : [];
+        const contenteditableEls = toRemoveSelector ? selectElements(root, toRemoveSelector) : [];
         for (const contenteditableEl of contenteditableEls) {
             contenteditableEl.removeAttribute("contenteditable");
         }

--- a/addons/html_editor/static/src/main/feff_plugin.js
+++ b/addons/html_editor/static/src/main/feff_plugin.js
@@ -125,7 +125,7 @@ export class FeffPlugin extends Plugin {
         if (!combinedSelector) {
             return [];
         }
-        const elements = [...selectElements(root, combinedSelector)];
+        const elements = selectElements(root, combinedSelector);
         const isEditable = (node) => node.parentElement?.isContentEditable;
         const feffNodes = elements
             .filter(isEditable)

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -15,7 +15,7 @@ export class InlineCodePlugin extends Plugin {
         input_handlers: this.onInput.bind(this),
         selectionchange_handlers: this.handleSelectionChange.bind(this),
         feff_providers: (root, cursors) =>
-            [...selectElements(root, ".o_inline_code")].flatMap((code) =>
+            selectElements(root, ".o_inline_code").flatMap((code) =>
                 this.dependencies.feff.surroundWithFeffs(code, cursors)
             ),
     };

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -739,7 +739,8 @@ export class LinkPlugin extends Plugin {
             // the anchor element itself.
             if (color && childNodes.every((n) => !isBlock(n))) {
                 anchorEl.style.removeProperty("color");
-                const font = selectElements(anchorEl, "font").next().value;
+                const font =
+                    anchorEl.nodeName === "FONT" ? anchorEl : anchorEl.querySelector("font");
                 if (font && cleanZWChars(anchorEl.textContent) === font.textContent) {
                     continue;
                 }

--- a/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
@@ -1,15 +1,13 @@
 import { Plugin } from "@html_editor/plugin";
 import { isBlock } from "@html_editor/utils/blocks";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 export class OdooLinkSelectionPlugin extends Plugin {
     static id = "odooLinkSelection";
     /** @type {import("plugins").EditorResources} */
     resources = {
         ineligible_link_for_zwnbsp_predicates: [
-            (link) =>
-                [link, ...link.querySelectorAll("*")].some(
-                    (el) => el.nodeName === "IMG" || isBlock(el)
-                ),
+            (link) => selectElements(link, "*").some((el) => el.nodeName === "IMG" || isBlock(el)),
         ],
         ineligible_link_for_selection_indication_predicates: (link) => link.matches(".btn"),
     };

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -55,7 +55,7 @@ export class LinkSelectionPlugin extends Plugin {
     };
 
     addFeffsToLinks(root, cursors) {
-        return [...selectElements(root, "a")]
+        return selectElements(root, "a")
             .filter(this.isLinkEligibleForZwnbsp.bind(this))
             .flatMap((link) => this.dependencies.feff.surroundWithFeffs(link, cursors));
     }

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -10,6 +10,7 @@ import {
     closestElement,
     getAdjacentNextSiblings,
     getAdjacentPreviousSiblings,
+    selectElements,
 } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
@@ -37,7 +38,11 @@ export class SelectionPlaceholderPlugin extends Plugin {
             }
         },
         selection_blocker_predicates: (blocker) => {
-            if ((blocker.nodeType === Node.ELEMENT_NODE && blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) || !isBlock(blocker)) {
+            if (
+                (blocker.nodeType === Node.ELEMENT_NODE &&
+                    blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) ||
+                !isBlock(blocker)
+            ) {
                 return false;
             } else if (isNotEditableNode(blocker)) {
                 return true;
@@ -81,8 +86,8 @@ export class SelectionPlaceholderPlugin extends Plugin {
             return !!results.length && results.every(Boolean);
         };
         const isSelectionBlocker = (node) => checkPredicate("selection_blocker_predicates", node);
-        const placeholderParents = [this.editable, ...this.editable.querySelectorAll("*")].filter(
-            (container) => checkPredicate("selection_placeholder_container_predicates", container)
+        const placeholderParents = selectElements(this.editable, "*").filter((container) =>
+            checkPredicate("selection_placeholder_container_predicates", container)
         );
 
         // 1. Update current placeholders.

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -31,7 +31,7 @@ export class SeparatorPlugin extends Plugin {
             categoryId: "structure",
             commandId: "insertSeparator",
         }),
-        content_not_editable_providers: (rootEl) => [...selectElements(rootEl, "hr")],
+        content_not_editable_providers: (rootEl) => selectElements(rootEl, "hr"),
         contenteditable_to_remove_selector: "hr[contenteditable]",
         shorthands: [
             {

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -62,7 +62,7 @@ export class TabulationPlugin extends Plugin {
             { hotkey: "tab", commandId: "tab" },
             { hotkey: "shift+tab", commandId: "shiftTab" },
         ],
-        content_not_editable_providers: (rootEl) => [...selectElements(rootEl, ".oe-tabs")],
+        content_not_editable_providers: (rootEl) => selectElements(rootEl, ".oe-tabs"),
         contenteditable_to_remove_selector: "span.oe-tabs",
 
         /** Handlers */

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -214,10 +214,10 @@ export class QWebPlugin extends Plugin {
             // If there is no element in groupId activated, activate the first
             // one.
             if (!isOneElementActive) {
-                const firstElementToActivate = selectElements(
-                    root,
-                    `[data-oe-t-group='${groupId}']`
-                ).next().value;
+                const firstElementToActivate =
+                    root.getAttribute("data-oe-t-group") === groupId.toString()
+                        ? root
+                        : root.querySelector(`[data-oe-t-group='${groupId}']`);
                 firstElementToActivate.setAttribute("data-oe-t-group-active", "true");
             }
         }

--- a/addons/html_editor/static/src/utils/dom_traversal.js
+++ b/addons/html_editor/static/src/utils/dom_traversal.js
@@ -343,13 +343,13 @@ export function getCommonAncestor(nodes, root = undefined) {
  *
  * @param {Element} root
  * @param {string} selector
- * @returns {Generator<Element>}
+ * @returns {Element[]}
  */
-export const selectElements = function* (root, selector) {
+export const selectElements = function (root, selector) {
+    const elements = [];
     if (root.matches(selector)) {
-        yield root;
+        elements.push(root);
     }
-    for (const elem of root.querySelectorAll(selector)) {
-        yield elem;
-    }
+    elements.push(...root.querySelectorAll(selector));
+    return elements;
 };

--- a/addons/html_editor/static/tests/content_editable.test.js
+++ b/addons/html_editor/static/tests/content_editable.test.js
@@ -8,8 +8,8 @@ test("set o_editable_media class on contenteditable false media elements", async
     class TestPlugin extends Plugin {
         static id = "test";
         resources = {
-            content_not_editable_providers: (rootEl) => [...selectElements(rootEl, "i")],
-            content_editable_providers: (rootEl) => [...selectElements(rootEl, "i")],
+            content_not_editable_providers: (rootEl) => selectElements(rootEl, "i"),
+            content_editable_providers: (rootEl) => selectElements(rootEl, "i"),
         };
     }
     const Plugins = [...MAIN_PLUGINS, TestPlugin];

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -74,8 +74,8 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p>ab c[]</p>",
                 stepFunction: deleteBackward,
-                // The space should be converted to an unbreakable space
-                // so it is visible.
+                // The space should be converted to a non-breaking space so it
+                // is visible.
                 contentAfter: "<p>ab&nbsp;[]</p>",
             });
         });
@@ -365,7 +365,7 @@ describe("Selection collapsed", () => {
             });
         });
 
-        test("should unwrap a block next to an inline unbreakable element", async () => {
+        test("should unwrap a block next to an inline unsplittable element", async () => {
             await testEditor({
                 contentBefore: `<div><p>abc</p><div class="o_image"></div><p>[]def</p></div>`,
                 stepFunction: async (editor) => {
@@ -375,7 +375,7 @@ describe("Selection collapsed", () => {
             });
         });
 
-        test("should remove an inline unbreakable contenteditable='false' sibling element", async () => {
+        test("should remove an inline unsplittable contenteditable='false' sibling element", async () => {
             await testEditor({
                 contentBefore: `<div><p>abc</p><div class="o_image"></div>[]def</div>`,
                 stepFunction: async (editor) => {

--- a/addons/html_editor/static/tests/delete/backward_line.test.js
+++ b/addons/html_editor/static/tests/delete/backward_line.test.js
@@ -74,7 +74,7 @@ test("should not remove an unremovable element on CTRL+SHIFT+BACKSPACE", async (
     });
 });
 
-test("should not merge an unbreakable element on CTRL+SHIFT+BACKSPACE", async () => {
+test("should not merge an unsplittable element on CTRL+SHIFT+BACKSPACE", async () => {
     await testEditor({
         contentBefore: unformat(`
             <div class="oe_unbreakable">abc</div>
@@ -86,7 +86,7 @@ test("should not merge an unbreakable element on CTRL+SHIFT+BACKSPACE", async ()
     });
 });
 
-test("should not merge an unbreakable element on CTRL+SHIFT+BACKSPACE (2)", async () => {
+test("should not merge an unsplittable element on CTRL+SHIFT+BACKSPACE (2)", async () => {
     await testEditor({
         contentBefore: unformat(`
             <p>abc</p>

--- a/addons/html_editor/static/tests/delete/backward_word.test.js
+++ b/addons/html_editor/static/tests/delete/backward_word.test.js
@@ -86,7 +86,7 @@ test("should not remove an unremovable element on CTRL+BACKSPACE (2)", async () 
     });
 });
 
-test("should not merge an unbreakable element on CTRL+BACKSPACE", async () => {
+test("should not merge an unsplittable element on CTRL+BACKSPACE", async () => {
     await testEditor({
         contentBefore: unformat(`
             <div class="oe_unbreakable">abc</div>
@@ -98,7 +98,7 @@ test("should not merge an unbreakable element on CTRL+BACKSPACE", async () => {
     });
 });
 
-test("should not merge an unbreakable element on CTRL+BACKSPACE (2)", async () => {
+test("should not merge an unsplittable element on CTRL+BACKSPACE (2)", async () => {
     await testEditor({
         contentBefore: unformat(`
             <p>abc</p>

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -76,8 +76,8 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p>ab []c</p>",
                 stepFunction: deleteForward,
-                // The space should be converted to an unbreakable space
-                // so it is visible.
+                // The space should be converted to a non-breaking space so it
+                // is visible.
                 contentAfter: "<p>ab&nbsp;[]</p>",
             });
         });

--- a/addons/html_editor/static/tests/delete/forward_line.test.js
+++ b/addons/html_editor/static/tests/delete/forward_line.test.js
@@ -73,7 +73,7 @@ test("should not remove an unremovable element on CTRL+SHIFT+DELETE", async () =
     });
 });
 
-test("should not merge an unbreakable element on CTRL+SHIFT+DELETE", async () => {
+test("should not merge an unsplittable element on CTRL+SHIFT+DELETE", async () => {
     await testEditor({
         contentBefore: unformat(`
             <div class="oe_unbreakable">abc[]</div>
@@ -85,7 +85,7 @@ test("should not merge an unbreakable element on CTRL+SHIFT+DELETE", async () =>
     });
 });
 
-test("should not merge an unbreakable element on CTRL+SHIFT+DELETE (2)", async () => {
+test("should not merge an unsplittable element on CTRL+SHIFT+DELETE (2)", async () => {
     await testEditor({
         contentBefore: unformat(`
             <p>abc[]</p>

--- a/addons/html_editor/static/tests/delete/forward_word.test.js
+++ b/addons/html_editor/static/tests/delete/forward_word.test.js
@@ -16,7 +16,7 @@ test("should not remove an unremovable element on CTRL+DELETE", async () => {
     });
 });
 
-test("should not merge an unbreakable element on CTRL+DELETE", async () => {
+test("should not merge an unsplittable element on CTRL+DELETE", async () => {
     await testEditor({
         contentBefore: unformat(`
             <div class="oe_unbreakable">abc[]</div>
@@ -28,7 +28,7 @@ test("should not merge an unbreakable element on CTRL+DELETE", async () => {
     });
 });
 
-test("should not merge an unbreakable element on CTRL+DELETE (2)", async () => {
+test("should not merge an unsplittable element on CTRL+DELETE (2)", async () => {
     await testEditor({
         contentBefore: unformat(`
             <p>abc[]</p>

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -153,7 +153,7 @@ test("should add font size in selected table cells with h1 as first child", asyn
     });
 });
 
-test("should apply font size in unbreakable span with class", async () => {
+test("should apply font size in unsplittable span with class", async () => {
     await testEditor({
         contentBefore: `<h1><span class="oe_unbreakable">some [text]</span></h1>`,
         stepFunction: setFontSize("18px"),
@@ -161,17 +161,17 @@ test("should apply font size in unbreakable span with class", async () => {
     });
 });
 
-test("should apply font size in unbreakable span without class", async () => {
+test("should apply font size in unsplittable span without class", async () => {
     class AddUnsplittableRulePlugin extends Plugin {
         static id = "addUnsplittableRule";
         resources = {
-            unsplittable_node_predicates: (node) => node.getAttribute?.("t") === "unbreakable",
+            unsplittable_node_predicates: (node) => node.getAttribute?.("t") === "unsplittable",
         };
     }
     await testEditor({
-        contentBefore: `<h1><span t="unbreakable">some [text]</span></h1>`,
+        contentBefore: `<h1><span t="unsplittable">some [text]</span></h1>`,
         stepFunction: setFontSize("18px"),
-        contentAfter: `<h1><span t="unbreakable">some <span style="font-size: 18px;">[text]</span></span></h1>`,
+        contentAfter: `<h1><span t="unsplittable">some <span style="font-size: 18px;">[text]</span></span></h1>`,
         config: { Plugins: [...MAIN_PLUGINS, AddUnsplittableRulePlugin] },
     });
 });

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -191,9 +191,9 @@ describe("collapsed selection", () => {
         );
     });
 
-    test("should not unwrap table in unbreakable paragraph find a suitable spot to insert table element", async () => {
+    test("should not unwrap table in unsplittable paragraph find a suitable spot to insert table element", async () => {
         // P elements' content can only be "phrasing" content
-        // Adding a table within an unbreakable p is not possible
+        // Adding a table within an unsplittable p is not possible
         // We have to find a better spot to insert the table
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content
@@ -223,7 +223,7 @@ describe("collapsed selection", () => {
         );
     });
 
-    test("Should ensure a paragraph after an inserted unbreakable (add)", async () => {
+    test("Should ensure a paragraph after an inserted unsplittable (add)", async () => {
         const { editor } = await setupEditor(`<p>cont[]</p>`, {});
         insertHTML(`<p class="oe_unbreakable">1</p>`)(editor);
         expect(getContent(editor.editable)).toBe(
@@ -232,7 +232,7 @@ describe("collapsed selection", () => {
         );
     });
 
-    test("Should ensure a paragraph after an inserted unbreakable (keep)", async () => {
+    test("Should ensure a paragraph after an inserted unsplittable (keep)", async () => {
         const { editor } = await setupEditor(`<p>cont[]</p><p>+</p>`, {});
         insertHTML(`<p class="oe_unbreakable">1</p>`)(editor);
         expect(getContent(editor.editable)).toBe(
@@ -240,7 +240,7 @@ describe("collapsed selection", () => {
         );
     });
 
-    test("Should ensure a paragraph after inserting multiple unbreakables (add)", async () => {
+    test("Should ensure a paragraph after inserting multiple unsplittables (add)", async () => {
         const { editor } = await setupEditor(`<p>cont[]</p>`, {});
         editor.shared.dom.insert(
             parseHTML(
@@ -257,7 +257,7 @@ describe("collapsed selection", () => {
         );
     });
 
-    test("Should ensure a paragraph after inserting multiple unbreakables (keep)", async () => {
+    test("Should ensure a paragraph after inserting multiple unsplittables (keep)", async () => {
         const { editor } = await setupEditor(`<p>cont[]</p><p>+</p>`, {});
         editor.shared.dom.insert(
             parseHTML(

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -491,7 +491,7 @@ describe("Selection collapsed", () => {
             // skipping these tests cause with the link isolation the cursor can be put
             // inside/outside the link so the user can choose where to insert the line break
             // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
-            test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
+            test("should insert line breaks outside the edges of an anchor in unsplittable", async () => {
                 await testEditor({
                     contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
                     stepFunction: splitBlockA,

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -272,7 +272,7 @@ describe("Simple text", () => {
             });
         });
 
-        test("should paste text and understand \\n newlines within UNBREAKABLE node", async () => {
+        test("should paste text and understand \\n newlines within UNSPLITTABLE node", async () => {
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable">[]<br></div>`,
                 stepFunction: async (editor) => {
@@ -282,7 +282,7 @@ describe("Simple text", () => {
             });
         });
 
-        test("should paste text and understand \\n newlines within UNBREAKABLE node(2)", async () => {
+        test("should paste text and understand \\n newlines within UNSPLITTABLE node(2)", async () => {
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable"><span style="font-size: 9px;">a[]</span></div>`,
                 stepFunction: async (editor) => {
@@ -1479,7 +1479,7 @@ describe("Complex html p", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (5) unbreakable", async () => {
+        test("should paste a text when selection leave a span (5) unsplittable", async () => {
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>`,
                 stepFunction: async (editor) => {
@@ -1537,7 +1537,7 @@ describe("Complex html p", () => {
             });
         });
 
-        test("should paste a text when selection across two element (6) unbreakable", async () => {
+        test("should paste a text when selection across two element (6) unsplittable", async () => {
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable">2a<span class="a">b[c</span><p>d]e</p>f</div>`,
                 stepFunction: async (editor) => {
@@ -1667,7 +1667,7 @@ describe("Complex html 3 p", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (7) unbreakable", async () => {
+        test("should paste a text when selection leave a span (7) unsplittable", async () => {
             await testEditor({
                 contentBefore: '<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {
@@ -1841,7 +1841,7 @@ describe("Complex html p+i", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (9) unbreakable", async () => {
+        test("should paste a text when selection leave a span (9) unsplittable", async () => {
             await testEditor({
                 contentBefore: '<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {
@@ -1898,7 +1898,7 @@ describe("Complex html p+i", () => {
             });
         });
 
-        test("should paste a text when selection across two element (10) unbreakable", async () => {
+        test("should paste a text when selection across two element (10) unsplittable", async () => {
             await testEditor({
                 contentBefore: `<div class="oe_unbreakable">2a<span class="a">b[c</span><p>d]e</p>f</div>`,
                 stepFunction: async (editor) => {
@@ -2021,7 +2021,7 @@ describe("Complex html 3p+b", () => {
             });
         });
 
-        test("should paste a text when selection leave a span (11) unbreakable", async () => {
+        test("should paste a text when selection leave a span (11) unsplittable", async () => {
             await testEditor({
                 contentBefore: '<div class="oe_unbreakable">1ab<span class="a">c[d</span>e]f</div>',
                 stepFunction: async (editor) => {

--- a/addons/html_editor/static/tests/split/split_block_segments.test.js
+++ b/addons/html_editor/static/tests/split/split_block_segments.test.js
@@ -34,8 +34,8 @@ describe("basic", () => {
     });
 });
 
-describe("unbreakable", () => {
-    test("should isolate a line in an unbreakable block", async () => {
+describe("unsplittable", () => {
+    test("should isolate a line in an unsplittable block", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">a<br>b<br>[c]<br>d<br>e</div>`,
             stepFunction: splitBlockSegments,
@@ -43,7 +43,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate a line in an unbreakable block (collapsed)", async () => {
+    test("should isolate a line in an unsplittable block (collapsed)", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">a<br>b<br>[]c<br>d<br>e</div>`,
             stepFunction: splitBlockSegments,
@@ -51,7 +51,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate multiple lines in an unbreakable block", async () => {
+    test("should isolate multiple lines in an unsplittable block", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">a<br>b<br>[c<br>d]<br>e<br>f</div>`,
             stepFunction: splitBlockSegments,
@@ -59,7 +59,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate all lines in an unbreakable block", async () => {
+    test("should isolate all lines in an unsplittable block", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b<br>c<br>d<br>e]</div>`,
             stepFunction: splitBlockSegments,
@@ -67,7 +67,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate a line in an unbreakable block starting with a block (do not wrap said block)", async () => {
+    test("should isolate a line in an unsplittable block starting with a block (do not wrap said block)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">
@@ -87,7 +87,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate a line in an unbreakable block ending with a block (do not wrap said block)", async () => {
+    test("should isolate a line in an unsplittable block ending with a block (do not wrap said block)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">
@@ -107,7 +107,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate a line in an unbreakable block starting and ending with a block (do not wrap said blocks)", async () => {
+    test("should isolate a line in an unsplittable block starting and ending with a block (do not wrap said blocks)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">
@@ -129,7 +129,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate a line in an unbreakable block containing blocks (do not wrap said blocks)", async () => {
+    test("should isolate a line in an unsplittable block containing blocks (do not wrap said blocks)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">
@@ -155,7 +155,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate all lines in an unbreakable block containing blocks (do not wrap said blocks)", async () => {
+    test("should isolate all lines in an unsplittable block containing blocks (do not wrap said blocks)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">
@@ -183,7 +183,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should not isolate a line in an unbreakable node that doesn't accept paragraph-related elements (inline)", async () => {
+    test("should not isolate a line in an unsplittable node that doesn't accept paragraph-related elements (inline)", async () => {
         await testEditor({
             contentBefore: `<p>a<br><span class="oe_unbreakable">b<br>[c]<br>d</span><br>e</p>`,
             stepFunction: splitBlockSegments,
@@ -191,7 +191,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should not isolate a line in an unbreakable node that doesn't accept paragraph-related elements (paragraph)", async () => {
+    test("should not isolate a line in an unsplittable node that doesn't accept paragraph-related elements (paragraph)", async () => {
         await testEditor({
             contentBefore: `<p class="oe_unbreakable">a<br>b<br>[c]<br>d<br>e</p>`,
             stepFunction: splitBlockSegments,
@@ -199,7 +199,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate a line in an unbreakable block (deep)", async () => {
+    test("should isolate a line in an unsplittable block (deep)", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable"><span>a<br>b<br>[c]<br>d<br>e</span></div>`,
             stepFunction: splitBlockSegments,
@@ -213,7 +213,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate lines in and out of an unbreakable block (at start)", async () => {
+    test("should isolate lines in and out of an unsplittable block (at start)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">
@@ -239,7 +239,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate lines in and out of an unbreakable block (at end)", async () => {
+    test("should isolate lines in and out of an unsplittable block (at end)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<p>
@@ -265,7 +265,7 @@ describe("unbreakable", () => {
         });
     });
 
-    test("should isolate lines in and out of an unbreakable block (at start and end)", async () => {
+    test("should isolate lines in and out of an unsplittable block (at start and end)", async () => {
         await testEditor({
             contentBefore: unformat(
                 `<div class="oe_unbreakable">

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -131,7 +131,7 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should not turn an unbreakable div into a paragraph", async () => {
+    test("should not turn an unsplittable div into a paragraph", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[ab]</div>`,
             stepFunction: setTag("p"),
@@ -139,7 +139,7 @@ describe("to paragraph", () => {
         });
     });
 
-    test("should not turn an unbreakable div into a paragraph, with line breaks", async () => {
+    test("should not turn an unsplittable div into a paragraph, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("p"),
@@ -405,7 +405,7 @@ describe("to heading 1", () => {
         });
     });
 
-    test("should not turn an unbreakable div into a heading 1, with line breaks", async () => {
+    test("should not turn an unsplittable div into a heading 1, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("h1"),
@@ -538,7 +538,7 @@ describe("to heading 2", () => {
         });
     });
 
-    test("should not turn an unbreakable div into a heading 2, with line breaks", async () => {
+    test("should not turn an unsplittable div into a heading 2, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("h2"),
@@ -667,7 +667,7 @@ describe("to heading 3", () => {
         });
     });
 
-    test("should not turn an unbreakable div into a heading 3, with line breaks", async () => {
+    test("should not turn an unsplittable div into a heading 3, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("h3"),
@@ -938,7 +938,7 @@ describe("to blockquote", () => {
         });
     });
 
-    test("should not turn an unbreakable div into a blockquote, with line breaks", async () => {
+    test("should not turn an unsplittable div into a blockquote, with line breaks", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
             stepFunction: setTag("blockquote"),

--- a/addons/html_editor/static/tests/unbreakable/delete.test.js
+++ b/addons/html_editor/static/tests/unbreakable/delete.test.js
@@ -6,21 +6,21 @@ import { unformat } from "../_helpers/format";
 describe("backward", () => {
     describe("selection collapsed", () => {
         describe("start empty", () => {
-            test("should delete empty p after an unbreakable (backward)", async () => {
+            test("should delete empty p after an unsplittable (backward)", async () => {
                 await testEditor({
                     contentBefore: `<div class="oe_unbreakable">a</div><p>[]<br></p>`,
                     stepFunction: deleteBackward,
                     contentAfter: `<div class="oe_unbreakable">a[]</div>`,
                 });
             });
-            test("should delete empty p/br after an unbreakable (backward)", async () => {
+            test("should delete empty p/br after an unsplittable (backward)", async () => {
                 await testEditor({
                     contentBefore: `<div class="oe_unbreakable">a</div><p>[]<br></p>`,
                     stepFunction: deleteBackward,
                     contentAfter: `<div class="oe_unbreakable">a[]</div>`,
                 });
             });
-            test("should delete empty unbreakable (backward)", async () => {
+            test("should delete empty unsplittable (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                     <div>
@@ -36,7 +36,7 @@ describe("backward", () => {
                     </div>`),
                 });
             });
-            test("should not delete an empty unbreakable when there is no elements to delete before (backward)", async () => {
+            test("should not delete an empty unsplittable when there is no elements to delete before (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -54,14 +54,14 @@ describe("backward", () => {
         });
 
         describe("start text", () => {
-            test("should not merge p with an unbreakable (backward)", async () => {
+            test("should not merge p with an unsplittable (backward)", async () => {
                 await testEditor({
                     contentBefore: `<div class="oe_unbreakable">b</div><p>[]a</p>`,
                     stepFunction: deleteBackward,
                     contentAfter: `<div class="oe_unbreakable">b</div><p>[]a</p>`,
                 });
             });
-            test("should not merge unbreakable before an unbreakable (backward)", async () => {
+            test("should not merge unsplittable before an unsplittable (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -76,7 +76,7 @@ describe("backward", () => {
                         </div>`),
                 });
             });
-            test("should not merge unbreakable before a p (backward)", async () => {
+            test("should not merge unsplittable before a p (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -91,7 +91,7 @@ describe("backward", () => {
                         </div>`),
                 });
             });
-            test("should not merge unbreakable before an empty unbreakable (backward)", async () => {
+            test("should not merge unsplittable before an empty unsplittable (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -106,7 +106,7 @@ describe("backward", () => {
                         </div>`),
                 });
             });
-            test("should not merge unbreakable before an empty p (backward)", async () => {
+            test("should not merge unsplittable before an empty p (backward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -126,7 +126,7 @@ describe("backward", () => {
     describe("selection not collapsed", () => {
         describe("monolevel", () => {
             describe("anchor start", () => {
-                test("should remove sandwitched unbreakable (anchor start, focus start) (backward)", async () => {
+                test("should remove sandwitched unsplittable (anchor start, focus start) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -141,7 +141,7 @@ describe("backward", () => {
                             </div>`),
                     });
                 });
-                test("should remove sandwitched unbreakable (anchor start, focus between) (backward)", async () => {
+                test("should remove sandwitched unsplittable (anchor start, focus between) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -159,7 +159,7 @@ describe("backward", () => {
             });
 
             describe("anchor between", () => {
-                test("should remove sandwitched unbreakable (anchor between, focus between) (backward)", async () => {
+                test("should remove sandwitched unsplittable (anchor between, focus between) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -175,7 +175,7 @@ describe("backward", () => {
                             </div>`),
                     });
                 });
-                test("should remove sandwitched unbreakable (anchor between, focus end) (backward)", async () => {
+                test("should remove sandwitched unsplittable (anchor between, focus end) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -195,7 +195,7 @@ describe("backward", () => {
 
         describe("multilevel", () => {
             describe("anchor start", () => {
-                test("should remove sandwitched unbreakable (multilevel, anchor start, focus between) (backward)", async () => {
+                test("should remove sandwitched unsplittable (multilevel, anchor start, focus between) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -217,7 +217,7 @@ describe("backward", () => {
                 });
             });
             describe("anchor between", () => {
-                test("should remove sandwitched unbreakable (multilevel, anchor between, focus between) (backward)", async () => {
+                test("should remove sandwitched unsplittable (multilevel, anchor between, focus between) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -240,7 +240,7 @@ describe("backward", () => {
                             </div>`),
                     });
                 });
-                test("should remove sandwitched unbreakable (multilevel, anchor between, focus end) (backward)", async () => {
+                test("should remove sandwitched unsplittable (multilevel, anchor between, focus end) (backward)", async () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <div>
@@ -263,7 +263,7 @@ describe("backward", () => {
             });
         });
 
-        test("should delete last character of paragraph but not merge it with unbreakable", async () => {
+        test("should delete last character of paragraph but not merge it with unsplittable", async () => {
             await testEditor({
                 contentBefore: `<p>ab[c</p><p class="oe_unbreakable">]def</p>`,
                 stepFunction: deleteBackward,
@@ -271,7 +271,7 @@ describe("backward", () => {
             });
         });
 
-        test("should delete last character of paragraph and fully selected empty unbreakable", async () => {
+        test("should delete last character of paragraph and fully selected empty unsplittable", async () => {
             await testEditor({
                 contentBefore: `<p>ab[c</p><p class="oe_unbreakable">]<br></p><p>def</p>`,
                 stepFunction: deleteBackward,
@@ -279,7 +279,7 @@ describe("backward", () => {
             });
         });
 
-        test("should delete first character of unbreakable, ignoring selected paragraph break (backward)", async () => {
+        test("should delete first character of unsplittable, ignoring selected paragraph break (backward)", async () => {
             await testEditor({
                 contentBefore: `<p>abc[</p><p class="oe_unbreakable">d]ef</p>`,
                 stepFunction: deleteBackward,
@@ -291,21 +291,21 @@ describe("backward", () => {
 describe("forward", () => {
     describe("selection collapsed", () => {
         describe("start empty", () => {
-            test("should delete empty p just before an unbreakable (forward)", async () => {
+            test("should delete empty p just before an unsplittable (forward)", async () => {
                 await testEditor({
                     contentBefore: `<p>[]</p><div class="oe_unbreakable">a</div>`,
                     stepFunction: deleteForward,
                     contentAfter: `<div class="oe_unbreakable">[]a</div>`,
                 });
             });
-            test("should delete empty p/br just before an unbreakable (forward)", async () => {
+            test("should delete empty p/br just before an unsplittable (forward)", async () => {
                 await testEditor({
                     contentBefore: `<p><br>[]</p><div class="oe_unbreakable">a</div>`,
                     stepFunction: deleteForward,
                     contentAfter: `<div class="oe_unbreakable">[]a</div>`,
                 });
             });
-            test("should delete empty unbreakables (forward)", async () => {
+            test("should delete empty unsplittables (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                     <div>
@@ -319,7 +319,7 @@ describe("forward", () => {
                     </div>`),
                 });
             });
-            test("should not delete an empty unbreakable when there is no elements to delete after (forward)", async () => {
+            test("should not delete an empty unsplittable when there is no elements to delete after (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -337,14 +337,14 @@ describe("forward", () => {
         });
 
         describe("start text", () => {
-            test("should not merge p with an unbreakable (forward)", async () => {
+            test("should not merge p with an unsplittable (forward)", async () => {
                 await testEditor({
                     contentBefore: `<p>a[]</p><div class="oe_unbreakable">b</div>`,
                     stepFunction: deleteForward,
                     contentAfter: `<p>a[]</p><div class="oe_unbreakable">b</div>`,
                 });
             });
-            test("should not remove unbreakable after an unbreakable (forward)", async () => {
+            test("should not remove unsplittable after an unsplittable (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -359,7 +359,7 @@ describe("forward", () => {
                         </div>`),
                 });
             });
-            test("should not merge unbreakable after a p (forward)", async () => {
+            test("should not merge unsplittable after a p (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -374,7 +374,7 @@ describe("forward", () => {
                         </div>`),
                 });
             });
-            test("should not merge unbreakable after an empty unbreakable (forward)", async () => {
+            test("should not merge unsplittable after an empty unsplittable (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -389,7 +389,7 @@ describe("forward", () => {
                         </div>`),
                 });
             });
-            test("should not merge unbreakable after an empty p (forward)", async () => {
+            test("should not merge unsplittable after an empty p (forward)", async () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <div>
@@ -409,7 +409,7 @@ describe("forward", () => {
     // Only few tests are made with the selection not collapsed it should use the
     // same logic as for the backward (deleteRange).
     describe("selection not collapsed", () => {
-        test("should not break unbreakables (delete forward) (1)", async () => {
+        test("should not break unsplittables (delete forward) (1)", async () => {
             await testEditor({
                 contentBefore: unformat(`
                         <div>
@@ -425,7 +425,7 @@ describe("forward", () => {
             });
         });
 
-        test("should not break unbreakables (delete forward) (2)", async () => {
+        test("should not break unsplittables (delete forward) (2)", async () => {
             await testEditor({
                 contentBefore: unformat(`
                         <p class="oe_unbreakable">a[b</p>
@@ -437,7 +437,7 @@ describe("forward", () => {
             });
         });
 
-        test("should delete first character of unbreakable, ignoring selected paragraph break (forward)", async () => {
+        test("should delete first character of unsplittable, ignoring selected paragraph break (forward)", async () => {
             await testEditor({
                 contentBefore: '<p>abc[</p><p class="oe_unbreakable">d]ef</p>',
                 stepFunction: deleteForward,
@@ -449,7 +449,7 @@ describe("forward", () => {
 
 describe("list", () => {
     describe("selection collapsed", () => {
-        test("should not outdent while nested within a list item if the list is unbreakable", async () => {
+        test("should not outdent while nested within a list item if the list is unsplittable", async () => {
             // Only one LI.
             await testEditor({
                 contentBefore: '<p>abc</p><ol class="oe_unbreakable"><li>[]def</li></ol>',
@@ -547,7 +547,7 @@ describe("list", () => {
         });
     });
     describe("selection not collapsed", () => {
-        test("shoud not merge list item in the previous unbreakable sibling (1)", async () => {
+        test("shoud not merge list item in the previous unsplittable sibling (1)", async () => {
             await testEditor({
                 contentBefore: unformat(`
                         <p class="oe_unbreakable">a[bc</p>
@@ -565,7 +565,7 @@ describe("list", () => {
             });
         });
 
-        test("shoud not merge list item in the previous unbreakable sibling (2)", async () => {
+        test("shoud not merge list item in the previous unsplittable sibling (2)", async () => {
             await testEditor({
                 contentBefore: unformat(`
                         <div class="oe_unbreakable">

--- a/addons/website/static/src/builder/plugins/company_team_plugin.js
+++ b/addons/website/static/src/builder/plugins/company_team_plugin.js
@@ -12,7 +12,7 @@ class CompanyTeamPlugin extends Plugin {
 
     getEditableEls(rootEl) {
         // To fix db in stable
-        const contentEditableEls = [...selectElements(rootEl, ".s_company_team .o_not_editable *")];
+        const contentEditableEls = selectElements(rootEl, ".s_company_team .o_not_editable *");
         return contentEditableEls.filter((el) => isMediaElement(el));
     }
 }

--- a/addons/website/static/src/builder/plugins/options/facebook_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/facebook_option_plugin.js
@@ -40,7 +40,7 @@ class FacebookOptionPlugin extends Plugin {
             }
         }
 
-        const nodes = [...selectElements(root, ".o_facebook_page:not([data-href])")];
+        const nodes = selectElements(root, ".o_facebook_page:not([data-href])");
         if (nodes.length) {
             this.loadAndSetEmptyLink(nodes);
         }

--- a/addons/website/static/src/builder/plugins/options/instagram_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/instagram_option_plugin.js
@@ -37,9 +37,7 @@ class InstagramOptionPlugin extends Plugin {
     }
 
     normalize(root) {
-        const nodes = [
-            ...selectElements(root, ".s_instagram_page[data-instagram-page-is-default]"),
-        ];
+        const nodes = selectElements(root, ".s_instagram_page[data-instagram-page-is-default]");
         if (nodes.length) {
             this.loadAndSetPage(nodes);
         }


### PR DESCRIPTION
A couple of minor refactorings.

We have a utility function `selectElements` that is a wrapper around `querySelectorAll` that returns a `Generator` object and includes the root element. This commit changes it so it returns an array since we didn't really need the features of a generator. It then makes the code cleaner and easier to read by using that function where we can instead of the verbose `[...root, root.querySelectorAll(selector)]`.

"Unbreakable" is a legacy term that was replaced by "unsplittable", but we still had lots of references to the old term in tests, which could be confusing. This updates those references to use the modern terminology.

task-5420399

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
