### PR TITLE
[FIX] purchase_stock: extra journal items for standard cost prod

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -194,8 +194,9 @@ class StockMove(models.Model):
         returned_move = self.origin_returned_move_id
         move = (self | returned_move).with_prefetch(self._prefetch_ids)
         pdiff_exists = bool(move.stock_valuation_layer_ids.stock_valuation_layer_ids.account_move_line_id)
+        cost_method = self.product_id.categ_id.property_cost_method
 
-        if not am_vals_list or not self.purchase_line_id or pdiff_exists or float_is_zero(qty, precision_rounding=self.product_id.uom_id.rounding):
+        if not am_vals_list or not self.purchase_line_id or pdiff_exists or float_is_zero(qty, precision_rounding=self.product_id.uom_id.rounding) or cost_method != 'fifo':
             return am_vals_list
 
         layer = self.env['stock.valuation.layer'].browse(svl_id)


### PR DESCRIPTION
Currently, when a user needs to reverse a return for a standard cost product, extra journal items are created to balance the initial purchase operation.

Steps to reproduce:
1. Create a standard price/automated product category
2. Create a storable product with such category and cost 10
3. Create a PO with 1 @ 100, Confirm and receive the product
4. Return the full quantity
5. Return the return for the full quantity

Issue:
During the last operation two additional journal items are created to balance the returned svl with the original purchase price. However this is not needed when the item has a standard cost inventory valuation.

opw-5133716