### PR TITLE
[IMP] hr_holidays: add missing required supporting document filter

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -46,6 +46,8 @@
                     string="Waiting For Me"
                     name="waiting_for_me_manager"
                     groups="hr_holidays.group_hr_holidays_user"/>
+                <filter name="missing_document" string="Missing Document"
+                    domain="['&amp;', ('holiday_status_id.support_document', '=', True), ('attachment_ids', '=', False)]"/>
                 <separator/>
                 <filter domain="[('state', '=', 'confirm')]" string="First Approval" name="approve"/>
                 <filter domain="[('state', '=', 'validate1')]" string="Second Approval" name="second_approval"/>


### PR DESCRIPTION
Introduce a new "Missing Document" filter to easily identify time off requests where the time off type requires a support document, but the request itself does not include one.

Implemented through a domain filter combining:
- `holiday_status_id.support_document = True`
- `attachment_ids = False`

This provides HR with a quick way to track incomplete or non-compliant leave requests.

task-5403526

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
