### PR TITLE
[FIX] {sale_,}mrp: rounding on product packaging quantity

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -106,7 +106,7 @@ class StockMoveLine(models.Model):
             # calculate the number of kit on the move line according to the number of comp
             kit_qty = qty_bom_uom / kit_ratio
             # calculate the quantity needed of packaging
-            move_line.product_packaging_qty = kit_qty / move_line.move_id.product_packaging_id.qty
+            move_line.product_packaging_qty = move_line.move_id.product_packaging_id._compute_qty(kit_qty)
         super(StockMoveLine, self - kit_lines)._compute_product_packaging_qty()
 
     @api.model

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -774,3 +774,72 @@ class TestSaleMrpKitBom(TransactionCase):
         aggr_prod_qty = so.picking_ids.move_ids.move_line_ids[0]._get_aggregated_product_quantities(kit_name='Kit')
         key = f"{comp_product.id}_{comp_product.display_name}__{comp_product.uom_id.id}_{packaging_comp}_{kit_product.bom_ids.id}"
         self.assertEqual(aggr_prod_qty[key]['packaging_quantity'], 2)
+
+    def test_kit_product_packaging_qty_rounding(self):
+        """
+        Test that when selling a kit and the componenet product is delivered using multiple lots
+        that the product packaging quantity is rounded correctly.
+        """
+        self.env.user.write({'groups_id': [Command.link(self.ref('product.group_stock_packaging'))]})
+
+        kit_product = self._create_product('Kit', 'product', 1)
+        product_packaging = self.env['product.packaging'].create({
+            'name': "pack of 9",
+            'product_id': kit_product.id,
+            'qty': 9.0,
+        })
+
+        comp_product = self._create_product('Component', 'product', 1)
+        comp_product.tracking = 'lot'
+
+        lot1 = self.env['stock.lot'].create({
+            'name': 'lot1',
+            'product_id': comp_product.id,
+            'company_id': self.env.company.id,
+        })
+        lot2 = self.env['stock.lot'].create({
+            'name': 'lot2',
+            'product_id': comp_product.id,
+            'company_id': self.env.company.id,
+        })
+
+        warehouse = self.env["stock.warehouse"].create({
+            'name': 'WH',
+            'code': 'WH Test',
+        })
+        stock_location = warehouse.lot_stock_id
+
+        self.env['stock.quant']._update_available_quantity(comp_product, stock_location, 9.0, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(comp_product, stock_location, 12.6, lot_id=lot2)
+
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': kit_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': comp_product.id,
+                    'product_qty': 0.1,
+                }),
+            ]
+        })
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [
+                Command.create({
+                    'name': kit_product.name,
+                    'product_id': kit_product.id,
+                    'product_uom_qty': 216,
+                    'product_packaging_id': product_packaging.id
+                }),
+            ],
+            'warehouse_id': warehouse.id,
+        })
+        so.action_confirm()
+
+        so.picking_ids.button_validate()
+
+        self.assertEqual(len(so.picking_ids.move_ids.move_line_ids), 2)
+        self.assertEqual(so.picking_ids.move_ids.move_line_ids[0].product_packaging_qty, 10)
+        self.assertEqual(so.picking_ids.move_ids.move_line_ids[1].product_packaging_qty, 14)


### PR DESCRIPTION
Problem: There is no rounding done for the packaging quantity computation for kit products. This is inconsistent with non-kit products as we call _compute_qty and round.

Purpose: This will properly round the kit quantity and make the behavior consistent with the non-kit products.

Steps to Reproduce on Runbot:
1. Enable product packages and display lots on delivery slips.
2. Create a kit product.
3. On the kit product create a product package that holds 9 units.
4. Create a component product and make it tracked by lots.
5. On the component product create one lot with 9.0 units and a second lot with 12.6 units.
6. Create a kit type BoM for the kit product and add the component product with a quantity of 0.1 units.
7. Create a sale order for 216 units of the kit product, which will use 24 packages.
8. Validate the receipt and print the delivery slip.
9. Observe that the delivery slip shows 13 packages used for the 12.6 units instead of 14.

opw-5258735

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
