### PR TITLE
[FIX] microsoft_calendar: prevent duplicate events by raising timeout

### DIFF
--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -108,7 +108,7 @@ class MicrosoftSync(models.AbstractModel):
         if self.env.user._get_microsoft_sync_status() != "sync_paused":
             for record in records:
                 if record.need_sync_m and record.active:
-                    record._microsoft_insert(record._microsoft_values(self._get_microsoft_synced_fields()), timeout=3)
+                    record._microsoft_insert(record._microsoft_values(self._get_microsoft_synced_fields()), timeout=10)
         return records
 
     @api.depends('microsoft_id')


### PR DESCRIPTION
Before this fix, the timeout was only 3 seconds when syncing from Microsoft Graph API. Sometimes, we would not receive a response in time, and the event would be created twice in Odoo and then in Outlook.

This change increases the timeout to 10 seconds, selected from opw-4164679.

opw-5300061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
