### PR TITLE
[FIX] base: fixed traceback on re-installing the payroll modules

### DIFF
--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -101,8 +101,8 @@ class ResPartnerBank(models.Model):
     note = fields.Text('Notes')
     color = fields.Integer(compute='_compute_color')
 
-    _unique_number = models.Constraint(
-        'unique(sanitized_acc_number, partner_id)',
+    _unique_number = models.UniqueIndex(
+        '(sanitized_acc_number, partner_id) WHERE (active IS TRUE)',
         "The combination Account Number/Partner must be unique.",
     )
 

--- a/odoo/addons/base/tests/test_res_partner_merge.py
+++ b/odoo/addons/base/tests/test_res_partner_merge.py
@@ -91,7 +91,7 @@ class TestMergePartner(TransactionCase):
         self.assertTrue(self.partner1.exists(), "Destination partner should exist after merge")
         self.assertEqual(len(self.partner1.bank_ids), 1, "There should be a single bank account after merge")
         self.assertIn(self.bank1, self.partner1.bank_ids, "The original bank account of the destination partner should remain")
-        self.assertFalse(self.bank3.exists(), "The duplicate bank account should have been deleted.")
+        self.assertFalse(self.bank3.active, "The duplicate bank account should be archived.")
 
     def test_merge_partners_with_references(self):
         """ Test merging partners with references """


### PR DESCRIPTION
## Issue
- When we install any module having account demo data, then after uninstalling this account data gets archived instead of being deleted. So when we try to install it again, it throws a traceback for unique constraint expecting a unique pair of '(sanitized_acc_number, partner_id)' . Fixed to check the constraint for active accounts only.

## Steps to reproduce
1. Install any payroll module l10n_*_hr_payroll(exception - l10n_be_hr_payroll) with demo data.
2. Go to Apps -> and uninstall that module.
3. Now install it again you will get a traceback.

## Fix
- Instead of checking duplicate records with unique pair of  '(sanitized_acc_number, partner_id)' in the whole db changed the constraint to check duplicate records only for the active records.

task-5368848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
