### PR TITLE
[IMP] mail: muted 'No one else is here.' text on welcome page

### DIFF
--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -18,9 +18,9 @@
                     <input class="form-control bg-white rounded" type="text" name="guest_name" placeholder="Your name" t-model="state.userName" t-on-keydown="onKeydownInput"/>
                     <small class="form-text text-end" t-att-class="{'text-danger': state.userName.length > 60}"><t t-out="state.userName.length"/>/60</small>
                 </div>
-                <div class="fs-3" t-if="store.self_user">
-                    <p>Ready to join?</p>
-                    <p t-if="showCallPreview and noActiveParticipants">No one else is here.</p>
+                <div t-if="store.self_user">
+                    <p class="fs-3">Ready to join?</p>
+                    <p t-if="showCallPreview and noActiveParticipants" class="fs-4 mt-n3 text-muted">No one else is here.</p>
                 </div>
                 <button class="d-flex btn btn-light rounded-pill align-items-center justify-content-center gap-3 px-4 fs-3" title="Join Channel" t-att-disabled="!canJoin" t-on-click="joinChannel">
                     <t t-if="showCallPreview" t-set="joinText">Join call</t>


### PR DESCRIPTION
Purpose of this commit,
To make the 'No one else is here' text muted to improve the overall text appearance.

|Before|After|
|------|------|
|<img width="276" height="159" alt="image" src="https://github.com/user-attachments/assets/b79264e2-38d1-48d4-a1ee-ed30bf87fe29" />|<img width="230" height="166" alt="image" src="https://github.com/user-attachments/assets/1f15698e-6aa2-4b9b-90de-ed7dfc675754" />|
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
