### PR TITLE
[FIX] pos_sale: avoid creating downpayment line on every sync_from_ui

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -54,7 +54,15 @@ class PosOrder(models.Model):
 
         order_ids = self.browse([o['id'] for o in data["pos.order"]])
         for order in order_ids:
-            for line in order.lines.filtered(lambda l: l.product_id == order.config_id.down_payment_product_id and l.qty != 0 and (l.sale_order_origin_id or l.refunded_orderline_id.sale_order_origin_id)):
+            for line in order.lines.filtered(
+                lambda l: l.product_id == order.config_id.down_payment_product_id
+                and l.qty != 0
+                and not l.sale_order_line_id
+                and (
+                    l.sale_order_origin_id
+                    or l.refunded_orderline_id.sale_order_origin_id
+                )
+            ):
                 sale_lines = line.sale_order_origin_id.order_line or line.refunded_orderline_id.sale_order_origin_id.order_line
                 sale_order_origin = line.sale_order_origin_id or line.refunded_orderline_id.sale_order_origin_id
                 if not line.sale_order_line_id:

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -227,6 +227,22 @@ registry.category("web_tour.tours").add("PoSSaleOrderWithDownpayment", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_so_downpayment_with_avatax", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.downPaymentFirstOrder("+10"),
+            ProductScreen.selectedOrderlineHas("Down Payment (POS)"),
+            ProductScreen.totalAmountIs(10.0),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.endTour(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_settle_so_with_non_pos_groupable_uom", {
     steps: () =>
         [

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -653,6 +653,26 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSSaleOrderWithDownpayment', login="accountman")
 
+    def test_so_downpayment_with_avatax(self):
+        self.product_a.available_in_pos = True
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': self.product_a.uom_id.id,
+                    'price_unit': 100,
+                    'tax_id': False,
+                })],
+        })
+        so.action_confirm()
+        self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
+        self.main_pos_config.module_pos_avatax = True
+        self.main_pos_config.open_ui()
+        self.start_pos_tour("test_so_downpayment_with_avatax", login="accountman")
+
     def test_downpayment_with_taxed_product(self):
         tax_1 = self.env['account.tax'].create({
             'name': '10',


### PR DESCRIPTION
Step to reproduce:
- configure pos for Avatax from settings
- create a SO in draft
- open POS and and settle this SO (set a 10% down-payment line)
- settle this order
- open this SO

Observation:
- there are 2 down-payment lines for same tax

Cause:
- `sync_from_ui` from pos_sale keeps creating sol on each call to `sync_from_ui` 

Fix:
- we check if there is already a line or not before creating a new line

opw-5089351

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
