### PR TITLE
[FIX] hr_recruitment: hr.job.tag is not access error to assigned interviewer

### DIFF
--- a/addons/hr_recruitment/security/ir.model.access.csv
+++ b/addons/hr_recruitment/security/ir.model.access.csv
@@ -10,6 +10,7 @@ access_hr_recruitment_stage_interviewer,hr.recruitment.stage.interviewer,model_h
 access_hr_recruitment_stage_user,hr.recruitment.stage.user,model_hr_recruitment_stage,group_hr_recruitment_user,1,0,0,0
 access_hr_recruitment_stage_manager,hr.recruitment.stage.manager,model_hr_recruitment_stage,group_hr_recruitment_manager,1,1,1,1
 access_hr_recruitment_degree,hr.recruitment.degree,model_hr_recruitment_degree,group_hr_recruitment_user,1,1,1,1
+access_hr_recruitment_degree_interviewer,hr.recruitment.degree.interviewer,model_hr_recruitment_degree,group_hr_recruitment_interviewer,1,0,0,0
 access_hr_recruitment_refuse_reason_interviewer,hr.applicant.refuse.reason.interviewer,model_hr_applicant_refuse_reason,group_hr_recruitment_interviewer,1,0,0,0
 access_hr_recruitment_refuse_reason,hr.applicant.refuse.reason,model_hr_applicant_refuse_reason,group_hr_recruitment_user,1,1,1,1
 access_res_partner_hr_user,res.partner.user,base.model_res_partner,group_hr_recruitment_user,1,1,1,1
@@ -31,3 +32,4 @@ access_talent_pool_add_applicants,access.talent.pool.add.applicants,model_talent
 access_job_add_applicants_interviewer,access.job.add.applicants.interviewer,model_job_add_applicants,group_hr_recruitment_interviewer,0,0,0,0
 access_job_add_applicants,access.job.add.applicants,model_job_add_applicants,group_hr_recruitment_user,1,1,1,1
 access_hr_job_tag_manager,hr.job_tag,model_hr_job_tag,group_hr_recruitment_user,1,1,1,1
+access_hr_job_tag_interviewer,hr.job_tag.interviewer,model_hr_job_tag,group_hr_recruitment_interviewer,1,0,0,0


### PR DESCRIPTION
### Steps to reproduce:
- Install hr_recruitment.
- Create a new user with no access rights to Recruitment.
- Assign the created user as an interviewer to an applicant.
- Switch to the newly created user and try to access the applicant.
- An access error is raised for the model hr.job.tag.

### Root cause:
- Issue causing PR: https://github.com/odoo/odoo/pull/233595
- While assigning a user as an interviewer, we temporarily grant the Interviewer access rights to that user.
- However, these access rights were not provided for the hr.job.tag model in ir.model.access.csv file, which resulted in the access error.

### Fix:
- Added Interviewer access rights to the hr.job.tag model.

### Before:
- The interviewer user encountered an access error when accessing the applicant.

### After:
- No access error is displayed, and the interviewer can access the applicant without any issues.

task: 5410983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
