### PR TITLE
[IMP] orm: assume not null for required compute_sql field

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -801,12 +801,14 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 for field_name, field in Model._fields.items():
                     if field_name == 'id':
                         self.not_null_fields.add(field)
-                        continue
-                    if field.column_type and field.store and field.required:
-                        if (Model._table, field_name) in not_null_columns:
+                    elif field.required and field.column_type:
+                        if field.store:
+                            if (Model._table, field_name) in not_null_columns:
+                                self.not_null_fields.add(field)
+                            else:
+                                _schema.warning("Missing not-null constraint on %s", field)
+                        elif field.compute_sql:
                             self.not_null_fields.add(field)
-                        else:
-                            _schema.warning("Missing not-null constraint on %s", field)
 
     def check_indexes(self, cr: Cursor, model_names: Iterable[str]) -> None:
         """ Create or drop column indexes for the given models. """


### PR DESCRIPTION
When generating a condition for a field which has a `compute_sql` defined and is required, do not add conditions for null value checks.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
