### PR TITLE
[FIX] auth_totp: search needs sudo for totp_enable_search

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -233,7 +233,7 @@ class ResUsers(models.Model):
     def _totp_enable_search(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        domain = Domain.custom(to_sql=lambda table: SQL("%s <> 'false'", table.totp_secret))
+        domain = Domain.custom(to_sql=lambda table: SQL("%s <> 'false'", table._sudo().totp_secret))
         if not (self.env.su or self.env.user.has_group('base.group_erp_manager')):
             domain &= Domain('id', '=', self.env.uid)
         return domain


### PR DESCRIPTION
Missing sudo to access the field.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
