### PR TITLE
[FIX] point_of_sale: include archived config too

### DIFF
--- a/addons/point_of_sale/models/account_fiscal_position.py
+++ b/addons/point_of_sale/models/account_fiscal_position.py
@@ -5,6 +5,6 @@ class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 
     def action_archive(self):
-        configs = self.env['pos.config'].search([('default_fiscal_position_id', 'in', self.ids)])
+        configs = self.env['pos.config'].with_context(active_test=False).search([('default_fiscal_position_id', 'in', self.ids)])
         configs.default_fiscal_position_id = False
         return super().action_archive()


### PR DESCRIPTION
Follow-up PR of this https://github.com/odoo/odoo/pull/233358 include archived config to otherwise issue can be reproducable if archived config first and then fiscal position and then re-activate the config recursion error can be reproducible.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
