### PR TITLE
[IMP] core: test_module_operations reporting to runbot

### DIFF
--- a/odoo/tests/test_module_operations.py
+++ b/odoo/tests/test_module_operations.py
@@ -231,5 +231,5 @@ if __name__ == '__main__':
     try:
         args.func(args)
     except Exception:
-        _logger.error("%s tests failed", args.func.__name__[5:])
-        raise
+        _logger.exception("%s tests failed", args.func.__name__[5:])
+        exit(1)


### PR DESCRIPTION
One of the changes in #118332 was to let exceptions bubble up to the interpreter in case of error, to improve the experience while running the script locally.

This turns out to have downgraded runbot reporting significantly as it doesn't account for stderr / log tracebacks if it got error-level (and possibly even warning-level) logs during the run.

Hopefully get the best of both world (and shorten tracebacks slightly) by restoring `logging.exception` at the script level but triggering an abnormal exit for local CLI utility.
