### PR TITLE
[FIX] {l10n_ar_,}website_sale: handle missing l10n fields on checkout

### DIFF
--- a/addons/website_sale/static/src/js/address.js
+++ b/addons/website_sale/static/src/js/address.js
@@ -199,7 +199,7 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
                     }
                 })
                 result.invalid_fields.forEach(
-                    fieldName => this.addressForm[fieldName].classList.add('is-invalid')
+                    fieldName => this.addressForm[fieldName]?.classList.add('is-invalid')
                 );
 
                 // Display the error messages


### PR DESCRIPTION
Versions
--------
- 18.0

`l10n_ar_website_sale` was removed in later versions via 5a93da8e9220

Steps
-----
1. Create a partner with an address;
2. set up a company with Argentinian localization;
3. assign website to Argentinian company;
4. as partner, go to website & add something to your cart;
5. go to checkout.

Issue
-----
Cannot get past the address form.

Cause
-----
The `l10n_latam_identification_type_id` and `l10n_ar_afip_responsibility_type_id` fields are required, but not shown. Because they're not editable, the `website_sale` controller doesn't consider them "missing", making the `l10n_ar_website_sale` override not handle the missing fields.

Going to "My Account" to edit details also doesn't allow you to add them, as the form lacks the `can_edit_vat` value.

Solution
--------
Instead of relying on the `missing_fields` value from the base method call, have the `_validate_address_values` override explicitly check the presence of those fields in either the address values or the current partner record (adding them to address values if it's the latter).

If the values are missing, show an error message telling the client to add the missing info via "My Account".

In the portal controller, provide the `can_edit_vat` value to make the fields editable.

opw-5376149