### PR TITLE
[FIX] l10n_au:fix BAS W2 sign handling

### DIFF
--- a/addons/l10n_au/data/account_tax_report_data.xml
+++ b/addons/l10n_au/data/account_tax_report_data.xml
@@ -238,7 +238,7 @@
                             <record id="account_tax_report_payg_w2_tag" model="account.report.expression">
                                 <field name="label">sub_balance</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">-W2</field>
+                                <field name="formula">W2</field>
                             </record>
                             <record id="account_tax_report_payg_w2_balance" model="account.report.expression">
                                 <field name="label">balance</field>


### PR DESCRIPTION
Since 19.0, sign handling was moved out of tax tags.
In community commit 9f55bc242e71e96260edc425d227409775b6b096,
the sign was removed from tax tags, but for BAS line W2 a negative sign was
mistakenly kept at the tag level, while the report aggregation already
applies a negative sign.
This resulted in a double sign inversion.

This commit fixes W2 by applying the correct sign.

enterprise pr -https://github.com/odoo/enterprise/pull/102114
task- [5416350](https://www.odoo.com/odoo/project.task/5416350)

