### PR TITLE
[IMP] html_builder: lazy-load records in BuilderList

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -1,4 +1,4 @@
-import { useRef } from "@web/owl2/utils";
+import { useLayoutEffect, useRef, useState } from "@web/owl2/utils";
 import { BuilderComponent } from "@html_builder/core/building_blocks/builder_component";
 import { BuilderListDialog } from "@html_builder/core/building_blocks/builder_list_dialog";
 import {
@@ -40,6 +40,7 @@ export class BuilderList extends Component {
         columnWidth: { optional: true },
         forbidLastItemRemoval: { type: Boolean, optional: true },
         isEditable: { type: Boolean, optional: true },
+        limit: { type: Number, optional: true },
     };
     static defaultProps = {
         addItemTitle: _t("Add"),
@@ -51,6 +52,7 @@ export class BuilderList extends Component {
         columnWidth: {},
         forbidLastItemRemoval: false,
         isEditable: true,
+        limit: 50,
     };
     static components = { BuilderComponent, SelectMenu };
 
@@ -70,6 +72,34 @@ export class BuilderList extends Component {
         this.commit = commit;
         this.preview = preview;
         this.allRecords = this.formatRawValue(this.props.records);
+        this.visibilityState = useState({
+            limit: this.props.limit,
+        });
+        this.tableRef = useRef("table");
+        this.sentinelRef = useRef("sentinel");
+        useLayoutEffect(
+            () => {
+                const sentinelEl = this.sentinelRef.el;
+                if (!sentinelEl) {
+                    return;
+                }
+                const observer = new IntersectionObserver(
+                    ([entry]) => {
+                        if (entry.isIntersecting && this.hasMoreItems) {
+                            this.visibilityState.limit += this.props.limit;
+                        }
+                    },
+                    {
+                        root: this.tableRef.el.parentElement,
+                        threshold: 1.0,
+                        rootMargin: "100px",
+                    }
+                );
+                observer.observe(sentinelEl);
+                return () => observer.disconnect();
+            },
+            () => []
+        );
 
         onWillUpdateProps((props) => {
             this.allRecords = this.formatRawValue(props.records);
@@ -78,7 +108,7 @@ export class BuilderList extends Component {
         if (this.props.sortable) {
             useSortable({
                 enable: () => this.props.sortable,
-                ref: useRef("table"),
+                ref: this.tableRef,
                 elements: ".o_row_draggable",
                 handle: ".o_handle_cell",
                 cursor: "grabbing",
@@ -89,6 +119,14 @@ export class BuilderList extends Component {
                 },
             });
         }
+    }
+
+    get cappedItems() {
+        return this.getIncludedRecords().slice(0, this.visibilityState.limit);
+    }
+
+    get hasMoreItems() {
+        return this.cappedItems.length < this.getIncludedRecords().length;
     }
 
     validateProps() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -8,7 +8,7 @@
             <t t-if="this.state.value?.length > 2">
                 <div class="o_we_table_wrapper">
                     <table t-custom-ref="table">
-                        <t t-set="items" t-value="this.formatRawValue(this.state.value)"/>
+                        <t t-set="items" t-value="this.cappedItems"/>
                         <t t-foreach="items" t-as="item" t-key="item._id">
                             <tr class="o_row_draggable" t-att-data-id="item._id">
                                 <td t-if="this.props.sortable" class="o_handle_cell w-0">
@@ -52,6 +52,9 @@
                                 </td>
                             </tr>
                         </t>
+                        <tr t-custom-ref="sentinel" t-if="this.hasMoreItems">
+                            <td colspan="99"/>
+                        </tr>
                     </table>
                 </div>
             </t>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -5,7 +5,7 @@ import {
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
-import { expect, test, describe } from "@odoo/hoot";
+import { expect, test, describe, animationFrame } from "@odoo/hoot";
 import { onError, xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import { press } from "@odoo/hoot-dom";
@@ -462,4 +462,36 @@ test("drops blank textual entries", async () => {
     await contains(".we-bg-options-container input").clear();
     await press("enter");
     expect(".we-bg-options-container input").toHaveCount(1);
+});
+
+test("loads more items when the last row intersects", async () => {
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement: fieldEl }) {
+                const list = [];
+                for (let i = 0; i < 150; i++) {
+                    list.push({ value: `item ${i + 1}` });
+                }
+                return JSON.stringify(list);
+            }
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderList action="'customAction'" itemShape="{ value: 'text' }"/>`;
+        }
+    );
+    await setupHTMLBuilder(`<div class="test-options-target">content</div>`);
+    await contains(":iframe .test-options-target").click();
+    expect(".we-bg-options-container .o_row_draggable").toHaveCount(50);
+
+    await contains(".we-bg-options-container .o_we_table_wrapper").scroll({ top: 9999 });
+    await animationFrame();
+    expect(".we-bg-options-container .o_row_draggable").toHaveCount(100);
+
+    await contains(".we-bg-options-container .o_we_table_wrapper").scroll({ top: 9999 });
+    await animationFrame();
+    expect(".we-bg-options-container .o_row_draggable").toHaveCount(150);
 });


### PR DESCRIPTION
Steps to reproduce:

1. Drag a Form snippet.
2. Change the Form action to "Create a customer".
3. Add a field to the form with the type "State".
4. Try to remove a record from the "Option List".
-  The list takes a long time to load because the browser struggles to
   render a large number of items.

This commit reduces browser rendering overhead by loading records
incrementally in BuilderList as the user scrolls.

When the last visible item enters the viewport, the component increases
the displayed record limit and renders the next batch of records.
A ~250 ms debounce is applied to prevent excessive updates during
rapid scrolling.

task-5405106