### PR TITLE
[FIX] point_of_sale: apply simplified invoice limit in VeriFactu POS

### DIFF
--- a/addons/l10n_es_edi_verifactu_pos/models/__init__.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_move
 from . import pos_config
 from . import pos_order
+from . import pos_session
 from . import verifactu_document

--- a/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
@@ -273,8 +273,13 @@ class PosOrder(models.Model):
     def _process_saved_order(self, draft):
         self.ensure_one()
         if self.l10n_es_edi_verifactu_required:
-            if not self.to_invoice and self.amount_total > 400:
-                raise UserError(_("The order needs to be invoiced since its total amount is above 400€."))
+            simplified_invoice_limit = self.env['ir.config_parameter'].sudo().get_param(
+                'l10n_es_edi_verifactu_pos.simplified_invoice_limit',
+                '400'
+            )
+            limit = float(simplified_invoice_limit)
+            if not self.to_invoice and self.amount_total > limit:
+                raise UserError(_("The order needs to be invoiced since its total amount is above %(limit)s€.", limit=limit))
             refunded_order = self.refunded_order_ids
             if len(refunded_order) > 1:
                 raise UserError(_("You can only refund products from the same order."))

--- a/addons/l10n_es_edi_verifactu_pos/models/pos_session.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/pos_session.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    def _get_pos_ui_pos_config(self, params):
+        config = super()._get_pos_ui_pos_config(params)
+        if config.get('l10n_es_edi_verifactu_required'):
+            simplified_invoice_limit = self.env['ir.config_parameter'].sudo().get_param(
+                'l10n_es_edi_verifactu_pos.simplified_invoice_limit',
+                '400'
+            )
+            config['l10n_es_edi_verifactu_simplified_invoice_limit'] = float(simplified_invoice_limit)
+        return config

--- a/addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -9,11 +9,12 @@ patch(PaymentScreen.prototype, {
         if (this.pos.config.l10n_es_edi_verifactu_required) {
             const order = this.currentOrder;
             order.l10n_es_edi_verifactu_required = true;
-            const canBeSimplified = this.env.utils.roundCurrency(order.get_total_with_tax()) <= 400;
+            const simplifiedInvoiceLimit = this.pos.config.l10n_es_edi_verifactu_simplified_invoice_limit ?? 400;
+            const canBeSimplified = this.env.utils.roundCurrency(order.get_total_with_tax()) <= simplifiedInvoiceLimit;
             if (!canBeSimplified && !order.to_invoice) {
                 this.popup.add(ErrorPopup, {
                     title: _t("Error"),
-                    body: _t("The order needs to be invoiced since its total amount is above 400€."),
+                    body: _t("Order amount is too large for a simplified invoice, use an invoice instead."),
                 });
                 return false;
             }

--- a/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
@@ -110,7 +110,7 @@ class TestL10nEsEdiVerifactuPosOrder(TestL10nEsEdiVerifactuPosCommon):
 
     def test_error_above_simplified_limit(self):
         with self.with_pos_session():
-            with self.assertRaisesRegex(UserError, "The order needs to be invoiced since its total amount is above 400€."), \
+            with self.assertRaisesRegex(UserError, "The order needs to be invoiced since its total amount is above 400.0€."), \
                  mute_logger('odoo.addons.point_of_sale.models.pos_order'):
                 self._create_order({
                     'pos_order_lines_ui_args': [


### PR DESCRIPTION
We had a bug whith simplified invoice limit when verifactu and pos_es were installed. The limit was always 400 no matter how it was set in the settings.

Steps to reproduce:
-------------------
* Install l10n_es_edi_verifactu_pos (with or without l10n_es_pos)
* Enable VeriFactu
* Set a simplified invoice limit different from 400
* Create a POS order above the configured limit
* Validate without invoicing
> Observation:
we had the error message saying it's above 400.

Why the fix:
------------
To respect configuration, keep behavior consistent when l10n_es_pos is uninstalled. Error message and test are now resilient to limit and not hard-coded.

opw-5351516