### PR TITLE
[FIX] im_livechat: fix crash with deleted channel in _onClose

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/chat_window_model_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 patch(ChatWindow.prototype, {
     _onClose(options = {}) {
         if (
-            this.channel.channel_type === "livechat" &&
+            this.channel?.channel_type === "livechat" &&
             this.channel.livechatVisitorMember?.persona?.notEq(this.store.self) &&
             options.notifyState
         ) {


### PR DESCRIPTION
It's not clear how to reproduce the issue, but it is known that chat window flows are very sensitive to channel being deleted.