### PR TITLE
[FIX] {stock_,}account: prevent currency rate to apply on cogs

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1522,7 +1522,7 @@ class AccountMoveLine(models.Model):
             ):
                 line.amount_currency = line.balance
             if (
-                (changed('amount_currency') or changed('currency_rate') or changed('move_type'))
+                (changed('amount_currency') or (changed('currency_rate') and line.display_type != "cogs") or changed('move_type'))
                 and not self.env.is_protected(self._fields['balance'], line)
                 and (not changed('balance') or (line not in before and not line.balance))
             ):

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -659,10 +659,10 @@ class AccountTestInvoicingCommon(ProductCommon):
                 date = invoice_date
             elif date and not invoice_date:
                 invoice_date = date
-            elif not date and not invoice_date:
+            elif date is None and not invoice_date:
                 invoice_date = fields.Date.today()
 
-        invoice_args |= {'date': date, 'invoice_date': invoice_date}
+        invoice_args |= {'date': date or None, 'invoice_date': invoice_date}
 
         # QoL: allow passing record immediately instead of getting the id / creating [Command.set(...)] everytime
         # QoL: delete all keys with None value from invoice_args
@@ -685,7 +685,7 @@ class AccountTestInvoicingCommon(ProductCommon):
         return invoice
 
     @classmethod
-    def _create_invoice_one_line(cls, price_unit=None, product_id=None, name=None, quantity=1.0, tax_ids=None, discount=None, account_id=None, move_name=None, **invoice_args):
+    def _create_invoice_one_line(cls, price_unit=None, product_id=None, name=None, quantity=1.0, tax_ids=None, discount=None, account_id=None, move_name=None, date=None, **invoice_args):
         return cls._create_invoice(
             invoice_line_ids=[
                 cls._prepare_invoice_line(
@@ -698,6 +698,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                     account_id=account_id,
                 )
             ],
+            date=date,
             name=move_name,
             **invoice_args,
         )


### PR DESCRIPTION
**Steps to reproduce:**
- in settings enable "automatic accounting" and 
"anglo-saxon accounting"
- make sure dollar is the main currency
- activate euro as another currency
- set a rate for today as 1$->10 euros
- set another rate for a week ago 1$->2euros
- create a storable product with standard price/automated 
category and a cost of 10
- create a new invoice for 1 unit of your product
- do not set a date on the invoice
- set the currency as euro 
- click on the calendar widget to choose the rate and select the
date of yesterday
(- the rate applied should now be 1$->2euros)
- confirm the invoice

**Current behavior:**
the cogs line (credit stock interim delivered and debit expenses)
have a value of 5

**Expected behavior:**
the cogs value should be 10. It shouldn't be impacted by the 
currency rate.

**Cause of the issue:**
when the invoice is confirmed, because there is no date, 
the date is set at today inside _post()
https://github.com/odoo/odoo/blob/626d06734991bcd3b94a6c9454317f311164e9dc/addons/account/models/account_move.py#L5090
This results in a call to write with invoice_date in the vals.

Inside the override of the write() method of AccountMove, 
the call to super is inside a 'with self._sync_dynamic_lines' bloc.
https://github.com/odoo/odoo/blob/626d06734991bcd3b94a6c9454317f311164e9dc/addons/account/models/account_move.py#L3413-L3419
So the first part (up until the yield) of _sync_dynamic_lines is 
executed before the call to super.
In _sync_dynamic_lines() the yield is inside a 'with _sync_invoice'
bloc. 
https://github.com/odoo/odoo/blob/626d06734991bcd3b94a6c9454317f311164e9dc/addons/account/models/account_move.py#L3239-L3241

As a result, the first part of sync_invoice() (until the yield) is 
executed before the call to super method write().
https://github.com/odoo/odoo/blob/626d06734991bcd3b94a6c9454317f311164e9dc/addons/account/models/account_move_line.py#L1513-L1515
And the second part is executed after the call to write() and 
after the update of line_container['records'] inside 
_sync_dynamic_lines().

Because the change of date, changes the currency_rate, 
changed('currency_rate') will return True, and the balance will 
be recomputed for each line. 
https://github.com/odoo/odoo/blob/0dabb221225fba96c0e55779afadd9f12b369777/addons/account/models/account_move_line.py#L1524-L1530

This causes 2 problems: 
1) for the non cogs line, the rate set manually by the user 
is replaced by the rate of today
2) for the cogs line, a rate is applied where no currency 
rate should be applied at all.

The problem 1) was fixed in this PR https://github.com/odoo/odoo/pull/239012
But this does not fix problem 2) as the fix consists in letting the 
recomputation happen for the balance of the account move lines
and then re-recompute their balance in the manually set currency_rate.
Whereas for our cogs line we need no currency_rate based 
recomputation at all.

**fix**
prevent balance recomputation based on currency_rate change
for cogs lines.

opw-5266804