### PR TITLE
[FIX] pos_hr: disable opening employee form from PoS frontend

### DIFF
--- a/addons/pos_hr/views/pos_order_view.xml
+++ b/addons/pos_hr/views/pos_order_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position='replace'>
-                <field name="employee_id" readonly="1" invisible="not employee_id"/>
+                <field name="employee_id" readonly="1" invisible="not employee_id" options="{'no_open': True}"/>
                 <field name="user_id" readonly="1" invisible="employee_id"/>
             </xpath>
         </field>


### PR DESCRIPTION
Steps to reproduce
------------------
1. Enable "Log in with Employees"
2. Login with any employee and make an order
3. Switch to the admin, "Mitchell Admin" usually
4. Go to the paid orders (we are still in PoS UI not in the backend),
   and select the order paid in step 2.
5. Click on "Details", the order form will appear, click on the
   "Cashier" name

A traceback will appear, saying 'Cannot find key "hr_employee_form" in
the "views" registry'.

The fix
-------
We simply disable the employee_id field; it will not try to open the
employee form anymore.

That is much simpler than adding all the required hr assets to the PoS
frontend. Employee details are meant to be seen and navigated from the
backend.

opw-5252486