### PR TITLE
[FIX] core: Prevent crash with hierarchy default filter

### DIFF
--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -121,6 +121,32 @@ class TestParentStore(TransactionCase):
         self.assertEqual(len(old_struct), 4, "After duplication, previous record must have old childs records only")
         self.assertFalse(new_struct & old_struct, "After duplication, nodes should not be mixed")
 
+    def test_missing_parent(self):
+        """ Missing parent id should not raise an error. """
+        # Missing parent with _parent_store
+        new_cat0 = self.cat0.copy()
+        records = new_cat0.search([('parent_id', 'parent_of', 999999999)])
+        self.assertEqual(len(records), 0)
+
+        # Missing parent without _parent_store
+        category = self.env['res.partner.category']
+        self.patch(self.env.registry['res.partner.category'], '_parent_store', False)
+        records = category.search([('parent_id', 'child_of', 999999999)])
+        self.assertEqual(len(records), 0)
+
+    def test_missing_child(self):
+        """ Missing child id should not raise an error. """
+        # Missing child with _parent_store
+        new_cat0 = self.cat0.copy()
+        records = new_cat0.search([('parent_id', 'child_of', 999999999)])
+        self.assertEqual(len(records), 0)
+
+        # Missing child without _parent_store
+        category = self.env['res.partner.category']
+        self.patch(self.env.registry['res.partner.category'], '_parent_store', False)
+        records = category.search([('parent_id', 'child_of', 999999999)])
+        self.assertEqual(len(records), 0)
+
     def test_duplicate_children_01(self):
         """ Duplicate the children then reassign them to the new parent (1st method). """
         new_cat1 = self.cat1.copy()


### PR DESCRIPTION
Reproduce the crash:
1- Create departement in Employees.
2- Create a default filter with child_of or parent_of on the previously
created departement.
3- Delete the departement.
4- Go back to Employees
=> Crash 'Missing Record'

This commit adds a check for record exitence in `child_of_domain` and
`parent_of_domain` in the case where `_parent_store` is True. This
change prevents the `Missing Record` Error.

task-5217722