### PR TITLE
[FIX] hr: prevent error on loading scenario data

### DIFF
--- a/addons/hr/data/scenarios/hr_scenario.xml
+++ b/addons/hr/data/scenarios/hr_scenario.xml
@@ -28,7 +28,7 @@
             <field name="name">Experienced Developer</field>
             <field name="department_id" ref="hr.dep_rd"/>
             <field name="no_of_recruitment">5</field>
-            <field name="contract_type_id" ref="hr.contract_type_permanent"/>
+            <field name="contract_type_id" eval="ref('hr.contract_type_permanent', raise_if_not_found=False)"/>
             <field name="description">We are currently looking for someone like that to join our Web team.
                 Someone who can snap out of coding and perform analysis or meet clients to explain the technical
                 possibilities that can meet their needs.</field>
@@ -58,7 +58,7 @@
                 Result driven.
                 Excellent analytical skills, ability to think logically and "out of the box"
             </field>
-            <field name="contract_type_id" ref="hr.contract_type_permanent"/>
+            <field name="contract_type_id" eval="ref('hr.contract_type_permanent', raise_if_not_found=False)"/>
         </record>
 
         <!-- Employee category -->
@@ -133,7 +133,7 @@
             <field name="private_country_id" ref="base.us"/>
             <field name="private_phone">+1 555-555-5757</field>
             <field name="work_email">williams@mycompany.example.com</field>
-            <field name="department_id" ref="hr.dep_administration"/>
+            <field name="department_id" eval="ref('hr.dep_administration', raise_if_not_found=False)"/>
             <field name="job_id" ref="job_ceo"/>
             <field name="job_title">Chief Executive Officer</field>
             <field name="company_id" ref="base.main_company"/>


### PR DESCRIPTION
The system crash with error when user tries to load sample data of employees.

Steps to produce:-
- Install the Attendances module without demo data.
- Navigate to Employees > Departments and delete the Administrative department.
- Navigate to Employees > Configuration > Employment Types > delete all records.
- Go to Attendances > Load Demo.
- Observe the error.

Error:-
```
ValueError: External ID not found in the system: hr.contract_type_permanent
ValueError: External ID not found in the system: hr.dep_administration
```
Cause:
- The error occurs because the user deleted the records, and then try to load data, this causes the corresponding external ID to be missing from the system.

Solution:
- This commit resolves the error by providing a False value for the field if the referenced xmlid is missing from the database.

sentry-6856979884
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
