### PR TITLE
[IMP] purchase: hide payment terms on PO report when not set

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -138,8 +138,10 @@
             <p t-field="o.note" class="mt-4"/>
             <div class="oe_structure"/>
 
-            <strong>Payment Terms: </strong>
-            <span t-field="o.payment_term_id" class="mt-4"></span>
+            <t t-if="o.payment_term_id">
+                <strong>Payment Terms: </strong>
+                <span t-field="o.payment_term_id" class="mt-4"></span>
+            </t>
 
             <t t-set="base_address" t-value="o.env['ir.config_parameter'].sudo().get_str('web.base.url')"/>
             <t t-set="portal_url" t-value="base_address + '/my/purchase/' + str(o.id) + '#portal_connect_software_modal'"/>


### PR DESCRIPTION
- Currently, the Purchase Order report always displays the Payment Terms label,
  even when no payment term is defined on the purchase order. This can be
  confusing for users, as it suggests that a payment term exists when it does
  not.
- This commit improves the PO report by displaying the Payment Terms label only
  when a value is set on the purchase order. If no payment term is defined, both
  the label and the value are hidden.
- This behaviour makes the Purchase Order report cleaner and avoids confusion.

Task Id: 5413989