### PR TITLE
[IMP] mail: reorder chatter sections to prioritize files and pinned messages

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -67,12 +67,6 @@
         </div>
         <div class="o-mail-Chatter-content d-flex flex-column flex-grow-1 bg-inherit">
             <t>
-                <t t-if="props.has_activities and activities.length and !messageSearch.searching and !messageSearch.searched">
-                    <t t-call="mail.ActivityList"/>
-                </t>
-                <t t-if="scheduledMessages.length">
-                    <t t-call="mail.ScheduledMessagesList"/>
-                </t>
                 <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative">
                     <div class="d-flex align-items-center">
                         <hr class="flex-grow-1"/>
@@ -106,6 +100,12 @@
                         <MessageCardList messages="state.thread.pinnedMessages" thread="state.thread" mode="'pin'"/>
                     </div>
                 </div>
+                <t t-if="props.has_activities and activities.length and !messageSearch.searching and !messageSearch.searched">
+                    <t t-call="mail.ActivityList"/>
+                </t>
+                <t t-if="scheduledMessages.length">
+                    <t t-call="mail.ScheduledMessagesList"/>
+                </t>
                 <SearchMessageResult t-if="messageSearch.searching or messageSearch.searched" thread="state.thread"  messageSearch="messageSearch" onClickJump.bind="closeSearch"/>
                 <Thread t-else="" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
             </t>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Reorder chatter sections

**Desired behavior after PR is merged:**
With long activity descriptions, both the Files and Pinned Messages sections 
could get pushed out of view in the chatter.

This change reorders the sections to:
**Files -> Pinned Messages -> Activities -> Messages**

task-[5404841](https://www.odoo.com/odoo/project/1519/tasks/5404841)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
