### PR TITLE
[FIX] google_gmail, *:  log a warning instead of error in the IAP request error

### DIFF
--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -113,7 +113,7 @@ class GoogleGmailMixin(models.AbstractModel):
                     timeout=GMAIL_TOKEN_REQUEST_TIMEOUT)
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
-                _logger.error('Can not contact IAP: %s.', e)
+                _logger.warning('Can not contact IAP: %s.', e)
                 raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
 
             response = response.json()
@@ -221,7 +221,7 @@ class GoogleGmailMixin(models.AbstractModel):
         )
 
         if not response.ok:
-            _logger.error('Can not contact IAP: %s.', response.text)
+            _logger.warning('Can not contact IAP: %s.', response.text)
             raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
 
         response = response.json()

--- a/addons/microsoft_outlook/models/microsoft_outlook_mixin.py
+++ b/addons/microsoft_outlook/models/microsoft_outlook_mixin.py
@@ -112,7 +112,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
                     timeout=OUTLOOK_TOKEN_REQUEST_TIMEOUT)
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
-                _logger.error('Can not contact IAP: %s.', e)
+                _logger.warning('Can not contact IAP: %s.', e)
                 raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
 
             response = response.json()
@@ -224,7 +224,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
         )
 
         if not response.ok:
-            _logger.error('Can not contact IAP: %s.', response.text)
+            _logger.warning('Can not contact IAP: %s.', response.text)
             raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
 
         response = response.json()


### PR DESCRIPTION

*=mircosoft_outlook

Currently the logger records an error in the logs whenever an IAP request encounters an error.

Error: `Can not contact IAP: <!doctype html>`

Since this is a request-related error, the user receives an appropriate message when this type of error occurs, so Therefore, it is better to log this as a warning rather than an error.

sentry-6992264566

