### PR TITLE
[FIX] mail, im_livechat: fix sidebar channel order

### DIFF
--- a/addons/im_livechat/static/tests/discuss_app_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_app_patch.test.js
@@ -58,10 +58,7 @@ test("add livechat in the sidebar on visitor sending first message", async () =>
         })
     );
     await contains(
-        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-container",
-        {
-            text: "Visitor",
-        }
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarCategory-channels:has(:text(Visitor))"
     );
 });
 

--- a/addons/im_livechat/static/tests/tours/looking_for_help_discuss_category_tour.js
+++ b/addons/im_livechat/static/tests/tours/looking_for_help_discuss_category_tour.js
@@ -5,7 +5,7 @@ registry.category("web_tour.tours").add("im_livechat.looking_for_help_discuss_ca
         {
             // Two live chats are looking for help, they are both in the "Looking for help" category.
             trigger:
-                ".o-mail-DiscussSidebarCategory-livechatNeedHelp + .o-mail-DiscussSidebarChannel-container:contains(Visitor Accounting) + .o-mail-DiscussSidebarChannel-container:contains(Visitor Sales)",
+                ".o-mail-DiscussSidebarCategory-livechatNeedHelp + .o-mail-DiscussSidebarCategory-channels .o-mail-DiscussSidebarChannel-container:contains(Visitor Accounting) + .o-mail-DiscussSidebarChannel-container:contains(Visitor Sales)",
         },
         {
             trigger: ".o-mail-DiscussSidebarChannel:contains(Sales) .o-mail-starred",

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.js
@@ -1,6 +1,5 @@
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_app/sidebar/sidebar";
 import { DiscussSidebarCategory } from "@mail/discuss/core/public_web/discuss_app/sidebar/category";
-import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel";
 
 import { Component } from "@odoo/owl";
 
@@ -14,11 +13,7 @@ import { useService } from "@web/core/utils/hooks";
 export class DiscussSidebarCategories extends Component {
     static template = "mail.DiscussSidebarCategories";
     static props = {};
-    static components = {
-        DiscussSidebarCategory,
-        DiscussSidebarChannel,
-        Dropdown,
-    };
+    static components = { DiscussSidebarCategory, Dropdown };
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/categories.xml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
-        <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat.id">
-            <t t-if="cat.isVisible" t-call="mail.DiscussSidebarCategories.category">
-                <t t-set="category" t-value="cat"/>
-            </t>
+        <t t-foreach="store.discuss.allCategories" t-as="category" t-key="category.localId">
+            <DiscussSidebarCategory t-if="category.isVisible" category="category"/>
         </t>
-    </t>
-
-    <t t-name="mail.DiscussSidebarCategories.category">
-        <DiscussSidebarCategory category="category"/>
-        <t t-if="category.is_open">
-            <DiscussSidebarChannel t-foreach="category.channels.filter((channel) => channel.isDisplayInSidebar)" t-as="channel" t-key="channel.localId" channel="channel"/>
-        </t>
-        <DiscussSidebarChannel t-elif="store.discuss.thread?.channel?.in(category.channels)" channel="store.discuss.thread?.channel"/>
-        <DiscussSidebarChannel t-elif="store.discuss.thread?.parent_channel_id?.channel?.in(category.channels)" channel="store.discuss.thread.parent_channel_id.channel" />
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.js
@@ -1,5 +1,8 @@
+import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel";
 import { useHover } from "@mail/utils/common/hooks";
+
 import { Component } from "@odoo/owl";
+
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { useService } from "@web/core/utils/hooks";
@@ -7,7 +10,7 @@ import { useService } from "@web/core/utils/hooks";
 export class DiscussSidebarCategory extends Component {
     static template = "mail.DiscussSidebarCategory";
     static props = ["category"];
-    static components = { Dropdown };
+    static components = { DiscussSidebarChannel, Dropdown };
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
@@ -11,6 +11,13 @@
             </t>
         </Dropdown>
         <t t-else="" t-call="mail.DiscussSidebarCategory.main"/>
+        <div class="o-mail-DiscussSidebarCategory-channels">
+            <t t-if="category.is_open">
+                <DiscussSidebarChannel t-foreach="category.channels.filter((channel) => channel.isDisplayInSidebar)" t-as="channel" t-key="channel.localId" channel="channel"/>
+            </t>
+            <DiscussSidebarChannel t-elif="store.discuss.thread?.channel?.in(category.channels)" channel="store.discuss.thread?.channel"/>
+            <DiscussSidebarChannel t-elif="store.discuss.thread?.parent_channel_id?.channel?.in(category.channels)" channel="store.discuss.thread.parent_channel_id.channel" />
+        </div>
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.main">

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1199,9 +1199,9 @@ test("add and remove channel from favorites updates sidebar", async () => {
         channel_type: "channel",
     });
     const channelContainerSelector =
-        ".o-mail-DiscussSidebarCategory-channel + .o-mail-DiscussSidebarChannel-container";
+        ".o-mail-DiscussSidebarCategory-channel + .o-mail-DiscussSidebarCategory-channels";
     const favoriteContainerSelector =
-        ".o-mail-DiscussSidebarCategory-favorite + .o-mail-DiscussSidebarChannel-container";
+        ".o-mail-DiscussSidebarCategory-favorite + .o-mail-DiscussSidebarCategory-channels";
     const generalChannelSelector = ".o-mail-DiscussSidebarChannel:has(:text(General))";
     await start();
     await openDiscuss();


### PR DESCRIPTION
For an unknown reason, Owl is not able to properly render the channels in the sidebar in the correct order in some situations, in particular when categories are initially folded and then opened.

Some channels are pushed at the very bottom of the list instead of being right after their category.

This commit fixes the issue by wrapping the channels loop into a div, which helps Owl to reconcile the items properly. Other attempts such as adding various t-key have failed.

This also makes the DOM structure easier to understand as all the channels of the same category are now in a common parent element.

The opportunity is taken to move the channels into the category template itself rather than Categories (list) template.