### PR TITLE
[FIX] mail: prevent livechat close confirmation for non-members

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
@@ -30,6 +30,10 @@ const chatWindowPatch = {
                     super.close(...arguments);
                     break;
                 }
+                if (!this.thread.hasSelfAsMember) {
+                    super.close(...arguments);
+                    break;
+                }
                 if (this.thread.livechat_end_dt) {
                     if (isSelfVisitor) {
                         this.livechatStep = CW_LIVECHAT_STEP.FEEDBACK;

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -193,3 +193,22 @@ test("Show livechats with new message in chat hub even when in discuss app)", as
     await openFormView("res.partner", serverState.partnerId);
     await contains(".o-mail-ChatWindow-header:contains('Visitor 11')");
 });
+
+test("livechat: non-member can close immediately", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor ABC" });
+    const PartnerId = pyEnv["res.partner"].create({ name: "Agent" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: PartnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        livechat_operator_id: PartnerId,
+        channel_type: "livechat",
+    });
+    await start();
+    setupChatHub({ opened: [channelId] });
+    await contains(".o-mail-ChatWindow");
+    await click("[title*='Close Chat Window']");
+    await contains(".o-mail-ChatWindow", { count: 0 });
+});


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
When an internal user who is not a member of a livechat channel opens a chat
window for a conversation in “looking for help” mode, closing the window
incorrectly displays the Leave Conversation confirmation dialog.
This is misleading because non-members cannot actually end the livechat
session—the confirmation dialog suggests an action they do not have permission
to perform.

**Current behavior before PR:**
----------------------------------------------
- Non-member internal users see the close confirmation dialog
- The dialog implies they can leave/end the livechat, which is not true
- UI shows functionality that does not apply to them
- Poor user experience and inconsistent behavior

**Desired behavior after PR is merged:**
----------------------------------------------
- Confirmation dialog is shown only to actual livechat members(assigned agent or visitor)
- Non-members close the chat window immediately without any prompt
- UI accurately reflects real permissions
- Clearer and more consistent livechat experience

Task-5384846

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr
