### PR TITLE
[FIX] website,(_*): fine-tune solo dynamic snippets

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -45,7 +45,7 @@
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Cover Image" t-if="isSingleMode">
+    <BuilderRow label.translate="Cover Image" t-if="isSingleMode and !!showCoverImage?.()">
         <BuilderButtonGroup>
             <BuilderButton title.translate="Left" classAction="'s_dynamic_snippet_cover_left'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
             <BuilderButton title.translate="Right" classAction="''" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
@@ -66,4 +66,10 @@ export class DynamicSnippetBlogPostsOption extends BaseOptionComponent {
             "website_blog.dynamic_filter_template_blog_post_big_picture"
         );
     }
+    showCoverImage() {
+        return (
+            this.templateKeyState.templateKey ===
+            "website_blog.dynamic_filter_template_blog_post_single_aside"
+        );
+    }
 }

--- a/addons/website_event/static/src/website_builder/dynamic_snippet_events_option.js
+++ b/addons/website_event/static/src/website_builder/dynamic_snippet_events_option.js
@@ -1,4 +1,4 @@
-import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { useDynamicSnippetOption } from "@website/builder/plugins/options/dynamic_snippet_hook";
 
 export class DynamicSnippetEventsOption extends BaseOptionComponent {
@@ -9,5 +9,14 @@ export class DynamicSnippetEventsOption extends BaseOptionComponent {
         super.setup();
         const { getModelNameFilter } = this.dependencies.dynamicSnippetEventsOption;
         this.dynamicOptionParams = useDynamicSnippetOption(getModelNameFilter());
+        this.templateKeyState = useDomState((el) => ({
+            templateKey: el.dataset.templateKey,
+        }));
+    }
+    showCoverImage() {
+        return (
+            this.templateKeyState.templateKey ===
+            "website_event.dynamic_filter_template_event_event_single_aside"
+        );
     }
 }


### PR DESCRIPTION
*: blog, event

This PR fixes an issue about the `Cover Image` option being displayed even if the snippet doesn't come with any cover image.

task-5104447

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
