### PR TITLE
[IMP] html_builder, *: move theme colors into a sliding panel

### DIFF
--- a/addons/html_builder/static/src/core/builder_component_plugin.js
+++ b/addons/html_builder/static/src/core/builder_component_plugin.js
@@ -16,6 +16,7 @@ import { BuilderRange } from "./building_blocks/builder_range";
 import { BuilderContext } from "./building_blocks/builder_context";
 import { BasicMany2Many } from "./building_blocks/basic_many2many";
 import { BuilderMany2Many } from "./building_blocks/builder_many2many";
+import { BuilderOptionsSection } from "./building_blocks/builder_options_section";
 import { BuilderMany2One } from "./building_blocks/builder_many2one";
 import { ModelMany2Many } from "./building_blocks/model_many2many";
 import { Plugin } from "@html_editor/plugin";
@@ -42,6 +43,7 @@ export class BuilderComponentPlugin extends Plugin {
             BuilderFontFamilyPicker,
             BuilderRow,
             BuilderSlidingPanel,
+            BuilderOptionsSection,
             BuilderUrlPicker,
             Dropdown,
             DropdownItem,

--- a/addons/html_builder/static/src/core/building_blocks/builder_options_section.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_options_section.js
@@ -1,0 +1,10 @@
+import { Component } from "@odoo/owl";
+
+export class BuilderOptionsSection extends Component {
+    static template = "html_builder.BuilderOptionsSection";
+    static props = {
+        title: { type: String, optional: true },
+        containerClass: { type: String, optional: true },
+        slots: { type: Object, optional: true },
+    };
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_options_section.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_options_section.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.BuilderOptionsSection">
+    <div class="options-container mb-1" t-att-data-container-title="props.title" t-att-class="props.containerClass">
+        <div t-if="props.title" class="options-container-header d-flex align-items-center">
+            <span class="options-container-label ps-2 py-2" t-out="props.title"/>
+        </div>
+        <div class="we-bg-options-container pb-3">
+            <t t-slot="default"/>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.js
@@ -11,18 +11,14 @@ export class BuilderSlidingPanel extends Component {
     static props = {
         ...basicContainerBuilderComponentProps,
         label: { type: String, optional: false },
-        class: { type: String, optional: true },
-        icon: { type: String, optional: true },
-        textContent: { type: String, optional: true },
+        extraClasses: { type: String, optional: true },
         fullHeight: { type: Boolean, optional: true },
         darkBackground: { type: Boolean, optional: true },
         openByDefault: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },
     };
     static defaultProps = {
-        class: "btn-secondary",
-        icon: "fa-paint-brush",
-        textContent: "",
+        extraClasses: "",
         fullHeight: false,
         darkBackground: false,
         openByDefault: false,
@@ -36,8 +32,6 @@ export class BuilderSlidingPanel extends Component {
             optionContainerName: "",
         });
         onMounted(() => {
-            this.optionsContainerEls = document.querySelectorAll("div.options-container");
-
             const slidingPanelEl = this.slidingPanelRef.el;
             const optionsContainerEl = slidingPanelEl.closest("div.options-container");
             this.state.optionContainerName = optionsContainerEl.dataset.containerTitle;

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.scss
@@ -27,7 +27,7 @@
 
     // Dark
     &.hb-sliding-panel-dark {
-        .hb-sliding-panel-content {
+        .hb-sliding-panel-content, .hb-sliding-panel-header {
             background-color: $o-we-bg-darker;
         }
     }
@@ -60,8 +60,8 @@
 // The .options-container elements are hidden when a .hb-sliding-panel is opened 
 // in order to prevent the user from accessing them with keyboard navigation.
 // It is also required since we only use "position: absolute" while sliding.
-.o_customize_tab:has(.hb-sliding-panel.d-block) {
-    .options-container {
+[role="tabpanel"]:has(.hb-sliding-panel.d-block) {
+    :not(.hb-sliding-panel-content) > .options-container {
         display: none;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.xml
@@ -5,9 +5,9 @@
     <button t-ref="openButton"
         class="o-hb-btn btn"
         t-on-click="showSlidingPanel"
-        t-att-class="props.class + (props.textContent ? '' : ' fa ' + props.icon)"
+        t-att-class="props.extraClasses"
     >
-        <t t-out="props.textContent"/>
+        <t t-slot="default"/>
     </button>
     <div t-ref="slidingPanel"
         class="hb-sliding-panel mb-1 h-100 d-none"
@@ -23,7 +23,7 @@
                     </button>
                 </div>
             </div>
-            <t t-slot="default" close="this.hideSlidingPanel.bind(this)"/>
+            <t t-slot="content" close="this.hideSlidingPanel.bind(this)"/>
         </div>
     </div>
 </t>

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
@@ -5,20 +5,22 @@
     <BuilderRow label.translate="Shape">
         <div class="btn-group o-hb-button-group">
             <BuilderSlidingPanel
-                t-slot-scope="panel"
                 label.translate="Shape"
+                extraClasses="'btn-secondary'"
                 fullHeight="true"
-                darkBackground="true"
-                textContent="state.shapeName">
-                <BackgroundShapeSelector
-                    onClose="panel.close"
-                    shapeActionId="'setBackgroundShape'"
-                    buttonWrapperClassName="'o-hb-bg-shape-btn'"
-                    selectorTitle.translate="Background Shapes"
-                    shapeGroups="getBackgroundShapeGroups()"
-                    imgThroughDiv="true"
-                    getShapeUrl="getShapeStyleUrl"
-                />
+                darkBackground="true">
+                <t t-out="state.shapeName"/>
+                <t t-set-slot="content" t-slot-scope="panel">
+                    <BackgroundShapeSelector
+                        onClose="panel.close"
+                        shapeActionId="'setBackgroundShape'"
+                        buttonWrapperClassName="'o-hb-bg-shape-btn'"
+                        selectorTitle.translate="Background Shapes"
+                        shapeGroups="getBackgroundShapeGroups()"
+                        imgThroughDiv="true"
+                        getShapeUrl="getShapeStyleUrl"
+                    />
+                </t>
             </BuilderSlidingPanel>
             <BuilderButton 
                 title.translate="Remove the shape"

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.xml
@@ -5,18 +5,20 @@
     <BuilderRow label.translate="Shape">
         <div class="btn-group o-hb-button-group">
             <BuilderSlidingPanel
-                t-slot-scope="panel"
                 label.translate="Shape"
+                extraClasses="'btn-secondary'"
                 fullHeight="true"
-                darkBackground="true"
-                textContent="state.shapeLabel">
-                <ShapeSelector
-                    onClose="panel.close"
-                    shapeActionId="'setImageShape'"
-                    buttonWrapperClassName="'o-hb-img-shape-btn'"
-                    selectorTitle.translate="Shapes"
-                    shapeGroups="getFilteredGroups()"
-                />
+                darkBackground="true">
+                <t t-out="state.shapeLabel"/>
+                <t t-set-slot="content" t-slot-scope="panel">
+                    <ShapeSelector
+                        onClose="panel.close"
+                        shapeActionId="'setImageShape'"
+                        buttonWrapperClassName="'o-hb-img-shape-btn'"
+                        selectorTitle.translate="Shapes"
+                        shapeGroups="getFilteredGroups()"
+                    />
+                </t>
             </BuilderSlidingPanel>
             <BuilderButton
                 title.translate="Remove the shape"

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -201,3 +201,8 @@ span.o_force_ltr {
     font-family: inherit;
     font-size: 100%;
 }
+
+// Chess-like background
+.o_preview_alpha_background {
+    @extend %o-preview-alpha-background;
+}

--- a/addons/website/static/src/builder/plugins/theme/theme_advanced_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_advanced_option.js
@@ -1,16 +1,5 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
-import { useState } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
 
 export class ThemeAdvancedOption extends BaseOptionComponent {
     static template = "website.ThemeAdvancedOption";
-    static dependencies = ["themeTab"];
-    setup() {
-        super.setup();
-        this.grays = useState(this.dependencies.themeTab.getGrays());
-    }
-
-    getGrayTitle(grayCode) {
-        return _t("Gray %(grayCode)s", { grayCode });
-    }
 }

--- a/addons/website/static/src/builder/plugins/theme/theme_advanced_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_advanced_option.xml
@@ -16,58 +16,6 @@
         <BuilderRow label.translate="Google Map">
             <BuilderButton title.translate="Custom Key" action="'configureApiKey'">Custom Key</BuilderButton>
         </BuilderRow>
-        <BuilderRow label.translate="Status Colors">
-            <BuilderColorPicker title.translate="Success"
-                enabledTabs="['solid', 'custom']"
-                action="'customizeWebsiteColor'"
-                actionParam="{colorType: 'theme', mainParam: 'success'}"
-                selectedTab="'custom'"
-            />
-            <BuilderColorPicker title.translate="Info"
-                enabledTabs="['solid', 'custom']"
-                action="'customizeWebsiteColor'"
-                actionParam="{colorType: 'theme', mainParam: 'info'}"
-                selectedTab="'custom'"
-            />
-            <BuilderColorPicker title.translate="Warning"
-                enabledTabs="['solid', 'custom']"
-                action="'customizeWebsiteColor'"
-                actionParam="{colorType: 'theme', mainParam: 'warning'}"
-                selectedTab="'custom'"
-            />
-            <BuilderColorPicker title.translate="Error"
-                enabledTabs="['solid', 'custom']"
-                action="'customizeWebsiteColor'"
-                actionParam="{colorType: 'theme', mainParam: 'danger'}"
-                selectedTab="'custom'"
-            />
-        </BuilderRow>
-        <BuilderRow label.translate="Grays" fullRowToggler="true">
-            <div class="o_we_gray_preview d-flex w-100">
-	            <t t-foreach="[0,1,2,3,4,5,6,7,8]" t-as="i" t-key="i">
-	                <t t-set="grayCode" t-value="(9 - i) * 100"/>
-	                <span t-att-title="getGrayTitle(grayCode)"
-	                      t-attf-variable="#{grayCode}"
-	                      t-attf-class="o_we_user_value_widget o_we_gray_preview bg-#{grayCode}"
-	                      t-attf-style="background-color: {{grays[grayCode]}} !important"
-	                />
-	            </t>
-            </div>
-            <t t-set-slot="collapse">
-                <BuilderRow label.translate="Hue" level="1">
-                    <div class="o_we_slider_tint">
-	                    <BuilderRange action="'customizeGray'" actionParam="'gray-hue'"
-	                        min="0" max="359.9" step="0.1"
-	                    />
-                    </div>
-                </BuilderRow>
-                <BuilderRow label.translate="Saturation" level="1">
-                    <BuilderRange action="'customizeGray'" actionParam="'gray-extra-saturation'"
-                        step="0.1"
-                    />
-                </BuilderRow>
-            </t>
-        </BuilderRow>
     </BuilderContext>
 </t>
 

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
@@ -1,13 +1,16 @@
 import { onMounted } from "@odoo/owl";
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { getCSSVariableValue } from "@html_editor/utils/formatting";
+import { _t } from "@web/core/l10n/translation";
 
 export class ThemeColorsOption extends BaseOptionComponent {
     static template = "website.ThemeColorsOption";
+    static dependencies = ["themeTab"];
     setup() {
         super.setup();
         this.palettes = this.getPalettes();
         this.colorPresetToShow = this.env.colorPresetToShow;
+        this.grays = this.dependencies.themeTab.getGrays();
         this.state = useDomState(() => ({
             presets: this.getPresets(),
         }));
@@ -36,6 +39,10 @@ export class ThemeColorsOption extends BaseOptionComponent {
             palettes.push(palette);
         }
         return palettes;
+    }
+
+    getGrayTitle(grayCode) {
+        return _t("Gray %(grayCode)s", { grayCode });
     }
 
     getPresets() {

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.scss
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.scss
@@ -24,3 +24,28 @@
     }
 
 }
+
+.o-hb-theme-color-slider-btn {
+    position: relative;
+    min-height: unset;
+    height: 22px;
+
+    &::after {
+        content: "";
+        @include o-position-absolute(1px, 1px, 1px, 1px);
+        outline: 1px solid rgba(white, 0.5);
+        border-radius: 3px;
+    }
+
+    &:hover::after {
+        outline: 1px solid rgba(white, 0.65);
+    }
+
+    &:focus-visible::after {
+        outline: 1px solid var(--o-hb-btn-active-color, $o-we-color-accent);;
+    }
+}
+
+.hb-sliding-panel .o_cc_preview_wrapper:hover {
+    cursor: pointer;
+}

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -1,160 +1,230 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="website.ThemeColorsOption">
-        <BuilderContext preview="false">
-            <!-- TODO
-            <we-alert class="o_old_color_system_warning d-none mt-2">
-                It appears your website is still using the old color system of
-                Odoo 13.0 in some places. We made sure it is still working but
-                we recommend you to try to use the new color system, which is
-                still customizable.
-            </we-alert>-->
-            <BuilderRow>
-                <div class="d-flex flex-row gap-3 w-100 justify-content-between ps-2" style="height: 50px">
-                    <div class="d-flex flex-column h-100 justify-content-between">
-                        <span class="fst-italic">Main</span>
-                        <div class="d-flex flex-row gap-1">
-                            <BuilderColorPicker
-                                title="Primary"
-                                action="'customizeWebsiteColor'"
-                                actionParam="'o-color-1'"
-                                enabledTabs="['solid', 'custom']"
-                                selectedTab="'custom'"/>
-                            <BuilderColorPicker
-                                title="Secondary"
-                                action="'customizeWebsiteColor'"
-                                actionParam="'o-color-2'"
-                                enabledTabs="['solid', 'custom']"
-                                selectedTab="'custom'"/>
-                            <BuilderColorPicker
-                                action="'customizeWebsiteColor'"
-                                actionParam="'o-color-3'"
-                                enabledTabs="['solid', 'custom']"
-                                selectedTab="'custom'"/>
-                        </div>
+        <t t-name="website.ThemeColorsOption">
+            <BuilderRow label.translate="Colors">
+                <BuilderSlidingPanel
+                    label.translate="Colors"
+                    extraClasses="'btn-secondary p-0 d-flex o-hb-theme-color-slider-btn'"
+                    darkBackground="true"
+                    openByDefault="!!colorPresetToShow">
+                    <div class="d-flex w-100">
+                        <t t-foreach="[1,2,3,4,5]" t-as="i" t-key="i">
+                            <span class="flex-grow-1 o_preview_alpha_background"
+                                t-attf-style="background-color: var(--hb-cp-o-color-#{i}, transparent);">
+                            </span>
+                        </t>
                     </div>
-                    <div class="d-flex flex-column h-100 justify-content-between">
-                        <span class="fst-italic">Light &amp; Dark</span>
-                        <div class="d-flex flex-row gap-1">
-                            <BuilderColorPicker
-                                action="'customizeWebsiteColor'"
-                                actionParam="'o-color-4'"
-                                enabledTabs="['solid', 'custom']"
-                                selectedTab="'custom'"/>
-                            <BuilderColorPicker
-                                action="'customizeWebsiteColor'"
-                                actionParam="'o-color-5'"
-                                enabledTabs="['solid', 'custom']"
-                                selectedTab="'custom'"/>
-                        </div>
-                    </div>
-                    <div class="d-flex flex-column h-100">
-                        <div class="d-flex flex-column h-100 justify-content-center">
-                            <BuilderSelect action="'changeColorPalette'" actionParam="'color-palettes-name'" dropdownContainerClass="'o-color-palette-dropdown'">
-                                <t t-set-slot="fixedButton">
-                                    <Image class="'h-100'" src="'/website/static/src/img/snippets_options/palette.svg'"/>
-                                </t>
-                                <t t-foreach="palettes" t-as="palette" t-key="palette.name">
-                                    <BuilderSelectItem actionValue="`'${palette.name}'`">
-                                        <div class="o-color-palette-pill d-flex flex-row border rounded-pill overflow-hidden">
-                                            <t t-foreach="palette.colors" t-as="color" t-key="color">
-                                                <span class="w-100" t-attf-style="background-color: {{color}};"></span>
-                                            </t>
-                                        </div>
-                                    </BuilderSelectItem>
-                                </t>
-                            </BuilderSelect>
-                        </div>
-                    </div>
-                </div>
-            </BuilderRow>
-            <BuilderRow label.translate="Color Presets" expand="!!colorPresetToShow">
-                <div></div>     <!-- This is required, without it the row is not displayed at all -->
-                <t t-set-slot="collapse">
-                    <t t-foreach="state.presets" t-as="preset" t-key="preset.id">
-                        <BuilderRow t-slot-scope="row" initialExpandAnim="colorPresetToShow === preset.id">
-                            <div class="o_cc_preview_wrapper w-100" t-on-click="row.toggleCollapseContent">
-                                <div inert="" t-att-class="`o_cc${preset.id}`"
-                                     class="p-2 d-flex justify-content-between align-items-center ms-3">
-                                    <h3 class="m-0">
-                                        Title
-                                    </h3>
-                                    <p class="my-0 ms-3 me-auto">
-                                        Text
-                                    </p>
-                                    <button class="btn btn-primary btn-sm me-2">
-                                        Button
-                                    </button>
-                                    <button class="btn btn-secondary btn-sm">
-                                        Button
-                                    </button>
-                                </div>
-                            </div>
-                            <t t-set-slot="collapse">
-                                <BuilderRow label.translate="Background">
-                                    <BuilderColorPicker
-                                        enabledTabs="['solid', 'custom', 'gradient']"
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="{ mainParam: `o-cc${preset.id}-bg`, gradientColor: `o-cc${preset.id}-bg-gradient` }"
-                                    />
-                                </BuilderRow>
-                                <BuilderRow label.translate="Text">
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-text`"
-                                        enabledTabs="['solid', 'custom']"/>
-                                </BuilderRow>
-                                <BuilderRow label.translate="Headings">
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-headings`"
-                                        enabledTabs="['solid', 'custom']"/>
-                                    <t t-set-slot="collapse">
-                                        <t t-foreach="[2, 3, 4, 5, 6]" t-as="j" t-key="j">
-                                            <BuilderRow label="`Headings ${j}`">
+                    <t t-set-slot="content">
+                        <BuilderContext preview="false">
+                            <!-- TODO
+                            <we-alert class="o_old_color_system_warning d-none mt-2">
+                                It appears your website is still using the old color system of
+                                Odoo 13.0 in some places. We made sure it is still working but
+                                we recommend you to try to use the new color system, which is
+                                still customizable.
+                            </we-alert>-->
+                            <BuilderOptionsSection>
+                                <BuilderRow>
+                                    <div class="d-flex flex-row gap-3 w-100 justify-content-between ps-2" style="height: 50px">
+                                        <div class="d-flex flex-column h-100 justify-content-between">
+                                            <span class="fst-italic">Main</span>
+                                            <div class="d-flex flex-row gap-1">
+                                                <BuilderColorPicker
+                                                    title="Primary"
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="'o-color-1'"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    selectedTab="'custom'"/>
+                                                <BuilderColorPicker
+                                                    title="Secondary"
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="'o-color-2'"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    selectedTab="'custom'"/>
                                                 <BuilderColorPicker
                                                     action="'customizeWebsiteColor'"
-                                                    actionParam="`o-cc${preset.id}-h${j}`"
+                                                    actionParam="'o-color-3'"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    selectedTab="'custom'"/>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex flex-column h-100 justify-content-between">
+                                            <span class="fst-italic">Light &amp; Dark</span>
+                                            <div class="d-flex flex-row gap-1">
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="'o-color-4'"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    selectedTab="'custom'"/>
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="'o-color-5'"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    selectedTab="'custom'"/>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex flex-column h-100">
+                                            <div class="d-flex flex-column h-100 justify-content-center">
+                                                <BuilderSelect action="'changeColorPalette'" actionParam="'color-palettes-name'" dropdownContainerClass="'o-color-palette-dropdown'">
+                                                    <t t-set-slot="fixedButton">
+                                                        <Image class="'h-100'" src="'/website/static/src/img/snippets_options/palette.svg'"/>
+                                                    </t>
+                                                    <t t-foreach="palettes" t-as="palette" t-key="palette.name">
+                                                        <BuilderSelectItem actionValue="`'${palette.name}'`">
+                                                            <div class="o-color-palette-pill d-flex flex-row border rounded-pill overflow-hidden">
+                                                                <t t-foreach="palette.colors" t-as="color" t-key="color">
+                                                                    <span class="w-100" t-attf-style="background-color: {{color}};"></span>
+                                                                </t>
+                                                            </div>
+                                                        </BuilderSelectItem>
+                                                    </t>
+                                                </BuilderSelect>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </BuilderRow>
+                            </BuilderOptionsSection>
+                            <BuilderOptionsSection title.translate="Color Presets">
+                                <t t-foreach="state.presets" t-as="preset" t-key="preset.id">
+                                    <BuilderRow t-slot-scope="row" initialExpandAnim="colorPresetToShow === preset.id">
+                                        <div class="o_cc_preview_wrapper w-100" t-on-click="row.toggleCollapseContent">
+                                            <div inert="" t-att-class="`o_cc${preset.id}`"
+                                                class="p-2 d-flex justify-content-between align-items-center ms-3">
+                                                <h3 class="m-0">
+                                                    Title
+                                                </h3>
+                                                <p class="my-0 ms-3 me-auto">
+                                                    Text
+                                                </p>
+                                                <button class="btn btn-primary btn-sm me-2">
+                                                    Button
+                                                </button>
+                                                <button class="btn btn-secondary btn-sm">
+                                                    Button
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <t t-set-slot="collapse">
+                                            <BuilderRow label.translate="Background">
+                                                <BuilderColorPicker
+                                                    enabledTabs="['solid', 'custom', 'gradient']"
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="{ mainParam: `o-cc${preset.id}-bg`, gradientColor: `o-cc${preset.id}-bg-gradient` }"
+                                                />
+                                            </BuilderRow>
+                                            <BuilderRow label.translate="Text">
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-text`"
                                                     enabledTabs="['solid', 'custom']"/>
                                             </BuilderRow>
+                                            <BuilderRow label.translate="Headings">
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-headings`"
+                                                    enabledTabs="['solid', 'custom']"/>
+                                                <t t-set-slot="collapse">
+                                                    <t t-foreach="[2, 3, 4, 5, 6]" t-as="j" t-key="j">
+                                                        <BuilderRow label="`Headings ${j}`">
+                                                            <BuilderColorPicker
+                                                                action="'customizeWebsiteColor'"
+                                                                actionParam="`o-cc${preset.id}-h${j}`"
+                                                                enabledTabs="['solid', 'custom']"/>
+                                                        </BuilderRow>
+                                                    </t>
+                                                </t>
+                                            </BuilderRow>
+                                            <BuilderRow label.translate="Links">
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-link`"
+                                                    enabledTabs="['solid', 'custom']"/>
+                                            </BuilderRow>
+                                            <BuilderRow label.translate="Primary Buttons">
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-btn-primary`"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    tooltip.translate="Fill Color"/>
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-btn-primary-border`"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    tooltip.translate="Border Color"/>
+                                            </BuilderRow>
+                                            <BuilderRow label.translate="Secondary Buttons">
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-btn-secondary`"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    tooltip.translate="Fill Color"/>
+                                                <BuilderColorPicker
+                                                    action="'customizeWebsiteColor'"
+                                                    actionParam="`o-cc${preset.id}-btn-secondary-border`"
+                                                    enabledTabs="['solid', 'custom']"
+                                                    tooltip.translate="Border Color"/>
+                                            </BuilderRow>
                                         </t>
+                                    </BuilderRow>
+                                </t>
+                            </BuilderOptionsSection>
+                            <BuilderOptionsSection title.translate="Advanced">
+                                <BuilderRow label.translate="Status Colors">
+                                    <BuilderColorPicker title.translate="Success"
+                                        enabledTabs="['solid', 'custom']"
+                                        action="'customizeWebsiteColor'"
+                                        actionParam="{colorType: 'theme', mainParam: 'success'}"
+                                        selectedTab="'custom'"
+                                    />
+                                    <BuilderColorPicker title.translate="Info"
+                                        enabledTabs="['solid', 'custom']"
+                                        action="'customizeWebsiteColor'"
+                                        actionParam="{colorType: 'theme', mainParam: 'info'}"
+                                        selectedTab="'custom'"
+                                    />
+                                    <BuilderColorPicker title.translate="Warning"
+                                        enabledTabs="['solid', 'custom']"
+                                        action="'customizeWebsiteColor'"
+                                        actionParam="{colorType: 'theme', mainParam: 'warning'}"
+                                        selectedTab="'custom'"
+                                    />
+                                    <BuilderColorPicker title.translate="Error"
+                                        enabledTabs="['solid', 'custom']"
+                                        action="'customizeWebsiteColor'"
+                                        actionParam="{colorType: 'theme', mainParam: 'danger'}"
+                                        selectedTab="'custom'"
+                                    />
+                                </BuilderRow>
+                                <BuilderRow label.translate="Grays" fullRowToggler="true">
+                                    <div class="o_we_gray_preview d-flex w-100">
+                                        <t t-foreach="[0,1,2,3,4,5,6,7,8]" t-as="i" t-key="i">
+                                            <t t-set="grayCode" t-value="(9 - i) * 100"/>
+                                            <span t-att-title="getGrayTitle(grayCode)"
+                                                t-attf-variable="#{grayCode}"
+                                                t-attf-class="o_we_user_value_widget o_we_gray_preview bg-#{grayCode}"
+                                                t-attf-style="background-color: {{grays[grayCode]}} !important"
+                                            />
+                                        </t>
+                                    </div>
+                                    <t t-set-slot="collapse">
+                                        <BuilderRow label.translate="Hue" level="1">
+                                            <div class="o_we_slider_tint">
+                                                <BuilderRange action="'customizeGray'" actionParam="'gray-hue'"
+                                                    min="0" max="359.9" step="0.1"
+                                                />
+                                            </div>
+                                        </BuilderRow>
+                                        <BuilderRow label.translate="Saturation" level="1">
+                                            <BuilderRange action="'customizeGray'" actionParam="'gray-extra-saturation'"
+                                                step="0.1"
+                                            />
+                                        </BuilderRow>
                                     </t>
                                 </BuilderRow>
-                                <BuilderRow label.translate="Links">
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-link`"
-                                        enabledTabs="['solid', 'custom']"/>
-                                </BuilderRow>
-                                <BuilderRow label.translate="Primary Buttons">
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-btn-primary`"
-                                        enabledTabs="['solid', 'custom']"
-                                        tooltip.translate="Fill Color"/>
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-btn-primary-border`"
-                                        enabledTabs="['solid', 'custom']"
-                                        tooltip.translate="Border Color"/>
-                                </BuilderRow>
-                                <BuilderRow label.translate="Secondary Buttons">
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-btn-secondary`"
-                                        enabledTabs="['solid', 'custom']"
-                                        tooltip.translate="Fill Color"/>
-                                    <BuilderColorPicker
-                                        action="'customizeWebsiteColor'"
-                                        actionParam="`o-cc${preset.id}-btn-secondary-border`"
-                                        enabledTabs="['solid', 'custom']"
-                                        tooltip.translate="Border Color"/>
-                                </BuilderRow>
-                            </t>
-                        </BuilderRow>
+                            </BuilderOptionsSection>
+                        </BuilderContext>
                     </t>
-                </t>
+                </BuilderSlidingPanel>
             </BuilderRow>
-        </BuilderContext>
-    </t>
+        </t>
 </templates>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -68,18 +68,13 @@ export class ThemeTabPlugin extends Plugin {
         },
         theme_options: [
             withSequence(
-                OPTION_POSITIONS.COLORS,
-                this.getThemeOptionBlock("theme-colors", _t("Colors"), ThemeColorsOption)
-            ),
-            withSequence(
                 OPTION_POSITIONS.SETTINGS,
-                this.getThemeOptionBlock(
-                    "website-settings",
-                    _t("Website"),
+                this.getThemeOptionBlock("website-settings", _t("Website"), [
+                    ThemeColorsOption,
                     class ThemeWebsiteSettingsOption extends BaseOptionComponent {
                         static template = "website.ThemeWebsiteSettingsOption";
-                    }
-                )
+                    },
+                ])
             ),
             withSequence(
                 OPTION_POSITIONS.PARAGRAPH,
@@ -238,7 +233,10 @@ export class ThemeTabPlugin extends Plugin {
         el.dataset.name = name;
         this.document.body.appendChild(el); // Currently editingElement needs to be isConnected
 
-        options.selector = "*";
+        const optionsArray = Array.isArray(options) ? options : [options];
+        optionsArray.forEach((option) => {
+            option.selector = "*";
+        });
 
         return {
             id: id,
@@ -247,7 +245,7 @@ export class ThemeTabPlugin extends Plugin {
             headerMiddleButton: false,
             isClonable: false,
             isRemovable: false,
-            options: [options],
+            options: optionsArray,
             optionsContainerTopButtons: [],
             snippetModel: {},
         };

--- a/addons/website/static/tests/builder/theme_tab/palette.test.js
+++ b/addons/website/static/tests/builder/theme_tab/palette.test.js
@@ -26,6 +26,7 @@ test("theme tab: warning on palette change", async () => {
         styleContent: 'body { --has-customized-colors: "true"; }',
     });
     await contains(".o-snippets-tabs button[data-name=theme]").click();
+    await contains(".o-tab-content .o-hb-theme-color-slider-btn").click();
     await contains(
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();
@@ -64,6 +65,7 @@ test("theme tab: no warning on palette change", async () => {
 
     await setupWebsiteBuilder("");
     await contains(".o-snippets-tabs button[data-name=theme]").click();
+    await contains(".o-tab-content .o-hb-theme-color-slider-btn").click();
     await contains(
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -136,9 +136,13 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     ]);
 
     await contains('.o-snippets-tabs button[data-name="theme"]').click();
-    await contains('.o_theme_tab div[data-label="Color Presets"] button').click();
-    await contains('div[id^="builder_collapse_content_"] button').click();
-    await contains('div[data-label="Background"] .o_we_color_preview').click();
+    await contains(".o-tab-content .o-hb-theme-color-slider-btn").click();
+    await contains(
+        '.hb-sliding-panel-content button[aria-controls^="builder_collapse_content_"]'
+    ).click();
+    await contains(
+        '.hb-sliding-panel-content div[data-label="Background"] .o_we_color_preview'
+    ).click();
     await contains(".o-hb-colorpicker .custom-tab").click();
     await contains(".o_color_picker_inputs input.o_hex_input").edit("#77FF006E");
     await expect.waitForSteps([
@@ -146,9 +150,7 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         '/website/static/src/scss/options/user_values.scss {"o-cc1-bg-gradient":"null"}',
         "asset reload",
     ]);
-    const colorPresetEl = document.querySelector(
-        'div[id^="builder_collapse_content_"] .o_cc_preview_wrapper div'
-    );
+    const colorPresetEl = document.querySelector("div .o_cc_preview_wrapper div");
     const presetElStyles = window.getComputedStyle(colorPresetEl, "::before");
     expect(presetElStyles.backgroundImage).toInclude("transparent.png");
     expect(presetElStyles.backgroundSize).toBe("32px");

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -18,6 +18,11 @@ registerWebsitePreviewTour(
     () => [
         ...goToTheme(),
         {
+            content: "Open the theme color slider",
+            trigger: "button.o-hb-theme-color-slider-btn",
+            run: "click",
+        },
+        {
             content: "Toggle gray color palette",
             trigger: ".we-bg-options-container [data-label=Grays] div",
             run: "click",

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -9,7 +9,7 @@ registerWebsitePreviewTour(
     () => [
         ...goToTheme(),
         {
-            trigger: "div[data-container-title='Colors'] div.we-bg-options-container",
+            trigger: "div[data-container-title='Website'] div.we-bg-options-container",
         },
         {
             content: "Click on the empty 'DRAG BUILDING BLOCKS HERE' area.",

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -68,13 +68,13 @@ registerWebsitePreviewTour(
             run: checkFontSize,
         },
         {
-            content: "Open the color combinations area",
-            trigger: "div[data-label='Color Presets'] button",
+            content: "Open the theme color slider",
+            trigger: "button.o-hb-theme-color-slider-btn",
             run: "click",
         },
         {
             content: "Open a color combination",
-            trigger: "div[id^='builder_collapse_content'] button.o_hb_collapse_toggler",
+            trigger: "div[data-container-title='Color Presets'] button.o_hb_collapse_toggler",
             run: "click",
         },
         {

--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -201,479 +201,481 @@
             <t t-set="showImages" t-value="false"/>
         </t>
         <BuilderSlidingPanel
-            class="'btn-primary'"
             label.translate="Design"
+            extraClasses="'btn-primary fa fa-paint-brush'"
             openByDefault="props.openByDefault"
         >
-            <!-- Presets with images -->
-            <BuilderRow
-                label.translate="Preset"
-                tooltip.translate="Choose one pre-made preset and customise it as you wish"
-            >
-                <t t-call="website_sale.ProductsDesignPanelPresets">
-                    <t t-set="label">Presets</t>
-                    <t t-set="showImages" t-value="true"/>
-                </t>
-            </BuilderRow>
-
-            <div class="o_wsale_design_panel_section_title ps-2 pt-2 pb-1 fw-bold">General</div>
-            <hr class="mx-2 mt-0 mb-2"/>
-
-            <!-- Designs Map -->
-            <t
-                t-set="anyCatalog"
-                t-value="this.isActiveItem('wsale_design_thumbs_catalog') || this.isActiveItem('wsale_design_cards_catalog') || this.isActiveItem('wsale_design_chips_catalog') || this.isActiveItem('wsale_design_grid_catalog')"
-            />
-            <t
-                t-set="anyThumb"
-                t-value="this.isActiveItem('wsale_design_thumbs_catalog') || this.isActiveItem('wsale_design_thumbs_list')"
-            />
-            <t
-                t-set="anyCard"
-                t-value="this.isActiveItem('wsale_design_cards_catalog') || this.isActiveItem('wsale_design_cards_list')"
-            />
-            <t
-                t-set="catalogThumb"
-                t-value="this.isActiveItem('wsale_design_thumbs_catalog')"
-            />
-            <t
-                t-set="catalogChips"
-                t-value="this.isActiveItem('wsale_design_chips_catalog')"
-            />
-            <t
-                t-set="listCondensed"
-                t-value="this.isActiveItem('wsale_design_condensed_list')"
-            />
-            <t
-                t-set="catalogBento"
-                t-value="this.isActiveItem('wsale_design_bento_catalog')"
-            />
-
-            <BuilderRow
-                label.translate="Hover Effect"
-                t-if="anyThumb || anyCard || catalogThumb || catalogChips || listCondensed || (catalogPanel and this.isActiveItem('o_has_description_opt'))"
+            <t t-set-slot="content">
+                <!-- Presets with images -->
+                <BuilderRow
+                    label.translate="Preset"
+                    tooltip.translate="Choose one pre-made preset and customise it as you wish"
                 >
-                <BuilderSelect>
-                    <BuilderSelectItem
-                        classAction="''">
-                        None
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="anyThumb || listCondensed"
-                        classAction="'o_wsale_products_opt_hover_background'">
-                        Background
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="anyThumb || listCondensed"
-                        classAction="'o_wsale_products_opt_hover_background o_wsale_products_opt_hover_background_zoom'">
-                        Background Zoom
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="anyCard || catalogChips"
-                        classAction="'o_wsale_products_opt_hover_shadow_out'">
-                        Shadow-Out
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="anyCard || catalogChips"
-                        classAction="'o_wsale_products_opt_hover_shadow_in'">
-                        Shadow-In
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="anyCard || catalogChips"
-                        classAction="'o_wsale_products_opt_hover_border_primary'">
-                        Border-Primary
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="catalogPanel"
-                        classAction="'o_wsale_products_opt_hover_show_description'">
-                        Show description
-                    </BuilderSelectItem>
-                </BuilderSelect>
-            </BuilderRow>
-
-            <BuilderRow label.translate="Gap">
-                <BuilderRange
-                    t-if="props.recordName === 'wishlist_opt_products_design_classes'"
-                    action="'wishlistSetGap'"
-                    min="0"
-                    max="28"
-                    unit="'px'"
-                    displayRangeValue="true"
-                />
-                <BuilderRange
-                    t-else=""
-                    action="'setGap'"
-                    min="0"
-                    max="28"
-                    unit="'px'"
-                    displayRangeValue="true"
-                />
-            </BuilderRow>
-
-            <BuilderRow
-                label.translate="Roundness"
-                t-if="!this.isActiveItem('wsale_design_grid_catalog') &amp;&amp; !this.isActiveItem('wsale_design_grid_list')"
-            >
-                <BuilderRange
-                    max="5"
-                    action="'setClassRange'"
-                    actionParam="[
-                        'o_wsale_products_opt_rounded_0','o_wsale_products_opt_rounded_1',
-                        'o_wsale_products_opt_rounded_2','o_wsale_products_opt_rounded_3',
-                        'o_wsale_products_opt_rounded_4','o_wsale_products_opt_rounded_5'
-                    ]"
-                />
-            </BuilderRow>
-
-            <BuilderRow
-                label.translate="Colors"
-                tooltip.translate="Color combinations are defined in the Theme Tab"
-            >
-                <BuilderSelect t-if="!anyThumb and !this.isActiveItem('wsale_design_condensed_list') and !this.isActiveItem('wsale_design_list_large')">
-                    <BuilderSelectItem
-                        classAction="'.o_wsale_products_opt_cc o_wsale_products_opt_cc1'"
-                    >
-                        Theme Preset n&#176;1 (default)
-                    </BuilderSelectItem>
-                    <t t-foreach="[2, 3, 4, 5]" t-as="colorIndex" t-key="colorIndex_index">
-                        <BuilderSelectItem
-                            classAction="'o_wsale_products_opt_cc o_wsale_products_opt_cc' + colorIndex"
-                        >
-                            Theme Preset n&#176;<t t-out="colorIndex"/>
-                        </BuilderSelectItem>
+                    <t t-call="website_sale.ProductsDesignPanelPresets">
+                        <t t-set="label">Presets</t>
+                        <t t-set="showImages" t-value="true"/>
                     </t>
-                </BuilderSelect>
-            </BuilderRow>
-            <BuilderRow
-                label.translate="Overlay"
-                tooltip.translate="Opacity of the overlay"
-                level="1"
-                t-if="this.isActiveItem('wsale_design_showcase_list') || catalogBento"
-            >
-                <BuilderRange
-                    action="'setClassRange'"
-                    actionParam="[
-                        'o_wsale_products_opt_overlay_opacity_0',
-                        'o_wsale_products_opt_overlay_opacity_1',
-                        'o_wsale_products_opt_overlay_opacity_2',
-                        'o_wsale_products_opt_overlay_opacity_3',
-                        'o_wsale_products_opt_overlay_opacity_4',
-                        'o_wsale_products_opt_overlay_opacity_5',
-                        'o_wsale_products_opt_overlay_opacity_6',
-                        'o_wsale_products_opt_overlay_opacity_7',
-                        'o_wsale_products_opt_overlay_opacity_8',
-                        'o_wsale_products_opt_overlay_opacity_9',
-                        'o_wsale_products_opt_overlay_opacity_10'
-                    ]" max="10"/>
-            </BuilderRow>
+                </BuilderRow>
 
-            <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Text &amp; content</div>
-            <hr class="mx-2 mt-0 mb-2"/>
+                <div class="o_wsale_design_panel_section_title ps-2 pt-2 pb-1 fw-bold">General</div>
+                <hr class="mx-2 mt-0 mb-2"/>
 
-            <BuilderRow t-if="anyCatalog" label.translate="Alignment">
-                <BuilderButtonGroup classAction="">
-                    <BuilderButton
-                        classAction="''"
-                    >
-                        Regular
-                    </BuilderButton>
-                    <BuilderButton
-                        classAction="'o_wsale_products_opt_text_align_center'"
-                    >
-                        Center
-                    </BuilderButton>
-                </BuilderButtonGroup>
-            </BuilderRow>
+                <!-- Designs Map -->
+                <t
+                    t-set="anyCatalog"
+                    t-value="this.isActiveItem('wsale_design_thumbs_catalog') || this.isActiveItem('wsale_design_cards_catalog') || this.isActiveItem('wsale_design_chips_catalog') || this.isActiveItem('wsale_design_grid_catalog')"
+                />
+                <t
+                    t-set="anyThumb"
+                    t-value="this.isActiveItem('wsale_design_thumbs_catalog') || this.isActiveItem('wsale_design_thumbs_list')"
+                />
+                <t
+                    t-set="anyCard"
+                    t-value="this.isActiveItem('wsale_design_cards_catalog') || this.isActiveItem('wsale_design_cards_list')"
+                />
+                <t
+                    t-set="catalogThumb"
+                    t-value="this.isActiveItem('wsale_design_thumbs_catalog')"
+                />
+                <t
+                    t-set="catalogChips"
+                    t-value="this.isActiveItem('wsale_design_chips_catalog')"
+                />
+                <t
+                    t-set="listCondensed"
+                    t-value="this.isActiveItem('wsale_design_condensed_list')"
+                />
+                <t
+                    t-set="catalogBento"
+                    t-value="this.isActiveItem('wsale_design_bento_catalog')"
+                />
 
-            <BuilderRow
-                label.translate="Title Style"
-                tooltip.translate="Use auto values or force the link-color defined in the Theme Tab"
-            >
-                <BuilderSelect>
-                    <BuilderSelectItem
-                        classAction="''"
+                <BuilderRow
+                    label.translate="Hover Effect"
+                    t-if="anyThumb || anyCard || catalogThumb || catalogChips || listCondensed || (catalogPanel and this.isActiveItem('o_has_description_opt'))"
                     >
-                        Link Color
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_name_color_regular'"
-                    >
-                        Default Color
-                    </BuilderSelectItem>
-                </BuilderSelect>
-                <t t-set-slot="collapse">
-                    <BuilderRow label.translate="Bold" level="1">
-                        <BuilderCheckbox classAction="'o_wsale_products_opt_name_weight_bold'"/>
-                    </BuilderRow>
-                    <BuilderRow label.translate="Font Size" level="1">
+                    <BuilderSelect>
+                        <BuilderSelectItem
+                            classAction="''">
+                            None
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="anyThumb || listCondensed"
+                            classAction="'o_wsale_products_opt_hover_background'">
+                            Background
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="anyThumb || listCondensed"
+                            classAction="'o_wsale_products_opt_hover_background o_wsale_products_opt_hover_background_zoom'">
+                            Background Zoom
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="anyCard || catalogChips"
+                            classAction="'o_wsale_products_opt_hover_shadow_out'">
+                            Shadow-Out
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="anyCard || catalogChips"
+                            classAction="'o_wsale_products_opt_hover_shadow_in'">
+                            Shadow-In
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="anyCard || catalogChips"
+                            classAction="'o_wsale_products_opt_hover_border_primary'">
+                            Border-Primary
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="catalogPanel"
+                            classAction="'o_wsale_products_opt_hover_show_description'">
+                            Show description
+                        </BuilderSelectItem>
+                    </BuilderSelect>
+                </BuilderRow>
+
+                <BuilderRow label.translate="Gap">
+                    <BuilderRange
+                        t-if="props.recordName === 'wishlist_opt_products_design_classes'"
+                        action="'wishlistSetGap'"
+                        min="0"
+                        max="28"
+                        unit="'px'"
+                        displayRangeValue="true"
+                    />
+                    <BuilderRange
+                        t-else=""
+                        action="'setGap'"
+                        min="0"
+                        max="28"
+                        unit="'px'"
+                        displayRangeValue="true"
+                    />
+                </BuilderRow>
+
+                <BuilderRow
+                    label.translate="Roundness"
+                    t-if="!this.isActiveItem('wsale_design_grid_catalog') &amp;&amp; !this.isActiveItem('wsale_design_grid_list')"
+                >
+                    <BuilderRange
+                        max="5"
+                        action="'setClassRange'"
+                        actionParam="[
+                            'o_wsale_products_opt_rounded_0','o_wsale_products_opt_rounded_1',
+                            'o_wsale_products_opt_rounded_2','o_wsale_products_opt_rounded_3',
+                            'o_wsale_products_opt_rounded_4','o_wsale_products_opt_rounded_5'
+                        ]"
+                    />
+                </BuilderRow>
+
+                <BuilderRow
+                    label.translate="Colors"
+                    tooltip.translate="Color combinations are defined in the Theme Tab"
+                >
+                    <BuilderSelect t-if="!anyThumb and !this.isActiveItem('wsale_design_condensed_list') and !this.isActiveItem('wsale_design_list_large')">
+                        <BuilderSelectItem
+                            classAction="'.o_wsale_products_opt_cc o_wsale_products_opt_cc1'"
+                        >
+                            Theme Preset n&#176;1 (default)
+                        </BuilderSelectItem>
+                        <t t-foreach="[2, 3, 4, 5]" t-as="colorIndex" t-key="colorIndex_index">
+                            <BuilderSelectItem
+                                classAction="'o_wsale_products_opt_cc o_wsale_products_opt_cc' + colorIndex"
+                            >
+                                Theme Preset n&#176;<t t-out="colorIndex"/>
+                            </BuilderSelectItem>
+                        </t>
+                    </BuilderSelect>
+                </BuilderRow>
+                <BuilderRow
+                    label.translate="Overlay"
+                    tooltip.translate="Opacity of the overlay"
+                    level="1"
+                    t-if="this.isActiveItem('wsale_design_showcase_list') || catalogBento"
+                >
+                    <BuilderRange
+                        action="'setClassRange'"
+                        actionParam="[
+                            'o_wsale_products_opt_overlay_opacity_0',
+                            'o_wsale_products_opt_overlay_opacity_1',
+                            'o_wsale_products_opt_overlay_opacity_2',
+                            'o_wsale_products_opt_overlay_opacity_3',
+                            'o_wsale_products_opt_overlay_opacity_4',
+                            'o_wsale_products_opt_overlay_opacity_5',
+                            'o_wsale_products_opt_overlay_opacity_6',
+                            'o_wsale_products_opt_overlay_opacity_7',
+                            'o_wsale_products_opt_overlay_opacity_8',
+                            'o_wsale_products_opt_overlay_opacity_9',
+                            'o_wsale_products_opt_overlay_opacity_10'
+                        ]" max="10"/>
+                </BuilderRow>
+
+                <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Text &amp; content</div>
+                <hr class="mx-2 mt-0 mb-2"/>
+
+                <BuilderRow t-if="anyCatalog" label.translate="Alignment">
+                    <BuilderButtonGroup classAction="">
+                        <BuilderButton
+                            classAction="''"
+                        >
+                            Regular
+                        </BuilderButton>
+                        <BuilderButton
+                            classAction="'o_wsale_products_opt_text_align_center'"
+                        >
+                            Center
+                        </BuilderButton>
+                    </BuilderButtonGroup>
+                </BuilderRow>
+
+                <BuilderRow
+                    label.translate="Title Style"
+                    tooltip.translate="Use auto values or force the link-color defined in the Theme Tab"
+                >
+                    <BuilderSelect>
+                        <BuilderSelectItem
+                            classAction="''"
+                        >
+                            Link Color
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_name_color_regular'"
+                        >
+                            Default Color
+                        </BuilderSelectItem>
+                    </BuilderSelect>
+                    <t t-set-slot="collapse">
+                        <BuilderRow label.translate="Bold" level="1">
+                            <BuilderCheckbox classAction="'o_wsale_products_opt_name_weight_bold'"/>
+                        </BuilderRow>
+                        <BuilderRow label.translate="Font Size" level="1">
+                            <BuilderSelect>
+                                <BuilderSelectItem classAction="''">Responsive</BuilderSelectItem>
+                                <BuilderSelectItem classAction="'o_wsale_products_opt_name_size_body'">
+                                    Theme default
+                                </BuilderSelectItem>
+                            </BuilderSelect>
+                        </BuilderRow>
+                    </t>
+                </BuilderRow>
+
+                <BuilderRow label.translate="Description">
+                    <BuilderCheckbox id="'o_has_description_opt'" classAction="'o_wsale_products_opt_has_description'"/>
+                </BuilderRow>
+
+                <BuilderRow
+                    label.translate="Ratings"
+                    tooltip.translate="Needs 'Reviews' to be enabled in the Product Page"
+                >
+                    <BuilderCheckbox classAction="'o_wsale_products_opt_has_rating'"/>
+                </BuilderRow>
+
+                <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Images</div>
+                <hr class="mx-2 mt-0 mb-2"/>
+
+                <!--
+                    Fake controller to showcase the user that the option is locked to "16/9"
+                -->
+                <BuilderRow
+                    label.translate="Desktop Ratio"
+                    t-if="this.isActiveItem('wsale_design_showcase_list')"
+                    tooltip.translate="Desktop ratio in enforced with this design"
+                >
+                    <div class="d-content pe-none flex-grow-1 opacity-75">
                         <BuilderSelect>
-                            <BuilderSelectItem classAction="''">Responsive</BuilderSelectItem>
-                            <BuilderSelectItem classAction="'o_wsale_products_opt_name_size_body'">
-                                Theme default
+                            <BuilderSelectItem classAction="''">
+                                <span class="opacity-50">16/9</span>
                             </BuilderSelectItem>
                         </BuilderSelect>
-                    </BuilderRow>
-                </t>
-            </BuilderRow>
+                    </div>
+                </BuilderRow>
 
-            <BuilderRow label.translate="Description">
-                <BuilderCheckbox id="'o_has_description_opt'" classAction="'o_wsale_products_opt_has_description'"/>
-            </BuilderRow>
+                <t t-set="imageRatioLabel">Image Ratio</t>
 
-            <BuilderRow
-                label.translate="Ratings"
-                tooltip.translate="Needs 'Reviews' to be enabled in the Product Page"
-            >
-                <BuilderCheckbox classAction="'o_wsale_products_opt_has_rating'"/>
-            </BuilderRow>
+                <t t-set="imgRatios" t-value="[
+                    {
+                        label: 'WideScreen (16/9)',
+                        className: 'o_wsale_products_opt_thumb_16_9',
+                    },
+                    {
+                        label: 'Landscape (4/3)',
+                        className: 'o_wsale_products_opt_thumb_4_3',
+                    },
+                    {
+                        label: 'Horizontal (6/5)',
+                        className: 'o_wsale_products_opt_thumb_6_5',
+                    },
+                    {
+                        label: 'Default (1/1)',
+                        className: '',
+                    },
+                    {
+                        label: 'Portrait (4/5)',
+                        className: 'o_wsale_products_opt_thumb_4_5',
+                    },
+                    {
+                        label: 'Vertical (2/3)',
+                        className: 'o_wsale_products_opt_thumb_2_3',
+                    },
+                ]"/>
+                <t t-set="imgRatiosBento" t-value="[
+                    {
+                        label: 'Horizontal (6/5)', className: 'o_wsale_products_opt_thumb_6_5',
+                    },
+                    {
+                        label: 'Default (1/1)', className: '',
+                    },
+                    {
+                        label: 'Portrait (4/5)', className: 'o_wsale_products_opt_thumb_4_5',
+                    },
+                    {
+                        label: 'Vertical (2/3)', className: 'o_wsale_products_opt_thumb_2_3',
+                    },
+                ]"/>
 
-            <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Images</div>
-            <hr class="mx-2 mt-0 mb-2"/>
-
-            <!--
-                Fake controller to showcase the user that the option is locked to "16/9"
-            -->
-            <BuilderRow
-                label.translate="Desktop Ratio"
-                t-if="this.isActiveItem('wsale_design_showcase_list')"
-                tooltip.translate="Desktop ratio in enforced with this design"
-            >
-                <div class="d-content pe-none flex-grow-1 opacity-75">
+                <!-- Desktop/Image Ratio (visible for all except Showcase) -->
+                <BuilderRow
+                    label="this.isActiveItem('wsale_design_list_large') ? 'Desktop Ratio' : imageRatioLabel"
+                    t-if="!this.isActiveItem('wsale_design_showcase_list')"
+                >
                     <BuilderSelect>
-                        <BuilderSelectItem classAction="''">
-                            <span class="opacity-50">16/9</span>
-                        </BuilderSelectItem>
+                        <t t-set="currentRatios" t-value="catalogBento ? imgRatiosBento : imgRatios"/>
+                        <t t-foreach="currentRatios" t-as="imgRatio" t-key="imgRatio_index">
+                            <BuilderSelectItem classAction="imgRatio.className">
+                                <t t-out="imgRatio.label"/>
+                            </BuilderSelectItem>
+                        </t>
                     </BuilderSelect>
-                </div>
-            </BuilderRow>
-
-            <t t-set="imageRatioLabel">Image Ratio</t>
-
-            <t t-set="imgRatios" t-value="[
-                {
-                    label: 'WideScreen (16/9)',
-                    className: 'o_wsale_products_opt_thumb_16_9',
-                },
-                {
-                    label: 'Landscape (4/3)',
-                    className: 'o_wsale_products_opt_thumb_4_3',
-                },
-                {
-                    label: 'Horizontal (6/5)',
-                    className: 'o_wsale_products_opt_thumb_6_5',
-                },
-                {
-                    label: 'Default (1/1)',
-                    className: '',
-                },
-                {
-                    label: 'Portrait (4/5)',
-                    className: 'o_wsale_products_opt_thumb_4_5',
-                },
-                {
-                    label: 'Vertical (2/3)',
-                    className: 'o_wsale_products_opt_thumb_2_3',
-                },
-            ]"/>
-            <t t-set="imgRatiosBento" t-value="[
-                {
-                    label: 'Horizontal (6/5)', className: 'o_wsale_products_opt_thumb_6_5',
-                },
-                {
-                    label: 'Default (1/1)', className: '',
-                },
-                {
-                    label: 'Portrait (4/5)', className: 'o_wsale_products_opt_thumb_4_5',
-                },
-                {
-                    label: 'Vertical (2/3)', className: 'o_wsale_products_opt_thumb_2_3',
-                },
-            ]"/>
-
-            <!-- Desktop/Image Ratio (visible for all except Showcase) -->
-            <BuilderRow
-                label="this.isActiveItem('wsale_design_list_large') ? 'Desktop Ratio' : imageRatioLabel"
-                t-if="!this.isActiveItem('wsale_design_showcase_list')"
-            >
-                <BuilderSelect>
-                    <t t-set="currentRatios" t-value="catalogBento ? imgRatiosBento : imgRatios"/>
-                    <t t-foreach="currentRatios" t-as="imgRatio" t-key="imgRatio_index">
-                        <BuilderSelectItem classAction="imgRatio.className">
-                            <t t-out="imgRatio.label"/>
-                        </BuilderSelectItem>
+                    <t t-set-slot="collapse">
+                        <BuilderRow label.translate="Auto-crop" level="1">
+                            <BuilderCheckbox classAction="'o_wsale_products_opt_thumb_cover'"/>
+                        </BuilderRow>
                     </t>
-                </BuilderSelect>
-                <t t-set-slot="collapse">
-                    <BuilderRow label.translate="Auto-crop" level="1">
-                        <BuilderCheckbox classAction="'o_wsale_products_opt_thumb_cover'"/>
-                    </BuilderRow>
-                </t>
-            </BuilderRow>
+                </BuilderRow>
 
-            <!-- Mobile Ratio (visible for Showcase and List Large) -->
-            <BuilderRow
-                label.translate="Mobile Ratio"
-                t-if="this.isActiveItem('wsale_design_showcase_list') || this.isActiveItem('wsale_design_list_large')"
-            >
-                <BuilderSelect>
-                    <t t-foreach="imgRatios" t-as="imgRatio" t-key="imgRatio_index">
+                <!-- Mobile Ratio (visible for Showcase and List Large) -->
+                <BuilderRow
+                    label.translate="Mobile Ratio"
+                    t-if="this.isActiveItem('wsale_design_showcase_list') || this.isActiveItem('wsale_design_list_large')"
+                >
+                    <BuilderSelect>
+                        <t t-foreach="imgRatios" t-as="imgRatio" t-key="imgRatio_index">
+                            <BuilderSelectItem
+                                classAction="imgRatio.className ? imgRatio.className + '_mobile' : ''">
+                                <t t-out="imgRatio.label"/>
+                            </BuilderSelectItem>
+                        </t>
+                    </BuilderSelect>
+                </BuilderRow>
+
+                <BuilderRow label.translate="Hover Effect">
+                    <BuilderSelect>
                         <BuilderSelectItem
-                            classAction="imgRatio.className ? imgRatio.className + '_mobile' : ''">
-                            <t t-out="imgRatio.label"/>
+                            id="'wsale_products_opt_img_hover_none'"
+                            classAction="''">
+                            None
                         </BuilderSelectItem>
-                    </t>
-                </BuilderSelect>
-            </BuilderRow>
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_img_hover_zoom_in'">
+                            Zoom-In
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_img_hover_zoom_in_light'">
+                            Zoom-In Light
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_img_hover_zoom_out'">
+                            Zoom-Out
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_img_hover_zoom_out_light'">
+                            Zoom-Out Light
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="this.isActiveItem('wsale_design_thumbs_catalog')"
+                            classAction="'o_wsale_products_opt_img_hover_shadow'">
+                            Image Shadow
+                        </BuilderSelectItem>
+                    </BuilderSelect>
+                </BuilderRow>
 
-            <BuilderRow label.translate="Hover Effect">
-                <BuilderSelect>
-                    <BuilderSelectItem
-                        id="'wsale_products_opt_img_hover_none'"
-                        classAction="''">
-                        None
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_img_hover_zoom_in'">
-                        Zoom-In
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_img_hover_zoom_in_light'">
-                        Zoom-In Light
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_img_hover_zoom_out'">
-                        Zoom-Out
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_img_hover_zoom_out_light'">
-                        Zoom-Out Light
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="this.isActiveItem('wsale_design_thumbs_catalog')"
-                        classAction="'o_wsale_products_opt_img_hover_shadow'">
-                        Image Shadow
-                    </BuilderSelectItem>
-                </BuilderSelect>
-            </BuilderRow>
+                <BuilderRow
+                    t-if="props.showSecondaryImage &amp;&amp; !this.isActiveItem('wsale_design_showcase_list')"
+                    label.translate="Secondary Image"
+                    tooltip.translate="Needs at least two images to be defined in the Product Page"
+                >
+                    <BuilderCheckbox
+                        id="'wsale_products_opt_img_secondary_show'"
+                        classAction="'o_wsale_products_opt_img_secondary_show'"
+                    />
+                </BuilderRow>
 
-            <BuilderRow
-                t-if="props.showSecondaryImage &amp;&amp; !this.isActiveItem('wsale_design_showcase_list')"
-                label.translate="Secondary Image"
-                tooltip.translate="Needs at least two images to be defined in the Product Page"
-            >
-                <BuilderCheckbox
-                    id="'wsale_products_opt_img_secondary_show'"
-                    classAction="'o_wsale_products_opt_img_secondary_show'"
-                />
-            </BuilderRow>
+                <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Actions</div>
+                <hr class="mx-2 mt-0 mb-2"/>
 
-            <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Actions</div>
-            <hr class="mx-2 mt-0 mb-2"/>
+                <t t-set="isOnHoverAvailable" t-value="anyCatalog"/>
 
-            <t t-set="isOnHoverAvailable" t-value="anyCatalog"/>
+                <BuilderRow
+                    label.translate="Buttons"
+                    id="'o_wsale_buttons_opt'"
+                >
+                    <BuilderButton
+                        title.translate="Add to Cart"
+                        icon="'fa-shopping-cart'"
+                        classAction="'o_wsale_products_opt_has_cta'"
+                        id="'wsale_products_opt_add_to_cart'"
+                    />
+                    <BuilderButton
+                        t-if="props.recordName === 'shop_opt_products_design_classes'"
+                        title.translate="Compare"
+                        icon="'fa-exchange'"
+                        classAction="'o_wsale_products_opt_has_comparison'"
+                    />
+                    <span/><!-- Spacer -->
+                    <BuilderSelect t-if="isOnHoverAvailable || this.isActiveItem('wsale_design_bento_catalog')">
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_actions_inline'"
+                            id="'wsale_products_opt_actions_inline'"
+                        >
+                            Inline
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            id="'wsale_products_opt_actions_onhover'"
+                            classAction="'o_wsale_products_opt_actions_onhover o_wsale_products_opt_wishlist_fixed'"
+                        >
+                            On Hover
+                        </BuilderSelectItem>
+                    </BuilderSelect>
+                    <div t-else="" class="d-content pe-none flex-grow-1 opacity-75">
+                        <!--
+                            Fake controller to showcase the user that the option is locked to "Inline"
+                        -->
+                        <BuilderSelect>
+                            <BuilderSelectItem classAction="''">
+                                <span class="opacity-50">Inline</span>
+                            </BuilderSelectItem>
+                        </BuilderSelect>
+                    </div>
+                </BuilderRow>
 
-            <BuilderRow
-                label.translate="Buttons"
-                id="'o_wsale_buttons_opt'"
-            >
-                <BuilderButton
-                    title.translate="Add to Cart"
-                    icon="'fa-shopping-cart'"
-                    classAction="'o_wsale_products_opt_has_cta'"
-                    id="'wsale_products_opt_add_to_cart'"
-                />
-                <BuilderButton
+                <BuilderRow
                     t-if="props.recordName === 'shop_opt_products_design_classes'"
-                    title.translate="Compare"
-                    icon="'fa-exchange'"
-                    classAction="'o_wsale_products_opt_has_comparison'"
-                />
-                <span/><!-- Spacer -->
-                <BuilderSelect t-if="isOnHoverAvailable || this.isActiveItem('wsale_design_bento_catalog')">
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_actions_inline'"
-                        id="'wsale_products_opt_actions_inline'"
-                    >
-                        Inline
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        id="'wsale_products_opt_actions_onhover'"
-                        classAction="'o_wsale_products_opt_actions_onhover o_wsale_products_opt_wishlist_fixed'"
-                    >
-                        On Hover
-                    </BuilderSelectItem>
-                </BuilderSelect>
-                <div t-else="" class="d-content pe-none flex-grow-1 opacity-75">
-                    <!--
-                        Fake controller to showcase the user that the option is locked to "Inline"
-                    -->
-                    <BuilderSelect>
-                        <BuilderSelectItem classAction="''">
-                            <span class="opacity-50">Inline</span>
+                    label.translate="Wishlist"
+                    level="1"
+                >
+                    <BuilderButton
+                        title.translate="Wishlist"
+                        icon="'fa-heart'"
+                        classAction="'o_wsale_products_opt_has_wishlist'"
+                    />
+                    <BuilderSelect t-if="isOnHoverAvailable">
+                        <BuilderSelectItem
+                            classAction="''"
+                            t-if="this.isActiveItem('wsale_products_opt_actions_inline')"
+                        >
+                            Inline
+                        </BuilderSelectItem>
+                        <BuilderSelectItem classAction="'o_wsale_products_opt_wishlist_fixed'">
+                            Fixed
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            classAction="'o_wsale_products_opt_wishlist_fixed o_wsale_products_opt_wishlist_fixed_onhover'"
+                        >
+                            Fixed - On Hover
                         </BuilderSelectItem>
                     </BuilderSelect>
-                </div>
-            </BuilderRow>
+                    <div t-else="" class="d-content pe-none flex-grow-1 opacity-75">
+                        <!--
+                            Fake controller to showcase the user that the option is locked to "Inline"
+                        -->
+                        <BuilderSelect>
+                            <BuilderSelectItem classAction="''">
+                                <span class="opacity-50">Inline</span>
+                            </BuilderSelectItem>
+                        </BuilderSelect>
+                    </div>
+                </BuilderRow>
 
-            <BuilderRow
-                t-if="props.recordName === 'shop_opt_products_design_classes'"
-                label.translate="Wishlist"
-                level="1"
-            >
-                <BuilderButton
-                    title.translate="Wishlist"
-                    icon="'fa-heart'"
-                    classAction="'o_wsale_products_opt_has_wishlist'"
-                />
-                <BuilderSelect t-if="isOnHoverAvailable">
-                    <BuilderSelectItem
-                        classAction="''"
-                        t-if="this.isActiveItem('wsale_products_opt_actions_inline')"
-                    >
-                        Inline
-                    </BuilderSelectItem>
-                    <BuilderSelectItem classAction="'o_wsale_products_opt_wishlist_fixed'">
-                        Fixed
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        classAction="'o_wsale_products_opt_wishlist_fixed o_wsale_products_opt_wishlist_fixed_onhover'"
-                    >
-                        Fixed - On Hover
-                    </BuilderSelectItem>
-                </BuilderSelect>
-                <div t-else="" class="d-content pe-none flex-grow-1 opacity-75">
-                    <!--
-                        Fake controller to showcase the user that the option is locked to "Inline"
-                    -->
+                <BuilderRow label.translate="Style">
                     <BuilderSelect>
-                        <BuilderSelectItem classAction="''">
-                            <span class="opacity-50">Inline</span>
+                        <BuilderSelectItem classAction="'o_wsale_products_opt_actions_subtle'">
+                            Subtle
+                        </BuilderSelectItem>
+                        <t t-set=""> </t>
+                        <BuilderSelectItem
+                            t-if="this.isActiveItem('wsale_products_opt_add_to_cart')"
+                            classAction="'o_wsale_products_opt_actions_promote'">
+                            <div class="d-flex align-items-center">
+                                <span class="me-1">Promote</span>
+                                <i class="fa fa-shopping-cart ms-2"/>
+                            </div>
+                        </BuilderSelectItem>
+                        <BuilderSelectItem
+                            t-if="this.isActiveItem('wsale_products_opt_add_to_cart')"
+                            classAction="'o_wsale_products_opt_actions_theme'">
+                            Theme colors
                         </BuilderSelectItem>
                     </BuilderSelect>
-                </div>
-            </BuilderRow>
-
-            <BuilderRow label.translate="Style">
-                <BuilderSelect>
-                    <BuilderSelectItem classAction="'o_wsale_products_opt_actions_subtle'">
-                        Subtle
-                    </BuilderSelectItem>
-                    <t t-set=""> </t>
-                    <BuilderSelectItem
-                        t-if="this.isActiveItem('wsale_products_opt_add_to_cart')"
-                        classAction="'o_wsale_products_opt_actions_promote'">
-                        <div class="d-flex align-items-center">
-                            <span class="me-1">Promote</span>
-                            <i class="fa fa-shopping-cart ms-2"/>
-                        </div>
-                    </BuilderSelectItem>
-                    <BuilderSelectItem
-                        t-if="this.isActiveItem('wsale_products_opt_add_to_cart')"
-                        classAction="'o_wsale_products_opt_actions_theme'">
-                        Theme colors
-                    </BuilderSelectItem>
-                </BuilderSelect>
-            </BuilderRow>
+                </BuilderRow>
+            </t>
         </BuilderSlidingPanel>
     </BuilderRow>
 </t>


### PR DESCRIPTION
Before this commit the theme color settings were shown directly in the
"Theme" tab, making the Theme tab crowded.

After this commit the theme color options open in a sliding panel.

Steps to reproduce:

- Open the website editor.
- Go to the Theme tab.
- Open Colors and see the options now appear inside the sliding panel.

task-3919522