### PR TITLE
[FIX] hr: avoid access error for accountant with no hr access to employee_ids field

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -38,7 +38,7 @@ class Partner(models.Model):
     def _get_all_addr(self):
         self.ensure_one()
         employee_id = self.env['hr.employee'].search(
-            [('id', 'in', self.employee_ids.ids)],
+            [('id', 'in', self.sudo().employee_ids.ids)],
             limit=1,
         )
         if not employee_id:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
It is not possible to access batch payment orders if you are an accountant and are not at the same time in any HR security group.

**Current behavior before PR:**
Access Error for field `employee_ids`

**Desired behavior after PR is merged:**
Accessing is as expected.

Info: @wt-io-it

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
