### PR TITLE
[FIX] website: change the display mode for Images wall

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -372,7 +372,7 @@ class ImageGalleryOption extends Plugin {
             }
             clonedImgs.push(newImg);
         }
-        await Promise.all(imgLoaded);
+        await Promise.allSettled(imgLoaded);
         return { clonedImgs, imageToSelect };
     }
 

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -203,3 +203,28 @@ test("Cloning an image gallery should produce a unique ID", async () => {
     const imageCarousels = queryAll(":iframe .s_image_gallery .carousel");
     expect(imageCarousels[0].id).not.toEqual(imageCarousels[1].id);
 });
+
+test("Change gallery layout still works when img.decode() fails", async () => {
+    // to handle the Chrome bug where img.decode() can fail with "EncodingError:
+    // The source image cannot be decoded" when decoding many images simultaneously.
+    // See: https://bugs.chromium.org/p/chromium/issues/detail?id=1256288
+    // To reproduce the issue in the test we will set image src = "".
+    const builder = await setupWebsiteBuilderWithSnippet("s_images_wall");
+    // Change img source so decoding will fail
+    const images = queryAll(":iframe img");
+    images.forEach((imgEl) => {
+        imgEl.src = "";
+    });
+    await images.at(0).click();
+    await builder.waitSidebarUpdated();
+    await contains("[data-label='Mode'] .dropdown-toggle").click();
+
+    // This should NOT throw an error even img.decode() call will fail
+    await contains("[data-action-param='grid']").click();
+    await builder.waitSidebarUpdated();
+
+    // Verify the layout change worked despite decode failures
+    expect(":iframe .o_grid").toHaveCount(1);
+    expect(":iframe .o_masonry_col").toHaveCount(0);
+    expect("[data-label='Mode'] .dropdown-toggle").toHaveText("Grid");
+});


### PR DESCRIPTION
Steps to reproduce:
====================
- Go to the website in chrome
- Create a Image Wall (gallery)
- Add a lot of images. See attachments for a .zip file in task to test it.
- Try to change the display mode or number of column

-> An error will appear when the cursor get on the dropdown options.

Cause:
======
In Google Chrome, calling img.decode() on a large set of images simultaneously (e.g., in an image wall) can result in `EncodingError: The source image cannot be decoded for some images`. This is a known Chromium issue (See [1]) where the browser's image decoder gets overwhelmed or hits a concurrency limit, causing it to reject valid images.

The current implementation uses Promise.all(imgLoaded), which utilizes a "fail-fast" mechanism. Consequently, if a single image fails to decode due to this browser limitation, the entire promise rejects immediately. This unhandled rejection interrupts the execution flow, preventing the display mode or column options from functioning correctly when the user interacts with them.

Solution:
========
Replace `Promise.all(imgLoaded)` with `Promise.allSettled(imgLoaded)`.

Unlike `Promise.all`, `Promise.allSettled` waits for all promises to finish regardless of whether they succeeded or failed.

[1]: https://issues.chromium.org/issues/40261318

opw-5249130

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
