### PR TITLE
[FIX] website: handle save after footer visibility change without header

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -88,14 +88,20 @@ class WebsitePageConfigOptionPlugin extends Plugin {
         if (!this.isDirty) {
             return;
         }
-        const item = this.getVisibilityItem();
         const pageOptions = {
-            header_overlay: () => item === "overTheContent",
-            header_color: () => this.getColorValue("background-color", "bg-"),
-            header_text_color: () => this.getColorValue("color", "text-"),
-            header_visible: () => item !== "hidden",
             footer_visible: () => !this.getFooterVisibility(),
         };
+
+        const headerEl = this.document.querySelector("#wrapwrap > header");
+        if (headerEl) {
+            const item = this.getVisibilityItem();
+            Object.assign(pageOptions, {
+                header_overlay: () => item === "overTheContent",
+                header_color: () => this.getColorValue("background-color", "bg-"),
+                header_text_color: () => this.getColorValue("color", "text-"),
+                header_visible: () => item !== "hidden",
+            });
+        }
 
         const args = {};
         for (const [pageOptionName, valueGetter] of Object.entries(pageOptions)) {

--- a/addons/website/static/tests/builder/options/footer_option.test.js
+++ b/addons/website/static/tests/builder/options/footer_option.test.js
@@ -1,0 +1,45 @@
+import { expect, test } from "@odoo/hoot";
+import { contains, mockService, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("saving page after footer visibility change should work when header is not present", async () => {
+    mockService("website", {
+        get currentWebsite() {
+            return {
+                metadata: {
+                    mainObject: {
+                        model: "website.page",
+                        id: 4,
+                    },
+                },
+                default_lang_id: {
+                    code: "en_US",
+                },
+            };
+        },
+    });
+    await setupWebsiteBuilder("", {
+        beforeWrapwrapContent: `
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="header_overlay">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="header_color">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="header_text_color">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="header_visible">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="footer_visible">`,
+        footerContent: `
+            <footer data-name="Footer">Footer Content</footer>`,
+    });
+    onRpc("website.page", "write", ({ args }) => {
+        expect(args[1]).toEqual({
+            footer_visible: false,
+        });
+        return true;
+    });
+    await contains(":iframe #wrapwrap > footer").click();
+    await contains("[data-label='Page Visibility'] input").click();
+    await contains(".o-snippets-top-actions [data-action='save']").click();
+});

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -113,6 +113,7 @@ export async function setupWebsiteBuilder(
         versionControl = false,
         styleContent,
         headerContent = "",
+        footerContent = "",
         beforeWrapwrapContent = "",
         translateMode = false,
         onIframeLoaded = () => {},
@@ -136,7 +137,7 @@ export async function setupWebsiteBuilder(
         translateMode
             ? ""
             : `data-oe-model="ir.ui.view" data-oe-id="${setupWebsiteBuilderOeId}" data-oe-field="arch"`
-    }>${websiteContent}</div></div>`;
+    }>${websiteContent}</div> ${footerContent}</div>`;
     const iframeLoaded = new Promise((resolve) => {
         resolveIframeLoaded = async (el) => {
             const iframe = el;


### PR DESCRIPTION
### Issue:
- Saving the page after first hiding the header (from the Theme tab) and
  then the footer triggers an error.

### Steps to reproduce:
1. Open any website page and enter edit mode.
2. Make sure both the header and footer are visible.
3. From the 'Theme' tab, hide the header using the 'Show Header' option
   under 'Advanced'.
4. Select the footer and hide it using the 'Page Visibility' option.
5. Click on 'Save'.

### Reason:
- Header related page options are always evaluated during save, even
  when the header has been fully removed from the page by the 'Theme'
  tab option.
- This causes logic that depends on the header element to run while the
  element is no longer present in the DOM.

### Fix:
- Only compute and save header related page options when a header 
  element exists in the DOM.
- This prevents header visibility, color, and overlay logic from running
  when the header has been removed, avoiding the error during save.

task-[5135925](https://www.odoo.com/odoo/action-4043/5135925)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
