### PR TITLE
[PERF] mail: introduce discussAppAsThread inverse

### DIFF
--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -7,6 +7,7 @@ declare module "models" {
     export interface Thread {
         askLeaveConfirmation: (body: string) => Promise<void>;
         autoOpenChatWindowOnNewMessage: Readonly<boolean>;
+        discussAppAsThread: DiscussApp;
         inChathubOnNewMessage: Readonly<boolean>;
         setActiveURL: () => void;
         setAsDiscussThread: (pushState: boolean) => void;

--- a/addons/mail/static/src/core/public_web/discuss_app/client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/client_action.js
@@ -77,7 +77,7 @@ export class DiscussClientAction extends Component {
         }
         const [model, id] = parsedActiveId;
         const activeThread = await this.store["mail.thread"].getOrFetch({ model, id });
-        if (activeThread && activeThread.notEq(this.store.discuss.thread)) {
+        if (activeThread && !activeThread.discussAppAsThread) {
             const highlight_message_id =
                 props.action?.params?.highlight_message_id || router.current.highlight_message_id;
             if (highlight_message_id) {

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app.xml
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app.xml
@@ -12,7 +12,7 @@
 <t t-name="mail.MobileMailbox">
     <button class="btn btn-secondary flex-grow-1 p-2"
         t-att-class="{
-            'active o-active shadow-none': mailbox.eq(store.discuss.thread),
+            'active o-active shadow-none': mailbox.discussAppAsThread,
         }" t-on-click="mailbox.setAsDiscussThread" t-esc="mailbox.display_name"
     />
 </t>

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
@@ -11,6 +11,7 @@ export class DiscussApp extends Record {
     isSidebarCompact = fields.Attr(false, { localStorage: true });
     lastActiveId = fields.Attr(undefined, { localStorage: true });
     thread = fields.One("mail.thread", {
+        inverse: "discussAppAsThread",
         /** @this {import("models").DiscussApp} */
         onUpdate() {
             this._threadOnUpdate();

--- a/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
@@ -25,8 +25,8 @@
         <button
             class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 o-mx-2_5 border-0 rounded fw-normal text-reset"
             t-att-class="{
-                'bg-inherit': mailbox.notEq(store.discuss.thread),
-                'o-active': mailbox.eq(store.discuss.thread),
+                'bg-inherit': !mailbox.discussAppAsThread,
+                'o-active': mailbox.discussAppAsThread,
                 'justify-content-center position-relative o-compact py-2': store.discuss.isSidebarCompact,
                 'o-py-0_5': !store.discuss.isSidebarCompact,
                 'o-unread': mailbox.counter,

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -21,7 +21,7 @@ const threadPatch = {
             /** @this {import("models").Thread} */
             compute() {
                 if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
-                    return this.eq(this.store.discuss.thread);
+                    return Boolean(this.discussAppAsThread);
                 }
                 return false;
             },

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -60,8 +60,8 @@ export class DiscussSidebarChannel extends Component {
 
     get attClass() {
         return {
-            "bg-inherit": this.channel.notEq(this.store.discuss.thread?.channel),
-            "o-active": this.channel.eq(this.store.discuss.thread?.channel),
+            "bg-inherit": !this.channel.discussAppAsThread,
+            "o-active": this.channel.discussAppAsThread,
             "o-unread":
                 this.channel.self_member_id?.message_unread_counter > 0 &&
                 !this.channel.self_member_id?.mute_until_dt,
@@ -116,7 +116,7 @@ export class DiscussSidebarChannel extends Component {
     }
 
     showChannel(sub) {
-        if (sub.eq(this.store.discuss.thread?.channel)) {
+        if (sub.discussAppAsThread) {
             return true;
         }
         if (!this.channel.discussAppCategory.is_open) {
@@ -136,8 +136,8 @@ export class DiscussSidebarChannel extends Component {
 
     get isSelfOrThreadActive() {
         return (
-            this.channel.eq(this.store.discuss.thread?.channel) ||
-            this.store.discuss.thread?.channel?.in(this.subChannels)
+            this.channel.discussAppAsThread ||
+            this.subChannels.some((sub) => sub.discussAppAsThread)
         );
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
@@ -28,7 +28,7 @@
                 </svg>
             </t>
             <button class="o-mail-DiscussSidebarChannel-subChannel o-mail-DiscussSidebar-item btn btn-secondary border-0 bg-inherit d-flex flex-grow-1 smaller rounded-2 text-start text-truncate align-items-center" t-att-title="store.discuss.isSidebarCompact ? undefined : channel.displayName" t-on-click="(ev) => this.openChannel(ev, channel)" t-att-class="{
-                'o-active': channel.eq(this.store.discuss.thread?.channel),
+                'o-active': channel.discussAppAsThread,
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': store.discuss.isSidebarCompact,
                 'o-nonCompact me-1 pe-0 ps-1 o-py-0_5': !store.discuss.isSidebarCompact,
                 'o-unread': channel.self_member_id?.message_unread_counter > 0 and !channel.self_member_id?.mute_until_dt,

--- a/addons/mail/static/src/discuss/core/web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_channel_model_patch.js
@@ -5,11 +5,7 @@ import { patch } from "@web/core/utils/patch";
 const discussChannelPatch = {
     onPinStateUpdated() {
         super.onPinStateUpdated();
-        if (
-            !this.displayToSelf &&
-            !this.isLocallyPinned &&
-            this.eq(this.store.discuss.thread?.channel)
-        ) {
+        if (!this.displayToSelf && !this.isLocallyPinned && this.discussAppAsThread) {
             if (this.store.discuss.isActive) {
                 const newChannel =
                     this.store.discuss.channelCategory.channels.find(

--- a/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
+++ b/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
@@ -26,7 +26,7 @@ patch(DiscussCoreCommon.prototype, {
         this.store.history.messages = this.store.history.messages.filter(
             (msg) => !msg.thread?.eq(thread)
         );
-        if (thread.eq(this.store.discuss.thread)) {
+        if (thread.discussAppAsThread) {
             this.store.discuss.thread = undefined;
         }
         super._handleNotificationChannelDelete(thread, metadata);


### PR DESCRIPTION
All components/computes that compare discuss.thread to "current" thread have to rerender/recompute whenever the discuss.thread changes, even when they are not impacted by the change (when the result of the comparison does not change).

They should only rerender/recompute when the result of the comparison actually changes, which is when the discuss.thread changes to/from the thread in question.

This can be trivially fixed by making the inverse explicit and using it.