### PR TITLE
[FIX] website_slides: fix tour test_course_reviews_elearning_admin

### DIFF
--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -204,6 +204,7 @@ class TestUi(TestUICommon):
             'karma': 10,
             'group_ids': [(6, 0, (self.env.ref('base.group_user') | self.env.ref('website_slides.group_website_slides_officer')).ids)]
         })
+        self.user_admin.email = 'admin-test_course_reviews_elearning_admin@example.com'
         self.channel._action_add_members(user_demo.partner_id)
         self.channel.with_user(user_demo).message_post(
             body="Other user review",


### PR DESCRIPTION
We fix the tour test_course_reviews_elearning_admin that was failing when running it without demo data because user admin was posting a message on a channel without an email set on its partner. The same test works in version 18.0 and not in 18.2 because since 18.1, user admin no longer have an email by default (unless the demo data are installed, see odoo/odoo#185809).

To fix the test, we just set an email on the partner of user admin before posting the message.

Task-5418242