### PR TITLE
[IMP] account_peppol: Allow registering a branch as a parent

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -378,8 +378,7 @@ class AccountEdiProxyClientUser(models.Model):
         if self.company_id.account_peppol_proxy_state != 'not_registered':
             self._call_peppol_proxy(endpoint='/api/peppol/1/cancel_peppol_registration')
 
-        self.company_id.account_peppol_proxy_state = 'not_registered'
-        self.company_id.sudo().account_peppol_migration_key = False
+        self.company_id._reset_peppol_configuration()
         self.unlink()
 
     def _peppol_deregister_participant_to_sender(self):
@@ -397,7 +396,7 @@ class AccountEdiProxyClientUser(models.Model):
             self._call_peppol_proxy(endpoint='/api/peppol/1/unregister_to_sender')
 
         self.company_id.account_peppol_proxy_state = 'sender'
-        self.company_id.account_peppol_migration_key = False
+        self.company_id.sudo().account_peppol_migration_key = False
 
     @api.model
     def _peppol_auto_register_services(self, module):

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -72,16 +72,18 @@ class AccountMoveSend(models.AbstractModel):
                 'message': _("You can send this invoice electronically via Peppol."),
                 **what_is_peppol_alert,
             }
-        elif (peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, ['valid'])) and any_moves_not_sent_peppol:
-            # Check for not peppol partners that are on the network.
-            if len(peppol_not_selected_partners) == 1:
-                alerts['account_peppol_partner_want_peppol'] = {
-                    'message': _(
-                        "%s has requested electronic invoices reception on Peppol.",
-                        peppol_not_selected_partners.display_name
-                    ),
-                    **what_is_peppol_alert,
-                }
+        elif (
+            (peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, ['valid']))
+            and any_moves_not_sent_peppol
+            and len(peppol_not_selected_partners) == 1  # Check for not peppol partners that are on the network
+        ):
+            alerts['account_peppol_partner_want_peppol'] = {
+                'message': _(
+                    "%s has requested electronic invoices reception on Peppol.",
+                    peppol_not_selected_partners.display_name
+                ),
+                **what_is_peppol_alert,
+            }
         return alerts
 
     # -------------------------------------------------------------------------
@@ -201,8 +203,7 @@ class AccountMoveSend(models.AbstractModel):
         if not params['documents']:
             return
 
-        edi_user = next(iter(invoices_data)).company_id.account_edi_proxy_client_ids.filtered(
-            lambda u: u.proxy_type == 'peppol')
+        edi_user = next(iter(invoices_data)).company_id.account_peppol_edi_user
 
         try:
             response = edi_user._call_peppol_proxy(

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -9,11 +9,7 @@ from odoo.addons.account_peppol.tools.demo_utils import handle_demo
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    account_peppol_edi_user = fields.Many2one(
-        comodel_name='account_edi_proxy_client.user',
-        string='EDI user',
-        compute='_compute_account_peppol_edi_user',
-    )
+    account_peppol_edi_user = fields.Many2one(related='company_id.account_peppol_edi_user')
     account_peppol_edi_mode = fields.Selection(related='account_peppol_edi_user.edi_mode')
     account_peppol_contact_email = fields.Char(related='company_id.account_peppol_contact_email', readonly=False)
     account_peppol_eas = fields.Selection(related='company_id.peppol_eas', readonly=False)
@@ -23,22 +19,31 @@ class ResConfigSettings(models.TransientModel):
     account_peppol_phone_number = fields.Char(related='company_id.account_peppol_phone_number', readonly=False)
     account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state', readonly=False)
     account_peppol_purchase_journal_id = fields.Many2one(related='company_id.peppol_purchase_journal_id', readonly=False)
+    peppol_use_parent_company = fields.Boolean(compute='_compute_peppol_use_parent_company')
+    peppol_parent_company_name = fields.Char(compute='_compute_peppol_use_parent_company')
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
+
+    @api.depends('company_id.peppol_parent_company_id')
+    def _compute_peppol_use_parent_company(self):
+        for setting in self:
+            setting.peppol_use_parent_company = (
+                setting.company_id != setting.company_id.peppol_parent_company_id
+                and setting.company_id.peppol_can_send
+                and setting.company_id.peppol_parent_company_id.peppol_can_send
+            )
+            if setting.peppol_use_parent_company:
+                setting.peppol_parent_company_name = setting.company_id.peppol_parent_company_id.name
+            else:
+                setting.peppol_parent_company_name = None
 
     @api.depends('is_account_peppol_eligible', 'account_peppol_edi_user')
     def _compute_account_peppol_mode_constraint(self):
         mode_constraint = self.env['ir.config_parameter'].sudo().get_param('account_peppol.mode_constraint')
         trial_param = self.env['ir.config_parameter'].sudo().get_param('saas_trial.confirm_token')
         self.account_peppol_mode_constraint = trial_param and 'demo' or mode_constraint or 'prod'
-
-    @api.depends("company_id.account_edi_proxy_client_ids")
-    def _compute_account_peppol_edi_user(self):
-        for config in self:
-            config.account_peppol_edi_user = config.company_id.account_edi_proxy_client_ids.filtered(
-                lambda u: u.proxy_type == 'peppol')
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
@@ -103,6 +108,21 @@ class ResConfigSettings(models.TransientModel):
         Currently, reopening after migrating away is not supported.
         """
         raise UserError(_("This feature is deprecated. Contact Odoo support if you need a migration key."))
+
+    def button_peppol_disconnect_branch_from_parent(self):
+        self.ensure_one()
+        previous_parent_company_name = self.company_id.peppol_parent_company_id.name
+        self.account_peppol_edi_user._peppol_deregister_participant()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': None,
+                'type': 'success',
+                'message': _("Disconnected this branch company peppol configuration from %s.", previous_parent_company_name),
+                'next': {'type': 'ir.actions.act_window_close'},
+            }
+        }
 
     @handle_demo
     def button_deregister_peppol_participant(self):

--- a/addons/account_peppol/tests/common.py
+++ b/addons/account_peppol/tests/common.py
@@ -1,0 +1,148 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+from urllib.parse import parse_qs, quote_plus
+
+from odoo.tools import DotDict
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+ID_CLIENT = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+
+
+class PeppolConnectorCommon(AccountTestInvoicingCommon):
+
+    @staticmethod
+    def forge_id_client(company_id):
+        id_str = str(company_id).rjust(len(ID_CLIENT.split('x')) - 1, '0')
+        new_id_client_blocks = []
+        index = 0
+        for block in ID_CLIENT.split('-'):
+            new_id_client_blocks.append(id_str[index:index + len(block)])
+            index += len(block)
+        return '-'.join(new_id_client_blocks)
+
+    def _default_error_code(self):
+        return {'error': {'code': "spoutch", 'message': "failure"}}
+
+    def _empty_result_or_error(self, success=True):
+        if success:
+            return {'result': {}}
+        else:
+            return self._default_error_code()
+
+    def _mock_create_user(self, success=True):
+
+        def replacement_method(url, **kwargs):
+            if success:
+                company_id = kwargs['json']['params']['company_id']
+                return {
+                    'result': {
+                        'id_client': PeppolConnectorCommon.forge_id_client(company_id),
+                        'refresh_token': 'test_refresh_token'
+                    },
+                }
+            else:
+                return self._default_error_code()
+
+        return (
+            'https://peppol.test.odoo.com/iap/account_edi/2/create_user',
+            replacement_method,
+        )
+
+    def _mock_register_sender(self, success=True):
+        return (
+            'https://peppol.test.odoo.com/api/peppol/1/register_sender',
+            lambda url, **kwargs: self._empty_result_or_error(success=success),
+        )
+
+    def _mock_register_sender_as_receiver(self, success=True):
+        return (
+            'https://peppol.test.odoo.com/api/peppol/1/register_sender_as_receiver',
+            lambda url, **kwargs: self._empty_result_or_error(success=success),
+        )
+
+    def _mock_lookup_participant(self, already_exist=False):
+
+        def replacement_method(url, **kwargs):
+            if already_exist:
+                peppol_identifier = parse_qs(url.rsplit('?')[1])['peppol_identifier'][0]
+                return {
+                    'ok': True,
+                    'result': {
+                        "identifier": peppol_identifier,
+                        "smp_base_url": "http://example.com/smp",
+                        "ttl": 60,
+                        "service_group_url": "http://example.com/smp/iso6523-actorid-upis%3A%3A" + quote_plus(peppol_identifier),
+                        "services": [],
+                    },
+                }
+            else:
+                return {
+                    'status_code': 404,
+                    'error': {
+                        'code': "NOT_FOUND",
+                        'message': "no naptr record",
+                        'retryable': False,
+                    },
+                }
+
+        return (
+            'https://peppol.test.odoo.com/api/peppol/1/lookup',
+            replacement_method,
+        )
+
+    def _mock_participant_status(self, peppol_state):
+
+        def replacement_method(url, **kwargs):
+            assert peppol_state
+            return {
+                'result': {
+                    'peppol_state': peppol_state,
+                },
+            }
+
+        return (
+            'https://peppol.test.odoo.com/api/peppol/2/participant_status',
+            replacement_method,
+        )
+
+    def _mock_cancel_peppol_registration(self, success=True):
+        return (
+            'https://peppol.test.odoo.com/api/peppol/1/cancel_peppol_registration',
+            lambda url, **kwargs: self._empty_result_or_error(success=success),
+        )
+
+    def _mock_get_all_documents(self, success=True):
+        return (
+            'https://peppol.test.odoo.com/api/peppol/1/get_all_documents',
+            lambda url, **kwargs: self._empty_result_or_error(success=success),
+        )
+
+    def _mock_update_user(self, success=True):
+        return (
+            'https://peppol.test.odoo.com/api/peppol/1/update_user',
+            lambda url, **kwargs: self._empty_result_or_error(success=success),
+        )
+
+    @contextmanager
+    def _mock_requests(self, mocks_methods):
+        mocks = dict(mocks_methods)
+        called_urls = set()
+        mock_results = {'called': {}}
+
+        def mock_request(url, **kwargs):
+            for mocked_url, replacement_method in mocks.items():
+                if url.startswith(mocked_url):
+                    called_urls.add(mocked_url)
+                    mock_results['called'][mocked_url] = {
+                        'url': url,
+                        'kwargs': kwargs,
+                    }
+                    results = replacement_method(url, **kwargs)
+                    return DotDict({**results, 'json': lambda: results})
+            self.assertFalse(url, "Missing mock!")
+
+        with patch('requests.get', mock_request), patch('requests.post', mock_request):
+            yield mock_results
+
+        self.assertFalse([url for url in mocks if url not in called_urls], "Some mocks defined are not called at all.")

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -74,6 +74,18 @@ def _mock_call_peppol_proxy(func, self, *args, **kwargs):
         user.company_id.account_peppol_proxy_state = 'sender'
         return True
 
+    def _mock_participant_status(user, args, kwargs):
+        company = user.company_id
+        if (
+            company != company.peppol_parent_company_id
+            and company.peppol_can_send
+            and company.peppol_parent_company_id.peppol_can_send
+        ):
+            # Connected as a branch.
+            return {'peppol_state': 'sender'}
+        else:
+            return {'peppol_state': 'receiver'}
+
     endpoint = args[0].split('/')[-1]
     return {
         'ack': lambda _user, _args, _kwargs: {},
@@ -84,10 +96,11 @@ def _mock_call_peppol_proxy(func, self, *args, **kwargs):
         'unregister_to_sender': _mock_unregister_to_sender,
         'get_all_documents': _mock_get_all_documents,
         'get_document': _mock_get_document,
-        'participant_status': lambda _user, _args, _kwargs: {'peppol_state': 'receiver'},
+        'participant_status': _mock_participant_status,
         'send_document': _mock_send_document,
         'add_services': lambda _user, _args, _kwargs: {},
         'remove_services': lambda _user, _args, _kwargs: {},
+        'cancel_peppol_registration': lambda _user, _args, _kwargs: {},
     }[endpoint](self, args, kwargs)
 
 

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -7,20 +7,26 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='account_peppol_install']" position="replace">
                 <div id="account_peppol" class="col-12 o_setting_box">
+                    <field name="peppol_use_parent_company" invisible="1"/>
                     <div class="o_setting_right_pane border-0">
-                        <div invisible="account_peppol_proxy_state not in ('sender', 'receiver', 'smp_registration')">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'receiver', 'smp_registration')">
                             Your Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/> <field name="account_peppol_proxy_state" class="oe_inline o_form_label text-lowercase" readonly="1"/> invoices and credit notes.
                             <span class="ps-2" invisible="account_peppol_edi_mode == 'prod'">
                                 (<field class="oe_inline o_form_label text-uppercase" name="account_peppol_edi_mode" />)
                             </span>
                         </div>
-                        <div invisible="account_peppol_proxy_state != 'rejected'">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'rejected'">
                             You registration has been rejected, the reason has been sent to you via email.
                             Please contact our support if you need further assistance.
                         </div>
 
+                        <!-- Participant register as its parent company. -->
+                        <div invisible="not peppol_use_parent_company">
+                            You are sending from <field name="peppol_parent_company_name" class="oe_inline o_form_label" readonly="1"/>.
+                        </div>
+
                         <!-- The participant registered as a sender: display register as a receiver button, email, migration key field -->
-                        <div class="row" invisible="account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
+                        <div class="row" invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
                             <label string="Primary contact email"
                                    for="account_peppol_contact_email"
                                    class="col-lg-3 o_light_label"/>
@@ -28,7 +34,7 @@
                         </div>
 
                         <!-- The participant is waiting to be registered on the SMP -->
-                        <div invisible="account_peppol_proxy_state not in ('smp_registration', 'receiver')">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('smp_registration', 'receiver')">
                             <div class="row">
                                 <label string="Incoming Invoices Journal"
                                        for="account_peppol_purchase_journal_id"
@@ -44,7 +50,7 @@
                         </div>
 
                         <div class="mt-4"
-                             invisible="account_peppol_proxy_state != 'receiver'"
+                             invisible="peppol_use_parent_company or account_peppol_proxy_state != 'receiver'"
                              groups="base.group_no_one">
                             <div invisible="not account_peppol_migration_key">
                                 Your migration key is:
@@ -54,9 +60,8 @@
                             </div>
                         </div>
 
-
                         <!-- All action buttons -->
-                        <div invisible="account_peppol_proxy_state != 'receiver' or account_peppol_edi_mode == 'demo'">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'receiver' or account_peppol_edi_mode == 'demo'">
                             <!-- Note: Deprecated; the button is permanently invisible. -->
                             <!-- Disabling services can lead to complicance issues and is not necessary -->
                             <!-- since all existing services should just work. -->
@@ -69,7 +74,7 @@
                         </div>
 
                         <div class="d-flex gap-1 action_buttons" colspan="3">
-                            <div invisible="account_peppol_proxy_state not in ('not_registered', 'in_verification')">
+                            <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('not_registered', 'in_verification')">
                                 <div class="text-muted">
                                     Allow sending and receiving invoices through the PEPPOL network
                                 </div>
@@ -79,7 +84,15 @@
                                         class="oe_highlight mt-2"/>
                             </div>
                             <widget name="peppol_settings_buttons"
-                                    invisible="account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')"/>
+                                    invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')"/>
+                        </div>
+
+                        <!--Branch company connected to parent's active peppol connection.-->
+                        <div invisible="not peppol_use_parent_company" class="mt-2">
+                            <button string="Disconnect"
+                                    name="button_peppol_disconnect_branch_from_parent"
+                                    type="object"
+                                    class="btn-secondary me-1"/>
                         </div>
                     </div>
                 </div>

--- a/addons/account_peppol/wizard/peppol_registration_views.xml
+++ b/addons/account_peppol/wizard/peppol_registration_views.xml
@@ -8,14 +8,19 @@
             <form class="form_peppol_registration">
                 <field name="company_id" invisible="1"/>
                 <sheet>
-                    <div class="m-0" name="warnings" invisible="not peppol_warnings or account_peppol_proxy_state != 'not_registered'">
+                    <div class="m-0" name="warnings" invisible="not peppol_warnings">
                         <field name="peppol_warnings" class="o_field_html" widget="actionable_errors"/>
                     </div>
 
-                    <div name="peppol_registration" invisible="account_peppol_proxy_state not in ('not_registered', 'in_verification')">
-                        <p class="text-muted">Send electronic invoices, and receive bills automatically via Peppol</p>
-
-                            <!-- Optional step: receiver registration fields -->
+                    <div name="peppol_registration">
+                        <p class="text-muted" invisible="not use_parent_connection">
+                            This branch company will use the active Peppol connection found on
+                            <field name="parent_company_name" class="oe_inline o_form_label" readonly="1"/>
+                            and send invoices via Peppol on their behalf.
+                        </p>
+                        <p class="text-muted" invisible="use_parent_connection">
+                            Send electronic invoices, and receive bills automatically via Peppol.
+                        </p>
 
                         <group col="1">
                             <group>
@@ -25,9 +30,15 @@
                                        nolabel="1"
                                        widget="peppol_non_focusable_selection"
                                        class="o_field_peppol_eas_selection"/>
-                                <field name="peppol_endpoint" nolabel="1"/>
-                                <field name="contact_email" string="Email"/>
-                                <field name="phone_number" required="edi_mode not in ('demo', 'test')" string="Phone"/>
+                                <field name="peppol_endpoint"
+                                       nolabel="1"/>
+                                <field name="contact_email"
+                                       string="Email"
+                                       readonly="use_parent_connection"/>
+                                <field name="phone_number"
+                                       required="edi_mode not in ('demo', 'test')"
+                                       readonly="use_parent_connection"
+                                       string="Phone"/>
                             </group>
 
                             <!-- edi mode info -->


### PR DESCRIPTION
This commit implements the functionality to allow all branch company to
use Peppol.

With this commit, the user can register a branch company in the peppol
network in two ways:
- By setting the same EAS/Endpoint than the one set on the parent company,
the branch will be registered as a sender for the parent company.
- By setting another EAS/Endpoint than the one set on the parent company,
the branch will do a new registration.

task-4852830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
