### PR TITLE
[FIX] mail: restore paragraph bottom margin in chatter messages

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -78,7 +78,7 @@
         }
     }
 
-    & > p {
+    & > p:last-child {
         margin-bottom: 0 !important;
     }
 


### PR DESCRIPTION
Problem:
When adding a paragraph in the composer and sending the message, the paragraph posted in the chatter has a `margin-bottom` of 0.

Cause:
Paragraphs in the chatter rendering override the default bottom margin, resulting in inconsistent spacing compared to the composer and the sent email.

Solution:
Update selector to only target the last `p`.

Steps to reproduce:
- Open the chatter composer.
- Add a paragraph using "/Paragraph".
- Add some text.
- Send the message.
- Observe that the message posted in the chatter has no bottom margin, unlike in the composer.

opw-5378129

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
