### PR TITLE
[FIX] account: fix currency fetching after activation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6178,6 +6178,10 @@ class AccountMove(models.Model):
 
     def action_activate_currency(self):
         self.currency_id.filtered(lambda currency: not currency.active).write({'active': True})
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'reload',
+        }
 
     def action_delete_duplicates(self):
         for move in self:

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -751,7 +751,7 @@ export class ListRenderer extends Component {
                                 }
                                 if (currency !== currencyId) {
                                     fieldValues[i] *= currency
-                                        ? this.currencyRates[currency].rate
+                                        ? this.currencyRates[currency]?.rate
                                         : 1;
                                 }
                             }

--- a/addons/web/static/src/views/view_components/multi_currency_popover.js
+++ b/addons/web/static/src/views/view_components/multi_currency_popover.js
@@ -30,7 +30,7 @@ export class MultiCurrencyPopover extends Component {
 
     get currencies() {
         return this.props.currencyIds.reduce((currencies, currencyId) => {
-            if (currencyId && currencyId !== this.defaultCurrency) {
+            if (currencyId && currencyId !== this.defaultCurrency && getCurrency(currencyId)) {
                 currencies.push({
                     ...getCurrency(currencyId),
                     id: currencyId,


### PR DESCRIPTION
In the form view of invoices and bills, if the currency is changed to an inactive one, an option to activate it from the form view was available, but when the button is pressed the front-end doesn't receive the new data related to the currency which resulted in unexpected errors when trying to view the invoice/bill or the list of invoices/bills 
task-5412003