### PR TITLE
[FIX] pos_loyalty: prevent post processing draft orders

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -784,7 +784,9 @@ patch(PosStore.prototype, {
                     });
                 }
             }
-            await this._postProcessLoyalty(order);
+            if (!["draft", "cancel"].includes(order.state)) {
+                await this._postProcessLoyalty(order);
+            }
         }
     },
     async _postProcessLoyalty(order) {


### PR DESCRIPTION
Before this commit, when a draft order with point changes existed, syncing an order would trigger the post processing of all orders, including draft ones. This could lead to issues.

opw-5370267

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
