### PR TITLE
[FIX] web: Make kanban card dropdown items navigable and handle hover style

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_dropdown_menu_wrapper.js
+++ b/addons/web/static/src/views/kanban/kanban_dropdown_menu_wrapper.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useEffect, useRef } from "@odoo/owl";
 import { useDropdownCloser } from "@web/core/dropdown/dropdown_hooks";
 
 export class KanbanDropdownMenuWrapper extends Component {
@@ -9,6 +9,11 @@ export class KanbanDropdownMenuWrapper extends Component {
 
     setup() {
         this.dropdownControl = useDropdownCloser();
+        this.rootRef = useRef("rootRef");
+        useEffect(() => {
+            const dropdownEls = this.rootRef.el.querySelectorAll(".dropdown-item");
+            dropdownEls.forEach((el) => el.classList.add("o-navigable"));
+        });
     }
 
     onClick(ev) {

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -125,7 +125,7 @@
     </t>
 
     <t t-name="web.KanbanDropdownMenuWrapper">
-        <div t-on-click="onClick" style="display:contents">
+        <div t-on-click="onClick" style="display:contents" t-ref="rootRef">
             <t t-slot="default"/>
         </div>
     </t>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13645,3 +13645,41 @@ test("limit is reset when restoring a view after ungrouping", async () => {
     await switchView("kanban");
     expect.verifySteps(["limit=40"]);
 });
+
+test.tags("desktop");
+test("add o-navigable to buttons with dropdown-item class and view buttons", async () => {
+    Partner._records.splice(1, 3); // keep one record only
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="menu">
+                        <a role="menuitem" class="dropdown-item">Item</a>
+                        <a role="menuitem" type="set_cover" class="dropdown-item">Item</a>
+                        <a role="menuitem" type="object" class="dropdown-item">Item</a>
+                    </t>
+                    <t t-name="card">
+                        <div/>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o-dropdown--menu").toHaveCount(0);
+    await toggleKanbanRecordDropdown();
+    expect(".o-dropdown--menu .dropdown-item.o-navigable").toHaveCount(3);
+    expect(".o-dropdown--menu .dropdown-item.o-navigable.focus").toHaveCount(0);
+
+    // Check that navigation is working
+    await hover(".o-dropdown--menu .dropdown-item.o-navigable");
+    expect(".o-dropdown--menu .dropdown-item.o-navigable.focus").toHaveCount(1);
+
+    await press("arrowdown");
+    expect(".o-dropdown--menu .dropdown-item.o-navigable:nth-child(2)").toHaveClass("focus");
+
+    await press("arrowdown");
+    expect(".o-dropdown--menu .dropdown-item.o-navigable:nth-child(3)").toHaveClass("focus");
+});


### PR DESCRIPTION
Issue:
Dropdown item-ish (such as `<a class="dropdown-item">` and ViewButton) inside kanban cards dropdown do not have the proper hover styling and are not navigable.

Steps to reproduce:
- Go to project -> open any card dropdown menu ("...") -> Items are not navigable
- Go to CRM -> open any card dropdown menu ("...") -> Items are not highlighted on hover

Fix:
This commit adds the "o-navigable" class to dropdown items and view buttons
which are inside a kanban card's dropdown menu, this makes them navigable
and adds proper hover and focus styling.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
