### PR TITLE
[FIX] point_of_sale: differentiate between priceUnit and priceUnitExcl

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -72,6 +72,11 @@ export class PosOrderlineAccounting extends Base {
     get displayPriceUnitExcl() {
         return this.unitPrices.total_excluded;
     }
+    get displayPriceUnitNoDiscount() {
+        return this.config.iface_tax_included === "total"
+            ? this.unitPrices.no_discount_total_included
+            : this.unitPrices.no_discount_total_excluded;
+    }
 
     get priceIncl() {
         return this.currency.round(this.prices.total_included * this.order_id.orderSign);

--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -33,6 +33,9 @@ export class PosOrderlineAccounting extends Base {
     get currencyDisplayPriceUnit() {
         return formatCurrency(this.displayPriceUnit, this.currency.id);
     }
+    get currencyDisplayPriceUnitExcl() {
+        return formatCurrency(this.displayPriceUnitExcl, this.currency.id);
+    }
 
     /**
      * Display price depending on the tax configuration (included or excluded).
@@ -62,6 +65,11 @@ export class PosOrderlineAccounting extends Base {
               }, 0);
     }
     get displayPriceUnit() {
+        return this.config.iface_tax_included === "total"
+            ? this.unitPrices.total_included
+            : this.unitPrices.total_excluded;
+    }
+    get displayPriceUnitExcl() {
         return this.unitPrices.total_excluded;
     }
 
@@ -116,7 +124,7 @@ export class PosOrderlineAccounting extends Base {
 
     get comboTotalPriceWithoutTax() {
         const allLines = this.getAllLinesInCombo();
-        return allLines.reduce((total, line) => total + line.displayPriceUnit, 0);
+        return allLines.reduce((total, line) => total + line.displayPriceUnitExcl, 0);
     }
 
     get taxGroupLabels() {

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -508,8 +508,7 @@ export class PosOrder extends PosOrderAccounting {
                         orderLine.discount == 0
                     ) {
                         sum +=
-                            (orderLine.currencyDisplayPriceUnitExcl -
-                                orderLine.unitPrices.no_discount_total_included) *
+                            (orderLine.displayPriceUnit - orderLine.displayPriceUnitNoDiscount) *
                             orderLine.getQuantity();
                     }
                 }

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -508,7 +508,7 @@ export class PosOrder extends PosOrderAccounting {
                         orderLine.discount == 0
                     ) {
                         sum +=
-                            (orderLine.currencyDisplayPriceUnit -
+                            (orderLine.currencyDisplayPriceUnitExcl -
                                 orderLine.unitPrices.no_discount_total_included) *
                             orderLine.getQuantity();
                     }

--- a/addons/point_of_sale/static/tests/unit/accounting/discount.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/discount.test.js
@@ -24,9 +24,11 @@ test("Taxes object should contain no discount values", async () => {
     expectFormattedPrice(order.currencyDisplayPrice, "$ 1,237.00");
     expectFormattedPrice(order.currencyAmountTaxes, "$ 257.00");
     expectFormattedPrice(order.lines[0].currencyDisplayPrice, "$ 1,125.00");
-    expectFormattedPrice(order.lines[0].currencyDisplayPriceUnit, "$ 900.00");
+    expectFormattedPrice(order.lines[0].currencyDisplayPriceUnit, "$ 1,125.00");
+    expectFormattedPrice(order.lines[0].currencyDisplayPriceUnitExcl, "$ 900.00");
     expectFormattedPrice(order.lines[1].currencyDisplayPrice, "$ 112.00");
-    expectFormattedPrice(order.lines[1].currencyDisplayPriceUnit, "$ 80.00");
+    expectFormattedPrice(order.lines[1].currencyDisplayPriceUnit, "$ 112.00");
+    expectFormattedPrice(order.lines[1].currencyDisplayPriceUnitExcl, "$ 80.00");
 
     // First line (25% on 1000) - no discount
     expect(line1.no_discount_total_included).toBe(1250);

--- a/addons/point_of_sale/static/tests/unit/accounting/price.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/price.test.js
@@ -35,9 +35,11 @@ test("Prices includes", async () => {
     expectFormattedPrice(order.currencyDisplayPrice, "$ 1,390.00");
     expectFormattedPrice(order.currencyAmountTaxes, "$ 290.00");
     expectFormattedPrice(order.lines[0].currencyDisplayPrice, "$ 1,250.00");
-    expectFormattedPrice(order.lines[0].currencyDisplayPriceUnit, "$ 1,000.00");
+    expectFormattedPrice(order.lines[0].currencyDisplayPriceUnit, "$ 1,250.00");
+    expectFormattedPrice(order.lines[0].currencyDisplayPriceUnitExcl, "$ 1,000.00");
     expectFormattedPrice(order.lines[1].currencyDisplayPrice, "$ 140.00");
-    expectFormattedPrice(order.lines[1].currencyDisplayPriceUnit, "$ 100.00");
+    expectFormattedPrice(order.lines[1].currencyDisplayPriceUnit, "$ 140.00");
+    expectFormattedPrice(order.lines[1].currencyDisplayPriceUnitExcl, "$ 100.00");
 });
 
 test("Prices excludes", async () => {


### PR DESCRIPTION
Steps to reproduce
------------------
1. Set the PoS taxes display to tax-included
2. In PoS, add a product, change its quantity to 2, and change its price too

Notice that the new price / unit is shown as price excluded, even though we set the prices to tax-included in the PoS settings.

Reason
------
We were using the getter `currencyDisplayPriceUnit` which uses `displayPriceUnit` which always shows the price as `tax_exluded`.

Fix
---
Now we change `displayPriceUnit` to adapt to the `iface_tax_included` config in PoS. That follows well the convention used for the non-unit price getter, `displayPrice`.

For the cases where we want to explicitly use the tax excluded unit price, we have created the getters `displayPriceUnitExcl` and `currencyDisplayPriceUnitExcl` for that, which replaces some usages of the old getters.

opw-5405572
