### PR TITLE
[FIX] account_peppol: missing PDF in XML

### DIFF
--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
 from odoo.tools import cleanup_xml_node
 from odoo.tools.pdf import OdooPdfFileReader, OdooPdfFileWriter
 
@@ -21,8 +21,12 @@ class IrActionsReport(models.Model):
         custom_templates = [report.strip() for report in custom_templates.split(',')]
         return super()._is_invoice_report(report_ref) or self._get_report(report_ref).report_name in custom_templates
 
+    @api.model
+    def _get_edi_document_format_codes_for_pdf_embedding(self):
+        return ['ubl_bis3', 'ubl_de', 'nlcius_1', 'efff_1']
+
     def _add_pdf_into_invoice_xml(self, invoice, stream_data):
-        format_codes = ['ubl_bis3', 'ubl_de', 'nlcius_1', 'efff_1']
+        format_codes = self._get_edi_document_format_codes_for_pdf_embedding()
         edi_attachments = invoice.edi_document_ids.filtered(lambda d: d.edi_format_id.code in format_codes).sudo().attachment_id
         for edi_attachment in edi_attachments:
             old_xml = base64.b64decode(edi_attachment.with_context(bin_size=False).datas, validate=True)

--- a/addons/account_peppol/models/__init__.py
+++ b/addons/account_peppol/models/__init__.py
@@ -4,6 +4,7 @@ from . import account_edi_format
 from . import account_edi_proxy_user
 from . import account_journal
 from . import account_move
+from . import ir_actions_report
 from . import res_company
 from . import res_config_settings
 from . import res_partner

--- a/addons/account_peppol/models/ir_actions_report.py
+++ b/addons/account_peppol/models/ir_actions_report.py
@@ -1,0 +1,9 @@
+from odoo import api, models
+
+
+class IrActionsReport(models.Model):
+    _inherit = 'ir.actions.report'
+
+    @api.model
+    def _get_edi_document_format_codes_for_pdf_embedding(self):
+        return super()._get_edi_document_format_codes_for_pdf_embedding() + ['peppol']


### PR DESCRIPTION
Currently the PDF is not embedded into the XML files sent via Peppol.

This commit fixes that.
The PDF is embedded into the XML file at the point where the PDF is generated. It (re)uses the existing logic for other account EDI formats.

opw-5405357 (among others)