### PR TITLE
[FIX] hr_work_entry: don't try to find all conflict

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -166,6 +166,7 @@ class HrWorkEntry(models.Model):
                 FROM hr_work_entry
                 WHERE active = TRUE
                   AND date BETWEEN %(start)s AND %(stop)s
+                  AND employee_id IN %(employee_ids)s
                 GROUP BY employee_id, date
                 HAVING 0 >= SUM(duration) OR SUM(duration) > 24
             )
@@ -179,6 +180,7 @@ class HrWorkEntry(models.Model):
         self.env.cr.execute(query, {
             "start": start,
             "stop": stop,
+            'employee_ids': tuple(self.employee_id.ids),
         })
         conflict_ids = [row[0] for row in self.env.cr.fetchall()]
         self.browse(conflict_ids).write({'state': 'conflict'})


### PR DESCRIPTION
When you call _mark_conflicting_work_entries on work entries, it tries to find the conflict off all employees of all companies in the date range of your work entries.

We don't need to chek all of that and it causes access error when you try to write the conflict status on the other company work entries.

So, as the conflict we are trying to find are linked the work entries in self, we only check the ones of the employees of the work entries.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
