### PR TITLE
[IMP] html_builder, website: use arrow keys to navigate in tab panes

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -21,6 +21,9 @@
         'web._assets_primary_variables': [
             'html_builder/static/src/**/*.variables.scss',
         ],
+        'web.assets_backend': [
+            'html_builder/static/src/utils/keyboard_navigation.js',
+        ],
         # this bundle is lazy loaded when the editor is ready
         'html_builder.assets': [
             ('include', 'web._assets_helpers'),

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -8,6 +8,7 @@ import { closest } from "@web/core/utils/ui";
 import { useDragAndDrop } from "@html_editor/utils/drag_and_drop";
 import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { useSnippets } from "@html_builder/snippets/snippet_service";
+import { useMatrixKeyNavigation } from "@html_builder/utils/keyboard_navigation";
 import { Snippet } from "./snippet";
 import { CustomInnerSnippet } from "./custom_inner_snippet";
 
@@ -36,8 +37,16 @@ export class BlockTab extends Component {
         this.popover = useService("popover");
         this.snippetModel = useSnippets(this.props.snippetsName);
         this.blockTabRef = useRef("block-tab");
+        this.groupSnippetsContainer = useRef("group-snippets-container");
+        this.innerSnippetsContainer = useRef("inner-snippets-container");
         // Needed to avoid race condition in tours.
         this.state = useState({ ongoingInsertion: false });
+
+        this.onSnippetKeydown = useMatrixKeyNavigation(
+            () => [this.groupSnippetsContainer.el, this.innerSnippetsContainer.el],
+            ".o_snippet",
+            ".o_snippet_thumbnail_area, .o_install_btn"
+        );
 
         onMounted(() => {
             this.makeSnippetDraggable();
@@ -443,7 +452,7 @@ export class BlockTab extends Component {
      * Opens the corresponding snippet group dialog after the installation of a
      * newly installed snippet module.
      *
-     * @param {string} newInstalledModule - The JSON object containing title of 
+     * @param {string} newInstalledModule - The JSON object containing title of
      * the snippet group to open.
      */
     async handlePostModuleInstall(newInstalledModule) {

--- a/addons/html_builder/static/src/sidebar/block_tab.xml
+++ b/addons/html_builder/static/src/sidebar/block_tab.xml
@@ -10,11 +10,12 @@
          role="tabpanel"
          aria-labelledby="blocks-tab">
         <div t-if="this.snippetModel.snippetGroups.length" class="o_snippets_container" id="snippet_groups">
-            <div class="o_snippets_container_body o_snippets_container_body_row_cols_2">
+            <div t-custom-ref="group-snippets-container" class="o_snippets_container_body o_snippets_container_body_row_cols_2">
                 <t t-foreach="this.snippetModel.snippetGroups" t-as="snippet" t-key="snippet.id">
                     <Snippet snippet="snippet"
                              snippetModel="this.snippetModel"
                              onClickHandler="() => this.onSnippetGroupClick(snippet)"
+                             onSnippetKeydown="this.onSnippetKeydown"
                              disabledTooltip="disabledGroupTooltip"/>
                 </t>
             </div>
@@ -37,11 +38,12 @@
         <div t-if="this.snippetModel.snippetInnerContents.length"
             class="o_snippets_container" id="snippet_content">
             <div class="o_snippets_container_header"><span>Inner Content</span></div>
-            <div class="o_snippets_container_body">
+            <div t-custom-ref="inner-snippets-container" class="o_snippets_container_body">
                 <t t-foreach="this.snippetModel.snippetInnerContents" t-as="snippet" t-key="snippet.id">
                     <Snippet snippet="snippet"
                              snippetModel="this.snippetModel"
                              onClickHandler.bind="this.showSnippetTooltip"
+                             onSnippetKeydown="this.onSnippetKeydown"
                              disabledTooltip="disabledBlockTooltip"/>
                 </t>
             </div>

--- a/addons/html_builder/static/src/sidebar/snippet.js
+++ b/addons/html_builder/static/src/sidebar/snippet.js
@@ -8,6 +8,7 @@ export class Snippet extends Component {
         snippetModel: { type: Object },
         snippet: { type: Object },
         onClickHandler: { type: Function },
+        onSnippetKeydown: { type: Function },
         disabledTooltip: { type: String },
     };
 

--- a/addons/html_builder/static/src/sidebar/snippet.xml
+++ b/addons/html_builder/static/src/sidebar/snippet.xml
@@ -11,7 +11,7 @@
          t-on-mouseover="this.onInstallableHover"
          t-on-mouseout="this.onInstallableHover">
         <div class="o_snippet_thumbnail" t-att-data-snippet="this.snippet.name">
-            <button t-if="!this.snippet.isInstallable and !this.snippet.isDisabled" class="o_snippet_thumbnail_area" t-on-click="this.props.onClickHandler" title="Insert snippet"/>
+            <button t-if="!this.snippet.isInstallable and !this.snippet.isDisabled" class="o_snippet_thumbnail_area" t-on-click="this.props.onClickHandler" t-on-keydown="this.props.onSnippetKeydown" t-attf-aria-label="Insert {{this.snippet.title}} block"/>
             <Image t-if="this.snippet.isDisabled" src="'/html_builder/static/img/snippet_disabled.svg'" class="'o_snippet_undroppable'"/>
             <div class="o_snippet_thumbnail_img" t-attf-style="background-image: url({{this.snippet.thumbnailSrc}});"/>
             <span class="o_snippet_thumbnail_title" t-out="this.snippet.title"/>
@@ -19,6 +19,7 @@
                 t-if="this.snippet.isInstallable"
                 class="o_install_btn btn btn-success btn-lg position-absolute start-50 bottom-50 translate-middle-x visually-hidden-focusable z-1"
                 t-on-click="this.onClickInstall"
+                t-on-keydown="this.props.onSnippetKeydown"
                 >
                 Install
             </button>

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -187,6 +187,9 @@ export class AddSnippetDialog extends Component {
      */
     onIframeDocumentKeydown(ev) {
         const hotkey = getActiveHotkey(ev);
+        if (hotkey === "escape") {
+            this.env.dialogData.close({ dismiss: true });
+        }
         if (!["tab", "shift+tab"].includes(hotkey)) {
             return;
         }

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.scss
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.scss
@@ -33,6 +33,12 @@
 
             min-width: 200px;
             max-width: 250px;
+
+            .list-group-item:focus-visible {
+                box-shadow: inset 0 0 0 2px $o-we-handles-accent-color;
+                border-color: $o-we-handles-accent-color;
+                outline: none;
+            }
         }
     }
 

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -1,5 +1,6 @@
 import { useRef } from "@web/owl2/utils";
 import { Component, markup } from "@odoo/owl";
+import { useMatrixKeyNavigation } from "@html_builder/utils/keyboard_navigation";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
@@ -24,6 +25,11 @@ export class SnippetViewer extends Component {
         this.dialog = useService("dialog");
         this.content = useRef("content");
         this.backendDirection = localization.direction;
+
+        this.handleMatrixKeyNavigation = useMatrixKeyNavigation(
+            () => [this.content.el],
+            ".o_snippet_preview_wrap"
+        );
     }
 
     /**
@@ -134,6 +140,7 @@ export class SnippetViewer extends Component {
         if (hotkey === "enter" || hotkey === "space") {
             this.onClick(snippet);
         }
+        this.handleMatrixKeyNavigation(ev);
     }
 
     getContent(elem) {

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -3,10 +3,16 @@
 
 
 <t t-name="html_builder.SnippetViewer">
+    <div id="o_snippet_viewer_description" class="visually-hidden">
+        Navigate around the blocks with <kbd>Tab</kbd> or the arrow keys. Select with <kbd>Enter</kbd> or <kbd>Space</kbd>.
+    </div>
     <div t-custom-ref="content"
          class="row g-0 o_snippets_preview_row"
          t-att-class="{ 'flex-row-reverse': this.props.frontendDirection !== this.backendDirection }"
-         t-att-dir="this.props.frontendDirection">
+         t-att-dir="this.props.frontendDirection"
+         role="application"
+         aria-roledescription="Block Viewer"
+         aria-describedby="o_snippet_viewer_description">
         <div class="col-lg-6" t-foreach="this.getSnippetColumns()" t-as="snippetsColumn" t-key="snippetsColumn_index">
             <t t-foreach="snippetsColumn" t-as="snippet" t-key="snippet.id">
                 <div t-on-click="() => this.onClick(snippet)"
@@ -15,6 +21,7 @@
                      t-att-data-label="snippet.label ? snippet.label : ''"
                      t-attf-class="o_snippet_preview_wrap position-relative #{ snippet.isCustom ? 'mb-0' : '' } #{snippet.moduleId ? 'o_snippet_preview_install' : '' }"
                      t-att-tabindex="snippet.moduleId ? '-1' : '0'"
+                     t-att-role="snippet.moduleId ? undefined : 'button'"
                      t-att-aria-label="snippet.label || snippet.title">
                     <div inert="inert">
                         <div t-if="snippet.imagePreviewSrc" class="s_dialog_preview s_dialog_preview_image">

--- a/addons/html_builder/static/src/utils/keyboard_navigation.js
+++ b/addons/html_builder/static/src/utils/keyboard_navigation.js
@@ -1,0 +1,157 @@
+import { onMounted, onPatched } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { localization } from "@web/core/l10n/localization";
+
+/**
+ * Makes a 2D matrix of elements from left to right and from top to bottom.
+ *
+ * @param {HTMLElement} containerEl
+ * @param {string} selector - selector for descendants of containerEl
+ * @returns {Array<Array<HTMLElement>>} matrix
+ */
+function makeElementsPositionMatrix(containerEl, selector) {
+    const leftMap = new Map();
+    for (const el of containerEl.querySelectorAll(selector)) {
+        if (!leftMap.has(el.offsetLeft)) {
+            leftMap.set(el.offsetLeft, [el]);
+        } else {
+            leftMap.get(el.offsetLeft).push(el);
+        }
+    }
+    const matrix = [...leftMap.keys()]
+        .sort((a, b) => a - b)
+        .map((leftPos) => leftMap.get(leftPos).sort((a, b) => a.offsetTop - b.offsetTop));
+
+    return matrix;
+}
+
+/**
+ * Handles navigation keys (arrows, home, end, page up, page down) on a 2D
+ * layout.
+ *
+ * @param {KeyboardEvent} ev
+ * @param {Object} options
+ * @param {Array<Array<HTMLElement>>} options.matrix - 2D navigation matrix
+ * @param {HTMLElement} options.activeMatrixEl - currently active matrix sibling
+ * @param {string} [options.focusableChildSelector] - selector used if the
+ * actual focusable element is a child of `activeMatrixEl`
+ */
+function handleMatrixKeyNavigation(ev, { matrix, activeMatrixEl, focusableChildSelector }) {
+    const hotkey = getActiveHotkey(ev);
+
+    if (
+        [
+            "arrowup",
+            "arrowdown",
+            "arrowleft",
+            "arrowright",
+            "home",
+            "end",
+            "pagedown",
+            "pageup",
+        ].includes(hotkey)
+    ) {
+        ev.preventDefault(); // Do not scroll.
+        let nextActiveMatrixEl;
+        const elMatrixColIdx = matrix.findIndex((col) => col.includes(activeMatrixEl));
+        if (["home", "end"].includes(hotkey)) {
+            const isRTL = localization.direction === "rtl";
+            const firstCol = isRTL ? matrix.at(-1) : matrix[0];
+            const lastCol = isRTL ? matrix[0] : matrix.at(-1);
+            nextActiveMatrixEl = hotkey === "home" ? firstCol[0] : lastCol.at(-1);
+        } else if (["arrowup", "arrowdown"].includes(hotkey)) {
+            const elMatrixColumn = matrix[elMatrixColIdx];
+            const elIdx = elMatrixColumn.indexOf(activeMatrixEl);
+            if (hotkey === "arrowup") {
+                nextActiveMatrixEl = elMatrixColumn[Math.max(elIdx - 1, 0)];
+            } else if (hotkey === "arrowdown") {
+                nextActiveMatrixEl = elMatrixColumn[Math.min(elIdx + 1, elMatrixColumn.length - 1)];
+            }
+        } else if (["arrowleft", "arrowright"].includes(hotkey)) {
+            const rect = activeMatrixEl.getBoundingClientRect();
+            let nextCol;
+            if (hotkey === "arrowleft") {
+                if (elMatrixColIdx === 0) {
+                    return;
+                }
+                nextCol = matrix[elMatrixColIdx - 1];
+            } else if (hotkey === "arrowright") {
+                if (elMatrixColIdx === matrix.length - 1) {
+                    return;
+                }
+                nextCol = matrix[elMatrixColIdx + 1];
+            }
+            nextActiveMatrixEl = nextCol.findLast(
+                (el) => rect.y + rect.height / 2 >= el.getBoundingClientRect().y
+            );
+        } else if (["pageup", "pagedown"].includes(hotkey)) {
+            // The default behavior is weird in this context, but implementing
+            // a behavior that makes sense (e.g. focus the last visible element
+            // and scroll) is complex for little use. Accessibility patterns of
+            // similar usecases don't seem to take these keys into account.
+            return;
+        }
+        if (focusableChildSelector) {
+            nextActiveMatrixEl = nextActiveMatrixEl.querySelector(focusableChildSelector);
+        }
+        const reducedMotion = browser.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        nextActiveMatrixEl.scrollIntoView({
+            block: "nearest",
+            behavior: reducedMotion ? "instant" : "smooth",
+        });
+        nextActiveMatrixEl.focus();
+    }
+}
+
+/**
+ * @param {() => HTMLElement[]} getContainerEls - common container ancestors
+ * (one per matrix group)
+ * @param {string} matrixSiblingSelector - selector to target the elements
+ * to use for the navigation logic (i.e. the elements whose siblings make up the
+ * masonry layout). The selector will be queried both up
+ * (`ev.currentTarget.closest`) and down (`containerEl.querySelectorAll`).
+ * @param {string} [focusableChildSelector] - selector used if the actual
+ * actual focusable element is a child of `matrixSiblingSelector`
+ * @returns {(ev: KeyboardEvent) => void} keydown event handler
+ */
+export function useMatrixKeyNavigation(
+    getContainerEls,
+    matrixSiblingSelector,
+    focusableChildSelector
+) {
+    const matrices = new WeakMap();
+
+    onMounted(() => {
+        for (const containerEl of getContainerEls()) {
+            const matrix = makeElementsPositionMatrix(containerEl, matrixSiblingSelector);
+            matrices.set(containerEl, matrix);
+        }
+    });
+
+    onPatched(() => {
+        for (const containerEl of getContainerEls()) {
+            if (
+                !matrices.has(containerEl) ||
+                !matrices.get(containerEl).flat().length !==
+                    containerEl.querySelectorAll(matrixSiblingSelector).length ||
+                !matrices.get(containerEl)[0][0].isConnected
+            ) {
+                const matrix = makeElementsPositionMatrix(containerEl, matrixSiblingSelector);
+                matrices.set(containerEl, matrix);
+            }
+        }
+    });
+
+    return (ev) => {
+        const currentContainerEl = getContainerEls().find((containerEl) =>
+            containerEl.contains(ev.currentTarget)
+        );
+        const activeMatrixEl = ev.currentTarget.closest(matrixSiblingSelector);
+        handleMatrixKeyNavigation(ev, {
+            matrix: matrices.get(currentContainerEl),
+            activeMatrixEl,
+            focusableChildSelector,
+        });
+    };
+}

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -6,6 +6,7 @@ import { renderToElement } from "@web/core/utils/render";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { WebsiteDialog } from "@website/components/dialog/dialog";
+import { useMatrixKeyNavigation } from "@html_builder/utils/keyboard_navigation";
 import { Switch } from "@html_editor/components/switch/switch";
 import {
     applyTextHighlight,
@@ -59,6 +60,7 @@ class AddPageTemplateBlank extends Component {
             type: Boolean,
             optional: true,
         },
+        onPageKeydown: { type: Function },
     };
 
     setup() {
@@ -88,6 +90,7 @@ class AddPageTemplatePreview extends Component {
             type: Boolean,
             optional: true,
         },
+        onPageKeydown: { type: Function },
     };
 
     setup() {
@@ -95,6 +98,7 @@ class AddPageTemplatePreview extends Component {
         this.iframeRef = useRef("iframe");
         this.previewRef = useRef("preview");
         this.holderRef = useRef("holder");
+
         this.resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
                 const targetEl = entry.target.querySelector(".o_text_highlight") || entry.target;
@@ -307,6 +311,13 @@ class AddPageTemplatePreviews extends Component {
 
     setup() {
         super.setup();
+        this.container = useRef("previews-container");
+
+        this.onPageKeydown = useMatrixKeyNavigation(
+            () => [this.container.el],
+            ".o_page_template",
+            ".o_button_area"
+        );
     }
 
     get columns() {

--- a/addons/website/static/src/components/dialog/add_page_dialog.scss
+++ b/addons/website/static/src/components/dialog/add_page_dialog.scss
@@ -12,6 +12,12 @@
 
             min-width: 200px;
             max-width: 250px;
+
+            .list-group-item:focus-visible {
+                box-shadow: inset 0 0 0 2px $o-we-handles-accent-color;
+                border-color: $o-we-handles-accent-color;
+                outline: none;
+            }
         }
     }
 
@@ -69,6 +75,7 @@
             opacity: 0;
             outline: $border-width * 2 solid $o-we-handles-accent-color;
             outline-offset: $border-width * -1;
+            box-shadow: none;
         }
 
         &:empty {

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -22,7 +22,7 @@
     <div t-custom-ref="holder" class="o_page_template position-relative placeholder-glow mx-auto transition-base" t-att-class="{ 'mt-4': !this.props.firstRow }" t-att-data-configurator-page="this.props.template and this.props.template.is_from_configurator">
         <div t-custom-ref="preview" class="o_page_template_preview border border-white bg-white rounded" t-out="0" inert="inert"/>
         <span class="placeholder position-absolute top-0 w-100 h-100 rounded" t-attf-style="animation-duration: #{this.props.animationDelay + 500}ms"/>
-        <button class="btn o_button_area position-absolute top-0 w-100 h-100 start-0 cursor-pointer rounded" t-on-click="this.select">
+        <button class="btn o_button_area position-absolute top-0 w-100 h-100 start-0 cursor-pointer rounded" t-on-click="this.select" t-on-keydown="this.props.onPageKeydown">
             <div t-if="this.props.template and this.props.template.name" class="position-absolute start-0 bottom-100 w-100 fw-bold lh-1 pb-1 pe-none text-center o_page_name" t-out="this.props.template.name"/>
         </button>
     </div>
@@ -48,7 +48,7 @@
 
 <t t-name="website.AddPageTemplatePreviews">
     <div class="container-fluid py-3 py-xl-4">
-        <div class="row g-0">
+        <div class="row g-0" t-custom-ref="previews-container">
             <div t-if="this.props.isCustom and !this.props.templates.length" class="col-12 alert alert-info d-flex">
                 <i class="fa fa-2x fa-info-circle me-3"/>
                 To add your page to this category, open the page properties: "Site -&gt; Properties".<br/>
@@ -57,10 +57,11 @@
             <t t-foreach="[...this.columns.entries()]" t-as="column" t-key="column[0]">
                 <div class="col-lg-4 col-12">
                     <t t-foreach="[...column[1].entries()]" t-as="template" t-key="template[0]">
-                        <AddPageTemplateBlank t-if="template[1].isBlank" firstRow="template_first"/>
+                        <AddPageTemplateBlank t-if="template[1].isBlank" firstRow="template_first" onPageKeydown="this.onPageKeydown"/>
                         <AddPageTemplatePreview t-else="" template="template[1]" firstRow="template_first"
                             animationDelay="(column_index * 500) + (template_index * 350)"
                             isCustom="this.props.isCustom"
+                            onPageKeydown="this.onPageKeydown"
                         />
                     </t>
                     <t t-if="column[1].length === 0">
@@ -100,7 +101,13 @@
                     </t>
                 </div>
             </aside>
-            <div t-custom-ref="panes" class="position-relative flex-grow-1 flex-shrink-1 bg-200">
+            <div t-custom-ref="panes" class="position-relative flex-grow-1 flex-shrink-1 bg-200"
+                 role="application"
+                 aria-roledescription="New page template"
+                 aria-describedby="o_page_templates_pane_description">
+                <div id="o_page_templates_pane_description" class="visually-hidden">
+                    Navigate around the blocks with <kbd>Tab</kbd> or the arrow keys. Select with <kbd>Enter</kbd> or <kbd>Space</kbd>.
+                </div>
                 <t t-foreach="this.state.pages" t-as="page" t-key="page.id">
                     <div t-att-data-id="page.id"
                         t-att-id="'pane_' + page.id"


### PR DESCRIPTION
The tab panes of the AddSnippetDialog and the AddPageDialog, as well as
the snippets blocks in the sidebar, would benefit from a proper keyboard
navigation. Since [9ae02d8], the snippets and page layouts are tabable.
But when there are many snippets or layouts, an approach using the
arrows would be more practical and intuitive, as it uses a masonry
layout.

The logic makes sure to handle both LTR and RTL languages.

[9ae02d8]: https://github.com/odoo/odoo/commit/9ae02d80894d4043e49d8e2cad068f8018e6f113

task-5109547