### PR TITLE
[FIX] website_sale: allow enabling gmc with 5000+ published products

### DIFF
--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -223,11 +223,7 @@ class ProductFeed(models.Model):
         }
 
     def _get_feed_product_domain(self):
-        product_domain = Domain.AND([
-            Domain('is_published', '=', True),
-            Domain('type', 'in', ('consu', 'combo')),
-            self.website_id.website_domain(),
-        ])
+        product_domain = self.website_id._get_basic_feed_product_domain()
         if self.product_category_ids:
             product_domain &= Domain('public_categ_ids', 'child_of', self.product_category_ids.ids)
 


### PR DESCRIPTION
### Issue:

It is currently impossible to enable the "Google Merchant Center" option if you have 5,001 or more products published on the website. As this would raise an error:
"A single feed cannot contain more than 5000 products. Please separate products with categories."

### Cause of the Issue:

Enabling the option will create a product feed without any set categories:
https://github.com/odoo/odoo/blob/51f1982367809581530e4d126ed515c0df6c4daa/addons/website_sale/models/res_config_settings.py#L117-L124 https://github.com/odoo/odoo/blob/51f1982367809581530e4d126ed515c0df6c4daa/addons/website_sale/models/website.py#L1071-L1077 This raises an error if you have more than 5000 products published on your website due to the constraint checking if the product feed is not associated with more than 5000 published products: https://github.com/odoo/odoo/blob/51f1982367809581530e4d126ed515c0df6c4daa/addons/website_sale/models/product_feed.py#L95-L110

### Fix:

Since product feeds can be manually created from the product feed list view opened by clicking on the setting "Manage Feeds" once GMC has been enabled, we allow the option to be enabled in all cases by only creating the default product feed when this one would not raise an error (due to the product count exceeding the soft limit). The user will then be able to create smaller product categories and associated product feeds via this list view to use the option.

opw-5224549
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
