### PR TITLE
[FIX] Html_editor: show overview of attachment in chatter

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -54,7 +54,7 @@
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>
                             </group>
-                            <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..."/>
+                            <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail" />
                         </group>
                         <div role="alert" class="alert alert-danger mb8" invisible="not has_error">
                             <field name="error"/>


### PR DESCRIPTION
---
## Short functional explanation of the error
When in the chatter, we can create an activity. If we add an attachment to the notes of this activity and save it, the overview of the attachment won't show in the chatter.

## Reproduction Steps
1. Open an app that gives you access to the chatter, for instance, an invoice in Accounting.
2. Click on Activity. Click on Log a Note... and on the button Upload a file. Upload an attachment and save.

### Expected behavior
The overview of the file (blue box with the name of the attachment) should appear.

### Unexpected behavior
The overview doesn't appear

## Origin of the issue
Since 19.0, we want to replace static rendering with embedded components everywhere for rendering attachments, but this creates issues for the rendering of the overview in the chatter. Therefore, after internal discussion, we agreed to keep rendering overviews statically.

opw-5356016


