### PR TITLE
[FIX] stock_account: prevent recursion in zero-cost FIFO valuation

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -423,8 +423,8 @@ class StockMove(models.Model):
 
     def _get_value_from_std_price(self, quantity, std_price=False, at_date=None):
         std_price = std_price if std_price else self.product_id.standard_price
-        if at_date:
-            std_price = std_price or self.product_id._get_standard_price_at_date(at_date)
+        if at_date and not self.env.context.get('stock_valuation_recursion'):
+            std_price = std_price or self.product_id.with_context(stock_valuation_recursion=True)._get_standard_price_at_date(at_date)
         return {
             'value': std_price * quantity,
             'quantity': quantity,

--- a/doc/cla/individual/iabhi4.md
+++ b/doc/cla/individual/iabhi4.md
@@ -1,0 +1,11 @@
+United States of America, 2025-12-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Abhinav Singh iamonecool@gmail.com https://github.com/iabhi4


### PR DESCRIPTION
Current behavior:
The server crashes with a `RecursionError`. This happens because the
valuation logic attempts to retrieve a historical cost when the current
standard price is 0.0. For FIFO products without prior history, the
system inspects the last move's value. Since that move also has 0 cost,
it calls `_get_value_from_std_price` again, triggering an infinite
loop.

Fix:
This commit adds a recursion guard using `self.env.context`. If the
valuation method detects it is already running for the current record,
it falls back to the current standard price (0.0) instead of attempting
another historical lookup.

Closes #239564