### PR TITLE
[FIX] web: Fix Safari version check for PWA support

### DIFF
--- a/addons/web/static/src/core/pwa/pwa_service.js
+++ b/addons/web/static/src/core/pwa/pwa_service.js
@@ -83,12 +83,20 @@ const pwaService = {
         // For Apple devices, PWA are supported on any mobile version of Safari, or in desktop since version 17
         // On Safari devices, the check is also done on the display-mode and we rely on the installationState to
         // decide whether we must show the prompt or not
+        // Determine Safari version safely (for macOS Safari PWA support >= 17)
+        let safariVersion = 0;
+        if (isMacOS() && isBrowserSafari()) {
+            const match = browser.navigator.userAgent.match(/Version\/(\d+)/);
+            if (match && match[1]) {
+                safariVersion = Number(match[1]) || 0;
+            }
+        }
+        
         state.isSupportedOnBrowser =
             browser.BeforeInstallPromptEvent !== undefined ||
             (isBrowserSafari() &&
                 !isDisplayStandalone() &&
-                (isIOS() ||
-                    (isMacOS() && browser.navigator.userAgent.match(/Version\/(\d+)/)[1] >= 17)));
+                (isIOS() || (isMacOS() && safariVersion >= 17)));
 
         const installationState = _getInstallationState();
 


### PR DESCRIPTION
Desired behavior after PR is merged:

In some customized browsers, such as Wecom and DingTalk, the userAgent may not contain the Version information, resulting in an error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
