### PR TITLE
[FIX] hr_expense: Fix computation for show partner bank

### DIFF
--- a/addons/hr_expense/models/account_payment.py
+++ b/addons/hr_expense/models/account_payment.py
@@ -18,7 +18,7 @@ class AccountPayment(models.Model):
 
     def _compute_show_require_partner_bank(self):
         expense_payments = self.filtered(lambda pay: pay.move_id.expense_ids)
-        super(AccountPayment, self - expense_payments)._compute_show_require_partner_bank()
+        super()._compute_show_require_partner_bank()
         expense_payments.require_partner_bank_account = False
 
     def write(self, vals):


### PR DESCRIPTION
For expense_payments records `show_partner_bank_account` didn't computed. So, letting it compute as purpose of this fix
https://github.com/odoo/odoo/commit/7e60eb45d7b4bb02ca7cacc2aba4a9016853fa61 was to set ``require_partner_bank_account``

```py

('account.menu_action_account_payments_payable', 141, 'Accounting > Vendors > Payments', 239):
 Traceback (most recent call last):
   File "/tmp/tmpevr57plf/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpevr57plf/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpevr57plf/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpevr57plf/migrations/base/tests/test_mock_crawl.py", line 539, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3487, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3744, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6680, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1749, in __get__
    raise ValueError(f"Compute method failed to assign {missing_recs}.{self.name}")
 ValueError: Compute method failed to assign account.payment(113,).show_partner_bank_account
```
upg-3574961
opw-5260147

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
