### PR TITLE
[FIX] point_of_sale: remove extra ok button from form dialogs

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.scss
+++ b/addons/point_of_sale/static/src/app/pos_app.scss
@@ -87,3 +87,11 @@ html {
 .pos .o_error_detail {
     user-select: text;
 }
+
+// .o-default-button would be hidden with web assets, but the dialog css file excluded from pos
+// as o-default-button is used inside custom pos dialogs, only apply it to form dialogs
+.o_dialog:has(.o_form_view) {
+    button.o-default-button:not(:only-child) {
+        display: none;
+    }
+}


### PR DESCRIPTION
Before this commit:
===================
- The extra `OK` button in form view dialogs was removed only when the
  `pos_appointment` module was installed.

After this commit:
==================
- The CSS to remove the extra `OK` button has been moved from
  `pos_appointment` to the base `point_of_sale` module, ensuring consistent
  behavior across POS form dialogs.

Task:5406858
Related Enterprise PR: https://github.com/odoo/enterprise/pull/102197