### PR TITLE
[IMP] hr_work_entry: prevent payroll code error on work entry type duplication

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -10,7 +10,7 @@ class HrWorkEntryType(models.Model):
 
     name = fields.Char(required=True, translate=True)
     display_code = fields.Char(string="Display Code", size=3, translate=True, help="This code can be changed, it is only for a display purpose (3 letters max)")
-    code = fields.Char(string="Payroll Code", required=True, help="The code is used as a reference in salary rules. Careful, changing an existing code can lead to unwanted behaviors.")
+    code = fields.Char(string="Payroll Code", copy=False, help="The code is used as a reference in salary rules. Careful, changing an existing code can lead to unwanted behaviors.")
     external_code = fields.Char(help="Use this code to export your data to a third party")
     color = fields.Integer(default=0)
     sequence = fields.Integer(default=25)
@@ -54,7 +54,7 @@ class HrWorkEntryType(models.Model):
     @api.constrains('code', 'country_id')
     def _check_code_unicity(self):
         similar_work_entry_types = self.search([
-            ('code', 'in', self.mapped('code')),
+            ('code', 'in', self.filtered(lambda m: m.code).mapped('code')),
             ('country_id', 'in', self.country_id.ids + [False]),
             ('id', 'not in', self.ids)
         ])


### PR DESCRIPTION
Duplicating a Work entry type was failing due to a conflict on the Payroll Code, which must be unique.
When Duplication, the original Payroll code was reused, causing a validation error.

Added `copy=False` on Payroll code field and removed `required=True` as it gives another validation error as `Missing required fields`.
The Payroll Code is no longer copied during duplication. The unique constraint has been adapted to ignore empty values, ensuring that duplicate work correctly without raising validation errors.

task-[5383663](https://www.odoo.com/odoo/project/1251/tasks/5383663)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
