### PR TITLE
[IMP] hr: show departments on Employee Activity Plan

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -9,7 +9,7 @@
         <record id="onboarding_plan" model="mail.activity.plan">
             <field name="name">Onboarding</field>
             <field name="res_model">hr.employee</field>
-            <field name="company_id" eval="False"/>
+            <field name="company_id" ref="base.main_company"/>
         </record>
 
         <record id="onboarding_setup_it_materials" model="mail.activity.plan.template">
@@ -36,7 +36,7 @@
         <record id="offboarding_plan" model="mail.activity.plan">
             <field name="name">Offboarding</field>
             <field name="res_model">hr.employee</field>
-            <field name="company_id" eval="False"/>
+            <field name="company_id" ref="base.main_company"/>
         </record>
 
         <record id="offboarding_setup_compute_out_delais" model="mail.activity.plan.template">


### PR DESCRIPTION
### Before:
- The Department field was empty in the default demo data for Onboarding and
  Offboarding employee activity plans.
- Even when departments existed for the current company, none were available in
  the dropdown.

### After:
- The base main company is now set by default on both activity plans.
- In a single-company setup, departments of the main company are shown
  automatically.
- In a multi-company environment, users can select the appropriate company using
  the existing `company_id` field.

### Impact:
Users can now correctly select departments of the main company for Onboarding
and Offboarding employee activity plans.

---

Task: 5404777

---

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
