### PR TITLE
[IMP] web: allow custom color and label inside progress bar widget

### DIFF
--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -19,6 +19,8 @@ export class ProgressBarField extends Component {
         isMaxValueEditable: { type: Boolean, optional: true },
         title: { type: String, optional: true },
         overflowClass: { type: String, optional: true },
+        progressColorClass: { type: String, optional: true },
+        progressBarInnerLabel: { type: String, optional: true },
     };
 
     setup() {
@@ -66,7 +68,7 @@ export class ProgressBarField extends Component {
     }
 
     get progressBarColorClass() {
-        return this.currentValue > this.maxValue ? this.props.overflowClass : "bg-primary";
+        return this.currentValue > this.maxValue ? this.props.overflowClass : this.props.progressColorClass;
     }
 
     formatCurrentValue(humanReadable = !this.state.isEditing) {
@@ -150,6 +152,18 @@ export const progressBarField = {
             ),
             default: "bg-secondary",
         },
+        {
+            label: _t("Progress bar color"),
+            name: "color_class",
+            type: "string",
+            help: _t("CSS class used to style the progress bar background."),
+        },
+        {
+            label: _t("Progress bar inner label"),
+            name: "inner_label",
+            type: "string",
+            help: _t("Text displayed inside the progress bar alongside the value."),
+        },
     ],
     supportedTypes: ["integer", "float"],
     extractProps: ({ attrs, options }) => ({
@@ -160,6 +174,8 @@ export const progressBarField = {
         isMaxValueEditable: options.editable && options.edit_max_value,
         title: attrs.title,
         overflowClass: options.overflow_class || "bg-secondary",
+        progressColorClass: options.color_class || "bg-primary",
+        progressBarInnerLabel: options.inner_label,
     }),
 };
 

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
@@ -4,51 +4,64 @@
     <t t-name="web.ProgressBarField">
         <div class="o_progressbar w-100 d-flex align-items-center" t-ref="numpadDecimal">
             <div t-if="props.title" class="o_progressbar_title text-nowrap pe-1"><t t-esc="props.title"/></div>
-            <div class="o_progress align-middle overflow-hidden" aria-valuemin="0" t-att-aria-valuemax="this.maxValue" t-att-aria-valuenow="this.currentValue">
+            <div class="o_progress align-middle overflow-hidden position-relative" aria-valuemin="0" t-att-aria-valuemax="this.maxValue" t-att-aria-valuenow="this.currentValue">
                 <div t-attf-class="{{ progressBarColorClass }} h-100" t-att-style="'width: min(' + 100 * this.currentValue / this.maxValue + '%, 100%)'"></div>
-            </div>
-            <div class="o_progressbar_value d-flex">
-                <t t-if="isPercentage">
-                    <input
-                        t-if="isEditable and props.isCurrentValueEditable"
-                        t-ref="currentValue"
-                        class="o_input h-100 text-center"
-                        type="text"
-                        inputmode="decimal"
-                        autocomplete="off"
-                        t-att-required="props.required"
-                        t-on-focus="onInputFocus"
-                        t-on-blur="onInputBlur"
-                    />
-                    <span t-else="" class="mx-1" t-esc="formatCurrentValue(true)"/>
-                    <span>%</span>
-                </t>
-                <t t-else="">
-                    <input
-                        t-if="isEditable and props.isCurrentValueEditable"
-                        t-ref="currentValue"
-                        class="o_input h-100 text-center"
-                        type="text"
-                        inputmode="decimal"
-                        autocomplete="off"
-                        t-on-focus="onInputFocus"
-                        t-on-blur="onInputBlur"
-                    />
-                    <span t-else="" class="mx-1" t-esc="formatCurrentValue(true)"/>
-                    /
-                    <input
-                        t-if="isEditable and props.isMaxValueEditable"
-                        t-ref="maxValue"
-                        class="o_input h-100 text-center"
-                        type="text"
-                        inputmode="decimal"
-                        autocomplete="off"
-                        t-on-focus="onInputFocus"
-                        t-on-blur="onInputBlur"
-                    />
-                    <span t-else="" class="mx-1" t-esc="formatMaxValue(true)"/>
+                <t t-if="props.progressBarInnerLabel">
+                    <div class="position-absolute top-50 start-50 translate-middle text-nowrap">
+                        <t t-call="web.ProgressBarField.valueBlock"/>
+                    </div>
                 </t>
             </div>
+            <t t-if="!props.progressBarInnerLabel">
+                <t t-call="web.ProgressBarField.valueBlock"/>
+            </t>
+        </div>
+    </t>
+
+    <t t-name="web.ProgressBarField.valueBlock">
+        <div class="o_progressbar_value d-flex">
+            <t t-if="isPercentage">
+                <input
+                    t-if="isEditable and props.isCurrentValueEditable"
+                    t-ref="currentValue"
+                    class="o_input h-100 text-center"
+                    type="text"
+                    inputmode="decimal"
+                    autocomplete="off"
+                    t-att-required="props.required"
+                    t-on-focus="onInputFocus"
+                    t-on-blur="onInputBlur"
+                />
+                <span t-else="" class="mx-1" t-esc="formatCurrentValue(true)"/>
+                <span>% <t t-esc="props.progressBarInnerLabel"/></span>
+            </t>
+            <t t-else="">
+                <input
+                    t-if="isEditable and props.isCurrentValueEditable"
+                    t-ref="currentValue"
+                    class="o_input h-100 text-center"
+                    type="text"
+                    inputmode="decimal"
+                    autocomplete="off"
+                    t-on-focus="onInputFocus"
+                    t-on-blur="onInputBlur"
+                />
+                <span t-else="" class="mx-1" t-esc="formatCurrentValue(true)"/>
+                /
+                <input
+                    t-if="isEditable and props.isMaxValueEditable"
+                    t-ref="maxValue"
+                    class="o_input h-100 text-center"
+                    type="text"
+                    inputmode="decimal"
+                    autocomplete="off"
+                    t-on-focus="onInputFocus"
+                    t-on-blur="onInputBlur"
+                />
+                <span t-else="" class="mx-1">
+                    <t t-esc="formatMaxValue(true)"/> <t t-esc="props.progressBarInnerLabel"/>
+                </span>
+            </t>
         </div>
     </t>
 

--- a/addons/web/static/tests/views/fields/progress_bar_field.test.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field.test.js
@@ -405,3 +405,23 @@ test("ProgressBarField: color is correctly set when value > max value", async ()
         message: "As the value has excedded the max value, the color should be set to bg-warning",
     });
 });
+
+test("ProgressBarField: apply custom background colour and render the label inside the bar", async () => {
+    Partner._records[0].int_field = 75;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="int_field" widget="progressbar" options="{'color_class': 'bg-success', 'inner_label': 'on-time'}"/>
+            </form>`,
+        resId: 1,
+    });
+
+    expect(".o_progressbar .bg-success").toHaveCount(1, {
+        message: "Custom background color class is applied to the progress bar",
+    });
+    expect(".o_progress").toHaveText("75\n% on-time", {
+        message: "Progress value and inner label are rendered inside the progress bar",
+    });
+});


### PR DESCRIPTION
- The progress bar widget is used to display status or metric-based values, but it currently offers limited customization. The default `percentage-only` or `ratio` rendering is not always sufficient to provide clear context. Additionally, customizing the `progress bar color` currently requires `extending` the widget.
- This change improves the progress bar by allowing a `configurable color` and an `optional label` rendered directly inside the bar. This makes it possible to convey meaningful context alongside the value, visually distinguish progress states, and reduce the need for custom widget extensions.

TaskID-5164148