### PR TITLE
[FIX] product_margin: avoid aggregate traceback

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -58,7 +58,7 @@ class ProductProduct(models.Model):
         # the purpose of this override is to flag the aggregates above as such:
         # field._description_aggregator() should simply not fail
         if aggregate_spec in self._SPECIAL_SUM_AGGREGATES:
-            return SQL()
+            return SQL("NULL")
         return super()._read_group_select(aggregate_spec, query)
 
     @api.model


### PR DESCRIPTION
Prevent a SQL traceback when selecting non-stored computed measures in pivot views.

Steps to reproduce:
- Open Inventory > Reporting > Stock
- Enable developer mode and open the developer tools > Action
- Create a pivot view (on action action_product_stock_view)
- Open the new pivot view
- Select a computed measure, for example “Normal Cost”

A SQL syntax error was raised during aggregation because non-stored computed fields return an empty SQL expression in _read_group_select.

This fix prevents the traceback from occurring. The report will not display a value for these fields, but it remains usable.

Due to the complexity of computed fields, reproducing their logic directly in SQL don't seem feasible.

opw-5411631