### PR TITLE
[FIX] hw_drivers: always detect TM-m30 printer as receipt printer

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -87,9 +87,9 @@ class PrinterDriver(Driver):
 
         self.receipt_protocol = 'star' if 'STR_T' in device['device-id'] else 'escpos'
 
-        if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']):
+        if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']) or "tm-m30" in self.device_name.lower():
             self.device_subtype = "receipt_printer"
-        elif any(cmd in device['device-id'] for cmd in ['COMMAND SET:ZPL;', 'CMD:ESCLABEL;']):
+        elif any(cmd in device['device-id'] for cmd in ['COMMAND SET:ZPL;', 'CMD:ESCLABEL;']) or "zpl" in self.device_name.lower():
             self.device_subtype = "label_printer"
         else:
             self.device_subtype = "office_printer"


### PR DESCRIPTION
Before this commit, the receipt printer subtype was assigned based on the presence of `CMD:ESC/POS;` in the `device-id` of the printer. However, this string was only present for the `lpd` backend, for `dnssd` it was not resulting in a subtype of Office printer.

After this commit, we additionally check for the string `TM-m30` in the device name, and if it is present we set it as a receipt printer. We also check for the string `ZPL` and if found set it as a label printer.

task-5411994

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
