### PR TITLE
[FIX] website: ensure view reset on enable

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -899,6 +899,8 @@ class Website(Home):
 
         if enable:
             records = self._get_customize_data(enable, is_view_data)
+            if reset_view_arch:
+                records.reset_arch(mode='hard')
             if 'website_blog.opt_blog_cover_post' in enable:
                 # TODO: In master, set the priority in XML directly.
                 records.filtered_domain([('key', '=', 'website_blog.opt_blog_cover_post')]).priority = 17


### PR DESCRIPTION
Fix an issue where toggling a website option that controls a view with
reset enabled (e.g., "Show/hide text element" in Header) fails to
restore the original template on the first toggle cycle.

Steps to reproduce:
1. Edit the phonr number element in the Header.
2. Toggle OFF the "Show/hide text element" option.
3. Toggle ON the option.
    Current Behavior: The text does not reset; the edited version reappears.
4. Toggle OFF and ON again.
    Current Behavior: Only now does the text reset to the original version.

Reason:
When disabling an option, the backend resets the view as expected.
However, the frontend editor triggers an auto-save of the user's changes
shortly after. This save operation overwrites the recently reset view
with the old "dirty" content, leaving the view inactive but modified.
Consequently, re-enabling the option simply activates this modified
version instead of the clean template.

Fix:
Explicitly force a hard reset of the view architecture during the
'enable' phase if `reset_view_arch` is requested. This ensures the
content is always restored to its original state when the view becomes
visible, preventing any stale edited content from persisting.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
