### PR TITLE
[FIX] html_editor: enable heading link scrolling in locked articles

### DIFF
--- a/addons/html_editor/static/src/components/html_viewer/html_viewer.js
+++ b/addons/html_editor/static/src/components/html_viewer/html_viewer.js
@@ -16,6 +16,7 @@ import { fixInvalidHTML, instanceofMarkup } from "@html_editor/utils/sanitize";
 import { HtmlUpgradeManager } from "@html_editor/html_migrations/html_upgrade_manager";
 import { TableOfContentManager } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content_manager";
 import { getDeepestPosition } from "@html_editor/utils/dom_info";
+import { scrollAndHighlightHeading } from "@html_editor/utils/url";
 
 export class HtmlViewer extends Component {
     static template = "html_editor.HtmlViewer";
@@ -72,6 +73,10 @@ export class HtmlViewer extends Component {
                 () => [this.props.config.value.toString(), this.readonlyElementRef?.el]
             );
         }
+
+        onMounted(() => {
+            scrollAndHighlightHeading(this.readonlyElementRef?.el || this.iframeRef?.el);
+        });
 
         if (this.props.config.cssAssetId) {
             onWillStart(async () => {

--- a/addons/html_editor/static/src/utils/url.js
+++ b/addons/html_editor/static/src/utils/url.js
@@ -1,3 +1,5 @@
+import { browser } from "@web/core/browser/browser";
+
 /**
  * Checks if the given URL contains the specified hostname and returns a reconstructed URL if it does.
  *
@@ -55,4 +57,27 @@ export function getVideoUrl(platform, videoId, params) {
     }
     url.search = new URLSearchParams(params);
     return url;
+}
+
+export function scrollAndHighlightHeading(
+    content,
+    headingId = browser?.location?.hash?.replace?.(/^#/, "")
+) {
+    if (content && headingId) {
+        // Wait until the browser has rendered the editor before
+        // scrolling. The timeout value of 500 is a little arbitrary,
+        // but it should be enough to prevent an irritating case where
+        // a Youtube video is in the document and loads while the
+        // autoscroll is happening, and stops it.
+        setTimeout(() => {
+            const heading = content.querySelector(`[data-heading-link-id="${headingId}"]`);
+            if (heading) {
+                heading.scrollIntoView({ behavior: "smooth" });
+                heading.classList.add("o-highlight-heading");
+                setTimeout(() => {
+                    heading.classList.remove("o-highlight-heading");
+                }, 2000);
+            }
+        }, 500);
+    }
 }


### PR DESCRIPTION
Problem:
When navigating to a link that points to a heading in a locked article, the page does not scroll to the target heading after load.

Cause:
When an article is locked, `HtmlViewer` is used instead of the editor. In this mode, `HeadingLinkPlugin` is not loaded, even though it is the component responsible for scrolling to elements with `data-heading-link-id`.

Solution:
Add the same heading link scrolling logic to `HtmlViewer` so that links to headings work consistently, even when the article is locked.

Steps to reproduce:
- Go to Knowledge.
- Copy a heading link.
- Lock the article.
- Paste the URL in the browser.
- When the page loads, it does not scroll to the heading.

opw-5418474

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
