### PR TITLE
[FIX] l10n_es_edi_verifactu: restrain certificate access

### DIFF
--- a/addons/l10n_es_edi_verifactu/__manifest__.py
+++ b/addons/l10n_es_edi_verifactu/__manifest__.py
@@ -9,6 +9,7 @@
     'depends': ['l10n_es'],
     'data': [
         'security/ir.model.access.csv',
+        'security/l10n_es_edi_verifactu_security.xml',
         'wizard/account_move_reversal_views.xml',
         'wizard/account_move_send_views.xml',
         'views/account_move_views.xml',

--- a/addons/l10n_es_edi_verifactu/security/l10n_es_edi_verifactu_security.xml
+++ b/addons/l10n_es_edi_verifactu/security/l10n_es_edi_verifactu_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="verifactu_digital_certificate" model="ir.rule">
+        <field name="name">verifactu Digital Certificate</field>
+        <field name="model_id" ref="l10n_es_edi_verifactu.model_l10n_es_edi_verifactu_certificate"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+</odoo>


### PR DESCRIPTION
**PROBLEM**
In 17.0, you can access the verifactu certificate of all companies.

**STEP TO REPRODUCE**
- Have 2 companies.
- Create a certificate for each of them.
- Setup Marc Demo with the Accountant role for the invoicing/accounting app.
- Remove him from the ES company.
- When accessing the verifactu certificate view, he will still have access to the ES company certificate.

opw-5354383