### PR TITLE
[FIX] point_of_sale: create cogs line on closing in perpetual continental

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -973,7 +973,7 @@ class PosOrder(models.Model):
                         'display_type': 'rounding',
                     })
         # Stock.
-        if self.company_id.anglo_saxon_accounting and self.picking_ids.ids:
+        if self.company_id.inventory_valuation == 'real_time' and self.picking_ids.ids:
             stock_moves = self.env['stock.move'].sudo().search([
                 ('picking_id', 'in', self.picking_ids.ids),
                 ('product_id.valuation', '=', 'real_time'),

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -950,14 +950,14 @@ class PosSession(models.Model):
                 partners = (order.partner_id | order.partner_id.commercial_partner_id)
                 partners._increase_rank('customer_rank')
 
-        if self.company_id.anglo_saxon_accounting:
+        if self.company_id.inventory_valuation == 'real_time':
             all_picking_ids = self.order_ids.filtered(lambda p: not p.is_invoiced and not p.shipping_date).picking_ids.ids + self.picking_ids.filtered(lambda p: not p.pos_order_id).ids
             if all_picking_ids:
                 # Combine stock lines
                 stock_move_sudo = self.env['stock.move'].sudo()
                 stock_moves = stock_move_sudo.search([
                     ('picking_id', 'in', all_picking_ids),
-                    ('company_id.anglo_saxon_accounting', '=', True),
+                    ('company_id.inventory_valuation', '=', 'real_time'),
                     ('product_id.categ_id.property_valuation', '=', 'real_time'),
                     ('product_id.is_storable', '=', True),
                 ])

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_frontend
 from . import test_performances
 from . import test_point_of_sale_ui
 from . import test_anglo_saxon
+from . import test_continental
 from . import test_point_of_sale
 from . import test_pos_controller
 from . import test_pos_invoice_consolidation

--- a/addons/point_of_sale/tests/test_continental.py
+++ b/addons/point_of_sale/tests/test_continental.py
@@ -1,0 +1,78 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_anglo_saxon import TestAngloSaxonCommon
+
+
+class TestContinentalCommon(TestAngloSaxonCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.anglo_saxon_accounting = False
+
+
+@tagged('post_install', '-at_install')
+class TestContinentalPerpetualFlow(TestContinentalCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.inventory_valuation = 'real_time'
+        cls.category.property_valuation = 'real_time'
+        cls.product.write({
+            'name': "Real time valo product",
+            'categ_id': cls.category,
+            'standard_price': 20,
+            'list_price': 100
+        })
+
+    def test_inventory_valuation_session_closing_no_invoice(self):
+        """ Tests that closing the session posts the stock valuation
+        move line entries, even if order was not invoiced. """
+        self.pos_config.open_ui()
+        pos_session = self.pos_config.current_session_id
+        pos_session.set_opening_control(0, None)
+
+        # create order
+        pos_order_values = {
+            'company_id': self.company.id,
+            'partner_id': self.partner.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.product.id,
+                'price_unit': 100,
+                'discount': 0.0,
+                'qty': 1.0,
+                'price_subtotal': 100,
+                'price_subtotal_incl': 100,
+            })],
+            'amount_total': 100,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'last_order_preparation_change': '{}'
+        }
+
+        pos_order = self.PosOrder.create(pos_order_values)
+
+        # register payment
+        context_make_payment = {"active_ids": [pos_order.id], "active_id": pos_order.id}
+        pos_payment = self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 100.0,
+            'payment_method_id': self.cash_payment_method.id,
+        })
+        context_payment = {'active_id': pos_order.id}
+        pos_payment.with_context(context_payment).check()
+
+        # validate the session
+        current_session_id = self.pos_config.current_session_id
+        current_session_id.post_closing_cash_details(100.0)
+        current_session_id.close_session_from_ui()
+
+        valuation_account = self.category.property_stock_valuation_account_id
+        valuation_lines = current_session_id.move_id.line_ids.filtered(lambda line: line.account_id == valuation_account)
+
+        self.assertEqual(len(valuation_lines), 1)
+        self.assertEqual(valuation_lines.credit, 20.0)


### PR DESCRIPTION
Currently, in a continental perpetual setting for the stock valuation, the inventory valuation lines are not created when closing the session if the orders when not invoiced.

Steps to reproduce:
-------------------
* Using My Belgian Company
* In the settings search for inventory valuation
  * Set inventory valuation to Perpetual
  * Any cost method, AVCO for example
  * Set up valuation account and journal
* Create a product
  * Type -> Goods
  * Track inventory by quantity
  * Set a purchase cost
  * Put some quantity on hand
  * Add category
* In the settings of the category
  * Set up Stock account
  * Set up costing method, AVCO for example
  * Set inventory valuation to perpetual
* Open pos session
* Make an order for the product, put partner, invoice it
* Close session, go to session journal items
> Observation: Valuation lines are present
* Open pos session
* Make an order for the product, no partner, no invoice
* Close session, go to session journal items
> Observation: Valuation lines are missing.

Why the fix:
------------
When the company is set with perpetual inventory valuation, in the context of the point of sale, there should not be any difference between anglo saxon and continental accounting.

When we check the same flow with anglo-saxon, there is no difference for the creation of the inventory valuation move line whether we invoice the order or not. Inventory valuation lines are always present.

Valuation entries are created in `_create_stock_valuation_lines()` if information is available regarding `stock_valuation`. https://github.com/odoo/odoo/blob/51f1982367809581530e4d126ed515c0df6c4daa/addons/point_of_sale/models/pos_session.py#L1258-L1273

The information for `stock_valuation` is supposed to be computed in `_accumulate_amount()`.

However this is currently only computed when we have the anglo saxon accounting:
https://github.com/odoo/odoo/blob/51f1982367809581530e4d126ed515c0df6c4daa/addons/point_of_sale/models/pos_session.py#L953

Instead we will now only check if the company is valuating the inventory in real time.

We also apply the same fix on paid orders we want to invoice afterwards.

opw-5167946