### PR TITLE
[IMP] account_peppol: partner improvements

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -409,6 +409,10 @@ class ResPartner(models.Model):
             else:
                 partner.ubl_cii_format = partner.ubl_cii_format
 
+    def _get_peppol_endpoint_value(self, country_code, field):
+        self.ensure_one()
+        return field in self._fields and self[field]
+
     @api.depends(lambda self: self._peppol_eas_endpoint_depends() + ['peppol_eas'])
     def _compute_peppol_endpoint(self):
         """ If the EAS changes and a valid endpoint is available, set it. Otherwise, keep the existing value."""
@@ -417,11 +421,9 @@ class ResPartner(models.Model):
             country_code = partner._deduce_country_code()
             if country_code in EAS_MAPPING:
                 field = EAS_MAPPING[country_code].get(partner.peppol_eas)
-                if field \
-                        and field in partner._fields \
-                        and partner[field] \
-                        and not partner._build_error_peppol_endpoint(partner.peppol_eas, partner[field]):
-                    partner.peppol_endpoint = partner[field]
+                value = partner._get_peppol_endpoint_value(country_code, field)
+                if field and value and not partner._build_error_peppol_endpoint(partner.peppol_eas, value):
+                    partner.peppol_endpoint = value
 
     @api.depends(lambda self: self._peppol_eas_endpoint_depends())
     def _compute_peppol_eas(self):
@@ -438,8 +440,9 @@ class ResPartner(models.Model):
                     new_eas = next(iter(EAS_MAPPING[country_code].keys()))
                     # Iterate on the possible EAS until a valid one is found
                     for eas, field in eas_to_field.items():
-                        if field and field in partner._fields and partner[field]:
-                            if not partner._build_error_peppol_endpoint(eas, partner[field]):
+                        if field and field in partner._fields:
+                            value = partner._get_peppol_endpoint_value(country_code, field)
+                            if value and not partner._build_error_peppol_endpoint(eas, value):
                                 new_eas = eas
                                 break
                     partner.peppol_eas = new_eas


### PR DESCRIPTION
This commit improves the UX by displaying more intuitive placeholders
for the peppol identifier. The peppol information is also automatically
verified when important data changes.

It also adds a special case for Belgium in which we try to use the vat
number as the peppol identifier with the company registry endpoint.

back-port of: https://github.com/odoo/odoo/pull/233160
task: 5172378
