### PR TITLE
[FIX] iot_drivers: status receipt not printing offline

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -155,7 +155,13 @@ class PrinterDriver(PrinterDriverBase):
                     dev.printer.textln(title.decode())
                     dev.printer.set_with_default(align='center', double_height=False, double_width=False)
                     dev.writelines(body.decode())
-                    dev.printer.qr(f"http://{helpers.get_ip()}", size=6)
+                    ip = helpers.get_ip()
+                    if ip:
+                        dev.printer.qr(f"http://{ip}", size=6)
+                    else:
+                        wifi_qr = wifi.get_qr_data_for_wifi()
+                        if wifi_qr:
+                            dev.printer.qr(wifi_qr, size=6)
                 self.send_status(status='success')
                 return
             except (escpos.exceptions.Error, OSError, AssertionError):
@@ -222,11 +228,14 @@ class PrinterDriver(PrinterDriverBase):
         else:
             ip = '\nIoT Box IP Addresses:\n%s\n' % '\n'.join(ips)
 
-        network_quality = "\nNetwork quality:\n - To Odoo server: %s\n" % wan_quality
-        if to_gateway_quality:
-            network_quality += " - To Modem: %s\n" % to_gateway_quality
-        if to_printer_quality:
-            network_quality += " - To Printer (%s): %s\n" % (self.ip, to_printer_quality)
+        if len(ips) == 0:
+            network_quality = ""
+        else:
+            network_quality = "\nNetwork quality:\n - To Odoo server: %s\n" % wan_quality
+            if to_gateway_quality:
+                network_quality += " - To Modem: %s\n" % to_gateway_quality
+            if to_printer_quality:
+                network_quality += " - To Printer (%s): %s\n" % (self.ip, to_printer_quality)
 
         if len(ips) >= 1:
             identifier = '\nIdentifier:\n%s\n' % iot_status["identifier"]

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -651,7 +651,10 @@ def check_network(host=None):
     if not host:
         return None
 
-    host = socket.gethostbyname(host)
+    try:
+        host = socket.gethostbyname(host)
+    except socket.gaierror:
+        return "unreachable"
     packet_loss, avg_latency = mtr(host)
     thresholds = {"fast": 5, "normal": 20} if ip_address(host).is_private else {"fast": 50, "normal": 150}
 

--- a/addons/iot_drivers/tools/wifi.py
+++ b/addons/iot_drivers/tools/wifi.py
@@ -281,6 +281,16 @@ def is_access_point():
     ).returncode == 0
 
 
+def get_qr_data_for_wifi():
+    if is_access_point():
+        return f"WIFI:S:{get_access_point_ssid()};T:nopass;;;"
+    wifi_ssid = get_conf('wifi_ssid')
+    wifi_password = get_conf('wifi_password')
+    if wifi_ssid and wifi_password:
+        return f"WIFI:S:{wifi_ssid};T:WPA;P:{wifi_password};;;"
+    return None
+
+
 @cache
 def generate_qr_code_image(qr_code_data):
     """Generate a QR code based on data argument and return it in base64 image format
@@ -312,20 +322,8 @@ def generate_network_qr_codes():
     :return: A dictionary containing the QR codes in base64 format
     :rtype: dict
     """
-    qr_code_images = {
-        'qr_wifi': None,
+    wifi_network_qr_data = get_qr_data_for_wifi()
+    return {
+        'qr_wifi': generate_qr_code_image(wifi_network_qr_data) if wifi_network_qr_data else None,
         'qr_url': generate_qr_code_image(f'http://{get_ip()}'),
     }
-
-    # Generate QR codes which can be used to connect to the IoT Box Wi-Fi network
-    if not is_access_point():
-        wifi_ssid = get_conf('wifi_ssid')
-        wifi_password = get_conf('wifi_password')
-        if wifi_ssid and wifi_password:
-            wifi_data = f"WIFI:S:{wifi_ssid};T:WPA;P:{wifi_password};;;"
-            qr_code_images['qr_wifi'] = generate_qr_code_image(wifi_data)
-    else:
-        access_point_data = f"WIFI:S:{get_access_point_ssid()};T:nopass;;;"
-        qr_code_images['qr_wifi'] = generate_qr_code_image(access_point_data)
-
-    return qr_code_images


### PR DESCRIPTION
Before this commit, the status receipt was failing when offline due to a traceback in the `helpers.check_network` function.

After this commit, the following changes are made:
- A `try/except` is added to the `helpers.check_network` function, and it returns `"unreachable"` in this case.
- If there is no network, the network quality section is no longer printed in the status receipt.
- If there is no network, instead of a homepage QR code, a QR code for the Wi-Fi hotspot is printed instead.

task-5411999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
