### PR TITLE
[IMP] hr_payroll: unlock work entries

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -310,16 +310,4 @@
         </field>
     </record>
 
-    <record model="ir.actions.server" id="action_hr_work_entry_set_to_draft">
-        <field name="name">Set to Draft</field>
-        <field name="sequence" eval="50"/>
-        <field name="model_id" ref="hr_work_entry.model_hr_work_entry"/>
-        <field name="binding_model_id" ref="hr_work_entry.model_hr_work_entry"/>
-        <field name="binding_view_types">list,form</field>
-        <field name="state">code</field>
-        <field name="code">
-records.action_set_to_draft()
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
-The action_set_to_draft should set any work entry to draft regardless of the situation.
-The record has been moved inside hr_payroll module.