### PR TITLE
[FIX] hr_expense: fix missing field compute

### DIFF
--- a/addons/hr_expense/models/account_payment.py
+++ b/addons/hr_expense/models/account_payment.py
@@ -20,6 +20,7 @@ class AccountPayment(models.Model):
         expense_payments = self.filtered(lambda pay: pay.move_id.expense_ids)
         super(AccountPayment, self - expense_payments)._compute_show_require_partner_bank()
         expense_payments.require_partner_bank_account = False
+        expense_payments.show_partner_bank_account = False
 
     def write(self, vals):
         trigger_fields = {


### PR DESCRIPTION
Commit f66c8373e4f86145b03a2390d9e9a94f6d7a7156 introduced an override of _compute_show_require_partner_bank in hr_expense which is a compute for two fields: require_partner_bank_account and show_partner_bank_account

However, the field show_partner_bank_account was not set in this override which created a traceback when trying to access the journal entry created via hr_expense.

- Create an expense paid by the company.
- Submit and post the journal entries.
- Traceback when clicking on the journal entry smart button:

"Compute method failed to assign show_partner_bank_account"

opw-5418236


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
