### PR TITLE
[FIX] hr_work_entry: add test on work entry generation

### DIFF
--- a/addons/hr_work_entry/tests/test_hr_work_entry.py
+++ b/addons/hr_work_entry/tests/test_hr_work_entry.py
@@ -120,3 +120,21 @@ class TestHrWorkEntry(TransactionCase):
             (work_entry | work_entry_2).mapped('state'), ['draft', 'draft'],
             "Work entries with a total duration for a same day > 0h and <= 24h should not conflict.",
         )
+
+    def test_nullify_work_entry_tz(self):
+        """
+        Test that the work entries of the previous month are not affected when regenerating the next month work entries
+        no matter what's the timezone of the employee
+        """
+        self.employee_a.tz = 'Europe/Brussels'
+        self.employee_a.resource_calendar_id.tz = 'Europe/Brussels'
+
+        january_work_entries = self.employee_a.generate_work_entries(date(2024, 1, 1), date(2024, 1, 31), force=True)
+        self.employee_a.generate_work_entries(date(2024, 2, 1), date(2024, 2, 28), force=True)
+
+        new_january_work_entries = self.env['hr.work.entry'].search([
+            ('employee_id', '=', self.employee_a.id),
+            ('date', '>=', date(2024, 1, 1)),
+            ('date', '<=', date(2024, 1, 31)),
+        ])
+        self.assertEqual(january_work_entries, new_january_work_entries)


### PR DESCRIPTION
This commit adds a test for this fix PR: https://github.com/odoo/odoo/pull/239855

task-5413594

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
