### PR TITLE
[FIX] mail: fix z-index of a avatar in avatar-stack

### DIFF
--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.AvatarStack">
         <div t-if="props.personas.length > 0" class="bg-inherit" t-att-class="props.containerClass" t-on-click="props.onClick">
-            <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
+            <div class="d-flex bg-inherit position-relative z-1" t-att-class="{'flex-column': props.direction === 'v'}">
                 <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle position-relative" t-attf-style="{{getStyle(persona_index)}}">
                     <img t-att-src="persona.avatarUrl" t-att-title="persona.displayName" class="w-100 h-100 rounded-circle o_object_fit_cover" t-attf-class="{{props.avatarClass(persona)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>


### PR DESCRIPTION
Before this commit, the avatar's in the avatar stack z-index was derived from the participant’s position in the recordset, resulting in descending z-index values greater than 1. Since .o-mail-DiscussSidebar-top has a z-index of 2, avatars with a higher z-index could incorrectly appear above it when multiple avatars were present.

This commit fixes the issue by assigning a fixed z-index of 1 to all avatars, ensuring a consistent and correct stacking behavior.







task-5417539


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
