### PR TITLE
[FIX] account_edi_proxy_client,account_peppol: sync edi_identification

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -199,7 +199,7 @@ class AccountEdiProxyClientUser(models.Model):
             'company_id': company.id,
             'proxy_type': proxy_type,
             'edi_mode': edi_mode,
-            'edi_identification': edi_identification,
+            'edi_identification': response.get('edi_identification', edi_identification),
             'private_key_id': private_key_sudo.id,
             'refresh_token': response['refresh_token'],
         })


### PR DESCRIPTION
We introduced for Peppol the possibility to deduce an identification from another one therefore, the provided edi_identification at registration can sometimes not be the one that is actually used when registering to the AP. This commit adds ways to synchronize it to keep it consistent.

See https://github.com/odoo/iap-apps/pull/1334
task-none