### PR TITLE
[FIX] website: fix `add_to_cart_snippet_tour` when search is needed

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -161,35 +161,31 @@ export function changeOption(
  * @param {string} optionName - The name of the option (e.g., "Visibility").
  * @param {string} elementName - The name of the element to be clicked inside
  *                               the popover (e.g., "Conditionally").
- * @param {Boolean} searchNeeded - If the widget is a m2o widget and a search is needed.
  *
  * Example:
  *      ...changeOptionInPopover("Text - Image", "Visibility", "Conditionally")
  */
-export function changeOptionInPopover(blockName, optionName, elementName, searchNeeded = false) {
-    const steps = [changeOption(blockName, `[data-label='${optionName}'] .dropdown-toggle`)];
-
-    if (searchNeeded) {
-        steps.push({
-            content: `Inputing ${elementName} in toogle option search`,
-            trigger: `.o_popover input`,
-            run: `edit ${elementName}`,
-        });
-    }
-
-    steps.push(
-        clickOnElement(
-            `${elementName} in the ${optionName} option`,
-            [
-                `.o_popover div.o-dropdown-item:contains("${elementName}")`,
-                `.o_popover span.o-dropdown-item:contains("${elementName}")`,
-                `.o_popover div.o-dropdown-item[title="${elementName}"]`,
-                `.o_popover span.o-dropdown-item[title="${elementName}"]`,
-                `.o_popover ${elementName}`,
-            ].join(", ")
-        )
-    );
-    return steps;
+export function changeOptionInPopover(blockName, optionName, elementName) {
+    const itemSelector = [
+        `.o_popover div.o-dropdown-item:contains("${elementName}")`,
+        `.o_popover span.o-dropdown-item:contains("${elementName}")`,
+        `.o_popover div.o-dropdown-item[title="${elementName}"]`,
+        `.o_popover span.o-dropdown-item[title="${elementName}"]`,
+        `.o_popover ${elementName}`,
+    ].join(", ");
+    return [
+        changeOption(blockName, `[data-label='${optionName}'] .dropdown-toggle`),
+        {
+            content: `Check if "${elementName}" option is shown. If not, search for it.`,
+            trigger: ".o_popover .o-dropdown-item",
+            async run(helpers) {
+                if (!helpers.queryFirst(itemSelector)) {
+                    await helpers.edit(elementName, ".o_popover input");
+                }
+            },
+        },
+        clickOnElement(`${elementName} in the ${optionName} option`, itemSelector),
+    ];
 }
 
 export function selectNested(

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -33,14 +33,14 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
 
         // Basic product with no variants
         ...clickOnSnippet({id: 's_add_to_cart'}),
-        ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant", true),
+        ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant"),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
         checkQuanityInCart("1"),
 
         // Product with 2 variants with visitor choice (will open modal)
         ...editAddToCartSnippet(),
-        ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 1", true),
+        ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 1"),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
         clickOnElement("add to cart", ":iframe .modal button:contains(Add to Cart)"),
@@ -83,7 +83,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
             content: "Check if action option is visible",
             trigger: "[data-container-title='Add to Cart Button'] [data-label='Action']"
         },
-        ...changeOptionInPopover("Add to Cart Button", "Action", "Buy Now", false),
+        ...changeOptionInPopover("Add to Cart Button", "Action", "Buy Now"),
         // At this point the "Add to cart" button was changed to a "Buy Now" button
         ...clickOnSave(),
         clickOnElement('"Buy Now" button', ':iframe .s_add_to_cart_btn'),


### PR DESCRIPTION
__Behavior before commit:__
When `searchNeeded` is `true`, `changeOptionInPopover` adds a step to
search the option in the dropdown.
This step is not working if the dropdown is not ready.

This causes `add_to_cart_snippet_tour` to timeout when the tests are run
with demo data because the products created in the python side of the
test are not showing directly.

If the demo data are not included and `searchNeeded` is `true`, it is
useless to search. Furthermore in this case, it might click on the item
before the search request is finished. The popover will then be kept
open when the request end (without result because the search will
exclude the already selected item).

__Fix:__
- Wait for the dropdown to be ready by waiting for the items to appear
in the dropwdown. Then only make the search if the item isn't already in
the list.
- Remove the now useless `searchNeeded` parameter

runbot-234680