### PR TITLE
[FIX] stock_account: Fix memory issue calculating run_avco

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -314,13 +314,9 @@ class ProductProduct(models.Model):
         avco_total_value = 0
 
         if method == "realtime":
-            moves_full_domain = moves_domain & Domain([
-                '|',
-                '|', ('is_in', '=', True),
-                ('is_out', '=', True),
-                ('is_dropship', '=', True)
-            ])
-            moves = self.env['stock.move'].search_fetch(moves_full_domain, field_names=move_fields, order='date, id')
+            moves_full_domain = moves_domain & Domain([('is_out', '=', True)])
+            moves = moves_in | self.env['stock.move'].search_fetch(moves_full_domain, field_names=move_fields)
+            moves = moves.sorted('date, id')
         else:
             # no needed to join + reorder
             moves = moves_in


### PR DESCRIPTION
Fix memory by prefetching the field data in pre and do not let fetch during computation of avco and invaliadate cache afterward

```sql

select count(id), product_id from stock_move group by product_id order by count(id) desc limit 20;
 count  | product_id
--------+------------
 273979 |       1633
 221535 |       1639
 208664 |       2162
 208397 |       1540
 167044 |       1646
 163120 |       1651
 156553 |       1635
 148142 |       1620
 140095 |       1587
 125547 |       2193
 120156 |       3353
 116135 |       1565
 108266 |       1940
 106072 |       1629
 105039 |       1656
  99151 |       1936
  85211 |       3548
  84128 |       3364
  81539 |       3158
  77480 |       4053
(20 rows)
```
```py

Traceback (most recent call last):
   File "/tmp/tmp1422i2m4/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmp1422i2m4/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmp1422i2m4/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmp1422i2m4/migrations/base/tests/test_mock_crawl.py", line 644, in mock_view_list
    return self.mock_view_tree(model, view, fields_list, domain, group_by)
   File "/tmp/tmp1422i2m4/migrations/base/tests/test_mock_crawl.py", line 657, in mock_view_tree
    self.mock_web_search_read(model, view, [domain], fields_list)
   File "/tmp/tmp1422i2m4/migrations/base/tests/test_mock_crawl.py", line 691, in mock_web_search_read
    data = model.search_read(domain=domain, fields=fields_list, limit=80, order=filter_order(model))
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5779, in search_read
    return records._read_format(fnames=fields, **read_kwargs)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3744, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6680, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1737, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1908, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/19.0/addons/mail/models/mail_thread.py", line 483, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4949, in _compute_field_value
    determine(field.compute, self)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/19.0/addons/stock_account/models/product.py", line 165, in _compute_value
    product.total_value = product._run_avco(at_date=at_date)[1] * qty_available / total_qty_available
   File "/home/odoo/src/odoo/19.0/addons/stock_account/models/product.py", line 297, in _run_avco
    moves = moves.sorted('date, id')
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6282, in sorted
    ids = tuple(item.id for item in sorted(self, key=key, reverse=reverse))
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6336, in <lambda>
    return lambda rec: tuple(fn(rec) for fn in item_makers)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6336, in <genexpr>
    return lambda rec: tuple(fn(rec) for fn in item_makers)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6330, in <lambda>
    return lambda rec: comparator(getter(rec))
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6322, in getter
    value = raw_getter(rec)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1693, in __get__
    recs._fetch_field(self)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3769, in _fetch_field
    self.fetch(fnames)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3809, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3930, in _fetch_query
    field._insert_cache(fetched, values)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1600, in _insert_cache
    collections.deque(map(field_cache.setdefault, records._ids, values), maxlen=0)
 MemoryError

```

UPG-3530462
OPW-5222760

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
