### PR TITLE
[FIX] website_sale: fix tour failing on demo data

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -63,6 +63,10 @@ registerWebsitePreviewTour("shop_editor_no_alternative_products_visibility_tour"
         trigger: ':iframe form.oe_product_cart:has(.o_wsale_product_information_text a[content="product_with_alternative"]) a',
         run: "click",
     },
+    {
+        content: "Ensure product page is loaded before clicking on Edit",
+        trigger: ':iframe #product_details',
+    },
     ...clickOnEditAndWaitEditMode(),
     {
         trigger: ':iframe .s_dynamic_snippet_title h4',

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -411,9 +411,11 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
             'name': 'product_without_alternative',
             'is_published': True,
         })
-        self.env['product.template'].create({
+        product_with_alternative = self.env['product.template'].create({
             'name': 'product_with_alternative',
             'is_published': True,
             'alternative_product_ids': product_no_alternative.ids,
         })
+        product_no_alternative.set_sequence_top()
+        product_with_alternative.set_sequence_top()
         self.start_tour('/', 'shop_editor_no_alternative_products_visibility_tour', login="admin")


### PR DESCRIPTION
### Issue:

The tour introduced in #237117 is failing when demo data is available.

This is due to `product_with_alternative` not being in the first page in shop when demo data is available.

runbot-234699
