### PR TITLE
[FIX] account: clean new mail template

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -382,8 +382,6 @@
 <t t-set="portal_url" t-value="object.get_portal_url()"/>
 <t t-set="unsubscribe_url" t-value="ctx.get('unsubscribe_url', False)"/>
 
-<t t-set="payment_state" t-value="object.payment_state != 'not_paid' and object.payment_state.replace('_', ' ')"/>
-
 <div style="margin:0; padding:0; color:#2c2431;">
     <table cellpadding="0" cellspacing="0" border="0" style="width:100%; background:#f7f4f8; padding:40px 0;">
         <tr>


### PR DESCRIPTION
Remove unused declared variable.
Beside being useless, this assignment fails if `payment_state` is not set on the move (possible for the records created before saas~15.3).
