### PR TITLE
[FIX] pos_self_order: correctly get line changes state

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -192,7 +192,7 @@ export class CartPage extends Component {
         const order = this.selfOrder.currentOrder;
         this.selfOrder.editedLine = line;
 
-        if (order.state === "draft" && !order.lastChangesSent[line.uuid]) {
+        if (order.state === "draft" && !order.uiState.lineChanges[line.uuid]) {
             this.selfOrder.selectedOrderUuid = order.uuid;
 
             if (line.combo_line_ids.length > 0) {

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -47,7 +47,7 @@ export class ComboPage extends Component {
         return !(
             this.selfOrder.editedLine &&
             this.selfOrder.editedLine.uuid &&
-            order.lastChangesSent[this.selfOrder.editedLine.uuid]
+            order.uiState.lineChanges[this.selfOrder.editedLine.uuid]
         );
     }
 

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -46,7 +46,7 @@ export class ProductPage extends Component {
         return !(
             this.selfOrder.editedLine &&
             this.selfOrder.editedLine.uuid &&
-            order.lastChangesSent[this.selfOrder.editedLine.uuid]
+            order.uiState.lineChanges[this.selfOrder.editedLine.uuid]
         );
     }
 


### PR DESCRIPTION
Before this commit, to check line changes the lastChangesSent was used, which doesn't exist anymore. This commit replaces its usage with uiState.lineChanges.

opw-5407191

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
