### PR TITLE
[REV] account: displays correct number to reconcile

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -453,6 +453,7 @@ class account_journal(models.Model):
                AND st_line.company_id IN %s
                AND NOT st_line.is_reconciled
                AND st_line_move.checked IS TRUE
+               AND st_line_move.state = 'posted'
           GROUP BY st_line.journal_id
         """, [tuple(bank_cash_journals.ids), tuple(self.env.companies.ids)])
         number_to_reconcile = {


### PR DESCRIPTION
This recent commit is causing an issue for lots of databases. The wrong number of entries to reconcile is displayed on the dashboard. After clicking on the "N to reconcile" button, no entries appear in the reconciliation view.

this is a revert of commit #ed71144

opw-5414718
opw-5418442
opw-5418117
opw-5417268
opw-5417879
opw-5417291