### PR TITLE
[FIX] web: revert add 20px buffer to popover positioning

### DIFF
--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -155,15 +155,7 @@ function computePosition(
     // Boxes
     const popBox = popper.getBoundingClientRect();
     const targetBox = target.getBoundingClientRect();
-    const contRect = container.getBoundingClientRect();
-    // Shrink the container a little bit (up to 20px) so that the popper avoids sticking to its edges
-    const getContainerMargin = (val) => Math.min(20, Math.max(0, Math.round((val - 40) / 2)));
-    const contBox = {
-        top: contRect.top + getContainerMargin(contRect.height),
-        left: contRect.left + getContainerMargin(contRect.width),
-        right: contRect.right - getContainerMargin(contRect.width),
-        bottom: contRect.bottom - getContainerMargin(contRect.height),
-    };
+    const contBox = container.getBoundingClientRect();
     const iframeBox = iframe?.getBoundingClientRect() ?? { top: 0, left: 0 };
 
     const containerIsHTMLNode = container === container.ownerDocument.firstElementChild;

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -455,7 +455,6 @@ test("arrow follows target and can get sucked", async () => {
         }
         .popover-target {
             background-color: bisque;
-            margin-left: 20px;
             width: 50px;
             height: 50px;
         }

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -674,8 +674,8 @@ test("popper as child of another", async () => {
     class Parent extends Component {
         static components = { Child };
         static template = /* xml */ xml`
-            <div id="container" t-ref="container" style="background-color: salmon; display: flex; align-items: center; justify-content: center; width: 450px; height: 350px; margin: 25px; overflow: auto">
-                <div id="target" t-ref="target" style="background-color: tomato; width: 200px; height: 500px"/>
+            <div id="container" t-ref="container" style="background-color: salmon; display: flex; align-items: center; justify-content: center; width: 450px; height: 450px; margin: 25px; overflow: auto">
+                <div id="target" t-ref="target" style="background-color: tomato; width: 200px; height: 600px"/>
                 <div id="popper" t-ref="popper"><Child/></div>
             </div>
         `;
@@ -790,14 +790,8 @@ function shrinkPopperTest(position, offset, onPositioned, popperStyle = {}) {
                     container: () => container.el,
                     onPositioned(el) {
                         expect.step("onPositioned");
-                        const contRect = container.el.getBoundingClientRect();
                         onPositioned({
-                            c: {
-                                top: contRect.top + 20,
-                                left: contRect.left + 20,
-                                right: contRect.right - 20,
-                                bottom: contRect.bottom - 20,
-                            },
+                            c: container.el.getBoundingClientRect(),
                             p: el.getBoundingClientRect(),
                             t: target.el.getBoundingClientRect(),
                         });
@@ -985,13 +979,13 @@ function getRepositionTest(from, to, containerStyleChanges, extendedFlipping = f
 test("reposition from top-start to top", getRepositionTest("top-start", "bottom-start", "top"));
 test(
     "reposition from top-start to top right",
-    getRepositionTest("top-start", "bottom-start", "top right")
+    getRepositionTest("top-start", "bottom-end", "top right")
 );
 test(
     "reposition from top-start to slimfit bottom",
     getRepositionTest("top-start", "top-start", "slimfit bottom")
 );
-test("reposition from top-start to right", getRepositionTest("top-start", "top-start", "right"));
+test("reposition from top-start to right", getRepositionTest("top-start", "top-end", "right"));
 // -----------------------------------------------------------------------------
 test("reposition from top-middle to top", getRepositionTest("top-middle", "bottom-middle", "top"));
 test(
@@ -999,9 +993,12 @@ test(
     getRepositionTest("top-middle", "top-middle", "slimfit bottom")
 );
 // -----------------------------------------------------------------------------
-test("reposition from top-end to top left", getRepositionTest("top-end", "bottom-end", "top left"));
+test(
+    "reposition from top-end to top left",
+    getRepositionTest("top-end", "bottom-start", "top left")
+);
 test("reposition from top-end to top", getRepositionTest("top-end", "bottom-end", "top"));
-test("reposition from top-end to left", getRepositionTest("top-end", "top-end", "left"));
+test("reposition from top-end to left", getRepositionTest("top-end", "top-start", "left"));
 test(
     "reposition from top-end to slimfit bottom",
     getRepositionTest("top-end", "top-end", "slimfit bottom")
@@ -1010,16 +1007,13 @@ test(
 test("reposition from left-start to left", getRepositionTest("left-start", "right-start", "left"));
 test(
     "reposition from left-start to left bottom",
-    getRepositionTest("left-start", "right-start", "left bottom")
+    getRepositionTest("left-start", "right-end", "left bottom")
 );
 test(
     "reposition from left-start to slimfit top",
     getRepositionTest("left-start", "left-start", "slimfit top")
 );
-test(
-    "reposition from left-start to bottom",
-    getRepositionTest("left-start", "left-start", "bottom")
-);
+test("reposition from left-start to bottom", getRepositionTest("left-start", "left-end", "bottom"));
 // -----------------------------------------------------------------------------
 test(
     "reposition from left-middle to left",
@@ -1032,10 +1026,10 @@ test(
 // -----------------------------------------------------------------------------
 test(
     "reposition from left-end to left top",
-    getRepositionTest("left-end", "right-end", "left top")
+    getRepositionTest("left-end", "right-start", "left top")
 );
 test("reposition from left-end to left", getRepositionTest("left-end", "right-end", "left"));
-test("reposition from left-end to top", getRepositionTest("left-end", "left-end", "top"));
+test("reposition from left-end to top", getRepositionTest("left-end", "left-start", "top"));
 test(
     "reposition from left-end to slimfit bottom",
     getRepositionTest("left-end", "left-end", "slimfit bottom")
@@ -1047,7 +1041,7 @@ test(
 );
 test(
     "reposition from bottom-start to right",
-    getRepositionTest("bottom-start", "bottom-start", "right")
+    getRepositionTest("bottom-start", "bottom-end", "right")
 );
 test(
     "reposition from bottom-start to bottom",
@@ -1055,7 +1049,7 @@ test(
 );
 test(
     "reposition from bottom-start to bottom right",
-    getRepositionTest("bottom-start", "top-start", "bottom right")
+    getRepositionTest("bottom-start", "top-end", "bottom right")
 );
 // -----------------------------------------------------------------------------
 test(
@@ -1067,14 +1061,14 @@ test(
     getRepositionTest("bottom-middle", "top-middle", "bottom")
 );
 // -----------------------------------------------------------------------------
-test("reposition from bottom-end to left", getRepositionTest("bottom-end", "bottom-end", "left"));
+test("reposition from bottom-end to left", getRepositionTest("bottom-end", "bottom-start", "left"));
 test(
     "reposition from bottom-end to slimfit top",
     getRepositionTest("bottom-end", "bottom-end", "slimfit top")
 );
 test(
     "reposition from bottom-end to bottom left",
-    getRepositionTest("bottom-end", "top-end", "bottom left")
+    getRepositionTest("bottom-end", "top-start", "bottom left")
 );
 test("reposition from bottom-end to bottom", getRepositionTest("bottom-end", "top-end", "bottom"));
 // -----------------------------------------------------------------------------
@@ -1084,7 +1078,7 @@ test(
 );
 test(
     "reposition from right-start to bottom",
-    getRepositionTest("right-start", "right-start", "bottom")
+    getRepositionTest("right-start", "right-end", "bottom")
 );
 test(
     "reposition from right-start to right",
@@ -1092,7 +1086,7 @@ test(
 );
 test(
     "reposition from right-start to right bottom",
-    getRepositionTest("right-start", "left-start", "right bottom")
+    getRepositionTest("right-start", "left-end", "right bottom")
 );
 // -----------------------------------------------------------------------------
 test(
@@ -1104,14 +1098,14 @@ test(
     getRepositionTest("right-middle", "left-middle", "right")
 );
 // -----------------------------------------------------------------------------
-test("reposition from right-end to top", getRepositionTest("right-end", "right-end", "top"));
+test("reposition from right-end to top", getRepositionTest("right-end", "right-start", "top"));
 test(
     "reposition from right-end to slimfit bottom",
     getRepositionTest("right-end", "right-end", "slimfit bottom")
 );
 test(
     "reposition from right-end to right top",
-    getRepositionTest("right-end", "left-end", "right top")
+    getRepositionTest("right-end", "left-start", "right top")
 );
 test("reposition from right-end to right", getRepositionTest("right-end", "left-end", "right"));
 // Reposition with all flipping directions allowed
@@ -1121,7 +1115,7 @@ test(
 );
 test(
     "extended reposition from top-start to right",
-    getRepositionTest("top-start", "left-start", "right", true)
+    getRepositionTest("top-start", "top-end", "right", true)
 );
 test(
     "extended reposition from top-middle to slimfit bottom",
@@ -1129,7 +1123,7 @@ test(
 );
 test(
     "extended reposition from top-end to left",
-    getRepositionTest("top-end", "right-end", "left", true)
+    getRepositionTest("top-end", "top-start", "left", true)
 );
 test(
     "extended reposition from top-end to slimfit bottom",
@@ -1141,7 +1135,7 @@ test(
 );
 test(
     "extended reposition from left-start to bottom",
-    getRepositionTest("left-start", "top-start", "bottom", true)
+    getRepositionTest("left-start", "left-end", "bottom", true)
 );
 test(
     "extended reposition from left-middle to slimfit bottom",
@@ -1149,7 +1143,7 @@ test(
 );
 test(
     "extended reposition from left-end to top",
-    getRepositionTest("left-end", "bottom-end", "top", true)
+    getRepositionTest("left-end", "left-start", "top", true)
 );
 test(
     "extended reposition from left-end to slimfit bottom",
@@ -1161,7 +1155,7 @@ test(
 );
 test(
     "extended reposition from bottom-start to right",
-    getRepositionTest("bottom-start", "left-start", "right", true)
+    getRepositionTest("bottom-start", "bottom-end", "right", true)
 );
 test(
     "extended reposition from bottom-middle to slimfit top",
@@ -1169,7 +1163,7 @@ test(
 );
 test(
     "extended reposition from bottom-end to left",
-    getRepositionTest("bottom-end", "right-end", "left", true)
+    getRepositionTest("bottom-end", "bottom-start", "left", true)
 );
 test(
     "extended reposition from bottom-end to slimfit top",
@@ -1181,7 +1175,7 @@ test(
 );
 test(
     "extended reposition from right-start to bottom",
-    getRepositionTest("right-start", "top-start", "bottom", true)
+    getRepositionTest("right-start", "right-end", "bottom", true)
 );
 test(
     "extended reposition from right-middle to slimfit bottom",
@@ -1189,7 +1183,7 @@ test(
 );
 test(
     "extended reposition from right-end to top",
-    getRepositionTest("right-end", "bottom-end", "top", true)
+    getRepositionTest("right-end", "right-start", "top", true)
 );
 test(
     "extended reposition from right-end to slimfit bottom",


### PR DESCRIPTION
This commit reverts changes made in https://github.com/odoo/odoo/pull/236503/commits/c400a5299f0dd9215bb29acc1a3e82cdc166d9a6 because it had too many unwanted side effects (see task-5413492 for example).
