### PR TITLE
[FIX] website_sale: keep products unpublished until a website category is set

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -177,6 +177,12 @@ class ProductTemplate(models.Model):
 
     #=== CRUD METHODS ===#
 
+    def create(self, vals_list):
+        for vals in vals_list:
+            if 'website_published' not in vals:
+                vals['website_published'] = bool(vals.get('public_categ_ids'))
+        return super().create(vals_list)
+
     def write(self, vals):
         # Clear empty ecommerce description content to avoid side-effects on product pages
         # when there is no content to display anyway.
@@ -186,6 +192,10 @@ class ProductTemplate(models.Model):
             and 'media_iframe_video' not in description_ecommerce  # don't remove "empty" video div
         ):
             vals['description_ecommerce'] = ''
+
+        if 'public_categ_ids' in vals and 'website_published' not in vals:
+            vals['website_published'] = bool(vals.get('public_categ_ids'))
+
         return super().write(vals)
 
     #=== BUSINESS METHODS ===#


### PR DESCRIPTION
Before:
- Products were automatically published on the website even when no Website Product Category was assigned.
- This caused inconsistencies where products appeared as published while showing them as “Unpublished”. 

After:
- Products remain unpublished as long as no website category is set.
- Products are automatically published when at least one website category is added. 

Fix:
- Explicitly synchronize the website publication state with `public_categ_ids` during product create and write operations.
- Ensures consistent behavior across UI actions. 

opw-5408903

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
