### PR TITLE
[REF] spreadsheet: extract relational field fetching logic

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -8,6 +8,7 @@ import { EvaluationError, PivotRuntimeDefinition, registries, helpers } from "@o
 import { LOADING_ERROR } from "@spreadsheet/data_sources/data_source";
 import { omit } from "@web/core/utils/objects";
 import { OdooPivotLoader } from "./odoo_pivot_loader";
+import { getRelationalFieldDefinition } from "./pivot_helpers";
 
 const { pivotRegistry, supportedPivotPositionalFormulaRegistry } = registries;
 const {
@@ -493,17 +494,11 @@ export class OdooPivot {
             );
         await Promise.all(
             related.map((dimension) =>
-                this.odooDataProvider.fieldService
-                    .loadPath(this.coreDefinition.model, dimension.fieldName)
-                    .then(({ modelsInfo, names }) => {
-                        this._fields[dimension.fieldName] = {
-                            ...modelsInfo.at(-1).fieldDefs[dimension.fieldName.split(".").at(-1)],
-                            string: names
-                                .map((name, i) => modelsInfo[i].fieldDefs[name].string)
-                                .join(" > "),
-                            name: dimension.fieldName,
-                        };
-                    })
+                getRelationalFieldDefinition(
+                    this.coreDefinition.model,
+                    dimension.fieldName,
+                    this.odooDataProvider.fieldService
+                ).then((definition) => (this._fields[dimension.fieldName] = definition))
             )
         );
     }

--- a/addons/spreadsheet/static/src/pivot/pivot_helpers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_helpers.js
@@ -91,3 +91,12 @@ export function parseGroupField(allFields, groupFieldString) {
 export function domainHasNoRecordAtThisPosition(domain) {
     return domain.some((node) => node.value === "NO_RECORD_AT_THIS_POSITION");
 }
+
+export async function getRelationalFieldDefinition(resModel, fieldName, fieldService) {
+    const { modelsInfo, names } = await fieldService.loadPath(resModel, fieldName);
+    return {
+        ...modelsInfo.at(-1).fieldDefs[fieldName.split(".").at(-1)],
+        string: names.map((name, i) => modelsInfo[i].fieldDefs[name].string).join(" > "),
+        name: fieldName,
+    };
+}


### PR DESCRIPTION
This commit extracts the logic to fetch relational field definitions into a separate utility function `getRelationalFieldDefinition`. This function will be used in the enterprise commit to fix an issue with invalid dimension addition in pivot tables.

Task: 5411336

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
