### PR TITLE
[IMP] website(_sale): align dynamic product snippet features with shop behavior

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
@@ -15,15 +15,16 @@
         </div>
     </t>
     <t t-name="website.s_dynamic_snippet.carousel.base">
+        <t t-set="slideSize" t-value="rowSize * this.rowPerSlide" />
+        <t t-set="slideIndexGenerator" t-value="Array(Math.ceil(this.data.length/slideSize))"/>
         <div t-att-id="unique_id" t-attf-class="carousel slide #{extraCarouselClass || ''}"
              t-att-style="extraCarouselStyle"
-             t-att-data-bs-interval="this.interval" data-bs-ride="carousel">
+             t-att-data-bs-interval="slideIndexGenerator.length > minControlValue ? this.interval : 0"
+             t-att-data-bs-ride="slideIndexGenerator.length > minControlValue and 'carousel'">
             <!-- Content -->
-            <t t-set="slideSize" t-value="rowSize * this.rowPerSlide" />
-            <t t-set="slideIndexGenerator" t-value="Array(Math.ceil(this.data.length/slideSize))"/>
             <t t-set="rowIndexGenerator" t-value="Array(this.rowPerSlide)"/>
             <t t-set="colIndexGenerator" t-value="Array(rowSize)"/>
-            <div class="carousel-inner w-100 mx-auto" role="listbox"
+            <div id="s_dynamic_snippet_carousel" class="carousel-inner w-100 mx-auto" role="listbox"
                  aria-label="Carousel">
                 <t t-foreach="slideIndexGenerator" t-as="slideIndex" t-key="slideIndex_index">
                     <t t-set="slideOffset" t-value="slideIndex_index * slideSize"/>

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -149,6 +149,7 @@ class WebsiteSnippetFilter(models.Model):
                         res_product["product_id"] = product.product_variant_id.id
                     else:
                         res_product.update(product._get_combination_info())
+                    res_product['hide_variants'] = hide_variants
 
                     if records.env.context.get("add2cart_rerender"):
                         res_product["_add2cart_rerender"] = True

--- a/addons/website_sale/static/src/interactions/comparison_bottom_bar.js
+++ b/addons/website_sale/static/src/interactions/comparison_bottom_bar.js
@@ -5,7 +5,7 @@ import {
 } from '@website_sale/js/product_comparison_bottom_bar/product_comparison_bottom_bar';
 
 export class ComparisonBottomBar extends Interaction {
-    static selector = '.o_wsale_product_page, .o_wsale_products_page, .o_wsale_wishlist_page';
+    static selector = 'main:has(.o_wsale_product_page, .o_wsale_products_page, .o_wsale_wishlist_page, .s_dynamic_snippet_products)';
 
     setup() {
         // Mount the ProductComparisonBottomBar on pages with comparison functionality.

--- a/addons/website_sale/static/src/interactions/product/product_variant_preview.js
+++ b/addons/website_sale/static/src/interactions/product/product_variant_preview.js
@@ -2,7 +2,7 @@ import { Interaction } from '@web/public/interaction';
 import { registry } from '@web/core/registry';
 
 export class ProductVariantPreview extends Interaction {
-    static selector = "#o_wsale_products_grid";
+    static selector = "#o_wsale_products_grid, .s_dynamic_snippet_products #s_dynamic_snippet_carousel";
 
     dynamicContent = {
         _window: {

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
@@ -38,6 +38,22 @@ export class DynamicSnippetProducts extends DynamicSnippetCarousel {
         return searchDomain;
     }
 
+    getRibbonSearchDomain() {
+        const productRibbonIds = JSON.parse(this.el.dataset.productRibbonIds || '[]');
+        if (!productRibbonIds.length) {
+            return [];
+        }
+        const ribbonIds = productRibbonIds.map(productRibbon => productRibbon.id);
+
+        return [
+            '|',
+                ['variant_ribbon_id', 'in', ribbonIds],
+                '&',
+                    ['variant_ribbon_id', '=', false],
+                    ['product_tmpl_id.website_ribbon_id', 'in', ribbonIds],
+        ];
+    }
+
     getTagSearchDomain() {
         const searchDomain = [];
         let productTagIds = this.el.dataset.productTagIds;
@@ -54,6 +70,7 @@ export class DynamicSnippetProducts extends DynamicSnippetCarousel {
     getSearchDomain() {
         const searchDomain = super.getSearchDomain(...arguments);
         searchDomain.push(...this.getCategorySearchDomain());
+        searchDomain.push(...this.getRibbonSearchDomain());
         searchDomain.push(...this.getTagSearchDomain());
         const productNames = this.el.dataset.productNames;
         if (productNames) {

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option.xml
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option.xml
@@ -9,7 +9,12 @@
     </xpath>
     <xpath expr="//BuilderRow[*[@id=&quot;'filter_opt'&quot;]]" position="after">
 
-        <ProductsDesignPanel showLists="false" label.translate="Cards Design"/>
+        <ProductsDesignPanel
+            label.translate="Cards Design"
+            recordName="'shop_opt_products_design_classes'"
+            showLists="false"
+            showSecondaryImage="true"
+        />
 
         <BuilderRow label.translate="Category" t-if="!this.domState.isAlternative and !this.isSingleMode">
             <BuilderSelect dataAttributeAction="'productCategoryId'" preview="false" id="'product_category_opt'">
@@ -23,6 +28,17 @@
         <BuilderRow label.translate="Tags" preview="false" t-if="!this.domState.isAlternative and !this.isSingleMode">
 	        <BuilderMany2Many id="'product_tag_opt'" model="'product.tag'" limit="10"
 	            dataAttributeAction="'productTagIds'"
+	        />
+	    </BuilderRow>
+        <BuilderRow
+            t-if="!this.domState.isAlternative and !isSingleMode"
+            label.translate="Ribbons"
+            preview="false"
+        >
+	        <BuilderMany2Many
+                id="'product_ribbon_opt'"
+                model="'product.ribbon'"
+                dataAttributeAction="'productRibbonIds'"
 	        />
 	    </BuilderRow>
 <!-- TODO when many2many is fully supported

--- a/addons/website_sale/templates/comparison_templates.xml
+++ b/addons/website_sale/templates/comparison_templates.xml
@@ -246,4 +246,19 @@
         </t>
     </template>
 
+    <!-- Comparison button -->
+    <template id="website_sale.comparison_button">
+        <button
+            t-if="product._can_be_added_to_comparison()"
+            class="btn o_add_compare"
+            title="Compare"
+            aria-label="Compare"
+            t-att-data-product-id="product_variant.id"
+            t-att-data-product-template-id="product.id"
+        >
+            <span class="fa fa-exchange fa-fw o_not-animable"/>
+            <span class="o_label small ms-2">Compare</span>
+        </button>
+    </template>
+
 </odoo>

--- a/addons/website_sale/templates/product_tile_templates.xml
+++ b/addons/website_sale/templates/product_tile_templates.xml
@@ -45,125 +45,9 @@
         t-att-aria-label="product.name"
     >
         <t t-if="not product.website_published" t-call="website.unpublished_badge" badge_position="'left'"/>
-        <div t-attf-class="oe_product_image position-relative flex-grow-0 overflow-hidden">
-            <!-- Fetch Images Data -->
-            <t
-                t-if="product_variant and product_variant.with_context(bin_size=True).image_128"
-                t-set="all_images_list"
-                t-value="product_variant._get_images()"
-            />
-            <t
-                t-else=""
-                t-set="all_images_list"
-                t-value="product._get_images()"
-            />
-            <!--
-                Image holders are records of different types (`product.template`, `product.product`
-                or `product.image`) and are returned as a list.
-             -->
-            <t
-                t-set="primary_image_holder"
-                t-value="(all_images_list[:1]+[product])[0]"
-            />
-            <t
-                t-set="secondary_image_holder"
-                t-value="(all_images_list[1:2]+[False])[0]"
-            />
-
-            <a
-                t-att-href="product_href"
-                t-attf-class="oe_product_image_link position-relative {{secondary_image_holder and 'oe_product_image_link_has_secondary'}}"
-                contenteditable="false"
-                t-att-title="product.name"
-            >
-                <!-- Primary image -->
-                <span
-                    t-field="primary_image_holder.image_1920"
-                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img h-100 w-100'}"
-                    class="oe_product_image_img_wrapper oe_product_image_img_wrapper_primary d-flex h-100 justify-content-center align-items-center"
-                />
-
-                <!-- Secondary image -->
-                <span
-                    t-if="secondary_image_holder"
-                    t-field="secondary_image_holder.image_1920"
-                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img_secondary h-100 w-100'}"
-                    class="oe_product_image_img_wrapper oe_product_image_img_wrapper_secondary h-100 justify-content-center align-items-center"
-                />
-
-                <!-- Ribbon -->
-                <t t-if="show_ribbons">
-                    <t t-set="bg_color" t-value="ribbon.bg_color"/>
-                    <t t-set="text_color" t-value="ribbon.text_color"/>
-                    <span
-                        t-att-data-ribbon-id="ribbon.id"
-                        t-attf-class="o_ribbons o_not_editable #{ribbon._get_css_classes()}"
-                        t-attf-style="#{text_color and ('color: %s;' % text_color)} #{bg_color and 'background-color:' + bg_color}"
-                        t-out="ribbon.name or ''"
-                    />
-                </t>
-            </a>
-        </div>
+        <t t-call="website_sale.product_image_and_ribbon" product_image_title="product.name"/>
         <div class="o_wsale_product_information flex-grow-1 flex-shrink-1">
-            <div class="o_wsale_product_info_attributes_wrapper">
-                <!-- Variations/Attributes -->
-                <t
-                    t-if="product_ptavs_data"
-                    t-call="website_sale.product_variant_preview"
-                />
-
-                <!-- Information -->
-                <div class="o_wsale_product_information_text">
-                    <!-- Product Name -->
-                    <h2 class="o_wsale_products_item_title text-break">
-                        <a
-                            class="text-decoration-none"
-                            t-att-href="product_href"
-                        >
-                            <span t-field="product.name"/>
-                            <t t-if="show_combination_name">
-                                <t
-                                    t-set="combination_name"
-                                    t-value="product_variant.product_template_attribute_value_ids._get_combination_name()"
-                                />
-                                <span
-                                    t-if="combination_name"
-                                    t-out="'('+combination_name+')'"
-                                />
-                            </t>
-                        </a>
-                    </h2>
-                    <!-- Description -->
-                    <t t-call="website_sale.product_tile_element_visibility"
-                        visible_element_class.f="o_wsale_products_opt_has_description">
-
-                        <div class="oe_subdescription_wrapper">
-                            <div
-                                class="oe_subdescription text-muted small"
-                                contenteditable="false"
-                            >
-                                <div t-field="product.description_sale"/>
-                            </div>
-                        </div>
-                    </t>
-                    <!-- Rating -->
-                    <t
-                        t-if="is_view_active('website_sale.product_comment')"
-                        t-call="website_sale.product_tile_element_visibility"
-                        visible_element_class.f="o_wsale_products_opt_has_rating"
-                    >
-
-                        <div class="o_wsale_product_rating_wrapper">
-                            <t t-call="portal_rating.rating_widget_stars_static"
-                                rating_avg="product.sudo().rating_avg"
-                                rating_count="product.rating_count">
-                                <!-- sudo: product.product - visitor can access product average rating -->
-                            </t>
-                        </div>
-                    </t>
-                    <t t-if="product_extra_information" t-out="product_extra_information"/>
-                </div>
-            </div>
+            <t t-call="website_sale.product_title_and_details"/>
             <div class="o_wsale_product_sub justify-content-between gap-2">
                 <!-- Price(s) -->
                 <t t-if="product_price" t-out="product_price"/>
@@ -213,6 +97,133 @@
             <t t-if="extra_actions" t-out="extra_actions"/>
         </div>
     </article>
+</template>
+
+<template id="website_sale.product_image_and_ribbon" name="Products Images and Ribbons">
+    <div class="oe_product_image position-relative flex-grow-0 overflow-hidden">
+        <!-- Fetch Images Data -->
+        <t
+            t-if="product_variant and product_variant.with_context(bin_size=True).image_128"
+            t-set="all_images_list"
+            t-value="product_variant._get_images()"
+        />
+        <t
+            t-else=""
+            t-set="all_images_list"
+            t-value="product._get_images()"
+        />
+        <!--
+            Image holders are records of different types (`product.template`, `product.product`
+            or `product.image`) and are returned as a list.
+            -->
+        <t
+            t-set="primary_image_holder"
+            t-value="(all_images_list[:1]+[product])[0]"
+        />
+        <t
+            t-set="secondary_image_holder"
+            t-value="(all_images_list[1:2]+[False])[0]"
+        />
+
+        <a
+            t-att-href="product_href"
+            t-attf-class="oe_product_image_link position-relative {{secondary_image_holder and 'oe_product_image_link_has_secondary'}}"
+            contenteditable="false"
+            t-att-title="product_image_title"
+        >
+            <!-- Primary image -->
+            <span
+                t-field="primary_image_holder.image_1920"
+                t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img h-100 w-100'}"
+                class="oe_product_image_img_wrapper oe_product_image_img_wrapper_primary d-flex h-100 justify-content-center align-items-center"
+            />
+
+            <!-- Secondary image -->
+            <span
+                t-if="secondary_image_holder"
+                t-field="secondary_image_holder.image_1920"
+                t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img_secondary h-100 w-100'}"
+                class="oe_product_image_img_wrapper oe_product_image_img_wrapper_secondary h-100 justify-content-center align-items-center"
+            />
+
+            <!-- Ribbon -->
+            <t t-if="show_ribbons">
+                <t t-set="bg_color" t-value="ribbon.bg_color"/>
+                <t t-set="text_color" t-value="ribbon.text_color"/>
+                <span
+                    t-att-data-ribbon-id="ribbon.id"
+                    t-attf-class="o_ribbons o_not_editable #{ribbon._get_css_classes()}"
+                    t-attf-style="#{text_color and ('color: %s;' % text_color)} #{bg_color and 'background-color:' + bg_color}"
+                    t-out="ribbon.name or ''"
+                />
+            </t>
+        </a>
+        <div t-if="is_sample" class="o_ribbon_right small text-bg-primary">Sample</div>
+    </div>
+</template>
+
+<template id="website_sale.product_title_and_details">
+    <div class="o_wsale_product_info_attributes_wrapper">
+        <!-- Variations/Attributes -->
+        <t
+            t-if="product_ptavs_data"
+            t-call="website_sale.product_variant_preview"
+        />
+
+        <!-- Information -->
+        <div class="o_wsale_product_information_text">
+            <!-- Product Name -->
+            <h2 class="o_wsale_products_item_title text-break">
+                <a
+                    class="text-decoration-none"
+                    t-att-href="product_href"
+                >
+                    <span t-field="product.name"/>
+                    <t t-if="show_combination_name">
+                        <t
+                            t-set="combination_name"
+                            t-value="product_variant.product_template_attribute_value_ids._get_combination_name()"
+                        />
+                        <span
+                            t-if="combination_name"
+                            t-out="'('+combination_name+')'"
+                        />
+                    </t>
+                </a>
+            </h2>
+            <!-- Description -->
+            <t
+                t-call="website_sale.product_tile_element_visibility"
+                visible_element_class.f="o_wsale_products_opt_has_description"
+            >
+                <div class="oe_subdescription_wrapper">
+                    <div
+                        class="oe_subdescription text-muted small"
+                        contenteditable="false"
+                    >
+                        <div t-field="product.description_sale"/>
+                    </div>
+                </div>
+            </t>
+            <!-- Rating -->
+            <t
+                t-if="is_view_active('website_sale.product_comment')"
+                t-call="website_sale.product_tile_element_visibility"
+                visible_element_class.f="o_wsale_products_opt_has_rating"
+            >
+                <div class="o_wsale_product_rating_wrapper">
+                    <t
+                        t-call="portal_rating.rating_widget_stars_static"
+                        rating_avg="product.sudo().rating_avg"
+                        rating_count="product.rating_count"
+                    >
+                        <!-- sudo: product.product - visitor can access product average rating -->
+                    </t>
+                </div>
+            </t>
+            <t t-if="product_extra_information" t-out="product_extra_information"/>
+        </div>
+    </div>
 </template>
 
 <!-- TODO: rename `shop_product_buttons` to `product_tile_actions` -->
@@ -266,24 +277,7 @@
         <t name="buttons_container" position="inside">
             <t t-call="website_sale.product_tile_element_visibility">
                 <t t-set="visible_element_class" t-value="'o_wsale_products_opt_has_wishlist'"/>
-
-                <t t-set="btnTitle">Add to wishlist</t>
-                <t t-set="btnTitleActive">Handle your wishlist from the menu icon.</t>
-
-                <button
-                    t-attf-class="btn o_add_wishlist #{in_wish and 'o_in_wishlist'}"
-                    t-att-disabled="product in products_in_wishlist"
-                    t-att-data-product-id="product_variant.id"
-                    t-att-data-product-template-id="product.id"
-                    t-att-title="in_wish and btnTitleActive or btnTitle"
-                >
-                    <span
-                        t-attf-class="fa o_not-animable #{in_wish and 'fa-heart' or 'fa-heart-o'}"
-                        role="presentation"
-                    />
-                    <span t-if="not in_wish" class="o_label small ms-2">Add to wishlist</span>
-                    <span t-else="" class="o_label small ms-2">In your wishlist</span>
-                </button>
+                <t t-call="website_sale.wishlist_button"/>
             </t>
         </t>
     </template>
@@ -306,19 +300,7 @@
                 t-call="website_sale.product_tile_element_visibility"
                 visible_element_class.f="o_wsale_products_opt_has_comparison"
             >
-
-                <button
-                    t-if="product._can_be_added_to_comparison()"
-                    class="btn o_add_compare"
-                    title="Compare"
-                    aria-label="Compare"
-                    t-att-data-product-id="product_variant.id"
-                    t-att-data-product-template-id="product.id"
-                >
-                    <span class="fa fa-exchange fa-fw o_not-animable"/>
-                    <span class="o_label small ms-2">Compare</span>
-                </button>
-
+                <t t-call="website_sale.comparison_button"/>
             </t>
             <t t-else="" t-call="website_sale.product_tile_element_visibility">
                 <!--

--- a/addons/website_sale/templates/snippets/product_snippet_template_data.xml
+++ b/addons/website_sale/templates/snippets/product_snippet_template_data.xml
@@ -10,81 +10,75 @@
             data-number-of-elements-sm="2"
         >
             <t t-foreach="records" t-as="data">
-                <t t-set="record" t-value="data['_record']"/>
-                <t t-set="product" t-value="record"/>
-                <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
-                <t t-set="product_id" t-value="record.id if record.is_product_variant else record.product_variant_id.id"/>
+                <t t-set="product" t-value="data['_record']"/>
+                <t
+                    t-set="product_template"
+                    t-value="product if not product.is_product_variant else product.product_tmpl_id"
+                />
+                <t
+                    t-set="product_variant"
+                    t-value="product if product.is_product_variant else product_template._create_first_product_variant()"
+                />
+                <t t-if="data.get('hide_variants')">
+                    <t
+                        t-set="product_ptavs_data"
+                        t-value="product_template._get_previewed_attribute_values()[product_template.id]"
+                    />
+                    <t t-if="product_ptavs_data">
+                        <t
+                            t-set="product_ptavs"
+                            t-value="product_ptavs_data.get('ptavs_data')"
+                        />
+                        <t
+                            t-if="product_ptavs[0]['ptav'].attribute_id.preview_variants == 'hover'"
+                            t-set="ptavs_classes"
+                            t-value="'o_has_variations o_has_variations_onhover'"
+                        />
+                        <t
+                            t-else=""
+                            t-set="ptavs_classes"
+                            t-value="'o_has_variations o_has_variations_static'"
+                        />
+                    </t>
+                </t>
 
                 <div
-                    class="oe_product_cart o_carousel_product_card d-flex"
+                    t-attf-class="oe_product_cart o_carousel_product_card d-flex {{ptavs_classes}}"
                     role="article"
                     t-att-aria-label="product.display_name"
                     t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
                     t-att-data-publish="product.website_published and 'on' or 'off'"
                 >
-                    <!-- Image -->
-                    <div t-attf-class="oe_product_image position-relative flex-grow-0 overflow-hidden">
-                        <a
-                            t-att-href="product.website_url"
-                            t-attf-class="oe_product_image_link position-relative"
-                            contenteditable="false"
-                            t-att-title="product.display_name"
-                            >
-                            <span
-                                role="img"
-                                t-attf-alt="{{product.display_name}} image"
-                                class="oe_product_image_img_wrapper d-flex h-100 justify-content-center align-items-center"
-                            >
-                                <span
-                                    class="oe_product_image_img h-100 w-100"
-                                    t-attf-style="background-image: url({{data['image_512']}});"
-                                />
-                            </span>
-                        </a>
-                        <div t-if="is_sample" class="o_ribbon_right small text-bg-primary">Sample</div>
-                    </div>
+                    <t
+                        t-set="ribbon"
+                        t-value="product_template._get_ribbon(
+                            price_vals=data,
+                            variant=product_variant,
+                        )"
+                    />
+                    <t
+                        t-call="website_sale.product_image_and_ribbon"
+                        product="product_template"
+                        product_href="product.website_url"
+                        product_image_title="product.display_name"
+                        show_ribbons="True"
+                    />
                     <button t-if="data.get('_latest_viewed')"
                         class="btn o_carousel_product_remove js_remove rounded-pill lh-1"
-                        t-att-data-product-id="product_id"
-                        t-att-data-product-selected="record.is_product_variant"
-                        t-att-data-product-template-id="product_template_id"
+                        t-att-data-product-id="product_variant.id"
+                        t-att-data-product-selected="product.is_product_variant"
+                        t-att-data-product-template-id="product_template.id"
                         title="Remove from recently viewed"
                     >
                         <i class="oi oi-close" role="presentation"/>
                     </button>
                     <div class="o_wsale_product_information flex-grow-1 flex-shrink-1">
-                        <div class="o_wsale_product_info_attributes_wrapper">
-                            <div class="o_wsale_product_information_text">
-                                <!-- Product Name -->
-                                <h2 class="o_wsale_products_item_title h6 text-break">
-                                    <a
-                                        class="text-decoration-none"
-                                        t-att-href="product.website_url"
-                                        t-att-content="data.get('display_name')"
-                                        t-att-title="data.get('display_name')"
-                                        t-out="data.get('display_name')"
-                                    />
-                                </h2>
-                                <!-- Description -->
-                                <div class="oe_subdescription_wrapper">
-                                    <div
-                                        class="oe_subdescription text-muted small"
-                                        contenteditable="false"
-                                    >
-                                        <div t-field="product.description_sale"/>
-                                    </div>
-                                </div>
-                                <!-- Rating -->
-                                <div
-                                    t-if="is_view_active('website_sale.product_comment')"
-                                    class="o_wsale_product_rating_wrapper"
-                                >
-                                    <t t-call="portal_rating.rating_widget_stars_static"
-                                        rating_avg="record.rating_avg"
-                                        rating_count="record.rating_count"/>
-                                </div>
-                            </div>
-                        </div>
+                        <t
+                            t-call="website_sale.product_title_and_details"
+                            product="product_template"
+                            product_href="product.website_url"
+                            show_combination_name="not data.get('hide_variants')"
+                        />
                         <div class="o_wsale_product_sub justify-content-between gap-2">
                             <!-- Price(s) -->
                             <div class="product_price" aria-label="Price information">
@@ -98,9 +92,9 @@
                                             name="add_to_cart"
                                             class="o_wsale_product_btn_primary btn"
                                             title="Add to Cart"
-                                            t-att-data-product-id="product.id if product.is_product_variant else product.product_variant_id.id"
+                                            t-att-data-product-id="product_variant.id"
                                             t-att-data-product-selected="product.is_product_variant"
-                                            t-att-data-product-template-id="product.id if not product.is_product_variant else product.product_tmpl_id.id"
+                                            t-att-data-product-template-id="product_template.id"
                                             t-att-data-product-type="product.type"
                                             t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                         >
@@ -119,7 +113,16 @@
                                             <span class="o_label small ms-1">Contact Us</span>
                                         </a>
                                     </t>
+                                    <t
+                                        t-call="website_sale.comparison_button"
+                                        product="product_template"
+                                    />
                                 </div>
+                                <t
+                                    t-if="not data.get('_latest_viewed')"
+                                    t-call="website_sale.wishlist_button"
+                                    product="product_template"
+                                />
                             </div>
                         </div>
                     </div>
@@ -133,14 +136,22 @@
                       class="mb-0 fw-bold"
                       name="product_price"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
+                <t
+                    t-set="comparison_price"
+                    t-value="
+                        data.get('list_price') if data.get('has_discounted_price')
+                        else data.get('compare_list_price') if data.get('compare_list_price') and data.get('compare_list_price') > data.get('price')
+                        else False
+                    "
+                />
                 <del
-                    t-if="data.get('has_discounted_price')"
+                    t-if="comparison_price"
                     aria-label="Original price"
                     t-attf-class="text-muted me-1 mb-0"
                     style="white-space: nowrap;"
                 >
                     <small
-                        t-out="data['list_price']"
+                        t-out="comparison_price"
                         t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                     />
                 </del>

--- a/addons/website_sale/templates/wishlist_templates.xml
+++ b/addons/website_sale/templates/wishlist_templates.xml
@@ -149,4 +149,29 @@
         </t>
     </template>
 
+    <!-- Wishlist button -->
+    <template id="website_sale.wishlist_button">
+        <t
+            t-set="in_wish"
+            t-value="product_variant and product_variant._is_in_wishlist()"
+        />
+        <t t-set="btnTitle">Add to wishlist</t>
+        <t t-set="btnTitleActive">Handle your wishlist from the menu icon.</t>
+
+        <button
+            t-attf-class="btn o_add_wishlist #{in_wish and 'o_in_wishlist'}"
+            t-att-disabled="in_wish"
+            t-att-data-product-id="product_variant.id"
+            t-att-data-product-template-id="product.id"
+            t-att-title="in_wish and btnTitleActive or btnTitle"
+        >
+            <span
+                t-attf-class="fa o_not-animable #{in_wish and 'fa-heart' or 'fa-heart-o'}"
+                role="presentation"
+            />
+            <span t-if="not in_wish" class="o_label small ms-2">Add to wishlist</span>
+            <span t-else="" class="o_label small ms-2">In your wishlist</span>
+        </button>
+    </template>
+
 </odoo>


### PR DESCRIPTION
Prior this commit:
- Dynamic product snippets did not fully support all product features available
  on the shop page.

Post this commit:
- Dynamic product snippets now handle product features exactly the same way as
  the shop page, including:
   - Product ribbons
   - Compare to price
   - Attribute previews
   - Secondary product image
   - Wishlist
- Added a 'Ribbons' filter option.
- Prevent sliding when there are not enough products to display navigation
  arrows.

task-5167703