### PR TITLE
[FIX] mail: record thread write access

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -15,7 +15,9 @@ from odoo.addons.mail.tools.discuss import Store
 class ThreadController(http.Controller):
     @http.route("/mail/thread/data", methods=["POST"], type="json", auth="public", readonly=True)
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
-        thread = request.env[thread_model]._get_thread_with_access(thread_id, **kwargs)
+        cids_str = request.cookies.get('cids', str(request.env.user.company_id.id))
+        cids = [int(cid) for cid in cids_str.split('-')]
+        thread = request.env[thread_model].with_context(allowed_company_ids=cids)._get_thread_with_access(thread_id, **kwargs)
         if not thread:
             return Store(
                 request.env[thread_model].browse(thread_id),

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -198,6 +198,18 @@ class MailTestMultiCompany(models.Model):
     company_id = fields.Many2one('res.company')
 
 
+class MailTestMultiCompanyRestrictWrite(models.Model):
+    """ This model can be used in multi company tests, with attachments support
+    for checking record update in MC. It is readable for all companies, but
+    write is company-restricted to the current main company. """
+    _name = 'mail.test.multi.company.restrict.write'
+    _description = "Test Multi Company Mail Restrict Write"
+    _inherit = 'mail.thread.main.attachment'
+
+    name = fields.Char()
+    company_id = fields.Many2one('res.company')
+
+
 class MailTestMultiCompanyRead(models.Model):
     """ Just mail.test.simple, but multi company and supporting posting
     even if the user has no write access. """

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -49,6 +49,8 @@ access_mail_test_lang_portal,mail.test.lang.portal,model_mail_test_lang,base.gro
 access_mail_test_lang_user,mail.test.lang.user,model_mail_test_lang,base.group_user,1,1,1,1
 access_mail_test_multi_company_user,mail.test.multi.company.user,model_mail_test_multi_company,base.group_user,1,1,1,1
 access_mail_test_multi_company_portal,mail.test.multi.company.portal,model_mail_test_multi_company,base.group_portal,1,0,0,0
+access_mail_test_multi_company_restrict_write_user,mail.test.multi.company.user.restrict.write,model_mail_test_multi_company_restrict_write,base.group_user,1,1,1,1
+access_mail_test_multi_company_restrict_write_portal,mail.test.multi.company.portal.restrict.write,model_mail_test_multi_company_restrict_write,base.group_portal,1,0,0,0
 access_mail_test_multi_company_read_user,mail.test.multi.company.read.user,model_mail_test_multi_company_read,base.group_user,1,1,1,1
 access_mail_test_multi_company_read_portal,mail.test.multi.company.read.portal,model_mail_test_multi_company_read,base.group_portal,1,0,0,0
 access_mail_test_multi_company_with_activity_user,mail.test.multi.company.with.activity.user,model_mail_test_multi_company_with_activity,base.group_user,1,1,1,1

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -112,6 +112,27 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record id="mail_test_multi_company_rule_restrict_write_1" model="ir.rule">
+        <field name="name">Mail Test Multi Company Restrict Write</field>
+        <field name="model_id" ref="test_mail.model_mail_test_multi_company_restrict_write"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="mail_test_multi_company_rule_restrict_write_2" model="ir.rule">
+        <field name="name">Mail Test Multi Company Restrict Write</field>
+        <field name="model_id" ref="test_mail.model_mail_test_multi_company_restrict_write"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">[('company_id', '=', company_id)]</field>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
     <record id="mail_test_multi_company_read_rule" model="ir.rule">
         <field name="name">MC Readonly Rule</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company_read"/>

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -327,7 +327,9 @@ class TestMultiCompanyControllers(TestMailMCCommon, HttpCase):
             ),
         ):
             with self.subTest(user_name=test_user.name):
+                # Authenticate as test_user and enable all the companies in the UI via cookies
                 self.authenticate(test_user.login, test_user.login)
+                self.opener.cookies.set("cids", '-'.join(str(num) for num in test_user.company_ids.ids))
                 # crash if calling using portal users -> dedicated portal routes currently
                 if test_user in self.user_portal + self.user_portal_c2:
                     with self.assertRaises(JsonRpcException):
@@ -364,6 +366,8 @@ class TestMultiCompanyControllers(TestMailMCCommon, HttpCase):
         self.assertEqual(len(messages['data']['mail.message']), 1)
 
     def test_mail_thread_data_access(self):
+        """ Test to check the read and write access reflected in the records'
+         chatter, in MC environment"""
         # Record belonging to company_3
         # The model enforces write access only when the active company is company_3
         record = self.env["mail.test.multi.company.restrict.write"].create(
@@ -393,11 +397,49 @@ class TestMultiCompanyControllers(TestMailMCCommon, HttpCase):
         # Chatter permissions must match record permissions
         self.assertTrue(data["mail.thread"][0]["hasReadAccess"])
         self.assertFalse(data["mail.thread"][0]["hasWriteAccess"])
-        # Case 2: UI-selected company = company_3 (via cids)
+        # Case 2: UI-selected company = company_2 (main) + company_3 (via cookies, cids)
+        # - User can read the record
+        # - User cannot write the record
+        # - Chatter must reflect the same permissions
+        self.opener.cookies.set("cids", str(self.company_2.id) + "-" + str(self.company_3.id))
+        data = self.make_jsonrpc_request(
+            "/mail/thread/data",
+            {
+                "thread_id": record.id,
+                "thread_model": "mail.test.multi.company.restrict.write",
+                "request_list": [],
+            },
+        )
+        # Sanity check: ORM access behaves as expected
+        self.assertTrue(record.sudo(False).with_user(self.user_employee_c2).with_company(self.company_2).has_access("read"))
+        self.assertFalse(record.sudo(False).with_user(self.user_employee_c2).with_company(self.company_2).has_access("write"))
+        # Chatter permissions must match record permissions
+        self.assertTrue(data["mail.thread"][0]["hasReadAccess"])
+        self.assertFalse(data["mail.thread"][0]["hasWriteAccess"])
+        # Case 3: UI-selected company = company_3 (via cids)
         # - User can read the record
         # - User can now write the record
         # - Chatter must grant write access accordingly
         self.opener.cookies.set("cids", str(self.company_3.id))
+        data = self.make_jsonrpc_request(
+            "/mail/thread/data",
+            {
+                "thread_id": record.id,
+                "thread_model": "mail.test.multi.company.restrict.write",
+                "request_list": [],
+            },
+        )
+        # ORM access is unchanged (write depends on active company context)
+        self.assertTrue(record.sudo(False).with_user(self.user_employee_c2).with_company(self.company_3).has_access("read"))
+        self.assertTrue(record.sudo(False).with_user(self.user_employee_c2).with_company(self.company_3).has_access("write"))
+        # Chatter permissions must now correctly grant write access
+        self.assertTrue(data["mail.thread"][0]["hasReadAccess"])
+        self.assertTrue(data["mail.thread"][0]["hasWriteAccess"])
+        # Case 4: UI-selected company = company_3 (main) + company_2 (via cids)
+        # - User can read the record
+        # - User can now write the record
+        # - Chatter must grant write access accordingly
+        self.opener.cookies.set("cids", str(self.company_3.id) + "-" + str(self.company_2.id))
         data = self.make_jsonrpc_request(
             "/mail/thread/data",
             {


### PR DESCRIPTION
Chatter messages (especially the write permissions `hasWriteAccess` for the records' chatter) fetched via the `/mail/thread/data` endpoint can have permissions inconsistencies in multi-company setups. The issue arises because `request.env.company` falls back to the user’s main company instead of the company selected in the UI switcher, causing record rules to evaluate messages under the wrong company.

Imagine a scenario where we have a record rule that only allows users to write or read records belonging to their selected main company. Currently, users may have access to a record in the UI, but cannot access its chatter messages (cannot write in the chatter) if the company selected in the UI differs from their profile’s main company. This happens because HTTP controllers, including the chatter route, ignore the UI-selected company and fall back to the user’s main company. As a result, permissions are evaluated inconsistently, leading to mismatched access between the record and its chatter messages.

With the changes in this PR, the server reads the selected company from the `cids` cookie and injects `allowed_company_ids` into the context. Chatter messages now respect the same company context as the parent record, ensuring record and chatter permissions are consistent while preserving fallback for external calls.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
