### PR TITLE
[IMP] auth_signup: get reset password link

### DIFF
--- a/addons/auth_signup/__manifest__.py
+++ b/addons/auth_signup/__manifest__.py
@@ -25,8 +25,11 @@ Allow users to sign up and reset their password
         ],
     'bootstrap': True,
     'assets': {
+        'web.assets_backend': [
+            'auth_signup/static/src/components/**/*',
+        ],
         'web.assets_frontend': [
-            'auth_signup/static/**/*',
+            'auth_signup/static/src/interactions/**/*',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/auth_signup/static/src/components/signup.js
+++ b/addons/auth_signup/static/src/components/signup.js
@@ -1,0 +1,37 @@
+import { _t } from "@web/core/l10n/translation";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { browser } from "@web/core/browser/browser";
+import { useService } from "@web/core/utils/hooks";
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+
+export class ResetPasswordLinkButton extends Component {
+    static template = "auth_signup.reset_password_link_button";
+    static props = {
+        ...standardWidgetProps,
+    };
+
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+    }
+
+    async copyResetPasswordLink() {
+        const resetPasswordLink = await this.orm.call("res.users", "get_reset_password_link", [
+            this.props.record.resId,
+        ]);
+        setTimeout(async () => {
+            await browser.navigator.clipboard.writeText(resetPasswordLink);
+            this.notification.add(_t("Link copied to clipboard!"), { type: "success" });
+        });
+    }
+}
+
+export const buttonResetPasswordLink = {
+    component: ResetPasswordLinkButton,
+    additionalClasses: ["h-100", "ms-2", "my-auto"],
+};
+registry
+    .category("view_widgets")
+    .add("auth_signup.button_reset_password_link", buttonResetPasswordLink);

--- a/addons/auth_signup/static/src/components/signup.xml
+++ b/addons/auth_signup/static/src/components/signup.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+
+   <t t-name="auth_signup.reset_password_link_button">
+        <button t-on-click="copyResetPasswordLink" class="btn btn-secondary">
+            Copy Reset Password Link
+        </button>
+   </t>
+
+</templates>

--- a/addons/auth_signup/views/res_users_views.xml
+++ b/addons/auth_signup/views/res_users_views.xml
@@ -17,6 +17,9 @@
                     <button string="Send Password Reset"
                             type="object" name="action_reset_password"
                             invisible="id == uid or state != 'active'" class="btn btn-secondary h-100 ms-2 my-auto"/>
+                    <widget name="auth_signup.button_reset_password_link"
+                            groups="base.group_erp_manager"
+                            invisible="id == uid"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
It is sometimes useful to be able to obtain the reset password link via
the user's form view (for example, if a mail server is not configured).

An administrator can generate a password reset link for users
(other than themselves) via a button.
The link is placed directly in the clipboard.

task-5365791