### PR TITLE
[IMP] point_of_sale: move customer display URL into getter

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
@@ -43,7 +43,7 @@ class DisplayDriver(Driver):
             'rotate_screen': self._action_rotate_screen,
             'open': self._action_open_customer_display,
             'close': self._action_close_customer_display,
-            'set': self._action_set_customer_display,
+            'set': self._action_set_customer_display,  # TODO: Remove customer display actions when v19 is deprecated
         })
 
     @classmethod
@@ -138,6 +138,7 @@ class DisplayDriver(Driver):
         helpers.save_browser_state(orientation=orientation)
 
 
+# TODO: Remove when v19 is deprecated
 class DisplayController(http.Controller):
     @route.iot_route('/hw_proxy/customer_facing_display', type='jsonrpc', cors='*')
     def customer_facing_display(self, action, pos_id=None, access_token=None, data=None):

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -130,6 +130,14 @@ export class Navbar extends Component {
         )}&path=${encodeURIComponent(`pos/ui/${this.pos.config.id}`)}`;
     }
 
+    get customerDisplayPath() {
+        if (!localStorage.getItem("device_uuid")) {
+            localStorage.setItem("device_uuid", uuidv4());
+        }
+        const deviceUuid = localStorage.getItem("device_uuid");
+        return `/pos_customer_display/${this.pos.config.id}/${deviceUuid}`;
+    }
+
     async reloadProducts() {
         this.dialog.add(SyncPopup, {
             title: _t("Reload Data"),
@@ -138,23 +146,13 @@ export class Navbar extends Component {
     }
 
     openCustomerDisplay() {
-        const getDeviceUuid = () => {
-            if (!localStorage.getItem("device_uuid")) {
-                localStorage.setItem("device_uuid", uuidv4());
-            }
-            return localStorage.getItem("device_uuid");
-        };
-        const customer_display_url = `/pos_customer_display/${
-            this.pos.config.id
-        }/${getDeviceUuid()}`;
-
         if (this.ui.isSmall) {
             this.dialog.add(QrCodeCustomerDisplay, {
-                customerDisplayURL: `${this.pos.config._base_url}${customer_display_url}`,
+                customerDisplayURL: `${this.pos.config._base_url}${this.customerDisplayPath}`,
             });
             return;
         }
-        window.open(customer_display_url, "newWindow", "width=800,height=600,left=200,top=200");
+        window.open(this.customerDisplayPath, "newWindow", "width=800,height=600,left=200,top=200");
         this.notification.add(_t("PoS Customer Display opened in a new window"));
     }
 


### PR DESCRIPTION
This commit extracts the customer display URL generation in the Navbar component into a getter, so that it can more easily be re-used by overrides.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
