### PR TITLE
[CLN] mail: clean duplicated member access tests

### DIFF
--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -28,133 +28,32 @@ class TestDiscussChannelMember(MailCommon):
         cls.user_3 = new_test_user(
             cls.env, login="user_3", name="User 3", groups="base.group_user,mail.secret_group"
         )
-        cls.user_portal = new_test_user(
-            cls.env, login="user_portal", name="User Portal", groups="base.group_portal"
-        )
-        cls.user_public = new_test_user(
-            cls.env, login="user_public", name="User Public", groups="base.group_public"
-        )
+        cls.group = cls.env["discuss.channel"].create({"name": "Group", "channel_type": "group"})
+        cls.group.channel_member_ids.unlink()
 
+    def test_cannot_change_member_immutable_fields(self):
+        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
+        bob = new_test_user(self.env, "bob", groups="base.group_user")
+        another_channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Another channel")
+        another_partner = self.env["res.partner"].create({"name": "John"})
+        guest = self.env["mail.guest"].create({"name": "Jane"})
+        member = channel._add_members(users=bob)
+        with self.assertRaises(AccessError):
+            member.channel_id = another_channel
+        with self.assertRaises(AccessError):
+            member.partner_id = another_partner
+        with self.assertRaises(AccessError):
+            member.guest_id = guest
 
-        cls.group = cls.env['discuss.channel'].create({
-            'name': 'Group',
-            'channel_type': 'group',
-        })
-        cls.group_restricted_channel = cls.env['discuss.channel'].create({
-            'name': 'Group restricted channel',
-            'channel_type': 'channel',
-            'group_public_id': cls.secret_group.id,
-        })
-        cls.public_channel = cls.env['discuss.channel']._create_channel(group_id=None, name='Public channel of user 1')
-        (cls.group | cls.group_restricted_channel | cls.public_channel).channel_member_ids.unlink()
+    def test_user_public_cannot_join_channel(self):
+        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Public")
+        public = new_test_user(self.env, "public_user", groups="base.group_public")
+        with self.assertRaises(ValidationError):
+            channel._add_members(users=public)
 
     # ------------------------------------------------------------
     # GROUP
     # ------------------------------------------------------------
-
-    def test_group_01(self):
-        """Test access on group."""
-        res = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertFalse(res)
-
-        # User 1 can join group with SUDO
-        self.group.with_user(self.user_1).sudo()._add_members(users=self.user_1)
-        res = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(res.partner_id, self.user_1.partner_id)
-
-        # User 2 can not join group
-        with self.assertRaises(AccessError):
-            self.group.with_user(self.user_2)._add_members(users=self.user_2)
-
-        # User 2 can not create a `discuss.channel.member` to join the group
-        with self.assertRaises(AccessError):
-            self.env['discuss.channel.member'].with_user(self.user_2).create({
-                'partner_id': self.user_2.partner_id.id,
-                'channel_id': self.group.id,
-            })
-
-        # User 2 can not write on `discuss.channel.member` to join the group
-        channel_member = self.env['discuss.channel.member'].with_user(self.user_2).search([('is_self', '=', True)])[0]
-        with self.assertRaises(AccessError):
-            channel_member.channel_id = self.group.id
-        with self.assertRaises(AccessError):
-            channel_member.write({'channel_id': self.group.id})
-
-        # Even with SUDO, channel_id of channel.member should not be changed.
-        with self.assertRaises(AccessError):
-            channel_member.sudo().channel_id = self.group.id
-
-        # User 2 can not write on the `partner_id` of `discuss.channel.member`
-        # of an other partner to join a group
-        channel_member_1 = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id), ('partner_id', '=', self.user_1.partner_id.id)])
-        with self.assertRaises(AccessError):
-            channel_member_1.with_user(self.user_2).partner_id = self.user_2.partner_id
-        self.assertEqual(channel_member_1.partner_id, self.user_1.partner_id)
-
-        # Even with SUDO, partner_id of channel.member should not be changed.
-        with self.assertRaises(AccessError):
-            channel_member_1.with_user(self.user_2).sudo().partner_id = self.user_2.partner_id
-
-    def test_group_members(self):
-        """Test invitation in group part 1 (invite using crud methods)."""
-        self.group.with_user(self.user_1).sudo()._add_members(users=self.user_1)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(len(channel_members), 1)
-
-        # User 2 is not in the group, they can not invite user 3
-        with self.assertRaises(AccessError):
-            self.env['discuss.channel.member'].with_user(self.user_2).create({
-                'partner_id': self.user_portal.partner_id.id,
-                'channel_id': self.group.id,
-            })
-
-        # User 1 is in the group, they can invite other users
-        self.env['discuss.channel.member'].with_user(self.user_1).create({
-            'partner_id': self.user_portal.partner_id.id,
-            'channel_id': self.group.id,
-        })
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id | self.user_portal.partner_id)
-
-        # But User 3 can not write on the `discuss.channel.member` of other user
-        channel_member_1 = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id), ('partner_id', '=', self.user_1.partner_id.id)])
-        channel_member_3 = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id), ('partner_id', '=', self.user_portal.partner_id.id)])
-        channel_member_3.with_user(self.user_portal).custom_channel_name = 'Test'
-        with self.assertRaises(AccessError):
-            channel_member_1.with_user(self.user_2).custom_channel_name = 'Blabla'
-        self.assertNotEqual(channel_member_1.custom_channel_name, 'Blabla')
-
-    def test_group_invite(self):
-        """Test invitation in group part 2 (use `invite` action)."""
-        self.group.with_user(self.user_1).sudo()._add_members(users=self.user_1)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id)
-
-        # User 2 is not in the group, they can not invite user_portal
-        with self.assertRaises(AccessError):
-            self.group.with_user(self.user_2)._add_members(users=self.user_portal)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id)
-
-        # User 1 is in the group, they can invite user_portal
-        self.group.with_user(self.user_1)._add_members(users=self.user_portal)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id | self.user_portal.partner_id)
-
-    def test_group_leave(self):
-        """Test kick/leave channel."""
-        self.group.with_user(self.user_1).sudo()._add_members(users=self.user_1)
-        self.group.with_user(self.user_portal).sudo()._add_members(users=self.user_portal)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group.id)])
-        self.assertEqual(len(channel_members), 2)
-
-        # User 2 is not in the group, they can not kick user 1
-        with self.assertRaises(AccessError):
-            channel_members.with_user(self.user_2).unlink()
-
-        # User 3 is in the group, but not admin/owner, they can not kick user 1
-        with self.assertRaises(AccessError):
-            channel_members.with_user(self.user_portal).unlink()
 
     def test_group_subchannel_join(self):
         """Test join subchannel."""
@@ -164,61 +63,11 @@ class TestDiscussChannelMember(MailCommon):
         self.assertEqual(group_subchannel.channel_member_ids.partner_id, (self.user_1 | self.user_2).partner_id)
 
     # ------------------------------------------------------------
-    # GROUP BASED CHANNELS
-    # ------------------------------------------------------------
-
-    def test_group_restricted_channel(self):
-        """Test basics on group channel."""
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group_restricted_channel.id)])
-        self.assertFalse(channel_members)
-
-        # user 1 is in the channel, they can join the channel
-        self.group_restricted_channel.with_user(self.user_1)._add_members(users=self.user_1)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group_restricted_channel.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id)
-
-        # user 3 is not in the channel, they can not join
-        with self.assertRaises(AccessError):
-            self.group_restricted_channel.with_user(self.user_portal)._add_members(users=self.user_portal)
-
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group_restricted_channel.id)])
-        with self.assertRaises(AccessError):
-            channel_members.with_user(self.user_portal).partner_id = self.user_portal.partner_id
-
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group_restricted_channel.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id)
-
-        self.group_restricted_channel.with_user(self.user_1)._add_members(users=self.user_portal)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group_restricted_channel.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id | self.user_portal.partner_id)
-
-        # but user 2 is in the channel and can be invited by user 1
-        self.group_restricted_channel.with_user(self.user_1)._add_members(users=self.user_2)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.group_restricted_channel.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id | self.user_2.partner_id | self.user_portal.partner_id)
-
-    # ------------------------------------------------------------
     # PUBLIC CHANNELS
     # ------------------------------------------------------------
 
-    def test_public_channel(self):
-        """ Test access on public channels """
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.public_channel.id)])
-        self.assertFalse(channel_members)
-
-        self.public_channel.with_user(self.user_1)._add_members(users=self.user_1)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.public_channel.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id)
-
-        self.public_channel.with_user(self.user_2)._add_members(users=self.user_2)
-        channel_members = self.env['discuss.channel.member'].search([('channel_id', '=', self.public_channel.id)])
-        self.assertEqual(channel_members.mapped('partner_id'), self.user_1.partner_id | self.user_2.partner_id)
-
-        self.public_channel.with_user(self.user_portal)._add_members(users=self.user_portal)
-        with self.assertRaises(ValidationError):  # public cannot join without having a guest
-            self.public_channel.with_user(self.user_public)._add_members(users=self.user_public)
-
     def test_channel_member_invite_with_guest(self):
+        public_channel = self.env["discuss.channel"]._create_channel(group_id=None, name="Public")
         guest = self.env['mail.guest'].create({'name': 'Guest'})
         partner = self.env['res.partner'].create({
             'name': 'ToInvite',
@@ -226,9 +75,10 @@ class TestDiscussChannelMember(MailCommon):
             'type': 'contact',
             'user_ids': self.user_1,
         })
-        self.public_channel._add_members(guests=guest)
+        public_channel._add_members(guests=guest)
         data = self.env["res.partner"].search_for_channel_invite(
-            partner.name, channel_id=self.public_channel.id
+            partner.name,
+            channel_id=public_channel.id,
         )["store_data"]
         self.assertEqual(len(data["res.partner"]), 1)
         self.assertEqual(data["res.partner"][0]["id"], partner.id)


### PR DESCRIPTION
Many tests inside the `TestDiscussChannelMember` test suite are actually duplicates from the exhaustive `TestDiscussChannelAccess` suite.

Moreover, those tests are not easy to read, mostly due to bad variable names (`user_{1,2,3}`) and incorrect comments.

part of task-5231553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
