### PR TITLE
[PERF] point_of_sale: prevent loading all of the account.move records

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -124,6 +124,10 @@ class AccountMove(models.Model):
         result = super()._load_pos_data_fields(config)
         return result or ['id', 'name']
 
+    @api.model
+    def _load_pos_data_domain(self, data, config):
+        return False
+
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 


### PR DESCRIPTION
Before this commit, when loading the PoS all of the account.move records were loaded to the client side, which could lead to performance issues in databases with a large number of invoices.

opw-5409082

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
