### PR TITLE
[FIX] spreadsheet: fix `Show Value` option in odoo charts

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemClick, onOdooChartItemHover } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemClick,
+    onOdooChartItemHover,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -87,7 +91,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getBarChartLegend(definition, chartData),
                 tooltip: getBarChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_helpers.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_helpers.js
@@ -233,3 +233,13 @@ export function isChartJSMiddleClick(event) {
         (event.type === "mouseup" && event.native.button === 1)
     );
 }
+
+/**
+ * Change the chart definition type from odoo_xxx to xxx so it can be used by spreadsheet chart helpers
+ */
+export function changeTypeToSpreadsheetChart(definition) {
+    return {
+        ...definition,
+        type: definition.type.replace("odoo_", ""),
+    };
+}

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_combo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_combo_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -90,7 +94,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getComboChartLegend(definition, chartData),
                 tooltip: getBarChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_funnel_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_funnel_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -75,7 +79,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: { display: false },
                 tooltip: getFunnelChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemClick, onOdooChartItemHover } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemClick,
+    onOdooChartItemHover,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -97,7 +101,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getLineChartLegend(definition, chartData),
                 tooltip: getLineChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -67,7 +71,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getPieChartLegend(definition, chartData),
                 tooltip: getPieChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pyramid_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pyramid_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -83,7 +87,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getBarChartLegend(definition, chartData),
                 tooltip: getPyramidChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getPyramidChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getPyramidChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_radar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_radar_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -70,7 +74,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getRadarChartLegend(definition, chartData),
                 tooltip: getRadarChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -84,7 +88,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getScatterChartLegend(definition, chartData),
                 tooltip: getLineChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
             },
             onHover: onOdooChartItemHover(),
             onClick: onOdooChartItemClick(getters, chart),

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_waterfall_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_waterfall_chart.js
@@ -1,7 +1,11 @@
 import { registries, chartHelpers } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
 import { OdooChart } from "./odoo_chart";
-import { onOdooChartItemHover, onWaterfallOdooChartItemClick } from "./odoo_chart_helpers";
+import {
+    onOdooChartItemHover,
+    onWaterfallOdooChartItemClick,
+    changeTypeToSpreadsheetChart,
+} from "./odoo_chart_helpers";
 
 const { chartRegistry } = registries;
 
@@ -85,7 +89,10 @@ function createOdooChartRuntime(chart, getters) {
                 title: getChartTitle(definition, getters),
                 legend: getWaterfallChartLegend(definition, chartData),
                 tooltip: getWaterfallChartTooltip(definition, chartData),
-                chartShowValuesPlugin: getWaterfallChartShowValues(definition, chartData),
+                chartShowValuesPlugin: getWaterfallChartShowValues(
+                    changeTypeToSpreadsheetChart(definition),
+                    chartData
+                ),
                 waterfallLinesPlugin: { showConnectorLines: definition.showConnectorLines },
             },
             onHover: onOdooChartItemHover(),

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -1316,6 +1316,7 @@ test("Show values is taken into account in the runtime", async () => {
     });
     const runtime = model.getters.getChartRuntime(chartId);
     expect(runtime.chartJsConfig.options.plugins.chartShowValuesPlugin.showValues).toBe(true);
+    expect(runtime.chartJsConfig.options.plugins.chartShowValuesPlugin.type).toBe("bar"); // Not odoo_bar
 });
 
 test("Odoo line and bar charts display only horizontal grid lines", async () => {


### PR DESCRIPTION
Since the introduction of calendar charts, the chart show value plugin takes the type of the chart as argument. But for odoo charts, we gave it the odoo chart type (eg: odoo_bar, odoo_line, etc) instead of the base chart type (bar, line, etc), which made the show value plugin not work.

Task: [5421194](https://www.odoo.com/web#id=5421194&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
