### PR TITLE
[IMP] hr: Organization chart Job - yoahm

### DIFF
--- a/addons/hr/controllers/hr_org_chart.py
+++ b/addons/hr/controllers/hr_org_chart.py
@@ -20,14 +20,14 @@ class HrOrgChartController(http.Controller):
         employee = Employee.browse(employee_id)
         return employee if employee.has_access('read') else Employee.browse()
 
-    def _prepare_employee_data(self, employee):
+    def _prepare_employee_data(self, employee, new_job_title=None):
         job = employee.sudo().job_id
         return dict(
             id=employee.id,
             name=employee.name,
             link='/mail/view?model=%s&res_id=%s' % ('hr.employee.public', employee.id),
             job_id=job.id,
-            job_name=job.name or '',
+            job_title=new_job_title or employee.job_title or '',
             direct_sub_count=len(employee.child_ids - employee),
             indirect_sub_count=employee.child_all_count,
         )
@@ -39,7 +39,7 @@ class HrOrgChartController(http.Controller):
         return 'hr.employee.public'
 
     @http.route('/hr/get_org_chart', type='jsonrpc', auth='user')
-    def get_org_chart(self, employee_id, new_parent_id=None, **kw):
+    def get_org_chart(self, employee_id, new_parent_id=None, new_job_title=None, **kw):
         employee = self._get_employee(employee_id, **kw)
         new_parent = self._get_employee(new_parent_id, **kw)
         if not employee:  # to check
@@ -60,7 +60,7 @@ class HrOrgChartController(http.Controller):
             ancestors += current
 
         values = dict(
-            self=self._prepare_employee_data(employee),
+            self=self._prepare_employee_data(employee, new_job_title),
             managers=[
                 self._prepare_employee_data(ancestor)
                 for idx, ancestor in enumerate(ancestors)

--- a/addons/hr/static/src/fields/hr_org_chart.js
+++ b/addons/hr/static/src/fields/hr_org_chart.js
@@ -48,21 +48,24 @@ export class HrOrgChart extends Component {
         this.state = useState({'employee_id': null});
         this.max_level = null;
         this.lastEmployeeId = null;
+        this.lastJobTitle = null;
         this._onEmployeeSubRedirect = onEmployeeSubRedirect();
 
         useRecordObserver(async (record) => {
             const newParentId = record.data.parent_id?.id || false;
             const newEmployeeId = record.resId || false;
-            if (this.lastParent !== newParentId || this.state.employee_id !== newEmployeeId) {
+            const newJobTitle = record.data.job_title || false;
+            if (this.lastParent !== newParentId || this.state.employee_id !== newEmployeeId || this.lastJobTitle !== newJobTitle) {
                 this.lastParent = newParentId;
                 this.max_level = null; // Reset max_level to default
-                await this.fetchEmployeeData(newEmployeeId, newParentId, true);
+                this.lastJobTitle = newJobTitle;
+                await this.fetchEmployeeData(newEmployeeId, newParentId, newJobTitle, true);
             }
             this.state.employee_id = newEmployeeId;
         });
     }
 
-    async fetchEmployeeData(employeeId, newParentId = null, force = false) {
+    async fetchEmployeeData(employeeId, newParentId = null, newJobTitle = null, force = false) {
         if (!employeeId) {
             this.managers = [];
             this.children = [];
@@ -77,6 +80,7 @@ export class HrOrgChart extends Component {
                 {
                     employee_id: employeeId,
                     new_parent_id: newParentId,
+                    new_job_title: newJobTitle,
                     context: {
                         ...user.context,
                     max_level: this.max_level,

--- a/addons/hr/static/src/fields/hr_org_chart.xml
+++ b/addons/hr/static/src/fields/hr_org_chart.xml
@@ -30,7 +30,7 @@
     </div>
     <div class="position-relative d-flex flex-column flex-grow-1 justify-content-center ps-2 lh-sm">
         <b class="o_media_heading fs-6 fw-bold" t-esc="employee.name"/>
-        <small class="o_employee_job text-muted" t-attf-class="#{is_self ? 'fw-bold' : 'opacity-75 opacity-100-hover'}" t-esc="employee.job_name"/>
+        <small class="o_employee_job text-muted" t-attf-class="#{is_self ? 'fw-bold' : 'opacity-75 opacity-100-hover'}" t-esc="employee.job_title"/>
     </div>
 </t>
 

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -666,7 +666,7 @@
             <field name="arch" type="xml">
                 <hierarchy child_field="child_ids" js_class="hr_employee_hierarchy" icon="fa-users" draggable="1">
                     <field name="name" />
-                    <field name="job_id" />
+                    <field name="job_title" />
                     <field name="department_color" />
                     <field name="hr_icon_display" />
                     <field name="department_id" />


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
. The job position is displayed in both the side organization chart and the full organization chart views.
. Need to reload the page to show the job title changes on the side organization chart

Desired behavior after PR is merged:
. Display job title instead of job position on  the side Organization chart & full chart form
. Update the organization chart instantly in the UI when the job title changes, without requiring a page reload as it was before

task-5420763

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
