### PR TITLE
[FIX] mail: use alias_id in priority in reply-to

### DIFF
--- a/addons/mail/models/mail_alias_mixin_optional.py
+++ b/addons/mail/models/mail_alias_mixin_optional.py
@@ -157,6 +157,22 @@ class MailAliasMixinOptional(models.AbstractModel):
         creating inactive aliases (falsy name). """
         return not record_vals.get('alias_id') and record_vals.get('alias_name')
 
+    def _notify_get_alias_reply_to(self, res_ids):
+        """ Override to use the primary alias_id directly, giving it priority
+        over any other alias pointing to the same record. """
+        reply_to_email = {}
+        valid_aliases = self.alias_id.filtered_domain([
+            ('alias_parent_thread_id', '!=', False),
+            ('alias_name', '!=', False),
+            ('alias_domain_id', '!=', False),
+        ])
+        for alias in valid_aliases:
+            reply_to_email[alias.alias_parent_thread_id] = alias.alias_full_name
+        missing_ids = [res_id for res_id in res_ids if res_id not in reply_to_email]
+        if missing_ids:
+            reply_to_email.update(super()._notify_get_alias_reply_to(missing_ids))
+        return reply_to_email
+
     # --------------------------------------------------
     # MIXIN TOOL OVERRIDE METHODS
     # --------------------------------------------------

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -704,15 +704,7 @@ class Base(models.AbstractModel):
         # begin with aliases (independent from company, alias_domain_id on alias wins)
         reply_to_email = {}
         if model and res_ids:
-            mail_aliases = self.env['mail.alias'].sudo().search([
-                ('alias_domain_id', '!=', False),
-                ('alias_parent_model_id.model', '=', model),
-                ('alias_parent_thread_id', 'in', res_ids),
-                ('alias_name', '!=', False)
-            ])
-            # take only first found alias for each thread_id, to match order (1 found -> limit=1 for each res_id)
-            for alias in mail_aliases:
-                reply_to_email.setdefault(alias.alias_parent_thread_id, alias.alias_full_name)
+            reply_to_email = _records_sudo._notify_get_alias_reply_to(res_ids)
 
         # continue with company alias
         left_ids = set(_res_ids) - set(reply_to_email)
@@ -733,6 +725,21 @@ class Base(models.AbstractModel):
             )
 
         return reply_to_formatted
+
+    def _notify_get_alias_reply_to(self, res_ids):
+        """ Returns a dict of record id to alias full name for records that
+        have a valid alias. """
+        mail_aliases = self.env['mail.alias'].sudo().search([
+            ('alias_domain_id', '!=', False),
+            ('alias_parent_model_id.model', '=', self._name),
+            ('alias_parent_thread_id', 'in', res_ids),
+            ('alias_name', '!=', False),
+        ])
+        # take only first found alias for each thread_id, to match order (1 found -> limit=1 for each res_id)
+        reply_to_email = {}
+        for alias in mail_aliases:
+            reply_to_email.setdefault(alias.alias_parent_thread_id, alias.alias_full_name)
+        return reply_to_email
 
     def _notify_get_reply_to_formatted_email(self, record_email, author_id=False):
         """ Compute formatted email for reply_to and try to avoid refold issue

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -430,6 +430,14 @@ class TestMessageValues(MailCommon):
         self.assertEqual(msg.reply_to, formataddr((reply_to_name, reply_to_email)))
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
+        # primary alias_id wins over other aliases pointing to the same record
+        self.alias_record.sudo().alias_id.copy({'alias_name': 'aaa-alias-first-in-alphabetical-order'})
+        msg = self.Message.create({
+            'model': 'mail.test.container',
+            'res_id': self.alias_record.id
+        })
+        self.assertEqual(msg.reply_to, formataddr((reply_to_name, reply_to_email)))
+
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_mail_message_values_fromto_document_no_alias(self):


### PR DESCRIPTION
**Steps to reproduce**
- Install helpdesk
- Set the alias domain in the general settings
- Go to technical > alias and duplicate the 'customer-care' alias
- Now one helpdesk team has two associated aliases. Set the alias coming last in alphabetical order as the alias for the helpdesk team (e.g. use 'b-customer-care@domain.com' as the alias of the team when the other alias is 'a-customer-care@domain.com')
- Go to a ticket of this helpdesk team and send a message.
- Look at the message sent and notice that the 'reply-to' email used is not the one of the alias of the team, but the one coming first in alphabetical order.

**Change**
For models inheriting from `mail.alias.mixin`, we can directly use the `alias_id` set on the record, which is more intuitive.

opw-5168282
