### PR TITLE
[FIX] web: vat not displayed in document layout

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -327,7 +327,12 @@
                                 </div>
                             </span>
                         </li>
-                        <li t-if="not forced_vat"/>
+                        <li t-if="not forced_vat">
+                            <t t-if="company.vat">
+                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-esc="company.vat">US12345671</span>
+                            </t>
+                        </li>
                         <li t-else="">
                             <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                             <span t-esc="forced_vat">US12345671</span>
@@ -382,7 +387,12 @@
                                     </div>
                                 </span>
                             </li>
-                            <li t-if="not forced_vat"/>
+                            <li t-if="not forced_vat">
+                                <t t-if="company.vat">
+                                    <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                    <span t-esc="company.vat">US12345671</span>
+                                </t>
+                            </li>
                             <li t-else="">
                                 <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                                 <span t-esc="forced_vat">US12345671</span>
@@ -441,7 +451,12 @@
                                 </div>
                             </span>
                         </li>
-                        <li t-if="not forced_vat"/>
+                        <li t-if="not forced_vat">
+                            <t t-if="company.vat">
+                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-esc="company.vat">US12345671</span>
+                            </t>
+                        </li>
                         <li t-else="">
                             <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                             <span t-esc="forced_vat">US12345671</span>
@@ -501,7 +516,12 @@
                                 </div>
                             </span>
                         </li>
-                        <li t-if="not forced_vat"/>
+                        <li t-if="not forced_vat">
+                            <t t-if="company.vat">
+                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-esc="company.vat">US12345671</span>
+                            </t>
+                        </li>
                         <li t-else="">
                             <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                             <span t-esc="forced_vat">US12345671</span>
@@ -575,7 +595,12 @@
                                 </div>
                             </span>
                         </li>
-                        <li t-if="not forced_vat"/>
+                        <li t-if="not forced_vat">
+                            <t t-if="company.vat">
+                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-esc="company.vat">US12345671</span>
+                            </t>
+                        </li>
                         <li t-else="">
                             <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                             <span t-esc="forced_vat">US12345671</span>
@@ -644,7 +669,12 @@
                                 </div>
                             </span>
                         </li>
-                        <li t-if="not forced_vat"/>
+                        <li t-if="not forced_vat">
+                            <t t-if="company.vat">
+                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-esc="company.vat">US12345671</span>
+                            </t>
+                        </li>
                         <li t-else="">
                             <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                             <span t-esc="forced_vat">US12345671</span>
@@ -710,7 +740,12 @@
                                 </div>
                             </span>
                         </li>
-                        <li t-if="not forced_vat"/>
+                        <li t-if="not forced_vat">
+                            <t t-if="company.vat">
+                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-esc="company.vat">US12345671</span>
+                            </t>
+                        </li>
                         <li t-else="">
                             <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
                             <span t-esc="forced_vat">US12345671</span>


### PR DESCRIPTION
Steps to reproduce
1. Install `account`.
2. Go to Settings → Configure Document Layout.
3. Enter a value in the Tax ID field.
4. Generate a document (invoice / preview document).

Issue
Unlike other fields in the document layout, the `Tax ID` value is not updated and does not appear in the document preview.

Cause
The VAT (Tax ID) rendering logic was missing from the document layout template XML.

Solution
Add proper logic to display the Tax ID using the company VAT

Before:
<img width="1089" height="750" alt="image" src="https://github.com/user-attachments/assets/8d27808f-d605-447c-807a-d5f3450eef36" />

After:
<img width="1080" height="722" alt="image" src="https://github.com/user-attachments/assets/0af04d77-a318-4e39-9a4b-0911f2446e60" />


opw-5373374