### PR TITLE
[FIX] website_sale_stock: Preserve line breaks in out-of-stock message

### DIFF
--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -10,9 +10,11 @@
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} mb-1">
                 <div id="out_of_stock_message" class="mb-3">
                     <t t-if="has_out_of_stock_message">
-                        <div class="d-inline-flex align-items-center badge text-bg-danger text-wrap">
+                        <div class="d-flex align-items-center badge text-start text-bg-danger text-wrap">
                             <i class="fa fa-circle text-danger me-2"/>
-                            <t t-out="out_of_stock_message"/>
+                            <span>
+                                <t t-out="out_of_stock_message"/>
+                            </span>
                         </div>
                     </t>
                     <t t-elif="!allow_out_of_stock_order">


### PR DESCRIPTION
- Before saas-18.4, the [out-of-stock](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml#L8) message was rendered as plain text without
any layout-specific classes, allowing the message to wrap naturally.

**Reference of version saas-18.3**
<img width="1920" height="768" alt="2025-12-16_18-53" src="https://github.com/user-attachments/assets/d7670fa4-6808-40d7-9bad-768d0637f366" />

- From saas-18.4, the [out-of-stock](https://github.com/odoo/odoo/blob/saas-18.4/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml#L13-L16) message is rendered using `t-out`, which outputs plain text and collapses line breaks, causing the message to appear on a single line and overflow when used with `d-inline-flex`.
See screenshots in the PR description (Before fix).
<img width="1920" height="672" alt="2025-12-16_14-28" src="https://github.com/user-attachments/assets/927080cd-f2b0-45cd-ae0a-2917699c05f6" />

- Updated the layout to replace `d-inline-flex` with `d-flex` and apply `text-break` on the message container so long and dynamic texts wrap correctly inside the badge.
See screenshots in the PR description (After fix).
<img width="1918" height="682" alt="2025-12-16_14-31" src="https://github.com/user-attachments/assets/2cafdc61-e494-468a-9d41-08ab3c83b041" />


opw-5274850

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
