### PR TITLE
[IMP] mail: add xpath target to activity label.

### DIFF
--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -12,7 +12,10 @@
         <template id="message_activity_done">
 <div>
     <p>
-        <span t-attf-class="fa #{activity.activity_type_id.icon} fa-fw"/><span t-field="activity.activity_type_id.name"/> done
+        <span t-attf-class="fa #{activity.activity_type_id.icon} fa-fw"/>
+        <t name="activity_done_label_xpath_target">
+            <span t-field="activity.activity_type_id.name"/> done
+        </t>
         <t t-if="display_assignee"> (originally assigned to <span t-field="activity.user_id.name"/>)</t>
         <span t-if="activity.summary">: </span><span t-if="activity.summary" t-field="activity.summary"/>
     </p>


### PR DESCRIPTION
This commit adds a <t> node that wraps the activity-done label so that it's easier and cleaner to target and customize it. It was first needed to customize the message attached with an activity of type phone call. See: https://github.com/odoo/enterprise/pull/100838

Task-5343433

Enterprise: https://github.com/odoo/enterprise/pull/100838