### PR TITLE
[FIX] l10n_din5008_sale: fix position numbering in sale order report

### DIFF
--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -95,7 +95,7 @@
             </t>
         </xpath>
         <!-- Insert Position Column as the First Column in the Table Header -->
-        <xpath expr="//table/thead/tr/th[1]" position="before">
+        <xpath expr="//th[@name='th_description']" position="before">
             <t t-if="doc.company_id.has_position_column">
                 <th name="th_position" class="text-start">Position</th>
             </t>
@@ -105,7 +105,7 @@
                 <t t-set="line_number" t-value="1"/>
             </t>
         </xpath>
-        <xpath expr="//table/tbody//tr[1]//td[1]" position="before">
+        <xpath expr="//td[@name='td_name']" position="before">
             <t t-if="doc.company_id.has_position_column">
                <td class="text-start" t-esc="line_number"/>
                 <t t-set="line_number" t-value="line_number+1"/>


### PR DESCRIPTION
Before this commit, when printing a Sale Order using the German localization, the "Position" column in the PDF report was empty. Additionally, the table formatting was broken due to this missing data.

This issue occurred because the index variable used to calculate the line number in the report template (QWeb) was incorrect.

This commit fixes the index logic in the report template.

Now, the "Position" column correctly displays sequential numbers (1, 2, etc.), and the table formatting renders correctly.

ticket-5225647

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
