### PR TITLE
[FIX] website_sale: Decouple form submission from cart summary button

### DIFF
--- a/addons/website_sale/static/src/interactions/extra_info_form.js
+++ b/addons/website_sale/static/src/interactions/extra_info_form.js
@@ -5,12 +5,17 @@ import { Form } from '@website/snippets/s_website_form/form';
 patch(Form.prototype, {
     setup() {
         super.setup();
-        this.dynamicSelectors = {
-            ...this.dynamicSelectors,
-            _submitbuttons: () => document.querySelectorAll('[name="website_sale_main_button"]'),
-        };
-        patchDynamicContent(this.dynamicContent, {
-            _submitbuttons: { 't-on-click.prevent.stop': this.locked(this.send.bind(this), true) },
-        });
+        // Only tie checkout-specific forms (with data-force_action="shop.sale.order") to the
+        // cart summary button. Other forms (e.g., custom form snippets added by users) should
+        // only respond to their own submit buttons, not block checkout progression.
+        if (this.el.dataset.force_action === 'shop.sale.order') {
+            this.dynamicSelectors = {
+                ...this.dynamicSelectors,
+                _submitbuttons: () => document.querySelectorAll('[name="website_sale_main_button"]'),
+            };
+            patchDynamicContent(this.dynamicContent, {
+                _submitbuttons: { 't-on-click.prevent.stop': this.locked(this.send.bind(this), true) },
+            });
+        }
     },
 });

--- a/addons/website_sale/static/tests/interactions/extra_info_form.test.js
+++ b/addons/website_sale/static/tests/interactions/extra_info_form.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { click } from "@odoo/hoot-dom";
+import { onRpc } from "@web/../tests/web_test_helpers";
+import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
+
+setupInteractionWhiteList("website.form");
+describe.current.tags("interaction_dev");
+
+test("only checkout form submits via main button", async () => {
+    onRpc("/website/form/shop.sale.order", async (a) => {
+        expect.step("checkoutForm");
+    });
+    onRpc("/website/form/mail.mail", async (a) => {
+        expect.step("customForm");
+    });
+
+    await startInteractions(`
+        <div id="wrapwrap">
+            <section class="s_website_form">
+                <form action="/website/form/" data-model_name="mail.mail" data-force_action="shop.sale.order" data-success-mode="nothing">
+                    <input type="hidden" name="email_to" value="test@test.com"/>
+                    <input type="hidden" name="name" value="checkout"/>
+                    <span id="s_website_form_result"></span>
+                </form>
+            </section>
+            <section class="s_website_form">
+                <form action="/website/form/" data-model_name="mail.mail" data-success-mode="nothing">
+                    <input type="hidden" name="email_to" value="test@test.com"/>
+                    <input type="hidden" name="name" value="custom"/>
+                    <span id="s_website_form_result"></span>
+                </form>
+            </section>
+            <button name="website_sale_main_button">Checkout</button>
+        </div>
+    `);
+
+    await click('[name="website_sale_main_button"]');
+    expect.verifySteps(["checkoutForm"]);
+});


### PR DESCRIPTION
Dropping a custom "Form" snippet onto the checkout page would prevent the user from completing their order.

Steps to reproduce:
===================
1. On a website with eCommerce, add a product to the cart.
2. Proceed to the checkout page.
3. Enter Edit mode and drag a "Form" snippet onto the page.
4. Save and exit Edit mode.
5. Click the main "Process Checkout" button. -> The checkout process is blocked, and the custom form  show validation errors.

Cause:
======
A Extra info patch is intended for the "Extra Info" checkout form only, but It was applied to all `s_website_form` instances on the checkout page.

This caused any dropped form snippet to listen for a click on the main checkout button. When a user tried to proceed, the custom form would incorrectly intercept the event and trigger its own validation. If the form had required fields, this validation would fail and block the entire checkout process.

Solution:
=========
The patch has been refined to be more specific. It now only targets forms that have the `data-force_action="shop.sale.order"` attribute.

note: issue introduced in this commit: [1]

[1]:https://github.com/odoo/odoo/commit/a6489b9a2f84efa270b3b1951b8c542355de291b

opw-5391286

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
