### PR TITLE
[FIX] bus: fix non deterministic test

### DIFF
--- a/addons/bus/static/tests/bus_service.test.js
+++ b/addons/bus/static/tests/bus_service.test.js
@@ -204,6 +204,7 @@ test("pass last notification id on initialization", async () => {
 test("websocket disconnects when user logs out", async () => {
     addBusServiceListeners(
         ["connect", () => asyncStep("connect")],
+        ["reconnect", () => asyncStep("connect")],
         ["disconnect", () => asyncStep("disconnect")]
     );
     patchWithCleanup(session, { user_id: null, db: "openerp" });
@@ -471,7 +472,8 @@ test("show notification when version is outdated", async () => {
     await waitForSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
     await runAllTimers();
     await waitFor(".o_notification", {
-        contains: "Save your work and refresh to get the latest updates and avoid potential issues.",
+        contains:
+            "Save your work and refresh to get the latest updates and avoid potential issues.",
     });
     await contains(".o_notification button:contains(Refresh)").click();
     await waitForSteps(["reload"]);


### PR DESCRIPTION
Before this commit, the `websocket disconnects when user logs out` was sometimes failing. This test ensures that the websocket reconnects when the user logs out.

When the environment is initially created, a lot of places call the `bus_service@start` method. The worker starts the websocket when receiving the first event, and discard the others.

However, in this case, the call to `_start` can happen before the closing handshake is completed. As a result, the websocket is still in closing mode and the handshake is aborted. Since the disconnection wasn't clean, the `reconnect` event is triggered instead of the `connect` one.

This is not a big deal and shouldn't impact the test. What matters is that a new connection is established.

This commit fixes the issue by checking that a reconnection is done, either via the `connect` or the `reconnect` event.

fixes runbot-234056

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
