### PR TITLE
[FIX] im_livechat: non-deterministic visitor info test

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_channel.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_channel.xml
@@ -4,10 +4,6 @@
         <record id="base.user_demo" model="res.users">
             <field name="group_ids" eval="[(3, ref('im_livechat.im_livechat_group_manager'))]"/>
         </record>
-
-        <record id="base.default_user_group" model="res.groups">
-            <field name="implied_ids" eval="[(4, ref('im_livechat.im_livechat_group_manager'))]"/>
-        </record>
         <record id="base.user_admin" model="res.users">
             <field name="livechat_username">Mitchou Pitchou</field>
         </record>


### PR DESCRIPTION
The `test_channel_get_livechat_visitor_info` tests what is
sent alongside the created live chat when calling `get_session`.
When the route is called with an authentified user, it returns
whether the user is a live chat manager.

This information changes when demo data is installed (live chat
manager is added as an implied id of the user group). As a result,
this information cannot be hardcoded.

The demo data shouldn't add implied ids to the user group. This
commit removes it.

fixes runbot-234138,234697,234080