### PR TITLE
[FIX] spreadsheet: broken `Use compact format` chart checkbox

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
@@ -50,6 +50,7 @@ export class OdooChart extends AbstractChart {
         this.actionXmlId = definition.actionXmlId;
         this.showValues = definition.showValues;
         this._dataSets = definition.dataSets || [];
+        this.humanize = definition.humanize ?? true;
     }
 
     static transformDefinition(definition) {
@@ -90,6 +91,7 @@ export class OdooChart extends AbstractChart {
             showValues: this.showValues,
             dataSets: this.dataSets,
             datasetsConfig: this.datasetsConfig,
+            humanize: this.humanize,
         };
     }
 


### PR DESCRIPTION
The checkbox to toggle the `Use compact format` option in the chart side panel was present for odoo charts, but did nothing.

Task: [5405064](https://www.odoo.com/web#id=5405064&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
