### PR TITLE
[FIX] account_edi_ubl_cii: cannot export document having negative tax

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -91,9 +91,7 @@ class AccountEdiUBL(models.AbstractModel):
         """
         return {
             **tax_grouping_key,
-            # Temporary solution to have withholding taxes merged with others until we know how to manage them.
-            # Should be: `'is_withholding': tax_grouping_key['is_withholding'],`
-            'is_withholding': False,
+            'is_withholding': tax_grouping_key['is_withholding'],
         }
 
     def _ubl_default_tax_total_grouping_key(self, tax_subtotal_grouping_key, vals):

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -399,6 +399,32 @@ class TestAccountEdiUblCii(TestUblCiiCommon):
             'zip': '8010',
         }])
 
+    def test_export_mixed_taxes(self):
+        special_tax = self.env['account.tax'].create({
+            'name': "negative_tax_10",
+            'amount_type': 'percent',
+            'amount': -10.0,
+        })
+        partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'invoice_edi_format': 'ubl_bis3',
+            'country_id': self.env.ref('base.be').id,
+        })
+        invoice = self.env['account.move'].create({
+            'partner_id': partner.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [Command.set(special_tax.ids)],
+                }),
+            ],
+        })
+        invoice.action_post()
+        invoice._generate_and_send()
+
     def test_import_discount(self):
         invoice = self.env['account.move'].create({
             'partner_id': self.partner_a.id,


### PR DESCRIPTION
Steps to reproduce:
- Create an invoice with a negative tax on a line.
- Confirm
- Send & Print

Issue:
Traceback will show
It occurs because when grouping tax subtotal vals we don't handle the withholding taxes properly, causing a KeyError when we later want to retrieve the correct values from `ubl_values`

opw-5419227