### PR TITLE
[FIX] point_of_sale: fix multiple order printing

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -48,6 +48,7 @@ import { EpsonPrinter } from "@point_of_sale/app/utils/printer/epson_printer";
 import OrderPaymentValidation from "../utils/order_payment_validation";
 import { logPosMessage } from "../utils/pretty_console_log";
 import { initLNA } from "../utils/init_lna";
+import { uuid } from "@web/core/utils/strings";
 
 const { DateTime } = luxon;
 export const CONSOLE_COLOR = "#F5B427";
@@ -2049,10 +2050,11 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async printOrderChanges(data, printer) {
+        const actionId = data.changes.data[0]?.uuid || uuid();
         const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
             data: data,
         });
-        return await printer.printReceipt(receipt);
+        return await printer.printReceipt(receipt, actionId);
     }
 
     filterChangeByCategories(categories, currentOrderChange) {

--- a/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
@@ -17,9 +17,10 @@ export class BasePrinter {
      * Add the receipt to the queue of receipts to be printed and process it.
      * We clear the print queue if printing is not successful.
      * @param {String} receipt: The receipt to be printed, in HTML
+     * @param {String} receiptId: uuid uniquely identifying a receipt to be printed
      * @returns {{ successful: boolean; message?: { title: string; body?: string }}}
      */
-    async printReceipt(receipt) {
+    async printReceipt(receipt, receiptId) {
         if (receipt) {
             this.receiptQueue.push(receipt);
         }
@@ -30,7 +31,7 @@ export class BasePrinter {
                 await htmlToCanvas(receipt, { addClass: "pos-receipt-print" })
             );
             try {
-                printResult = await this.sendPrintingJob(image);
+                printResult = await this.sendPrintingJob(image, receiptId);
             } catch (error) {
                 // Error in communicating to the IoT box.
                 this.receiptQueue.length = 0;


### PR DESCRIPTION
Currently multiple clients report double order receipts printing. This PR fixes the issue where due to slow network connection a request would be sent to the iot box but the iot box didn't reply in time to confirm the action finish.

The user would then get an error showing 'printing failed' (due to a timout). If he cliks on retry the iot box would still print the previous receipt and then receive the new "retry" request with now a new action uuid which would also be printed because uuid is different from the 1st request.

This PR adds a consistent uuid for both the initial and all the subsequent retry requests so that double actions would never be done by the iot box.
