### PR TITLE
[FIX] base: add help attribute on field element in rng validation

### DIFF
--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -196,6 +196,7 @@
             <rng:optional><rng:attribute name="domain_filter"/></rng:optional>
             <rng:optional><rng:attribute name="class"/></rng:optional>
             <rng:optional><rng:attribute name="string"/></rng:optional>
+            <rng:optional><rng:attribute name="help"/></rng:optional>
             <rng:optional><rng:attribute name="completion"/></rng:optional>
             <rng:optional><rng:attribute name="width"/></rng:optional>
             <rng:optional><rng:attribute name="type"/></rng:optional>


### PR DESCRIPTION
Steps to reproduce
==================

- Install web_studio,contacts
- Go to Contacts
- Open the list view
- Click on a field
- Set a "Help tooltip"

=> Validation Error
Invalid view Odoo Studio: res.partner.tree customization

Cause of the issue
==================

The help attribute is missing from the field definition

opw-5379357