### PR TITLE
[FIX] website: block Escape key on cookies bar

### DIFF
--- a/addons/website/static/src/interactions/cookies/cookies_bar.js
+++ b/addons/website/static/src/interactions/cookies/cookies_bar.js
@@ -25,6 +25,15 @@ export class CookiesBar extends Popup {
         "#cookies-consent-essential, #cookies-consent-all": { "t-on-click": this.onAcceptClick },
         // Override to avoid side effects on hide.
         ".js_close_popup": { "t-on-click": () => { } },
+        ".modal": {
+            "t-on-keydown.capture": (ev) => {
+                if (ev.key === "Escape") {
+                    // Circumvent Bootstrap's keydown behavior which triggers a
+                    // UI glitch.
+                    ev.stopImmediatePropagation();
+                }
+            },
+        },
     };
 
     setup() {


### PR DESCRIPTION
When pressing `Escape` with a Bootstrap modal open, even if the config key `keyboard` is set to `false` (preventing escape from closing the modal), Bootstrap sets a class `modal-static` on the modal element and removes it shortly after. This causes a UI glitch in the case of the cookies bar. Stopping the event propagation prevents it from happening.

task-5421993