### PR TITLE
[FIX] hr_expense: keep original list classnames in override

### DIFF
--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -61,7 +61,7 @@
             </div>
         </xpath>
         <xpath expr="//div[hasclass('o_list_renderer')]" position="attributes">
-            <attribute name="class">o_list_renderer hr_expense h-auto o_forbidden_tooltip_parent</attribute>
+            <attribute name="class" add="hr_expense h-auto o_forbidden_tooltip_parent" separator=" "/>
         </xpath>
     </t>
 


### PR DESCRIPTION
Before this commit, some classnames set on the list renderer were lost in the expense override. As a consequence, the column width logic couldn't be applied correctly. The widths were computed with a wrong available width (the width of table's parent element, which is the renderer itself).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
