### PR TITLE
[FIX] Base : prevent create fields on SQL views

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -701,11 +701,17 @@ class IrModelFields(models.Model):
         except ValidationError as e:
             return {'warning': {'title': _("Model %s does not exist", self.relation), 'message': e}}
 
-    @api.constrains('relation')
+    @api.constrains('relation', 'store')
     def _check_relation(self):
         for rec in self:
-            if rec.state == 'manual' and rec.relation and not rec.env['ir.model']._get_id(rec.relation):
-                raise ValidationError(_("Unknown model name '%s' in Related Model", rec.relation))
+            if rec.state == 'manual':
+                if rec.store and rec.model and not self._is_manual_name(rec.model):
+                    Model = self.env[rec.model]
+                    table_kind = tools.table_kind(self.env.cr, Model._table)
+                    if table_kind != tools.TableKind.Regular:
+                        raise UserError(_('The model %s doesn\'t support adding stored fields.', Model._name))
+                if rec.relation and not rec.env['ir.model']._get_id(rec.relation):
+                    raise ValidationError(_("Unknown model name '%s' in Related Model", rec.relation))
 
     @api.constrains('depends')
     def _check_depends(self):


### PR DESCRIPTION
Prevent creating fields on SQL views 

### Impacted versions:

17.0 and later

### Steps to reproduce:
Create a new field on sale_report
Open sales -> reporting -> sales -> measures

### Current behavior:
When you try to create fields with Studio on models based on SQL views such as sale_report you will get a user error. However it's still possible to create these fields manually, which consequently will break some flows and it doesn't make sense to add fields

Task: [5394158](https://www.odoo.com/odoo/project/49/tasks/5394158)