### PR TITLE
[FIX] point_of_sale: fix NFC-e sequence

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -657,8 +657,11 @@ class PosOrder(models.Model):
         if self.refunded_order_id.exists():
             return _('%(refunded_order)s REFUND', refunded_order=self.refunded_order_id.name)
         else:
-            last_reference_part = self.pos_reference.split('-')[-1]
+            last_reference_part = self.get_reference_last_part()
             return f"{session.config_id.name} - {last_reference_part}"
+
+    def get_reference_last_part(self):
+        return self.pos_reference.split('-')[-1]
 
     def action_stock_picking(self):
         self.ensure_one()


### PR DESCRIPTION
Brazilian order shoud follow the NFC-e sequence defined in the POS config.

Steps to reproduce:
-------------------
* Setup a POS in Brazil with NFC-e sequence (set the sequence to 1234)
* Create a new order in the POS
* Validate the order
* Check the order name in backend
> Observation: The order name is like: POS-00001 instead of POS-1234

Why the fix:
------------
We adapt the method _compute_order_name to get the correct sequence number if the country is Brazil.

opw-5243454