### PR TITLE
[FIX] project: prevent null task_id in task share wizard

### DIFF
--- a/addons/project/wizard/project_task_share_wizard.py
+++ b/addons/project/wizard/project_task_share_wizard.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class TaskShareWizard(models.TransientModel):
@@ -6,5 +6,14 @@ class TaskShareWizard(models.TransientModel):
     _inherit = ['portal.share']
     _description = 'Task Sharing'
 
-    task_id = fields.Many2one('project.task', default=lambda self: self.res_id)
+    @api.model
+    def default_get(self, fields):
+        result = super().default_get(fields)
+        if 'task_id' in fields and not result.get('task_id') and result['res_id']:
+            result['task_id'] = result['res_id']
+        else:
+            result['task_id'] = False
+        return result
+
+    task_id = fields.Many2one('project.task')
     project_privacy_visibility = fields.Selection(related='task_id.project_privacy_visibility')


### PR DESCRIPTION
**Steps to reproduce:**
1. Install Project with demo data
2. Go to Tasks → cog menu → click on "Share Task"
3. Click on the "Send" button

**Issue:**
The `task_id` becomes NULL in the task share wizard.

```psql
test_m19=> select id,res_id,task_id,res_model from task_share_wizard;
 id | res_id | task_id |  res_model
----+--------+---------+--------------
  1 |     34 |         | project.task
(1 row)
```
In master (19.1), this leads to a crash:
```AssertionError: Invalid falsy real id```
This happens since commit [4290724](https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f), where falsy IDs are no longer allowed.

**Cause**:
When clicking on the "Send" button, the wizard relies on [default_get](https://github.com/odoo/odoo/blob/174d5dc63048720533708b8ae4d1ad34774caabe/addons/portal/wizard/portal_share.py#L10-L18)
to populate default field values. However, a falsy value is passed to the
`task_id` from [here](https://github.com/odoo/odoo/blob/0a97fa64783e4b58bb17db79343fb566196e71eb/odoo/orm/models.py#L1306-L1307) since `self` is a empty record set and later during
[related field](https://github.com/odoo/odoo/blob/0a97fa64783e4b58bb17db79343fb566196e71eb/odoo/orm/fields.py#L720) computation, resulting in an invalid falsy record.

**Solution**:
Ensure that task_id is properly set during `default_get`.

**After fix:**
```psql
test_m19=> select id,res_id,task_id,res_model from task_share_wizard;
 id | res_id | task_id |  res_model   
----+--------+---------+--------------
  3 |     34 |      34 | project.task
(1 row)

```

opw-5342875





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
