### PR TITLE
[FIX] pos_restaurant: ensure deleted floors are not shown later

### DIFF
--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -27,7 +27,7 @@ class RestaurantFloor(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['name', 'background_color', 'table_ids', 'sequence', 'pos_config_ids', 'floor_background_image']
+        return ['name', 'background_color', 'table_ids', 'sequence', 'pos_config_ids', 'floor_background_image', 'active']
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_active_pos_session(self):

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -49,7 +49,7 @@ patch(PosOrder.prototype, {
             if (this.getTable()) {
                 const table = this.getTable();
                 const child_tables = this.models["restaurant.table"].filter((t) => {
-                    if (t.floor_id && t.floor_id.id === table.floor_id.id) {
+                    if (t.floor_id && t.floor_id.id === table.floor_id?.id) {
                         return table.isParent(t);
                     }
                 });

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -6,7 +6,7 @@
             <t t-set="hasSelectedTable" t-value="selectedTables.length > 0" />
             <t t-set="firstSelectedTable" t-value="selectedTables.length ? selectedTables[0] : null" />
             <div t-attf-class="d-flex flex-row {{pos.isEditMode ? 'flex-wrap' : ''}} justify-content-between px-2 gap-1 border-bottom bg-view">
-                <button t-if="!pos.isEditMode" class="new-order btn btn-lg lh-lg my-2" t-attf-class="{{ this.pos.getOrder()?.isDirectSale ? 'btn-secondary' : 'btn-primary'}}" 
+                <button t-if="!pos.isEditMode" class="new-order btn btn-lg lh-lg my-2" t-attf-class="{{ this.pos.getOrder()?.isDirectSale ? 'btn-secondary' : 'btn-primary'}}"
                     t-on-click="() => this.clickNewOrder()">
                     <t t-if="this.pos.getOrder()?.isDirectSale">
                         <i class="fa fa-angle-double-left fa-fw" role="img" aria-label="Back" title="Back"/>
@@ -19,7 +19,7 @@
                 </button>
                 <!-- Center Side Div -->
                 <div class="floor-selector d-flex gap-1 py-2 overflow-auto">
-                    <t t-foreach="pos.models['restaurant.floor'].getAll()" t-as="floor" t-key="floor.id">
+                    <t t-foreach="pos.models['restaurant.floor'].filter(f => f.active !== false)" t-as="floor" t-key="floor.id">
                         <button class="button button-floor btn btn-outline-secondary btn-lg px-3 lh-lg text-nowrap text-body" t-attf-class="{{ floor.id === state.selectedFloorId ? 'active' : '' }}" t-on-click="() => this.selectFloor(floor)">
                             <t t-esc="floor.name" />
                             <t t-set="changeCount" t-value="this.getFloorChangeCount(floor)"/>
@@ -105,10 +105,10 @@
             </div>
             <t t-set="isKanban" t-value="pos.floorPlanStyle == 'kanban'"/>
             <div
-                t-ref="floor-map-scroll" 
-                class="overflow-auto flex-grow-1 flex-shrink-1 flex-basis-0 w-auto" 
+                t-ref="floor-map-scroll"
+                class="overflow-auto flex-grow-1 flex-shrink-1 flex-basis-0 w-auto"
                 t-att-class="{
-                    'floor-grid': pos.isEditMode, 
+                    'floor-grid': pos.isEditMode,
                     'bg-view': !activeFloor?.background_color
                 }"
                 t-attf-style="background-color: rgba({{this._getColors()[activeFloor?.background_color]}},.75)">

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -36,6 +36,22 @@ export function clickFloor(name) {
         },
     ];
 }
+export function hasFloor(name) {
+    return [
+        {
+            content: `has '${name}' floor`,
+            trigger: `.floor-selector .button-floor:contains("${name}")`,
+        },
+    ];
+}
+export function hasNotFloor(name) {
+    return [
+        {
+            content: `has not '${name}' floor`,
+            trigger: negate(`.floor-selector .button-floor:contains("${name}")`),
+        },
+    ];
+}
 export function clickEditButton(button) {
     return [
         {

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -536,6 +536,11 @@ class TestFrontend(TestFrontendCommon):
         self.assertEqual(line_1.tax_ids, self.tax_sale_a)
         self.assertEqual(line_2.tax_ids, self.tax_sale_a)
 
+    def test_no_ghost_floor(self):
+        self.pos_config.is_order_printer = False
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('no_ghost_floor', login="pos_admin")
+
     def test_multiple_preparation_printer_different_categories(self):
         """This test make sure that no empty receipt are sent when using multiple printer with different categories
            The tour will check that we tried did not try to print two receipt. We can achieve that by checking the content


### PR DESCRIPTION
Task: [#5421683](https://www.odoo.com/odoo/project/1737/tasks/5421683)

---

**Steps to reproduce:**

* Create a new floor with one table
* Create and pay an order on that table
* Delete the floor
* Refund one line of the order ==> The deleted floor is shown again in the floor selector, without its table.

This happens because the deleted floor is loaded when fetching the table of the order in the Ticket Screen. If an order is linked to a table that belonged to a deleted floor, that floor is loaded again and displayed in the floor selector.

**Fix:**
Filter out inactive floors from the floor selector.