### PR TITLE
[FIX] html_editor,knowledge,web: add a flag to disable website dynamic theme in colorPicker

### DIFF
--- a/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.xml
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.xml
@@ -6,9 +6,16 @@
         t-on-keydown="props.colorPickerNavigation">
         <div class="o_colorpicker_section">
             <t t-foreach="props.defaultThemeColorVars" t-as="color" t-key="color">
-                <button t-att-data-color="color" t-att-class="{'selected': color === props.defaultColorSet}"
-                    t-att-style="`background-color: var(--${props.cssVarColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')"
-                    class="btn p-0 o_color_button o_color_picker_button"/>
+                <t t-if="color.startsWith('#')">
+                    <button t-att-data-color="color" t-att-class="{'selected': color === props.defaultColorSet}"
+                        t-att-style="`background-color: ${color}` + (color_index === 3 ? '; grid-column: 5' : '')"
+                        class="btn p-0 o_color_button o_color_picker_button"/>
+                </t>
+                <t t-else="">
+                    <button t-att-data-color="color" t-att-class="{'selected': color === props.defaultColorSet}"
+                        t-att-style="`background-color: var(--${props.cssVarColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')"
+                        class="btn p-0 o_color_button o_color_picker_button"/>
+                </t>
             </t>
         </div>
 


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Knowledge app
- Go to any article
- Try to change the color of the text
- Theme colors of the website are shown in the colorPicker
- When applied they are mapped to `text-o-color-x` attributes
- Changing the website theme affects the article colors
- Published articles will have different colors if the theme was modified

**Issue:**
Some modules (`Knowledge`) should not be affected by the website styling. But there is no direct way to prevent this on the colorPicker.

```
// Overwrite user-defined website styles in Knowledge published articles, mainly
// to avoid color customization from affecting articles content.
```

**Fix:**
Add a flag to hardcode theme color values instead of using dynamic css attributes.

Another solution would be to just remove the first row of the color picker when the theme should not be used.

related: https://github.com/odoo/enterprise/commit/e042faab3d1d992cb471dcf9141d0a2756d06ced
knowledge color overwrite: https://github.com/odoo/enterprise/pull/77597

opw-5148839
