### PR TITLE
[FIX] pos_loyalty: fix discount value specific

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -133,6 +133,10 @@ export class PosOrderlineAccounting extends Base {
         return result;
     }
 
+    get basePrice() {
+        return this.qty * this.price_unit * (1 - this.getDiscount() / 100);
+    }
+
     /**
      * Prepare extra values for the base line used in taxes computation.
      */

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -956,7 +956,7 @@ patch(PosOrder.prototype, {
             if (!discountablePerTax[taxKey]) {
                 discountablePerTax[taxKey] = 0;
             }
-            discountablePerTax[taxKey] += line.prices.total_excluded;
+            discountablePerTax[taxKey] += line.basePrice;
         }
         return { discountable, discountablePerTax };
     },
@@ -1101,8 +1101,7 @@ patch(PosOrder.prototype, {
                 discountablePerTax[taxKey] = 0;
             }
             discountablePerTax[taxKey] +=
-                line.prices.total_excluded *
-                (remainingAmountPerLine[line.uuid] / line.prices.total_included);
+                line.basePrice * (remainingAmountPerLine[line.uuid] / line.prices.total_included);
         }
         return { discountable, discountablePerTax };
     },

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -721,6 +721,48 @@ registry.category("web_tour.tours").add("test_confirm_coupon_programs_one_by_one
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_order_reward_product_tax_included_included", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Product Include", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.hasRewardLine("$ 10 on your order", "-10.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_order_reward_product_tax_included_excluded", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.addOrderline("Product Include", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.hasRewardLine("$ 10 on your order", "-10.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_specific_reward_product_tax_included_included", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Product Include", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.hasRewardLine("$ 10 on Product Include", "-10.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_specific_reward_product_tax_included_excluded", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.addOrderline("Product Include", "1"),
+            PosLoyalty.enterCode("hellopromo"),
+            PosLoyalty.hasRewardLine("$ 10 on Product Include", "-10.00"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_race_conditions_update_program", {
     steps: () =>
         [

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3485,6 +3485,97 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.start_pos_tour("test_confirm_coupon_programs_one_by_one", login="pos_user")
             self.assertEqual(sync_counter['count'], 6)
 
+    def test_specific_reward_product_tax_included_excluded(self):
+        """This test makes sure that the value of a reward applied on a specific product is
+        the same whether the tax is included or excluded in the product price.
+        """
+        tax_01 = self.env['account.tax'].create({
+                "name": "Tax 1",
+                "amount": 10,
+                "price_include_override": "tax_included",
+        })
+
+        product = self.env['product.product'].create({
+            "name": "Product Include",
+            "lst_price": 100,
+            "available_in_pos": True,
+            "taxes_id": [Command.set(tax_01.ids)],
+        })
+
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env["loyalty.program"].create(
+            {
+                "name": "Test Loyalty Program",
+                "program_type": "promotion",
+                "trigger": "with_code",
+                'pos_ok': True,
+                "rule_ids": [
+                    Command.create({"mode": "with_code", "code": "hellopromo"}),
+                ],
+                "reward_ids": [
+                    Command.create({
+                        "reward_type": "discount",
+                        "discount": 10,
+                        "discount_mode": "per_order",
+                        "discount_applicability": "specific",
+                        "required_points": 1,
+                        "discount_product_ids": product.ids,
+                    }),
+                ],
+            }
+        )
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_specific_reward_product_tax_included_included', login="pos_user")
+        tax_01.price_include_override = "tax_excluded"
+        # Discount should be the same even if tax mode is changed
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_specific_reward_product_tax_included_excluded', login="pos_user")
+
+    def test_order_reward_product_tax_included_excluded(self):
+        """This test makes sure that the value of a reward applied on a specific product is
+        the same whether the tax is included or excluded in the product price.
+        """
+        tax_01 = self.env['account.tax'].create({
+                "name": "Tax 1",
+                "amount": 10,
+                "price_include_override": "tax_included",
+        })
+
+        self.env['product.product'].create({
+            "name": "Product Include",
+            "lst_price": 100,
+            "available_in_pos": True,
+            "taxes_id": [Command.set(tax_01.ids)],
+        })
+
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env["loyalty.program"].create(
+            {
+                "name": "Test Loyalty Program",
+                "program_type": "promotion",
+                "trigger": "with_code",
+                'pos_ok': True,
+                "rule_ids": [
+                    Command.create({"mode": "with_code", "code": "hellopromo"}),
+                ],
+                "reward_ids": [
+                    Command.create({
+                        "reward_type": "discount",
+                        "discount": 10,
+                        "discount_mode": "per_order",
+                        "discount_applicability": "order",
+                        "required_points": 1,
+                    }),
+                ],
+            }
+        )
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_order_reward_product_tax_included_included', login="pos_user")
+        tax_01.price_include_override = "tax_excluded"
+        # Discount should be the same even if tax mode is changed
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_order_reward_product_tax_included_excluded', login="pos_user")
+
     def test_race_conditions_update_program(self):
         """This test ensures that the loyalty program update are correctly applied, even if a lot of programs applies on one order."""
         product_test = self.env['product.product'].create({


### PR DESCRIPTION
When using a promotion program applied only on specific products with
tax included prices, the discount value was incorrect.

Steps to reproduce:
-------------------
* Create a product with a price of 100$ and tax of 10% included
* Create a promotion program with:
  - Apply on: Specific Products (the product created above)
  - Discount Type: $ Fixed Discount
  - Discount Value: 10$
* Open PoS and add the product to the order
* Apply the promotion code
> Observation: The value of the discount is 9.09$ instead of 10$

The same steps also applies to the discount reward applied on the whole
order.

Why the fix:
------------
When computing the discountable amount for the promotion it would take
the amount excluding tax instead of the base price. The base price
should be the unit price of the product multiplied by the quantity. As
it was before here :
https://github.com/odoo/odoo/blob/8568baa35c9caa4c8cd3b1f5d737e1ecbec76434/addons/point_of_sale/static/src/app/models/pos_order_line.js#L470-L474
https://github.com/odoo/odoo/blob/8568baa35c9caa4c8cd3b1f5d737e1ecbec76434/addons/pos_loyalty/static/src/app/models/pos_order.js#L1112
To do so we modified the accounting helpers to provide this value
instead of computing it manually.

opw-[5260067](https://www.odoo.com/web#id=5260067&view_type=form&model=project.task)
opw-[5242194](https://www.odoo.com/web#id=5242194&view_type=form&model=project.task)