### PR TITLE
[IMP] pos_{,sale}: set correct default products on POS config

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -616,6 +616,9 @@ class PosConfig(models.Model):
         if 'iface_tipproduct' in vals and not vals['iface_tipproduct']:
             vals['tip_product_id'] = False
             vals['set_tip_after_payment'] = False
+        else:
+            if 'tip_product_id' not in vals and (default_tip := self._get_default_tip_product()):
+                vals['tip_product_id'] = default_tip.id
 
         self._check_header_footer(vals)
         self._reset_default_on_vals(vals)

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -135,6 +135,16 @@ class ResConfigSettings(models.TransientModel):
             }
         }
 
+    @api.onchange('pos_iface_tipproduct')
+    def _onchange_iface_tipproduct(self):
+        for res_config in self:
+            if not res_config.pos_iface_tipproduct:
+                res_config.pos_tip_product_id = False
+                res_config.pos_set_tip_after_payment = False
+            else:
+                if not res_config.pos_tip_product_id:
+                    res_config.pos_tip_product_id = res_config.pos_config_id._get_default_tip_product()
+
     @api.model_create_multi
     def create(self, vals_list):
         # STEP: Remove the 'pos' fields from each vals.


### PR DESCRIPTION
Before this commit:
===================
- The down payment product was automatically set only on `pos_config_main`
  (Furniture Shop); other POS configurations required manual setup.
- The tip product was not set by default when activating the tips feature.

After this commit:
==================
- Removed the `pos_config_main` restriction and ensured the default down payment
  product is set for all POS configurations.
- Ensured the tip product is correctly set and unset.

Task-5418545