### PR TITLE
[FIX] product,website_sale: avoid showing variants on alternate product titles

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -566,16 +566,19 @@ class ProductTemplate(models.Model):
         return res
 
     @api.depends('name', 'default_code')
-    @api.depends_context('formatted_display_name')
+    @api.depends_context('formatted_display_name', 'display_default_code')
     def _compute_display_name(self):
+        display_default_code = self.env.context.get('display_default_code', True)
         for template in self:
             if not template.name:
                 template.display_name = False
+            elif not (display_default_code and template.default_code):
+                template.display_name = template.name
             elif self.env.context.get('formatted_display_name'):
-                code_prefix = f'\t--{template.default_code}--' if template.default_code else ''
+                code_prefix = f'\t--{template.default_code}--'
                 template.display_name = f'{template.name}{code_prefix}'
             else:
-                code_prefix = f'[{template.default_code}] ' if template.default_code else ''
+                code_prefix = f'[{template.default_code}] '
                 template.display_name = f'{code_prefix}{template.name}'
 
     @api.model

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -128,6 +128,10 @@ class WebsiteSnippetFilter(models.Model):
                     # factorize and avoid computing the rest
                     if product.is_product_variant:
                         res_product.update(product._get_combination_info_variant())
+                    elif hide_variants:
+                        res_product.update(product._get_combination_info(only_template=True))
+                        # Re-add product_id since it is set to false and required by some tests
+                        res_product['product_id'] = product.product_variant_id.id
                     else:
                         res_product.update(product._get_combination_info())
 


### PR DESCRIPTION
Currently when the user adds an alternate product with a variant, the product title shows the variant name instead of the template name, even when `Show Variants` is disabled.

**Steps to produce:**
* Install `website_sale`
* products > Select any product > sales
* Add any product with variant to alternate products
* Go to that product's website page and scroll to alternate products section.

**Observed Behavior:**
* Product variant names are shown instead of product template names, even though `Show Variants` is disabled.

**Root cause:**
* This happens because loading the alternative product snippet calls `_get_products` [1], which then calls`_filter_records_to_values`. That function calls `_get_combination_info` [2],causing the display names to be updated to the combination display name.

**Solution:**
 Show the product template name instead of the combination name when `Show Variants` is disabled, by using only product templates and updating the product template display name computation to account for `display_default_code`, to ensure the internal reference remains hidden when it is set to `False`.

**Before:**
<img width="1847" height="932" alt="image" src="https://github.com/user-attachments/assets/81ffaf94-d63d-4e2c-9b46-dd369d34bc7b" />

**After:**
<img width="1847" height="932" alt="image" src="https://github.com/user-attachments/assets/4a6d3fa6-541d-4091-9691-e8b10f542833" />

[1]:
https://github.com/odoo/odoo/blob/c4448d2e16e6f4b0b5ea99f6e883cb69d226cfba/addons/website_sale/models/website_snippet_filter.py#L173-L190 
[2]:
https://github.com/odoo/odoo/blob/c4448d2e16e6f4b0b5ea99f6e883cb69d226cfba/addons/website_sale/models/website_snippet_filter.py#L132

opw-5365320