### PR TITLE
[FIX] auth_totp: hacked field search

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -233,7 +233,8 @@ class ResUsers(models.Model):
     def _totp_enable_search(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        domain = Domain.custom(to_sql=lambda table: SQL("%s <> 'false'", table._sudo().totp_secret))
+        # HACK: totp_secret is not a stored field, but still present in table!
+        domain = Domain.custom(to_sql=lambda table: SQL("%s.totp_secret <> 'false'", table))
         if not (self.env.su or self.env.user.has_group('base.group_erp_manager')):
             domain &= Domain('id', '=', self.env.uid)
         return domain


### PR DESCRIPTION
The field is in the table, but not stored on the ORM level. We need to write directly the SQL to get the column.

runbot-234903


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
