### PR TITLE
[IMP] base: add the sequence for the first company created

### DIFF
--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -123,7 +123,7 @@ insert into res_currency (id, name, symbol) VALUES (1, 'USD', '$');
 insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('USD', 'base', 'res.currency', true, 1);
 select setval('res_currency_id_seq', 1);
 
-insert into res_company (id, name, partner_id, currency_id, create_date) VALUES (1, 'My Company', 1, 1, now() at time zone 'UTC');
+insert into res_company (id, name, partner_id, currency_id, sequence, create_date) VALUES (1, 'My Company', 1, 1, 10, now() at time zone 'UTC');
 insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('main_company', 'base', 'res.company', true, 1);
 select setval('res_company_id_seq', 1);
 


### PR DESCRIPTION
For the first company, created from sql sequence is not added to it. And for the rest, case companies created via the model default sequence are already provided.
This will avoid the issue when companies are filtered based on sequence number.

The Intention is to add the sequence to first company is because in the model we are
providing the sequence in order so it should be consistent everywhere.

Ent:- https://github.com/odoo/enterprise/pull/102317