### PR TITLE
[IMP] product: allow hiding upload button in product document kanban

### DIFF
--- a/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.js
+++ b/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.js
@@ -10,6 +10,7 @@ export class ProductDocumentKanbanController extends KanbanController {
         this.formData = {
             'res_model': this.props.context.default_res_model,
             'res_id': this.props.context.default_res_id,
+            'hideUploadButton': !!this.props.context.hide_upload_button,
         };
     }
 }

--- a/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
+++ b/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
@@ -12,6 +12,7 @@
         <button
             type="button"
             name="product_upload_document"
+            t-if="!props.formData.hideUploadButton"
             t-attf-class="btn btn-primary"
             t-on-click.stop.prevent="() => this.uploadFileInputRef.el.click()"
         >


### PR DESCRIPTION
- Allow controlling the visibility of the upload button through context
- Enable Enterprise to hide the button without overriding the entire
  document kanban template
- Reduce duplication of Community code and make the behaviour easier to
  maintain and extend

Task ID: 5358428