### PR TITLE
[FIX] website: block Escape key on cookies bar

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -429,6 +429,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @override
      */
     start() {
+        this.el.querySelector(".modal").addEventListener("keydown", this._onKeydown);
         this._super(...arguments);
 
         this.isCookiePolicyPage = window.location.pathname === "/cookie-policy";
@@ -502,6 +503,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
             this.toggleEl.removeEventListener("click", this._onToggleCookiesBar);
             this.toggleEl.remove();
         }
+        this.el.querySelector(".modal").removeEventListener("keydown", this._onKeydown);
         this._super(...arguments);
     },
 
@@ -621,7 +623,18 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
             }
         }
         setUtmsHtmlDataset();
-    }
+    },
+    /**
+     * @private
+     * @param {KeyboardEvent} ev
+     */
+    _onKeydown: (ev) => {
+        if (ev.key === "Escape") {
+            // Circumvent Bootstrap's keydown behavior which triggers a UI
+            // glitch.
+            ev.stopImmediatePropagation();
+        }
+    },
 });
 
 export default PopupWidget;


### PR DESCRIPTION
When pressing `Escape` with a Bootstrap modal open, even if the config key `keyboard` is set to `false` (preventing escape from closing the modal), Bootstrap sets a class `modal-static` on the modal element and removes it shortly after. This causes a UI glitch in the case of the cookies bar. Stopping the event propagation prevents it from happening.

task-5421993