### PR TITLE
[FIX] portal, *: correctly compute portal_partner for portal user

### DIFF
--- a/addons/portal/controllers/portal_thread.py
+++ b/addons/portal/controllers/portal_thread.py
@@ -45,7 +45,8 @@ class PortalChatter(ThreadController):
     def _store_portal_thread_fields(cls, res: Store.FieldList, **kwargs):
         portal_partner_by_thread = {
             thread: get_portal_partner(
-                thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token"),
+                # need to use sudo because portal users might not have the right to read the portal partner
+                thread.sudo(), kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token"),
             ) for thread in res.records
         }
 

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mail_test_portal_user,mail.test.portal.user,model_mail_test_portal,base.group_user,1,1,1,1
+access_mail_test_portal_portal,mail.test.portal.portal,model_mail_test_portal,base.group_portal,1,1,0,0
 access_mail_test_portal_no_partner_portal,mail.test.portal.no.partner.all,model_mail_test_portal_no_partner,base.group_portal,1,0,0,0
 access_mail_test_portal_no_partner_user,mail.test.portal.no.partner.user,model_mail_test_portal_no_partner,base.group_user,1,1,1,1
 access_mail_test_portal_public_access_action_portal,mail.test.portal.public.access.action.portal,model_mail_test_portal_public_access_action,base.group_portal,1,0,0,0

--- a/addons/test_mail_full/security/ir_rule_data.xml
+++ b/addons/test_mail_full/security/ir_rule_data.xml
@@ -13,5 +13,11 @@
         <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
+    <record id="mail_test_portal_rule_portal" model="ir.rule">
+        <field name="name">TestPortal: Portal should follow</field>
+        <field name="model_id" ref="test_mail_full.model_mail_test_portal"/>
+        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+    </record>
 
 </odoo>

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -69,6 +69,17 @@ class TestUIPortal(TestPortal):
             "message_actions_tour",
         )
 
+    def test_message_actions_portal_when_follower(self):
+        portal_user = self._create_portal_user()
+        self.record_portal.message_subscribe(partner_ids=[portal_user.partner_id.id])
+        self.assertTrue(self.record_portal.with_user(portal_user).has_access('read'))
+        self.assertFalse(self.record_portal.partner_id.with_user(portal_user).has_access('read'))
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}?token={self.record_portal._portal_ensure_token()}",
+            "message_actions_tour",
+            login=portal_user.login,
+        )
+
     def test_rating_record_portal(self):
         record_rating = self.env["mail.test.rating"].create({"name": "Test rating record"})
         self.start_tour(


### PR DESCRIPTION
Use case:
- Create an Helpdesk team with `Visibility` (`privacy_visibility`) set to 'portal'
- Create a ticket for that helpdesk team
- Add a portal user as follower of that ticket, then with that user open the ticket from the portal

An error is logged:
```
Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, Chell Gladys (id=67) (base.group_portal) doesn't have 'read' access to:
- Contact (res.partner)

[16/Dec/2025 15:41:49] "POST /portal/chatter_init HTTP/1.1" 200 - 51 0.018 0.096
```

Before odoo/odoo@2a2feff92ee8, the `portal_partner` was only computed for public user. Now its also computed for portal user; but in such case the thread returned by `_get_thread_with_access()` will be with `su=False`, meaning that if the portal partner is not of the same commercial company as the portal user it won't have rights to read it, thus raise the warning.

This commit force computing the portal partner as superuser (access rights have already been validated beforehand)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
