### PR TITLE
[FIX] web: adapt loading indicator z-index

### DIFF
--- a/addons/web/static/src/webclient/loading_indicator/loading_indicator.scss
+++ b/addons/web/static/src/webclient/loading_indicator/loading_indicator.scss
@@ -1,6 +1,6 @@
 .o_loading_indicator_wrap {
     left: auto;
-    z-index: $zindex-modal + 1;
+    z-index: $zindex-toast + 1;
 
     .spinner-border {
         --#{$prefix}spinner-height: 1em;


### PR DESCRIPTION
Prior to this commit, some elements could appear above the loading indicator due to insufficient z-index value, leading to a poor user experience during loading phases.

This commit adapts the z-index of the loading indicator to ensure it always appears above other elements, enhancing visibility and feedback to the user during loading operations.

task-5420571

| Before | After |
|--------|--------|
| <img width="380" height="653" alt="Capture d’écran 2025-12-17 à 10 25 47" src="https://github.com/user-attachments/assets/c8a44073-cefb-4d19-a275-350fe65721b1" /> | <img width="382" height="659" alt="Capture d’écran 2025-12-17 à 10 24 49" src="https://github.com/user-attachments/assets/dddfa90d-828a-4cfa-a524-3221c2921ee9" /> |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
