### PR TITLE
[IMP] hr_attendance: adjust access rights for attendance officers

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -14,38 +14,38 @@ class HrEmployee(models.Model):
         'res.users', store=True, readonly=False,
         string="Attendance Approver",
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
-        groups="hr_attendance.group_hr_attendance_own",
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer",
         help="The user set in Attendance will access the attendance of the employee through the dedicated app and will be able to edit them.")
     attendance_ids = fields.One2many(
-        'hr.attendance', 'employee_id', groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        'hr.attendance', 'employee_id', groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     last_attendance_id = fields.Many2one(
         'hr.attendance', compute='_compute_last_attendance_id', store=True,
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     last_check_in = fields.Datetime(
         related='last_attendance_id.check_in', store=True,
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user", tracking=False)
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user", tracking=False)
     last_check_out = fields.Datetime(
         related='last_attendance_id.check_out', store=True,
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user", tracking=False)
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user", tracking=False)
     attendance_state = fields.Selection(
         string="Attendance Status", compute='_compute_attendance_state',
         selection=[('checked_out', "Checked out"), ('checked_in', "Checked in")],
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     hours_last_month = fields.Float(compute='_compute_hours_last_month')
     hours_last_month_overtime = fields.Float(compute='_compute_hours_last_month')
     hours_today = fields.Float(
         compute='_compute_hours_today',
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     hours_previously_today = fields.Float(
         compute='_compute_hours_today',
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     last_attendance_worked_hours = fields.Float(
         compute='_compute_hours_today',
-        groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     hours_last_month_display = fields.Char(
         compute='_compute_hours_last_month', groups="hr.group_hr_user")
     overtime_ids = fields.One2many(
-        'hr.attendance.overtime.line', 'employee_id', groups="hr_attendance.group_hr_attendance_own,hr.group_hr_user")
+        'hr.attendance.overtime.line', 'employee_id', groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
     total_overtime = fields.Float(compute='_compute_total_overtime', compute_sudo=True)
     display_extra_hours = fields.Boolean(related='company_id.hr_attendance_display_overtime')
 

--- a/addons/hr_attendance/models/hr_employee_public.py
+++ b/addons/hr_attendance/models/hr_employee_public.py
@@ -9,20 +9,20 @@ class HrEmployeePublic(models.Model):
 
     # These are required for manual attendance
     attendance_state = fields.Selection(related='employee_id.attendance_state', readonly=True,
-        groups="hr_attendance.group_hr_attendance_own")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     hours_today = fields.Float(related='employee_id.hours_today', readonly=True,
-        groups="hr_attendance.group_hr_attendance_own")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     hours_last_month = fields.Float(related='employee_id.hours_last_month')
     hours_last_month_overtime = fields.Float(related='employee_id.hours_last_month_overtime')
     last_attendance_id = fields.Many2one(related='employee_id.last_attendance_id', readonly=True,
-        groups="hr_attendance.group_hr_attendance_own")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     total_overtime = fields.Float(related='employee_id.total_overtime', readonly=True)
     attendance_manager_id = fields.Many2one(related='employee_id.attendance_manager_id',
-        groups="hr_attendance.group_hr_attendance_own")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     last_check_in = fields.Datetime(related='employee_id.last_check_in',
-        groups="hr_attendance.group_hr_attendance_own")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     last_check_out = fields.Datetime(related='employee_id.last_check_out',
-        groups="hr_attendance.group_hr_attendance_own")
+        groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer")
     display_extra_hours = fields.Boolean(related='company_id.hr_attendance_display_overtime')
 
     def action_open_last_month_attendances(self):

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -26,7 +26,8 @@
     <record id="group_hr_attendance_officer" model="res.groups">
         <field name="name">Officer: Manage attendances</field>
         <field name="sequence">10</field>
-        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own'))]"/>
+        <field name="privilege_id" ref="res_groups_privilege_attendances"/>
+        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own_reader'))]"/>
         <field name="comment">The user will have access to the attendance records and reporting of employees where he's set as an attendance manager</field>
     </record>
 
@@ -34,7 +35,7 @@
         <field name="name">Officer: Manage all attendances</field>
         <field name="sequence">15</field>
         <field name="privilege_id" ref="res_groups_privilege_attendances"/>
-        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
+        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_officer')), (4, ref('hr_attendance.group_hr_attendance_own'))]"/>
         <field name="comment">The user will have access to all attendance records and reports for all employees.</field>
     </record>
     

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -322,7 +322,7 @@
         <field name="name">Attendances</field>
         <field name="path">attendances</field>
         <field name="res_model">hr.attendance</field>
-        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own'))]"/>
+        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_own')), (4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
         <field name="view_mode">list,form</field>
         <field name="context">
             {
@@ -465,7 +465,7 @@
 
     <!-- Menus -->
 
-    <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="205" groups="hr_attendance.group_hr_attendance_own" web_icon="hr_attendance,static/description/icon.png"/>
+    <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="205" groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer" web_icon="hr_attendance,static/description/icon.png"/>
 
     <menuitem id="menu_action_open_form" name="Kiosk Mode" action="open_kiosk_url" parent="menu_hr_attendance_root" sequence="10" groups="hr_attendance.group_hr_attendance_user"/>
 
@@ -483,7 +483,7 @@
         parent="menu_hr_attendance_reporting"
         sequence="10"/>
 
-    <menuitem id="menu_hr_attendance_overview" name="Overview" parent="menu_hr_attendance_root" sequence="5" groups="hr_attendance.group_hr_attendance_own"/>
+    <menuitem id="menu_hr_attendance_overview" name="Overview" parent="menu_hr_attendance_root" sequence="5" groups="hr_attendance.group_hr_attendance_own,hr_attendance.group_hr_attendance_officer"/>
 
     <menuitem id="menu_hr_attendance_view_dashboard" name="Dashboard" action="hr_attendance_action" parent="menu_hr_attendance_overview" sequence="1"/>
 


### PR DESCRIPTION
Currently, attendance managers of some employee are assigned implicitly the right to self edit their own attendance, which should not be the case.

This PR removes the implicit right of self attendance edit from the "Officer: Manage attendances" group.

Task: 5384284

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
