### PR TITLE
[FIX] html_editor: hide table handler when not fully visible

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, onMounted, onWillUpdateProps, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
@@ -14,7 +14,7 @@ export class TableMenu extends Component {
         addRow: Function,
         removeRow: Function,
         resetTableSize: Function,
-        overlay: Object,
+        close: Function,
         dropdownState: Object,
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
         direction: { type: String, optional: true },
@@ -23,6 +23,7 @@ export class TableMenu extends Component {
     static components = { Dropdown, DropdownItem };
 
     setup() {
+        this.dropdownRef = useRef("dropdown");
         if (this.props.type === "column") {
             this.isFirst = this.props.target.cellIndex === 0;
             this.isLast = !this.props.target.nextElementSibling;
@@ -32,6 +33,13 @@ export class TableMenu extends Component {
             this.isLast = !tr.nextElementSibling;
         }
         this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
+        onWillUpdateProps((newProps) => {
+            this.updatePosition(newProps);
+        });
+        onMounted(() => {
+            this.overlayEl = this.dropdownRef.el;
+            this.updatePosition(this.props);
+        });
     }
 
     get hasCustomSize() {
@@ -42,9 +50,34 @@ export class TableMenu extends Component {
         );
     }
 
+    updatePosition({ target, type, direction }) {
+        if (!this.overlayEl || !target) {
+            return;
+        }
+        const targetRect = target.getBoundingClientRect();
+        const container = this.overlayEl.parentElement;
+        const containerRect = container.getBoundingClientRect();
+        if (type === "column") {
+            Object.assign(this.overlayEl.style, {
+                top: `${targetRect.top - containerRect.top - this.overlayEl.offsetHeight}px`,
+                left: `${targetRect.left - containerRect.left}px`,
+                width: `${targetRect.width}px`,
+            });
+        } else {
+            const isLTR = direction === "ltr";
+            const inlineStartOffset = isLTR
+                ? targetRect.left - containerRect.left
+                : containerRect.right - targetRect.right;
+            Object.assign(this.overlayEl.style, {
+                top: `${targetRect.top - containerRect.top}px`,
+                insetInlineStart: `${inlineStartOffset - this.overlayEl.offsetWidth}px`,
+                height: `${targetRect.height}px`,
+            });
+        }
+    }
     onSelected(item) {
         item.action(this.props.target);
-        this.props.overlay.close();
+        this.props.close();
     }
 
     colItems() {

--- a/addons/html_editor/static/src/main/table/table_menu.scss
+++ b/addons/html_editor/static/src/main/table/table_menu.scss
@@ -2,6 +2,7 @@
     border: $border-width solid rgba($color: $o-brand-odoo, $alpha: 1.0);
     color: #fff;
     background-color: rgba($color: $o-brand-odoo, $alpha: 0.7);
+    position: absolute;
 
     &.fa-ellipsis-v {
         width: 17px;

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.TableMenu">
         <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState">
-            <button t-on-pointerdown.prevent="() => {}" t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100'}}" />
+            <button t-on-pointerdown.prevent="() => {}" t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h' : 'v'}}" t-ref="dropdown"/>
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">
                     <t t-foreach="items" t-as="item" t-key="item_index">
@@ -12,7 +12,7 @@
                             </div>
                         </DropdownItem>
                     </t>
-                 </div>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -89,21 +89,17 @@ export class TableUIPlugin extends Plugin {
         if (this.isMenuOpened) {
             return;
         }
-        if (
-            ["TD", "TH"].includes(target.tagName) &&
-            target !== this.activeTd &&
-            this.editable.contains(target)
-        ) {
+        const targetCell = closestElement(target, "td, th");
+        if (targetCell && targetCell !== this.activeTd && this.editable.contains(targetCell)) {
             if (ev.target.isContentEditable) {
-                this.setActiveTd(target);
+                this.setActiveTd(targetCell);
             }
         } else if (this.activeTd) {
             const isOverlay = target.closest(".o-we-table-menu");
             if (isOverlay) {
                 return;
             }
-            const parentTd = closestElement(target, "td, th");
-            if (!parentTd) {
+            if (!targetCell) {
                 this.setActiveTd(null);
             }
         }

--- a/addons/html_editor/static/tests/overlay.test.js
+++ b/addons/html_editor/static/tests/overlay.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { setSelection } from "./_helpers/selection";
-import { click, hover, queryAll, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
+import { click, hover, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
 import { animationFrame } from "@odoo/hoot-mock";
 import { unformat } from "./_helpers/format";
@@ -109,7 +109,7 @@ test("Table column control should always be displayed on top of the table", asyn
     const columnControl = await waitFor(".o-we-table-menu[data-type='column']");
 
     // Table column control displayed on hover should be above the table
-    expect(bottom(columnControl)).toBeLessThan(top(table));
+    expect(bottom(columnControl)).toBe(top(table));
 
     // Scroll down so that the table is close to the top
     const distanceToTop = top(table) - top(scrollableElement);
@@ -119,9 +119,8 @@ test("Table column control should always be displayed on top of the table", asyn
     await hover(".odoo-editor-editable td");
     await animationFrame();
 
-    // Table control should not be displayed (it should not overflow the scroll
-    // container, nor be placed below the first row).
-    expect(queryAll(".o-we-table-menu[data-type='column']")).toHaveCount(0);
+    // Table column control displayed on hover should be above the table
+    expect(bottom(columnControl)).toBe(top(table));
 });
 
 test.tags("desktop");

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -126,6 +126,26 @@ test("should not display the resizeCursor if the table element isContentEditable
     expect(".o_col_resize").toHaveCount(0);
 });
 
+test("should show the table UI menus when hovering a list inside a table cell", async () => {
+    const { el } = await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td>
+                        <ul><li>1</li><li>2</li><li>3</li></ul>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+
+    await expectElementCount(".o-we-table-menu", 0);
+
+    await hover(el.querySelector("ul"));
+    // Should display both the row and column menus
+    await expectElementCount(".o-we-table-menu", 2);
+});
+
 test("list of table commands in first column", async () => {
     const { el } = await setupEditor(`
         <p><br></p>


### PR DESCRIPTION
**Current behavior before PR:**

- Table menu handlers could overflow into adjacent table areas when the targeted part of the table was only partially visible within the container.
- When a table cell contained a list, hovering over the list element did not display the table UI menus, even though the mouse was inside the cell.

**Desired behavior after PR is merged:**

- Use a local overlay for the table menu to prevent overflow into adjacent cells.
- Table UI menus are now correctly displayed when hovering over list elements inside a table cell.

task-5353518