### PR TITLE
[FIX] pos_online_payment: prevent multiple online pm per POS config

### DIFF
--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -50,6 +50,15 @@ class PosPaymentMethod(models.Model):
             else:
                 pm.has_an_online_payment_provider = False
 
+    @api.constrains('config_ids', 'is_online_payment')
+    def _check_pos_config_online_payment(self):
+        """ Check that each POS config has at most one online payment method,"""
+        for pm in self.filtered('is_online_payment'):
+            for config in pm.config_ids:
+                other_online_pms = config.payment_method_ids.filtered(lambda other_pm: other_pm.is_online_payment and other_pm.id != pm.id)
+                if other_online_pms:
+                    raise ValidationError(_("The %s already has one online payment.", config.name))
+
     def _is_write_forbidden(self, fields):
         return super(PosPaymentMethod, self)._is_write_forbidden(fields - {'online_payment_provider_ids'})
 


### PR DESCRIPTION
Task: [#5420237](https://www.odoo.com/odoo/project/1737/tasks/5420237)

---

There is a constraint on the `pos.config` model that prevents opening a POS session when multiple online payment methods are configured for the same POS config. However, from the `pos.payment.method` model, it is still possible to add multiple online payment methods to a single POS config, which then prevents opening a session.

In addition, if a session is already open, it is no longer possible to resolve the situation:

* From `pos.payment.method`: the POS session must be closed before removing the POS config from an online payment method.
* From `pos.config`: the payment methods field is read-only when there is an open session.

We had to delete one of the online payment methods from the database directly to be able to open the POS session again.

To prevent this inconsistent state, a constraint is added on `pos.payment.method` to ensure that each POS config has at most one online payment method.