### PR TITLE
[IMP] point_of_sale: show config name on splash/login screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.scss
@@ -16,4 +16,16 @@
             height: $pos-navbar-height;
         }
     }
+    .fade-effect {
+        animation-name: fade-in;
+        animation-duration: 2.5s;
+    }
+    @keyframes fade-in {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
 }

--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.xml
@@ -3,16 +3,22 @@
     <t t-name="point_of_sale.LoginScreen">
         <div class="login-overlay o_attendance_background fixed-top w-100 h-100 p-4 d-flex flex-column">
             <div class="screen-login-header d-flex justify-content-between">
-                <div t-if="!ui.isSmall" class="screen-login-timer d-flex align-items-center gap-2 bg-transparent">
+                <div t-if="!ui.isSmall" class="screen-login-timer d-flex align-items-center gap-2 w-50">
                     <div class="timer-hours fs-1" t-esc="time.hours"> </div>
                     <div class="timer-date-container d-flex flex-column smaller">
                         <div class="timer-day" t-esc="time.day"> </div>
                         <div class="timer-date" t-esc="time.date"> </div>
                     </div>
                 </div>
-                <div t-attf-class="screen-login-logo {{ ui.isSmall ? 'mx-auto' : 'ms-auto'}}">
+                <div t-if="!ui.isSmall" class="fs-1 fw-bold d-flex justify-content-center align-items-end overflow-hidden w-100 fade-effect">
+                    <t t-esc="this.pos.config.name"/>
+                </div>
+                <div t-attf-class="screen-login-logo {{ ui.isSmall ? 'mx-auto' : 'd-flex justify-content-end w-50'}}">
                     <img t-attf-src="/web/image?model=res.company&amp;id={{pos.company.id}}&amp;field=logo" alt="Logo"/>
                 </div>
+            </div>
+            <div t-if="ui.isSmall" class="fs-1 fw-bold mt-4 d-flex justify-content-center fade-effect">
+                <t t-esc="this.pos.config.name"/>
             </div>
             <div class="screen-login flex-grow-1 d-flex flex-column">
                 <div class="login-body d-flex flex-column flex-md-row gap-3 m-auto">


### PR DESCRIPTION
In this commit,
Introduces the POS name on the splash screen to help users easily identify the active POS during login.

<img width="1920" height="852" alt="image" src="https://github.com/user-attachments/assets/50026f45-26fb-4d91-bd08-1accbf9f56dd" /><img width="331" height="718" alt="image" src="https://github.com/user-attachments/assets/c563ead5-ede3-49d4-bfa9-bafe63585e15" />



Task-5421728







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr